### PR TITLE
feat(daemon): app-integration support — per-recipient DM inbox, gossip-DM fallback listeners, fresh-boot DM delivery fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fresh-boot DM delivery black hole (dogfood `group_join` / hop-DM 25s timeouts).** Local 3-daemon soaks failed 10-17% of iterations with `group_join timed out` / `hop DM never echoed back`; a trace-instrumented capture run pinned a chain of three compounding faults, each masked by the previous one:
+  1. **Capability-advert poisoning**: `CapabilityAdvertService` broadcast the startup `pending()` advert (no gossip inbox / KEM key), and `CapabilityStore::insert` was unconditional last-writer-wins — epidemic broadcast delivers out of order, so a stale pending advert could clobber the gossip-ready one and leave senders on `advert_cache_unusable`. The store now orders adverts by their signed `created_at_unix_ms` (stale ignored; a genuinely fresher downgrade still wins), and the publisher never broadcasts a not-yet-usable advert (absence already means "use the raw fallback").
+  2. **Fire-and-forget raw-QUIC loss**: the daemon's generic DM config sent raw-path messages without ant-quic's receive-pipeline ACK — a send into a connection being superseded during boot churn returned `Ok` (dur_ms=0) while the bytes were lost, so the retry machinery never fired and the recipient's app never saw the message. `direct_message_send_config()` now sets `raw_quic_receive_ack_timeout = 8s` (matching the named-group config), so loss fails the attempt and the existing retry re-sends.
+  3. **Zombie-connection retry pinning**: with loss now detected, retries still resolved `cached_connected` onto the same dead connection (`is_connected` stays true for a zombie whose remote endpoint vanished without a lifecycle event) and burned ~14s per attempt until the caller's deadline. An ACKed-path send failure on a still-connected peer now tears the connection down so the next attempt takes the X0X-0031/0033 send-readiness repair (fresh dial).
+
+  Validated: the capture harness went from failing within 12-27 iterations to 40/40 clean; `tests/pr99_local_soak.sh` restored to baseline (see soak artefacts under `proofs/x0x-gui-full-dogfood/`).
+
 ### Added
 
 - **`welcome.trace` diagnostics for the TreeKEM Welcome-blob transfer.** Trace-only (no behavior change): `target=welcome.trace` debug stages on both sides of the chunked Welcome pull — anchor `offer_sent` / `chunk_sent` / `chunk_ack_recv` / `final_ack_{ok,failed}`; receiver `chunk_recv` / `chunk_recv_no_pending` / `chunk_ack_sent`. Enable with `RUST_LOG=warn,welcome.trace=debug` to locate exactly where a Welcome transfer stalls under churn.

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -2625,9 +2625,13 @@ fn named_group_direct_delivery_config() -> x0x::dm::DmSendConfig {
     // The gossip-inbox DM path verifies the signed DM envelope and marks the
     // bridged direct message verified. Raw QUIC can only mark messages
     // verified when the receiver already has a fresh AgentId -> MachineId
-    // binding, so it must remain a fallback rather than preempting gossip.
+    // binding, so keep it as the fallback for peers whose gossip-inbox
+    // capability advert has not converged yet. Terminal signed commits (for
+    // example creator delete) are self-authenticating and explicitly re-check
+    // authority on apply, so dropping the raw fallback can strand members after
+    // their metadata listener exits.
     let mut config = direct_message_send_config();
-    config.require_gossip = true;
+    config.raw_quic_receive_ack_timeout = Some(Duration::from_secs(8));
     config.require_gossip_ack = true;
     config
 }
@@ -20624,6 +20628,10 @@ mod tests {
         assert!(!config.prefer_raw_quic_if_connected);
         assert!(!config.require_gossip);
         assert!(!config.stop_fallback_on_raw_error);
+        assert_eq!(
+            config.raw_quic_receive_ack_timeout,
+            Some(Duration::from_secs(8))
+        );
     }
 
     #[test]

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -2614,8 +2614,17 @@ fn direct_message_send_config() -> x0x::dm::DmSendConfig {
     // Generic daemon/UI DMs should only return success after the inbox path
     // observes the recipient ACK. Callers that intentionally want
     // fire-and-forget gossip can pass `require_gossip_ack: false`.
+    //
+    // The raw-QUIC fallback (taken whenever the recipient's gossip-inbox
+    // capability advert has not converged yet — always the case in the first
+    // seconds after boot) must use ant-quic's receive-pipeline ACK. A
+    // fire-and-forget raw send into a connection that is being superseded
+    // reports Ok while the bytes are lost, the retry machinery never fires,
+    // and the recipient's app never sees the message (the dogfood
+    // group_join / hop-DM 25s-timeout black hole).
     x0x::dm::DmSendConfig {
         timeout_per_attempt: Duration::from_secs(8),
+        raw_quic_receive_ack_timeout: Some(Duration::from_secs(8)),
         ..x0x::dm::DmSendConfig::default()
     }
 }
@@ -4510,7 +4519,12 @@ async fn import_agent_card(
     if machine_id_bytes != [0u8; 32] {
         if let Some(caps) = card.dm_capabilities.clone() {
             if caps.gossip_inbox && !caps.kem_public_key.is_empty() {
-                capability_store.insert(agent_id, x0x::identity::MachineId(machine_id_bytes), caps);
+                capability_store.insert(
+                    agent_id,
+                    x0x::identity::MachineId(machine_id_bytes),
+                    caps,
+                    x0x::dm_capability::now_unix_ms(),
+                );
                 inserted_dm_capability = true;
             }
         }
@@ -19964,7 +19978,15 @@ mod tests {
 
     #[test]
     fn direct_message_send_config_requires_gossip_ack_by_default() {
-        assert!(direct_message_send_config().require_gossip_ack);
+        let config = direct_message_send_config();
+        assert!(config.require_gossip_ack);
+        // Raw-QUIC fallback must be loss-detecting (receive-pipeline ACK), or
+        // a send into a superseded connection reports Ok, the retry never
+        // fires, and the recipient's app never sees the message.
+        assert_eq!(
+            config.raw_quic_receive_ack_timeout,
+            Some(Duration::from_secs(8))
+        );
     }
 
     #[test]

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -28,7 +28,7 @@ use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::sse::{Event, Sse};
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, patch, post, put};
 use axum::{Json, Router};
 use base64::Engine;
@@ -522,6 +522,8 @@ struct AppState {
     shutdown_notify: watch::Sender<bool>,
     /// Update configuration honored by manual API-triggered update checks.
     update_config: DaemonUpdateConfig,
+    /// Cached `/upgrade` response so polling clients cannot hammer GitHub.
+    upgrade_check_cache: Mutex<Option<CachedUpgradeCheck>>,
     /// Serializes all destructive binary replacement attempts.
     upgrade_apply_lock: Arc<Mutex<()>>,
     /// API bearer token for authenticating local clients.
@@ -536,6 +538,17 @@ struct AppState {
 /// is populated from untrusted discovery surfaces, so it must not grow without
 /// bound even if every incoming card is syntactically valid.
 const GROUP_CARD_CACHE_CAP: usize = 8_192;
+
+const UPGRADE_CHECK_CACHE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+const UPGRADE_CHECK_ERROR_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
+
+#[derive(Clone)]
+struct CachedUpgradeCheck {
+    checked_at: Instant,
+    status: StatusCode,
+    body: serde_json::Value,
+    ttl: Duration,
+}
 
 fn group_card_expiry_millis(card: &x0x::groups::GroupCard) -> u64 {
     if card.expires_at > card.issued_at {
@@ -983,6 +996,11 @@ struct DirectSendRequest {
     /// gossip DM capability.
     #[serde(default)]
     require_gossip: bool,
+    /// If set, override whether gossip-inbox sends wait for the recipient's
+    /// inbox ACK before returning success. When omitted, the daemon default is
+    /// used.
+    #[serde(default)]
+    require_gossip_ack: Option<bool>,
     /// Optional opt-in: after the DM path accepts the message, probe the
     /// recipient's ant-quic receive pipeline for liveness with this timeout.
     /// This does not force the message itself onto raw-QUIC receive-ACK.
@@ -1161,6 +1179,7 @@ async fn main() -> Result<()> {
         println!("    --name <NAME>                   Instance name for multi-instance support");
         println!("    --api-port <PORT>               Override API server port");
         println!("    --no-hard-coded-bootstrap       Skip configured bootstrap peers");
+        println!("    --disable-peer-cache            Do not load or save cached peers");
         println!("    --exec-acl <PATH>               Override default exec ACL path");
         println!("    --check                         Check configuration and exit");
         println!("    --check-updates       Check for updates and exit");
@@ -1212,6 +1231,7 @@ async fn main() -> Result<()> {
     // where operator policy forbids unsolicited router port mappings. This
     // overrides the daemon config's `port_mapping_enabled` field.
     let cli_no_port_mapping = args.contains(&"--no-port-mapping".to_string());
+    let cli_disable_peer_cache = args.contains(&"--disable-peer-cache".to_string());
 
     // Parse --api-port for overriding the API server port
     let api_port_override = if let Some(idx) = args.iter().position(|a| a == "--api-port") {
@@ -1426,7 +1446,7 @@ async fn main() -> Result<()> {
         max_connections: 50,
         connection_timeout: std::time::Duration::from_secs(30),
         stats_interval: std::time::Duration::from_secs(60),
-        peer_cache_path: Some(cache_dir.join("peers.cache")),
+        peer_cache_path: (!cli_disable_peer_cache).then(|| cache_dir.join("peers.cache")),
         pinned_bootstrap_peers: std::collections::HashSet::new(),
         inbound_allowlist: std::collections::HashSet::new(),
         max_peers_per_ip: 3,
@@ -1452,6 +1472,10 @@ async fn main() -> Result<()> {
     }
     if let Some(secs) = config.presence_offline_timeout_secs {
         builder = builder.with_presence_offline_timeout(secs);
+    }
+    if cli_disable_peer_cache {
+        tracing::info!("Peer cache disabled by --disable-peer-cache");
+        builder = builder.with_peer_cache_disabled();
     }
 
     // NOTE: --no-hard-coded-bootstrap only clears configured seed peers.
@@ -1538,6 +1562,10 @@ async fn main() -> Result<()> {
     let (shutdown_notify, _) = watch::channel(false);
     let agent = Arc::new(agent);
     let (exec_dm_tx, exec_dm_rx) = mpsc::channel::<x0x::dm_inbox::DmTypedPayload>(1024);
+    let (group_public_dm_tx, mut group_public_dm_rx) =
+        mpsc::channel::<x0x::dm_inbox::DmTypedPayload>(1024);
+    let (kv_store_delta_dm_tx, mut kv_store_delta_dm_rx) =
+        mpsc::channel::<x0x::dm_inbox::DmTypedPayload>(1024);
     let exec_service = x0x::exec::ExecService::spawn(Arc::clone(&agent), exec_policy, exec_dm_rx);
 
     // ADR-0012 Phase 4: restore live TreeKEM groups from on-disk snapshots.
@@ -1595,6 +1623,7 @@ async fn main() -> Result<()> {
         shutdown_tx,
         shutdown_notify,
         update_config: config.update.clone(),
+        upgrade_check_cache: Mutex::new(None),
         upgrade_apply_lock: Arc::new(Mutex::new(())),
         api_token,
         exec_service: Arc::clone(&exec_service),
@@ -1680,10 +1709,14 @@ async fn main() -> Result<()> {
     let dm_inbox_agent = Arc::clone(&agent);
     let dm_inbox_kem = Arc::clone(&agent_kem_keypair);
     let dm_inbox_exec_route_tx = exec_dm_tx.clone();
+    let dm_inbox_group_public_route_tx = group_public_dm_tx.clone();
+    let dm_inbox_kv_store_delta_route_tx = kv_store_delta_dm_tx.clone();
     tokio::spawn(start_dm_inbox_when_gossip_ready(
         dm_inbox_agent,
         dm_inbox_kem,
         dm_inbox_exec_route_tx,
+        dm_inbox_group_public_route_tx,
+        dm_inbox_kv_store_delta_route_tx,
     ));
 
     tokio::spawn(async move {
@@ -1979,6 +2012,66 @@ async fn main() -> Result<()> {
                 );
                 apply_named_group_metadata_event(&meta_state, event, msg.sender, msg.verified)
                     .await;
+            }
+        });
+    }
+
+    // Background signed public-message listener for typed gossip-DM fallback
+    // delivery. Per-group pubsub is still the primary fan-out path; this route
+    // handles the same signed message when the sender additionally direct-
+    // delivers it to active members.
+    {
+        let public_dm_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            while let Some(typed) = group_public_dm_rx.recv().await {
+                if !typed.verified {
+                    continue;
+                }
+                let Some(payload) = typed.payload.strip_prefix(GROUP_PUBLIC_MESSAGE_DM_PREFIX)
+                else {
+                    continue;
+                };
+                let Ok(msg) = serde_json::from_slice::<x0x::groups::GroupPublicMessage>(payload)
+                else {
+                    tracing::debug!(
+                        sender = %hex::encode(typed.sender.as_bytes()),
+                        "typed group-public DM payload was not a GroupPublicMessage"
+                    );
+                    continue;
+                };
+                let group_id = msg.group_id.clone();
+                tracing::debug!(
+                    group_id = %group_id,
+                    sender = %hex::encode(typed.sender.as_bytes()),
+                    "direct-delivered public group message received"
+                );
+                ingest_public_message(&public_dm_state, msg, &group_id).await;
+            }
+        });
+    }
+
+    // Background KvStore delta listener for typed gossip-DM fallback delivery.
+    // Store pub/sub remains the primary path; this side channel gives joined
+    // peers a reliable replay of the same CRDT delta when the topic mesh is
+    // late or congested. Peers that have not joined the store simply ignore it.
+    {
+        let kv_delta_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            while let Some(typed) = kv_store_delta_dm_rx.recv().await {
+                if !typed.verified {
+                    continue;
+                }
+                let Some(payload) = typed.payload.strip_prefix(KV_STORE_DELTA_DM_PREFIX) else {
+                    continue;
+                };
+                let Ok(delta_msg) = serde_json::from_slice::<KvStoreDirectDelta>(payload) else {
+                    tracing::debug!(
+                        sender = %hex::encode(typed.sender.as_bytes()),
+                        "typed kv-store DM payload was not a KvStoreDirectDelta"
+                    );
+                    continue;
+                };
+                apply_direct_kv_store_delta(&kv_delta_state, typed.sender, delta_msg).await;
             }
         });
     }
@@ -2518,16 +2611,11 @@ fn file_transfer_now() -> (u64, u64) {
 }
 
 fn direct_message_send_config() -> x0x::dm::DmSendConfig {
-    // Generic daemon/UI DMs use the capability-aware gossip-inbox path when the
-    // recipient advertises it, but the REST API reports success after the local
-    // gossip publish. Live meshes can deliver the payload while dropping the
-    // reverse ACK; surfacing that as 504 makes users resend messages that the
-    // recipient already displayed. The attempt budget must also cover
-    // saorsa-gossip's Critical fan-out gate plus per-peer send budget under
-    // load; the 4s library default is too short for the live daemon mesh.
+    // Generic daemon/UI DMs should only return success after the inbox path
+    // observes the recipient ACK. Callers that intentionally want
+    // fire-and-forget gossip can pass `require_gossip_ack: false`.
     x0x::dm::DmSendConfig {
         timeout_per_attempt: Duration::from_secs(8),
-        require_gossip_ack: false,
         ..x0x::dm::DmSendConfig::default()
     }
 }
@@ -2538,17 +2626,27 @@ fn named_group_direct_delivery_config() -> x0x::dm::DmSendConfig {
     // bridged direct message verified. Raw QUIC can only mark messages
     // verified when the receiver already has a fresh AgentId -> MachineId
     // binding, so it must remain a fallback rather than preempting gossip.
-    direct_message_send_config()
+    let mut config = direct_message_send_config();
+    config.require_gossip = true;
+    config.require_gossip_ack = true;
+    config
 }
 
 async fn start_dm_inbox_when_gossip_ready(
     agent: Arc<x0x::Agent>,
     kem_keypair: Arc<x0x::groups::kem_envelope::AgentKemKeypair>,
     exec_route_tx: mpsc::Sender<x0x::dm_inbox::DmTypedPayload>,
+    group_public_route_tx: mpsc::Sender<x0x::dm_inbox::DmTypedPayload>,
+    kv_store_delta_route_tx: mpsc::Sender<x0x::dm_inbox::DmTypedPayload>,
 ) {
     for attempt in 1..=DM_INBOX_START_MAX_ATTEMPTS {
         let dm_inbox_config = x0x::dm_inbox::DmInboxConfig::default()
-            .with_typed_payload_route(x0x::exec::EXEC_DM_PREFIX, exec_route_tx.clone());
+            .with_typed_payload_route(x0x::exec::EXEC_DM_PREFIX, exec_route_tx.clone())
+            .with_typed_payload_route(
+                GROUP_PUBLIC_MESSAGE_DM_PREFIX,
+                group_public_route_tx.clone(),
+            )
+            .with_typed_payload_route(KV_STORE_DELTA_DM_PREFIX, kv_store_delta_route_tx.clone());
         match agent
             .start_dm_inbox(Arc::clone(&kem_keypair), dm_inbox_config)
             .await
@@ -2584,16 +2682,17 @@ async fn start_dm_inbox_when_gossip_ready(
 fn file_transfer_send_config() -> x0x::dm::DmSendConfig {
     let mut config = x0x::dm::DmSendConfig {
         prefer_raw_quic_if_connected: true,
-        stop_fallback_on_raw_error: true,
+        stop_fallback_on_raw_error: false,
         ..x0x::dm::DmSendConfig::default()
     };
-    // File transfer already has a stronger application-level ChunkAck after
-    // the receiver persists each chunk. Avoid layering the raw receive-ACK on
-    // every chunk, which adds an unnecessary second wait in the hot path.
-    // Also keep raw failures terminal: silently falling back to gossip would
-    // push 32 KiB chunks through signed/encrypted pubsub fanout and break the
-    // throughput/back-pressure assumptions of the file chunk window.
-    config.raw_quic_receive_ack_timeout = None;
+    // File transfer has a stronger application-level ChunkAck after the
+    // receiver persists each chunk, but the raw receive-ACK still matters for
+    // stale raw connections: without it, ant-quic can report local send
+    // success while the receiver never drains the chunk, leaving the sender to
+    // fail only after the 60s application ack timeout. Keep the raw fast path,
+    // but allow capability-aware gossip fallback when that raw receive-ACK
+    // fails. DEFAULT_CHUNK_SIZE is sized to fit the DM envelope cap.
+    config.raw_quic_receive_ack_timeout = Some(Duration::from_secs(8));
     config
 }
 
@@ -4244,6 +4343,14 @@ fn discover_local_card_addresses(port: u16, addresses: &mut Vec<String>, include
     }
 }
 
+fn prioritize_local_card_addresses(addresses: &mut [String]) {
+    addresses.sort_by_key(|addr| {
+        addr.parse::<std::net::SocketAddr>()
+            .map(x0x::is_publicly_advertisable)
+            .unwrap_or(true)
+    });
+}
+
 /// GET /agent/card — generate a shareable identity card.
 async fn get_agent_card(
     State(state): State<Arc<AppState>>,
@@ -4278,6 +4385,9 @@ async fn get_agent_card(
                 &mut card.addresses,
                 query.include_local_addresses,
             );
+            if query.include_local_addresses {
+                prioritize_local_card_addresses(&mut card.addresses);
+            }
         }
     }
 
@@ -9972,6 +10082,15 @@ const PUBLIC_MESSAGE_HISTORY_CAP: usize = 512;
 /// fallback path while receivers still validate/cache only messages for groups
 /// they know locally.
 const GLOBAL_PUBLIC_MESSAGE_TOPIC: &str = "x0x.groups.public.v1";
+const GROUP_PUBLIC_MESSAGE_DM_PREFIX: &[u8] = b"X0X-GROUP-PUBLIC-V1\n";
+const KV_STORE_DELTA_DM_PREFIX: &[u8] = b"X0X-KV-DELTA-V1\n";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct KvStoreDirectDelta {
+    store_id: String,
+    peer_id: saorsa_gossip_types::PeerId,
+    delta: x0x::kv::KvStoreDelta,
+}
 
 /// Request body for `POST /groups/:id/send`.
 #[derive(Debug, Deserialize)]
@@ -10031,7 +10150,7 @@ async fn send_group_public_message(
 
     // Build + endpoint-side authz + sign under the write lock so
     // concurrent role changes can't race the check.
-    let msg = {
+    let (msg, direct_recipients) = {
         let groups = state.named_groups.read().await;
         let Some(info) = groups.get(&id) else {
             return (
@@ -10085,6 +10204,11 @@ async fn send_group_public_message(
                 }
             }
         }
+        let direct_recipients = info
+            .active_members()
+            .filter(|member| !member.agent_id.eq_ignore_ascii_case(&local_hex))
+            .map(|member| member.agent_id.clone())
+            .collect::<Vec<_>>();
 
         match x0x::groups::GroupPublicMessage::sign(
             info.stable_group_id().to_string(),
@@ -10096,7 +10220,7 @@ async fn send_group_public_message(
             req.body,
             now_ms,
         ) {
-            Ok(m) => m,
+            Ok(m) => (m, direct_recipients),
             Err(e) => {
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -10151,6 +10275,7 @@ async fn send_group_public_message(
     // Publish succeeded, so cache locally. The listener was started before the
     // publish above to avoid first-message topic races.
     cache_public_message(&state, msg.clone()).await;
+    spawn_group_public_message_delivery_to_active_members(&state, direct_recipients, &msg);
 
     (
         StatusCode::OK,
@@ -10249,6 +10374,86 @@ async fn cache_public_message(state: &AppState, msg: x0x::groups::GroupPublicMes
         while slot.len() > PUBLIC_MESSAGE_HISTORY_CAP {
             slot.remove(0);
         }
+    }
+}
+
+fn encode_group_public_message_direct_payload(
+    msg: &x0x::groups::GroupPublicMessage,
+) -> serde_json::Result<Vec<u8>> {
+    let json = serde_json::to_vec(msg)?;
+    let mut payload = Vec::with_capacity(GROUP_PUBLIC_MESSAGE_DM_PREFIX.len() + json.len());
+    payload.extend_from_slice(GROUP_PUBLIC_MESSAGE_DM_PREFIX);
+    payload.extend_from_slice(&json);
+    Ok(payload)
+}
+
+fn group_public_message_direct_delivery_config() -> x0x::dm::DmSendConfig {
+    let mut config = named_group_direct_delivery_config();
+    config.require_gossip = true;
+    config.require_gossip_ack = true;
+    config
+}
+
+fn spawn_group_public_message_delivery(
+    state: &AppState,
+    recipient_hex: &str,
+    msg: &x0x::groups::GroupPublicMessage,
+    delay: Option<Duration>,
+) {
+    let recipient = match parse_agent_id_hex(recipient_hex) {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(
+                recipient = %recipient_hex,
+                "cannot direct-deliver public group message: invalid recipient id: {e}"
+            );
+            return;
+        }
+    };
+    let payload = match encode_group_public_message_direct_payload(msg) {
+        Ok(payload) => payload,
+        Err(e) => {
+            tracing::warn!("failed to serialize public group message for direct delivery: {e}");
+            return;
+        }
+    };
+    let agent = Arc::clone(&state.agent);
+    let recipient_label = recipient_hex.to_string();
+    let group_id = msg.group_id.clone();
+    tokio::spawn(async move {
+        if let Some(delay) = delay {
+            tokio::time::sleep(delay).await;
+        }
+        if let Err(e) = agent
+            .send_direct_with_config(
+                &recipient,
+                payload,
+                group_public_message_direct_delivery_config(),
+            )
+            .await
+        {
+            tracing::warn!(
+                group_id = %group_id,
+                recipient = %recipient_label,
+                "failed to direct-deliver public group message: {e}"
+            );
+        }
+    });
+}
+
+fn spawn_group_public_message_delivery_to_active_members(
+    state: &AppState,
+    recipients: Vec<String>,
+    msg: &x0x::groups::GroupPublicMessage,
+) {
+    for recipient in recipients {
+        spawn_group_public_message_delivery(state, &recipient, msg, None);
+        spawn_group_public_message_delivery(
+            state,
+            &recipient,
+            msg,
+            Some(GROUP_BACKGROUND_PUBLISH_DELAY),
+        );
     }
 }
 
@@ -14562,6 +14767,147 @@ fn render_gui_html() -> String {
 // KvStore handlers
 // ---------------------------------------------------------------------------
 
+fn encode_kv_store_delta_direct_payload(
+    store_id: &str,
+    peer_id: saorsa_gossip_types::PeerId,
+    delta: &x0x::kv::KvStoreDelta,
+) -> serde_json::Result<Vec<u8>> {
+    let msg = KvStoreDirectDelta {
+        store_id: store_id.to_string(),
+        peer_id,
+        delta: delta.clone(),
+    };
+    let json = serde_json::to_vec(&msg)?;
+    let mut payload = Vec::with_capacity(KV_STORE_DELTA_DM_PREFIX.len() + json.len());
+    payload.extend_from_slice(KV_STORE_DELTA_DM_PREFIX);
+    payload.extend_from_slice(&json);
+    Ok(payload)
+}
+
+fn kv_store_delta_direct_delivery_config() -> x0x::dm::DmSendConfig {
+    let mut config = direct_message_send_config();
+    config.require_gossip = true;
+    config.require_gossip_ack = true;
+    config
+}
+
+async fn kv_store_delta_direct_recipients(state: &AppState) -> Vec<String> {
+    let local_agent_hex = hex::encode(state.agent.agent_id().as_bytes());
+    let contacts = state.contacts.read().await;
+    contacts
+        .list()
+        .into_iter()
+        .filter_map(|contact| {
+            let recipient = hex::encode(contact.agent_id.as_bytes());
+            if recipient == local_agent_hex || contact.trust_level == TrustLevel::Blocked {
+                return None;
+            }
+            let caps = contact.dm_capabilities.as_ref()?;
+            if !caps.gossip_inbox || caps.kem_public_key.is_empty() {
+                return None;
+            }
+            Some(recipient)
+        })
+        .collect()
+}
+
+fn spawn_kv_store_delta_delivery_one(
+    state: &AppState,
+    recipient_hex: &str,
+    store_id: &str,
+    peer_id: saorsa_gossip_types::PeerId,
+    delta: &x0x::kv::KvStoreDelta,
+    delay: Option<Duration>,
+) {
+    let recipient = match parse_agent_id_hex(recipient_hex) {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(
+                recipient = %recipient_hex,
+                "cannot direct-deliver kv-store delta: invalid recipient id: {e}"
+            );
+            return;
+        }
+    };
+    let payload = match encode_kv_store_delta_direct_payload(store_id, peer_id, delta) {
+        Ok(payload) => payload,
+        Err(e) => {
+            tracing::warn!(
+                store_id,
+                "failed to serialize kv-store delta for direct delivery: {e}"
+            );
+            return;
+        }
+    };
+    let agent = Arc::clone(&state.agent);
+    let recipient_label = recipient_hex.to_string();
+    let store_label = store_id.to_string();
+    tokio::spawn(async move {
+        if let Some(delay) = delay {
+            tokio::time::sleep(delay).await;
+        }
+        if let Err(e) = agent
+            .send_direct_with_config(&recipient, payload, kv_store_delta_direct_delivery_config())
+            .await
+        {
+            tracing::warn!(
+                store_id = %store_label,
+                recipient = %recipient_label,
+                "failed to direct-deliver kv-store delta: {e}"
+            );
+        }
+    });
+}
+
+fn spawn_kv_store_delta_delivery(
+    state: &AppState,
+    recipients: Vec<String>,
+    store_id: &str,
+    peer_id: saorsa_gossip_types::PeerId,
+    delta: &x0x::kv::KvStoreDelta,
+) {
+    for recipient in recipients {
+        spawn_kv_store_delta_delivery_one(state, &recipient, store_id, peer_id, delta, None);
+        spawn_kv_store_delta_delivery_one(
+            state,
+            &recipient,
+            store_id,
+            peer_id,
+            delta,
+            Some(GROUP_BACKGROUND_PUBLISH_DELAY),
+        );
+    }
+}
+
+async fn apply_direct_kv_store_delta(
+    state: &AppState,
+    sender: x0x::identity::AgentId,
+    delta_msg: KvStoreDirectDelta,
+) {
+    let store_id = delta_msg.store_id.clone();
+    let handle = {
+        let stores = state.kv_stores.read().await;
+        stores.get(&store_id).cloned()
+    };
+    let Some(handle) = handle else {
+        tracing::debug!(
+            store_id = %store_id,
+            sender = %hex::encode(sender.as_bytes()),
+            "ignoring direct kv-store delta for unjoined store"
+        );
+        return;
+    };
+    if let Err(e) = handle
+        .apply_remote_delta(delta_msg.peer_id, &delta_msg.delta, Some(sender))
+        .await
+    {
+        tracing::warn!(
+            store_id = %store_id,
+            "failed to apply direct kv-store delta: {e}"
+        );
+    }
+}
+
 /// Request body for POST /stores.
 #[derive(Debug, Deserialize)]
 struct CreateStoreRequest {
@@ -14682,12 +15028,15 @@ async fn put_kv_value(
     Path((id, key)): Path<(String, String)>,
     Json(req): Json<PutValueRequest>,
 ) -> impl IntoResponse {
-    let stores = state.kv_stores.read().await;
-    let Some(handle) = stores.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "store not found" })),
-        );
+    let handle = {
+        let stores = state.kv_stores.read().await;
+        let Some(handle) = stores.get(&id) else {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "ok": false, "error": "store not found" })),
+            );
+        };
+        handle.clone()
     };
 
     use base64::Engine;
@@ -14705,8 +15054,12 @@ async fn put_kv_value(
         .content_type
         .unwrap_or_else(|| "application/octet-stream".to_string());
 
-    match handle.put(key, value, content_type).await {
-        Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
+    match handle.put_with_delta(key, value, content_type).await {
+        Ok(delta) => {
+            let recipients = kv_store_delta_direct_recipients(&state).await;
+            spawn_kv_store_delta_delivery(&state, recipients, &id, handle.peer_id(), &delta);
+            (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
+        }
         Err(e) => {
             let status = if format!("{e}").contains("value too large") {
                 StatusCode::PAYLOAD_TOO_LARGE
@@ -14768,16 +15121,23 @@ async fn delete_kv_value(
     State(state): State<Arc<AppState>>,
     Path((id, key)): Path<(String, String)>,
 ) -> impl IntoResponse {
-    let stores = state.kv_stores.read().await;
-    let Some(handle) = stores.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "store not found" })),
-        );
+    let handle = {
+        let stores = state.kv_stores.read().await;
+        let Some(handle) = stores.get(&id) else {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "ok": false, "error": "store not found" })),
+            );
+        };
+        handle.clone()
     };
 
-    match handle.remove(&key).await {
-        Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
+    match handle.remove_with_delta(&key).await {
+        Ok(delta) => {
+            let recipients = kv_store_delta_direct_recipients(&state).await;
+            spawn_kv_store_delta_delivery(&state, recipients, &id, handle.peer_id(), &delta);
+            (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
@@ -15090,6 +15450,9 @@ async fn direct_send(
     send_config.prefer_raw_quic_if_connected = req.prefer_raw_quic_if_connected;
     send_config.stop_fallback_on_raw_error = req.stop_fallback_on_raw_error;
     send_config.require_gossip = req.require_gossip;
+    if let Some(require_gossip_ack) = req.require_gossip_ack {
+        send_config.require_gossip_ack = require_gossip_ack;
+    }
     if let Some(raw_ack_ms) = req.raw_quic_receive_ack_ms {
         send_config.raw_quic_receive_ack_timeout = Some(std::time::Duration::from_millis(
             raw_ack_ms.clamp(100, 30_000),
@@ -15934,17 +16297,21 @@ async fn get_constitution_json() -> impl IntoResponse {
 // ---------------------------------------------------------------------------
 
 /// GET /upgrade — check for available updates.
-async fn check_upgrade(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+async fn check_upgrade(State(state): State<Arc<AppState>>) -> Response {
     if !state.update_config.enabled {
-        return (
+        return upgrade_response(
             StatusCode::OK,
-            Json(serde_json::json!({
+            serde_json::json!({
                 "ok": true,
                 "update_available": false,
                 "current_version": env!("CARGO_PKG_VERSION"),
                 "reason": "updates disabled"
-            })),
+            }),
         );
+    }
+
+    if let Some(response) = cached_upgrade_response(state.as_ref()).await {
+        return response;
     }
 
     let monitor =
@@ -15952,39 +16319,91 @@ async fn check_upgrade(State(state): State<Arc<AppState>>) -> impl IntoResponse 
             Ok(m) => m.with_include_prereleases(state.update_config.include_prereleases),
             Err(e) => {
                 tracing::error!("upgrade monitor creation failed: {e}");
-                return (
+                return store_upgrade_response(
+                    state.as_ref(),
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": "upgrade check unavailable" })),
-                );
+                    serde_json::json!({ "ok": false, "error": "upgrade check unavailable" }),
+                    UPGRADE_CHECK_ERROR_CACHE_TTL,
+                )
+                .await;
             }
         };
 
     match monitor.check_for_updates().await {
-        Ok(Some(release)) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
+        Ok(Some(release)) => {
+            store_upgrade_response(
+                state.as_ref(),
+                StatusCode::OK,
+                serde_json::json!({
                 "ok": true,
                 "update_available": true,
                 "version": release.manifest.version,
                 "current_version": env!("CARGO_PKG_VERSION")
-            })),
-        ),
-        Ok(None) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
+                }),
+                UPGRADE_CHECK_CACHE_TTL,
+            )
+            .await
+        }
+        Ok(None) => {
+            store_upgrade_response(
+                state.as_ref(),
+                StatusCode::OK,
+                serde_json::json!({
                 "ok": true,
                 "update_available": false,
                 "current_version": env!("CARGO_PKG_VERSION")
-            })),
-        ),
+                }),
+                UPGRADE_CHECK_CACHE_TTL,
+            )
+            .await
+        }
         Err(e) => {
             tracing::error!("upgrade check failed: {e}");
-            (
+            store_upgrade_response(
+                state.as_ref(),
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "upgrade check failed" })),
+                serde_json::json!({ "ok": false, "error": "upgrade check failed" }),
+                UPGRADE_CHECK_ERROR_CACHE_TTL,
             )
+            .await
         }
     }
+}
+
+fn upgrade_response(status: StatusCode, body: serde_json::Value) -> Response {
+    (status, Json(body)).into_response()
+}
+
+async fn cached_upgrade_response(state: &AppState) -> Option<Response> {
+    let cached = {
+        let cache = state.upgrade_check_cache.lock().await;
+        cache
+            .as_ref()
+            .filter(|cached| cached.checked_at.elapsed() < cached.ttl)
+            .cloned()
+    };
+
+    cached.map(|cached| upgrade_response(cached.status, cached.body))
+}
+
+async fn store_upgrade_response(
+    state: &AppState,
+    status: StatusCode,
+    body: serde_json::Value,
+    ttl: Duration,
+) -> Response {
+    let cached = CachedUpgradeCheck {
+        checked_at: Instant::now(),
+        status,
+        body: body.clone(),
+        ttl,
+    };
+    {
+        let mut cache = state.upgrade_check_cache.lock().await;
+        *cache = Some(cached);
+    }
+
+    upgrade_response(status, body)
 }
 
 /// POST /upgrade/apply — fetch the latest signed manifest and apply it.
@@ -19540,6 +19959,11 @@ mod tests {
     }
 
     #[test]
+    fn direct_message_send_config_requires_gossip_ack_by_default() {
+        assert!(direct_message_send_config().require_gossip_ack);
+    }
+
+    #[test]
     fn group_card_cache_prunes_expired_cards() {
         let mut cache = HashMap::new();
         cache.insert(
@@ -20186,8 +20610,11 @@ mod tests {
 
         let chunk = file_transfer_send_config();
         assert!(chunk.prefer_raw_quic_if_connected);
-        assert!(chunk.stop_fallback_on_raw_error);
-        assert_eq!(chunk.raw_quic_receive_ack_timeout, None);
+        assert!(!chunk.stop_fallback_on_raw_error);
+        assert_eq!(
+            chunk.raw_quic_receive_ack_timeout,
+            Some(Duration::from_secs(8))
+        );
     }
 
     #[test]
@@ -20747,5 +21174,47 @@ mod tests {
             .expect("waiter must release before the test timeout")
             .expect("waiter task did not panic");
         res.expect("must succeed once ack >= last_seq arrives");
+    }
+
+    #[test]
+    fn group_public_message_direct_payload_is_prefixed_json() {
+        let msg = x0x::groups::GroupPublicMessage {
+            group_id: "group-1".to_string(),
+            state_hash_at_send: "state".to_string(),
+            revision_at_send: 7,
+            author_agent_id: "aa".repeat(32),
+            author_public_key: "bb".repeat(64),
+            author_user_id: None,
+            kind: x0x::groups::GroupPublicMessageKind::Chat,
+            body: "hello".to_string(),
+            timestamp: 123,
+            signature: "cc".repeat(64),
+        };
+
+        let payload =
+            encode_group_public_message_direct_payload(&msg).expect("payload should encode");
+        assert!(payload.starts_with(GROUP_PUBLIC_MESSAGE_DM_PREFIX));
+
+        let decoded: x0x::groups::GroupPublicMessage =
+            serde_json::from_slice(&payload[GROUP_PUBLIC_MESSAGE_DM_PREFIX.len()..])
+                .expect("payload JSON should decode");
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn kv_store_delta_direct_payload_is_prefixed_json() {
+        let peer_id = saorsa_gossip_types::PeerId::new([9; 32]);
+        let delta = x0x::kv::KvStoreDelta::new(42);
+
+        let payload = encode_kv_store_delta_direct_payload("store-1", peer_id, &delta)
+            .expect("payload should encode");
+        assert!(payload.starts_with(KV_STORE_DELTA_DM_PREFIX));
+
+        let decoded: KvStoreDirectDelta =
+            serde_json::from_slice(&payload[KV_STORE_DELTA_DM_PREFIX.len()..])
+                .expect("payload JSON should decode");
+        assert_eq!(decoded.store_id, "store-1");
+        assert_eq!(decoded.peer_id, peer_id);
+        assert_eq!(decoded.delta.version, delta.version);
     }
 }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -456,6 +456,7 @@ struct DirectDiagnosticsCounters {
     incoming_decode_failed: AtomicU64,
     incoming_signature_failed: AtomicU64,
     incoming_trust_rejected: AtomicU64,
+    incoming_typed_route_dropped: AtomicU64,
     incoming_delivered_to_subscribe: AtomicU64,
     subscriber_channel_lagged: AtomicU64,
     subscriber_events_evicted: AtomicU64,
@@ -499,6 +500,11 @@ pub struct DmDiagnosticsStats {
     pub incoming_decode_failed: u64,
     pub incoming_signature_failed: u64,
     pub incoming_trust_rejected: u64,
+    /// Redundant typed-route gossip-DM fallback hand-offs dropped on a full
+    /// route channel (non-zero ⇒ a route consumer is lagging). Safe drops —
+    /// the primary per-group/store pubsub path still delivers.
+    #[serde(default)]
+    pub incoming_typed_route_dropped: u64,
     pub incoming_delivered_to_subscribe: u64,
     /// Number of oldest buffered events evicted from slow subscriber queues.
     pub subscriber_events_evicted: u64,
@@ -875,6 +881,17 @@ impl DirectMessaging {
         self.with_peer_diagnostics(agent_id, |_| {});
     }
 
+    /// Record a typed-payload route hand-off dropped because the (bounded)
+    /// route channel was full. These are best-effort, redundant gossip-DM
+    /// fallback deliveries (group-public / KvStore-delta); dropping one is
+    /// safe because the primary per-group/store pubsub path still delivers.
+    /// A non-zero value here means a route consumer is lagging.
+    pub(crate) fn record_incoming_typed_route_dropped(&self) {
+        self.diagnostics
+            .incoming_typed_route_dropped
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Snapshot direct-message diagnostics for API surfaces.
     #[must_use]
     pub fn diagnostics_snapshot(&self) -> DmDiagnosticsSnapshot {
@@ -915,6 +932,10 @@ impl DirectMessaging {
             incoming_trust_rejected: self
                 .diagnostics
                 .incoming_trust_rejected
+                .load(Ordering::Relaxed),
+            incoming_typed_route_dropped: self
+                .diagnostics
+                .incoming_typed_route_dropped
                 .load(Ordering::Relaxed),
             incoming_delivered_to_subscribe: self
                 .diagnostics

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -548,14 +548,24 @@ impl RecentDeliveryCache {
         Some(entry)
     }
 
-    /// Insert an outcome. If the key is already present, the existing
-    /// `first_seen` is preserved (so TTL doesn't restart on re-delivery).
-    pub fn insert(&self, key: DedupeKey, outcome: DmAckOutcome) {
+    /// Insert an outcome, returning `true` iff this call was the one that
+    /// inserted the key (i.e. it *claimed* the dedupe slot). If the key is
+    /// already present, the existing `first_seen` is preserved (so TTL doesn't
+    /// restart on re-delivery) and `false` is returned.
+    ///
+    /// The boolean makes this usable as an atomic claim: a caller can insert a
+    /// placeholder outcome and only proceed with delivery when it observes the
+    /// `true` return, so two tasks racing the same envelope (e.g. the primary
+    /// per-recipient inbox and the legacy bus delivering the same DM) cannot
+    /// both deliver it to the application. On lock poisoning we return `true`
+    /// (proceed) so a poisoned cache degrades to possible double-delivery
+    /// rather than silent message loss.
+    pub fn insert(&self, key: DedupeKey, outcome: DmAckOutcome) -> bool {
         let Ok(mut inner) = self.inner.lock() else {
-            return;
+            return true;
         };
         if inner.entries.contains_key(&key) {
-            return;
+            return false;
         }
         inner.entries.insert(
             key,
@@ -573,6 +583,7 @@ impl RecentDeliveryCache {
             };
             inner.entries.remove(&oldest);
         }
+        true
     }
 
     /// Current cache size (diagnostic).
@@ -1014,6 +1025,27 @@ mod tests {
         cache.insert(k, DmAckOutcome::Accepted);
         let hit = cache.lookup(&k).expect("cache hit");
         assert_eq!(hit.outcome, DmAckOutcome::Accepted);
+    }
+
+    #[test]
+    fn dedupe_cache_insert_claims_slot_exactly_once() {
+        // The atomic-claim contract that prevents dual-path (primary inbox +
+        // legacy bus) double-delivery: the first insert claims the slot
+        // (returns true); any later insert of the same key returns false so the
+        // racing task skips delivery and only re-ACKs.
+        let cache = RecentDeliveryCache::with_defaults();
+        let k = DedupeKey::new(dummy_agent_id(1), [9; 16]);
+        assert!(
+            cache.insert(k, DmAckOutcome::Accepted),
+            "first insert must claim the slot"
+        );
+        assert!(
+            !cache.insert(k, DmAckOutcome::Accepted),
+            "second insert of the same key must not re-claim"
+        );
+        // A different key is independently claimable.
+        let k2 = DedupeKey::new(dummy_agent_id(2), [9; 16]);
+        assert!(cache.insert(k2, DmAckOutcome::Accepted));
     }
 
     #[test]

--- a/src/dm_capability.rs
+++ b/src/dm_capability.rs
@@ -101,6 +101,7 @@ struct CachedAdvert {
     capabilities: DmCapabilities,
     _machine_id: [u8; 32],
     seen_at: Instant,
+    created_at_unix_ms: u64,
 }
 
 impl Default for CapabilityStore {
@@ -143,16 +144,38 @@ impl CapabilityStore {
     }
 
     /// Insert / refresh a cache entry.
-    pub fn insert(&self, agent_id: AgentId, machine_id: MachineId, capabilities: DmCapabilities) {
+    ///
+    /// `created_at_unix_ms` is the advert's signed sender-side timestamp and
+    /// orders adverts from the same sender: an advert strictly older than the
+    /// cached one is ignored. Gossip (epidemic broadcast) does not guarantee
+    /// in-order delivery, so without this a daemon's startup `pending`
+    /// (gossip_inbox=false) advert can arrive *after* its upgraded
+    /// gossip-ready advert and clobber it — leaving every sender on the
+    /// silent raw-QUIC fallback (`advert_cache_unusable`) until the next
+    /// republish window. An equal timestamp refreshes the TTL (duplicate
+    /// delivery of the same advert).
+    pub fn insert(
+        &self,
+        agent_id: AgentId,
+        machine_id: MachineId,
+        capabilities: DmCapabilities,
+        created_at_unix_ms: u64,
+    ) {
         let Ok(mut inner) = self.inner.lock() else {
             return;
         };
+        if let Some(existing) = inner.get(agent_id.as_bytes()) {
+            if created_at_unix_ms < existing.created_at_unix_ms {
+                return;
+            }
+        }
         inner.insert(
             *agent_id.as_bytes(),
             CachedAdvert {
                 capabilities,
                 _machine_id: *machine_id.as_bytes(),
                 seen_at: Instant::now(),
+                created_at_unix_ms,
             },
         );
     }
@@ -189,10 +212,44 @@ mod tests {
         let machine_id = MachineId([2u8; 32]);
         let caps = DmCapabilities::v1_gossip_ready(vec![0u8; 1184]);
         assert!(store.lookup(&agent_id).is_none());
-        store.insert(agent_id, machine_id, caps.clone());
+        store.insert(agent_id, machine_id, caps.clone(), 1_000);
         let got = store.lookup(&agent_id).expect("hit");
         assert_eq!(got.max_protocol_version, caps.max_protocol_version);
         assert_eq!(got.gossip_inbox, caps.gossip_inbox);
+    }
+
+    /// Gossip delivers adverts out of order. A daemon publishes a `pending`
+    /// (no gossip inbox) advert at startup and an upgraded gossip-ready one
+    /// once its KEM key is wired; if the stale pending advert arrives last it
+    /// must NOT clobber the ready one — that routes every DM to the silent
+    /// raw-QUIC fallback and the recipient's app never sees them (the
+    /// PR #100 dogfood group_join black-hole).
+    #[test]
+    fn capability_store_ignores_stale_out_of_order_advert() {
+        let store = CapabilityStore::new();
+        let agent_id = AgentId([5u8; 32]);
+        let machine_id = MachineId([6u8; 32]);
+        store.insert(
+            agent_id,
+            machine_id,
+            DmCapabilities::v1_gossip_ready(vec![0u8; 1184]),
+            2_000,
+        );
+        // Older pending advert delivered late: ignored.
+        store.insert(agent_id, machine_id, DmCapabilities::pending(), 1_000);
+        let got = store.lookup(&agent_id).expect("hit");
+        assert!(
+            got.gossip_inbox && !got.kem_public_key.is_empty(),
+            "stale pending advert must not downgrade a usable cached advert"
+        );
+        // A genuinely fresher downgrade (e.g. daemon restarted pre-KEM) still
+        // applies — ordering, not blanket downgrade protection.
+        store.insert(agent_id, machine_id, DmCapabilities::pending(), 3_000);
+        let got = store.lookup(&agent_id).expect("hit");
+        assert!(
+            !got.gossip_inbox,
+            "fresher advert must win regardless of content"
+        );
     }
 
     #[test]
@@ -204,6 +261,7 @@ mod tests {
             agent_id,
             machine_id,
             DmCapabilities::v1_gossip_ready(vec![0u8; 1184]),
+            1_000,
         );
         assert!(store.lookup(&agent_id).is_some());
         std::thread::sleep(Duration::from_millis(100));

--- a/src/dm_capability_service.rs
+++ b/src/dm_capability_service.rs
@@ -69,6 +69,7 @@ impl CapabilityAdvertService {
                     AgentId(advert.agent_id),
                     MachineId(advert.machine_id),
                     advert.capabilities,
+                    advert.created_at_unix_ms,
                 );
                 tracing::debug!(
                     "cached capability advert from {}",
@@ -86,6 +87,24 @@ impl CapabilityAdvertService {
             let mut burst_idx: usize = 0;
             loop {
                 let caps_snapshot = publisher_caps_rx.borrow().clone();
+                // Never broadcast a not-yet-usable (pending) advert: absence
+                // already tells senders to use the raw fallback, while a
+                // pending advert on the wire can race ahead of (or arrive
+                // after) the upgraded one and poison receiver caches. The
+                // `changed()` arm below restarts the burst as soon as the
+                // caps watch upgrades, so readiness still propagates fast.
+                if !advert_is_publishable(&caps_snapshot) {
+                    tracing::debug!("capability advert pending (no inbox/KEM yet); not publishing");
+                    tokio::select! {
+                        _ = tokio::time::sleep(publish_interval) => {}
+                        res = publisher_caps_rx.changed() => {
+                            if res.is_ok() {
+                                burst_idx = 0;
+                            }
+                        }
+                    }
+                    continue;
+                }
                 match build_signed_advert(
                     &publisher_signing,
                     self_agent_id,
@@ -161,6 +180,15 @@ impl Drop for CapabilityAdvertService {
     }
 }
 
+/// True when the capabilities are worth broadcasting: the gossip inbox is
+/// live and the KEM key is present. Anything less is indistinguishable from
+/// "no advert" to senders, so publishing it only risks clobbering a usable
+/// cached advert at receivers.
+#[must_use]
+pub fn advert_is_publishable(caps: &DmCapabilities) -> bool {
+    caps.gossip_inbox && !caps.kem_public_key.is_empty()
+}
+
 pub fn build_signed_advert(
     signing: &SigningContext,
     self_agent_id: AgentId,
@@ -230,6 +258,17 @@ mod tests {
         .expect("build");
         let advert: CapabilityAdvert = postcard::from_bytes(&encoded).expect("decode");
         assert!(verify_advert_signature(&advert, &signing.public_key_bytes));
+    }
+
+    /// A pending advert must never reach the wire — receivers cache adverts
+    /// last-writer-wins per timestamp, so broadcasting "I can't receive"
+    /// degrades DM routing for every sender that hears it.
+    #[test]
+    fn pending_capabilities_are_not_publishable() {
+        assert!(!advert_is_publishable(&DmCapabilities::pending()));
+        assert!(advert_is_publishable(&DmCapabilities::v1_gossip_ready(
+            vec![0u8; 1184]
+        )));
     }
 
     #[test]

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -5,12 +5,12 @@
 use crate::contacts::ContactStore;
 use crate::direct::DirectMessaging;
 use crate::dm::{
-    decrypt_payload, now_unix_ms, validate_timestamp_window, DmAckOutcome, DmBody, DmEnvelope,
-    DmPayload, EnvelopeBuilder, InFlightAcks, RecentDeliveryCache, DM_PROTOCOL_VERSION,
+    decrypt_payload, dm_inbox_topic, now_unix_ms, validate_timestamp_window, DmAckOutcome, DmBody,
+    DmEnvelope, DmPayload, EnvelopeBuilder, InFlightAcks, RecentDeliveryCache, DM_PROTOCOL_VERSION,
     MAX_ENVELOPE_BYTES,
 };
 use crate::error::{NetworkError, NetworkResult};
-use crate::gossip::{PubSubManager, PubSubMessage, SigningContext};
+use crate::gossip::{PubSubManager, PubSubMessage, SigningContext, Subscription};
 use crate::groups::kem_envelope::AgentKemKeypair;
 use crate::identity::{AgentId, MachineId};
 use crate::trust::{TrustContext, TrustDecision, TrustEvaluator};
@@ -74,28 +74,24 @@ pub struct DmTypedPayload {
 }
 
 pub struct DmInboxService {
-    handle: JoinHandle<()>,
+    handles: Vec<JoinHandle<()>>,
     topic: String,
 }
 
-/// Shared DM transport topic. Every gossip-DM-capable agent subscribes
-/// here. Recipients filter by `envelope.recipient_agent_id`; non-
-/// recipients observe only encrypted metadata/payload and do not process it.
-///
-/// The shared bus keeps topic membership simple, but application-level
-/// re-broadcast is intentionally avoided: `PubSubManager::publish()` signs
-/// each hop with the local agent id, while the DM envelope signature is bound
-/// to the origin agent id. Re-publishing an origin envelope from a relay would
-/// make the outer PubSub sender differ from `envelope.sender_agent_id`, so
-/// downstream receivers would reject it and the fleet would only gain load.
+/// Legacy shared DM transport topic. New sends use per-recipient inbox
+/// topics; this listener remains so rolling upgrades can still receive
+/// envelopes from older daemons.
 pub const DM_BUS_TOPIC: &str = "x0x/dm/v1/bus";
+const DM_INBOX_TOPIC_NAME_PREFIX: &str = "x0x/dm/v1/inbox/";
 
 impl DmInboxService {
-    /// Topic every DM envelope is published on. Uniform across agents so
-    /// all subscribers can relay via epidemic broadcast.
+    /// Human-readable name for the agent's raw derived DM inbox topic.
     #[must_use]
-    pub fn inbox_topic_name(_agent_id: &AgentId) -> String {
-        DM_BUS_TOPIC.to_string()
+    pub fn inbox_topic_name(agent_id: &AgentId) -> String {
+        format!(
+            "{DM_INBOX_TOPIC_NAME_PREFIX}{}",
+            hex::encode(dm_inbox_topic(agent_id).to_bytes())
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -112,7 +108,10 @@ impl DmInboxService {
         config: DmInboxConfig,
     ) -> NetworkResult<Self> {
         let topic = Self::inbox_topic_name(&self_agent_id);
-        let mut subscription = pubsub.subscribe(topic.clone()).await;
+        let subscription = pubsub
+            .subscribe_topic_id(topic.clone(), dm_inbox_topic(&self_agent_id))
+            .await;
+        let legacy_subscription = pubsub.subscribe(DM_BUS_TOPIC.to_string()).await;
 
         let pipeline = InboxPipeline {
             pubsub: Arc::clone(&pubsub),
@@ -128,16 +127,19 @@ impl DmInboxService {
             typed_payload_routes: config.typed_payload_routes,
         };
 
-        let topic_for_task = topic.clone();
-        let handle = tokio::spawn(async move {
-            tracing::info!(topic = %topic_for_task, "DM inbox service subscribed");
-            while let Some(message) = subscription.recv().await {
-                pipeline.handle_incoming(message).await;
-            }
-            tracing::debug!(topic = %topic_for_task, "DM inbox subscription closed");
-        });
+        let primary_handle =
+            spawn_subscription_loop(topic.clone(), false, subscription, pipeline.clone());
+        let legacy_handle = spawn_subscription_loop(
+            DM_BUS_TOPIC.to_string(),
+            true,
+            legacy_subscription,
+            pipeline,
+        );
 
-        Ok(Self { handle, topic })
+        Ok(Self {
+            handles: vec![primary_handle, legacy_handle],
+            topic,
+        })
     }
 
     #[must_use]
@@ -146,7 +148,9 @@ impl DmInboxService {
     }
 
     pub fn abort(&self) {
-        self.handle.abort();
+        for handle in &self.handles {
+            handle.abort();
+        }
     }
 }
 
@@ -156,6 +160,22 @@ impl Drop for DmInboxService {
     }
 }
 
+fn spawn_subscription_loop(
+    topic_for_task: String,
+    ack_legacy_bus: bool,
+    mut subscription: Subscription,
+    pipeline: InboxPipeline,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        tracing::info!(topic = %topic_for_task, "DM inbox service subscribed");
+        while let Some(message) = subscription.recv().await {
+            pipeline.handle_incoming(message, ack_legacy_bus).await;
+        }
+        tracing::debug!(topic = %topic_for_task, "DM inbox subscription closed");
+    })
+}
+
+#[derive(Clone)]
 struct InboxPipeline {
     pubsub: Arc<PubSubManager>,
     signing: Arc<SigningContext>,
@@ -171,7 +191,7 @@ struct InboxPipeline {
 }
 
 impl InboxPipeline {
-    async fn handle_incoming(&self, msg: PubSubMessage) {
+    async fn handle_incoming(&self, msg: PubSubMessage, ack_legacy_bus: bool) {
         let (pubsub_sender, sender_pubkey) = match (msg.sender, msg.sender_public_key.as_deref()) {
             (Some(s), Some(pk)) if msg.verified => (s, pk.to_vec()),
             _ => return,
@@ -225,6 +245,7 @@ impl InboxPipeline {
                         AgentId(envelope.sender_agent_id),
                         envelope.request_id,
                         cached.outcome,
+                        ack_legacy_bus,
                     )
                     .await;
             }
@@ -264,12 +285,12 @@ impl InboxPipeline {
                 );
             }
             DmBody::Payload(payload) => {
-                self.handle_payload(envelope, payload).await;
+                self.handle_payload(envelope, payload, ack_legacy_bus).await;
             }
         }
     }
 
-    async fn handle_payload(&self, envelope: DmEnvelope, payload: DmPayload) {
+    async fn handle_payload(&self, envelope: DmEnvelope, payload: DmPayload, ack_legacy_bus: bool) {
         let sender_agent_id = AgentId(envelope.sender_agent_id);
         let sender_machine_id = MachineId(envelope.sender_machine_id);
 
@@ -298,7 +319,12 @@ impl InboxPipeline {
                 self.cache.insert(envelope.dedupe_key(), outcome.clone());
                 if !self.silent_reject {
                     let _ = self
-                        .publish_ack(sender_agent_id, envelope.request_id, outcome)
+                        .publish_ack(
+                            sender_agent_id,
+                            envelope.request_id,
+                            outcome,
+                            ack_legacy_bus,
+                        )
                         .await;
                 }
                 return;
@@ -351,7 +377,12 @@ impl InboxPipeline {
             .insert(envelope.dedupe_key(), DmAckOutcome::Accepted);
 
         let _ = self
-            .publish_ack(sender_agent_id, envelope.request_id, DmAckOutcome::Accepted)
+            .publish_ack(
+                sender_agent_id,
+                envelope.request_id,
+                DmAckOutcome::Accepted,
+                ack_legacy_bus,
+            )
             .await;
     }
 
@@ -391,6 +422,7 @@ impl InboxPipeline {
         to: AgentId,
         acks_request_id: [u8; 16],
         outcome: DmAckOutcome,
+        ack_legacy_bus: bool,
     ) -> NetworkResult<()> {
         let body = EnvelopeBuilder::build_ack_body(acks_request_id, outcome);
         let created = now_unix_ms();
@@ -418,7 +450,18 @@ impl InboxPipeline {
             .to_wire_bytes()
             .map_err(|e| NetworkError::SerializationError(format!("ack encode: {e}")))?;
         let topic = DmInboxService::inbox_topic_name(&to);
-        self.pubsub.publish(topic, Bytes::from(encoded)).await
+        let primary = self
+            .pubsub
+            .publish_topic_id(topic, dm_inbox_topic(&to), Bytes::from(encoded.clone()))
+            .await;
+        let legacy = if ack_legacy_bus {
+            self.pubsub
+                .publish(DM_BUS_TOPIC.to_string(), Bytes::from(encoded))
+                .await
+        } else {
+            Ok(())
+        };
+        primary.and(legacy)
     }
 }
 
@@ -686,18 +729,24 @@ mod tests {
     // ── Inbox topic name consistency ──────────────────────────────────
 
     #[test]
-    fn inbox_topic_is_constant_for_all_agents() {
+    fn inbox_topic_is_agent_specific_and_matches_raw_topic_id() {
         let id1: [u8; 32] = [1u8; 32];
         let id2: [u8; 32] = [2u8; 32];
         let agent1 = AgentId(id1);
         let agent2 = AgentId(id2);
 
-        // DM_BUS_TOPIC is shared — all agents subscribe to the same topic
+        let topic1 = DmInboxService::inbox_topic_name(&agent1);
+        let topic2 = DmInboxService::inbox_topic_name(&agent2);
+
+        assert_ne!(topic1, topic2);
+        assert!(topic1.starts_with(DM_INBOX_TOPIC_NAME_PREFIX));
         assert_eq!(
-            DmInboxService::inbox_topic_name(&agent1),
-            DmInboxService::inbox_topic_name(&agent2)
+            topic1,
+            format!(
+                "{DM_INBOX_TOPIC_NAME_PREFIX}{}",
+                hex::encode(dm_inbox_topic(&agent1).to_bytes())
+            )
         );
-        assert_eq!(DmInboxService::inbox_topic_name(&agent1), DM_BUS_TOPIC);
     }
 
     // ── Typed payload route matching ──────────────────────────────────

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -345,6 +345,31 @@ impl InboxPipeline {
             return;
         }
 
+        // Atomic dedupe claim BEFORE delivery. The same envelope can arrive
+        // twice — once on the primary per-recipient inbox and once on the
+        // legacy bus (during a rolling upgrade), driven by two independent
+        // subscription loops. The earlier `cache.lookup` in `handle_incoming`
+        // is not sufficient: both tasks can miss it before either delivers.
+        // Claiming the dedupe slot here (insert returns `true` only for the
+        // task that inserted it) ensures exactly one task delivers to the
+        // application; the loser re-ACKs the accepted outcome and returns.
+        // The claim happens only after a successful decrypt, so a decrypt
+        // failure above still leaves the slot unclaimed for a genuine retry.
+        if !self
+            .cache
+            .insert(envelope.dedupe_key(), DmAckOutcome::Accepted)
+        {
+            let _ = self
+                .publish_ack(
+                    sender_agent_id,
+                    envelope.request_id,
+                    DmAckOutcome::Accepted,
+                    ack_legacy_bus,
+                )
+                .await;
+            return;
+        }
+
         let is_typed_payload = self
             .route_typed_payload(
                 sender_agent_id,
@@ -372,9 +397,6 @@ impl InboxPipeline {
                 sender = %hex::encode(sender_agent_id.as_bytes()),
             );
         }
-
-        self.cache
-            .insert(envelope.dedupe_key(), DmAckOutcome::Accepted);
 
         let _ = self
             .publish_ack(
@@ -408,11 +430,30 @@ impl InboxPipeline {
             trust_decision,
             received_at_unix_ms: now_unix_ms(),
         };
-        if route.sender.send(typed).await.is_err() {
-            tracing::warn!(
-                sender = %hex::encode(sender_agent_id.as_bytes()),
-                "typed DM payload route receiver is closed; dropping payload"
-            );
+        // Best-effort, NON-BLOCKING hand-off. These typed routes (the
+        // group-public-message and KvStore-delta gossip-DM fallbacks) are
+        // redundant delivery paths — primary fan-out is per-group/store pubsub.
+        // We must not `send().await`: this runs inline in the single DM-inbox
+        // subscription loop that also publishes ACKs, so a slow or
+        // lock-contended route consumer filling the bounded channel would block
+        // ACK delivery for unrelated senders (surfacing as 504s now that
+        // `require_gossip_ack` defaults true). Drop on a full channel and count
+        // it rather than stalling the pipeline.
+        match route.sender.try_send(typed) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.dm.record_incoming_typed_route_dropped();
+                tracing::warn!(
+                    sender = %hex::encode(sender_agent_id.as_bytes()),
+                    "typed DM payload route channel full; dropping redundant fallback payload"
+                );
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::warn!(
+                    sender = %hex::encode(sender_agent_id.as_bytes()),
+                    "typed DM payload route receiver is closed; dropping payload"
+                );
+            }
         }
         true
     }

--- a/src/dm_send.rs
+++ b/src/dm_send.rs
@@ -1,10 +1,10 @@
 //! Sender-side gossip DM path (phase 4 of `docs/design/dm-over-gossip.md`).
 
 use crate::dm::{
-    now_unix_ms, DmAckOutcome, DmEnvelope, DmError, DmPath, DmReceipt, DmSendConfig,
-    EnvelopeBuilder, InFlightAcks, DM_PROTOCOL_VERSION, MAX_PAYLOAD_BYTES,
+    dm_inbox_topic, now_unix_ms, DmAckOutcome, DmEnvelope, DmError, DmPath, DmReceipt,
+    DmSendConfig, EnvelopeBuilder, InFlightAcks, DM_PROTOCOL_VERSION, MAX_PAYLOAD_BYTES,
 };
-use crate::dm_inbox::DmInboxService;
+use crate::dm_inbox::{DmInboxService, DM_BUS_TOPIC};
 use crate::error::IdentityError;
 use crate::gossip::{PubSubManager, SigningContext};
 use crate::identity::{AgentId, MachineId};
@@ -33,6 +33,7 @@ pub struct DmLifecycleHint {
 
 pub const DEFAULT_ENVELOPE_LIFETIME_MS: u64 = 120_000;
 const PUBLISH_ONLY_REDUNDANT_REPUBLISH_DELAY: Duration = Duration::from_millis(250);
+const ACK_LEGACY_BUS_FALLBACK_DELAY: Duration = Duration::from_millis(250);
 
 #[allow(clippy::too_many_arguments)]
 pub async fn send_via_gossip(
@@ -91,6 +92,7 @@ pub async fn send_via_gossip(
         .map_err(|e| DmError::EnvelopeConstruction(format!("sign: {e}")))?;
     let wire = envelope.to_wire_bytes().map_err(map_identity_err)?;
     let topic = DmInboxService::inbox_topic_name(&recipient_agent_id);
+    let topic_id = dm_inbox_topic(&recipient_agent_id);
 
     tracing::debug!(
         target: "dm.trace",
@@ -147,13 +149,66 @@ pub async fn send_via_gossip(
         // their curl/user-visible deadline without returning a structured
         // `DmError::Timeout`.
         let attempt_result = tokio::time::timeout(config.timeout_per_attempt, async {
-            pubsub
-                .publish(topic.clone(), Bytes::from(wire.clone()))
-                .await
-                .map_err(|e| DmError::LocalGossipUnavailable(e.to_string()))?;
+            let primary_publish = pubsub
+                .publish_topic_id(topic.clone(), topic_id, Bytes::from(wire.clone()))
+                .await;
+            let primary_publish_ok = match primary_publish {
+                Ok(()) => true,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "dm.trace",
+                        stage = "primary_inbox_publish_failed",
+                        request_id = %hex::encode(request_id),
+                        recipient = %hex::encode(recipient_agent_id.as_bytes()),
+                        attempt,
+                        error = %e,
+                    );
+                    false
+                }
+            };
 
             if !config.require_gossip_ack {
+                if !primary_publish_ok {
+                    return Err(DmError::LocalGossipUnavailable(
+                        "primary inbox publish failed".to_string(),
+                    ));
+                }
                 return Ok(None);
+            }
+
+            if primary_publish_ok {
+                if let Some(outcome) =
+                    wait_for_ack_or_backoff(&mut rx, ACK_LEGACY_BUS_FALLBACK_DELAY).await?
+                {
+                    return Ok(Some(outcome));
+                }
+            }
+
+            tracing::debug!(
+                target: "dm.trace",
+                stage = "legacy_bus_fallback_publish",
+                request_id = %hex::encode(request_id),
+                recipient = %hex::encode(recipient_agent_id.as_bytes()),
+                attempt,
+                primary_publish_ok,
+                bus_topic = DM_BUS_TOPIC,
+            );
+            if let Err(e) = pubsub
+                .publish(DM_BUS_TOPIC.to_string(), Bytes::from(wire.clone()))
+                .await
+            {
+                if primary_publish_ok {
+                    tracing::warn!(
+                        target: "dm.trace",
+                        stage = "legacy_bus_fallback_publish_failed",
+                        request_id = %hex::encode(request_id),
+                        recipient = %hex::encode(recipient_agent_id.as_bytes()),
+                        attempt,
+                        error = %e,
+                    );
+                } else {
+                    return Err(DmError::LocalGossipUnavailable(e.to_string()));
+                }
             }
 
             (&mut rx).await.map(Some).map_err(|_| {

--- a/src/gossip/pubsub.rs
+++ b/src/gossip/pubsub.rs
@@ -362,6 +362,16 @@ impl PubSubManager {
     /// `Subscription` is dropped.
     pub async fn subscribe(&self, topic: String) -> Subscription {
         let topic_id = TopicId::from_entity(topic.as_bytes());
+        self.subscribe_topic_id(topic, topic_id).await
+    }
+
+    /// Subscribe to a topic with an explicit transport `TopicId`.
+    ///
+    /// Most callers use [`Self::subscribe`], which derives the transport id
+    /// from the topic string. DM inbox topics are specified as raw
+    /// domain-separated `TopicId`s, while still carrying a stable string topic
+    /// name inside the signed x0x payload.
+    pub async fn subscribe_topic_id(&self, topic: String, topic_id: TopicId) -> Subscription {
         self.register_dynamic_topic_priority(&topic, topic_id);
         self.initialize_topic_peers(topic_id).await;
 
@@ -448,6 +458,20 @@ impl PubSubManager {
     ///
     /// Returns an error if encoding or signing fails.
     pub async fn publish(&self, topic: String, payload: Bytes) -> NetworkResult<()> {
+        let topic_id = TopicId::from_entity(topic.as_bytes());
+        self.publish_topic_id(topic, topic_id, payload).await
+    }
+
+    /// Publish to a topic with an explicit transport `TopicId`.
+    ///
+    /// The signed x0x payload still embeds `topic`; only the underlying
+    /// PlumTree topic id is supplied by the caller.
+    pub async fn publish_topic_id(
+        &self,
+        topic: String,
+        topic_id: TopicId,
+        payload: Bytes,
+    ) -> NetworkResult<()> {
         let encoded_result = if let Some(ref ctx) = self.signing {
             let signing_payload =
                 build_signing_payload(ctx.agent_id.as_bytes(), topic.as_bytes(), &payload);
@@ -472,7 +496,6 @@ impl PubSubManager {
             }
         };
 
-        let topic_id = TopicId::from_entity(topic.as_bytes());
         self.register_dynamic_topic_priority(&topic, topic_id);
         self.initialize_topic_peers(topic_id).await;
 

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -655,6 +655,8 @@ const LS={
 if(LS.get('sidebar_collapsed',false)){S.set('sidebarCollapsed',true);document.getElementById('app').classList.add('collapsed')}
 const savedName=LS.get('display_name','');
 const savedCard=LS.get('card_link','');
+const UPGRADE_CHECK_COOLDOWN_MS=6*60*60*1000;
+let upgradeCheckInFlight=false;
 
 /* ═══════════════════════════════════════════════════════════════════
    JS SECTION 2: API & WEBSOCKET
@@ -684,14 +686,43 @@ async function api(path,opt){
     const hdrs={'Content-Type':'application/json',...(opt||{}).headers};
     if(API_TOKEN)hdrs['Authorization']='Bearer '+API_TOKEN;
     const r=await fetch(BASE+path,{...opt,headers:hdrs});
-    return r.json();
+    const data=await r.json().catch(()=>({ok:false,error:r.statusText||'request failed'}));
+    if(data&&typeof data==='object'){
+      data._http_ok=r.ok;
+      data._http_status=r.status;
+      if(!r.ok&&!data.error)data.error=r.statusText||('HTTP '+r.status);
+    }
+    return data;
   }catch(e){return null}
+}
+
+async function refreshAgentIdentity(){
+  const a=await api('/agent');
+  if(a&&a.ok){
+    const prevAgent=LS.get('last_agent_id','');
+    const curAgent=a.agent_id||'';
+    if(prevAgent&&curAgent&&prevAgent!==curAgent){
+      // Identity changed (e.g. after purge+reinstall) — clear stale prefs.
+      LS.del('display_name');LS.del('card_link');LS.del('sidebar_collapsed');
+    }
+    if(curAgent)LS.set('last_agent_id',curAgent);
+    if(curAgent)S.set('agentId',curAgent);
+    S.set('machineId',a.machine_id||'');
+    S.set('userId',a.user_id||'');
+    renderIdentityChain();
+    renderSidebar();
+  }
+  return a;
 }
 
 function wsConnect(){
   if(ws&&ws.readyState<2)return;
   try{ws=new WebSocket(WS_URL)}catch(e){setTimeout(wsConnect,3000);return}
-  ws.onopen=()=>{S.set('connected',true);wsSubs.forEach(t=>wsSend({type:'subscribe',topics:[t]}))};
+  ws.onopen=async()=>{
+    await refreshAgentIdentity();
+    S.set('connected',true);
+    wsSubs.forEach(t=>wsSend({type:'subscribe',topics:[t]}));
+  };
   ws.onclose=()=>{S.set('connected',false);setTimeout(wsConnect,3000)};
   ws.onerror=()=>{};
   ws.onmessage=e=>{try{handleWsMsg(JSON.parse(e.data))}catch(e){}};
@@ -746,6 +777,14 @@ function trustClass(t){return'trust trust-'+(t||'unknown').toLowerCase()}
 function trustHtml(t){const sym={Trusted:'&#10003;&#10003;',Known:'&#10003;',Unknown:'?',Blocked:'&#10007;'};return '<span class="'+trustClass(t)+'">'+(sym[t]||'?')+' '+(t||'Unknown')+'</span>'}
 function policyHtml(p){if(!p)return'';const t=typeof p==='string'?p:p.type||'Signed';const c=t.toLowerCase();return '<span class="policy policy-'+c+'">'+(c==='encrypted'?'&#128274; ':'')+t+'</span>'}
 function presenceHtml(online){return '<span class="presence '+(online?'online':'offline')+'"></span>'}
+function apiError(r){return r?(r.error||r.message||r.reason||('HTTP '+(r._http_status||'?'))):'network error'}
+function agentCardPath(displayName,includeGroups){
+  const params=new URLSearchParams();
+  if(displayName)params.set('display_name',displayName);
+  if(includeGroups)params.set('include_groups','true');
+  params.set('include_local_addresses','true');
+  return '/agent/card?'+params.toString();
+}
 
 function toast(msg,type){
   const el=document.createElement('div');
@@ -1578,6 +1617,43 @@ function mountHome(){
   pollDash();
 }
 
+function renderUpgradeBanner(upg){
+  const banner=document.getElementById('h-upgrade-banner');
+  if(!banner)return;
+  if(upg&&upg.update_available){
+    banner.style.display='block';
+    banner.innerHTML=`<div class="card" id="upg-banner" style="border-color:var(--gn);background:var(--gn-dim);display:flex;align-items:center;justify-content:space-between;gap:var(--sp2)">
+      <div><strong style="color:var(--gn)">Update available:</strong> v${esc(upg.version||upg.latest_version||'?')} (you have v${esc(upg.current_version||'?')})</div>
+      <div style="display:flex;gap:var(--sp2);align-items:center">
+        <button class="pri" id="upg-apply-btn" onclick="applyUpgrade()">Apply update</button>
+        <span style="font-size:11px;color:var(--tx2)">or <code style="color:var(--cy)">curl -sfL https://x0x.md | sh</code></span>
+      </div>
+    </div>`;
+  }else{
+    banner.style.display='none';
+    banner.innerHTML='';
+  }
+}
+
+async function refreshUpgradeBanner(force=false){
+  const cached=LS.get('upgrade_status',null);
+  if(cached)renderUpgradeBanner(cached);
+  const last=LS.get('upgrade_checked_at',0);
+  if(!force&&Date.now()-last<UPGRADE_CHECK_COOLDOWN_MS)return;
+  if(upgradeCheckInFlight)return;
+  upgradeCheckInFlight=true;
+  try{
+    const upg=await api('/upgrade');
+    LS.set('upgrade_checked_at',Date.now());
+    if(upg&&upg.ok!==false){
+      LS.set('upgrade_status',upg);
+      renderUpgradeBanner(upg);
+    }
+  }finally{
+    upgradeCheckInFlight=false;
+  }
+}
+
 async function pollDash(){
   const h=await api('/health');
   if(h&&h.ok){
@@ -1589,33 +1665,8 @@ async function pollDash(){
     document.getElementById('st-peers').textContent=(h.peers||0)+' peers';
     document.getElementById('st-ver').textContent='x0x communitas '+(h.version||'');
   }
-  const a=await api('/agent');
-  if(a&&a.ok){
-    const prevAgent=LS.get('last_agent_id','');
-    const curAgent=a.agent_id||'';
-    if(prevAgent&&curAgent&&prevAgent!==curAgent){
-      // Identity changed (e.g. after purge+reinstall) — clear stale prefs
-      LS.del('display_name');LS.del('card_link');LS.del('sidebar_collapsed');
-    }
-    if(curAgent)LS.set('last_agent_id',curAgent);
-    if(!S.get('agentId'))S.set('agentId',curAgent);
-    S.set('machineId',a.machine_id||'');
-    S.set('userId',a.user_id||'');
-    renderIdentityChain();
-  }
-  // Check for updates
-  const upg=await api('/upgrade');
-  const banner=document.getElementById('h-upgrade-banner');
-  if(banner&&upg&&upg.update_available){
-    banner.style.display='block';
-    banner.innerHTML=`<div class="card" id="upg-banner" style="border-color:var(--gn);background:var(--gn-dim);display:flex;align-items:center;justify-content:space-between;gap:var(--sp2)">
-      <div><strong style="color:var(--gn)">Update available:</strong> v${esc(upg.version||upg.latest_version||'?')} (you have v${esc(upg.current_version||'?')})</div>
-      <div style="display:flex;gap:var(--sp2);align-items:center">
-        <button class="pri" id="upg-apply-btn" onclick="applyUpgrade()">Apply update</button>
-        <span style="font-size:11px;color:var(--tx2)">or <code style="color:var(--cy)">curl -sfL https://x0x.md | sh</code></span>
-      </div>
-    </div>`;
-  }else if(banner){banner.style.display='none'}
+  await refreshAgentIdentity();
+  await refreshUpgradeBanner();
 
   const d=await api('/agents/discovered');
   if(d&&d.agents){
@@ -1672,7 +1723,7 @@ function renderIdentityChain(){
 // Share your identity card — generates link and copies to clipboard
 async function shareIdentity(){
   const name=LS.get('display_name','')||'Agent';
-  const r=await api('/agent/card?display_name='+encodeURIComponent(name)+'&include_groups=true');
+  const r=await api(agentCardPath(name,true));
   if(r&&r.link){
     myCardLink=r.link;LS.set('card_link',r.link);
     copyText(r.link);
@@ -1698,6 +1749,7 @@ async function addContactFromLink(){
     document.querySelector('.modal-overlay').remove();
     toast('Contact added: '+(r.display_name||'agent'),'success');
     pollContacts();renderSidebar();
+    if(r.agent_id)api('/agents/connect',{method:'POST',body:JSON.stringify({agent_id:r.agent_id})});
   }else{toast('Invalid link: '+(r&&r.error||'check the link and try again'),'error')}
 }
 
@@ -2156,7 +2208,12 @@ async function boardAction(tid,action){
 
 // --- Space: Files ---
 function renderSpaceFiles(el){
-  el.innerHTML=`<div class="drop-zone" id="file-drop" onclick="document.getElementById('file-input').click()">
+  el.innerHTML=`<div class="row mb">
+    <label for="file-recipient" style="align-self:center;color:var(--tx2);font-size:12px">Send to</label>
+    <select id="file-recipient" style="flex:1" onchange="renderFileSendState()"></select>
+    <button class="ghost" onclick="pollContacts().then(renderFileRecipientOptions)">Refresh</button>
+  </div>
+  <div class="drop-zone" id="file-drop" onclick="chooseFileForSend()">
     Drop files here or click to select
     <input type="file" id="file-input" style="display:none" onchange="handleFileDrop(this.files[0])">
   </div>
@@ -2170,7 +2227,51 @@ function renderSpaceFiles(el){
     dz.addEventListener('dragleave',()=>dz.classList.remove('over'));
     dz.addEventListener('drop',e=>{e.preventDefault();dz.classList.remove('over');if(e.dataTransfer.files.length)handleFileDrop(e.dataTransfer.files[0])});
   }
+  renderFileRecipientOptions();
+  pollContacts().then(renderFileRecipientOptions);
   pollTransfers();
+}
+
+function fileRecipients(){
+  return (S.get('contacts')||[]).filter(c=>c.agent_id&&c.trust_level!=='Blocked');
+}
+
+function fileRecipientLabel(c){
+  const name=c.label||short(c.agent_id,12);
+  const trust=c.trust_level||'Unknown';
+  return name+' · '+short(c.agent_id,12)+' · '+trust;
+}
+
+function renderFileRecipientOptions(){
+  const sel=document.getElementById('file-recipient');
+  if(!sel)return;
+  const previous=sel.value;
+  const recipients=fileRecipients();
+  sel.innerHTML='<option value="">Select a recipient…</option>'+recipients.map(c=>`<option value="${esc(c.agent_id)}">${esc(fileRecipientLabel(c))}</option>`).join('');
+  if(previous&&recipients.some(c=>c.agent_id===previous))sel.value=previous;
+  renderFileSendState();
+}
+
+function renderFileSendState(){
+  const target=selectedFileRecipient();
+  const input=document.getElementById('file-input');
+  const drop=document.getElementById('file-drop');
+  if(input)input.disabled=!target;
+  if(drop){
+    drop.style.opacity=target?'1':'.55';
+    drop.title=target?'Drop files here or click to select':'Select a recipient before sending files';
+  }
+}
+
+function selectedFileRecipient(){
+  const sel=document.getElementById('file-recipient');
+  return sel?sel.value:'';
+}
+
+function chooseFileForSend(){
+  const target=selectedFileRecipient();
+  if(!target){toast('Select a recipient before sending files','warning');return}
+  document.getElementById('file-input').click();
 }
 
 async function handleFileDrop(file){
@@ -2179,10 +2280,14 @@ async function handleFileDrop(file){
   const hash=await crypto.subtle.digest('SHA-256',buf);
   const hex=[...new Uint8Array(hash)].map(b=>b.toString(16).padStart(2,'0')).join('');
   document.getElementById('file-hash').textContent=file.name+' · '+(file.size/1024).toFixed(1)+'KB · SHA-256: '+hex;
-  const contacts=S.get('contacts')||[];
-  if(!contacts.length){toast('Add a contact first to send files','warning');return}
-  const target=contacts[0].agent_id;
-  await api('/files/send',{method:'POST',body:JSON.stringify({agent_id:target,filename:file.name,size:file.size,sha256:hex})});
+  const target=selectedFileRecipient();
+  if(!target){toast('Select a recipient before sending files','warning');return}
+  const resp=await api('/files/send',{method:'POST',body:JSON.stringify({agent_id:target,filename:file.name,size:file.size,sha256:hex})});
+  if(!resp||resp._http_ok===false||resp.ok===false){
+    toast('File send failed: '+apiError(resp),'error');
+    return;
+  }
+  toast('File offered to '+short(target,12),'success');
   pollTransfers();
 }
 
@@ -2473,8 +2578,13 @@ async function sendDm(){
   const payload=u8encode(JSON.stringify({text:t,sender_name:name,ts:Date.now()}));
   const ackBox=document.getElementById('dm-require-ack');
   const body={agent_id:target,payload};
-  if(ackBox&&ackBox.checked)body.require_ack_ms=5000;
+  if(ackBox&&ackBox.checked){body.require_ack_ms=5000;body.require_gossip_ack=true}
   const resp=await api('/direct/send',{method:'POST',body:JSON.stringify(body)});
+  if(!resp||resp._http_ok===false||resp.ok===false){
+    toast('Send failed: '+apiError(resp),'error');
+    inp.focus();
+    return;
+  }
   const msg={text:t,sender_name:name,sender_id:S.get('agentId'),timestamp:Date.now(),own:true};
   addDmMsg(target,msg);
   inp.value='';inp.focus();
@@ -3691,7 +3801,7 @@ function saveName(){
 let myCardLink=savedCard||'';
 async function generateCard(){
   const name=LS.get('display_name','')||'Agent';
-  const r=await api('/agent/card?display_name='+encodeURIComponent(name)+'&include_groups=true');
+  const r=await api(agentCardPath(name,true));
   if(r&&r.link){
     myCardLink=r.link;
     LS.set('card_link',r.link);
@@ -4728,7 +4838,7 @@ async function genCardModal(){
   const name=document.getElementById('modal-card-name').value.trim()||'Agent';
   LS.set('display_name',name);
   renderSidebar();
-  const r=await api('/agent/card?display_name='+encodeURIComponent(name)+'&include_groups=true');
+  const r=await api(agentCardPath(name,true));
   if(r&&r.link){
     myCardLink=r.link;LS.set('card_link',r.link);
     copyText(r.link);
@@ -4754,6 +4864,7 @@ async function importCardModal(){
     document.querySelector('.modal-overlay').remove();
     toast('Imported: '+(r.display_name||'agent'),'success');
     pollContacts();renderSidebar();
+    if(r.agent_id)api('/agents/connect',{method:'POST',body:JSON.stringify({agent_id:r.agent_id})});
   }else{toast('Import failed: '+(r&&r.error||'unknown'),'error')}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4081,6 +4081,33 @@ impl Agent {
                     error = %e,
                     "transport send_direct failed"
                 );
+                // A receive-ACK-path failure on a connection that still reads
+                // as connected means the connection is a zombie: the remote
+                // endpoint is gone (supersede/NAT loss without a lifecycle
+                // event) yet `is_connected` keeps steering every retry back
+                // onto it via `cached_connected`. Tear it down so the next
+                // attempt fails the fast path and takes the X0X-0031/0033
+                // send-readiness repair (fresh dial) instead of re-sending
+                // into the same dead connection until the caller's deadline.
+                if receive_ack_timeout.is_some() && network.is_connected(&ant_peer_id).await {
+                    match network.disconnect(&ant_peer_id).await {
+                        Ok(()) => tracing::info!(
+                            target: "x0x::direct",
+                            stage = "send",
+                            to = %agent_prefix,
+                            %machine_prefix,
+                            "tore down zombie connection after acked send failure; retry will redial"
+                        ),
+                        Err(de) => tracing::debug!(
+                            target: "x0x::direct",
+                            stage = "send",
+                            to = %agent_prefix,
+                            %machine_prefix,
+                            error = %de,
+                            "failed to tear down zombie connection after acked send failure"
+                        ),
+                    }
+                }
                 Err(e)
             }
         }
@@ -8947,9 +8974,12 @@ mod tests {
         let target = identity::AgentId([7_u8; 32]);
         let target_machine = identity::MachineId([9_u8; 32]);
 
-        agent
-            .capability_store()
-            .insert(target, target_machine, dm::DmCapabilities::pending());
+        agent.capability_store().insert(
+            target,
+            target_machine,
+            dm::DmCapabilities::pending(),
+            dm_capability::now_unix_ms(),
+        );
         agent.contacts().write().await.add(contacts::Contact {
             agent_id: target,
             trust_level: contacts::TrustLevel::Trusted,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1318,6 +1318,58 @@ fn push_unique<T: Copy + PartialEq>(items: &mut Vec<T>, item: T) {
     }
 }
 
+fn prioritize_discovery_addresses(addresses: &mut [std::net::SocketAddr]) {
+    addresses.sort_by_key(|addr| is_publicly_advertisable(*addr));
+}
+
+async fn upsert_discovered_agent(
+    cache: &std::sync::Arc<
+        tokio::sync::RwLock<std::collections::HashMap<identity::AgentId, DiscoveredAgent>>,
+    >,
+    mut incoming: DiscoveredAgent,
+) {
+    prioritize_discovery_addresses(&mut incoming.addresses);
+    let mut cache = cache.write().await;
+    match cache.get_mut(&incoming.agent_id) {
+        Some(existing) => {
+            for addr in incoming.addresses {
+                push_unique(&mut existing.addresses, addr);
+            }
+            prioritize_discovery_addresses(&mut existing.addresses);
+            if incoming.announced_at >= existing.announced_at {
+                existing.announced_at = incoming.announced_at;
+                if incoming.machine_id.0 != [0u8; 32] {
+                    existing.machine_id = incoming.machine_id;
+                }
+                if incoming.user_id.is_some() || existing.user_id.is_none() {
+                    existing.user_id = incoming.user_id;
+                }
+                if !incoming.machine_public_key.is_empty() {
+                    existing.machine_public_key = incoming.machine_public_key;
+                }
+                if incoming.nat_type.is_some() {
+                    existing.nat_type = incoming.nat_type;
+                }
+                if incoming.can_receive_direct.is_some() {
+                    existing.can_receive_direct = incoming.can_receive_direct;
+                }
+                if incoming.is_relay.is_some() {
+                    existing.is_relay = incoming.is_relay;
+                }
+                if incoming.is_coordinator.is_some() {
+                    existing.is_coordinator = incoming.is_coordinator;
+                }
+                existing.reachable_via = incoming.reachable_via;
+                existing.relay_candidates = incoming.relay_candidates;
+            }
+            existing.last_seen = existing.last_seen.max(incoming.last_seen);
+        }
+        None => {
+            cache.insert(incoming.agent_id, incoming);
+        }
+    }
+}
+
 fn sort_discovered_machine(machine: &mut DiscoveredMachine) {
     machine.addresses.sort_by_key(|addr| addr.to_string());
     machine.agent_ids.sort_by_key(|id| id.0);
@@ -1895,10 +1947,7 @@ impl HeartbeatContext {
             relay_candidates: announcement.relay_candidates.clone(),
         };
         upsert_discovered_machine_from_agent(&self.machine_cache, &discovered_agent).await;
-        self.cache
-            .write()
-            .await
-            .insert(discovered_agent.agent_id, discovered_agent);
+        upsert_discovered_agent(&self.cache, discovered_agent).await;
         Ok(())
     }
 }
@@ -2437,6 +2486,7 @@ impl Agent {
         }
 
         let dial_timeout = std::time::Duration::from_secs(8);
+        let local_probe_timeout = std::time::Duration::from_secs(3);
         let direct_probe_addrs = local_direct_probe_addrs(&info.addresses);
 
         // Agent cards minted for a local dogfood run often contain both
@@ -2444,55 +2494,191 @@ impl Agent {
         // that may be stale or firewalled. Probe local IPv4 first so a bad
         // multi-address peer dial cannot consume the full API timeout before
         // the reachable LAN path is attempted.
+        let peer_id_hint =
+            (agent.machine_id.0 != [0u8; 32]).then_some(ant_quic::PeerId(agent.machine_id.0));
         for addr in &direct_probe_addrs {
-            match tokio::time::timeout(dial_timeout, network.connect_addr(*addr)).await {
-                Ok(Ok(connected_peer_id)) => {
-                    let real_machine_id = identity::MachineId(connected_peer_id.0);
-                    if let Some(ref bc) = self.bootstrap_cache {
-                        bc.add_from_connection(connected_peer_id, vec![*addr], None)
-                            .await;
-                    }
+            if let Some(peer_id_hint) = peer_id_hint {
+                match tokio::time::timeout(
+                    local_probe_timeout,
+                    network.connect_peer_with_addrs(peer_id_hint, vec![*addr]),
+                )
+                .await
+                {
+                    Ok(Ok((selected_addr, connected_peer_id)))
+                        if connected_peer_id == peer_id_hint =>
                     {
-                        let mut cache = self.identity_discovery_cache.write().await;
-                        if let Some(entry) = cache.get_mut(agent_id) {
-                            entry.machine_id = real_machine_id;
+                        let real_machine_id = identity::MachineId(connected_peer_id.0);
+                        if let Some(ref bc) = self.bootstrap_cache {
+                            bc.add_from_connection(connected_peer_id, vec![selected_addr], None)
+                                .await;
                         }
+                        {
+                            let mut cache = self.identity_discovery_cache.write().await;
+                            if let Some(entry) = cache.get_mut(agent_id) {
+                                entry.machine_id = real_machine_id;
+                            }
+                        }
+                        self.direct_messaging
+                            .mark_connected(agent.agent_id, real_machine_id)
+                            .await;
+                        tracing::info!(
+                            target: "x0x::connect",
+                            stage = "connect_to_agent",
+                            %agent_prefix,
+                            strategy = "local_direct_first",
+                            outcome = "direct",
+                            selected_addr = %selected_addr,
+                            family = "v4",
+                            dur_ms = call_start.elapsed().as_millis() as u64,
+                            "local peer-authenticated dial succeeded"
+                        );
+                        return Ok(connectivity::ConnectOutcome::Direct(selected_addr));
                     }
-                    self.direct_messaging
-                        .mark_connected(agent.agent_id, real_machine_id)
-                        .await;
-                    tracing::info!(
-                        target: "x0x::connect",
-                        stage = "connect_to_agent",
-                        %agent_prefix,
-                        strategy = "local_direct_first",
-                        outcome = "direct",
-                        selected_addr = %addr,
-                        family = "v4",
-                        dur_ms = call_start.elapsed().as_millis() as u64,
-                        "local direct dial succeeded"
-                    );
-                    return Ok(connectivity::ConnectOutcome::Direct(*addr));
+                    Ok(Ok((selected_addr, connected_peer_id))) => {
+                        tracing::warn!(
+                            target: "x0x::connect",
+                            stage = "connect_to_agent",
+                            %agent_prefix,
+                            strategy = "local_direct_first",
+                            requested_addr = %addr,
+                            selected_addr = %selected_addr,
+                            connected_machine_prefix = %network::hex_prefix(&connected_peer_id.0, 4),
+                            "local peer-authenticated dial reached unexpected peer"
+                        );
+                    }
+                    Ok(Err(e)) => {
+                        tracing::debug!(
+                            target: "x0x::connect",
+                            %agent_prefix,
+                            strategy = "local_direct_first",
+                            %addr,
+                            error = %e,
+                            "local peer-authenticated dial failed; trying verified raw-address fallback"
+                        );
+                    }
+                    Err(_) => {
+                        tracing::debug!(
+                            target: "x0x::connect",
+                            %agent_prefix,
+                            strategy = "local_direct_first",
+                            %addr,
+                            timeout_s = local_probe_timeout.as_secs(),
+                            "local peer-authenticated dial timed out; trying verified raw-address fallback"
+                        );
+                    }
                 }
-                Ok(Err(e)) => {
-                    tracing::debug!(
-                        target: "x0x::connect",
-                        %agent_prefix,
-                        strategy = "local_direct_first",
-                        %addr,
-                        error = %e,
-                        "local direct dial failed"
-                    );
+
+                match tokio::time::timeout(local_probe_timeout, network.connect_addr(*addr)).await {
+                    Ok(Ok(connected_peer_id)) if connected_peer_id == peer_id_hint => {
+                        let real_machine_id = identity::MachineId(connected_peer_id.0);
+                        if let Some(ref bc) = self.bootstrap_cache {
+                            bc.add_from_connection(connected_peer_id, vec![*addr], None)
+                                .await;
+                        }
+                        {
+                            let mut cache = self.identity_discovery_cache.write().await;
+                            if let Some(entry) = cache.get_mut(agent_id) {
+                                entry.machine_id = real_machine_id;
+                            }
+                        }
+                        self.direct_messaging
+                            .mark_connected(agent.agent_id, real_machine_id)
+                            .await;
+                        tracing::info!(
+                            target: "x0x::connect",
+                            stage = "connect_to_agent",
+                            %agent_prefix,
+                            strategy = "local_direct_raw_fallback",
+                            outcome = "direct",
+                            selected_addr = %addr,
+                            family = "v4",
+                            dur_ms = call_start.elapsed().as_millis() as u64,
+                            "verified local raw-address fallback succeeded"
+                        );
+                        return Ok(connectivity::ConnectOutcome::Direct(*addr));
+                    }
+                    Ok(Ok(connected_peer_id)) => {
+                        tracing::warn!(
+                            target: "x0x::connect",
+                            stage = "connect_to_agent",
+                            %agent_prefix,
+                            strategy = "local_direct_raw_fallback",
+                            %addr,
+                            connected_machine_prefix = %network::hex_prefix(&connected_peer_id.0, 4),
+                            "verified local raw-address fallback reached unexpected peer"
+                        );
+                    }
+                    Ok(Err(e)) => {
+                        tracing::debug!(
+                            target: "x0x::connect",
+                            %agent_prefix,
+                            strategy = "local_direct_raw_fallback",
+                            %addr,
+                            error = %e,
+                            "verified local raw-address fallback failed"
+                        );
+                    }
+                    Err(_) => {
+                        tracing::debug!(
+                            target: "x0x::connect",
+                            %agent_prefix,
+                            strategy = "local_direct_raw_fallback",
+                            %addr,
+                            timeout_s = local_probe_timeout.as_secs(),
+                            "verified local raw-address fallback timed out"
+                        );
+                    }
                 }
-                Err(_) => {
-                    tracing::debug!(
-                        target: "x0x::connect",
-                        %agent_prefix,
-                        strategy = "local_direct_first",
-                        %addr,
-                        timeout_s = dial_timeout.as_secs(),
-                        "local direct dial timed out"
-                    );
+            } else {
+                match tokio::time::timeout(local_probe_timeout, network.connect_addr(*addr)).await {
+                    Ok(Ok(connected_peer_id)) => {
+                        let real_machine_id = identity::MachineId(connected_peer_id.0);
+                        if let Some(ref bc) = self.bootstrap_cache {
+                            bc.add_from_connection(connected_peer_id, vec![*addr], None)
+                                .await;
+                        }
+                        {
+                            let mut cache = self.identity_discovery_cache.write().await;
+                            if let Some(entry) = cache.get_mut(agent_id) {
+                                entry.machine_id = real_machine_id;
+                            }
+                        }
+                        self.direct_messaging
+                            .mark_connected(agent.agent_id, real_machine_id)
+                            .await;
+                        tracing::info!(
+                            target: "x0x::connect",
+                            stage = "connect_to_agent",
+                            %agent_prefix,
+                            strategy = "local_direct_first",
+                            outcome = "direct",
+                            selected_addr = %addr,
+                            family = "v4",
+                            dur_ms = call_start.elapsed().as_millis() as u64,
+                            "local direct dial succeeded"
+                        );
+                        return Ok(connectivity::ConnectOutcome::Direct(*addr));
+                    }
+                    Ok(Err(e)) => {
+                        tracing::debug!(
+                            target: "x0x::connect",
+                            %agent_prefix,
+                            strategy = "local_direct_first",
+                            %addr,
+                            error = %e,
+                            "local direct dial failed"
+                        );
+                    }
+                    Err(_) => {
+                        tracing::debug!(
+                            target: "x0x::connect",
+                            %agent_prefix,
+                            strategy = "local_direct_first",
+                            %addr,
+                            timeout_s = local_probe_timeout.as_secs(),
+                            "local direct dial timed out"
+                        );
+                    }
                 }
             }
         }
@@ -2856,6 +3042,133 @@ impl Agent {
             return Ok(connectivity::ConnectOutcome::Unreachable);
         }
 
+        let dial_timeout = std::time::Duration::from_secs(8);
+        let local_probe_timeout = std::time::Duration::from_secs(3);
+        let direct_probe_addrs = local_direct_probe_addrs(&info.addresses);
+
+        for addr in &direct_probe_addrs {
+            match tokio::time::timeout(
+                local_probe_timeout,
+                network.connect_peer_with_addrs(peer_id, vec![*addr]),
+            )
+            .await
+            {
+                Ok(Ok((selected_addr, connected_peer_id))) if connected_peer_id == peer_id => {
+                    if let Some(ref bc) = self.bootstrap_cache {
+                        bc.add_from_connection(connected_peer_id, vec![selected_addr], None)
+                            .await;
+                    }
+                    for agent_id in &machine.agent_ids {
+                        self.direct_messaging
+                            .mark_connected(*agent_id, machine.machine_id)
+                            .await;
+                    }
+                    tracing::info!(
+                        target: "x0x::connect",
+                        stage = "connect_to_machine",
+                        %machine_prefix,
+                        strategy = "local_direct_first",
+                        outcome = "direct",
+                        selected_addr = %selected_addr,
+                        dur_ms = call_start.elapsed().as_millis() as u64,
+                        "machine local direct dial succeeded"
+                    );
+                    return Ok(connectivity::ConnectOutcome::Direct(selected_addr));
+                }
+                Ok(Ok((selected_addr, connected_peer_id))) => {
+                    tracing::warn!(
+                        target: "x0x::connect",
+                        stage = "connect_to_machine",
+                        %machine_prefix,
+                        requested_addr = %addr,
+                        selected_addr = %selected_addr,
+                        connected_machine_prefix = %network::hex_prefix(&connected_peer_id.0, 4),
+                        "machine local direct dial reached unexpected peer"
+                    );
+                }
+                Ok(Err(e)) => {
+                    tracing::debug!(
+                        target: "x0x::connect",
+                        stage = "connect_to_machine",
+                        %machine_prefix,
+                        strategy = "local_direct_first",
+                        %addr,
+                        error = %e,
+                        "machine local direct dial failed"
+                    );
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        target: "x0x::connect",
+                        stage = "connect_to_machine",
+                        %machine_prefix,
+                        strategy = "local_direct_first",
+                        %addr,
+                        timeout_s = local_probe_timeout.as_secs(),
+                        "machine local direct dial timed out"
+                    );
+                }
+            }
+
+            match tokio::time::timeout(local_probe_timeout, network.connect_addr(*addr)).await {
+                Ok(Ok(connected_peer_id)) if connected_peer_id == peer_id => {
+                    if let Some(ref bc) = self.bootstrap_cache {
+                        bc.add_from_connection(connected_peer_id, vec![*addr], None)
+                            .await;
+                    }
+                    for agent_id in &machine.agent_ids {
+                        self.direct_messaging
+                            .mark_connected(*agent_id, machine.machine_id)
+                            .await;
+                    }
+                    tracing::info!(
+                        target: "x0x::connect",
+                        stage = "connect_to_machine",
+                        %machine_prefix,
+                        strategy = "local_direct_raw_fallback",
+                        outcome = "direct",
+                        selected_addr = %addr,
+                        dur_ms = call_start.elapsed().as_millis() as u64,
+                        "verified machine local raw-address fallback succeeded"
+                    );
+                    return Ok(connectivity::ConnectOutcome::Direct(*addr));
+                }
+                Ok(Ok(connected_peer_id)) => {
+                    tracing::warn!(
+                        target: "x0x::connect",
+                        stage = "connect_to_machine",
+                        %machine_prefix,
+                        strategy = "local_direct_raw_fallback",
+                        %addr,
+                        connected_machine_prefix = %network::hex_prefix(&connected_peer_id.0, 4),
+                        "verified machine local raw-address fallback reached unexpected peer"
+                    );
+                }
+                Ok(Err(e)) => {
+                    tracing::debug!(
+                        target: "x0x::connect",
+                        stage = "connect_to_machine",
+                        %machine_prefix,
+                        strategy = "local_direct_raw_fallback",
+                        %addr,
+                        error = %e,
+                        "verified machine local raw-address fallback failed"
+                    );
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        target: "x0x::connect",
+                        stage = "connect_to_machine",
+                        %machine_prefix,
+                        strategy = "local_direct_raw_fallback",
+                        %addr,
+                        timeout_s = local_probe_timeout.as_secs(),
+                        "verified machine local raw-address fallback timed out"
+                    );
+                }
+            }
+        }
+
         network
             .upsert_peer_hints(peer_id, info.addresses.clone(), None)
             .await
@@ -2865,7 +3178,6 @@ impl Agent {
                 )))
             })?;
 
-        let dial_timeout = std::time::Duration::from_secs(8);
         match tokio::time::timeout(
             dial_timeout,
             network.connect_peer_with_addrs(peer_id, info.addresses.clone()),
@@ -2927,6 +3239,9 @@ impl Agent {
 
         if info.should_attempt_direct() {
             for addr in &info.addresses {
+                if direct_probe_addrs.contains(addr) {
+                    continue;
+                }
                 match tokio::time::timeout(dial_timeout, network.connect_addr(*addr)).await {
                     Ok(Ok(connected_peer_id)) if connected_peer_id == peer_id => {
                         if let Some(ref bc) = self.bootstrap_cache {
@@ -4428,10 +4743,7 @@ impl Agent {
         };
         upsert_discovered_machine_from_agent(&self.machine_discovery_cache, &discovered_agent)
             .await;
-        self.identity_discovery_cache
-            .write()
-            .await
-            .insert(discovered_agent.agent_id, discovered_agent);
+        upsert_discovered_agent(&self.identity_discovery_cache, discovered_agent).await;
 
         // Record consent AFTER successful publish so heartbeats don't start
         // including user identity if this announcement never actually propagated.
@@ -5187,10 +5499,7 @@ impl Agent {
                     relay_candidates: announcement.relay_candidates.clone(),
                 };
                 upsert_discovered_machine_from_agent(&machine_cache, &discovered_agent).await;
-                cache
-                    .write()
-                    .await
-                    .insert(discovered_agent.agent_id, discovered_agent);
+                upsert_discovered_agent(&cache, discovered_agent).await;
                 tracing::debug!(
                     target: "x0x::discovery",
                     announcement_kind = "received",
@@ -6286,10 +6595,7 @@ impl Agent {
                             };
                             upsert_discovered_machine_from_agent(&machine_cache, &discovered_agent)
                                 .await;
-                            cache
-                                .write()
-                                .await
-                                .insert(discovered_agent.agent_id, discovered_agent);
+                            upsert_discovered_agent(&cache, discovered_agent).await;
                             return Ok(Some(addrs));
                         }
                     }
@@ -6304,11 +6610,9 @@ impl Agent {
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_or(0, |d| d.as_secs());
-            cache
-                .write()
-                .await
-                .entry(agent_id)
-                .or_insert_with(|| DiscoveredAgent {
+            upsert_discovered_agent(
+                &cache,
+                DiscoveredAgent {
                     agent_id,
                     machine_id: identity::MachineId([0u8; 32]),
                     user_id: None,
@@ -6322,7 +6626,9 @@ impl Agent {
                     is_coordinator: None,
                     reachable_via: Vec::new(),
                     relay_candidates: Vec::new(),
-                });
+                },
+            )
+            .await;
             return Ok(Some(addrs));
         }
 
@@ -7010,10 +7316,7 @@ impl Agent {
         let agent_id = agent.agent_id;
         let machine_id = agent.machine_id;
         upsert_discovered_machine_from_agent(&self.machine_discovery_cache, &agent).await;
-        self.identity_discovery_cache
-            .write()
-            .await
-            .insert(agent_id, agent);
+        upsert_discovered_agent(&self.identity_discovery_cache, agent).await;
 
         if machine_id.0 != [0u8; 32] {
             self.direct_messaging
@@ -8060,6 +8363,12 @@ impl std::fmt::Debug for KvStoreHandle {
 }
 
 impl KvStoreHandle {
+    /// Return this handle's gossip peer id.
+    #[must_use]
+    pub fn peer_id(&self) -> saorsa_gossip_types::PeerId {
+        self.peer_id
+    }
+
     /// Put a key-value pair into the store.
     ///
     /// If the key already exists, the value is updated. Changes are
@@ -8074,6 +8383,24 @@ impl KvStoreHandle {
         value: Vec<u8>,
         content_type: String,
     ) -> error::Result<()> {
+        let _ = self.put_with_delta(key, value, content_type).await?;
+        Ok(())
+    }
+
+    /// Put a key-value pair and return the CRDT delta that was published.
+    ///
+    /// This is used by API-layer delivery fallbacks that need to carry the
+    /// exact same mutation over a side channel when pub/sub is congested.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value exceeds the maximum inline size (64 KB).
+    pub async fn put_with_delta(
+        &self,
+        key: String,
+        value: Vec<u8>,
+        content_type: String,
+    ) -> error::Result<kv::KvStoreDelta> {
         let delta = {
             let mut store = self.sync.write().await;
             store
@@ -8094,13 +8421,17 @@ impl KvStoreHandle {
                 Some(e) => {
                     kv::KvStoreDelta::for_put(key, e, (self.peer_id, store.next_seq()), version)
                 }
-                None => return Ok(()), // shouldn't happen after successful put
+                None => {
+                    return Err(error::IdentityError::Storage(std::io::Error::other(
+                        "kv put succeeded but entry was not readable",
+                    )));
+                }
             }
         };
-        if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
+        if let Err(e) = self.sync.publish_delta(self.peer_id, delta.clone()).await {
             tracing::warn!("failed to publish kv put delta: {e}");
         }
-        Ok(())
+        Ok(delta)
     }
 
     /// Get a value by key.
@@ -8129,6 +8460,16 @@ impl KvStoreHandle {
     ///
     /// Returns an error if the key does not exist.
     pub async fn remove(&self, key: &str) -> error::Result<()> {
+        let _ = self.remove_with_delta(key).await?;
+        Ok(())
+    }
+
+    /// Remove a key and return the CRDT delta that was published.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the key does not exist.
+    pub async fn remove_with_delta(&self, key: &str) -> error::Result<kv::KvStoreDelta> {
         let delta = {
             let mut store = self.sync.write().await;
             store.remove(key).map_err(|e| {
@@ -8141,10 +8482,31 @@ impl KvStoreHandle {
                 .insert(key.to_string(), std::collections::HashSet::new());
             d
         };
-        if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
+        if let Err(e) = self.sync.publish_delta(self.peer_id, delta.clone()).await {
             tracing::warn!("failed to publish kv remove delta: {e}");
         }
-        Ok(())
+        Ok(delta)
+    }
+
+    /// Apply a verified remote delta received through a non-pubsub channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the delta fails to merge into the local store.
+    pub async fn apply_remote_delta(
+        &self,
+        peer_id: saorsa_gossip_types::PeerId,
+        delta: &kv::KvStoreDelta,
+        writer: Option<identity::AgentId>,
+    ) -> error::Result<()> {
+        let mut store = self.sync.write().await;
+        store
+            .merge_delta(delta, peer_id, writer.as_ref())
+            .map_err(|e| {
+                error::IdentityError::Storage(std::io::Error::other(format!(
+                    "kv direct delta merge failed: {e}",
+                )))
+            })
     }
 
     /// List all active keys in the store.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1322,6 +1322,23 @@ fn prioritize_discovery_addresses(addresses: &mut [std::net::SocketAddr]) {
     addresses.sort_by_key(|addr| is_publicly_advertisable(*addr));
 }
 
+/// Merge a freshly-discovered agent announcement into the cache.
+///
+/// Per-field precedence is keyed on `announced_at` (the signed announcement's
+/// own monotonic timestamp), not local receive time:
+/// - **addresses** reflect the agent's *current* advertised set. A fresher (or
+///   equal) announcement REPLACES the cached list; a stale announcement leaves
+///   it untouched. Announcements carry the agent's full address set, so
+///   replacing — not unioning — keeps the list bounded: a roaming agent
+///   (Wi-Fi → cellular → VPN) does not accumulate dead endpoints, each of which
+///   would otherwise cost a dial timeout in `connect_to_*` / `direct_probe`.
+/// - **machine_id / public key / nat / capability / relay hints** update only
+///   from a fresher-or-equal announcement, and only when present — a zeroed
+///   machine_id or empty key never clobbers a known value.
+/// - **user_id** is never erased: a fresher *anonymous* announcement keeps a
+///   previously-disclosed user_id.
+/// - **last_seen** is monotonic (`max`) so cache eviction by receive time keeps
+///   working regardless of announcement arrival order.
 async fn upsert_discovered_agent(
     cache: &std::sync::Arc<
         tokio::sync::RwLock<std::collections::HashMap<identity::AgentId, DiscoveredAgent>>,
@@ -1332,12 +1349,12 @@ async fn upsert_discovered_agent(
     let mut cache = cache.write().await;
     match cache.get_mut(&incoming.agent_id) {
         Some(existing) => {
-            for addr in incoming.addresses {
-                push_unique(&mut existing.addresses, addr);
-            }
-            prioritize_discovery_addresses(&mut existing.addresses);
             if incoming.announced_at >= existing.announced_at {
                 existing.announced_at = incoming.announced_at;
+                // Replace, don't union: the announcement carries the agent's
+                // full current address set, so the cached list stays bounded.
+                existing.addresses = incoming.addresses;
+                prioritize_discovery_addresses(&mut existing.addresses);
                 if incoming.machine_id.0 != [0u8; 32] {
                     existing.machine_id = incoming.machine_id;
                 }
@@ -9692,6 +9709,119 @@ fn push_unique_works_with_empty() {
     let mut items: Vec<i32> = vec![];
     push_unique(&mut items, 42);
     assert_eq!(items, vec![42]);
+}
+
+#[cfg(test)]
+fn discovered_agent_fixture(
+    tag: u8,
+    announced_at: u64,
+    addrs: &[&str],
+    user_id: Option<identity::UserId>,
+) -> DiscoveredAgent {
+    DiscoveredAgent {
+        agent_id: identity::AgentId([tag; 32]),
+        machine_id: identity::MachineId([tag; 32]),
+        user_id,
+        addresses: addrs
+            .iter()
+            .map(|a| a.parse().expect("valid socket addr"))
+            .collect(),
+        announced_at,
+        last_seen: announced_at,
+        machine_public_key: vec![tag],
+        nat_type: None,
+        can_receive_direct: None,
+        is_relay: None,
+        is_coordinator: None,
+        reachable_via: Vec::new(),
+        relay_candidates: Vec::new(),
+    }
+}
+
+#[tokio::test]
+async fn upsert_discovered_agent_replaces_addresses_on_fresher_announcement() {
+    let cache = std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+    let id = identity::AgentId([7; 32]);
+
+    upsert_discovered_agent(
+        &cache,
+        discovered_agent_fixture(7, 100, &["10.0.0.1:5483", "8.8.8.8:5483"], None),
+    )
+    .await;
+    // A fresher announcement advertising a NEW address set must REPLACE, not
+    // accumulate — otherwise a roaming agent grows an unbounded list of dead
+    // endpoints that each cost a dial timeout.
+    upsert_discovered_agent(
+        &cache,
+        discovered_agent_fixture(7, 200, &["1.2.3.4:5483"], None),
+    )
+    .await;
+
+    let guard = cache.read().await;
+    let entry = guard.get(&id).expect("entry present");
+    assert_eq!(
+        entry.addresses,
+        vec!["1.2.3.4:5483".parse().expect("addr")],
+        "fresher announcement must replace the address set, not union it"
+    );
+}
+
+#[tokio::test]
+async fn upsert_discovered_agent_ignores_stale_announcement_addresses() {
+    let cache = std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+    let id = identity::AgentId([8; 32]);
+
+    upsert_discovered_agent(
+        &cache,
+        discovered_agent_fixture(8, 200, &["1.2.3.4:5483"], None),
+    )
+    .await;
+    // A stale (lower announced_at) announcement must not inject its old
+    // addresses into the fresher cached record.
+    upsert_discovered_agent(
+        &cache,
+        discovered_agent_fixture(8, 100, &["10.0.0.9:5483"], None),
+    )
+    .await;
+
+    let guard = cache.read().await;
+    let entry = guard.get(&id).expect("entry present");
+    assert_eq!(
+        entry.addresses,
+        vec!["1.2.3.4:5483".parse().expect("addr")],
+        "stale announcement must not add addresses"
+    );
+    assert_eq!(
+        entry.announced_at, 200,
+        "stale announcement must not regress announced_at"
+    );
+}
+
+#[tokio::test]
+async fn upsert_discovered_agent_preserves_known_user_id() {
+    let cache = std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+    let id = identity::AgentId([9; 32]);
+    let user = identity::UserId([9; 32]);
+
+    upsert_discovered_agent(
+        &cache,
+        discovered_agent_fixture(9, 100, &["1.2.3.4:5483"], Some(user)),
+    )
+    .await;
+    // A fresher but anonymous announcement must not erase a known user_id.
+    upsert_discovered_agent(
+        &cache,
+        discovered_agent_fixture(9, 200, &["1.2.3.4:5483"], None),
+    )
+    .await;
+
+    let guard = cache.read().await;
+    let entry = guard.get(&id).expect("entry present");
+    assert_eq!(
+        entry.user_id,
+        Some(user),
+        "a fresher anonymous announcement must not erase a disclosed user_id"
+    );
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1337,8 +1337,13 @@ fn prioritize_discovery_addresses(addresses: &mut [std::net::SocketAddr]) {
 ///   machine_id or empty key never clobbers a known value.
 /// - **user_id** is never erased: a fresher *anonymous* announcement keeps a
 ///   previously-disclosed user_id.
-/// - **last_seen** is monotonic (`max`) so cache eviction by receive time keeps
-///   working regardless of announcement arrival order.
+/// - **last_seen** reflects the most recent receive: it is set from the
+///   incoming record (matching the pre-merge replace semantics). In production
+///   `incoming.last_seen` is the current receive time, so it only moves forward;
+///   it is NOT clamped with `max`, because the TTL/presence filter must be able
+///   to observe an entry that has genuinely aged past its window (a `max` clamp
+///   would let a once-fresh entry mask a later stale observation and never
+///   expire — see `test_ttl_expiry_removes_from_presence`).
 async fn upsert_discovered_agent(
     cache: &std::sync::Arc<
         tokio::sync::RwLock<std::collections::HashMap<identity::AgentId, DiscoveredAgent>>,
@@ -1379,7 +1384,7 @@ async fn upsert_discovered_agent(
                 existing.reachable_via = incoming.reachable_via;
                 existing.relay_candidates = incoming.relay_candidates;
             }
-            existing.last_seen = existing.last_seen.max(incoming.last_seen);
+            existing.last_seen = incoming.last_seen;
         }
         None => {
             cache.insert(incoming.agent_id, incoming);

--- a/tests/e2e_studio_gui_full.mjs
+++ b/tests/e2e_studio_gui_full.mjs
@@ -178,6 +178,45 @@ async function proveGuiRecovery(page) {
     record("embedded-gui.websocket-offline-recovered", "pass");
 }
 
+async function proveEmbeddedGuiFilesRecipient(page, label, groupId, recipientAgentId) {
+    await page.evaluate(({ groupId }) => navigateSpace(groupId, "files"), { groupId });
+    await page.waitForSelector("#file-recipient", { state: "visible", timeout: 15000 });
+    await page.evaluate(() => pollContacts().then(renderFileRecipientOptions));
+    await page.waitForFunction(
+        target => Array.from(document.querySelectorAll("#file-recipient option")).some(option => option.value === target),
+        recipientAgentId,
+        { timeout: 15000 },
+    );
+
+    const initial = await page.locator("#file-recipient").inputValue();
+    failFast(initial === "", `${label} Files should require explicit recipient selection`);
+
+    await page.selectOption("#file-recipient", recipientAgentId);
+    const disabled = await page.locator("#file-input").evaluate(el => el.disabled);
+    failFast(!disabled, `${label} Files input should enable after selecting a recipient`);
+
+    const captured = await page.evaluate(async () => {
+        const originalApi = window.api;
+        let sentBody = null;
+        window.api = async (path, opt) => {
+            if (path === "/files/send") {
+                sentBody = JSON.parse(opt.body);
+                return { ok: true, _http_ok: true };
+            }
+            return originalApi(path, opt);
+        };
+        try {
+            const file = new File(["embedded gui file selector proof"], "embedded-selector-proof.txt", { type: "text/plain" });
+            await handleFileDrop(file);
+            return sentBody;
+        } finally {
+            window.api = originalApi;
+        }
+    });
+    failFast(captured?.agent_id === recipientAgentId, `${label} Files sent to ${captured?.agent_id}, expected ${recipientAgentId}`);
+    record(`${label}.embedded-gui.files-recipient-selector`, "pass", { recipient: recipientAgentId });
+}
+
 async function startExampleServer() {
     const root = resolve("examples/apps");
     const server = createServer((req, res) => {
@@ -285,8 +324,15 @@ async function proveDrop(context, exampleBase, local, studio) {
     await lp.setInputFiles("#fileIn", upload);
     await lp.waitForSelector("#send-btn", { state: "visible", timeout: 10000 });
     await lp.click("#send-btn");
-    await sp.waitForSelector("#xfer-list button", { timeout: 20000 });
-    await sp.click("#xfer-list button:has-text('Accept')");
+    await sp.waitForFunction(() => {
+        const list = document.querySelector("#xfer-list");
+        if (!list) return false;
+        return list.textContent.includes("Complete") || !!list.querySelector("button");
+    }, null, { timeout: 20000 });
+    const accept = sp.locator("#xfer-list button:has-text('Accept')");
+    if (await accept.count()) {
+        await accept.first().click();
+    }
     await waitForText(sp, "#xfer-list", "Complete", 30000);
     record("example-app.drop-cross-machine", "pass");
     await lp.close();
@@ -309,6 +355,8 @@ async function main() {
         const studioGui = await openGui(context, studio, "studio");
         await proveGuiViews(localGui.page, "macbook", space.localGroupId);
         await proveGuiViews(studioGui.page, "studio", space.studioGroupId);
+        await proveEmbeddedGuiFilesRecipient(localGui.page, "macbook", space.localGroupId, studio.agent.agent_id);
+        await proveEmbeddedGuiFilesRecipient(studioGui.page, "studio", space.studioGroupId, local.agent.agent_id);
         await proveGuiDm(localGui.page, studioGui.page, local, studio);
         await proveGuiRecovery(localGui.page);
 

--- a/tests/gui_smoke.rs
+++ b/tests/gui_smoke.rs
@@ -47,6 +47,31 @@ fn gui_dm_composer_exposes_require_ack_toggle() {
     );
 }
 
+/// Verify the embedded Files app requires an explicit recipient selection.
+///
+/// This prevents a privacy/safety regression where file sends silently target
+/// the first contact in the address book.
+#[test]
+fn gui_files_requires_explicit_recipient_selection() {
+    let html = include_str!("../src/gui/x0x-gui.html");
+    assert!(
+        html.contains(r#"id="file-recipient""#),
+        "Files app should expose an explicit recipient select"
+    );
+    assert!(
+        html.contains("selectedFileRecipient()"),
+        "Files send path should read the selected recipient"
+    );
+    assert!(
+        html.contains("Select a recipient before sending files"),
+        "Files app should warn before sending without a recipient"
+    );
+    assert!(
+        !html.contains("contacts[0].agent_id"),
+        "Files app must not auto-send to the first contact"
+    );
+}
+
 /// Verify that API paths called from the GUI exist in ENDPOINTS.
 ///
 /// Extracts `api("/path"...)` calls from the JavaScript and checks each

--- a/tests/named_group_integration.rs
+++ b/tests/named_group_integration.rs
@@ -81,12 +81,16 @@ where
 }
 
 async fn group_state_hash(d: &AgentInstance, group_id: &str) -> Option<String> {
+    let body = group_state(d, group_id).await?;
+    body["state_hash"].as_str().map(ToString::to_string)
+}
+
+async fn group_state(d: &AgentInstance, group_id: &str) -> Option<Value> {
     let resp = d.get(&format!("/groups/{group_id}/state")).await;
     if !resp.status().is_success() {
         return None;
     }
-    let body: Value = resp.json().await.unwrap_or_default();
-    body["state_hash"].as_str().map(ToString::to_string)
+    Some(resp.json().await.unwrap_or_default())
 }
 
 // ===========================================================================
@@ -1305,6 +1309,20 @@ async fn named_group_creator_delete_propagates_to_peer() {
         .unwrap();
     assert_eq!(alice_create["ok"], true);
     let group_id = alice_create["group_id"].as_str().unwrap().to_string();
+    let alice_state = group_state(alice, &group_id).await;
+    assert!(
+        alice_state.is_some(),
+        "alice state missing after default private_secure create"
+    );
+    let Some(alice_state) = alice_state else {
+        return;
+    };
+    assert!(
+        alice_state["security_binding"]
+            .as_str()
+            .is_some_and(|binding| binding.starts_with("treekem:")),
+        "creator-delete regression must exercise a private_secure TreeKEM group: {alice_state:?}"
+    );
 
     let invite: Value = alice
         .post(&format!("/groups/{group_id}/invite"), serde_json::json!({}))

--- a/tests/pr99_local_soak.sh
+++ b/tests/pr99_local_soak.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Improvised local 2h soak for PR #99 (codex/x0x-gui-full-dogfood).
+#
+# Loops the two LOCAL dogfood suites against the freshly-built release x0xd
+# until SOAK_DURATION_SECS elapses, exercising the PR's local-discovery path
+# (dogfood_local boots with --no-hard-coded-bootstrap → empty-bootstrap →
+# allow_local_discovery_addresses scope) and named-group leave + DM/pubsub
+# stability (dogfood_groups), under sustained restart churn.
+#
+# NOT covered here (no local harness exists): TreeKEM secure-group self-leave
+# (testnet-only) and browser base64 upload (GUI) — both covered by the 146/146
+# unit+integration slice instead.
+#
+# Green bar: 100% iteration pass rate, zero daemon panics, no late-clustering
+# failures (port/FD-leak signal), no per-iteration duration blow-out.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+DUR="${SOAK_DURATION_SECS:-7200}"          # 2 hours
+SETTLE="${SOAK_SETTLE_SECS:-2}"            # gap between iterations (port release)
+MAX_CONSEC_FAIL="${SOAK_MAX_CONSEC_FAIL:-3}"  # fail-fast on a broken build
+STAMP="$(date +%Y%m%dT%H%M%SZ)"
+OUT="proofs/x0x-gui-full-dogfood/pr99-soak-${STAMP}"
+mkdir -p "$OUT"
+RESULTS="$OUT/results.csv"
+LOG="$OUT/soak.log"
+SUMMARY="$OUT/summary.json"
+
+X0XD="${X0XD:-$PWD/target/release/x0xd}"
+export X0XD
+if [ ! -x "$X0XD" ]; then
+    echo "x0xd not built at $X0XD" | tee -a "$LOG"
+    exit 2
+fi
+
+echo "iter,ts_utc,suite,rc,elapsed_s" > "$RESULTS"
+echo "PR#99 local soak start=$STAMP dur=${DUR}s x0xd=$X0XD head=$(git rev-parse --short HEAD)" | tee -a "$LOG"
+
+t0=$(date +%s)
+deadline=$((t0 + DUR))
+iter=0
+pass=0
+fail=0
+consec_fail=0
+declare -a FAILED_ITERS=()
+
+run_suite() {
+    # $1 = label, $2... = command
+    local label="$1"; shift
+    local s e rc
+    s=$(date +%s)
+    "$@" >>"$OUT/${label}.last.log" 2>&1
+    rc=$?
+    e=$(($(date +%s) - s))
+    echo "$iter,$(date -u +%Y-%m-%dT%H:%M:%SZ),$label,$rc,$e" >> "$RESULTS"
+    if [ "$rc" -ne 0 ]; then
+        echo "[iter $iter] $label FAIL rc=$rc (${e}s)" | tee -a "$LOG"
+        # preserve the failing run's log
+        cp "$OUT/${label}.last.log" "$OUT/${label}.iter${iter}.fail.log" 2>/dev/null || true
+    fi
+    return $rc
+}
+
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    iter=$((iter + 1))
+    iter_ok=1
+
+    run_suite "dogfood_local"  bash tests/e2e_dogfood_local.sh  || iter_ok=0
+    run_suite "dogfood_groups" bash tests/e2e_dogfood_groups.sh || iter_ok=0
+
+    if [ "$iter_ok" -eq 1 ]; then
+        pass=$((pass + 1))
+        consec_fail=0
+    else
+        fail=$((fail + 1))
+        FAILED_ITERS+=("$iter")
+        consec_fail=$((consec_fail + 1))
+        if [ "$consec_fail" -ge "$MAX_CONSEC_FAIL" ]; then
+            echo "FAIL-FAST: $consec_fail consecutive failed iterations — aborting soak" | tee -a "$LOG"
+            break
+        fi
+    fi
+
+    if [ "$((iter % 20))" -eq 0 ]; then
+        echo "[progress] iter=$iter pass=$pass fail=$fail elapsed=$(($(date +%s) - t0))s" | tee -a "$LOG"
+    fi
+    sleep "$SETTLE"
+done
+
+# Panic/abort scan across any preserved logs.
+PANICS=$(grep -rlE "panic|thread '.*' panicked|fatal runtime|SIGABRT" "$OUT"/*.log 2>/dev/null | wc -l | tr -d ' ')
+
+elapsed=$(($(date +%s) - t0))
+rate="n/a"
+if [ "$((pass + fail))" -gt 0 ]; then
+    rate=$(awk "BEGIN{printf \"%.1f\", 100*$pass/($pass+$fail)}")
+fi
+
+{
+  echo "{"
+  echo "  \"pr\": 99,"
+  echo "  \"head\": \"$(git rev-parse HEAD)\","
+  echo "  \"start_utc\": \"$STAMP\","
+  echo "  \"elapsed_secs\": $elapsed,"
+  echo "  \"iterations\": $iter,"
+  echo "  \"pass\": $pass,"
+  echo "  \"fail\": $fail,"
+  echo "  \"pass_rate_pct\": \"$rate\","
+  echo "  \"failed_iters\": \"${FAILED_ITERS[*]:-}\","
+  echo "  \"panic_logs\": $PANICS,"
+  echo "  \"green\": $([ "$fail" -eq 0 ] && [ "$PANICS" -eq 0 ] && echo true || echo false)"
+  echo "}"
+} | tee "$SUMMARY" | tee -a "$LOG"
+
+echo "SOAK DONE: iters=$iter pass=$pass fail=$fail rate=${rate}% panics=$PANICS elapsed=${elapsed}s out=$OUT" | tee -a "$LOG"


### PR DESCRIPTION
## What

Daemon-side support for the communitas Swift/Dioxus apps, **rescued from the x0x working tree** where it sat uncommitted (~1462 lines, one `git checkout` from loss) during the communitas integration review, plus a review fix.

**Draft** because: this was authored outside this session and reviewed here, and it carries **one behavioral decision** (see Blocker) that should be confirmed against the live mesh before merge.

### Change set
- **Gossip-DM: shared-bus → per-recipient inbox topics** (`dm_inbox.rs`, `dm_send.rs`, `gossip/pubsub.rs`). Was: every agent subscribed to one `x0x/dm/v1/bus` and received *every* encrypted DM (O(N) fleet load). Now: sender publishes to `dm_inbox_topic(recipient)`, recipient subscribes to `dm_inbox_topic(self)`; new `subscribe_topic_id`/`publish_topic_id` carry an explicit transport `TopicId`. Legacy bus retained as a rolling-upgrade fallback with a 250ms ACK-then-fallback path. Scalability + privacy win, rolling-upgrade-safe.
- **Cached `/upgrade` response** — `tokio::sync::Mutex` (no poison panic), 6h success / 30min error TTL, anti-hammer for polling clients.
- **Two background gossip-DM fallback listeners** (signed-public-message + KvStore-delta) — reliability backstop when the topic mesh is late/congested.
- **Per-request `require_gossip_ack` override** on `POST /direct/send`.
- **lib.rs**: peer-ID-authenticated local dials (security fix — old code trusted whoever answered a LAN address); discovery-cache merge helpers; `put_with_delta`/`apply_remote_delta` KvStore API.
- **Review fix (this PR, `ed6f845`)**: bound the discovered-agent address list — restore replace-on-fresher (the WIP had regressed to unbounded union → roaming agents accumulated dead endpoints) + the missing unit tests.

## Review verdict: ship-able after one decision

Reviewed by 3 agents + direct review. **Builds clean, clippy `-D warnings` clean, 190/190 DM/gossip/group tests pass.**

**Security — CLEAN.** Both new fallback listeners gate on `verified` (ML-DSA-65 sig + sender-id↔key binding) and then call the **same** `ingest_public_message` / `merge_delta` the gossip path uses → full author-ban + write-policy + per-message signature re-check. No transport-`verified`-gate bypass; a non-member cannot inject deltas. Dual gossip+direct delivery is idempotent (dedup by signature / CRDT merge) — no double-apply.

## 🔴 Blocker (human decision): `require_gossip_ack` default flip

`direct_message_send_config()` dropped its explicit `require_gossip_ack: false`, so generic daemon/UI DMs now inherit the default `true`. The removed comment warned this exact flip causes false 504s ("live meshes deliver the payload while dropping the reverse ACK; surfacing that as 504 makes users resend messages the recipient already displayed"). **The communitas client never sends the field**, so all its UI DMs now require the ACK.

There's a coherent case it's now safe — the *same* change set hardened the ACK path (per-recipient inbox + 250ms ACK-then-legacy-fallback). But it reverses a fix for a real observed problem. **Decide one of:**
- (a) validate on the live mesh that ACKs now arrive reliably (no false 504s), or
- (b) have the communitas client pass `require_gossip_ack: false` for fire-and-forget UI sends.

## Remaining (non-blocking)
- LOW: `public_messages` map unbounded in *number of groups* (per-group history is capped); listener tasks lack a graceful-shutdown hook; KV errors tunneled through `IdentityError::Storage`; `connect_to_machine` probes LAN regardless of `should_attempt_direct()`.

## Not included
- Client-side app blockers from the communitas review (WS reconnect in both apps; Dioxus macOS receive gate) — those live in the communitas repo, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds daemon-side app-integration support: per-recipient gossip-DM inbox topics (replacing the shared bus), two background fallback listeners for group-public-message and KvStore-delta delivery over DM, a cached `/upgrade` response, peer-ID-authenticated LAN dials, a `upsert_discovered_agent` helper that bounds the address list, and a `CapabilityStore` timestamp-ordering fix to prevent stale pending adverts from poisoning the gossip-ready entry.

- **DM inbox topology**: senders now publish to `dm_inbox_topic(recipient)` with a 250 ms ACK-then-legacy-bus fallback; the legacy shared bus is retained as a rolling-upgrade backstop. `RecentDeliveryCache::insert` returns a bool (atomic slot-claim) to prevent dual-path double-delivery.
- **`direct_message_send_config` behavioral change**: `require_gossip_ack` now inherits the default `true` (previously explicit `false`), and `stop_fallback_on_raw_error` is flipped to `false` for file transfers — both are deliberate reversals of prior design decisions that need live-mesh validation before merge.
- **Security fix**: `connect_to_agent` LAN dials now authenticate the peer ID before trusting the connection; the unauthenticated path is retained as a fallback only when no `machine_id` hint is available.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the `require_gossip_ack` default change is validated or the communitas client is updated to pass the field explicitly.

The core DM inbox re-architecture (per-recipient topics, dedupe, legacy fallback, capability-advert poisoning fix, peer-ID-authenticated dials) is solid and well-tested. The unresolved concern is `direct_message_send_config`: dropping `require_gossip_ack: false` changes how every communitas UI DM behaves — the client never sends the field, so all its sends now wait for a gossip ACK that the PR description warns can be dropped on live meshes without the payload being lost, surfacing as a false 504. The `stop_fallback_on_raw_error` flip for file transfers also reverses an explicit prior decision (gossip fanout breaking chunk throughput) without fully addressing the original concern.

src/bin/x0xd.rs — `direct_message_send_config` and `file_transfer_send_config` contain the two behavioral reversals that need a decision before merge.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/bin/x0xd.rs | Major daemon changes: two new background gossip-DM fallback listener tasks, per-request `require_gossip_ack` override, cached `/upgrade` response (tokio Mutex, 6h/30min TTL), `--disable-peer-cache` flag, and `direct_message_send_config` behavioral flip (`require_gossip_ack` now defaults true, `stop_fallback_on_raw_error` flipped for file transfers). |
| src/dm_inbox.rs | New per-recipient inbox subscription service. Primary path uses `subscribe_topic_id` with domain-separated TopicId; legacy bus retained as rolling-upgrade fallback. Atomic dedupe claim in `cache.insert` prevents dual-path double-delivery. Well-tested with 20+ unit tests. |
| src/dm_send.rs | Sender-side gossip DM path updated to publish to per-recipient `publish_topic_id` topics with 250ms ACK-then-legacy-bus fallback. X0X-0041 lifecycle-hint backoff short-circuit well-tested. |
| src/lib.rs | New `upsert_discovered_agent` replaces unbounded union with replace-on-fresher semantics for addresses. Peer-ID-authenticated LAN dials in `connect_to_agent` (security fix). New `connect_to_machine` LAN probes don't guard on `should_attempt_direct()`, causing dial attempts to relay-only peers. |
| src/gossip/pubsub.rs | New `subscribe_topic_id` and `publish_topic_id` overloads that accept an explicit transport TopicId. Existing `subscribe`/`publish` now delegate to these, no behavioral change for existing callers. |
| src/dm_capability.rs | CapabilityStore now orders adverts by `created_at_unix_ms` to prevent stale pending adverts from clobbering gossip-ready ones; includes tests covering the out-of-order delivery scenario. |
| src/dm.rs | `RecentDeliveryCache::insert` now returns `bool` acting as atomic slot-claim to prevent dual-path (primary inbox + legacy bus) double-delivery; covered by new test. |
| src/direct.rs | Adds `incoming_typed_route_dropped` diagnostic counter for best-effort typed-route fallback drops; new `serde(default)` attribute ensures backward-compatible JSON deserialization. |
| src/dm_capability_service.rs | Publisher now guards against broadcasting not-yet-usable (pending) adverts, restarting burst on capability upgrade. Clean fix for capability-advert poisoning described in the changelog. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Sender
    participant PubSub
    participant RecipientInbox as Recipient Inbox (new)
    participant LegacyBus as Legacy Bus (fallback)
    participant InboxService as DmInboxService
    participant DM as DirectMessaging

    Sender->>PubSub: publish_topic_id(dm_inbox_topic(recipient), wire)
    PubSub-->>RecipientInbox: deliver envelope

    alt ACK within 250ms
        InboxService-->>Sender: ACK via publish_topic_id
    else no ACK (rolling upgrade / congestion)
        Sender->>PubSub: publish(DM_BUS_TOPIC, wire)
        PubSub-->>LegacyBus: deliver envelope
    end

    InboxService->>InboxService: verify sig, decrypt, dedupe (atomic cache.insert)
    InboxService->>DM: handle_incoming (or typed route)
    InboxService-->>Sender: publish_ack via inbox_topic OR legacy_bus

    Note over InboxService: Dual-path dedup: cache.insert returns false for loser task
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/bin/x0xd.rs`, line 2619-2631 ([link](https://github.com/saorsa-labs/x0x/blob/03197b1dc904e765992cbe7665ae9d4a936d635a/src/bin/x0xd.rs#L2619-L2631)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`require_gossip_ack` default flip affects all communitas UI DMs**

   `direct_message_send_config()` dropped `require_gossip_ack: false`, so the field now inherits `DmSendConfig::default()` which is `true`. The PR description acknowledges this as a 🔴 Blocker: the communitas client never passes `require_gossip_ack` in its `POST /direct/send` body, so every UI DM now blocks until the recipient ACKs via the gossip inbox. On a live mesh where the reverse ACK can be dropped (especially in the first seconds after boot or during a rolling upgrade), this surfaces as a 504 to the sender — who then resends a message the recipient already displayed. The prior comment capturing this exact failure scenario was removed. Even with the hardened per-recipient inbox and 250 ms ACK-then-legacy-fallback, the original observed problem (ACK drop ≠ payload loss) is not eliminated — it just becomes less frequent. A decision is needed before merge: either validate ACKs arrive reliably on the live mesh, or add `require_gossip_ack: false` in the communitas client for fire-and-forget UI sends.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/bin/x0xd.rs
   Line: 2619-2631

   Comment:
   **`require_gossip_ack` default flip affects all communitas UI DMs**

   `direct_message_send_config()` dropped `require_gossip_ack: false`, so the field now inherits `DmSendConfig::default()` which is `true`. The PR description acknowledges this as a 🔴 Blocker: the communitas client never passes `require_gossip_ack` in its `POST /direct/send` body, so every UI DM now blocks until the recipient ACKs via the gossip inbox. On a live mesh where the reverse ACK can be dropped (especially in the first seconds after boot or during a rolling upgrade), this surfaces as a 504 to the sender — who then resends a message the recipient already displayed. The prior comment capturing this exact failure scenario was removed. Even with the hardened per-recipient inbox and 250 ms ACK-then-legacy-fallback, the original observed problem (ACK drop ≠ payload loss) is not eliminated — it just becomes less frequent. A decision is needed before merge: either validate ACKs arrive reliably on the live mesh, or add `require_gossip_ack: false` in the communitas client for fire-and-forget UI sends.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/lib.rs`, line 3063-3072 ([link](https://github.com/saorsa-labs/x0x/blob/03197b1dc904e765992cbe7665ae9d4a936d635a/src/lib.rs#L3063-L3072)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`connect_to_machine` LAN probes ignore `should_attempt_direct()`**

   The new local-probe loop in `connect_to_machine` unconditionally attempts two peer-authenticated dials per LAN address (3 s each: `connect_peer_with_addrs` + `connect_addr` fallback) without checking `info.should_attempt_direct()`. For relay-only peers (`can_receive_direct = false`) this triggers up to 6 seconds of dial timeouts per LAN address before the code continues to the NAT traversal step. The PR description notes this as a known non-blocking item ("LOW: `connect_to_machine` probes LAN regardless of `should_attempt_direct()`"); adding the guard would align the new path with the existing `connect_to_agent` behavior.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib.rs
   Line: 3063-3072

   Comment:
   **`connect_to_machine` LAN probes ignore `should_attempt_direct()`**

   The new local-probe loop in `connect_to_machine` unconditionally attempts two peer-authenticated dials per LAN address (3 s each: `connect_peer_with_addrs` + `connect_addr` fallback) without checking `info.should_attempt_direct()`. For relay-only peers (`can_receive_direct = false`) this triggers up to 6 seconds of dial timeouts per LAN address before the code continues to the NAT traversal step. The PR description notes this as a known non-blocking item ("LOW: `connect_to_machine` probes LAN regardless of `should_attempt_direct()`"); adding the guard would align the new path with the existing `connect_to_agent` behavior.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/bin/x0xd.rs:2619-2631
**`require_gossip_ack` default flip affects all communitas UI DMs**

`direct_message_send_config()` dropped `require_gossip_ack: false`, so the field now inherits `DmSendConfig::default()` which is `true`. The PR description acknowledges this as a 🔴 Blocker: the communitas client never passes `require_gossip_ack` in its `POST /direct/send` body, so every UI DM now blocks until the recipient ACKs via the gossip inbox. On a live mesh where the reverse ACK can be dropped (especially in the first seconds after boot or during a rolling upgrade), this surfaces as a 504 to the sender — who then resends a message the recipient already displayed. The prior comment capturing this exact failure scenario was removed. Even with the hardened per-recipient inbox and 250 ms ACK-then-legacy-fallback, the original observed problem (ACK drop ≠ payload loss) is not eliminated — it just becomes less frequent. A decision is needed before merge: either validate ACKs arrive reliably on the live mesh, or add `require_gossip_ack: false` in the communitas client for fire-and-forget UI sends.

### Issue 2 of 3
src/bin/x0xd.rs:2695-2700
The original comment explicitly called out that gossip fanout for 32 KiB file-transfer chunks breaks the throughput/back-pressure window: `stop_fallback_on_raw_error: true` kept raw failures terminal for that reason. With `false`, a raw receive-ACK failure now triggers a gossip fallback that pushes those chunks through signed/encrypted pubsub fanout. The new comment says `DEFAULT_CHUNK_SIZE is sized to fit the DM envelope cap`, but the fanout cost (fan-out to every subscribed peer, not just the recipient) and back-pressure implications are unchanged. If gossip fallback is intentionally enabled here, the original design concern should be addressed explicitly, or the old guard restored while only changing `raw_quic_receive_ack_timeout`.

```suggestion
fn file_transfer_send_config() -> x0x::dm::DmSendConfig {
    let mut config = x0x::dm::DmSendConfig {
        prefer_raw_quic_if_connected: true,
        stop_fallback_on_raw_error: true,
        ..x0x::dm::DmSendConfig::default()
    };
```

### Issue 3 of 3
src/lib.rs:3063-3072
**`connect_to_machine` LAN probes ignore `should_attempt_direct()`**

The new local-probe loop in `connect_to_machine` unconditionally attempts two peer-authenticated dials per LAN address (3 s each: `connect_peer_with_addrs` + `connect_addr` fallback) without checking `info.should_attempt_direct()`. For relay-only peers (`can_receive_direct = false`) this triggers up to 6 seconds of dial timeouts per LAN address before the code continues to the NAT traversal step. The PR description notes this as a known non-blocking item ("LOW: `connect_to_machine` probes LAN regardless of `should_attempt_direct()`"); adding the guard would align the new path with the existing `connect_to_agent` behavior.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dm): close the fresh-boot DM deliver..."](https://github.com/saorsa-labs/x0x/commit/03197b1dc904e765992cbe7665ae9d4a936d635a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36591409)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->