### PR TITLE
fix: don't block install when piped without GPG

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,8 +103,9 @@ if [ "$GPG_AVAILABLE" = true ]; then
                 exit 1
             fi
         else
-            echo -e "${YELLOW}⚠ Continuing despite failed verification (non-interactive mode).${NC}"
-            echo ""
+            echo -e "${RED}✗ Signature verification failed in non-interactive mode. Aborting.${NC}"
+            echo "  Re-run interactively or set X0X_SKIP_GPG=true to bypass."
+            exit 1
         fi
     fi
 fi


### PR DESCRIPTION
The install script uses read prompts to ask whether to continue when GPG is missing or signature verification fails. When piped (curl | sh), there is no TTY so read receives no input, the default is No, and the script silently exits without installing.

This affects both humans (curl -sfL https://x0x.md | sh) and AI agents running the installer non-interactively.

Detect non-interactive mode via TTY check ([ -t 0 ]) and an explicit -y/--yes flag. In non-interactive mode, warn and continue instead of prompting. Interactive behaviour is unchanged.