### PR TITLE
release: x0x 0.19.37 — ant-quic 0.27.16 (X0X-0062 liveness timeout)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.19.36"
+version = "0.19.37"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.15"
+ant-quic = "0.27.16"
 saorsa-mls = "0.3.5"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
## Summary

- Bumps x0x 0.19.36 → 0.19.37
- Bumps ant-quic pin 0.27.15 → 0.27.16 — ships **X0X-0062** application-layer liveness timeout detection and force-close

## What ant-quic 0.27.16 fixes

The x0x 0.19.36 4 h confirmatory soak captured the X0X-0062 failure mode: nyc → nuremberg, `last_recv_ms_ago` at nuremberg reached **9.1 h** despite zero `Replaced`/`Closed`/`Closing`/`path_validation` events firing in 8 h of daemon journal, with 31% bidirectional `send_failed`. ant-quic couldn't self-detect the half-dead state.

ant-quic 0.27.16 adds an `AckLivenessTracker` that counts consecutive `SenderRetryFailed` outcomes (both the initial send AND its X0X-0060 retry timing out). After **5 consecutive failures in 60 s**, the tracker triggers `trigger_liveness_close`, which emits `Closing{LivenessTimeout}` + `Closed{LivenessTimeout}` and forces the QUIC transport to tear the connection down. Next outbound DM attempt re-dials on a fresh handshake.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --release --bin x0xd` against ant-quic 0.27.16
- [ ] Cross-compile + redeploy to all 6 VPS
- [ ] Pre-soak confirmation: Phase A 30/30 + 30/30 on freshly-restarted mesh
- [ ] 4 h broad-launch soak on the patched stack (X0X-0062 acceptance gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a minimal release bump that advances the package version to 0.19.37 and updates the `ant-quic` dependency from 0.27.15 to 0.27.16, which carries the `AckLivenessTracker` fix for the X0X-0062 half-dead connection failure mode.

- **Version bump**: `x0x` 0.19.36 → 0.19.37; `ant-quic` 0.27.15 → 0.27.16 — the only two lines changed in `Cargo.toml`.
- **Dependency semantics**: The specifier `\"0.27.16\"` is a Cargo compatible-version requirement (`^0.27.16`, i.e. `>=0.27.16, <0.28.0`), not an exact pin — consistent with all other dependencies in this file and with `Cargo.lock` being intentionally gitignored. The resolved version is locked at build time by the CI workflow, so reproducibility is maintained in practice.

<h3>Confidence Score: 5/5</h3>

Safe to merge — exactly two lines change in Cargo.toml, both are straightforward version bumps with no logic modifications.

The change is as narrow as a PR can get: a package version number and one dependency version string. The upstream ant-quic 0.27.16 change is well-documented in the PR description and addresses a confirmed production failure mode. The test plan clearly defers the 4 h soak gate to post-deploy, which is appropriate for this type of dependency update.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps package version 0.19.36 → 0.19.37 and upgrades ant-quic dependency 0.27.15 → 0.27.16 to pull in the AckLivenessTracker fix for X0X-0062. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant x0xd as x0xd daemon
    participant AckLiveness as AckLivenessTracker (ant-quic 0.27.16)
    participant QUIC as QUIC Transport

    x0xd->>QUIC: Send DM (outbound)
    QUIC-->>AckLiveness: SenderRetryFailed outcome
    Note over AckLiveness: consecutive_failures++
    x0xd->>QUIC: Send DM (retry, X0X-0060)
    QUIC-->>AckLiveness: SenderRetryFailed outcome (retry also timed out)
    Note over AckLiveness: consecutive_failures++

    loop After 5 consecutive failures within 60 s
        AckLiveness->>QUIC: trigger_liveness_close()
        QUIC-->>x0xd: "Closing{LivenessTimeout}"
        QUIC-->>x0xd: "Closed{LivenessTimeout}"
    end

    x0xd->>QUIC: Next outbound DM - fresh handshake (re-dial)
```

<sub>Reviews (1): Last reviewed commit: ["release: x0x 0.19.37 — ant-quic 0.27.16 ..."](https://github.com/saorsa-labs/x0x/commit/991b882f9ec939a0415df09f533c5ebe704863a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31561614)</sub>

<!-- /greptile_comment -->