### PR TITLE
Add x0x user-id create CLI subcommand to complete the user-identity surface

### DIFF
--- a/docs/adr/0007-three-layer-identity-model.md
+++ b/docs/adr/0007-three-layer-identity-model.md
@@ -65,7 +65,7 @@ agent.cert    # optional
 
 Named daemon instances use separate identity directories such as `~/.x0x-alice` and `~/.x0x-bob`.
 
-`machine.key` and `agent.key` are generated when missing. `user.key` is not generated automatically.
+`machine.key` and `agent.key` are generated when missing. `user.key` is not generated automatically. Create it explicitly with `x0x user-id create [PATH]`; without `PATH`, the command writes `~/.x0x/user.key`, overwriting any existing target file.
 
 If an existing `agent.cert` does not match the configured user key and current agent key, x0x should treat it as stale and issue a new certificate when a user key is active. Without an active user key, the certificate is inert local state.
 

--- a/docs/identity-architecture.md
+++ b/docs/identity-architecture.md
@@ -40,6 +40,10 @@ AgentCertificate = sign(UserKeypair, context || user_public_key || agent_public_
 
 Never auto-generated. Opt-in only (`with_user_key()` or `with_user_key_path()`). When included in an announcement, both the certificate and user ID are present or neither is. Announcement APIs also require explicit human consent before disclosing `user_id`.
 
+Create a user identity explicitly with `x0x user-id create [PATH]`. Without `PATH`, the command writes `~/.x0x/user.key`; with `PATH`, it writes there instead. Restart `x0xd`, or set `user_key_path` in `config.toml`, for the daemon to load it. The command overwrites an existing file at the target path, so back up an existing `user.key` first if you want to keep that identity.
+
+The standalone `x0x-user-keygen` binary remains buildable from source as a deprecated compatibility shim, but the canonical user-facing path is `x0x user-id create`.
+
 **Purpose**: Optional human accountability layer.
 
 ## Identity Unification

--- a/docs/primers/identity.md
+++ b/docs/primers/identity.md
@@ -34,6 +34,24 @@ All three IDs are 32-byte hashes of ML-DSA-65 public keys, shown as 64 hex chara
 
 The daemon generates `machine.key` and `agent.key` on first use. It does not generate `user.key` by default.
 
+## Creating a user identity
+
+```bash
+x0x user-id create
+```
+
+This writes a fresh ML-DSA-65 keypair to `~/.x0x/user.key`. Pass a path argument to write elsewhere:
+
+```bash
+x0x user-id create /path/to/user.key
+```
+
+Restart `x0xd`, or set `user_key_path` in `config.toml`, for the daemon to load the new identity. Per ADR 0007, this is an explicit opt-in command; no daemon or other CLI command creates a user key automatically. Once loaded, `x0x agent user-id` returns the resulting `user_id`.
+
+Note: `x0x user-id create` overwrites an existing file at the target path. Back up any existing `user.key` first if you want to keep that identity.
+
+The standalone `x0x-user-keygen` binary remains buildable from source as a deprecated compatibility shim for existing scripts, but new code should use `x0x user-id create`.
+
 Inspect your local identity:
 
 ```bash

--- a/docs/proof/NAMED_GROUPS_PARITY_SIGNOFF.md
+++ b/docs/proof/NAMED_GROUPS_PARITY_SIGNOFF.md
@@ -275,7 +275,7 @@ represent a silent gap.
 ## Appendix — reproducing this report
 
 ```bash
-cargo build --release --bin x0xd --bin x0x --bin x0x-user-keygen
+cargo build --release --bin x0xd --bin x0x
 
 # Static proofs (fast)
 cargo nextest run --test gui_named_group_parity --test api_manifest \
@@ -288,3 +288,6 @@ for i in 1 2 3; do bash tests/e2e_feature_parity.sh; done
 Logs land in `tests/proof-reports/parity/feature-parity-*.log`.
 The GUI per-endpoint coverage lands in
 `tests/proof-reports/parity/gui-named-groups-coverage.txt`.
+
+`x0x-user-keygen` remains buildable from source as a deprecated compatibility shim;
+runtime scripts use the canonical `x0x user-id create` command.

--- a/src/bin/x0x-user-keygen.rs
+++ b/src/bin/x0x-user-keygen.rs
@@ -3,11 +3,19 @@
 //! This binary remains buildable from source for scripts that invoke it
 //! directly. New code should use `x0x user-id create [PATH]`.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::PathBuf;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let output = std::env::args().nth(1).map(PathBuf::from);
-    x0x::cli::commands::user_id::create(output).await
+    eprintln!("warning: x0x-user-keygen is deprecated; use `x0x user-id create [PATH]` instead.");
+
+    let output = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .context("usage: x0x-user-keygen <output-path>")?;
+
+    let resolved = x0x::cli::commands::user_id::create(Some(output)).await?;
+    println!("{}", resolved.display());
+    Ok(())
 }

--- a/src/bin/x0x-user-keygen.rs
+++ b/src/bin/x0x-user-keygen.rs
@@ -1,20 +1,13 @@
-use anyhow::{Context, Result};
+//! Deprecated compatibility shim for `x0x user-id create`.
+//!
+//! This binary remains buildable from source for scripts that invoke it
+//! directly. New code should use `x0x user-id create [PATH]`.
+
+use anyhow::Result;
 use std::path::PathBuf;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let output = std::env::args()
-        .nth(1)
-        .map(PathBuf::from)
-        .context("usage: x0x-user-keygen <output-path>")?;
-
-    let keypair = x0x::identity::UserKeypair::generate()
-        .map_err(|e| anyhow::anyhow!("failed to generate user keypair: {e}"))?;
-
-    x0x::storage::save_user_keypair_to(&keypair, &output)
-        .await
-        .with_context(|| format!("failed to write user keypair to {}", output.display()))?;
-
-    println!("{}", output.display());
-    Ok(())
+    let output = std::env::args().nth(1).map(PathBuf::from);
+    x0x::cli::commands::user_id::create(output).await
 }

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -80,6 +80,11 @@ enum Commands {
         #[command(subcommand)]
         sub: Option<AgentSub>,
     },
+    /// Manage user identity.
+    UserId {
+        #[command(subcommand)]
+        sub: UserIdSub,
+    },
     /// Announce identity to network.
     Announce {
         /// Include user identity in announcement.
@@ -319,6 +324,15 @@ enum AgentSub {
         /// Base64-encoded bytes to sign.
         #[arg(long)]
         payload_b64: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum UserIdSub {
+    /// Create a new user identity keypair (ML-DSA-65). Defaults to ~/.x0x/user.key.
+    Create {
+        /// Output path. Existing file at this path is overwritten.
+        path: Option<PathBuf>,
     },
 }
 
@@ -1070,6 +1084,9 @@ async fn run(
                 commands::daemon::autostart(name).await
             };
         }
+        Commands::UserId { sub } => match sub {
+            UserIdSub::Create { path } => return commands::user_id::create(path.clone()).await,
+        },
         _ => {}
     }
 
@@ -1574,6 +1591,7 @@ async fn run(
         | Commands::Uninstall
         | Commands::Purge
         | Commands::Constitution { .. }
+        | Commands::UserId { .. }
         | Commands::Start { .. }
         | Commands::Instances
         | Commands::Autostart { .. } => unreachable!(),
@@ -1598,6 +1616,7 @@ x0x (v{VERSION})
 |   |   +-- user-id        Show user ID
 |   |   +-- card           Generate shareable identity card
 |   |   +-- import         Import an agent card to contacts
+|   +-- user-id create     Create user identity keypair
 |   +-- announce           Announce identity to network
 |
 +-- Network

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -1086,7 +1086,11 @@ async fn run(
             };
         }
         Commands::UserId { sub } => match sub {
-            UserIdSub::Create { path } => return commands::user_id::create(path.clone()).await,
+            UserIdSub::Create { path } => {
+                let resolved = commands::user_id::create(path.clone()).await?;
+                println!("Created user identity keypair at {}", resolved.display());
+                return Ok(());
+            }
         },
         _ => {}
     }

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -330,6 +330,7 @@ enum AgentSub {
 #[derive(Subcommand)]
 enum UserIdSub {
     /// Create a new user identity keypair (ML-DSA-65). Defaults to ~/.x0x/user.key.
+    /// Overwrites any existing file at the target path without prompting.
     Create {
         /// Output path. Existing file at this path is overwritten.
         path: Option<PathBuf>,

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -1088,7 +1088,15 @@ async fn run(
         Commands::UserId { sub } => match sub {
             UserIdSub::Create { path } => {
                 let resolved = commands::user_id::create(path.clone()).await?;
-                println!("Created user identity keypair at {}", resolved.display());
+                match format {
+                    OutputFormat::Json => x0x::cli::print_value(
+                        format,
+                        &serde_json::json!({ "path": resolved.to_string_lossy() }),
+                    ),
+                    OutputFormat::Text => {
+                        println!("Created user identity keypair at {}", resolved.display());
+                    }
+                }
                 return Ok(());
             }
         },

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod purge;
 pub mod store;
 pub mod tasks;
 pub mod upgrade;
+pub mod user_id;
 pub mod ws;
 
 use crate::api;

--- a/src/cli/commands/user_id.rs
+++ b/src/cli/commands/user_id.rs
@@ -1,0 +1,30 @@
+//! User identity CLI commands.
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+use crate::identity::UserKeypair;
+use crate::storage::save_user_keypair_to;
+
+/// Default user identity key path (`~/.x0x/user.key`).
+pub fn default_user_key_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".x0x").join("user.key"))
+}
+
+/// `x0x user-id create [PATH]` — create a user identity keypair on disk.
+pub async fn create(output: Option<PathBuf>) -> Result<()> {
+    let path = match output {
+        Some(path) => path,
+        None => default_user_key_path()?,
+    };
+
+    let keypair = UserKeypair::generate()
+        .map_err(|e| anyhow::anyhow!("failed to generate user keypair: {e}"))?;
+    save_user_keypair_to(&keypair, &path)
+        .await
+        .with_context(|| format!("failed to write user keypair to {}", path.display()))?;
+
+    println!("Created user identity keypair at {}", path.display());
+    Ok(())
+}

--- a/src/cli/commands/user_id.rs
+++ b/src/cli/commands/user_id.rs
@@ -13,7 +13,7 @@ pub fn default_user_key_path() -> Result<PathBuf> {
 }
 
 /// `x0x user-id create [PATH]` — create a user identity keypair on disk.
-pub async fn create(output: Option<PathBuf>) -> Result<()> {
+pub async fn create(output: Option<PathBuf>) -> Result<PathBuf> {
     let path = match output {
         Some(path) => path,
         None => default_user_key_path()?,
@@ -25,8 +25,7 @@ pub async fn create(output: Option<PathBuf>) -> Result<()> {
         .await
         .with_context(|| format!("failed to write user keypair to {}", path.display()))?;
 
-    println!("Created user identity keypair at {}", path.display());
-    Ok(())
+    Ok(path)
 }
 
 #[cfg(test)]
@@ -40,8 +39,12 @@ mod tests {
         let temp_dir = tempfile::tempdir()?;
         let path = temp_dir.path().join("user.key");
 
-        create(Some(path.clone())).await?;
+        let resolved = create(Some(path.clone())).await?;
 
+        ensure!(
+            resolved == path,
+            "resolved path should match requested path"
+        );
         ensure!(path.is_file(), "user key file should exist");
         ensure!(
             path.metadata()?.len() > 0,

--- a/src/cli/commands/user_id.rs
+++ b/src/cli/commands/user_id.rs
@@ -28,3 +28,28 @@ pub async fn create(output: Option<PathBuf>) -> Result<()> {
     println!("Created user identity keypair at {}", path.display());
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::load_user_keypair_from;
+    use anyhow::ensure;
+
+    #[tokio::test]
+    async fn create_writes_loadable_user_keypair() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("user.key");
+
+        create(Some(path.clone())).await?;
+
+        ensure!(path.is_file(), "user key file should exist");
+        ensure!(
+            path.metadata()?.len() > 0,
+            "user key file should not be empty"
+        );
+        let loaded = load_user_keypair_from(&path).await?;
+        let _user_id = loaded.user_id();
+
+        Ok(())
+    }
+}

--- a/tests/e2e_feature_parity.sh
+++ b/tests/e2e_feature_parity.sh
@@ -29,7 +29,6 @@ set -uo pipefail
 ROOT="$(pwd)"
 X0XD="${X0XD:-$ROOT/target/release/x0xd}"
 X0X="${X0X:-$ROOT/target/release/x0x}"
-X0X_USER_KEYGEN="${X0X_USER_KEYGEN:-$ROOT/target/release/x0x-user-keygen}"
 
 AA="http://127.0.0.1:19811"
 BA="http://127.0.0.1:19812"
@@ -58,8 +57,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [ ! -x "$X0XD" ] || [ ! -x "$X0X" ] || [ ! -x "$X0X_USER_KEYGEN" ]; then
-  echo "Build first: cargo build --release --bin x0xd --bin x0x --bin x0x-user-keygen" >&2
+if [ ! -x "$X0XD" ] || [ ! -x "$X0X" ]; then
+  echo "Build first: cargo build --release --bin x0xd --bin x0x" >&2
   exit 1
 fi
 
@@ -137,7 +136,7 @@ printf "${CYAN}║    Run: %-58s ║${NC}\n" "$TS"
 printf "${CYAN}║    Report: %-55s ║${NC}\n" "${REPORT#$ROOT/}"
 printf "${CYAN}╚══════════════════════════════════════════════════════════════════╝${NC}\n"
 
-"$X0X_USER_KEYGEN" "$USER_KEY_PATH" >/dev/null
+"$X0X" user-id create "$USER_KEY_PATH" >/dev/null
 
 info "Starting 2 daemons (alice + bob)…"
 AP=$(start_daemon "$ADIR" alice 19821 19811 '"127.0.0.1:19822"')

--- a/tests/e2e_full_audit.sh
+++ b/tests/e2e_full_audit.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 ROOT="$(pwd)"
 X0XD="${X0XD:-$ROOT/target/release/x0xd}"
 X0X="${X0X:-$ROOT/target/release/x0x}"
-X0X_USER_KEYGEN="${X0X_USER_KEYGEN:-$ROOT/target/release/x0x-user-keygen}"
 AA="http://127.0.0.1:19811"
 BA="http://127.0.0.1:19812"
 CA="http://127.0.0.1:19813"
@@ -36,12 +35,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [ ! -x "$X0XD" ] || [ ! -x "$X0X" ] || [ ! -x "$X0X_USER_KEYGEN" ]; then
-  echo "Build first: cargo build --release --bin x0xd --bin x0x --bin x0x-user-keygen" >&2
+if [ ! -x "$X0XD" ] || [ ! -x "$X0X" ]; then
+  echo "Build first: cargo build --release --bin x0xd --bin x0x" >&2
   exit 1
 fi
 
-"$X0X_USER_KEYGEN" "$USER_KEY_PATH" >/dev/null
+"$X0X" user-id create "$USER_KEY_PATH" >/dev/null
 
 for port in 19811 19812 19813 19881 19882 19883; do
   lsof -ti tcp:$port 2>/dev/null | xargs kill -9 2>/dev/null || true

--- a/tests/e2e_named_groups.sh
+++ b/tests/e2e_named_groups.sh
@@ -31,7 +31,7 @@ set -uo pipefail
 
 ROOT="$(pwd)"
 X0XD="${X0XD:-$ROOT/target/release/x0xd}"
-X0X_USER_KEYGEN="${X0X_USER_KEYGEN:-$ROOT/target/release/x0x-user-keygen}"
+X0X="${X0X:-$ROOT/target/release/x0x}"
 AA="http://127.0.0.1:19911"
 BA="http://127.0.0.1:19912"
 CA="http://127.0.0.1:19913"
@@ -56,8 +56,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [ ! -x "$X0XD" ] || [ ! -x "$X0X_USER_KEYGEN" ]; then
-  echo "Build first: cargo build --release --bin x0xd --bin x0x-user-keygen" >&2
+if [ ! -x "$X0XD" ] || [ ! -x "$X0X" ]; then
+  echo "Build first: cargo build --release --bin x0xd --bin x0x" >&2
   exit 1
 fi
 
@@ -171,7 +171,7 @@ printf "${CYAN}║    Run: $TS                                 ║${NC}\n"
 printf "${CYAN}╚══════════════════════════════════════════════════════════════════╝${NC}\n"
 
 # Generate shared user key so daemons have a common user identity.
-"$X0X_USER_KEYGEN" "$USER_KEY_PATH" >/dev/null
+"$X0X" user-id create "$USER_KEY_PATH" >/dev/null
 
 info "Starting 3 daemons..."
 AP=$(start_daemon "$ADIR" alice 19921 19911 '"127.0.0.1:19922"')

--- a/tests/proof-reports/PHASE_D3_REPORT.md
+++ b/tests/proof-reports/PHASE_D3_REPORT.md
@@ -134,9 +134,12 @@ commit so there is no window of uncommitted state.
 cargo fmt --all -- --check
 cargo clippy --all-features --all-targets -- -D warnings
 cargo nextest run --all-features --workspace
-cargo build --release --bin x0xd --bin x0x --bin x0x-user-keygen
+cargo build --release --bin x0xd --bin x0x
 bash tests/e2e_named_groups.sh > tests/proof-reports/named-groups-d3-run{1,2,3}.log 2>&1
 ```
+
+`x0x-user-keygen` remains buildable from source as a deprecated compatibility shim;
+runtime scripts use the canonical `x0x user-id create` command.
 
 ## Unit + Integration evidence
 

--- a/tests/proof-reports/PHASE_E_REPORT.md
+++ b/tests/proof-reports/PHASE_E_REPORT.md
@@ -175,7 +175,7 @@ cargo clippy --all-features --all-targets -- -D warnings
 cargo test --lib groups::public_message::tests --quiet
 cargo test --test named_group_public_messages --quiet
 cargo test --test named_group_discovery --quiet
-cargo build --release --bin x0xd --bin x0x-user-keygen
+cargo build --release --bin x0xd --bin x0x
 cargo test --test named_group_e_live -- --ignored --nocapture \
   > tests/proof-reports/named-groups-e-live-run1.log 2>&1
 cargo test --test named_group_e_live -- --ignored --nocapture \
@@ -187,6 +187,9 @@ cargo nextest run --test named_group_e_live --run-ignored ignored-only \
 bash tests/e2e_named_groups.sh > \
   tests/proof-reports/named-groups-phasef-clean.log 2>&1
 ```
+
+`x0x-user-keygen` remains buildable from source as a deprecated compatibility shim;
+runtime scripts use the canonical `x0x user-id create` command.
 
 Approved plan: D.3 → C.2 → **E (now landed)** → D.4 → F. C.2
 proof-hardening is now closed; broader final signoff remains under Phase F.


### PR DESCRIPTION
## Summary
- Adds canonical `x0x user-id create [PATH]` CLI support for explicit user identity creation.
- Defaults to `~/.x0x/user.key`, with optional path override.
- Keeps `x0x-user-keygen` buildable from source as a deprecated compatibility shim.
- Updates e2e scripts and identity docs/proof notes to use the canonical command.

## Motivation
User identity already exists in the runtime model, storage layer, announcements, and daemon config, but there was no obvious top-level `x0x` command for users to create the optional user key. The only practical entrypoint was the standalone `x0x-user-keygen` binary, which is not part of the primary CLI surface.

## Completing a Half-Finished Surface
This completes the existing user-identity surface rather than adding a new identity concept. The command writes a loadable `UserKeypair`, and the daemon continues to load it through the existing `user_key_path` mechanism.

## ADR Alignment
ADR 0007 treats Machine, Agent, and User as separate identity layers. Machine and Agent keys are generated automatically by normal setup/runtime paths; User identity remains explicit opt-in. A top-level `x0x user-id create` command makes that opt-in path discoverable while preserving the non-automatic user-key behavior.

## Changes
- Adds `src/cli/commands/user_id.rs` with shared creation logic.
- Adds top-level `x0x user-id create [PATH]` dispatch and help text.
- Reworks `src/bin/x0x-user-keygen.rs` into a deprecated shim delegating to the canonical command.
- Updates e2e scripts to call `x0x user-id create` and require only `x0xd` + `x0x` release binaries.
- Updates identity docs and proof reproduction notes.

## Packaging Note
This does not require shipping a new release artifact. The canonical installed interface is `x0x user-id create`; `x0x-user-keygen` remains source-buildable only for compatibility with existing scripts.

## Overwrite Behavior
The command preserves existing overwrite semantics and makes them explicit in help/docs: an existing file at the target path is overwritten without prompting.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo build --release`
- `HOME=/var/folders/f_/j942sskj6nx67b6gk3rqgsqm0000gn/T/opencode/x0x-nextest-home CARGO_HOME=/Users/jimcollinson/.cargo RUSTUP_HOME=/Users/jimcollinson/.rustup cargo nextest run --all-features --workspace` (`1564 passed`, `130 skipped`)

## Risk
Low. This is a CLI/docs/test-surface change over existing user-key generation and storage primitives; runtime daemon identity loading behavior is unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `x0x user-id create [PATH]` as the canonical top-level CLI entry point for user identity creation, extracting the shared logic into `src/cli/commands/user_id.rs` and reducing `x0x-user-keygen` to a thin delegation shim.

- New `user_id::create` function centralises keypair generation and disk write (inheriting parent-dir creation and 0o600 permissions from `save_user_keypair_to`); a roundtrip unit test verifies the written file is loadable.
- E2e scripts (`e2e_feature_parity.sh`, `e2e_full_audit.sh`, `e2e_named_groups.sh`) drop the `X0X_USER_KEYGEN` variable and replace all invocations with `"$X0X" user-id create "$USER_KEY_PATH"`.
- Docs and proof-report notes updated to reflect the canonical command and deprecation of the standalone binary.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the runtime daemon identity loading path is untouched and all changed code is limited to the CLI surface and test scripts.

The shim in x0x-user-keygen.rs silently changes two observable behaviors — missing-arg now writes to the default path instead of erroring, and stdout output is now a human-readable sentence rather than a bare path. Both differences are small and the binary is deprecated, but a deprecation warning on stderr would make the transition visible to any script authors still using it.

src/bin/x0x-user-keygen.rs — silent behavior change relative to the previous binary worth a second look.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/cli/commands/user_id.rs | New canonical command module — generates a UserKeypair, writes it via the existing save_user_keypair_to helper (parent-dir creation + 0600 perms), and includes a roundtrip loadability test. Logic is clean and correct. |
| src/bin/x0x-user-keygen.rs | Reworked into a thin shim delegating to user_id::create. Behavior change: previously required a path arg (errored without one); now silently defaults to ~/.x0x/user.key. Stdout also changed from bare path to a human-readable message. |
| src/bin/x0x.rs | Adds UserId command and UserIdSub enum; dispatch uses path.clone() correctly since the first match is by &command. Unreachable pattern and help text updated consistently. |
| src/cli/commands/mod.rs | Single-line addition exposing the new user_id module. No issues. |
| tests/e2e_feature_parity.sh | Drops X0X_USER_KEYGEN variable and binary check; replaces invocation with x0x user-id create. Change is clean. |
| tests/e2e_full_audit.sh | Same X0X_USER_KEYGEN → x0x user-id create migration as e2e_feature_parity.sh. Clean. |
| tests/e2e_named_groups.sh | Replaces X0X_USER_KEYGEN with X0X and updates invocation; binary existence check updated accordingly. Clean. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["x0x user-id create [PATH]"] --> B{PATH provided?}
    B -- yes --> C[use supplied path]
    B -- no --> D["default_user_key_path\n~/.x0x/user.key"]
    C --> E[UserKeypair::generate]
    D --> E
    E --> F["save_user_keypair_to\ncreates parent dirs\nsets 0o600 perms"]
    F --> G["println! Created user identity keypair at PATH"]

    H["x0x-user-keygen [PATH] (deprecated shim)"] --> I{PATH provided?}
    I -- yes --> A2["user_id::create(Some(path))"]
    I -- no --> A3["user_id::create(None)"]
    A2 --> E
    A3 --> D
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/bin/x0x-user-keygen.rs:9-13
The shim silently changes two observable behaviors relative to the old binary. Previously, calling `x0x-user-keygen` with no arguments produced a hard error ("usage: x0x-user-keygen <output-path>"); now it quietly writes to `~/.x0x/user.key`. Additionally, the stdout output changed from a bare path string (e.g. `/path/to/user.key`) to a human-readable sentence. Scripts that either rely on the missing-arg error or capture the bare-path output will behave differently without any warning. Printing a deprecation notice to stderr would make the change visible to script authors and is consistent with the "deprecated compatibility shim" framing.

```suggestion
#[tokio::main]
async fn main() -> Result<()> {
    eprintln!(
        "warning: x0x-user-keygen is deprecated; use `x0x user-id create [PATH]` instead."
    );
    let output = std::env::args().nth(1).map(PathBuf::from);
    x0x::cli::commands::user_id::create(output).await
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(cli): cover user-id create command"](https://github.com/saorsa-labs/x0x/commit/915d4c19397d87f216a7312495c8c2d625516978) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34359232)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->