### PR TITLE
release: x0x 0.19.41 — ant-quic 0.27.20 (X0X-0062 cancellation-safe)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.19.40"
+version = "0.19.41"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.19"
+ant-quic = "0.27.20"
 saorsa-mls = "0.3.5"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
Pin bump for [ant-quic#188](https://github.com/saorsa-labs/ant-quic/pull/188).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release pin-bump updates `ant-quic` from `0.27.19` to `0.27.20` to consume the cancellation-safe liveness recording fix from `ant-quic#188`, and increments the `x0x` crate version to `0.19.41`. The fix addresses a bug where outer-caller cancellation could skip the match arms responsible for incrementing the liveness counter.

- **`ant-quic` 0.27.19 → 0.27.20**: Pulls in the cancellation-safe liveness recording fix (X0X-0062), moving counter increment inside `send_ack_exchange_once`'s timeout site before any `.await` boundary.
- **`x0x` 0.19.40 → 0.19.41**: Package version incremented to reflect the patched dependency.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a minimal, targeted dependency pin bump with no logic changes.

The change touches only two version strings in `Cargo.toml`: the crate version increments to `0.19.41` and `ant-quic` is pinned to `0.27.20`. The upstream `ant-quic#188` fix narrows a real cancellation-safety gap (liveness counter skipped on task cancellation before an `.await` boundary), and the 1-hour soak on `0.19.40` mentioned in the commit message provides supporting evidence that the bump is needed. No API surface, business logic, or configuration is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps x0x package version from 0.19.40 to 0.19.41 and pins ant-quic from 0.27.19 to 0.27.20 to consume the cancellation-safe liveness recording fix |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant x0x as x0x 0.19.41
    participant antquic as ant-quic 0.27.20

    Caller->>x0x: initiate connection / ack exchange
    x0x->>antquic: send_ack_exchange_once()
    Note over antquic: liveness counter recorded<br/>inside timeout site,<br/>before .await boundary
    antquic-->>x0x: result (cancellation-safe)
    x0x-->>Caller: response

    Note over Caller,antquic: Previously (0.27.19): cancellation<br/>skipped liveness increment in match arms
```

<sub>Reviews (1): Last reviewed commit: ["release: x0x 0.19.41 — ant-quic 0.27.20 ..."](https://github.com/saorsa-labs/x0x/commit/348f5a47a983575b81bcd61d59b37fe1053217d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31624032)</sub>

<!-- /greptile_comment -->