### PR TITLE
release: x0x 0.19.36 — X0X-0063 data_tx capacity 10_000 → 50_000

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.19.35"
+version = "0.19.36"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/src/network.rs
+++ b/src/network.rs
@@ -859,8 +859,20 @@ impl NetworkNode {
             // pressure warnings below are the operator signal that the system is
             // leaning on this buffer and needs load shedding or a structural
             // recv-pump fix.
-            .data_channel_capacity(10_000)
-            .max_concurrent_uni_streams(10_000);
+            //
+            // X0X-0063 bumped this from 10_000 → 50_000 after the 4 h
+            // confirmatory soak on x0x 0.19.35 (sg 0.5.40, ant-quic 0.27.15)
+            // recorded **1,025,150 high_water_count events on nyc** —
+            // saturation occurring continuously at ~67/s. The 10_000 ceiling
+            // was insufficient once X0X-0061 bumped the saorsa-gossip
+            // PER_PEER_REPUBLISH_TIMEOUT 750 ms → 2500 ms, because each
+            // outbound send task now holds a data_tx slot for up to 2.5 s
+            // (3.3× the prior hold time). 50_000 gives proportional headroom.
+            // This remains a mitigation — under truly sustained overload
+            // backpressure earlier in the pubsub flush_ihave_batches loop is
+            // the proper fix.
+            .data_channel_capacity(50_000)
+            .max_concurrent_uni_streams(50_000);
 
         if let Some(bind_addr) = config.bind_addr {
             builder = builder.bind_addr(bind_addr);


### PR DESCRIPTION
## Summary

Bumps ant-quic `data_channel_capacity` from 10,000 to 50,000 (and `max_concurrent_uni_streams` to match). Fixes the X0X-0063 data_tx saturation surfaced by the confirmatory 4 h soak (1,025,150 high_water_count events on nyc over 4 h, ~67/sec continuous saturation).

## Root cause

X0X-0061's `PER_PEER_REPUBLISH_TIMEOUT` bump 750 ms → 2500 ms (saorsa-gossip 0.5.40) made each outbound pubsub task hold a data_tx slot for 3.3× longer. Under `launch_readiness` fanout_burst load, tasks accumulate in data_tx faster than they drain, hitting the 10,000 ceiling continuously.

50,000 gives ~5× headroom — proportional to the new hold time × sustained pubsub fanout.

This is mitigation, not the root fix. Under truly sustained overload, proper backpressure inside saorsa-gossip's `flush_ihave_batches` loop is the correct long-term answer.

**Does not address X0X-0062** (stuck-connection state at ant-quic layer). That needs a deeper fix in ant-quic for connection half-dead detection and forced reset.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo build --release --bin x0xd`
- [ ] Cross-compile + redeploy to all 6 VPS
- [ ] (No 4 h soak — X0X-0062 still unresolved per user direction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release bumps `data_channel_capacity` and `max_concurrent_uni_streams` from 10,000 to 50,000 in the ant-quic `NodeConfig` builder, addressing the channel saturation recorded during the X0X-0063 soak. The version is advanced to 0.19.36.

- **`src/network.rs`**: Both queue-size knobs raised 5× with a thorough inline comment tracing the causal chain from the X0X-0061 `PER_PEER_REPUBLISH_TIMEOUT` increase (750 ms → 2,500 ms) through the resulting slot-hold-time growth to the observed 67 events/sec saturation ceiling.
- **`Cargo.toml`**: Version incremented to 0.19.36; no dependency changes.

<h3>Confidence Score: 5/5</h3>

Two-line config change backed by soak-test data and thorough inline documentation; safe to merge.

The change is a targeted capacity increase to two related knobs, motivated by concrete saturation measurements from a 4-hour soak. The inline comment fully explains the causal chain. Both values stay consistent with each other, and the PR description explicitly acknowledges this as a mitigation with the long-term fix identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Version bump from 0.19.35 to 0.19.36; no dependency changes. |
| src/network.rs | Bumps `data_channel_capacity` and `max_concurrent_uni_streams` from 10,000 to 50,000, with detailed comments explaining the X0X-0063 saturation root cause and the proportional headroom rationale. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Outbound pubsub task\nPER_PEER_REPUBLISH_TIMEOUT = 2500ms] -->|acquires slot| B[data_tx channel\ncapacity: 10k → 50k]
    B -->|streams dispatched| C[ant-quic transport\nmax_concurrent_uni_streams: 10k → 50k]
    C -->|QUIC uni-stream| D[Remote peer]

    B -->|was: saturated at ~67 ev/s\nunder fanout_burst load| E[high_water_count events\n1,025,150 over 4h on nyc]
    B -->|now: 5× headroom| F[Saturation threshold raised\nproportional to hold-time increase]

    style E fill:#ffcccc,stroke:#cc0000
    style F fill:#ccffcc,stroke:#009900
```

<sub>Reviews (1): Last reviewed commit: ["release: x0x 0.19.36 — X0X-0063 data\_tx ..."](https://github.com/saorsa-labs/x0x/commit/0a47b5f1b38a7a59176b8a1aa8842d361d3fcbee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31543548)</sub>

<!-- /greptile_comment -->