### PR TITLE
fix: remove broken npm/PyPI install claims

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -431,16 +431,6 @@ jobs:
             cargo add x0x
             ```
 
-            **TypeScript/Node.js:**
-            ```bash
-            npm install x0x
-            ```
-
-            **Python:**
-            ```bash
-            pip install agent-x0x
-            ```
-
             ### Platform Binaries
 
             | Platform | File | Code Signed |
@@ -515,8 +505,10 @@ jobs:
 
   # ============================================================
   # Publish to npm (with provenance)
+  # Re-enable when npm/PyPI smoke tests pass
   # ============================================================
   publish-npm:
+    if: false
     name: Publish to npm
     needs: create-release
     runs-on: ubuntu-latest
@@ -539,8 +531,10 @@ jobs:
 
   # ============================================================
   # Publish to PyPI (via maturin)
+  # Re-enable when npm/PyPI smoke tests pass
   # ============================================================
   publish-pypi:
+    if: false
     name: Publish to PyPI
     needs: create-release
     runs-on: ubuntu-latest

--- a/.well-known/agent.json
+++ b/.well-known/agent.json
@@ -128,20 +128,6 @@
       "registry": "crates.io",
       "install": "cargo add x0x",
       "documentation": "https://docs.rs/x0x"
-    },
-    {
-      "language": "TypeScript",
-      "package": "x0x",
-      "registry": "npm",
-      "install": "npm install x0x",
-      "documentation": "https://www.npmjs.com/package/x0x"
-    },
-    {
-      "language": "Python",
-      "package": "agent-x0x",
-      "registry": "PyPI",
-      "install": "pip install agent-x0x",
-      "documentation": "https://pypi.org/project/agent-x0x/"
     }
   ],
   "security": {
@@ -174,5 +160,5 @@
     "encryption"
   ],
   "created": "2026-02-06",
-  "updated": "2026-03-24"
+  "updated": "2026-03-26"
 }


### PR DESCRIPTION
## Summary

- Remove npm/pip install snippets from release notes template — `npm install x0x` installs a hollow v0.1.0 package (JS loader only, no native binaries) and `pip install agent-x0x` doesn't exist on PyPI
- Disable `publish-npm` and `publish-pypi` CI jobs with `if: false` (preserves workflow structure for easy re-enable when bindings are ready)
- Remove TypeScript and Python SDK entries from `.well-known/agent.json` A2A agent card
- Bindings source code and READMEs left untouched — they're in-progress development work

## Test plan

- [ ] Verify no `npm install x0x` or `pip install agent-x0x` in release template or agent.json
- [ ] Verify `agent.json` is valid JSON and only lists Rust SDK
- [ ] Verify publish jobs exist but are gated by `if: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleans up inaccurate install instructions and CI publish jobs for npm and PyPI bindings that are not yet production-ready. It removes `npm install x0x` and `pip install agent-x0x` snippets from the release notes template, disables the corresponding publish CI jobs with `if: false` (preserving them for easy re-activation), and removes TypeScript and Python SDK entries from the A2A agent card in `.well-known/agent.json`.\n\n- Removes misleading install snippets for `x0x` (npm) and `agent-x0x` (PyPI) from the release notes body in `release.yml`\n- Disables `publish-npm` and `publish-pypi` jobs with `if: false` — jobs remain in the file and can be re-enabled when bindings are ready\n- Removes TypeScript and Python SDK entries from `.well-known/agent.json`, leaving only the Rust / `crates.io` entry\n- Updates the `updated` timestamp in `agent.json` to 2026-03-26

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes inaccurate documentation and disables unready publish jobs; no functional regressions.

The changes are purely subtractive: removing incorrect install instructions and gating two publish jobs. if: false is a well-supported GitHub Actions pattern for temporarily disabling a job without removing it. The resulting agent.json is valid JSON with a single SDK entry and a correct trailing comma removal. No logic, security, or reliability concerns are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Removes misleading npm/pip install snippets from release notes template and gates publish-npm/publish-pypi jobs with if: false — preserves workflow structure for easy re-enable later. |
| .well-known/agent.json | Removes TypeScript and Python SDK entries from the A2A agent card, leaving only the Rust entry; updates the updated timestamp to 2026-03-26. JSON remains structurally valid. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Release triggered]) --> B[create-release]
    B --> C[publish-cargo]
    B --> D[publish-npm\nif: false SKIPPED]
    B --> E[publish-pypi\nif: false SKIPPED]

    style D fill:#f5f5f5,stroke:#999,color:#999
    style E fill:#f5f5f5,stroke:#999,color:#999
    style C fill:#d4edda,stroke:#28a745
```

<sub>Reviews (1): Last reviewed commit: ["fix: remove broken npm/PyPI install clai..."](https://github.com/saorsa-labs/x0x/commit/c5279cf9c75d34acef0a3916d91aaf44f423bfe5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26436000)</sub>

<!-- /greptile_comment -->