### PR TITLE
release: x0x 0.19.39 — ant-quic 0.27.18 (X0X-0062 P2 round 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.19.38"
+version = "0.19.39"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.17"
+ant-quic = "0.27.18"
 saorsa-mls = "0.3.5"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
Pin bump only. ant-quic 0.27.18 ships the X0X-0062 P2 round-2 authoritative-cleanup fix from reviewer feedback (PR [ant-quic#186](https://github.com/saorsa-labs/ant-quic/pull/186)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `x0x` crate from `0.19.38` to `0.19.39` and advances the pinned `ant-quic` dependency from `0.27.17` to `0.27.18`, which carries the X0X-0062 P2 round-2 authoritative-cleanup fix. No other code, configuration, or dependency is touched.

- `Cargo.toml`: two-line version bump — package version and `ant-quic` pin, all other 40+ dependencies remain unchanged.
- The change is mechanical and carries no logic risk; correctness depends entirely on the upstream `ant-quic 0.27.18` release being correct.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the diff is exactly two version string changes and nothing else.

The change is a two-line dependency pin bump with no logic, API surface, or config alterations. The only risk is that ant-quic 0.27.18 itself introduces a regression, but that is an upstream concern already validated by the referenced ant-quic#186 review cycle.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Version bump: x0x 0.19.38→0.19.39 and ant-quic 0.27.17→0.27.18; no other dependency or config changes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["x0x 0.19.39 (bumped)"] -->|"depends on ant-quic 0.27.18 (bumped)"| B["ant-quic 0.27.18\n(X0X-0062 P2 round-2 fix)"]
    B --> C["authoritative-cleanup\nbug fix"]
    A --> D["saorsa-mls 0.3.5\n(unchanged)"]
    A --> E["saorsa-gossip-* 0.5.40\n(unchanged)"]
```

<sub>Reviews (1): Last reviewed commit: ["release: x0x 0.19.39 — ant-quic 0.27.18 ..."](https://github.com/saorsa-labs/x0x/commit/c51e7ce77fc764dbe46932c049a6931702a53747) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31574748)</sub>

<!-- /greptile_comment -->