### PR TITLE
feat: add ClawHub-compatible metadata to SKILL.md front matter

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -20,7 +20,7 @@ metadata:
       env: []
       bins:
         - curl
-    primaryEnv: ""
+    primaryEnv: ~
 ---
 
 # x0x: Secure Agent-to-Agent Communication Network


### PR DESCRIPTION
Add metadata.openclaw block declaring runtime requirements (curl for install script) so the skill can be published to ClawHub via the CLI.