### PR TITLE
[codex] Dogfood x0x GUI and local testnet flows

### DIFF
--- a/docs/adr/0014-treekem-self-leave-owner-driven-rekey.md
+++ b/docs/adr/0014-treekem-self-leave-owner-driven-rekey.md
@@ -1,0 +1,148 @@
+# ADR 0014: TreeKEM Self-Leave Is a Roster Removal; PCS Comes From an Owner-Driven Rekey
+
+- Status: Accepted (2026-06-07). The roster-removal half ships in PR #99
+  (codex/x0x-gui-full-dogfood); the owner responsive-rekey half is the tracked
+  follow-up (see "Implementation").
+- Date: 2026-06-07
+- Amends: [ADR 0012](./0012-treekem-default-secure-groups.md) — refines its
+  acceptance criterion "a removed member provably cannot read the next epoch"
+  for the **self-leave** sub-case.
+
+## Context
+
+PR #99 reworked the TreeKEM self-leave handler (`leave_treekem_group` in
+`src/bin/x0xd.rs`). The previous implementation tried to rekey the group from
+the **leaving member's own** `TreeKemGroup` (`guard.remove_member(local_agent)`)
+and publish the resulting commit. That path could not work:
+
+- `saorsa_mls::TreeKemGroup::remove_member` explicitly rejects self-removal —
+  `treekem_group.rs:454`: `if self.tree.own_leaf() == Some(leaf) { return
+  Err(InvalidGroupState("cannot remove self via remove_member")) }`. This is
+  RFC-9420 behaviour, not a library quirk: **the committer of a Remove cannot be
+  the member being removed.**
+- It also required the group's `TreeKemGroup` to be loaded in `treekem_groups`,
+  returning `FAILED_DEPENDENCY` otherwise.
+
+So pre-PR self-leave typically returned `409 CONFLICT` ("TreeKEM self removal
+failed") — the member could not leave, and **no forward secrecy was ever
+delivered by it**. The "FS/PCS on removal" guarantee in ADR-0012 was always
+carried by **owner/admin removal** (a *remaining* member commits), which still
+works and which PR #99 preserves (`creator_auth` keeps `treekem_commit_b64`).
+
+The reason a leaver cannot rekey themselves is fundamental. A TreeKEM rekey
+provides post-compromise security because the **committer** generates a fresh
+secret down its own direct path (`make_commit` → `generate_update_path` →
+`commit_secret`, `treekem_group.rs:479/495`) that the removed leaf never sees;
+`process_commit` refuses to advance for "the member who was removed". If the
+*leaver* authored that commit, the leaver would know the new epoch secret, so it
+would protect against nobody. **PCS against a departed member requires a
+remaining member to author the rotation.**
+
+PR #99 replaced the broken self-rekey with a reliable **metadata-only** leave: a
+signed `GroupStateCommit` that removes the member from the roster, with
+`treekem_commit_b64: None` and `treekem_epoch: None`. That is the correct first
+half. The consequence to make explicit: because leave now *succeeds* without a
+rotation, the group continues at the same epoch and the departed member retains
+the ability to read future group traffic until something else rekeys.
+
+## Decision
+
+Model self-leave as the MLS **propose → commit** split, with a single,
+well-defined committer:
+
+1. **Self-leave is a signed self-targeted roster removal** (PR #99's behaviour).
+   The leaver publishes a `MemberRemoved` carrying a signed `GroupStateCommit`,
+   `treekem_commit_b64: None`, authorized iff `sender_hex == agent_id &&
+   actor == sender_hex` (the member removing only themselves). The leaver does
+   **not** — and cannot — rekey. This always succeeds locally regardless of
+   whether the TreeKEM group is loaded, so leave is reliable.
+
+2. **The owner issues the responsive rekey.** On applying a self-leave
+   `MemberRemoved`, the group **owner** (a remaining member) issues a
+   `TreeKemGroup::remove_member(leaver_leaf)` commit — the existing admin-remove
+   path — which rotates keys, advances the epoch, and is fanned out to remaining
+   members as a `creator_auth` `MemberRemoved` carrying `treekem_commit_b64`.
+   This is what delivers PCS against the departed member.
+
+3. **Owner-only (single-writer).** Only the owner commits the rekey. This
+   codebase's TreeKEM convergence history (dueling commits / read-modify-write
+   roster clobber, the reason `group_membership_lock` exists) makes a
+   single-writer rotation the safe choice. We **accept** that the owner is a
+   single point of failure for *PCS timing*: if the owner is offline when a
+   member leaves, the rotation is deferred.
+
+4. **Lazy catch-up.** If the owner was offline at leave time, the rekey happens
+   on the owner's next online reconciliation pass / next group commit. The
+   exposure window is bounded by owner availability, not left open indefinitely
+   by design.
+
+5. **Admin/ban removal is unchanged.** Involuntary removal already rekeys (a
+   remaining member commits); PR #99 keeps the `treekem_commit_b64` requirement
+   on that path. No change.
+
+## Security properties
+
+- **Forward secrecy is unaffected.** A self-leaver legitimately held the
+  current and prior epoch secrets; FS is about protecting *past* content from a
+  *future* compromise and is not weakened by how leave is handled.
+- **Post-compromise security against the departed member is delivered by the
+  owner's responsive commit**, not by the leave itself. Between the self-leave
+  and the owner's rekey, the departed member can still read group traffic. This
+  is exactly the window any MLS group has between a Remove **proposal** and its
+  **commit** — bounded and well understood, now made explicit rather than hidden
+  behind a 409.
+- **Honest labelling (ADR-0010/0012 carry-over).** We do not claim self-leave
+  alone provides PCS. The guarantee is "PCS once the owner rekeys"; docs and any
+  status surface must say so.
+
+## Consequences
+
+### Positive
+- Leave actually works (was effectively broken: 409 on the self-remove).
+- Symmetric with admin/ban removal — one rotation mechanism (remaining-member
+  commit), reused, not a second crypto path.
+- Sidesteps the library's correct refusal to self-remove instead of fighting it.
+
+### Negative / cost
+- Owner is a SPOF for PCS *timing*; a permanently-gone owner leaves the group
+  unable to rotate out a self-leaver (see open question).
+- Adds an owner-side "on observed self-leave → issue remove commit" trigger plus
+  its lazy catch-up, with the same ordered-Commit-delivery care ADR-0012
+  Phase 3.5 calls out (epoch N's commit must apply before N+1's).
+
+## Implementation
+
+- **Shipped (PR #99):** metadata-only self-leave (`leave_treekem_group`
+  `LocalOnlyDrop`/`ActiveMember` dispositions; `authorized_treekem_membership_
+  event_for_queue` self-leave branch; apply path `self_leave_auth` →
+  `treekem_payload = None`). This half is safe to merge as-is — it is strictly
+  more correct than the 409 it replaces, provided this ADR records that the
+  rekey is a follow-up.
+- **Follow-up (tracked):** owner responsive rekey on observed self-leave +
+  lazy catch-up, reusing the admin-remove commit path; a test that a self-leaver
+  provably cannot `process_commit` the post-rekey epoch.
+
+## Acceptance criteria
+
+- Self-leave succeeds and removes the member from the roster **even when the
+  owner is offline and even when the leaver's TreeKEM group is not loaded**.
+- On observing a self-leave, the owner issues a `remove_member` commit that
+  advances the epoch; remaining members converge to it (single-writer, no epoch
+  race).
+- A member who self-left provably cannot derive/`process_commit` the
+  post-rekey epoch (the ADR-0012 "removed member cannot read the next epoch"
+  criterion, applied to self-leave).
+- If the owner was offline at leave time, the rekey lands on the owner's next
+  online pass; the deferral is logged, not silent.
+- No production `unwrap`/`expect`/`panic`; fmt + clippy `-D warnings` + nextest
+  green.
+
+## Open questions
+
+1. **Permanently-absent owner.** With owner-only rotation, a group whose owner
+   never returns cannot rekey out a self-leaver and is PCS-frozen at that epoch.
+   Do we (a) accept this (owner is expected to be available, as today for
+   creation/upgrade), or (b) add an "any remaining member, lowest leaf index"
+   fallback after a timeout — which reopens the dueling-commit risk
+   `group_membership_lock` exists to prevent? Lean (a) for now; revisit if
+   ownerless-group resilience becomes a requirement.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ This directory contains architecture decision records for x0x.
 - [ADR 0011: Bootstrap Dual-Listen UDP/443](./0011-bootstrap-dual-listen-udp-443.md) — second root x0xd on :443 per bootstrap host for WARP/full-tunnel-VPN reachability
 - [ADR 0013: Priority-Aware PubSub Receive-Pump Shedding](./0013-priority-aware-pubsub-shed.md) — refines ADR 0009 to shed low-priority PubSub control frames first (renumbered from 0010 to resolve a collision)
 - [ADR 0012: Real TreeKEM as the Default Secure Group Plane](./0012-treekem-default-secure-groups.md) — private `MlsEncrypted` (`Hidden`) groups run real `saorsa_mls::TreeKemGroup` (FS + PCS) by default; **multi-member convergence implemented and shipped in x0x 0.21.0**; legacy GSS groups grandfathered with owner opt-in upgrade; supersedes ADR 0010's forward path
+- [ADR 0014: TreeKEM Self-Leave Is a Roster Removal; PCS Comes From an Owner-Driven Rekey](./0014-treekem-self-leave-owner-driven-rekey.md) — a leaver cannot self-rekey (RFC-9420 / saorsa-mls forbids self-removal), so self-leave is a signed roster removal and the **owner** issues the responsive rekey commit that delivers PCS; owner-only single-writer with lazy catch-up; amends ADR 0012
 
 ## Accepted (Phase 1 Functionally Complete)
 

--- a/docs/design/treekem-self-leave-owner-rekey-scope.md
+++ b/docs/design/treekem-self-leave-owner-rekey-scope.md
@@ -1,0 +1,133 @@
+# Scope: Owner-Driven Rekey on TreeKEM Self-Leave
+
+**Status:** Proposed (follow-up to [ADR-0014](../adr/0014-treekem-self-leave-owner-driven-rekey.md))
+**Created:** 2026-06-07
+**Owner:** unassigned
+**Decision basis:** ADR-0014 (accepted). This doc scopes the *second half* — the
+owner responsive rekey. The *first half* (metadata-only self-leave) shipped in
+PR #99.
+
+## Problem
+
+After PR #99, a TreeKEM self-leave reliably removes the member from the roster
+but performs **no key rotation**, so the departed member can still decrypt the
+group's current epoch traffic until some unrelated event rekeys. A leaver cannot
+rekey themselves (RFC-9420 / `saorsa_mls::TreeKemGroup::remove_member`
+`treekem_group.rs:454` rejects self-removal). PCS must be delivered by a
+**remaining** member — per ADR-0014, the **owner**.
+
+## Goal / success criteria
+
+1. When the owner observes a self-leave `MemberRemoved` for a TreeKEM group it
+   owns, it issues a `remove_member` commit that advances the epoch and is
+   fanned out to remaining members.
+2. A daemon that self-left **provably cannot** `process_commit` / decrypt the
+   post-rekey epoch (the ADR-0012 "removed member cannot read next epoch"
+   criterion, applied to self-leave).
+3. Remaining members converge to the new epoch (single-writer, no epoch race).
+4. If the owner was **offline** at leave time, the rekey lands on the owner's
+   next online reconciliation pass; the deferral is logged, not silent.
+5. Owner-only: a non-owner member that observes a self-leave updates its roster
+   and **waits** — it must not attempt a rekey.
+6. fmt + clippy `-D warnings` + nextest green; no `unwrap`/`expect`/`panic` in
+   prod paths.
+
+## Design
+
+### Trigger (owner online)
+In `apply_named_group_metadata_event_inner` (`src/bin/x0xd.rs`), `MemberRemoved`
+arm, the `self_leave_auth` branch (~`x0xd.rs:8284-8332`). After the roster
+removal is applied and persisted:
+
+- Guard: `info.secure_plane == TreeKem` **and** `local_agent == info.creator`
+  (we are the owner) **and** `agent_id != local_agent_hex` (not our own leave —
+  the owner can't self-leave anyway; that path is `CreatorMustDelete`).
+- Load `state.treekem_groups[id]`, lock, call the x0x wrapper
+  `guard.remove_member(leaver_agent_id)` — the same call the **admin/creator
+  remove** path uses (the wrapper maps `AgentId → leaf` and, since the leaver is
+  not the owner, the self-removal guard does not fire). This yields a
+  `TreeKemCommit` and advances `guard.epoch()`.
+- Build a follow-up `MemberRemoved` with `actor = creator_hex`, `agent_id =
+  leaver`, `treekem_commit_b64 = Some(encode(commit))`, `treekem_epoch =
+  Some(new_epoch)`, signed `GroupStateCommit` (owner-sealed), and publish it via
+  the existing `publish_named_group_metadata_event`. This reuses the
+  `creator_auth` apply path verbatim — remaining members apply it as a normal
+  admin-removal rekey.
+- All of the above under the per-group `group_membership_lock` (single-writer;
+  prevents the dueling-commit / RMW clobber class — see
+  `treekem_multimember_fix_2026_06_03`).
+
+### Catch-up (owner was offline)
+- When the owner applies a self-leave but cannot rekey immediately (e.g. the
+  TreeKEM group isn't loaded yet at startup, or it's mid-reconciliation), record
+  the group in a **pending-rekey set** (persisted alongside named-group state).
+- On the owner's reconciliation pass (startup + the existing periodic group
+  reconcile), drain the pending-rekey set: for each group, detect members
+  present in the TreeKEM tree but absent from the active roster and issue the
+  rekey commit (same path as the online trigger). Log each deferred rekey when
+  queued and when drained.
+- Detection signal: roster active-member set vs. TreeKEM tree leaf occupancy, or
+  a simple `secret_epoch < roster_revision`-style marker — pick one and make it
+  the single source of truth; document it.
+
+### Ordered delivery (do not regress ADR-0012 Phase 3.5)
+The rekey is an epoch N→N+1 Commit. It MUST reach all remaining members and be
+applied in order. Reuse the group's existing Commit-delivery path; do not invent
+a parallel one. A member behind by a commit recovers via the existing
+catch-up/anti-entropy already built for TreeKEM membership.
+
+## Affected files (expected)
+
+- `src/bin/x0xd.rs` — `apply_named_group_metadata_event_inner` `MemberRemoved`
+  self-leave branch (trigger); owner reconciliation pass (catch-up drain);
+  pending-rekey persistence.
+- `src/groups/` (or `src/mls/treekem.rs`) — only if the `AgentId → leaf` remove
+  wrapper or a "rekey-removed-member" helper needs to be exposed; prefer reusing
+  the existing creator/admin-remove helper.
+- Persistence for the pending-rekey set (same `0600` model as other named-group
+  state; ADR-0012 decision #6).
+
+## Edge cases
+
+- **Owner self-leave:** impossible — `TreeKemLeaveDisposition::CreatorMustDelete`
+  forces delete, so the owner is always a remaining member when a self-leave
+  occurs. Simplifies the design (no "owner left, who rekeys" race here).
+- **Leaver already not in tree** (`LocalOnlyDrop` / pending stub): no rekey
+  needed; skip.
+- **Concurrent self-leaves:** owner processes serially under
+  `group_membership_lock`; each leave gets its own epoch bump (or batch into one
+  commit removing multiple leaves — decide; batching is fewer epochs but must
+  still be ordered).
+- **Non-owner observers:** roster-update only; never rekey.
+- **Owner permanently absent:** out of scope (ADR-0014 open question — group is
+  PCS-frozen; accepted for now).
+
+## Test plan (Rule 9 — encode intent)
+
+1. **Unit** (`x0xd.rs` tests): owner applying a self-leave `MemberRemoved`
+   emits a `creator_auth` follow-up with `treekem_commit_b64: Some` and an
+   advanced epoch; a non-owner applying the same self-leave emits nothing.
+2. **Integration** (3 daemons — owner + member A + member B; use
+   `trio_with_extra_config("")`, not the leaky `cluster()` singleton — see
+   `treekem_multimember_fix_2026_06_03`):
+   - Member A self-leaves.
+   - Assert owner's `secret_epoch` advances and member B converges to it.
+   - Assert member A (departed) **cannot decrypt** a message owner sends at the
+     new epoch (`process_commit` / decrypt fails). **This is the PCS assertion**
+     and the test that must fail on the pre-rekey behaviour.
+3. **Offline-owner**: owner down when A leaves; bring owner up; assert the rekey
+   lands on reconciliation and B converges; A still locked out.
+
+## Risks
+
+- **Convergence races** — mitigated by owner-only + `group_membership_lock`.
+- **Missed-commit recovery** — reuse existing TreeKEM catch-up; do not fork it.
+- **Test flake** — TreeKEM multi-member tests are historically flaky; use the
+  non-singleton trio harness and the `treekem.trace` instrumentation.
+
+## Out of scope
+
+- Ownerless-group PCS (ADR-0014 open question).
+- Any change to admin/ban removal (already rekeys correctly).
+- The Dioxus-hook pubsub delivery op (separate communitas-repo follow-up; see
+  the note in `tests/e2e_communitas_dioxus.sh`).

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -13,7 +13,22 @@ open examples/apps/x0x-chat.html      # macOS
 xdg-open examples/apps/x0x-chat.html  # Linux
 ```
 
-The apps connect to `http://localhost:12700` by default. If x0xd is running on a different port, edit the `API_URL` constant at the top of each file.
+The apps connect to `http://localhost:12700` by default. To target another daemon without editing files, pass `api` and `token` query parameters:
+
+```text
+x0x-chat.html?api=http://127.0.0.1:51555&token=<api-token>
+```
+
+The apps remember those values in `localStorage` as `x0x.apiBase` and `x0x.apiToken`. WebSocket apps derive their `ws://.../ws?token=...` endpoint from the configured API base.
+
+When using an authenticated daemon from a browser, serve these files from a loopback HTTP origin so the daemon CORS policy can allow the request:
+
+```bash
+cd examples/apps
+python3 -m http.server 8080 --bind 127.0.0.1
+```
+
+Then open `http://127.0.0.1:8080/x0x-chat.html?api=http://127.0.0.1:12700&token=<api-token>`.
 
 ## Apps
 

--- a/examples/apps/x0x-board.html
+++ b/examples/apps/x0x-board.html
@@ -112,11 +112,16 @@ header h1 span { color: var(--cyan); }
 </div>
 
 <script>
-const API_URL = "http://localhost:12700";
+const CONFIG = new URLSearchParams(location.search);
+const API_URL = (CONFIG.get("api") || localStorage.getItem("x0x.apiBase") || "http://localhost:12700").replace(/\/$/, "");
+const API_TOKEN = CONFIG.get("token") || localStorage.getItem("x0x.apiToken") || "";
+if (CONFIG.get("api")) localStorage.setItem("x0x.apiBase", API_URL);
+if (CONFIG.get("token")) localStorage.setItem("x0x.apiToken", API_TOKEN);
 let boardId = null, agentId = "", pollTimer = null, knownIds = new Set();
 
 async function api(path, opts = {}) {
-  const r = await fetch(API_URL + path, { ...opts, headers: { "Content-Type": "application/json", ...opts.headers } });
+  const headers = { "Content-Type": "application/json", ...(API_TOKEN ? { Authorization: "Bearer " + API_TOKEN } : {}), ...opts.headers };
+  const r = await fetch(API_URL + path, { ...opts, headers });
   return r.json();
 }
 function truncate(id) { return id ? id.slice(0, 8) + "…" : ""; }
@@ -178,12 +183,14 @@ function openBoard(id, name) {
   document.getElementById("newTask").addEventListener("keydown", e => { if (e.key === "Enter") addTask(); });
 }
 
+function normState(state) { return String(state || "").toLowerCase(); }
+
 function renderCard(t, colState) {
   const isNew = !knownIds.has(t.id); knownIds.add(t.id);
   const assignee = t.assignee || "";
   let btn = "";
-  if (colState === "Empty") btn = '<button class="card-btn claim" onclick="claimTask(\'' + t.id + "')\">" + "Claim</button>";
-  else if (colState === "Claimed") btn = '<button class="card-btn done" onclick="completeTask(\'' + t.id + "')\">" + "Done</button>";
+  if (colState === "empty") btn = '<button class="card-btn claim" onclick="claimTask(\'' + t.id + "')\">" + "Claim</button>";
+  else if (colState === "claimed") btn = '<button class="card-btn done" onclick="completeTask(\'' + t.id + "')\">" + "Done</button>";
   return '<div class="card' + (isNew ? " entering" : "") + '">' +
     '<div class="card-title">' + esc(t.title || "Untitled") + "</div>" +
     (t.description ? '<div class="card-desc">' + esc(t.description) + "</div>" : "") +
@@ -195,12 +202,12 @@ async function refresh() {
   try {
     const res = await api("/task-lists/" + boardId + "/tasks");
     const tasks = res.tasks || [];
-    const todo = tasks.filter(t => t.state === "Empty");
-    const prog = tasks.filter(t => t.state === "Claimed");
-    const done = tasks.filter(t => t.state === "Done");
-    document.getElementById("todoCards").innerHTML = todo.map(t => renderCard(t, "Empty")).join("");
-    document.getElementById("progressCards").innerHTML = prog.map(t => renderCard(t, "Claimed")).join("");
-    document.getElementById("doneCards").innerHTML = done.map(t => renderCard(t, "Done")).join("");
+    const todo = tasks.filter(t => normState(t.state) === "empty");
+    const prog = tasks.filter(t => normState(t.state).startsWith("claimed"));
+    const done = tasks.filter(t => normState(t.state).startsWith("done") || normState(t.state).startsWith("completed"));
+    document.getElementById("todoCards").innerHTML = todo.map(t => renderCard(t, "empty")).join("");
+    document.getElementById("progressCards").innerHTML = prog.map(t => renderCard(t, "claimed")).join("");
+    document.getElementById("doneCards").innerHTML = done.map(t => renderCard(t, "done")).join("");
     document.getElementById("countTodo").textContent = todo.length + " to do";
     document.getElementById("countProgress").textContent = prog.length + " in progress";
     document.getElementById("countDone").textContent = done.length + " done";
@@ -216,7 +223,7 @@ async function addTask() {
   const title = input.value.trim();
   if (!title || !boardId) return;
   input.value = "";
-  await api("/task-lists/" + boardId + "/tasks", { method: "POST", body: JSON.stringify({ title }) });
+  await api("/task-lists/" + boardId + "/tasks", { method: "POST", body: JSON.stringify({ title, description: "" }) });
   refresh();
 }
 

--- a/examples/apps/x0x-chat.html
+++ b/examples/apps/x0x-chat.html
@@ -132,8 +132,12 @@ header {
 </div>
 
 <script>
-const API_URL = "http://localhost:12700";
-const WS_URL = "ws://localhost:12700/ws";
+const CONFIG = new URLSearchParams(location.search);
+const API_URL = (CONFIG.get("api") || localStorage.getItem("x0x.apiBase") || "http://localhost:12700").replace(/\/$/, "");
+const API_TOKEN = CONFIG.get("token") || localStorage.getItem("x0x.apiToken") || "";
+if (CONFIG.get("api")) localStorage.setItem("x0x.apiBase", API_URL);
+if (CONFIG.get("token")) localStorage.setItem("x0x.apiToken", API_TOKEN);
+const WS_URL = API_URL.replace(/^http/, "ws") + "/ws" + (API_TOKEN ? "?token=" + encodeURIComponent(API_TOKEN) : "");
 
 const DEFAULT_ROOM = "x0x-chat/general";
 const RECONNECT_MS = 3000;

--- a/examples/apps/x0x-drop.html
+++ b/examples/apps/x0x-drop.html
@@ -90,8 +90,12 @@ input[type=file]{display:none}
   </div>
 </main>
 <script>
-const API_URL = "http://localhost:12700";
-let selectedAgent = null, chosenFile = null, fileHash = null;
+const CONFIG = new URLSearchParams(location.search);
+const API_URL = (CONFIG.get("api") || localStorage.getItem("x0x.apiBase") || "http://localhost:12700").replace(/\/$/, "");
+const API_TOKEN = CONFIG.get("token") || localStorage.getItem("x0x.apiToken") || "";
+if (CONFIG.get("api")) localStorage.setItem("x0x.apiBase", API_URL);
+if (CONFIG.get("token")) localStorage.setItem("x0x.apiToken", API_TOKEN);
+let selectedAgent = null, chosenFile = null, fileHash = null, fileDataB64 = null, myAgentId = null;
 
 function trunc(s, n) { n = n || 12; return s ? s.slice(0, n) + "…" : "—"; }
 function fmtSize(b) {
@@ -100,14 +104,36 @@ function fmtSize(b) {
   return (b / 1073741824).toFixed(2) + " GB";
 }
 function esc(s) { const d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
-async function api(path, opts) { try { const r = await fetch(API_URL + path, opts); return await r.json(); } catch { return null; } }
+function arrayBufferToBase64(buf) {
+  const bytes = new Uint8Array(buf);
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    out += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+  }
+  return btoa(out);
+}
+async function api(path, opts = {}) {
+  try {
+    const headers = { ...(API_TOKEN ? { Authorization: "Bearer " + API_TOKEN } : {}), ...opts.headers };
+    const r = await fetch(API_URL + path, { ...opts, headers });
+    return await r.json();
+  } catch {
+    return null;
+  }
+}
 
 async function checkHealth() {
   const d = await api("/health");
   const on = d && d.ok !== undefined;
   document.getElementById("conn-dot").className = "dot" + (on ? " on" : "");
   document.getElementById("conn-label").textContent = on ? "Connected" : "Disconnected";
-  if (on) { const a = await api("/agent"); if (a && a.agent_id) document.getElementById("my-id").textContent = trunc(a.agent_id, 16); }
+  if (on) {
+    const a = await api("/agent");
+    if (a && a.agent_id) {
+      myAgentId = a.agent_id;
+      document.getElementById("my-id").textContent = trunc(a.agent_id, 16);
+    }
+  }
   return on;
 }
 
@@ -115,8 +141,9 @@ let agents = [];
 async function fetchAgents() {
   const d = await api("/agents/discovered");
   const el = document.getElementById("agent-list");
-  if (!d || !d.agents || !d.agents.length) { el.innerHTML = '<div class="empty">No agents discovered</div>'; agents = []; return; }
-  agents = d.agents;
+  agents = ((d && d.agents) || []).filter(a => a.agent_id && a.agent_id !== myAgentId);
+  if (!agents.length) { el.innerHTML = '<div class="empty">No remote agents discovered</div>'; selectedAgent = null; updateSendBtn(); return; }
+  if (selectedAgent && !agents.some(a => a.agent_id === selectedAgent)) selectedAgent = null;
   el.innerHTML = agents.map(a => {
     const sel = selectedAgent === a.agent_id ? " sel" : "";
     const trust = a.trust_level || "Unknown";
@@ -135,25 +162,26 @@ dz.addEventListener("drop", ev => { if (ev.dataTransfer.files.length) handleFile
 document.getElementById("fileIn").addEventListener("change", ev => { if (ev.target.files.length) handleFile(ev.target.files[0]); });
 
 async function handleFile(f) {
-  chosenFile = f; fileHash = null;
+  chosenFile = f; fileHash = null; fileDataB64 = null;
   dz.classList.add("has-file");
   dz.innerHTML = '<div class="file-info"><div style="font-size:2.5em;margin-bottom:8px">&#128196;</div><div class="fname">' + esc(f.name) + '</div><div class="fsize">' + fmtSize(f.size) + '</div><div class="fhash mono">Hashing…</div></div>';
   const buf = await f.arrayBuffer();
   const hash = await crypto.subtle.digest("SHA-256", buf);
   fileHash = Array.from(new Uint8Array(hash)).map(b => b.toString(16).padStart(2, "0")).join("");
+  fileDataB64 = arrayBufferToBase64(buf);
   dz.querySelector(".fhash").textContent = "SHA-256: " + fileHash.slice(0, 16) + "…";
   updateSendBtn();
 }
-function updateSendBtn() { document.getElementById("send-btn").style.display = (chosenFile && fileHash && selectedAgent) ? "" : "none"; }
+function updateSendBtn() { document.getElementById("send-btn").style.display = (chosenFile && fileHash && fileDataB64 && selectedAgent) ? "" : "none"; }
 
 async function sendFile() {
-  if (!chosenFile || !fileHash || !selectedAgent) return;
+  if (!chosenFile || !fileHash || !fileDataB64 || !selectedAgent) return;
   const btn = document.getElementById("send-btn");
   btn.textContent = "Sending…"; btn.style.pointerEvents = "none";
-  const d = await api("/files/send", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ agent_id: selectedAgent, filename: chosenFile.name, size: chosenFile.size, sha256: fileHash }) });
+  const d = await api("/files/send", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ agent_id: selectedAgent, filename: chosenFile.name, size: chosenFile.size, sha256: fileHash, data_b64: fileDataB64 }) });
   btn.textContent = "Send File"; btn.style.pointerEvents = "";
   if (d && d.transfer_id) {
-    chosenFile = null; fileHash = null; selectedAgent = null;
+    chosenFile = null; fileHash = null; fileDataB64 = null; selectedAgent = null;
     dz.classList.remove("has-file");
     dz.innerHTML = '<div class="drop-icon">&#8693;</div><div class="drop-text">Drop files here or click to select</div>';
     updateSendBtn(); fetchAgents();

--- a/examples/apps/x0x-network.html
+++ b/examples/apps/x0x-network.html
@@ -107,7 +107,11 @@ tr:hover td { background: rgba(0,212,255,0.03); }
   </div>
 </div>
 <script>
-const API_URL = "http://localhost:12700";
+const CONFIG = new URLSearchParams(location.search);
+const API_URL = (CONFIG.get("api") || localStorage.getItem("x0x.apiBase") || "http://localhost:12700").replace(/\/$/, "");
+const API_TOKEN = CONFIG.get("token") || localStorage.getItem("x0x.apiToken") || "";
+if (CONFIG.get("api")) localStorage.setItem("x0x.apiBase", API_URL);
+if (CONFIG.get("token")) localStorage.setItem("x0x.apiToken", API_TOKEN);
 const POLL_MS = 3000;
 let online = false;
 
@@ -134,7 +138,11 @@ function copyId(el) {
   const t = el.textContent; if (!t || t === "--") return;
   navigator.clipboard.writeText(t).then(() => { $("toast").classList.add("show"); setTimeout(() => $("toast").classList.remove("show"), 1200); });
 }
-async function api(path) { const r = await fetch(API_URL + path, { signal: AbortSignal.timeout(2500) }); return r.json(); }
+async function api(path) {
+  const headers = API_TOKEN ? { Authorization: "Bearer " + API_TOKEN } : {};
+  const r = await fetch(API_URL + path, { headers, signal: AbortSignal.timeout(2500) });
+  return r.json();
+}
 function setOnline(v) { if (v === online) return; online = v; $("offline").style.display = v ? "none" : "flex"; $("app").style.display = v ? "block" : "none"; }
 
 async function poll() {

--- a/examples/apps/x0x-swarm.html
+++ b/examples/apps/x0x-swarm.html
@@ -91,8 +91,12 @@ textarea:focus,input:focus{outline:none;border-color:var(--cyan)}
   </div>
 </main>
 <script>
-const API_URL = "http://localhost:12700";
-const WS_URL = "ws://localhost:12700/ws";
+const CONFIG = new URLSearchParams(location.search);
+const API_URL = (CONFIG.get("api") || localStorage.getItem("x0x.apiBase") || "http://localhost:12700").replace(/\/$/, "");
+const API_TOKEN = CONFIG.get("token") || localStorage.getItem("x0x.apiToken") || "";
+if (CONFIG.get("api")) localStorage.setItem("x0x.apiBase", API_URL);
+if (CONFIG.get("token")) localStorage.setItem("x0x.apiToken", API_TOKEN);
+const WS_URL = API_URL.replace(/^http/, "ws") + "/ws" + (API_TOKEN ? "?token=" + encodeURIComponent(API_TOKEN) : "");
 
 let ws = null, connected = false, myAgentId = null, sessionId = null, taskListId = null;
 let myTasks = [], feedEvents = [], agents = new Map(), taskMap = new Map();
@@ -103,6 +107,8 @@ function ago(ts) { const s = Math.floor((Date.now() - ts) / 1000); if (s < 5) re
 function b64e(obj) { return btoa(JSON.stringify(obj)); }
 function b64d(s) { try { return JSON.parse(atob(s)); } catch { return null; } }
 function esc(s) { if (!s) return ""; const d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
+function taskTopic() { return "x0x-swarm/" + sessionId + "/tasks"; }
+function resultTopic() { return "x0x-swarm/" + sessionId + "/results"; }
 
 function initSession() {
   const hash = location.hash.slice(1);
@@ -124,7 +130,7 @@ function setStatus(ok, msg) {
 }
 
 async function api(method, path, body) {
-  const opts = { method, headers: { "Content-Type": "application/json" } };
+  const opts = { method, headers: { "Content-Type": "application/json", ...(API_TOKEN ? { Authorization: "Bearer " + API_TOKEN } : {}) } };
   if (body) opts.body = JSON.stringify(body);
   const r = await fetch(API_URL + path, opts);
   if (!r.ok) throw new Error(r.status + " " + r.statusText);
@@ -138,7 +144,7 @@ async function init() {
     const info = await api("GET", "/agent");
     myAgentId = info.agent_id || "unknown";
     document.getElementById("agentLabel").innerHTML = 'You: <code class="mono">' + shortId(myAgentId) + "</code>";
-    setStatus(true, "Connected to x0xd");
+    setStatus(false, "Opening websocket");
     await ensureTaskList();
     connectWs();
     pollLoop();
@@ -166,16 +172,21 @@ function connectWs() {
   if (ws) try { ws.close(); } catch (e) { /* ignore */ }
   ws = new WebSocket(WS_URL);
   ws.onopen = () => {
-    ws.send(JSON.stringify({ type: "subscribe", topics: ["x0x-swarm/tasks", "x0x-swarm/results"] }));
-    setStatus(true, "Connected");
+    setStatus(false, "Subscribing");
   };
   ws.onmessage = ev => {
     const msg = JSON.parse(ev.data);
-    if (msg.type === "message") {
+    if (msg.type === "connected") {
+      myAgentId = msg.agent_id || myAgentId;
+      document.getElementById("agentLabel").innerHTML = 'You: <code class="mono">' + shortId(myAgentId) + "</code>";
+      ws.send(JSON.stringify({ type: "subscribe", topics: [taskTopic(), resultTopic()] }));
+    } else if (msg.type === "subscribed") {
+      setStatus(true, "Connected");
+    } else if (msg.type === "message") {
       const data = b64d(msg.payload);
       if (!data) return;
-      if (msg.topic === "x0x-swarm/tasks") handleTaskEvent(data, msg.origin);
-      if (msg.topic === "x0x-swarm/results") handleResultEvent(data, msg.origin);
+      if (msg.topic === taskTopic()) handleTaskEvent(data, msg.origin);
+      if (msg.topic === resultTopic()) handleResultEvent(data, msg.origin);
     }
   };
   ws.onclose = () => { setStatus(false, "Disconnected"); setTimeout(connectWs, 3000); };
@@ -233,7 +244,7 @@ async function submitTask() {
   const taskId = genId(8);
   const task = { task_id: taskId, description: desc, capability: cap || null, requester: myAgentId, timestamp: Date.now() };
   if (taskListId) { try { await api("POST", "/task-lists/" + taskListId + "/tasks", { title: desc }); } catch (e) { /* ok */ } }
-  wsPub("x0x-swarm/tasks", { ...task, event: "posted" });
+  wsPub(taskTopic(), { ...task, event: "posted" });
   myTasks.unshift({ ...task, state: "pending", ts: Date.now() });
   taskMap.set(taskId, { ...task, state: "pending", ts: Date.now() });
   addFeedEvent("posted", '<span class="agent">' + shortId(myAgentId) + "</span> posted" + (cap ? ' <span class="tag tag-pending">' + esc(cap) + "</span>" : "") + '<div style="margin-top:.25rem;color:var(--text)">' + esc(desc) + "</div>");

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -7913,17 +7913,27 @@ async fn apply_named_group_metadata_event_inner(
     );
     // The transport `verified` flag asserts the sender's AgentId→MachineId
     // binding is in our identity-discovery cache — a best-effort annotation
-    // populated asynchronously from gossip announcements. A terminal
-    // `GroupDeleted` carries a self-authenticating ML-DSA-signed state commit
-    // (`validate_apply` → `verify_structure` proves the signer authored it and
-    // is the group Owner), so its authority does not depend on that cache. The
-    // delete is also one-shot — the creator stops its metadata listener and
-    // drops the group immediately, leaving no anti-entropy source — so unlike
-    // membership events it cannot recover from a transient unverified drop.
-    // Let it through; authority is re-checked from the signed commit below.
+    // populated asynchronously from gossip announcements. Both a terminal
+    // `GroupDeleted` and a `MemberRemoved` carry a self-authenticating
+    // ML-DSA-signed state commit (`validate_apply` → `verify_structure` proves
+    // the signer authored it), so their authority does not depend on that
+    // cache. Both are also delivery-critical to a peer that is not (or no
+    // longer) in the metadata-topic eager mesh and cannot be backfilled by the
+    // single gossip broadcast: the deleted group's members, and — for removal —
+    // the *removed member itself*, which is direct-delivered the commit so it
+    // learns it was cut from the roster. A transient unverified drop of either
+    // is unrecoverable, so let them through; the apply arms below re-check
+    // authority from the signed commit (GroupDeleted: OwnerOnly via
+    // `commit.committed_by`; MemberRemoved: creator/self auth + signed-commit
+    // validation). The authenticated DM `sender_hex` is reliable regardless of
+    // the cache, so bypassing `verified` does not weaken membership
+    // authorization — only the racy cache annotation is skipped.
     let bypass_verified = matches!(
         event,
         NamedGroupMetadataEvent::GroupDeleted {
+            commit: Some(_),
+            ..
+        } | NamedGroupMetadataEvent::MemberRemoved {
             commit: Some(_),
             ..
         }

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -2597,6 +2597,16 @@ fn file_transfer_send_config() -> x0x::dm::DmSendConfig {
     config
 }
 
+fn file_transfer_control_send_config() -> x0x::dm::DmSendConfig {
+    let mut config = file_transfer_send_config();
+    // Offer/accept/reject/complete are low-volume control messages. They must
+    // not be fire-and-forget: a stale raw connection can otherwise report local
+    // send success while the peer never updates transfer state.
+    config.raw_quic_receive_ack_timeout = Some(Duration::from_secs(8));
+    config.stop_fallback_on_raw_error = false;
+    config
+}
+
 /// Maximum number of file chunks a sender may have in flight (sent but
 /// not yet acked) at any time. Caps the broadcast/queue pressure that
 /// caused the 100M chunk-loss regression on 2026-04-30 — the previous
@@ -2710,7 +2720,7 @@ async fn send_file_message(
     let payload = serde_json::to_vec(msg).map_err(|e| format!("serialization failed: {e}"))?;
     state
         .agent
-        .send_direct_with_config(agent_id, payload, file_transfer_send_config())
+        .send_direct_with_config(agent_id, payload, file_transfer_control_send_config())
         .await
         .map_err(|e| e.to_string())
 }
@@ -2740,7 +2750,11 @@ async fn file_send_handler(
         .unwrap_or("unnamed");
     let size = body.get("size").and_then(|v| v.as_u64()).unwrap_or(0);
     let sha256 = body.get("sha256").and_then(|v| v.as_str()).unwrap_or("");
-    let source_path = body.get("path").and_then(|v| v.as_str()).unwrap_or("");
+    let mut source_path = body
+        .get("path")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
 
     if agent_id_hex.is_empty() || sha256.is_empty() {
         return (
@@ -2762,6 +2776,66 @@ async fn file_send_handler(
     let transfer_id = uuid::Uuid::new_v4().to_string();
     let (now_secs, now_ms) = file_transfer_now();
 
+    if source_path.is_empty() {
+        if let Some(data_b64) = body
+            .get("data_b64")
+            .or_else(|| body.get("data_base64"))
+            .and_then(|v| v.as_str())
+        {
+            let data = match base64::engine::general_purpose::STANDARD.decode(data_b64) {
+                Ok(data) => data,
+                Err(e) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "ok": false,
+                            "error": format!("invalid data_b64: {e}")
+                        })),
+                    );
+                }
+            };
+            if data.len() as u64 != size {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "ok": false,
+                        "error": "data_b64 length does not match size"
+                    })),
+                );
+            }
+            let actual_sha = hex::encode(Sha256::digest(&data));
+            if !sha256.eq_ignore_ascii_case(&actual_sha) {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "ok": false,
+                        "error": "data_b64 sha256 mismatch"
+                    })),
+                );
+            }
+            if let Err(e) = tokio::fs::create_dir_all(&state.transfers_dir).await {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "ok": false,
+                        "error": format!("failed to create transfer spool: {e}")
+                    })),
+                );
+            }
+            let spool_path = state.transfers_dir.join(format!("{transfer_id}.send"));
+            if let Err(e) = tokio::fs::write(&spool_path, data).await {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "ok": false,
+                        "error": format!("failed to spool upload: {e}")
+                    })),
+                );
+            }
+            source_path = spool_path.to_string_lossy().into_owned();
+        }
+    }
+
     let chunk_size = x0x::files::DEFAULT_CHUNK_SIZE;
     let total_chunks = x0x::files::total_chunks_for_size(size, chunk_size);
 
@@ -2781,7 +2855,7 @@ async fn file_send_handler(
         source_path: if source_path.is_empty() {
             None
         } else {
-            Some(source_path.to_string())
+            Some(source_path)
         },
         output_path: None,
         chunk_size,
@@ -7349,10 +7423,20 @@ fn authorized_treekem_membership_event_for_queue(
             actor,
             agent_id,
             commit: Some(_),
-            treekem_commit_b64: Some(_),
-            treekem_epoch: Some(_),
+            treekem_commit_b64,
+            treekem_epoch,
             ..
-        } => (sender_hex == creator_hex || sender_hex == agent_id) && actor == sender_hex,
+        } => {
+            let creator_remove = sender_hex == creator_hex
+                && actor == sender_hex
+                && treekem_commit_b64.is_some()
+                && treekem_epoch.is_some();
+            let self_leave = sender_hex == agent_id
+                && actor == sender_hex
+                && treekem_commit_b64.is_none()
+                && treekem_epoch.is_none();
+            creator_remove || self_leave
+        }
         NamedGroupMetadataEvent::MemberBanned {
             actor,
             agent_id,
@@ -7827,7 +7911,24 @@ async fn apply_named_group_metadata_event_inner(
         verified,
         allow_queue,
     );
-    if !verified {
+    // The transport `verified` flag asserts the sender's AgentId→MachineId
+    // binding is in our identity-discovery cache — a best-effort annotation
+    // populated asynchronously from gossip announcements. A terminal
+    // `GroupDeleted` carries a self-authenticating ML-DSA-signed state commit
+    // (`validate_apply` → `verify_structure` proves the signer authored it and
+    // is the group Owner), so its authority does not depend on that cache. The
+    // delete is also one-shot — the creator stops its metadata listener and
+    // drops the group immediately, leaving no anti-entropy source — so unlike
+    // membership events it cannot recover from a transient unverified drop.
+    // Let it through; authority is re-checked from the signed commit below.
+    let bypass_verified = matches!(
+        event,
+        NamedGroupMetadataEvent::GroupDeleted {
+            commit: Some(_),
+            ..
+        }
+    );
+    if !verified && !bypass_verified {
         tracing::debug!(
             target: "treekem.trace",
             stage = "apply_metadata_event_reject",
@@ -8186,13 +8287,20 @@ async fn apply_named_group_metadata_event_inner(
                 x0x::groups::ActionKind::AdminOrHigher
             };
             let treekem_payload = if info.secure_plane == x0x::mls::SecureGroupPlane::TreeKem {
-                let Some(commit_b64) = treekem_commit_b64 else {
-                    return false;
-                };
-                let Some(epoch) = treekem_epoch else {
-                    return false;
-                };
-                Some((commit_b64, epoch))
+                if self_leave_auth {
+                    if treekem_commit_b64.is_some() || treekem_epoch.is_some() {
+                        return false;
+                    }
+                    None
+                } else {
+                    let Some(commit_b64) = treekem_commit_b64 else {
+                        return false;
+                    };
+                    let Some(epoch) = treekem_epoch else {
+                        return false;
+                    };
+                    Some((commit_b64, epoch))
+                }
             } else {
                 None
             };
@@ -8297,11 +8405,22 @@ async fn apply_named_group_metadata_event_inner(
             let Some(commit) = commit else {
                 return false;
             };
-            if sender_hex != creator_hex || actor != sender_hex {
+            // Authority comes from the signed commit, not the transport
+            // sender. `validate_apply` (below) verifies the ML-DSA signature
+            // and that the signer (`commit.committed_by`) holds the Owner role
+            // — `OwnerOnly`. The `actor` field is advisory metadata, so we only
+            // require it to name the cryptographically-verified signer; we do
+            // *not* gate on `sender_hex`, which is the relaying/transport peer
+            // (wrong for gossip-relayed copies) and unreliable for an
+            // unverified direct delete. The signer must be this group's
+            // creator, preserving the original creator-only delete semantics.
+            // This lets a creator's terminal delete apply on a joiner whose
+            // identity-discovery cache hasn't yet bound the creator's AgentId.
+            if actor != commit.committed_by || commit.committed_by != creator_hex {
                 return false;
             }
             let current = info.clone();
-            if apply_stateful_event_to_group(
+            if let Err(e) = apply_stateful_event_to_group(
                 &current,
                 &commit,
                 x0x::groups::ActionKind::OwnerOnly,
@@ -8309,9 +8428,16 @@ async fn apply_named_group_metadata_event_inner(
                     next.roster_revision = revision.max(next.roster_revision);
                     next.updated_at = commit.committed_at;
                 },
-            )
-            .is_err()
-            {
+            ) {
+                tracing::debug!(
+                    target: "treekem.trace",
+                    stage = "apply_metadata_event_reject",
+                    reason = "group_deleted_state_commit_apply_failed",
+                    error = %e,
+                    event = event_kind,
+                    group_id = %resolved_group_key,
+                    sender = %sender_hex,
+                );
                 return false;
             }
             state.named_groups.write().await.remove(&resolved_group_key);
@@ -11160,17 +11286,51 @@ async fn remove_named_group_member(
     )
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TreeKemLeaveDisposition {
+    ActiveMember,
+    LocalOnlyDrop,
+    CreatorMustDelete,
+}
+
+fn treekem_leave_disposition(
+    info: &x0x::groups::GroupInfo,
+    local_agent: AgentId,
+    local_agent_hex: &str,
+) -> TreeKemLeaveDisposition {
+    if local_agent == info.creator {
+        TreeKemLeaveDisposition::CreatorMustDelete
+    } else if info.has_active_member(local_agent_hex) {
+        TreeKemLeaveDisposition::ActiveMember
+    } else {
+        TreeKemLeaveDisposition::LocalOnlyDrop
+    }
+}
+
+async fn drop_local_named_group_state(state: &AppState, id: &str, reason: &str) {
+    state.named_groups.write().await.remove(id);
+    state.group_card_cache.write().await.remove(id);
+    state.mls_groups.write().await.remove(id);
+    state.treekem_groups.write().await.remove(id);
+    let treekem_snapshot = state.treekem_dir.join(format!("{id}.snap"));
+    if let Err(e) = tokio::fs::remove_file(&treekem_snapshot).await {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(group_id = %id, reason = %reason, "failed to remove TreeKEM snapshot while dropping local group state: {e}");
+        }
+    }
+    save_named_groups(state).await;
+    save_mls_groups(state).await;
+}
+
 async fn leave_treekem_group(
     state: Arc<AppState>,
     id: String,
     local_agent: AgentId,
     local_agent_hex: String,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    use base64::Engine as _;
-
     let signing_kp = state.agent.identity().agent_keypair();
     let now_ms = now_millis_u64();
-    let (mut next, metadata_topic, event_group_id, name) = {
+    let (mut next, metadata_topic, event_group_id, name, disposition) = {
         let groups = state.named_groups.read().await;
         let Some(info) = groups.get(&id) else {
             return (
@@ -11178,46 +11338,35 @@ async fn leave_treekem_group(
                 Json(serde_json::json!({ "ok": false, "error": "group not found" })),
             );
         };
-        if local_agent == info.creator {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "creator must delete the group" })),
-            );
-        }
-        if !info.has_active_member(&local_agent_hex) {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({ "ok": false, "error": "not a member" })),
-            );
-        }
+        let disposition = treekem_leave_disposition(info, local_agent, &local_agent_hex);
         (
             info.clone(),
             info.metadata_topic.clone(),
             info.stable_group_id().to_string(),
             info.name.clone(),
+            disposition,
         )
     };
+    match disposition {
+        TreeKemLeaveDisposition::CreatorMustDelete => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "ok": false, "error": "creator must delete the group" })),
+            );
+        }
+        TreeKemLeaveDisposition::LocalOnlyDrop => {
+            drop_local_named_group_state(&state, &id, "treekem_non_active_leave").await;
+            return (
+                StatusCode::OK,
+                Json(serde_json::json!({ "ok": true, "left": name, "local_only": true })),
+            );
+        }
+        TreeKemLeaveDisposition::ActiveMember => {}
+    }
 
-    let group = {
-        let map = state.treekem_groups.read().await;
-        map.get(&id).cloned()
-    };
-    let Some(group) = group else {
-        return (
-            StatusCode::FAILED_DEPENDENCY,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "TreeKEM group not loaded — restart or re-share required"
-            })),
-        );
-    };
-    let mut guard = group.lock().await;
-    let treekem_epoch = guard.epoch().saturating_add(1);
     next.roster_revision = next.roster_revision.saturating_add(1);
     let revision = next.roster_revision;
     next.remove_member(&local_agent_hex, Some(local_agent_hex.clone()));
-    next.secret_epoch = treekem_epoch;
-    next.security_binding = Some(format!("treekem:epoch={treekem_epoch}"));
     let commit = match next.seal_commit(signing_kp, now_ms) {
         Ok(c) => c,
         Err(e) => {
@@ -11227,28 +11376,6 @@ async fn leave_treekem_group(
             );
         }
     };
-    let treekem_commit = match guard.remove_member(local_agent) {
-        Ok(commit) => commit,
-        Err(e) => {
-            return (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": format!("TreeKEM self removal failed: {e}")
-                })),
-            );
-        }
-    };
-    if guard.epoch() != treekem_epoch {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "TreeKEM epoch did not advance as expected"
-            })),
-        );
-    }
-    drop(guard);
 
     let mut groups = state.named_groups.write().await;
     groups.remove(&id);
@@ -11270,8 +11397,8 @@ async fn leave_treekem_group(
         revision,
         actor: local_agent_hex.clone(),
         agent_id: local_agent_hex,
-        treekem_commit_b64: Some(base64::engine::general_purpose::STANDARD.encode(treekem_commit)),
-        treekem_epoch: Some(treekem_epoch),
+        treekem_commit_b64: None,
+        treekem_epoch: None,
         commit: Some(commit),
     };
     publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
@@ -19340,6 +19467,28 @@ mod tests {
         x0x::upgrade::manifest::encode_signed_manifest(&manifest_json, b"test-signature")
     }
 
+    fn fake_group_state_commit(
+        group_id: &str,
+        revision: u64,
+        committed_by: &str,
+    ) -> x0x::groups::GroupStateCommit {
+        x0x::groups::GroupStateCommit {
+            group_id: group_id.to_string(),
+            revision,
+            prev_state_hash: Some(format!("state-{}", revision.saturating_sub(1))),
+            roster_root: "roster".to_string(),
+            policy_hash: "policy".to_string(),
+            public_meta_hash: "meta".to_string(),
+            security_binding: Some("treekem:epoch=1".to_string()),
+            state_hash: format!("state-{revision}"),
+            withdrawn: false,
+            committed_by: committed_by.to_string(),
+            committed_at: revision,
+            signer_public_key: "pub".to_string(),
+            signature: "sig".to_string(),
+        }
+    }
+
     fn sample_group_card(group_id: &str, revision: u64, issued_at: u64) -> x0x::groups::GroupCard {
         x0x::groups::GroupCard {
             group_id: group_id.to_string(),
@@ -19714,6 +19863,119 @@ mod tests {
     }
 
     #[test]
+    fn treekem_self_leave_metadata_is_authorized_without_transport_commit() {
+        let creator = AgentId([0x11; 32]);
+        let creator_hex = hex::encode(creator.as_bytes());
+        let member_hex = "22".repeat(32);
+        let mut info = x0x::groups::GroupInfo::with_policy(
+            "secure".to_string(),
+            String::new(),
+            creator,
+            "aa".repeat(16),
+            x0x::groups::GroupPolicy::default(),
+        );
+        info.secure_plane = x0x::mls::SecureGroupPlane::TreeKem;
+        let group_id = info.stable_group_id().to_string();
+
+        let self_leave = NamedGroupMetadataEvent::MemberRemoved {
+            group_id: group_id.clone(),
+            revision: 2,
+            actor: member_hex.clone(),
+            agent_id: member_hex.clone(),
+            treekem_commit_b64: None,
+            treekem_epoch: None,
+            commit: Some(fake_group_state_commit(&group_id, 2, &member_hex)),
+        };
+
+        assert!(authorized_treekem_membership_event_for_queue(
+            &info,
+            &self_leave,
+            &member_hex,
+            &creator_hex
+        ));
+        assert!(!authorized_treekem_membership_event_for_queue(
+            &info,
+            &self_leave,
+            &creator_hex,
+            &creator_hex
+        ));
+
+        let admin_remove_without_treekem = NamedGroupMetadataEvent::MemberRemoved {
+            group_id: group_id.clone(),
+            revision: 3,
+            actor: creator_hex.clone(),
+            agent_id: member_hex.clone(),
+            treekem_commit_b64: None,
+            treekem_epoch: None,
+            commit: Some(fake_group_state_commit(&group_id, 3, &creator_hex)),
+        };
+        assert!(!authorized_treekem_membership_event_for_queue(
+            &info,
+            &admin_remove_without_treekem,
+            &creator_hex,
+            &creator_hex
+        ));
+
+        let admin_remove_with_treekem = NamedGroupMetadataEvent::MemberRemoved {
+            group_id: group_id.clone(),
+            revision: 4,
+            actor: creator_hex.clone(),
+            agent_id: member_hex,
+            treekem_commit_b64: Some("Yw==".to_string()),
+            treekem_epoch: Some(2),
+            commit: Some(fake_group_state_commit(&group_id, 4, &creator_hex)),
+        };
+        assert!(authorized_treekem_membership_event_for_queue(
+            &info,
+            &admin_remove_with_treekem,
+            &creator_hex,
+            &creator_hex
+        ));
+    }
+
+    #[test]
+    fn treekem_leave_disposition_allows_local_pending_stub_cleanup() {
+        let creator = AgentId([0x11; 32]);
+        let member = AgentId([0x22; 32]);
+        let creator_hex = hex::encode(creator.as_bytes());
+        let member_hex = hex::encode(member.as_bytes());
+        let mut info = x0x::groups::GroupInfo::with_policy(
+            "secure".to_string(),
+            String::new(),
+            creator,
+            "aa".repeat(16),
+            x0x::groups::GroupPolicy::default(),
+        );
+        info.secure_plane = x0x::mls::SecureGroupPlane::TreeKem;
+
+        assert_eq!(
+            treekem_leave_disposition(&info, creator, &creator_hex),
+            TreeKemLeaveDisposition::CreatorMustDelete
+        );
+        assert_eq!(
+            treekem_leave_disposition(&info, member, &member_hex),
+            TreeKemLeaveDisposition::LocalOnlyDrop
+        );
+
+        info.add_member(
+            member_hex.clone(),
+            x0x::groups::GroupRole::Member,
+            Some(creator_hex.clone()),
+            None,
+        );
+        assert_eq!(
+            treekem_leave_disposition(&info, member, &member_hex),
+            TreeKemLeaveDisposition::ActiveMember
+        );
+
+        info.remove_member(&member_hex, Some(creator_hex));
+        assert_eq!(
+            treekem_leave_disposition(&info, member, &member_hex),
+            TreeKemLeaveDisposition::LocalOnlyDrop
+        );
+    }
+
+    #[test]
     fn treekem_invite_stub_matches_authority_base_hash() {
         let creator = AgentId([7; 32]);
         let group_id = "ab".repeat(32);
@@ -19900,6 +20162,22 @@ mod tests {
         let chunk_config = welcome_blob_send_config(&chunk);
         assert!(chunk_config.prefer_raw_quic_if_connected);
         assert!(chunk_config.stop_fallback_on_raw_error);
+    }
+
+    #[test]
+    fn file_transfer_control_messages_are_acked_but_chunks_are_windowed() {
+        let control = file_transfer_control_send_config();
+        assert!(control.prefer_raw_quic_if_connected);
+        assert!(!control.stop_fallback_on_raw_error);
+        assert_eq!(
+            control.raw_quic_receive_ack_timeout,
+            Some(Duration::from_secs(8))
+        );
+
+        let chunk = file_transfer_send_config();
+        assert!(chunk.prefer_raw_quic_if_connected);
+        assert!(chunk.stop_fallback_on_raw_error);
+        assert_eq!(chunk.raw_quic_receive_ack_timeout, None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,6 +430,75 @@ where
         .collect()
 }
 
+fn is_local_discovery_addr(addr: std::net::SocketAddr) -> bool {
+    if addr.port() == 0 {
+        return false;
+    }
+    match addr.ip() {
+        std::net::IpAddr::V4(v4) => {
+            !v4.is_unspecified()
+                && !v4.is_broadcast()
+                && !v4.is_documentation()
+                && !v4.is_link_local()
+        }
+        std::net::IpAddr::V6(v6) => {
+            let segs = v6.segments();
+            !v6.is_unspecified() && (segs[0] & 0xffc0) != 0xfe80 && (segs[0] & 0xfff0) != 0xfec0
+        }
+    }
+}
+
+fn filter_local_discovery_addrs<I>(addresses: I) -> Vec<std::net::SocketAddr>
+where
+    I: IntoIterator<Item = std::net::SocketAddr>,
+{
+    let mut filtered = Vec::new();
+    for addr in addresses {
+        if is_local_discovery_addr(addr) && !filtered.contains(&addr) {
+            filtered.push(addr);
+        }
+    }
+    filtered
+}
+
+fn filter_discovery_announcement_addrs<I>(
+    addresses: I,
+    allow_local_scope: bool,
+) -> Vec<std::net::SocketAddr>
+where
+    I: IntoIterator<Item = std::net::SocketAddr>,
+{
+    if allow_local_scope {
+        filter_local_discovery_addrs(addresses)
+    } else {
+        filter_publicly_advertisable_addrs(addresses)
+    }
+}
+
+fn local_scoped_bootstrap_addr(addr: std::net::SocketAddr) -> bool {
+    if addr.port() == 0 {
+        return false;
+    }
+    match addr.ip() {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_loopback() || v4.is_private() || is_cgnat_v4(v4) || v4.is_link_local()
+        }
+        std::net::IpAddr::V6(v6) => {
+            let segs = v6.segments();
+            v6.is_loopback() || (segs[0] & 0xfe00) == 0xfc00 || (segs[0] & 0xffc0) == 0xfe80
+        }
+    }
+}
+
+fn allow_local_discovery_addresses(config: &network::NetworkConfig) -> bool {
+    config.bootstrap_nodes.is_empty()
+        || config
+            .bootstrap_nodes
+            .iter()
+            .copied()
+            .all(local_scoped_bootstrap_addr)
+}
+
 pub fn collect_local_interface_addrs(port: u16) -> Vec<std::net::SocketAddr> {
     fn is_cgnat(v4: std::net::Ipv4Addr) -> bool {
         v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64
@@ -493,6 +562,63 @@ pub fn collect_local_interface_addrs(port: u16) -> Vec<std::net::SocketAddr> {
 
     ranked.sort_by_key(|(priority, addr)| (*priority, addr.is_ipv6()));
     ranked.into_iter().map(|(_, addr)| addr).collect()
+}
+
+fn is_cgnat_v4(v4: std::net::Ipv4Addr) -> bool {
+    v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64
+}
+
+fn same_v4_24(a: std::net::Ipv4Addr, b: std::net::Ipv4Addr) -> bool {
+    let a = a.octets();
+    let b = b.octets();
+    a[0] == b[0] && a[1] == b[1] && a[2] == b[2]
+}
+
+fn local_direct_probe_priority(
+    addr: std::net::SocketAddr,
+    local_v4s: &[std::net::Ipv4Addr],
+) -> Option<u8> {
+    let std::net::IpAddr::V4(v4) = addr.ip() else {
+        return None;
+    };
+    if addr.port() == 0 || v4.is_loopback() || v4.is_link_local() || v4.is_unspecified() {
+        return None;
+    }
+    if local_v4s.iter().any(|local| same_v4_24(*local, v4)) {
+        return Some(0);
+    }
+    if v4.is_private() {
+        return Some(1);
+    }
+    if is_cgnat_v4(v4) {
+        return Some(2);
+    }
+    None
+}
+
+fn local_direct_probe_addrs_with_local_v4s(
+    addresses: &[std::net::SocketAddr],
+    local_v4s: &[std::net::Ipv4Addr],
+) -> Vec<std::net::SocketAddr> {
+    let mut ranked = addresses
+        .iter()
+        .copied()
+        .filter_map(|addr| local_direct_probe_priority(addr, local_v4s).map(|rank| (rank, addr)))
+        .collect::<Vec<_>>();
+    ranked.sort_by_key(|(rank, addr)| (*rank, *addr));
+    ranked.dedup_by_key(|(_, addr)| *addr);
+    ranked.into_iter().map(|(_, addr)| addr).collect()
+}
+
+fn local_direct_probe_addrs(addresses: &[std::net::SocketAddr]) -> Vec<std::net::SocketAddr> {
+    let local_v4s = collect_local_interface_addrs(0)
+        .into_iter()
+        .filter_map(|addr| match addr.ip() {
+            std::net::IpAddr::V4(v4) => Some(v4),
+            std::net::IpAddr::V6(_) => None,
+        })
+        .collect::<Vec<_>>();
+    local_direct_probe_addrs_with_local_v4s(addresses, &local_v4s)
 }
 
 /// Default interval between identity heartbeat re-announcements (seconds).
@@ -1176,6 +1302,16 @@ impl AnnouncementAssistSnapshot {
     }
 }
 
+struct IdentityAnnouncementBuildOptions<'a> {
+    include_user_identity: bool,
+    human_consent: bool,
+    addresses: Vec<std::net::SocketAddr>,
+    assist_snapshot: Option<&'a AnnouncementAssistSnapshot>,
+    reachable_via: Vec<identity::MachineId>,
+    relay_candidates: Vec<identity::MachineId>,
+    allow_local_scope: bool,
+}
+
 fn push_unique<T: Copy + PartialEq>(items: &mut Vec<T>, item: T) {
     if !items.contains(&item) {
         items.push(item);
@@ -1356,8 +1492,9 @@ fn build_machine_announcement_for_identity(
     assist_snapshot: Option<&AnnouncementAssistSnapshot>,
     reachable_via: Vec<identity::MachineId>,
     relay_candidates: Vec<identity::MachineId>,
+    allow_local_scope: bool,
 ) -> error::Result<MachineAnnouncement> {
-    let addresses = filter_publicly_advertisable_addrs(addresses);
+    let addresses = filter_discovery_announcement_addrs(addresses, allow_local_scope);
     let machine_public_key = identity.machine_keypair().public_key().as_bytes().to_vec();
     let unsigned = MachineAnnouncementUnsigned {
         machine_id: identity.machine_id(),
@@ -1486,6 +1623,7 @@ struct HeartbeatContext {
     /// heartbeats include `user_id` and `agent_certificate` so they don't
     /// erase a consented disclosure.
     user_identity_consented: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    allow_local_discovery_addrs: bool,
 }
 
 impl HeartbeatContext {
@@ -1548,13 +1686,13 @@ impl HeartbeatContext {
             }
         }
 
-        // Heartbeat announcements propagate over global gossip. We MUST NOT
-        // include LAN-scope addresses here — LAN-peer discovery is handled by
-        // ant-quic's first-party mDNS, and shipping RFC1918/ULA/link-local
-        // addresses to remote peers causes them to burn ~50s per candidate on
-        // a dial that can never succeed (see investigation 2026-04-15, report
-        // tests/proof-reports/MDNS_VS_GOSSIP_ADDRESS_SCOPE_20260415.md).
-        addresses.retain(|a| is_publicly_advertisable(*a));
+        // Global bootstrap partitions must not ship LAN-scope addresses over
+        // gossip: remote peers cannot reach them and each dead dial consumes
+        // connect budget. Explicit local/testnet partitions are different; they
+        // need signed LAN/loopback hints because there may be no public endpoint
+        // or mDNS bridge between the isolated daemons.
+        addresses =
+            filter_discovery_announcement_addrs(addresses, self.allow_local_discovery_addrs);
 
         // Query reachability plus stable relay/coordinator capability from
         // the network layer. Runtime activity is logged separately so we do
@@ -1673,6 +1811,7 @@ impl HeartbeatContext {
             Some(&assist_snapshot),
             reachable_via.clone(),
             relay_candidates.clone(),
+            self.allow_local_discovery_addrs,
         )?;
         tracing::debug!(
             target: "x0x::discovery",
@@ -2298,6 +2437,65 @@ impl Agent {
         }
 
         let dial_timeout = std::time::Duration::from_secs(8);
+        let direct_probe_addrs = local_direct_probe_addrs(&info.addresses);
+
+        // Agent cards minted for a local dogfood run often contain both
+        // reachable LAN IPv4 hints and globally-scoped IPv6/Tailscale hints
+        // that may be stale or firewalled. Probe local IPv4 first so a bad
+        // multi-address peer dial cannot consume the full API timeout before
+        // the reachable LAN path is attempted.
+        for addr in &direct_probe_addrs {
+            match tokio::time::timeout(dial_timeout, network.connect_addr(*addr)).await {
+                Ok(Ok(connected_peer_id)) => {
+                    let real_machine_id = identity::MachineId(connected_peer_id.0);
+                    if let Some(ref bc) = self.bootstrap_cache {
+                        bc.add_from_connection(connected_peer_id, vec![*addr], None)
+                            .await;
+                    }
+                    {
+                        let mut cache = self.identity_discovery_cache.write().await;
+                        if let Some(entry) = cache.get_mut(agent_id) {
+                            entry.machine_id = real_machine_id;
+                        }
+                    }
+                    self.direct_messaging
+                        .mark_connected(agent.agent_id, real_machine_id)
+                        .await;
+                    tracing::info!(
+                        target: "x0x::connect",
+                        stage = "connect_to_agent",
+                        %agent_prefix,
+                        strategy = "local_direct_first",
+                        outcome = "direct",
+                        selected_addr = %addr,
+                        family = "v4",
+                        dur_ms = call_start.elapsed().as_millis() as u64,
+                        "local direct dial succeeded"
+                    );
+                    return Ok(connectivity::ConnectOutcome::Direct(*addr));
+                }
+                Ok(Err(e)) => {
+                    tracing::debug!(
+                        target: "x0x::connect",
+                        %agent_prefix,
+                        strategy = "local_direct_first",
+                        %addr,
+                        error = %e,
+                        "local direct dial failed"
+                    );
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        target: "x0x::connect",
+                        %agent_prefix,
+                        strategy = "local_direct_first",
+                        %addr,
+                        timeout_s = dial_timeout.as_secs(),
+                        "local direct dial timed out"
+                    );
+                }
+            }
+        }
 
         // 3. If we know the peer's machine ID, prefer a peer-authenticated dial
         //    with explicit address hints first. This is more reliable for agent
@@ -2374,6 +2572,9 @@ impl Agent {
         //    direct probe, especially for the first nodes in a new network.
         if info.should_attempt_direct() {
             for addr in &info.addresses {
+                if direct_probe_addrs.contains(addr) {
+                    continue;
+                }
                 match tokio::time::timeout(dial_timeout, network.connect_addr(*addr)).await {
                     Ok(Ok(connected_peer_id)) => {
                         // Use the real PeerId from the QUIC handshake (may differ
@@ -4070,10 +4271,14 @@ impl Agent {
             }
         }
 
-        // Same rule as HeartbeatContext::announce() — gossip is global, so
-        // LAN-scope addresses must never be published here. See the scope
-        // analysis report under tests/proof-reports/ for details.
-        addresses.retain(|a| is_publicly_advertisable(*a));
+        let allow_local_scope = self
+            .network
+            .as_ref()
+            .is_some_and(|network| allow_local_discovery_addresses(network.config()));
+        // Same rule as HeartbeatContext::announce(): global bootstrap partitions
+        // publish only globally-routable endpoints, while explicit local/testnet
+        // partitions may publish LAN/loopback hints for same-partition peers.
+        addresses = filter_discovery_announcement_addrs(addresses, allow_local_scope);
 
         // Emit coordinator / relay hints only when direct inbound is not
         // known to work. See HeartbeatContext::announce() for rationale.
@@ -4091,14 +4296,16 @@ impl Agent {
             (Vec::new(), Vec::new())
         };
 
-        let announcement = self.build_identity_announcement_with_addrs(
-            include_user_identity,
-            human_consent,
-            addresses,
-            Some(&assist_snapshot),
-            reachable_via,
-            relay_candidates,
-        )?;
+        let announcement =
+            self.build_identity_announcement_with_addrs(IdentityAnnouncementBuildOptions {
+                include_user_identity,
+                human_consent,
+                addresses,
+                assist_snapshot: Some(&assist_snapshot),
+                reachable_via,
+                relay_candidates,
+                allow_local_scope,
+            })?;
         tracing::debug!(
             target: "x0x::discovery",
             announcement_kind = "explicit",
@@ -4120,6 +4327,7 @@ impl Agent {
             Some(&assist_snapshot),
             announcement.reachable_via.clone(),
             announcement.relay_candidates.clone(),
+            allow_local_scope,
         )?;
         tracing::debug!(
             target: "x0x::discovery",
@@ -4629,6 +4837,9 @@ impl Agent {
         let contact_store = std::sync::Arc::clone(&self.contact_store);
         let direct_messaging = std::sync::Arc::clone(&self.direct_messaging);
         let network = self.network.as_ref().map(std::sync::Arc::clone);
+        let allow_local_scope = network
+            .as_ref()
+            .is_some_and(|network| allow_local_discovery_addresses(network.config()));
         let own_agent_id = self.agent_id();
         let own_machine_id = self.machine_id();
         let own_user_id = self.user_id();
@@ -4736,23 +4947,27 @@ impl Agent {
                             .duration_since(std::time::UNIX_EPOCH)
                             .map_or(0, |d| d.as_secs());
 
-                        let filtered_addresses = filter_publicly_advertisable_addrs(
+                        let bootstrap_addresses = filter_publicly_advertisable_addrs(
                             announcement.addresses.iter().copied(),
                         );
-                        if !filtered_addresses.is_empty() {
+                        if !bootstrap_addresses.is_empty() {
                             if let Some(ref bc) = &bootstrap_cache {
                                 let peer_id = ant_quic::PeerId(announcement.machine_id.0);
-                                bc.add_from_connection(peer_id, filtered_addresses.clone(), None)
+                                bc.add_from_connection(peer_id, bootstrap_addresses.clone(), None)
                                     .await;
                             }
                         }
 
-                        let filtered_addr_count = filtered_addresses.len();
+                        let discovery_addresses = filter_discovery_announcement_addrs(
+                            announcement.addresses.iter().copied(),
+                            allow_local_scope,
+                        );
+                        let filtered_addr_count = discovery_addresses.len();
                         upsert_discovered_machine(
                             &machine_cache,
                             DiscoveredMachine::from_machine_announcement(
                                 &announcement,
-                                filtered_addresses,
+                                discovery_addresses,
                                 now,
                             ),
                         )
@@ -4927,18 +5142,23 @@ impl Agent {
                 // loopback, or port-zero entries, but those are not useful
                 // outside link-local discovery and must not become dial
                 // candidates for globally propagated announcements.
-                let filtered_addresses =
+                let bootstrap_addresses =
                     filter_publicly_advertisable_addrs(announcement.addresses.iter().copied());
-                let filtered_addr_count = filtered_addresses.len();
+                let discovery_addresses = filter_discovery_announcement_addrs(
+                    announcement.addresses.iter().copied(),
+                    allow_local_scope,
+                );
+                let filtered_addr_count = discovery_addresses.len();
+                let auto_connect_addresses = discovery_addresses.clone();
                 {
-                    if !filtered_addresses.is_empty() {
+                    if !bootstrap_addresses.is_empty() {
                         if let Some(ref bc) = &bootstrap_cache {
                             let peer_id = ant_quic::PeerId(announcement.machine_id.0);
-                            bc.add_from_connection(peer_id, filtered_addresses.clone(), None)
+                            bc.add_from_connection(peer_id, bootstrap_addresses.clone(), None)
                                 .await;
                             tracing::debug!(
                                 "Added {} public addresses to bootstrap cache for agent {:?} (machine {:?})",
-                                filtered_addresses.len(),
+                                bootstrap_addresses.len(),
                                 announcement.agent_id,
                                 hex::encode(&announcement.machine_id.0[..8]),
                             );
@@ -4946,19 +5166,16 @@ impl Agent {
                     }
                 }
 
-                // Cache the announcement with its address list filtered to
-                // globally-advertisable scope only. Legacy peers that still
-                // ship RFC1918/ULA/loopback entries in their announcements
-                // must not force us to keep dialing their unreachable LAN
-                // addresses — LAN discovery is ant-quic's mDNS job. Empty
-                // address lists are preserved (the `AlreadyConnected` path in
-                // `connect_to_agent` handles gossip peers we only reach by
-                // an existing QUIC connection).
+                // Cache public addresses on global partitions, but keep
+                // LAN/loopback hints on explicit local/testnet partitions.
+                // Empty address lists are preserved (the `AlreadyConnected`
+                // path in `connect_to_agent` handles gossip peers we only reach
+                // by an existing QUIC connection).
                 let discovered_agent = DiscoveredAgent {
                     agent_id: announcement.agent_id,
                     machine_id: announcement.machine_id,
                     user_id: announcement.user_id,
-                    addresses: filtered_addresses.clone(),
+                    addresses: discovery_addresses,
                     announced_at: announcement.announced_at,
                     last_seen: now,
                     machine_public_key: announcement.machine_public_key.clone(),
@@ -5045,7 +5262,7 @@ impl Agent {
                 // The gossip topology refresh (every 1s) will add the new peer to
                 // PlumTree topic trees once the QUIC connection is established.
                 if announcement.agent_id != own_agent_id
-                    && !filtered_addresses.is_empty()
+                    && !auto_connect_addresses.is_empty()
                     && !auto_connect_attempted.contains(&announcement.agent_id)
                 {
                     if let Some(ref net) = &network {
@@ -5053,7 +5270,7 @@ impl Agent {
                         if !net.is_connected(&ant_peer).await {
                             auto_connect_attempted.insert(announcement.agent_id);
                             let net = std::sync::Arc::clone(net);
-                            let addresses = filtered_addresses.clone();
+                            let addresses = auto_connect_addresses.clone();
                             tokio::spawn(async move {
                                 for addr in &addresses {
                                     match net.connect_addr(*addr).await {
@@ -5090,9 +5307,12 @@ impl Agent {
 
     fn announcement_addresses(&self) -> Vec<std::net::SocketAddr> {
         match self.network.as_ref().and_then(|n| n.local_addr()) {
-            Some(addr) if addr.port() > 0 => {
-                filter_publicly_advertisable_addrs(collect_local_interface_addrs(addr.port()))
-            }
+            Some(addr) if addr.port() > 0 => filter_discovery_announcement_addrs(
+                collect_local_interface_addrs(addr.port()),
+                self.network
+                    .as_ref()
+                    .is_some_and(|network| allow_local_discovery_addresses(network.config())),
+            ),
             _ => Vec::new(),
         }
     }
@@ -5102,31 +5322,36 @@ impl Agent {
         include_user_identity: bool,
         human_consent: bool,
     ) -> error::Result<IdentityAnnouncement> {
-        self.build_identity_announcement_with_addrs(
+        self.build_identity_announcement_with_addrs(IdentityAnnouncementBuildOptions {
             include_user_identity,
             human_consent,
-            self.announcement_addresses(),
-            None,
-            Vec::new(),
-            Vec::new(),
-        )
+            addresses: self.announcement_addresses(),
+            assist_snapshot: None,
+            reachable_via: Vec::new(),
+            relay_candidates: Vec::new(),
+            allow_local_scope: false,
+        })
     }
 
     fn build_identity_announcement_with_addrs(
         &self,
-        include_user_identity: bool,
-        human_consent: bool,
-        addresses: Vec<std::net::SocketAddr>,
-        assist_snapshot: Option<&AnnouncementAssistSnapshot>,
-        reachable_via: Vec<identity::MachineId>,
-        relay_candidates: Vec<identity::MachineId>,
+        options: IdentityAnnouncementBuildOptions<'_>,
     ) -> error::Result<IdentityAnnouncement> {
+        let IdentityAnnouncementBuildOptions {
+            include_user_identity,
+            human_consent,
+            addresses,
+            assist_snapshot,
+            reachable_via,
+            relay_candidates,
+            allow_local_scope,
+        } = options;
         if include_user_identity && !human_consent {
             return Err(error::IdentityError::Storage(std::io::Error::other(
                 "human identity disclosure requires explicit human consent — set human_consent: true in the request body",
             )));
         }
-        let addresses = filter_publicly_advertisable_addrs(addresses);
+        let addresses = filter_discovery_announcement_addrs(addresses, allow_local_scope);
 
         let (user_id, agent_certificate) = if include_user_identity {
             let user_id = self.user_id().ok_or_else(|| {
@@ -5498,6 +5723,7 @@ impl Agent {
                 cache: std::sync::Arc::clone(&self.identity_discovery_cache),
                 machine_cache: std::sync::Arc::clone(&self.machine_discovery_cache),
                 user_identity_consented: std::sync::Arc::clone(&self.user_identity_consented),
+                allow_local_discovery_addrs: allow_local_discovery_addresses(network.config()),
             };
             tokio::spawn(async move {
                 tokio::time::sleep(std::time::Duration::from_secs(3)).await;
@@ -6020,6 +6246,10 @@ impl Agent {
         let mut sub = runtime.pubsub().subscribe(shard_topic).await;
         let cache = std::sync::Arc::clone(&self.identity_discovery_cache);
         let machine_cache = std::sync::Arc::clone(&self.machine_discovery_cache);
+        let allow_local_scope = self
+            .network
+            .as_ref()
+            .is_some_and(|network| allow_local_discovery_addresses(network.config()));
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
 
         loop {
@@ -6034,12 +6264,10 @@ impl Agent {
                             let now = std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .map_or(0, |d| d.as_secs());
-                            let filtered: Vec<std::net::SocketAddr> = ann
-                                .addresses
-                                .iter()
-                                .copied()
-                                .filter(|a| is_publicly_advertisable(*a))
-                                .collect();
+                            let filtered = filter_discovery_announcement_addrs(
+                                ann.addresses.iter().copied(),
+                                allow_local_scope,
+                            );
                             let addrs = filtered.clone();
                             let discovered_agent = DiscoveredAgent {
                                 agent_id: ann.agent_id,
@@ -6133,6 +6361,10 @@ impl Agent {
         let shard_topic = shard_topic_for_machine(&machine_id);
         let mut sub = runtime.pubsub().subscribe(shard_topic).await;
         let machine_cache = std::sync::Arc::clone(&self.machine_discovery_cache);
+        let allow_local_scope = self
+            .network
+            .as_ref()
+            .is_some_and(|network| allow_local_discovery_addresses(network.config()));
         let deadline =
             tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs.clamp(1, 60));
 
@@ -6148,12 +6380,10 @@ impl Agent {
                             let now = std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .map_or(0, |d| d.as_secs());
-                            let filtered: Vec<std::net::SocketAddr> = ann
-                                .addresses
-                                .iter()
-                                .copied()
-                                .filter(|a| is_publicly_advertisable(*a))
-                                .collect();
+                            let filtered = filter_discovery_announcement_addrs(
+                                ann.addresses.iter().copied(),
+                                allow_local_scope,
+                            );
                             let discovered = DiscoveredMachine::from_machine_announcement(
                                 &ann,
                                 filtered,
@@ -6270,6 +6500,9 @@ impl Agent {
             None,
             Vec::new(),
             Vec::new(),
+            self.network
+                .as_ref()
+                .is_some_and(|network| allow_local_discovery_addresses(network.config())),
         )
     }
 
@@ -6569,6 +6802,7 @@ impl Agent {
                 "network not initialized — cannot start heartbeat",
             )));
         };
+        let allow_local_discovery_addrs = allow_local_discovery_addresses(network.config());
         let ctx = HeartbeatContext {
             identity: std::sync::Arc::clone(&self.identity),
             runtime,
@@ -6577,6 +6811,7 @@ impl Agent {
             cache: std::sync::Arc::clone(&self.identity_discovery_cache),
             machine_cache: std::sync::Arc::clone(&self.machine_discovery_cache),
             user_identity_consented: std::sync::Arc::clone(&self.user_identity_consented),
+            allow_local_discovery_addrs,
         };
         let handle = tokio::task::spawn(async move {
             let mut ticker =
@@ -8114,6 +8349,74 @@ mod tests {
         assert_eq!(filtered, vec![sa("8.8.8.8:5483"), sa("[2001:db8::1]:5483")]);
     }
 
+    #[test]
+    fn local_discovery_filter_keeps_same_partition_candidates() {
+        let filtered = filter_discovery_announcement_addrs(
+            vec![
+                sa("127.0.0.1:5483"),
+                sa("10.1.2.3:5483"),
+                sa("100.64.1.1:5483"),
+                sa("169.254.1.1:5483"),
+                sa("1.2.3.4:0"),
+                sa("[::1]:5483"),
+                sa("[fd00::1]:5483"),
+                sa("8.8.8.8:5483"),
+            ],
+            true,
+        );
+
+        assert_eq!(
+            filtered,
+            vec![
+                sa("127.0.0.1:5483"),
+                sa("10.1.2.3:5483"),
+                sa("100.64.1.1:5483"),
+                sa("[::1]:5483"),
+                sa("[fd00::1]:5483"),
+                sa("8.8.8.8:5483"),
+            ],
+        );
+    }
+
+    #[test]
+    fn local_discovery_scope_tracks_bootstrap_partition() {
+        let mut config = network::NetworkConfig {
+            bootstrap_nodes: Vec::new(),
+            ..network::NetworkConfig::default()
+        };
+        assert!(allow_local_discovery_addresses(&config));
+
+        config.bootstrap_nodes = vec![sa("127.0.0.1:5483"), sa("192.168.1.10:5483")];
+        assert!(allow_local_discovery_addresses(&config));
+
+        config.bootstrap_nodes = vec![sa("127.0.0.1:5483"), sa("8.8.8.8:5483")];
+        assert!(!allow_local_discovery_addresses(&config));
+    }
+
+    #[test]
+    fn local_direct_probe_addrs_prioritizes_same_lan_ipv4() {
+        let local = [std::net::Ipv4Addr::new(192, 168, 1, 212)];
+        let ranked = local_direct_probe_addrs_with_local_v4s(
+            &[
+                sa("100.118.167.101:27749"),
+                sa("192.168.0.1:27749"),
+                sa("192.168.1.108:27749"),
+                sa("[2a0d:3344:32d:2e10::1]:27749"),
+                sa("[fd7a:115c:a1e0::b01:a7ac]:27749"),
+            ],
+            &local,
+        );
+
+        assert_eq!(
+            ranked,
+            vec![
+                sa("192.168.1.108:27749"),
+                sa("192.168.0.1:27749"),
+                sa("100.118.167.101:27749"),
+            ],
+        );
+    }
+
     #[tokio::test]
     async fn announcement_builders_filter_global_discovery_addresses() {
         let dir = tempfile::tempdir().expect("tmpdir");
@@ -8134,14 +8437,15 @@ mod tests {
         let expected = vec![sa("8.8.8.8:5483"), sa("[2001:db8::1]:5483")];
 
         let identity_announcement = agent
-            .build_identity_announcement_with_addrs(
-                false,
-                false,
-                addresses.clone(),
-                None,
-                Vec::new(),
-                Vec::new(),
-            )
+            .build_identity_announcement_with_addrs(IdentityAnnouncementBuildOptions {
+                include_user_identity: false,
+                human_consent: false,
+                addresses: addresses.clone(),
+                assist_snapshot: None,
+                reachable_via: Vec::new(),
+                relay_candidates: Vec::new(),
+                allow_local_scope: false,
+            })
             .expect("identity announcement");
         assert_eq!(identity_announcement.addresses, expected);
         identity_announcement
@@ -8155,6 +8459,7 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
+            false,
         )
         .expect("machine announcement");
         assert_eq!(machine_announcement.addresses, expected);

--- a/tests/e2e_communitas_dioxus.sh
+++ b/tests/e2e_communitas_dioxus.sh
@@ -150,4 +150,23 @@ do
     fi
 done
 
+# NOTE (PR #99): the previous `pubsub.roundtrip` assertion was removed here, NOT
+# silently dropped. The Dioxus e2e hook (communitas-dioxus/src/e2e_test_mode.rs)
+# no longer dispatches `pubsub.subscribe`/`pubsub.publish` — those ops now hit
+# its `_ => "unknown e2e op"` arm, so re-adding the old block would record a
+# guaranteed `fail`, not a real check.
+#
+# End-to-end pubsub *delivery* through the Communitas typed x0x client is now
+# covered — more strongly — by the typed-client contract test
+# `communitas-x0x-client/tests/live_mutation_contract.rs` (subscribe → publish →
+# receive frame → assert topic + decoded-payload-bytes equality, over BOTH SSE
+# and WS). That test runs in this same proof set and asserts payload equality,
+# vs. the old block's bare `.delivered == true`.
+#
+# FOLLOW-UP (tracked, communitas repo): to restore delivery coverage at the
+# Dioxus *app-hook* layer specifically, add a `messaging.pubsub_roundtrip` op to
+# e2e_test_mode.rs that drives X0xClient::{subscribe,publish} and confirms
+# delivery, then add that op to the loop above. Not a merge blocker — the
+# typed-client layer below the app already proves delivery.
+
 kill "$APP_PID" 2>/dev/null || true

--- a/tests/e2e_communitas_dioxus.sh
+++ b/tests/e2e_communitas_dioxus.sh
@@ -126,8 +126,21 @@ if [ -z "$HELLO" ] || ! echo "$HELLO" | jq -e '.ok == true' >/dev/null 2>&1; the
 fi
 record "app.handshake" "pass"
 
-# Probe a handful of golden paths via the test hook.
-for op in agent.identity presence.online groups.list stores.list diagnostics.gossip; do
+# Probe a handful of golden paths via the current Dioxus test hook. These ops
+# exercise the Communitas typed x0x client against the live daemon.
+for op in \
+    identity.agent_card \
+    identity.user_id \
+    identity.export_keypairs \
+    connectivity.discover_agents \
+    connectivity.four_word_bootstrap \
+    groups.discover \
+    kv.create_list \
+    kv.put_get_delete \
+    kv.access_policy_setup \
+    presence.foaf \
+    upgrade.check
+do
     send '{"op":"'"$op"'"}'
     RESP="$(read_response || true)"
     if echo "$RESP" | jq -e '.ok == true' >/dev/null 2>&1; then
@@ -136,17 +149,5 @@ for op in agent.identity presence.online groups.list stores.list diagnostics.gos
         record "$op" "fail" "${RESP:-no response}"
     fi
 done
-
-# Full DM round-trip.
-TOPIC="dioxus-e2e-$RANDOM"
-send '{"op":"pubsub.subscribe","topic":"'"$TOPIC"'"}'
-read_response >/dev/null || true
-send '{"op":"pubsub.publish","topic":"'"$TOPIC"'","payload":"hello-dioxus"}'
-RESP="$(read_response || true)"
-if echo "$RESP" | jq -e '.delivered == true' >/dev/null 2>&1; then
-    record "pubsub.roundtrip" "pass"
-else
-    record "pubsub.roundtrip" "fail" "${RESP:-no response}"
-fi
 
 kill "$APP_PID" 2>/dev/null || true

--- a/tests/e2e_studio_gui_full.mjs
+++ b/tests/e2e_studio_gui_full.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+// Browser proof for the live MacBook/studio x0x GUI dogfood run.
+//
+// Consumes the JSON manifest emitted by tests/e2e_studio_live.py and drives:
+// - daemon-served embedded GUIs for both daemons
+// - the shipped example apps via file:// with ?api=...&token=...
+
+import { chromium } from "playwright";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { resolve, join } from "node:path";
+
+const argv = process.argv.slice(2);
+const flag = (name, def = "") => {
+    const i = argv.indexOf(name);
+    return i >= 0 && i + 1 < argv.length ? argv[i + 1] : def;
+};
+
+const MANIFEST = resolve(flag("--manifest"));
+const PROOF_DIR = resolve(flag("--proof-dir", `proofs/studio-gui-full-${Date.now()}`));
+if (!MANIFEST) {
+    console.error("usage: node tests/e2e_studio_gui_full.mjs --manifest <manifest.json> --proof-dir <dir>");
+    process.exit(2);
+}
+mkdirSync(PROOF_DIR, { recursive: true });
+
+const manifest = JSON.parse(readFileSync(MANIFEST, "utf8"));
+const report = {
+    run_started_at: new Date().toISOString(),
+    manifest: MANIFEST,
+    capabilities: {},
+    totals: { pass: 0, fail: 0, skip: 0 },
+};
+
+function record(name, status, details = {}) {
+    report.capabilities[name] = { status, ...details };
+    report.totals[status] = (report.totals[status] || 0) + 1;
+    console.log(`[${status.toUpperCase()}] ${name}${details.reason ? " - " + details.reason : ""}`);
+}
+
+function failFast(cond, msg) {
+    if (!cond) throw new Error(msg);
+}
+
+function chromePath() {
+    if (!process.env.CHROME_BIN) return undefined;
+    return [
+        process.env.CHROME_BIN,
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        "/usr/bin/google-chrome",
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser",
+    ].filter(Boolean).find(p => existsSync(p));
+}
+
+function authHeaders(target, json = false) {
+    return {
+        ...(json ? { "content-type": "application/json" } : {}),
+        ...(target.token ? { authorization: `Bearer ${target.token}` } : {}),
+    };
+}
+
+async function api(target, method, path, body = undefined, accept = status => status >= 200 && status < 300) {
+    const res = await fetch(`${target.api_base}${path}`, {
+        method,
+        headers: authHeaders(target, body !== undefined),
+        body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    const parsed = text ? JSON.parse(text) : {};
+    if (!accept(res.status)) {
+        throw new Error(`${method} ${path} -> ${res.status}: ${text.slice(0, 500)}`);
+    }
+    return parsed;
+}
+
+async function waitForText(page, selector, text, timeout = 15000) {
+    await page.waitForFunction(
+        ({ selector, text }) => {
+            const el = document.querySelector(selector);
+            return !!el && el.textContent.includes(text);
+        },
+        { selector, text },
+        { timeout },
+    );
+}
+
+async function openGui(context, target, label) {
+    const page = await context.newPage();
+    const consoleLog = [];
+    page.on("console", msg => consoleLog.push({ type: msg.type(), text: msg.text(), location: msg.location() }));
+    page.on("pageerror", err => consoleLog.push({ type: "pageerror", text: String(err) }));
+    await page.goto(`${target.api_base}/gui?token=${encodeURIComponent(target.token)}`, { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => typeof S !== "undefined" && typeof navigate === "function" && typeof api === "function", null, { timeout: 30000 })
+        .catch(e => {
+            throw new Error(`${label} GUI runtime not ready: ${e.message}`);
+        });
+    await page.waitForFunction(() => document.getElementById("st-conn")?.textContent === "Connected", null, { timeout: 30000 })
+        .catch(async e => {
+            const status = await page.locator("#st-conn").textContent().catch(() => "<missing>");
+            throw new Error(`${label} GUI websocket not connected, status=${status}: ${e.message}`);
+        });
+    const agentId = await page.evaluate(() => S.get("agentId"));
+    failFast(agentId === target.agent.agent_id, `${label} GUI agent mismatch ${agentId}`);
+    try {
+        await page.screenshot({
+            path: join(PROOF_DIR, `${label}-gui-home.png`),
+            animations: "disabled",
+            timeout: 5000,
+        });
+    } catch (e) {
+        writeFileSync(join(PROOF_DIR, `${label}-gui-home.html`), await page.content());
+        writeFileSync(join(PROOF_DIR, `${label}-gui-screenshot-error.txt`), String(e?.message || e));
+        record(`${label}.embedded-gui-screenshot`, "skip", { reason: String(e?.message || e).slice(0, 200) });
+    }
+    writeFileSync(join(PROOF_DIR, `${label}-gui-console.jsonl`), consoleLog.map(x => JSON.stringify(x)).join("\n"));
+    return { page, consoleLog };
+}
+
+async function proveGuiViews(page, label, groupId) {
+    const views = ["home", "discover", "people", "network", "presence", "mls", "admin", "constitution", "settings", "about"];
+    for (const view of views) {
+        await page.evaluate(view => navigate(view), view);
+        await page.waitForTimeout(500);
+        const len = await page.locator("#view-container").evaluate(el => el.textContent.trim().length);
+        failFast(len > 20, `${label} ${view} rendered too little content`);
+    }
+    const apps = ["chat", "board", "files", "swarm", "feed", "wiki", "web"];
+    for (const app of apps) {
+        await page.evaluate(({ groupId, app }) => navigateSpace(groupId, app), { groupId, app });
+        await page.waitForTimeout(800);
+        const len = await page.locator("#view-container").evaluate(el => el.textContent.trim().length);
+        failFast(len > 20, `${label} space/${app} rendered too little content`);
+    }
+    record(`${label}.embedded-gui-visible-views`, "pass", { views, apps });
+}
+
+async function ensureSpace(local, studio) {
+    const created = await api(local, "POST", "/groups", {
+        name: `GUI Full ${Date.now()}`,
+        description: "Studio GUI full proof",
+        preset: "public_open",
+    });
+    const groupId = created.group_id || created.id;
+    failFast(groupId, "created group missing id");
+    const inviteRes = await api(local, "POST", `/groups/${groupId}/invite`);
+    const invite = inviteRes.invite_link || inviteRes.invite;
+    failFast(invite && invite.startsWith("x0x://invite/"), "missing invite link");
+    const joined = await api(studio, "POST", "/groups/join", { invite });
+    await new Promise(resolve => setTimeout(resolve, 2500));
+    return { localGroupId: groupId, studioGroupId: joined.group_id || joined.id || groupId };
+}
+
+async function proveGuiDm(localPage, studioPage, local, studio) {
+    const localMsg = `gui dm local to studio ${Date.now()}`;
+    const studioMsg = `gui dm studio to local ${Date.now()}`;
+    await localPage.evaluate(({ target, message }) => {
+        navigateDm(target);
+        document.getElementById("dm-in").value = message;
+        return sendDm();
+    }, { target: studio.agent.agent_id, message: localMsg });
+    await studioPage.evaluate(({ target, message }) => {
+        navigateDm(target);
+        document.getElementById("dm-in").value = message;
+        return sendDm();
+    }, { target: local.agent.agent_id, message: studioMsg });
+    await waitForText(localPage, "#dm-msgs", studioMsg, 20000);
+    await waitForText(studioPage, "#dm-msgs", localMsg, 20000);
+    record("embedded-gui.dm-bidirectional-visible", "pass");
+}
+
+async function proveGuiRecovery(page) {
+    await page.evaluate(() => ws.close());
+    await page.waitForFunction(() => document.getElementById("st-conn")?.textContent === "Disconnected", null, { timeout: 10000 });
+    await page.evaluate(() => wsConnect());
+    await page.waitForFunction(() => document.getElementById("st-conn")?.textContent === "Connected", null, { timeout: 15000 });
+    record("embedded-gui.websocket-offline-recovered", "pass");
+}
+
+async function startExampleServer() {
+    const root = resolve("examples/apps");
+    const server = createServer((req, res) => {
+        try {
+            const path = new URL(req.url || "/", "http://127.0.0.1").pathname;
+            const file = resolve(root, path.replace(/^\/+/, ""));
+            if (!file.startsWith(root) || !file.endsWith(".html")) {
+                res.writeHead(404);
+                res.end("not found");
+                return;
+            }
+            res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+            res.end(readFileSync(file));
+        } catch (e) {
+            res.writeHead(500);
+            res.end(String(e?.message || e));
+        }
+    });
+    await new Promise(resolveListen => server.listen(0, "127.0.0.1", resolveListen));
+    const addr = server.address();
+    return { server, base: `http://127.0.0.1:${addr.port}` };
+}
+
+function appUrl(exampleBase, name, target, extra = "") {
+    const url = new URL(`${exampleBase}/${name}.html`);
+    url.searchParams.set("api", target.api_base);
+    url.searchParams.set("token", target.token);
+    if (extra) url.hash = extra;
+    return url.toString();
+}
+
+async function proveChat(context, exampleBase, local, studio) {
+    const lp = await context.newPage();
+    const sp = await context.newPage();
+    await lp.goto(appUrl(exampleBase, "x0x-chat", local), { waitUntil: "domcontentloaded" });
+    await sp.goto(appUrl(exampleBase, "x0x-chat", studio), { waitUntil: "domcontentloaded" });
+    await waitForText(lp, "#statusText", "Connected");
+    await waitForText(sp, "#statusText", "Connected");
+    const msg = `example chat ${Date.now()}`;
+    await lp.fill("#msgInput", msg);
+    await lp.click("#btnSend");
+    await waitForText(sp, "#messages", msg, 20000);
+    record("example-app.chat-cross-machine", "pass");
+    await lp.close();
+    await sp.close();
+}
+
+async function proveBoard(context, exampleBase, target, label) {
+    const page = await context.newPage();
+    await page.goto(appUrl(exampleBase, "x0x-board", target), { waitUntil: "domcontentloaded" });
+    await page.waitForSelector("#selectView", { state: "visible", timeout: 15000 });
+    const boardName = `${label} board ${Date.now()}`;
+    await page.fill("#newBoardName", boardName);
+    await page.fill("#newBoardTopic", boardName.toLowerCase().replace(/\s+/g, "-"));
+    await page.click("button.btn-cyan");
+    await page.waitForSelector("#board", { state: "visible", timeout: 10000 });
+    await page.fill("#newTask", `${label} task`);
+    await page.keyboard.press("Enter");
+    await page.waitForSelector("#todoCards .card", { timeout: 10000 });
+    await page.click("#todoCards .card-btn.claim");
+    await page.waitForSelector("#progressCards .card", { timeout: 10000 });
+    await page.click("#progressCards .card-btn.done");
+    await page.waitForSelector("#doneCards .card", { timeout: 10000 });
+    record(`example-app.board-${label}`, "pass");
+    await page.close();
+}
+
+async function proveNetwork(context, exampleBase, target, label) {
+    const page = await context.newPage();
+    await page.goto(appUrl(exampleBase, "x0x-network", target), { waitUntil: "domcontentloaded" });
+    await waitForText(page, "#i-agent", target.agent.agent_id.slice(0, 16), 15000);
+    await waitForText(page, "#ct-count", "", 15000);
+    record(`example-app.network-${label}`, "pass");
+    await page.close();
+}
+
+async function proveSwarm(context, exampleBase, local, studio) {
+    const session = Math.random().toString(16).slice(2, 10);
+    const lp = await context.newPage();
+    const sp = await context.newPage();
+    await lp.goto(appUrl(exampleBase, "x0x-swarm", local, session), { waitUntil: "domcontentloaded" });
+    await sp.goto(appUrl(exampleBase, "x0x-swarm", studio, session), { waitUntil: "domcontentloaded" });
+    await waitForText(lp, "#statusText", "Connected", 15000);
+    await waitForText(sp, "#statusText", "Connected", 15000);
+    const task = `example swarm ${Date.now()}`;
+    await lp.fill("#taskDesc", task);
+    await lp.click("#submitBtn");
+    await waitForText(sp, "#feed", task, 20000);
+    record("example-app.swarm-cross-machine", "pass");
+    await lp.close();
+    await sp.close();
+}
+
+async function proveDrop(context, exampleBase, local, studio) {
+    const lp = await context.newPage();
+    const sp = await context.newPage();
+    await lp.goto(appUrl(exampleBase, "x0x-drop", local), { waitUntil: "domcontentloaded" });
+    await sp.goto(appUrl(exampleBase, "x0x-drop", studio), { waitUntil: "domcontentloaded" });
+    await waitForText(lp, "#conn-label", "Connected", 15000);
+    await waitForText(sp, "#conn-label", "Connected", 15000);
+    await lp.waitForSelector("#agent-list .peer", { timeout: 15000 });
+    await lp.click("#agent-list .peer");
+    const upload = join(PROOF_DIR, "example-drop-upload.txt");
+    writeFileSync(upload, `x0x drop proof ${Date.now()}`);
+    await lp.setInputFiles("#fileIn", upload);
+    await lp.waitForSelector("#send-btn", { state: "visible", timeout: 10000 });
+    await lp.click("#send-btn");
+    await sp.waitForSelector("#xfer-list button", { timeout: 20000 });
+    await sp.click("#xfer-list button:has-text('Accept')");
+    await waitForText(sp, "#xfer-list", "Complete", 30000);
+    record("example-app.drop-cross-machine", "pass");
+    await lp.close();
+    await sp.close();
+}
+
+async function main() {
+    const executablePath = chromePath();
+    const browser = await chromium.launch({ headless: !process.env.X0X_GUI_HEADED, ...(executablePath ? { executablePath } : {}) });
+    const context = await browser.newContext({ viewport: { width: 1440, height: 920 } });
+    const examples = await startExampleServer();
+    const local = manifest.local;
+    const studio = manifest.studio;
+    try {
+        record("setup.example-loopback-server", "pass", { base: examples.base });
+        const space = await ensureSpace(local, studio);
+        record("setup.public-open-space", "pass", space);
+
+        const localGui = await openGui(context, local, "macbook");
+        const studioGui = await openGui(context, studio, "studio");
+        await proveGuiViews(localGui.page, "macbook", space.localGroupId);
+        await proveGuiViews(studioGui.page, "studio", space.studioGroupId);
+        await proveGuiDm(localGui.page, studioGui.page, local, studio);
+        await proveGuiRecovery(localGui.page);
+
+        await proveChat(context, examples.base, local, studio);
+        await proveBoard(context, examples.base, local, "macbook");
+        await proveBoard(context, examples.base, studio, "studio");
+        await proveNetwork(context, examples.base, local, "macbook");
+        await proveNetwork(context, examples.base, studio, "studio");
+        await proveSwarm(context, examples.base, local, studio);
+        await proveDrop(context, examples.base, local, studio);
+    } catch (e) {
+        record("harness.failure", "fail", { reason: e.message });
+    } finally {
+        await context.close();
+        await browser.close();
+        await new Promise(resolveClose => examples.server.close(resolveClose));
+        report.run_completed_at = new Date().toISOString();
+        writeFileSync(join(PROOF_DIR, "studio-gui-full-report.json"), JSON.stringify(report, null, 2));
+    }
+    process.exit(report.totals.fail > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+    record("harness.uncaught", "fail", { reason: String(err?.message || err) });
+    writeFileSync(join(PROOF_DIR, "studio-gui-full-report.json"), JSON.stringify(report, null, 2));
+    process.exit(1);
+});

--- a/tests/e2e_studio_live.py
+++ b/tests/e2e_studio_live.py
@@ -42,6 +42,7 @@ if not LOCAL_X0XD.exists():
     LOCAL_X0XD = ROOT / "target" / "release" / "x0xd"
 REMOTE_X0XD = os.environ.get("REMOTE_X0XD", "/Users/studio1/.local/bin/x0xd")
 KEEP = os.environ.get("KEEP_X0X_STUDIO_LIVE") == "1"
+MANIFEST_PATH = os.environ.get("X0X_STUDIO_MANIFEST")
 
 
 def pick_tcp_port() -> int:
@@ -69,6 +70,7 @@ REMOTE_API = int(os.environ.get("REMOTE_API_PORT", "0"))
 REMOTE_QUIC = int(os.environ.get("REMOTE_QUIC_PORT", "0"))
 PROCS: list[subprocess.Popen[Any]] = []
 PASSES = 0
+REMOTE_PID: str | None = None
 
 
 def log(message: str) -> None:
@@ -346,6 +348,11 @@ def pubsub_topic(event: dict[str, Any]) -> str:
 
 
 def cleanup(success: bool) -> None:
+    if KEEP:
+        log("KEEP_X0X_STUDIO_LIVE=1; leaving run-created daemons and SSH tunnel running")
+        log(f"left local_dir={LOCAL_DIR}")
+        log(f"left remote_dir={REMOTE_DIR}")
+        return
     for proc in reversed(PROCS):
         try:
             proc.terminate()
@@ -400,7 +407,7 @@ def write_config(path: Path, api_port: int, quic_port: int, data_dir: str) -> No
 
 
 def start_daemons() -> tuple[str, str]:
-    global REMOTE_API, REMOTE_QUIC
+    global REMOTE_API, REMOTE_QUIC, REMOTE_PID
     if REMOTE_API <= 0 or REMOTE_QUIC <= 0:
         REMOTE_API, REMOTE_QUIC = pick_remote_tcp_ports(2)
     if REMOTE_API == REMOTE_QUIC:
@@ -482,7 +489,8 @@ cat {shlex.quote(REMOTE_DIR)}/pid
         input_text=remote_script,
         timeout=30,
     )
-    log(f"remote_pid={proc.stdout.strip()}")
+    REMOTE_PID = proc.stdout.strip()
+    log(f"remote_pid={REMOTE_PID}")
     ok("studio daemon started")
 
     tunnel = subprocess.Popen(
@@ -505,6 +513,52 @@ cat {shlex.quote(REMOTE_DIR)}/pid
     studio_token = ssh(f"cat {shlex.quote(REMOTE_DIR)}/api-token", timeout=15).stdout.strip()
     ok("studio token created")
     return local_token, studio_token
+
+
+def write_manifest(
+    local_token: str,
+    studio_token: str,
+    mac: dict[str, str] | None = None,
+    studio: dict[str, str] | None = None,
+) -> None:
+    if not MANIFEST_PATH:
+        return
+    manifest = {
+        "run_id": RUN_ID,
+        "keep": KEEP,
+        "studio_ssh_target": STUDIO,
+        "local": {
+            "name": LOCAL_NAME,
+            "api_base": f"http://127.0.0.1:{LOCAL_API}",
+            "api_port": LOCAL_API,
+            "quic_port": LOCAL_QUIC,
+            "token": local_token,
+            "data_dir": str(LOCAL_DIR),
+            "pid": PROCS[0].pid if PROCS else None,
+            "agent": mac,
+        },
+        "studio": {
+            "name": REMOTE_NAME,
+            "api_base": f"http://127.0.0.1:{TUNNEL_PORT}",
+            "tunnel_port": TUNNEL_PORT,
+            "remote_api_port": REMOTE_API,
+            "remote_quic_port": REMOTE_QUIC,
+            "token": studio_token,
+            "remote_dir": REMOTE_DIR,
+            "remote_pid": REMOTE_PID,
+            "agent": studio,
+        },
+        "ssh_tunnel": {
+            "local_port": TUNNEL_PORT,
+            "remote_host": "127.0.0.1",
+            "remote_port": REMOTE_API,
+            "pid": PROCS[-1].pid if PROCS else None,
+        },
+    }
+    path = Path(MANIFEST_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    ok("studio run manifest written", str(path))
 
 
 def assert_gui(studio_token: str) -> None:
@@ -1107,6 +1161,7 @@ def main() -> int:
         local_token, studio_token = start_daemons()
         assert_gui(studio_token)
         mac, studio = connect_agents(local_token, studio_token)
+        write_manifest(local_token, studio_token, mac, studio)
         direct_messages(local_token, studio_token, mac["agent_id"], studio["agent_id"])
         contacts(local_token, studio_token, mac, studio)
         diagnostics_and_signing(local_token, studio_token)


### PR DESCRIPTION
## What changed

- Fixed local/testnet discovery so explicit local bootstrap partitions can advertise and probe loopback, LAN, CGNAT, and ULA addresses while global bootstrap caches remain public-only.
- Fixed x0xd file-transfer control delivery by ACKing control messages while preserving raw/no-ACK chunk windowing.
- Added browser upload support for the Drop app via base64 payloads.
- Hardened TreeKEM group leave/delete handling for self-leave, pending local stubs, and creator-deletion flows.
- Updated the example GUI apps to share API/token configuration, use authenticated websocket/API calls, isolate Swarm topics per session, and fix board/drop/network flow issues.
- Added a Playwright-based studio GUI dogfood harness and expanded studio/Communitas proof scripts.

## Why

The x0x GUI dogfood run exposed gaps that only appear when two real daemons run on isolated machines with forwarded GUIs: local discovery was filtering out usable testnet endpoints, file control messages could time out under the raw transfer config, browser drop uploads could not provide file bytes, and some GUI apps were not consistently honoring the daemon API/token context.

## Validation

Proof root: `proofs/x0x-gui-full-dogfood/20260607-134430`

- `LIVE_STUDIO_E2E_OK passes=33`
- `tests/e2e_studio_gui_full.mjs`: 13 pass, 0 fail, 0 skip after the final file-control ACK fix
- `communitas-x0x-client` local contract: 2/2 matrix checks and 1/1 mutation checks passed
- Communitas Dioxus JSON hook: all identity, connectivity, groups, kv, presence, and upgrade operations passed
- Maintained Dioxus parity: all identity, trust_contacts, connectivity, groups, kv_store, presence, and upgrade cells passed
- `XCUITEST_SKIP=1 swift test --package-path communitas-apple --skip CommunitasUITests`: 87 Swift tests passed with the UI test target skipped
- `tests/e2e_dogfood_local.py`: 19/19 passed
- `tests/e2e_dogfood_groups.py`: 33/33 passed
- `tests/e2e_comprehensive.py`: all 147 tests passed, 145 passed and 2 optional direct-event annotations skipped
- `cargo test local_discovery --lib`: passed
- `cargo test file_transfer_control_messages_are_acked_but_chunks_are_windowed --bin x0xd`: passed
- `cargo build --release --bins`: passed
- `cargo fmt --all`: passed
- `cargo clippy --all-features --all-targets -- -D warnings`: passed
- `cargo check --workspace --all-targets`: passed

## Notes

The untracked `goals/` directory was intentionally left out of this PR because it contains planning/proof metadata rather than product code.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes local/testnet discovery address filtering, hardens the file-transfer control-message ACK path, adds browser base64 upload support for the Drop app, fixes the TreeKEM self-leave flow (replacing the always-failing self-rekey with a clean metadata-only roster removal), and brings all five example GUI apps up to the authenticated multi-daemon dogfood configuration.

- **Discovery**: `allow_local_scope` is now derived from the bootstrap-node list and propagated through the heartbeat context, gossip listeners, and announce paths, allowing isolated testnet partitions to advertise and cache LAN/loopback addresses. A local-direct-probe loop prioritises same-subnet IPv4 before falling through to the existing QUIC-peer-ID and relay paths.
- **TreeKEM self-leave**: `leave_treekem_group` now classifies membership as `CreatorMustDelete` / `LocalOnlyDrop` / `ActiveMember` and emits a signed metadata-only `MemberRemoved` (no `treekem_commit_b64`); the old broken `guard.remove_member(local_agent)` self-rekey is removed. ADR-0014 documents the PCS gap and the tracked owner-responsive-rekey follow-up.
- **GUI apps**: All five apps share `?api=&token=` query-param / `localStorage` config; the Swarm app uses per-session topics and awaits the `connected`/`subscribed` WS handshake; the Drop app adds base64 upload and filters self from the peer list.

<h3>Confidence Score: 4/5</h3>

The core Rust changes are well-tested and narrowly scoped, but one address-filtering inconsistency in the public `build_announcement` API partially undermines the local-discovery fix for manual agent-card sharing.

All hot paths for discovery correctly thread `allow_local_scope` through. However, `build_identity_announcement` calls `announcement_addresses()` — which now correctly includes LAN hints for local partitions — and then re-filters with a hardcoded `allow_local_scope: false`, silently discarding those hints. Any caller building an agent card for manual sharing or QR pairing on a local-partition daemon gets a public-only address list.

src/lib.rs — specifically the `build_identity_announcement` function (~line 5320) and its public wrapper `build_announcement`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib.rs | Adds local/testnet discovery: scope-aware address filtering, local-direct-probe priority dialing, and `allow_local_scope` threading through heartbeat and gossip listeners. Hot paths are correctly updated, but `build_identity_announcement` / `build_announcement` hardcodes `allow_local_scope: false` after `announcement_addresses()` has already applied local-scope filtering, silently stripping LAN hints for local-partition daemons on the public API path. |
| src/bin/x0xd.rs | Three targeted fixes: separate `file_transfer_control_send_config` enables ACK timeouts for control messages (verified by new unit test); `file_send_handler` adds base64 spool path for browser uploads with SHA-256 and size validation; TreeKEM self-leave refactored to disposition enum, removing the broken self-rekey. |
| examples/apps/x0x-drop.html | Adds API/token config, self-agent filtering, and base64 upload path. No file-size guard before the full ArrayBuffer→base64 encode, which can exhaust browser memory for large files. |
| examples/apps/x0x-swarm.html | API/token config, per-session Swarm topics, and WebSocket `connected`/`subscribed` handshake fix. Session isolation via `location.hash` is clean. |
| tests/e2e_studio_gui_full.mjs | New Playwright dogfood harness driving both daemon GUIs and example apps; includes a path-traversal guard in the local file server. Well-structured proof script. |
| docs/adr/0014-treekem-self-leave-owner-driven-rekey.md | New ADR documenting the shipped metadata-only self-leave and the tracked owner-responsive-rekey follow-up; clearly scopes the security gap window and acceptance criteria. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Bootstrap config] -->|all nodes local-scoped or empty| B{allow_local_scope = true}
    A -->|any public node| C{allow_local_scope = false}

    B --> D[filter_discovery_announcement_addrs\nkeeps LAN + loopback + public]
    C --> E[filter_publicly_advertisable_addrs\npublic only]

    D --> F[Heartbeat announcements\n✅ LAN addresses included]
    D --> G[Gossip listener cache\n✅ LAN addresses stored]
    D --> H[announcement_addresses\n✅ scope-aware]
    H -->|allow_local_scope: false hardcoded| I[build_identity_announcement\n❌ LAN stripped again]
    I --> J[build_announcement public API\n❌ returns public-only list]

    E --> K[bootstrap_cache\npublic only — always correct]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib.rs`, line 5320-5343 ([link](https://github.com/saorsa-labs/x0x/blob/4b2694fee656fc2941e1667bf02f00ffd376e4ca/src/lib.rs#L5320-L5343)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Double-filter strips LAN addresses from `build_announcement`**

   `announcement_addresses()` now correctly applies scope-aware filtering — it returns LAN/loopback addresses when the partition is local. But `build_identity_announcement` then calls `build_identity_announcement_with_addrs` with `allow_local_scope: false`, which re-runs `filter_discovery_announcement_addrs` on the already-filtered list and strips all non-public addresses out again. For a local/testnet-partition daemon this means `Agent::build_announcement()` — used for manual agent-card sharing, QR pairing, and the documented public API — will silently omit the LAN addresses that the PR is specifically trying to preserve. The fix is to derive `allow_local_scope` from the config here (same pattern used in `announcement_addresses()`) instead of hardcoding `false`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib.rs
   Line: 5320-5343

   Comment:
   **Double-filter strips LAN addresses from `build_announcement`**

   `announcement_addresses()` now correctly applies scope-aware filtering — it returns LAN/loopback addresses when the partition is local. But `build_identity_announcement` then calls `build_identity_announcement_with_addrs` with `allow_local_scope: false`, which re-runs `filter_discovery_announcement_addrs` on the already-filtered list and strips all non-public addresses out again. For a local/testnet-partition daemon this means `Agent::build_announcement()` — used for manual agent-card sharing, QR pairing, and the documented public API — will silently omit the LAN addresses that the PR is specifically trying to preserve. The fix is to derive `allow_local_scope` from the config here (same pattern used in `announcement_addresses()`) instead of hardcoding `false`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `examples/apps/x0x-drop.html`, line 444-504 ([link](https://github.com/saorsa-labs/x0x/blob/4b2694fee656fc2941e1667bf02f00ffd376e4ca/examples/apps/x0x-drop.html#L444-L504)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No file-size guard before base64 encoding**

   `handleFile` reads the entire `ArrayBuffer` into memory, encodes it as base64 (`fileDataB64`), and then embeds the result in a JSON body sent to `/files/send`. There is no upper-bound check on `f.size` before this path executes. Dropping a multi-hundred-MB file will exhaust the browser's JS heap (on many devices a 250 MB file becomes ~333 MB of base64 string), lock the UI during the encoding loop, and produce a JSON payload the HTTP server may reject with a 413. Consider adding a size cap (e.g. 10–50 MB) before the `f.arrayBuffer()` call and surfacing a user-visible error when the limit is exceeded.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: examples/apps/x0x-drop.html
   Line: 444-504

   Comment:
   **No file-size guard before base64 encoding**

   `handleFile` reads the entire `ArrayBuffer` into memory, encodes it as base64 (`fileDataB64`), and then embeds the result in a JSON body sent to `/files/send`. There is no upper-bound check on `f.size` before this path executes. Dropping a multi-hundred-MB file will exhaust the browser's JS heap (on many devices a 250 MB file becomes ~333 MB of base64 string), lock the UI during the encoding loop, and produce a JSON payload the HTTP server may reject with a 413. Consider adding a size cap (e.g. 10–50 MB) before the `f.arrayBuffer()` call and surfacing a user-visible error when the limit is exceeded.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib.rs:5320-5343
**Double-filter strips LAN addresses from `build_announcement`**

`announcement_addresses()` now correctly applies scope-aware filtering — it returns LAN/loopback addresses when the partition is local. But `build_identity_announcement` then calls `build_identity_announcement_with_addrs` with `allow_local_scope: false`, which re-runs `filter_discovery_announcement_addrs` on the already-filtered list and strips all non-public addresses out again. For a local/testnet-partition daemon this means `Agent::build_announcement()` — used for manual agent-card sharing, QR pairing, and the documented public API — will silently omit the LAN addresses that the PR is specifically trying to preserve. The fix is to derive `allow_local_scope` from the config here (same pattern used in `announcement_addresses()`) instead of hardcoding `false`.

### Issue 2 of 2
examples/apps/x0x-drop.html:444-504
**No file-size guard before base64 encoding**

`handleFile` reads the entire `ArrayBuffer` into memory, encodes it as base64 (`fileDataB64`), and then embeds the result in a JSON body sent to `/files/send`. There is no upper-bound check on `f.size` before this path executes. Dropping a multi-hundred-MB file will exhaust the browser's JS heap (on many devices a 250 MB file becomes ~333 MB of base64 string), lock the UI during the encoding loop, and produce a JSON payload the HTTP server may reject with a 413. Consider adding a size cap (e.g. 10–50 MB) before the `f.arrayBuffer()` call and surfacing a user-visible error when the limit is exceeded.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(groups): MemberRemoved with signed c..."](https://github.com/saorsa-labs/x0x/commit/4b2694fee656fc2941e1667bf02f00ffd376e4ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36107092)</sub>

<!-- /greptile_comment -->