### PR TITLE
docs: clarify encrypted KvStore policy status

### DIFF
--- a/src/kv/delta.rs
+++ b/src/kv/delta.rs
@@ -89,11 +89,10 @@ impl DeltaCrdt for KvStore {
 
     fn merge(&mut self, delta: &Self::Delta) -> anyhow::Result<()> {
         let peer_id = PeerId::new([0u8; 32]);
-        // Anti-entropy merges don't carry writer identity — for Encrypted
-        // stores this is fine (MLS group membership is the auth). For
-        // Signed/Allowlisted stores, the main sync path in KvStoreSync
-        // provides the writer identity; this trait-level merge is only
-        // used by the anti-entropy background task.
+        // Anti-entropy merges don't carry writer identity. Signed/Allowlisted
+        // stores rely on the main sync path in KvStoreSync to provide the
+        // writer identity; Encrypted is currently a reserved policy shape, not
+        // transport confidentiality for KvStore deltas.
         self.merge_delta(delta, peer_id, None)
             .map_err(|e| anyhow::anyhow!("KvStore delta merge failed: {e}"))
     }

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -9,8 +9,9 @@
 //!   from non-owners are rejected. Use for app stores, agent skill registries.
 //! - **Allowlisted**: Only explicitly allowed writers can write. The owner
 //!   manages the allowlist. Use for team workspaces, private swarms.
-//! - **Encrypted**: Only MLS group members can read or write. Deltas are
-//!   encrypted with the group key. Use for private data sharing.
+//! - **Encrypted**: Reserved for group-scoped encrypted stores. The current
+//!   KvStore sync path does not encrypt deltas; do not rely on this policy for
+//!   confidentiality until encrypted sync is wired.
 
 use crate::identity::AgentId;
 use crate::kv::{KvEntry, KvError, KvStoreDelta, Result};
@@ -32,8 +33,11 @@ pub enum AccessPolicy {
     /// The owner manages the allowlist.
     Allowlisted,
 
-    /// Only MLS group members can read or write.
-    /// Deltas are encrypted with the group key before gossip.
+    /// Reserved for group-scoped encrypted stores.
+    ///
+    /// The current KvStore sync path still publishes plaintext deltas and does
+    /// not enforce group membership by itself. Do not rely on this variant for
+    /// confidentiality until encrypted sync is wired.
     Encrypted {
         /// MLS group ID for this store.
         group_id: Vec<u8>,
@@ -221,8 +225,9 @@ impl KvStore {
                     || self.allowed_writers.contains(agent_id)
             }
             AccessPolicy::Encrypted { .. } => {
-                // Authorization is handled by MLS group membership;
-                // if you can decrypt, you're authorized.
+                // Reserved for encrypted sync. The store layer currently treats
+                // this as permissive; group membership enforcement belongs in
+                // the secure sync path once wired.
                 true
             }
         }
@@ -366,8 +371,9 @@ impl KvStore {
                 return Ok(()); // Silent rejection — don't propagate errors for spam
             }
         } else {
-            // No writer identity — only allowed for Encrypted stores
-            // (where MLS group membership is the authorization)
+            // No writer identity is only tolerated for the reserved Encrypted
+            // policy. KvStoreSync does not decrypt or verify group membership
+            // here today.
             match &self.policy {
                 AccessPolicy::Encrypted { .. } => {} // OK
                 _ => {


### PR DESCRIPTION
## Summary
- clarify that AccessPolicy::Encrypted is a reserved policy shape, not currently wired encrypted KvStore sync
- remove comments implying KvStore deltas are encrypted or group-authorized today
- leave behavior and APIs unchanged

## Verification
- cargo fmt --all -- --check
- cargo test --lib --all-features kv_store (blocked locally: x0x@0.19.47 requires rustc 1.95.0; active toolchain is rustc 1.94.0)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects misleading documentation in the `KvStore` module by accurately reflecting that `AccessPolicy::Encrypted` is a reserved policy shape — not a currently functional encryption mechanism. No behavior, APIs, or logic are changed.

- `src/kv/store.rs`: Updates the module-level doc comment, the `AccessPolicy::Encrypted` enum doc, and two inline comments to state that deltas are published in plaintext and group membership is not enforced today.
- `src/kv/delta.rs`: Updates one inline comment to remove the implication that anti-entropy merges are safe for `Encrypted` stores due to MLS group auth, replacing it with the accurate reserved-shape description.

<h3>Confidence Score: 5/5</h3>

Safe to merge — exclusively comment and doc changes with zero behavioral impact.

Every changed line is a comment or doc string. The updated text now correctly tells callers that `AccessPolicy::Encrypted` publishes plaintext deltas and allows any writer through, which matches the actual code paths. No logic, data structures, or public APIs are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/kv/store.rs | Three comment blocks updated to remove incorrect claims that Encrypted stores encrypt deltas or enforce MLS group membership; behavior and API unchanged. |
| src/kv/delta.rs | One inline comment corrected to drop the false statement that MLS group membership provides authorization for anti-entropy merges; no code changes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Delta / Write] --> B{Writer identity present?}
    B -- Yes --> C{Check AccessPolicy}
    B -- No --> D{AccessPolicy::Encrypted?}
    D -- Yes --> E[OK — reserved permissive path\nno group membership check today]
    D -- No --> F[Reject — Signed or Allowlisted\nrequire writer identity]
    C --> G{Signed}
    C --> H{Allowlisted}
    C --> I{Encrypted}
    G --> J{Is owner?}
    J -- Yes --> K[Accept]
    J -- No --> L[Silent reject]
    H --> M{Is owner or in allowlist?}
    M -- Yes --> K
    M -- No --> L
    I --> E
    E -. "future: encrypted sync\nwill enforce group membership" .-> N[Encrypted sync path\nnot yet wired]
```

<sub>Reviews (1): Last reviewed commit: ["docs: clarify encrypted KvStore policy s..."](https://github.com/saorsa-labs/x0x/commit/c98a8710f1db9ba8fb0d701d1dbe7483148e1b26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33228372)</sub>

<!-- /greptile_comment -->