### PR TITLE
feat(identity): add agent detached signing endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`POST /agent/sign`**: detached ML-DSA-65 signature over a caller-supplied payload using the running agent's signing key. Bearer-token authenticated; payloads are capped at 256 KiB. Response includes the agent_id (hex), the agent's public key (base64), the signature (base64), and the stable signing scheme identifier (`"x0x.agent-sign.v1.ml-dsa-65"`). Intended for applications that persist signed records to disk or distributed storage (audit logs, governance votes, content metadata) where transport-layer gossip signing doesn't survive a database read. Callers sign exact bytes, so applications must canonicalize structured payloads and should domain-separate them with an application/type/version prefix before signing. Matching CLI: `x0x agent sign --file <PATH>` (or `--payload-b64 <BASE64>`). Coverage: `daemon_api_agent_sign_*` integration tests + `api_coverage` registry entry.
+
 ## [v0.19.45] - 2026-05-13
 
 Metadata-fix release. The v0.19.44 release workflow failed validation

--- a/docs/design/api-manifest.json
+++ b/docs/design/api-manifest.json
@@ -1,5 +1,5 @@
 {
-  "endpoint_count": 130,
+  "endpoint_count": 131,
   "endpoints": [
     {
       "category": "status",
@@ -63,6 +63,13 @@
       "description": "Import agent card to contacts",
       "method": "POST",
       "path": "/agent/card/import"
+    },
+    {
+      "category": "identity",
+      "cli_name": "agent sign",
+      "description": "Detached ML-DSA-65 signature over a caller-supplied payload",
+      "method": "POST",
+      "path": "/agent/sign"
     },
     {
       "category": "network",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -112,6 +112,13 @@ pub const ENDPOINTS: &[EndpointDef] = &[
         description: "Import agent card to contacts",
         category: "identity",
     },
+    EndpointDef {
+        method: Method::Post,
+        path: "/agent/sign",
+        cli_name: "agent sign",
+        description: "Detached ML-DSA-65 signature over a caller-supplied payload",
+        category: "identity",
+    },
     // ── Network ─────────────────────────────────────────────────────────
     EndpointDef {
         method: Method::Get,

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -309,6 +309,17 @@ enum AgentSub {
         #[arg(long, default_value = "known")]
         trust: String,
     },
+    /// Produce a detached ML-DSA-65 signature over a payload using this
+    /// agent's signing key. Pass either `--file <PATH>` (use `-` for
+    /// stdin) or `--payload-b64 <BASE64>`.
+    Sign {
+        /// Path to a file whose bytes will be signed verbatim. Use `-` for stdin.
+        #[arg(long, conflicts_with = "payload_b64")]
+        file: Option<String>,
+        /// Base64-encoded bytes to sign.
+        #[arg(long)]
+        payload_b64: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1114,6 +1125,9 @@ async fn run(
             Some(AgentSub::Introduction) => commands::identity::introduction(&client).await,
             Some(AgentSub::Import { card, trust }) => {
                 commands::identity::import_card(&client, &card, Some(trust.as_str())).await
+            }
+            Some(AgentSub::Sign { file, payload_b64 }) => {
+                commands::identity::sign(&client, file.as_deref(), payload_b64.as_deref()).await
             }
         },
         Commands::Announce {

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -704,6 +704,16 @@ struct SubscribeRequest {
     topic: String,
 }
 
+/// POST /agent/sign request body — a single base64-encoded payload to
+/// sign with the agent's ML-DSA-65 secret key.
+#[derive(Debug, Deserialize)]
+struct AgentSignRequest {
+    /// Base64-encoded bytes to sign. The signature is computed over these
+    /// bytes verbatim — the caller is responsible for choosing a canonical
+    /// serialization for any structured payload.
+    payload_b64: String,
+}
+
 /// POST /announce request body.
 #[derive(Debug, Default, Deserialize)]
 struct AnnounceIdentityRequest {
@@ -1770,6 +1780,7 @@ async fn main() -> Result<()> {
         .route("/introduction", get(introduction))
         .route("/agent/card", get(get_agent_card))
         .route("/agent/card/import", post(import_agent_card))
+        .route("/agent/sign", post(agent_sign))
         .route("/announce", post(announce_identity))
         .route("/peers", get(peers))
         .route("/network/status", get(network_status))
@@ -3936,6 +3947,110 @@ async fn import_agent_card(
             "trust_level": format!("{trust:?}"),
             "groups": card.groups.len(),
             "stores": card.stores.len(),
+        })),
+    )
+}
+
+/// Maximum payload size accepted by `POST /agent/sign`, in bytes.
+/// Comfortably larger than any realistic audit-event or governance-vote
+/// envelope (≤1 KiB in practice) while still bounding worst-case work.
+const AGENT_SIGN_MAX_PAYLOAD_BYTES: usize = 256 * 1024;
+
+/// POST /agent/sign — produce a detached ML-DSA-65 signature over a
+/// caller-supplied payload using this agent's signing key.
+///
+/// Rationale. x0xd already signs gossip frames at the transport layer
+/// (saorsa-gossip-identity), but transport-layer signatures don't survive
+/// a database read. Applications that persist signed records to disk or
+/// to distributed storage (audit logs, governance votes, content
+/// metadata) need a detached signature that can be verified later from
+/// the stored bytes alone, by a verifier that may have never been on the
+/// network when the signature was issued. This endpoint provides that
+/// primitive without exposing the secret key itself.
+///
+/// Authentication. Bearer-token authenticated like every other endpoint
+/// — only callers with the agent's local API token can sign as the agent.
+///
+/// Payload. `payload_b64` is base64-decoded and signed verbatim. The
+/// caller is responsible for choosing a canonical serialization of any
+/// structured payload (e.g. `serde_canonical_json`, `postcard`, or an
+/// explicit field-order convention).
+///
+/// Response. Returns the agent_id (hex, 32 bytes), the agent's public
+/// key (base64), the signature (base64), and the algorithm identifier.
+/// All values are wire-format ready for inclusion in the signed record.
+async fn agent_sign(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<AgentSignRequest>,
+) -> impl IntoResponse {
+    let payload = match base64::engine::general_purpose::STANDARD.decode(&req.payload_b64) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "ok": false,
+                    "error": format!("invalid base64 payload: {e}"),
+                })),
+            );
+        }
+    };
+
+    if payload.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": "payload must be non-empty",
+            })),
+        );
+    }
+
+    if payload.len() > AGENT_SIGN_MAX_PAYLOAD_BYTES {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": format!(
+                    "payload exceeds maximum signable size of {} bytes",
+                    AGENT_SIGN_MAX_PAYLOAD_BYTES
+                ),
+            })),
+        );
+    }
+
+    let identity = state.agent.identity();
+    let keypair = identity.agent_keypair();
+
+    let signature = match ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
+        keypair.secret_key(),
+        &payload,
+    ) {
+        Ok(sig) => sig,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "ok": false,
+                    "error": format!("signing failed: {e:?}"),
+                })),
+            );
+        }
+    };
+
+    let signature_b64 = base64::engine::general_purpose::STANDARD.encode(signature.as_bytes());
+    let public_key_b64 =
+        base64::engine::general_purpose::STANDARD.encode(keypair.public_key().as_bytes());
+    let agent_id_hex = hex::encode(state.agent.agent_id().as_bytes());
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "ok": true,
+            "agent_id": agent_id_hex,
+            "public_key_b64": public_key_b64,
+            "signature_b64": signature_b64,
+            "algorithm": "ML-DSA-65",
         })),
     )
 }

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -3956,6 +3956,9 @@ async fn import_agent_card(
 /// envelope (≤1 KiB in practice) while still bounding worst-case work.
 const AGENT_SIGN_MAX_PAYLOAD_BYTES: usize = 256 * 1024;
 
+/// Stable scheme identifier returned by `POST /agent/sign`.
+const AGENT_SIGN_SCHEME_ID: &str = "x0x.agent-sign.v1.ml-dsa-65";
+
 /// POST /agent/sign — produce a detached ML-DSA-65 signature over a
 /// caller-supplied payload using this agent's signing key.
 ///
@@ -3974,11 +3977,14 @@ const AGENT_SIGN_MAX_PAYLOAD_BYTES: usize = 256 * 1024;
 /// Payload. `payload_b64` is base64-decoded and signed verbatim. The
 /// caller is responsible for choosing a canonical serialization of any
 /// structured payload (e.g. `serde_canonical_json`, `postcard`, or an
-/// explicit field-order convention).
+/// explicit field-order convention). Callers should also domain-separate
+/// payloads (for example, with an application/type/version prefix) so a
+/// signature produced for one protocol cannot be replayed as another.
 ///
 /// Response. Returns the agent_id (hex, 32 bytes), the agent's public
-/// key (base64), the signature (base64), and the algorithm identifier.
-/// All values are wire-format ready for inclusion in the signed record.
+/// key (base64), the signature (base64), and the stable signing scheme
+/// identifier. All values are wire-format ready for inclusion in the
+/// signed record.
 async fn agent_sign(
     State(state): State<Arc<AppState>>,
     Json(req): Json<AgentSignRequest>,
@@ -4050,7 +4056,7 @@ async fn agent_sign(
             "agent_id": agent_id_hex,
             "public_key_b64": public_key_b64,
             "signature_b64": signature_b64,
-            "algorithm": "ML-DSA-65",
+            "algorithm": AGENT_SIGN_SCHEME_ID,
         })),
     )
 }

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -1,8 +1,10 @@
 //! Identity CLI commands.
 
 use crate::cli::{print_value, DaemonClient};
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
+use base64::Engine;
 use four_word_networking::IdentityEncoder;
+use std::io::Read;
 
 /// Compute 4-word speakable identity from a hex agent/user ID.
 fn identity_words(encoder: &IdentityEncoder, hex_id: &str) -> Option<String> {
@@ -118,6 +120,44 @@ pub async fn import_card(
         body["trust_level"] = serde_json::Value::String(tl.to_string());
     }
     let resp = client.post("/agent/card/import", &body).await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}
+
+/// `x0x agent sign` — POST /agent/sign
+///
+/// Reads bytes from `--file <PATH>` (or stdin when path is `-`) OR uses
+/// `--payload-b64 <BASE64>` directly, base64-encodes the bytes, and asks
+/// the daemon to produce a detached ML-DSA-65 signature. The daemon signs
+/// exact bytes; callers should canonicalize structured payloads and
+/// domain-separate them before signing.
+pub async fn sign(
+    client: &DaemonClient,
+    file: Option<&str>,
+    payload_b64: Option<&str>,
+) -> Result<()> {
+    client.ensure_running().await?;
+
+    let payload_b64 = match (file, payload_b64) {
+        (Some(path), None) => {
+            let bytes = if path == "-" {
+                let mut buf = Vec::new();
+                std::io::stdin()
+                    .read_to_end(&mut buf)
+                    .context("failed to read stdin")?;
+                buf
+            } else {
+                std::fs::read(path).with_context(|| format!("failed to read file: {path}"))?
+            };
+            base64::engine::general_purpose::STANDARD.encode(bytes)
+        }
+        (None, Some(b64)) => b64.to_string(),
+        (Some(_), Some(_)) => bail!("pass either --file or --payload-b64, not both"),
+        (None, None) => bail!("pass either --file <PATH> or --payload-b64 <BASE64>"),
+    };
+
+    let body = serde_json::json!({ "payload_b64": payload_b64 });
+    let resp = client.post("/agent/sign", &body).await?;
     print_value(client.format(), &resp);
     Ok(())
 }

--- a/tests/api_coverage.rs
+++ b/tests/api_coverage.rs
@@ -30,6 +30,7 @@ const COVERED: &[(Method, &str)] = &[
     (Method::Get, "/agent/card"),
     (Method::Get, "/introduction"),
     (Method::Post, "/agent/card/import"),
+    (Method::Post, "/agent/sign"),
     // ── Network ─────────────────────────────────────────────────────────
     (Method::Get, "/peers"),
     // ── Presence ────────────────────────────────────────────────────────

--- a/tests/daemon_api_integration.rs
+++ b/tests/daemon_api_integration.rs
@@ -111,7 +111,7 @@ async fn daemon_api_agent_sign_roundtrip() {
         .unwrap();
 
     assert_eq!(r["ok"], true);
-    assert_eq!(r["algorithm"], "ML-DSA-65");
+    assert_eq!(r["algorithm"], "x0x.agent-sign.v1.ml-dsa-65");
     let agent_id_hex = r["agent_id"].as_str().expect("agent_id is a hex string");
     let public_key_b64 = r["public_key_b64"]
         .as_str()

--- a/tests/daemon_api_integration.rs
+++ b/tests/daemon_api_integration.rs
@@ -93,6 +93,104 @@ async fn daemon_api_agent() {
 
 #[tokio::test]
 #[ignore]
+async fn daemon_api_agent_sign_roundtrip() {
+    let d = daemon().await;
+
+    // Sign an arbitrary payload.
+    let payload = b"the bytes a downstream app would put into an audit record";
+    let body = serde_json::json!({ "payload_b64": b64(payload) });
+
+    let r: Value = ca(&d)
+        .post(d.url("/agent/sign"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["algorithm"], "ML-DSA-65");
+    let agent_id_hex = r["agent_id"].as_str().expect("agent_id is a hex string");
+    let public_key_b64 = r["public_key_b64"]
+        .as_str()
+        .expect("public_key_b64 is a base64 string");
+    let signature_b64 = r["signature_b64"]
+        .as_str()
+        .expect("signature_b64 is a base64 string");
+
+    // agent_id matches the agent's hex id.
+    let agent_resp: Value = ca(&d)
+        .get(d.url("/agent"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(agent_resp["agent_id"].as_str().unwrap(), agent_id_hex);
+
+    // Signature verifies under the returned public key.
+    let pk_bytes = base64::engine::general_purpose::STANDARD
+        .decode(public_key_b64)
+        .expect("public key decodes from base64");
+    let sig_bytes = base64::engine::general_purpose::STANDARD
+        .decode(signature_b64)
+        .expect("signature decodes from base64");
+
+    let public_key = ant_quic::MlDsaPublicKey::from_bytes(&pk_bytes)
+        .expect("public_key_b64 parses as an ML-DSA-65 public key");
+    let signature = ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(&sig_bytes)
+        .expect("signature_b64 parses as an ML-DSA-65 signature");
+
+    ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(&public_key, payload, &signature)
+        .expect("signature verifies under the agent's public key");
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_sign_rejects_empty_payload() {
+    let d = daemon().await;
+    let r = ca(&d)
+        .post(d.url("/agent/sign"))
+        .json(&serde_json::json!({ "payload_b64": "" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_sign_rejects_invalid_base64() {
+    let d = daemon().await;
+    let r = ca(&d)
+        .post(d.url("/agent/sign"))
+        .json(&serde_json::json!({ "payload_b64": "@@@not-base64@@@" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_sign_rejects_oversize_payload() {
+    let d = daemon().await;
+    // Just over the 256 KiB cap.
+    let oversize = vec![0u8; 256 * 1024 + 1];
+    let r = ca(&d)
+        .post(d.url("/agent/sign"))
+        .json(&serde_json::json!({ "payload_b64": b64(&oversize) }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+#[ignore]
 async fn daemon_api_peers() {
     let d = daemon().await;
     let r = ca(&d).get(d.url("/peers")).send().await.unwrap();


### PR DESCRIPTION
Closes #81.\n\nThanks @nkoteskey for the well-scoped implementation and tests. I applied the two review follow-ups before opening this maintainer PR:\n\n- return a stable/versioned signing scheme identifier: `x0x.agent-sign.v1.ml-dsa-65`\n- document exact-byte signing semantics, caller canonicalization, and domain separation\n\nValidation run locally:\n\n- `cargo fmt --all`\n- `cargo check --workspace --all-targets`\n- `cargo clippy --all-targets --bin x0xd --bin x0x --tests -- -D warnings`\n- `cargo test --test api_coverage --quiet`\n- `cargo build --release --bin x0xd`\n- `cargo test --test daemon_api_integration daemon_api_agent_sign -- --ignored --nocapture`\n\nNote: the stricter repo-wide command with `-D clippy::panic -D clippy::unwrap_used -D clippy::expect_used` still reports pre-existing test/helper panics and unwraps outside this change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `POST /agent/sign`, a detached ML-DSA-65 signing endpoint that lets bearer-token-authenticated callers produce application-layer signatures over arbitrary payloads using the agent's own signing key — filling the gap left by transport-layer signatures that don't survive a database read.

- **`src/bin/x0xd.rs`**: new `agent_sign` handler with `AgentSignRequest`; validates base64 decoding, rejects empty payloads, enforces a 256 KiB decoded-byte cap (`AGENT_SIGN_MAX_PAYLOAD_BYTES`), and returns `agent_id`, `public_key_b64`, `signature_b64`, and the stable `"x0x.agent-sign.v1.ml-dsa-65"` scheme identifier.
- **`src/bin/x0x.rs` / `src/cli/commands/identity.rs`**: new `agent sign` subcommand accepting `--file <PATH>` (including stdin via `-`) or `--payload-b64 <BASE64>` with mutually-exclusive arg validation.
- **`tests/daemon_api_integration.rs`**: four integration tests covering the full roundtrip (including ML-DSA-65 signature verification), empty-payload rejection, invalid-base64 rejection, and oversize-payload rejection.

<h3>Confidence Score: 5/5</h3>

The new signing endpoint is protected by the existing global bearer-token middleware and contains thorough payload validation; no authentication gaps or logic errors were found.

All validation steps (base64 decode, empty check, 256 KiB size cap) are ordered correctly and return appropriate HTTP status codes. The `agent_sign` handler is not in the middleware exemption list so it correctly requires a bearer token. The CLI correctly handles all four input combinations (`--file`, `--payload-b64`, both, neither). Integration tests verify the full ML-DSA-65 roundtrip as well as all three rejection cases.

No files require special attention; all changes are isolated to the new endpoint and its tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/bin/x0xd.rs | Adds `agent_sign` handler and `AgentSignRequest` struct; handler validates base64, empty payload, and 256 KiB size cap before signing; covered by the existing bearer-token middleware |
| src/cli/commands/identity.rs | Adds `sign()` CLI command that reads bytes from `--file`/stdin or `--payload-b64`, encodes to base64, and POSTs to `/agent/sign`; all four input cases handled correctly |
| src/bin/x0x.rs | Adds `Sign` subcommand to `AgentSub` enum with mutually-exclusive `--file`/`--payload-b64` args and delegates to `commands::identity::sign` |
| tests/daemon_api_integration.rs | Adds four ignored integration tests: roundtrip signing (including ML-DSA-65 signature verification), empty payload rejection, invalid base64 rejection, and oversize payload rejection |
| tests/api_coverage.rs | Adds `POST /agent/sign` to the `COVERED` registry; straightforward bookkeeping change |
| src/api/mod.rs | Adds `EndpointDef` entry for `POST /agent/sign` in the `identity` category |
| CHANGELOG.md | Documents the new endpoint under [Unreleased] with accurate description of payload cap, response fields, and usage guidance |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /agent/sign] --> B{Auth Middleware}
    B -->|token missing or wrong| C[401 Unauthorized]
    B -->|token valid| D[Decode base64 payload]
    D -->|decode error| E[400 Bad Request]
    D -->|decoded OK| F{Validate payload}
    F -->|empty| G[400 Bad Request]
    F -->|over 256 KiB| H[413 Payload Too Large]
    F -->|valid| I[sign_with_ml_dsa]
    I -->|error| J[500 Internal Server Error]
    I -->|success| K[200 OK - agent_id + public_key + signature + algorithm]
```

<sub>Reviews (1): Last reviewed commit: ["docs(identity): clarify agent signing sc..."](https://github.com/saorsa-labs/x0x/commit/beed7a513f7ee4f9411b6e9d7f24fbd75ec0645f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33009018)</sub>

<!-- /greptile_comment -->