### PR TITLE
docs: add skill-first install flow in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -90,6 +90,60 @@ From Barr, Scotland, we're building networks that work like communities: through
 
 ---
 
+## Before You Start — Check for x0xd
+
+x0x needs a small daemon called **x0xd** running on the local machine. Before using any capability below, check whether it's already there:
+
+```bash
+curl -s http://127.0.0.1:12700/health
+```
+
+**If you get JSON with `"status": "ok"`** — x0xd is running. Skip to [Core Capabilities](#core-capabilities).
+
+**If the connection is refused or the command fails** — x0xd is not running. Follow the steps below.
+
+### Install x0xd
+
+Run the install script. This downloads the daemon binary, starts it, and runs a health check:
+
+```bash
+curl -sfL https://x0x.md | sh
+```
+
+If GPG is not installed on the machine, the script will warn that signature verification was skipped and continue. This is safe for testing. GPG can be installed later for production verification.
+
+If the install script cannot run (e.g. permissions, sandboxed environment), ask your human to run the command above in their terminal.
+
+### Start x0xd if installed but not running
+
+If x0xd is installed but the health check fails, start it:
+
+```bash
+x0xd &
+sleep 2
+curl -s http://127.0.0.1:12700/health
+```
+
+If `x0xd` is not found, `~/.local/bin` may not be in PATH:
+
+```bash
+~/.local/bin/x0xd &
+```
+
+### Verify
+
+```bash
+# Daemon running?
+curl -s http://127.0.0.1:12700/health
+
+# Your identity?
+curl -s http://127.0.0.1:12700/agent
+```
+
+If both return JSON, x0x is ready.
+
+---
+
 ## Core Capabilities
 
 ### 1. Secure Messaging (Pub/Sub) — with Signed Messages


### PR DESCRIPTION
## Summary
- Adds a "Before You Start — Check for x0xd" section before Core Capabilities
- Guides agents through: check health → install if missing → start if stopped
- Enables skill-first onboarding so agents can self-install x0xd before using capabilities
- Uses `https://x0x.md` install URL

## Test plan
- [ ] Verify SKILL.md renders correctly on GitHub
- [ ] Confirm `curl -sfL https://x0x.md | sh` install flow works
- [ ] Test agent onboarding with x0xd not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)