### PR TITLE
docs: add ADR for seed-hint bootstrap model

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Six geographically distributed bootstrap nodes maintain network reachability. Th
 
 All nodes support dual-stack IPv4 + IPv6.
 
+The long-term decentralization direction is documented in [ADR 0001](./docs/adr/0001-bootstrap-peers-are-seed-hints-only.md): bootstrap peers are seed hints only, never a privileged control plane.
+
 ---
 
 ## Skill-Led Installation

--- a/docs/adr/0001-bootstrap-peers-are-seed-hints-only.md
+++ b/docs/adr/0001-bootstrap-peers-are-seed-hints-only.md
@@ -1,0 +1,103 @@
+# ADR 0001: Bootstrap Peers Are Seed Hints Only
+
+- Status: Proposed
+- Date: 2026-03-11
+
+## Context
+
+x0x is intended to be a decentralized agent network. That goal is undermined if a fixed operator-managed set of nodes becomes a privileged control plane for:
+
+- joining the network;
+- coordinating NAT traversal;
+- relaying traffic; or
+- propagating release authority.
+
+The underlying transport already supports a symmetric model. In `ant-quic`, any publicly reachable node can coordinate NAT traversal and relay traffic when conditions allow. The centralization pressure comes from x0x policy and wiring:
+
+- hard-coded bootstrap peers are treated as the default authority set for joining the network;
+- coordinator selection still bottoms out in configured bootstrap peers;
+- ordinary publicly reachable nodes are not promoted into the coordinator or relay pool by x0x policy; and
+- release propagation in the current self-update design privileges `x0x-bootstrap` nodes as the primary broadcasters.
+
+If those properties remain true in steady state, x0x is not meaningfully decentralized. It becomes a network that depends on a designated operator-managed class of nodes.
+
+## Decision
+
+x0x SHALL treat bootstrap peers as seed hints only, never as a privileged control plane.
+
+This means:
+
+1. Static bootstrap addresses MAY exist as a first-contact mechanism for cold start.
+2. Static bootstrap addresses MUST NOT remain the default authority set for coordinator or relay selection in steady state.
+3. Any ordinary node with suitable public reachability MUST be eligible to become a coordinator or relay candidate.
+4. Eligibility for coordination and relay duties MUST be based on signed, expiring capability advertisements plus local validation and scoring, not on operator-maintained allowlists.
+5. Release gossip MUST be treated as a hint only. No node, including `x0x-bootstrap`, is authoritative merely because it broadcast a release notification.
+6. A node MUST independently verify release artifacts before applying an update or rebroadcasting a release hint.
+7. The `x0x-bootstrap` binary, if retained, SHALL be understood as optional operator packaging for stable public seeds and observability, not as a protocol role required for correctness or liveness.
+
+## Consequences
+
+### Positive
+
+- Removes forced centralization from the protocol model.
+- Aligns x0x policy with the symmetric design already present in `ant-quic`.
+- Allows the network to become more resilient as ordinary public nodes join and contribute coordinator and relay capacity.
+- Prevents release propagation from becoming an operator-controlled broadcast channel.
+
+### Negative
+
+- Requires additional discovery, validation, and scoring work in x0x.
+- Makes coordinator and relay selection more dynamic, which raises implementation complexity.
+- Requires clearer signed capability advertisement semantics at the agent layer.
+
+### Non-goals
+
+- This ADR does not require removing all static seed addresses immediately.
+- This ADR does not require every node to be publicly reachable.
+- This ADR does not prohibit Saorsa Labs from operating stable public seed nodes.
+
+What it prohibits is protocol dependence on a permanently privileged Saorsa-operated node class.
+
+## Required Follow-up Work
+
+### Phase 1: Demote bootstrap peers to seed hints
+
+- Rename the concept in x0x documentation and code from privileged bootstrap peers to seed hints where appropriate.
+- Change startup peer selection to merge:
+  - configured seed hints;
+  - locally cached peers; and
+  - previously validated public coordinator candidates.
+- Ensure a previously participating node can rejoin without needing the hard-coded seed list to be reachable.
+
+### Phase 2: Signed capability advertisements
+
+- Extend the existing signed rendezvous advertisement flow to carry coordinator and relay capability metadata.
+- Publish only expiring, signed advertisements.
+- Admit nodes into the local coordinator pool only after signature and freshness validation.
+
+### Phase 3: Dynamic coordinator and relay selection
+
+- Prefer validated dynamic coordinator candidates over static seed hints.
+- Use static seed hints only as cold-start or empty-pool fallback.
+- Allow ordinary publicly reachable `x0xd` instances to enter the coordinator and relay pool automatically once validated.
+
+### Phase 4: Decentralized release propagation
+
+- Treat `ReleaseNotification` as a discovery hint, not an authority.
+- Require each node to independently fetch and verify the canonical release artifact before apply or rebroadcast.
+- Allow any verifying node to rebroadcast release hints.
+
+### Phase 5: Re-scope `x0x-bootstrap`
+
+- Keep `x0x-bootstrap` only as optional operational packaging for stable public seeds, health endpoints, and managed restarts.
+- Do not require `x0x-bootstrap` for protocol correctness, reachability, or upgrade authority.
+
+## Acceptance Criteria
+
+This ADR is satisfied only when all of the following are true:
+
+- a node can rejoin from cached peers without contacting the default seed list;
+- ordinary publicly reachable nodes can advertise signed coordinator and relay capability;
+- steady-state coordinator selection prefers validated dynamic peers over static seed hints;
+- release propagation does not depend on `x0x-bootstrap` nodes being the primary broadcasters; and
+- loss of the default Saorsa-operated seed set degrades cold-start convenience, not network legitimacy or steady-state operation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+This directory contains architecture decision records for x0x.
+
+- [ADR 0001: Bootstrap Peers Are Seed Hints Only](./0001-bootstrap-peers-are-seed-hints-only.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -115,6 +115,7 @@ Version **0.2.0**. x0x is functional but early-stage. Use it if the current capa
 - [Compared](https://x0x.md/docs/compared.md) — x0x vs MCP, A2A, direct HTTP
 - [Troubleshooting](https://x0x.md/docs/troubleshooting.md) — common errors and diagnostic steps
 - [Uninstall](https://x0x.md/docs/uninstall.md) — clean removal of x0x
+- [Architecture Decisions](https://x0x.md/docs/adr/README.md) — ADRs for protocol and network design
 - [SKILL.md](https://x0x.md/skill.md) — Agent Skills capability definition (inspect what gets installed)
 
 ## Trust and security
@@ -125,4 +126,3 @@ Version **0.2.0**. x0x is functional but early-stage. Use it if the current capa
 - The install script verifies artifact signatures via GPG when available.
 - Source code: [saorsa-labs/x0x](https://github.com/saorsa-labs/x0x) (Rust, MIT/Apache-2.0)
 - Maintained by [Saorsa Labs](https://saorsalabs.com).
-


### PR DESCRIPTION
## Summary
- add ADR 0001 stating that bootstrap peers are seed hints only, never a privileged control plane
- document that coordinator, relay, and release propagation authority must move away from a fixed operator-managed bootstrap set
- link the ADR from the main overview docs and README for discoverability

## Why
This captures the architectural constraint discussed in PR #11: forced centralization around privileged bootstrap nodes would undermine the purpose of x0x as a decentralized agent network.

The ADR makes the intended direction explicit:
- static bootstrap addresses may remain as cold-start seed hints
- ordinary publicly reachable nodes must be eligible for coordination and relay duties
- release gossip must be hint-only, not bootstrap-authoritative
- `x0x-bootstrap` is optional operator packaging, not a protocol role

## Scope
Docs only. No runtime behavior changes in this PR.

## Follow-up
The ADR includes phased implementation work for peer selection, signed capability advertisements, dynamic coordinator selection, and decentralized release propagation.