### PR TITLE
feat: user key identity, agent discovery fixes, and testnet tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,17 +30,17 @@ hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 rand = "0.8"
-saorsa-gossip-coordinator = "0.5"
-saorsa-gossip-crdt-sync = "0.5"
-saorsa-gossip-groups = "0.5"
-saorsa-gossip-identity = "0.5"
-saorsa-gossip-membership = "0.5"
-saorsa-gossip-presence = "0.5"
-saorsa-gossip-pubsub = "0.5"
-saorsa-gossip-rendezvous = "0.5"
-saorsa-gossip-runtime = "0.5"
-saorsa-gossip-transport = "0.5"
-saorsa-gossip-types = "0.5"
+saorsa-gossip-coordinator = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
+saorsa-gossip-crdt-sync = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
+saorsa-gossip-groups = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
+saorsa-gossip-identity = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
+saorsa-gossip-membership = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
+saorsa-gossip-presence = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
+saorsa-gossip-pubsub = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
+saorsa-gossip-rendezvous = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
+saorsa-gossip-runtime = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
+saorsa-gossip-transport = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
+saorsa-gossip-types = { git = "https://github.com/jacderida/saorsa-gossip.git", branch = "fix-do_not_abort_eager_forwarding" }
 saorsa-pqc = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -96,6 +96,11 @@ struct DaemonConfig {
     #[serde(default = "default_identity_ttl")]
     identity_ttl_secs: u64,
 
+    /// Optional path to a user keypair file for human identity.
+    /// When set, the agent can announce with `include_user_identity: true`.
+    #[serde(default)]
+    user_key_path: Option<PathBuf>,
+
     /// Enable rendezvous `ProviderSummary` advertisements for global findability.
     #[serde(default = "default_rendezvous_enabled")]
     rendezvous_enabled: bool,
@@ -179,6 +184,7 @@ impl Default for DaemonConfig {
             update_repo: default_update_repo(),
             heartbeat_interval_secs: default_heartbeat_interval(),
             identity_ttl_secs: default_identity_ttl(),
+            user_key_path: None,
             rendezvous_enabled: default_rendezvous_enabled(),
             rendezvous_validity_ms: default_rendezvous_validity_ms(),
         }
@@ -474,16 +480,23 @@ async fn main() -> Result<()> {
         peer_cache_path: Some(config.data_dir.join("peers.cache")),
     };
 
-    let agent = Agent::builder()
+    let mut builder = Agent::builder()
         .with_network_config(network_config)
         .with_heartbeat_interval(config.heartbeat_interval_secs)
-        .with_identity_ttl(config.identity_ttl_secs)
-        .build()
-        .await
-        .context("failed to create agent")?;
+        .with_identity_ttl(config.identity_ttl_secs);
+
+    if let Some(ref user_key_path) = config.user_key_path {
+        builder = builder.with_user_key_path(user_key_path);
+        tracing::info!("User key path: {}", user_key_path.display());
+    }
+
+    let agent = builder.build().await.context("failed to create agent")?;
 
     tracing::info!("Agent ID: {}", agent.agent_id());
     tracing::info!("Machine ID: {}", agent.machine_id());
+    if let Some(uid) = agent.user_id() {
+        tracing::info!("User ID: {}", uid);
+    }
 
     // Create contact store and attach to gossip layer for trust filtering
     let contacts = Arc::new(RwLock::new(ContactStore::new(

--- a/src/gossip/pubsub.rs
+++ b/src/gossip/pubsub.rs
@@ -331,6 +331,19 @@ impl PubSubManager {
         }
     }
 
+    /// Re-initialize PlumTree peers for all locally subscribed topics.
+    ///
+    /// This ensures that newly connected peers are added to the eager set
+    /// for existing topics. Without this, a peer that connects after a topic
+    /// is subscribed would never receive messages on that topic from this node.
+    pub async fn refresh_topic_peers(&self) {
+        let topics: Vec<String> = self.topic_ref_counts.read().await.keys().cloned().collect();
+        for topic in topics {
+            let topic_id = TopicId::from_entity(topic.as_bytes());
+            self.initialize_topic_peers(topic_id).await;
+        }
+    }
+
     /// Initialize PlumTree peers for a topic from currently connected peers.
     async fn initialize_topic_peers(&self, topic: TopicId) {
         let peers: Vec<PeerId> = self

--- a/src/gossip/pubsub.rs
+++ b/src/gossip/pubsub.rs
@@ -338,9 +338,16 @@ impl PubSubManager {
     /// is subscribed would never receive messages on that topic from this node.
     pub async fn refresh_topic_peers(&self) {
         let topics: Vec<String> = self.topic_ref_counts.read().await.keys().cloned().collect();
+        let peers: Vec<PeerId> = self
+            .network
+            .connected_peers()
+            .await
+            .into_iter()
+            .map(|peer| PeerId::new(peer.0))
+            .collect();
         for topic in topics {
             let topic_id = TopicId::from_entity(topic.as_bytes());
-            self.initialize_topic_peers(topic_id).await;
+            self.plumtree.set_topic_peers(topic_id, peers.clone()).await;
         }
     }
 

--- a/src/gossip/runtime.rs
+++ b/src/gossip/runtime.rs
@@ -20,6 +20,7 @@ pub struct GossipRuntime {
     pubsub: Arc<PubSubManager>,
     peer_id: PeerId,
     dispatcher_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    peer_sync_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl std::fmt::Debug for GossipRuntime {
@@ -74,6 +75,7 @@ impl GossipRuntime {
             pubsub,
             peer_id,
             dispatcher_handle: std::sync::Mutex::new(None),
+            peer_sync_handle: std::sync::Mutex::new(None),
         })
     }
 
@@ -116,6 +118,7 @@ impl GossipRuntime {
     /// Returns an error if initialization fails.
     pub async fn start(&self) -> NetworkResult<()> {
         let network = Arc::clone(&self.network);
+        let membership = Arc::clone(&self.membership);
         let pubsub = Arc::clone(&self.pubsub);
 
         let handle = tokio::spawn(async move {
@@ -126,6 +129,13 @@ impl GossipRuntime {
                     Ok((peer, stream_type, data)) => match stream_type {
                         GossipStreamType::PubSub => {
                             pubsub.handle_incoming(peer, data).await;
+                        }
+                        GossipStreamType::Membership => {
+                            if let Err(e) = membership.dispatch_message(peer, &data).await {
+                                tracing::debug!(
+                                    "Failed to handle membership message from {peer}: {e}"
+                                );
+                            }
                         }
                         other => {
                             tracing::debug!("Ignoring {:?} stream (not yet implemented)", other);
@@ -139,6 +149,21 @@ impl GossipRuntime {
             }
             tracing::info!("Gossip message dispatcher shut down");
         });
+
+        // Periodically refresh PlumTree topic peers with current connections.
+        // This ensures newly connected peers (discovered via HyParView or
+        // direct connection) are added to the eager set for existing topics.
+        let pubsub_refresh = Arc::clone(&self.pubsub);
+        let peer_sync_handle = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                pubsub_refresh.refresh_topic_peers().await;
+            }
+        });
+
+        if let Ok(mut guard) = self.peer_sync_handle.lock() {
+            *guard = Some(peer_sync_handle);
+        }
 
         match self.dispatcher_handle.lock() {
             Ok(mut guard) => *guard = Some(handle),
@@ -159,6 +184,11 @@ impl GossipRuntime {
     ///
     /// Returns an error if shutdown fails.
     pub async fn shutdown(&self) -> NetworkResult<()> {
+        if let Ok(mut guard) = self.peer_sync_handle.lock() {
+            if let Some(handle) = guard.take() {
+                handle.abort();
+            }
+        }
         if let Ok(mut guard) = self.dispatcher_handle.lock() {
             if let Some(handle) = guard.take() {
                 handle.abort();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,7 @@ impl Agent {
             .read()
             .await
             .values()
-            .filter(|a| a.last_seen >= cutoff)
+            .filter(|a| a.announced_at >= cutoff)
             .cloned()
             .collect();
         agents.sort_by(|a, b| a.agent_id.0.cmp(&b.agent_id.0));
@@ -762,31 +762,22 @@ impl Agent {
                     continue;
                 }
 
-                // Only update the cache if this announcement is newer than
-                // what we already have. Anti-entropy may replay stale cached
-                // messages, which would otherwise keep resetting last_seen
-                // and prevent dead agents from being evicted by TTL.
-                let mut cache = cache.write().await;
-                let dominated = cache
-                    .get(&announcement.agent_id)
-                    .is_some_and(|existing| existing.announced_at >= announcement.announced_at);
-                if !dominated {
-                    let now = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map_or(0, |d| d.as_secs());
-                    cache.insert(
-                        announcement.agent_id,
-                        DiscoveredAgent {
-                            agent_id: announcement.agent_id,
-                            machine_id: announcement.machine_id,
-                            user_id: announcement.user_id,
-                            addresses: announcement.addresses.clone(),
-                            announced_at: announcement.announced_at,
-                            last_seen: now,
-                            machine_public_key: announcement.machine_public_key.clone(),
-                        },
-                    );
-                }
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map_or(0, |d| d.as_secs());
+
+                cache.write().await.insert(
+                    announcement.agent_id,
+                    DiscoveredAgent {
+                        agent_id: announcement.agent_id,
+                        machine_id: announcement.machine_id,
+                        user_id: announcement.user_id,
+                        addresses: announcement.addresses.clone(),
+                        announced_at: announcement.announced_at,
+                        last_seen: now,
+                        machine_public_key: announcement.machine_public_key.clone(),
+                    },
+                );
             }
         });
 
@@ -1109,7 +1100,7 @@ impl Agent {
             .read()
             .await
             .values()
-            .filter(|a| a.last_seen >= cutoff)
+            .filter(|a| a.announced_at >= cutoff)
             .map(|a| a.agent_id)
             .collect();
         agents.sort_by(|a, b| a.0.cmp(&b.0));
@@ -1223,7 +1214,7 @@ impl Agent {
             .read()
             .await
             .values()
-            .filter(|a| a.last_seen >= cutoff && a.user_id == Some(user_id))
+            .filter(|a| a.announced_at >= cutoff && a.user_id == Some(user_id))
             .cloned()
             .collect())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ pub use gossip::{
     GossipConfig, GossipRuntime, PubSubManager, PubSubMessage, SigningContext, Subscription,
 };
 
+// Import Membership trait for HyParView join() method
+use saorsa_gossip_membership::Membership as _;
+
 /// The core agent that participates in the x0x gossip network.
 ///
 /// Each agent is a peer — there is no client/server distinction.
@@ -949,6 +952,23 @@ impl Agent {
             bootstrap_nodes.len() - failed.len(),
             bootstrap_nodes.len()
         );
+
+        // Join the HyParView membership overlay via bootstrap nodes.
+        // This triggers JOIN messages that propagate through the network,
+        // allowing other agents to discover this node and establish
+        // overlay connections for gossip dissemination.
+        if let Some(ref runtime) = self.gossip_runtime {
+            let seeds: Vec<String> = bootstrap_nodes
+                .iter()
+                .filter(|addr| !failed.contains(addr))
+                .map(|addr| addr.to_string())
+                .collect();
+            if !seeds.is_empty() {
+                if let Err(e) = runtime.membership().join(seeds).await {
+                    tracing::warn!("HyParView membership join failed: {e}");
+                }
+            }
+        }
 
         if let Err(e) = self.announce_identity(false, false).await {
             tracing::warn!("Initial identity announcement failed: {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,22 +762,31 @@ impl Agent {
                     continue;
                 }
 
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map_or(0, |d| d.as_secs());
-
-                cache.write().await.insert(
-                    announcement.agent_id,
-                    DiscoveredAgent {
-                        agent_id: announcement.agent_id,
-                        machine_id: announcement.machine_id,
-                        user_id: announcement.user_id,
-                        addresses: announcement.addresses.clone(),
-                        announced_at: announcement.announced_at,
-                        last_seen: now,
-                        machine_public_key: announcement.machine_public_key.clone(),
-                    },
-                );
+                // Only update the cache if this announcement is newer than
+                // what we already have. Anti-entropy may replay stale cached
+                // messages, which would otherwise keep resetting last_seen
+                // and prevent dead agents from being evicted by TTL.
+                let mut cache = cache.write().await;
+                let dominated = cache
+                    .get(&announcement.agent_id)
+                    .is_some_and(|existing| existing.announced_at >= announcement.announced_at);
+                if !dominated {
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map_or(0, |d| d.as_secs());
+                    cache.insert(
+                        announcement.agent_id,
+                        DiscoveredAgent {
+                            agent_id: announcement.agent_id,
+                            machine_id: announcement.machine_id,
+                            user_id: announcement.user_id,
+                            addresses: announcement.addresses.clone(),
+                            announced_at: announcement.announced_at,
+                            last_seen: now,
+                            machine_public_key: announcement.machine_public_key.clone(),
+                        },
+                    );
+                }
             }
         });
 

--- a/tests/testnet/run_identity_presence_tests.sh
+++ b/tests/testnet/run_identity_presence_tests.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+#
+# Testnet Identity & Presence Tests
+# ==================================
+# Automated checks for identity discovery and presence against live
+# DigitalOcean droplets running x0xd. Uses SSH + curl to exercise the REST API.
+#
+# Usage:
+#   ./tests/testnet/run_test_plan.sh <HOST_A> <HOST_B> <HOST_C>
+#
+# Each HOST is an SSH-accessible address (e.g. root@1.2.3.4).
+# x0xd must already be running on each droplet (port 12700).
+#
+# Droplets A and B have user_key_path configured (same key).
+# Droplet C has no user key.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+HOST_A="${1:?Usage: $0 <HOST_A> <HOST_B> <HOST_C>}"
+HOST_B="${2:?Usage: $0 <HOST_A> <HOST_B> <HOST_C>}"
+HOST_C="${3:?Usage: $0 <HOST_A> <HOST_B> <HOST_C>}"
+
+API_PORT=12700
+SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=5"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+api() {
+    local host="$1" method="$2" path="$3"
+    shift 3
+    ssh $SSH_OPTS "$host" "curl -sf -X $method http://localhost:${API_PORT}${path} $*" 2>/dev/null
+}
+
+api_json() {
+    local host="$1" method="$2" path="$3"
+    shift 3
+    ssh $SSH_OPTS "$host" "curl -sf -X $method -H 'Content-Type: application/json' http://localhost:${API_PORT}${path} $*" 2>/dev/null
+}
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected='$expected', actual='$actual')"
+    fi
+}
+
+assert_not_empty() {
+    local desc="$1" val="$2"
+    if [[ -n "$val" && "$val" != "null" ]]; then
+        pass "$desc"
+    else
+        fail "$desc (was empty/null)"
+    fi
+}
+
+assert_empty_or_null() {
+    local desc="$1" val="$2"
+    if [[ -z "$val" || "$val" == "null" ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected empty/null, got '$val')"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    if echo "$haystack" | grep -q "$needle"; then
+        pass "$desc"
+    else
+        fail "$desc (needle='$needle' not in haystack)"
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    if echo "$haystack" | grep -q "$needle"; then
+        fail "$desc (needle='$needle' found but should not be)"
+    else
+        pass "$desc"
+    fi
+}
+
+jq_field() {
+    echo "$1" | jq -r "$2" 2>/dev/null
+}
+
+separator() {
+    echo ""
+    echo "================================================================"
+    echo "$1"
+    echo "================================================================"
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight: check connectivity
+# ---------------------------------------------------------------------------
+separator "Pre-flight: checking SSH + x0xd connectivity"
+
+for host_var in HOST_A HOST_B HOST_C; do
+    host="${!host_var}"
+    result=$(api "$host" GET /health 2>/dev/null || echo "FAIL")
+    ok=$(jq_field "$result" '.ok')
+    if [[ "$ok" == "true" ]]; then
+        version=$(jq_field "$result" '.version')
+        peers=$(jq_field "$result" '.peers')
+        echo "  $host_var ($host): healthy, version=$version, peers=$peers"
+    else
+        echo "  $host_var ($host): UNREACHABLE - aborting"
+        exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Step 1: Check identities
+# ---------------------------------------------------------------------------
+separator "Step 1: Check identities"
+
+AGENT_A_JSON=$(api "$HOST_A" GET /agent)
+AGENT_B_JSON=$(api "$HOST_B" GET /agent)
+AGENT_C_JSON=$(api "$HOST_C" GET /agent)
+
+AGENT_A_ID=$(jq_field "$AGENT_A_JSON" '.agent_id')
+AGENT_B_ID=$(jq_field "$AGENT_B_JSON" '.agent_id')
+AGENT_C_ID=$(jq_field "$AGENT_C_JSON" '.agent_id')
+
+MACHINE_A_ID=$(jq_field "$AGENT_A_JSON" '.machine_id')
+MACHINE_B_ID=$(jq_field "$AGENT_B_JSON" '.machine_id')
+MACHINE_C_ID=$(jq_field "$AGENT_C_JSON" '.machine_id')
+
+USER_A_ID=$(jq_field "$AGENT_A_JSON" '.user_id')
+USER_B_ID=$(jq_field "$AGENT_B_JSON" '.user_id')
+USER_C_ID=$(jq_field "$AGENT_C_JSON" '.user_id')
+
+echo "  Agent A: agent=$AGENT_A_ID machine=$MACHINE_A_ID user=$USER_A_ID"
+echo "  Agent B: agent=$AGENT_B_ID machine=$MACHINE_B_ID user=$USER_B_ID"
+echo "  Agent C: agent=$AGENT_C_ID machine=$MACHINE_C_ID user=$USER_C_ID"
+
+# Each agent has a unique agent_id and machine_id
+assert_not_empty "A has agent_id" "$AGENT_A_ID"
+assert_not_empty "B has agent_id" "$AGENT_B_ID"
+assert_not_empty "C has agent_id" "$AGENT_C_ID"
+
+if [[ "$AGENT_A_ID" != "$AGENT_B_ID" && "$AGENT_A_ID" != "$AGENT_C_ID" && "$AGENT_B_ID" != "$AGENT_C_ID" ]]; then
+    pass "All agent_ids are unique"
+else
+    fail "Agent IDs are not all unique"
+fi
+
+# A and B share user_id, C has none
+assert_not_empty "A has user_id" "$USER_A_ID"
+assert_not_empty "B has user_id" "$USER_B_ID"
+assert_eq "A and B share the same user_id" "$USER_A_ID" "$USER_B_ID"
+assert_empty_or_null "C has no user_id" "$USER_C_ID"
+
+# ---------------------------------------------------------------------------
+# Step 2: Announce identities
+# ---------------------------------------------------------------------------
+separator "Step 2: Announce identities"
+
+# A and B announce with user identity
+ANNOUNCE_A=$(api_json "$HOST_A" POST /announce "-d '{\"include_user_identity\": true, \"human_consent\": true}'")
+ANNOUNCE_B=$(api_json "$HOST_B" POST /announce "-d '{\"include_user_identity\": true, \"human_consent\": true}'")
+ANNOUNCE_C=$(api_json "$HOST_C" POST /announce "-d '{\"include_user_identity\": false, \"human_consent\": false}'")
+
+assert_eq "A announced with user identity" "true" "$(jq_field "$ANNOUNCE_A" '.include_user_identity')"
+assert_eq "B announced with user identity" "true" "$(jq_field "$ANNOUNCE_B" '.include_user_identity')"
+assert_eq "C announced ok" "true" "$(jq_field "$ANNOUNCE_C" '.ok')"
+
+echo "  Waiting 30s for gossip propagation..."
+sleep 30
+
+# ---------------------------------------------------------------------------
+# Step 3: Check discovery
+# ---------------------------------------------------------------------------
+separator "Step 3: Check discovery"
+
+DISCOVERED_A=$(api "$HOST_A" GET /agents/discovered)
+DISCOVERED_B=$(api "$HOST_B" GET /agents/discovered)
+DISCOVERED_C=$(api "$HOST_C" GET /agents/discovered)
+
+DISCOVERED_A_IDS=$(jq_field "$DISCOVERED_A" '[.agents[].agent_id] | join(",")')
+DISCOVERED_B_IDS=$(jq_field "$DISCOVERED_B" '[.agents[].agent_id] | join(",")')
+DISCOVERED_C_IDS=$(jq_field "$DISCOVERED_C" '[.agents[].agent_id] | join(",")')
+
+echo "  A discovered: $DISCOVERED_A_IDS"
+echo "  B discovered: $DISCOVERED_B_IDS"
+echo "  C discovered: $DISCOVERED_C_IDS"
+
+# A sees B and C
+assert_contains "A sees B" "$DISCOVERED_A_IDS" "$AGENT_B_ID"
+assert_contains "A sees C" "$DISCOVERED_A_IDS" "$AGENT_C_ID"
+
+# B sees A and C
+assert_contains "B sees A" "$DISCOVERED_B_IDS" "$AGENT_A_ID"
+assert_contains "B sees C" "$DISCOVERED_B_IDS" "$AGENT_C_ID"
+
+# C sees A and B
+assert_contains "C sees A" "$DISCOVERED_C_IDS" "$AGENT_A_ID"
+assert_contains "C sees B" "$DISCOVERED_C_IDS" "$AGENT_B_ID"
+
+# Check user_id fields in discovered entries
+A_SEES_B_USER=$(jq_field "$DISCOVERED_A" ".agents[] | select(.agent_id==\"$AGENT_B_ID\") | .user_id")
+A_SEES_C_USER=$(jq_field "$DISCOVERED_A" ".agents[] | select(.agent_id==\"$AGENT_C_ID\") | .user_id")
+
+assert_eq "A sees B's user_id" "$USER_B_ID" "$A_SEES_B_USER"
+assert_empty_or_null "A sees C has no user_id" "$A_SEES_C_USER"
+
+# ---------------------------------------------------------------------------
+# Step 4: Check presence
+# ---------------------------------------------------------------------------
+separator "Step 4: Check presence (TTL-filtered)"
+
+PRESENCE_A=$(api "$HOST_A" GET /presence)
+PRESENCE_IDS=$(jq_field "$PRESENCE_A" '.agents | join(",")')
+echo "  Presence from A: $PRESENCE_IDS"
+
+assert_contains "Presence includes A" "$PRESENCE_IDS" "${AGENT_A_ID:0:8}"
+assert_contains "Presence includes B" "$PRESENCE_IDS" "${AGENT_B_ID:0:8}"
+assert_contains "Presence includes C" "$PRESENCE_IDS" "${AGENT_C_ID:0:8}"
+
+# ---------------------------------------------------------------------------
+# Step 5: Look up a specific agent (3-stage find_agent)
+# ---------------------------------------------------------------------------
+separator "Step 5: Find specific agent (3-stage lookup)"
+
+FIND_C_FROM_A=$(api "$HOST_A" GET "/agents/discovered/${AGENT_C_ID}?wait=true")
+FIND_OK=$(jq_field "$FIND_C_FROM_A" '.ok')
+FIND_AGENT_ID=$(jq_field "$FIND_C_FROM_A" '.agent.agent_id')
+
+echo "  A looked up C: ok=$FIND_OK agent_id=$FIND_AGENT_ID"
+assert_eq "find_agent returned ok" "true" "$FIND_OK"
+assert_eq "find_agent returned correct agent" "$AGENT_C_ID" "$FIND_AGENT_ID"
+
+# ---------------------------------------------------------------------------
+# Step 6: Find all agents belonging to a user
+# ---------------------------------------------------------------------------
+separator "Step 6: Find agents by user"
+
+# From C (anonymous) — look up the shared user_id
+USER_AGENTS_FROM_C=$(api "$HOST_C" GET "/users/${USER_A_ID}/agents")
+USER_AGENT_IDS=$(jq_field "$USER_AGENTS_FROM_C" '[.agents[].agent_id] | join(",")')
+echo "  C queried user $USER_A_ID: found agents=$USER_AGENT_IDS"
+
+assert_contains "User lookup includes A" "$USER_AGENT_IDS" "$AGENT_A_ID"
+assert_contains "User lookup includes B" "$USER_AGENT_IDS" "$AGENT_B_ID"
+assert_not_contains "User lookup excludes C" "$USER_AGENT_IDS" "$AGENT_C_ID"
+
+# From A — "find my own user's agents"
+USER_AGENTS_FROM_A=$(api "$HOST_A" GET "/users/${USER_A_ID}/agents")
+USER_AGENT_IDS_A=$(jq_field "$USER_AGENTS_FROM_A" '[.agents[].agent_id] | join(",")')
+echo "  A queried own user: found agents=$USER_AGENT_IDS_A"
+
+assert_contains "A's user lookup includes A" "$USER_AGENT_IDS_A" "$AGENT_A_ID"
+assert_contains "A's user lookup includes B" "$USER_AGENT_IDS_A" "$AGENT_B_ID"
+
+# ---------------------------------------------------------------------------
+# Step 7: Verify user ID configuration
+# ---------------------------------------------------------------------------
+separator "Step 7: Verify user ID endpoints"
+
+USER_ID_A=$(jq_field "$(api "$HOST_A" GET /agent/user-id)" '.user_id')
+USER_ID_B=$(jq_field "$(api "$HOST_B" GET /agent/user-id)" '.user_id')
+USER_ID_C=$(jq_field "$(api "$HOST_C" GET /agent/user-id)" '.user_id')
+
+assert_not_empty "A reports user_id" "$USER_ID_A"
+assert_not_empty "B reports user_id" "$USER_ID_B"
+assert_eq "A and B report same user_id" "$USER_ID_A" "$USER_ID_B"
+assert_empty_or_null "C reports no user_id" "$USER_ID_C"
+
+# ---------------------------------------------------------------------------
+# Step 8: TTL expiry — stop agent B and wait
+# ---------------------------------------------------------------------------
+separator "Step 8: TTL expiry (stopping agent B)"
+
+echo "  Stopping x0xd on B..."
+ssh $SSH_OPTS "$HOST_B" "sudo systemctl stop x0xd" 2>/dev/null
+
+echo "  Waiting 75s for TTL expiry (60s TTL + 15s buffer)..."
+sleep 75
+
+PRESENCE_AFTER=$(api "$HOST_A" GET /presence)
+PRESENCE_AFTER_IDS=$(jq_field "$PRESENCE_AFTER" '.agents | join(",")')
+echo "  Presence from A after B stopped: $PRESENCE_AFTER_IDS"
+
+assert_not_contains "B is no longer present" "$PRESENCE_AFTER_IDS" "${AGENT_B_ID:0:8}"
+assert_contains "A is still present" "$PRESENCE_AFTER_IDS" "${AGENT_A_ID:0:8}"
+assert_contains "C is still present" "$PRESENCE_AFTER_IDS" "${AGENT_C_ID:0:8}"
+
+# Also check find_agents_by_user — B should have dropped
+USER_AGENTS_AFTER=$(api "$HOST_A" GET "/users/${USER_A_ID}/agents")
+USER_AGENT_IDS_AFTER=$(jq_field "$USER_AGENTS_AFTER" '[.agents[].agent_id] | join(",")')
+echo "  User agents after B stopped: $USER_AGENT_IDS_AFTER"
+
+assert_contains "User lookup still includes A" "$USER_AGENT_IDS_AFTER" "$AGENT_A_ID"
+assert_not_contains "User lookup no longer includes B" "$USER_AGENT_IDS_AFTER" "$AGENT_B_ID"
+
+# ---------------------------------------------------------------------------
+# Step 9: Late-join heartbeat discovery (restart B)
+# ---------------------------------------------------------------------------
+separator "Step 9: Late-join heartbeat discovery (restarting B)"
+
+echo "  Restarting x0xd on B..."
+ssh $SSH_OPTS "$HOST_B" "sudo systemctl start x0xd" 2>/dev/null
+
+echo "  Waiting 45s for heartbeat propagation..."
+sleep 45
+
+DISCOVERED_B_AFTER=$(api "$HOST_B" GET /agents/discovered)
+DISCOVERED_B_AFTER_IDS=$(jq_field "$DISCOVERED_B_AFTER" '[.agents[].agent_id] | join(",")')
+echo "  B discovered after restart: $DISCOVERED_B_AFTER_IDS"
+
+assert_contains "B rediscovers A" "$DISCOVERED_B_AFTER_IDS" "$AGENT_A_ID"
+assert_contains "B rediscovers C" "$DISCOVERED_B_AFTER_IDS" "$AGENT_C_ID"
+
+# Check B reappears in A's presence
+PRESENCE_FINAL=$(api "$HOST_A" GET /presence)
+PRESENCE_FINAL_IDS=$(jq_field "$PRESENCE_FINAL" '.agents | join(",")')
+echo "  Final presence from A: $PRESENCE_FINAL_IDS"
+
+assert_contains "B reappears in A's presence" "$PRESENCE_FINAL_IDS" "${AGENT_B_ID:0:8}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+separator "Results"
+
+TOTAL=$((PASS + FAIL))
+echo ""
+echo "  Passed: $PASS / $TOTAL"
+echo "  Failed: $FAIL / $TOTAL"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+    echo "  TEST PLAN: FAILED"
+    exit 1
+else
+    echo "  TEST PLAN: PASSED"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- **User key identity** (`user_key_path` config): optional human identity that binds agents to a user via `AgentCertificate`. Two agents sharing the same user key report the same `user_id`, enabling cross-device agent lookup.
- **Agent discovery fixes**: wired up HyParView membership and periodic peer sync, fixed stale announcement replays, and fixed TTL filtering to use `announced_at` instead of blocking replays entirely.
- **Upstream gossip fix**: points saorsa-gossip deps at `jacderida/saorsa-gossip#fix-do_not_abort_eager_forwarding` which fixes two bugs — EAGER forward aborting on first failed peer send, and stale PeerId accumulation in PlumTree topic sets. Uses `set_topic_peers()` in `refresh_topic_peers()` to prune disconnected peers.
- **Testnet test script**: `tests/testnet/run_identity_presence_tests.sh` — 41 assertions across 9 steps covering identity, announcements, gossip discovery, presence, TTL expiry, and late-join recovery. Validated 41/41 against live 3-node testnet.

## Test plan

- [x] 41/41 passing on live 3-node DigitalOcean testnet (nyc1, sfo3, fra1)
- [ ] CI passes (fmt, clippy, nextest, doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)