### PR TITLE
release: x0x 0.19.38 — ant-quic 0.27.17 (X0X-0062 reviewer fixes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.19.37"
+version = "0.19.38"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.16"
+ant-quic = "0.27.17"
 saorsa-mls = "0.3.5"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
## Summary

Bumps ant-quic pin 0.27.16 → 0.27.17 to consume three X0X-0062 reviewer-finding fixes (PR [ant-quic#185](https://github.com/saorsa-labs/ant-quic/pull/185)):

- **P1.1** consecutive-failure contract
- **P1.2** retry-error class discrimination
- **P2** ACK frame decoder LivenessTimeout round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR bumps `x0x` from `0.19.37` to `0.19.38` and advances the `ant-quic` pin from `0.27.16` to `0.27.17` to consume three reviewer-identified fixes (consecutive-failure contract, retry-error class discrimination, and an ACK-frame decoder LivenessTimeout round-trip fix) shipped in ant-quic#185.

- **`Cargo.toml`**: Two-line change — `version` field incremented and `ant-quic` dependency updated to `0.27.17`. All other dependencies and features are untouched.
- The `ant-quic` specifier uses Cargo's default caret semantics (`^0.27.17`), allowing compatible patch updates up to `< 0.28.0`, which is consistent with existing dependency style in this file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line dependency version bump with no logic changes in this repository.

The only change is advancing ant-quic from 0.27.16 to 0.27.17 and incrementing the crate version. No source code is modified; the upstream patch release is described as fixing three bugs (two of which affected connection error handling). The version specifier continues to use Cargo's standard caret semantics, consistent with the rest of the file.

No files require special attention — Cargo.toml is the only changed file and the edit is minimal.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps x0x crate version 0.19.37→0.19.38 and pins ant-quic 0.27.16→0.27.17 to consume upstream bug-fix release; no other dependencies touched. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant x0x as x0x 0.19.38
    participant antquic as ant-quic 0.27.17
    participant peer as Remote Peer

    x0x->>antquic: open QUIC connection
    antquic->>peer: QUIC handshake
    peer-->>antquic: ACK frame (LivenessTimeout fix applied)
    antquic-->>x0x: connection established
    x0x->>antquic: send message
    antquic->>peer: data frame
    peer-->>antquic: error / timeout
    Note over antquic: consecutive-failure contract (P1.1 fix)<br/>retry-error class discrimination (P1.2 fix)
    antquic-->>x0x: correct error propagation
```

<sub>Reviews (1): Last reviewed commit: ["release: x0x 0.19.38 — ant-quic 0.27.17 ..."](https://github.com/saorsa-labs/x0x/commit/013a6dc8368b2d20054979904681f9a3f5f040eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31565823)</sub>

<!-- /greptile_comment -->