### PR TITLE
release: x0x 0.19.40 — ant-quic 0.27.19 (UPnP safety) + --no-port-mapping CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.19.39"
+version = "0.19.40"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.18"
+ant-quic = "0.27.19"
 saorsa-mls = "0.3.5"
 async-trait = "0.1"
 bincode = "1.3"

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -137,6 +137,14 @@ struct DaemonConfig {
     #[serde(default = "default_bootstrap_peers")]
     bootstrap_peers: Vec<SocketAddr>,
 
+    /// X0X-0062 reviewer P2 #2: enable or disable ant-quic's best-effort
+    /// UPnP IGD port-mapping. Default `true` (matches ant-quic). Set to
+    /// `false` in the daemon TOML (`port_mapping_enabled = false`) or via
+    /// the `--no-port-mapping` CLI flag on networks without IGD support
+    /// or where unsolicited router port mappings are policy-forbidden.
+    #[serde(default = "default_port_mapping_enabled")]
+    port_mapping_enabled: bool,
+
     /// Update configuration.
     #[serde(default)]
     update: DaemonUpdateConfig,
@@ -211,6 +219,10 @@ fn default_bootstrap_peers() -> Vec<SocketAddr> {
         .iter()
         .filter_map(|s| s.parse().ok())
         .collect()
+}
+
+fn default_port_mapping_enabled() -> bool {
+    true
 }
 
 fn default_bind_address() -> SocketAddr {
@@ -341,6 +353,7 @@ impl Default for DaemonConfig {
                 .iter()
                 .filter_map(|s| s.parse().ok())
                 .collect(),
+            port_mapping_enabled: default_port_mapping_enabled(),
             update: DaemonUpdateConfig::default(),
             gossip: x0x::gossip::GossipConfig::default(),
             heartbeat_interval_secs: default_heartbeat_interval(),
@@ -1116,6 +1129,12 @@ async fn main() -> Result<()> {
     }
     let disable_configured_bootstrap = no_hard_coded_bootstrap || legacy_no_bootstrap;
 
+    // X0X-0062 reviewer P2 #2: `--no-port-mapping` lets operators disable
+    // ant-quic's best-effort UPnP IGD on networks without IGD support or
+    // where operator policy forbids unsolicited router port mappings. This
+    // overrides the daemon config's `port_mapping_enabled` field.
+    let cli_no_port_mapping = args.contains(&"--no-port-mapping".to_string());
+
     // Parse --api-port for overriding the API server port
     let api_port_override = if let Some(idx) = args.iter().position(|a| a == "--api-port") {
         let port_str = args
@@ -1333,6 +1352,9 @@ async fn main() -> Result<()> {
         pinned_bootstrap_peers: std::collections::HashSet::new(),
         inbound_allowlist: std::collections::HashSet::new(),
         max_peers_per_ip: 3,
+        // CLI flag wins over config TOML so operators can override on a
+        // single invocation without editing the config file.
+        port_mapping_enabled: config.port_mapping_enabled && !cli_no_port_mapping,
     };
 
     let contacts_path = config.data_dir.join("contacts.json");

--- a/src/network.rs
+++ b/src/network.rs
@@ -188,10 +188,26 @@ pub struct NetworkConfig {
     /// Max concurrent connections from a single IP. Default: 3.
     #[serde(default = "default_max_peers_per_ip")]
     pub max_peers_per_ip: u32,
+
+    /// X0X-0062 reviewer P2 #2: surface ant-quic's best-effort UPnP IGD
+    /// port-mapping toggle at the x0x config layer so daemon operators on
+    /// networks without IGD support (or with policy against it) can
+    /// disable it. ant-quic's default is `true`; x0x mirrors that. When
+    /// `false`, x0x calls `port_mapping_enabled(false)` on the ant-quic
+    /// builder, which skips the UPnP discovery task entirely.
+    ///
+    /// Settable via the daemon's TOML config (`port_mapping_enabled = false`)
+    /// and via the `--no-port-mapping` CLI flag.
+    #[serde(default = "default_port_mapping_enabled")]
+    pub port_mapping_enabled: bool,
 }
 
 fn default_max_connections() -> u32 {
     DEFAULT_MAX_CONNECTIONS
+}
+
+fn default_port_mapping_enabled() -> bool {
+    true
 }
 
 fn default_connection_timeout() -> Duration {
@@ -236,6 +252,7 @@ impl Default for NetworkConfig {
             pinned_bootstrap_peers: std::collections::HashSet::new(),
             inbound_allowlist: std::collections::HashSet::new(),
             max_peers_per_ip: 3,
+            port_mapping_enabled: true,
         }
     }
 }
@@ -886,6 +903,12 @@ impl NetworkNode {
         if let Some((pk, sk)) = keypair {
             builder = builder.keypair(pk, sk);
         }
+
+        // X0X-0062 reviewer P2 #2: surface ant-quic's best-effort UPnP
+        // port-mapping toggle so operators on networks without IGD support
+        // (or with policy against it) can disable it via `NetworkConfig`
+        // (and downstream via the daemon's config TOML / CLI flag).
+        builder = builder.port_mapping_enabled(config.port_mapping_enabled);
 
         let node = Node::with_config(builder.build()).await.map_err(|e| {
             NetworkError::NodeCreation(format!("Failed to create ant-quic node: {}", e))
@@ -2625,6 +2648,7 @@ async fn test_mesh_connections_are_bidirectional() {
             pinned_bootstrap_peers: std::collections::HashSet::new(),
             inbound_allowlist: std::collections::HashSet::new(),
             max_peers_per_ip: 3,
+            port_mapping_enabled: true,
         };
 
         let node = NetworkNode::new(config, None, None).await.unwrap();


### PR DESCRIPTION
Bumps ant-quic pin 0.27.18 → 0.27.19 to consume four UPnP port-mapping safety fixes from PR [ant-quic#187](https://github.com/saorsa-labs/ant-quic/pull/187). Plus surfaces the port-mapping toggle in NetworkConfig + DaemonConfig + --no-port-mapping CLI flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release bumps ant-quic from 0.27.18 → 0.27.19 to pull in four UPnP port-mapping safety fixes, and surfaces the corresponding toggle as `port_mapping_enabled` in `NetworkConfig`/`DaemonConfig` plus a new `--no-port-mapping` CLI flag.

- **`Cargo.toml`**: version 0.19.39 → 0.19.40, ant-quic pin advanced one patch.
- **`src/network.rs`**: adds `port_mapping_enabled: bool` to `NetworkConfig`, wires it to `builder.port_mapping_enabled(...)`, and fills it in the test fixture — implementation correct.
- **`src/bin/x0xd.rs`**: adds `port_mapping_enabled` to `DaemonConfig`, parses `--no-port-mapping` from `args`, and computes the final value as `config.port_mapping_enabled && !cli_no_port_mapping`; however the new flag is missing from the `--help` text and its default function is duplicated from `network.rs`.

<h3>Confidence Score: 3/5</h3>

The flag works at runtime but is undiscoverable via --help, reducing operator usability of the new escape hatch.

The core ant-quic wiring and config propagation are correct. The gap is that --no-port-mapping does not appear in the --help output, so an operator troubleshooting UPnP on a production network cannot find the flag without reading source. A duplicate default function also creates a future drift risk between the TOML default and NetworkConfig::default().

src/bin/x0xd.rs — the help text block and the duplicated default_port_mapping_enabled function.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Version bumped 0.19.39 → 0.19.40 and ant-quic pin advanced 0.27.18 → 0.27.19; straightforward dependency update. |
| src/network.rs | Adds `port_mapping_enabled: bool` to `NetworkConfig`, wires it to `builder.port_mapping_enabled(...)`, and fills it in the test fixture — implementation looks correct. |
| src/bin/x0xd.rs | Adds `--no-port-mapping` CLI flag and `port_mapping_enabled` to `DaemonConfig`, but the flag is absent from the `--help` text and the default function is duplicated from `network.rs`. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[x0xd startup] --> B{--no-port-mapping in args?}
    B -- yes --> C[cli_no_port_mapping = true]
    B -- no --> D[cli_no_port_mapping = false]
    C --> E[port_mapping_enabled = false]
    D --> F[port_mapping_enabled from TOML or default true]
    E --> G[NetworkConfig.port_mapping_enabled]
    F --> G
    G --> H[NetworkNode::new]
    H --> I[builder.port_mapping_enabled — ant-quic 0.27.19]
    I --> J{enabled?}
    J -- true --> K[UPnP IGD discovery runs]
    J -- false --> L[UPnP discovery skipped]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/bin/x0xd.rs`, line 1085-1086 ([link](https://github.com/saorsa-labs/x0x/blob/aa1ff401cc1eb3971e5d80766841f43c2f0ee425/src/bin/x0xd.rs#L1085-L1086)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The `--no-port-mapping` flag is implemented and functional, but it is absent from the `--help` output. Operators who run `x0xd --help` to discover available flags will never find this option, making it invisible unless they read the source or release notes.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/bin/x0xd.rs
   Line: 1085-1086

   Comment:
   The `--no-port-mapping` flag is implemented and functional, but it is absent from the `--help` output. Operators who run `x0xd --help` to discover available flags will never find this option, making it invisible unless they read the source or release notes.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/bin/x0xd.rs:1085-1086
The `--no-port-mapping` flag is implemented and functional, but it is absent from the `--help` output. Operators who run `x0xd --help` to discover available flags will never find this option, making it invisible unless they read the source or release notes.

```suggestion
        println!("    --no-hard-coded-bootstrap       Skip configured bootstrap peers");
        println!("    --no-port-mapping               Disable UPnP IGD port-mapping (overrides config)");
        println!("    --exec-acl <PATH>               Override default exec ACL path");
```

### Issue 2 of 2
src/bin/x0xd.rs:224-228
`default_port_mapping_enabled()` is defined independently in both `x0xd.rs` and `network.rs`. If the two defaults ever diverge, the daemon TOML default will differ from the `NetworkConfig::default()` value, causing subtle config-resolution surprises. Prefer delegating to `NetworkConfig::default()` so there is a single source of truth.

```suggestion
fn default_port_mapping_enabled() -> bool {
    NetworkConfig::default().port_mapping_enabled
}

fn default_bind_address() -> SocketAddr {
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release: x0x 0.19.40 — ant-quic 0.27.19 ..."](https://github.com/saorsa-labs/x0x/commit/aa1ff401cc1eb3971e5d80766841f43c2f0ee425) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31589163)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->