### PR TITLE
Batch 1: fix #101 DM capability black-hole; add user-id inspect, sign domain separation, warn-default logging (#85 #90 #93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,26 @@ Each instance gets its own identity, port, and data directory.
 
 ---
 
+## Logging
+
+`x0xd` is quiet by default: when neither `RUST_LOG` nor the config
+`log_level` is set, only `warn` and `error` lines are emitted. This is a
+privacy default — verbose levels include peer and topic activity that an
+operator may not want written to logs.
+
+Opt in to verbose logging explicitly:
+
+```bash
+RUST_LOG=info x0xd            # standard verbosity
+RUST_LOG=debug x0xd           # full debugging
+RUST_LOG=ant_quic=debug x0xd  # per-module filters work too
+```
+
+Operator visibility via `GET /health` and `GET /diagnostics/*` is
+independent of the log level.
+
+---
+
 ## GUI
 
 x0x includes a built-in web interface. No download, no install — it's embedded in the binary.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -68,6 +68,7 @@ curl http://127.0.0.1:12700/status
 | GET | `/agent/user-id` | `x0x agent user-id` | Current user ID if configured |
 | GET | `/agent/card` | `x0x agent card` | Generate a shareable identity card |
 | POST | `/agent/card/import` | `x0x agent import` | Import a card into contacts |
+| POST | `/agent/sign` | `x0x agent sign` | Detached ML-DSA-65 signature over caller-supplied bytes |
 
 ### Announce request body
 
@@ -85,6 +86,26 @@ Notes:
 ### Agent card query params
 
 `GET /agent/card?display_name=Alice&include_groups=true`
+
+### Sign request body
+
+```json
+{
+  "payload_b64": "<base64 bytes to sign>",
+  "domain": "my-protocol.v1.register"
+}
+```
+
+Notes:
+- `payload_b64` is decoded and signed verbatim (max 256 KiB). Callers
+  canonicalize structured payloads themselves.
+- `domain` is optional. When present, the daemon signs
+  `domain || 0x00 || payload` and echoes `domain` in the response, so a
+  signature for one protocol context cannot be replayed in another.
+  Domains must be non-empty, NUL-free, and at most 1024 bytes.
+  `x0x.<purpose>.<version>` is the conventional shape for x0x protocols.
+- Response: `ok`, `agent_id` (hex), `public_key_b64`, `signature_b64`,
+  `algorithm` (`x0x.agent-sign.v1.ml-dsa-65`), and `domain` when supplied.
 
 ## Network
 

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -331,6 +331,9 @@ enum AgentSub {
         /// Base64-encoded bytes to sign.
         #[arg(long)]
         payload_b64: Option<String>,
+        /// Optional domain-separation string; signs `domain || 0x00 || payload`.
+        #[arg(long)]
+        domain: Option<String>,
     },
 }
 
@@ -340,6 +343,12 @@ enum UserIdSub {
     /// Overwrites any existing file at the target path without prompting.
     Create {
         /// Output path. Existing file at this path is overwritten.
+        path: Option<PathBuf>,
+    },
+    /// Read and validate a user identity file (no daemon needed).
+    /// Defaults to ~/.x0x/user.key.
+    Inspect {
+        /// Path of the key file to inspect.
         path: Option<PathBuf>,
     },
 }
@@ -1113,6 +1122,22 @@ async fn run(
                 }
                 return Ok(());
             }
+            UserIdSub::Inspect { path } => {
+                let report = commands::user_id::inspect(path.clone()).await?;
+                match format {
+                    OutputFormat::Json => {
+                        x0x::cli::print_value(format, &serde_json::to_value(&report)?)
+                    }
+                    OutputFormat::Text => {
+                        println!("User identity at {}:", report.path);
+                        println!("user_id:    {}", report.user_id);
+                        if let Some(words) = &report.user_words {
+                            println!("user_words: {words}");
+                        }
+                    }
+                }
+                return Ok(());
+            }
         },
         _ => {}
     }
@@ -1173,8 +1198,18 @@ async fn run(
             Some(AgentSub::Import { card, trust }) => {
                 commands::identity::import_card(&client, &card, Some(trust.as_str())).await
             }
-            Some(AgentSub::Sign { file, payload_b64 }) => {
-                commands::identity::sign(&client, file.as_deref(), payload_b64.as_deref()).await
+            Some(AgentSub::Sign {
+                file,
+                payload_b64,
+                domain,
+            }) => {
+                commands::identity::sign(
+                    &client,
+                    file.as_deref(),
+                    payload_b64.as_deref(),
+                    domain.as_deref(),
+                )
+                .await
             }
         },
         Commands::Announce {
@@ -1649,6 +1684,7 @@ x0x (v{VERSION})
 |   |   +-- card           Generate shareable identity card
 |   |   +-- import         Import an agent card to contacts
 |   +-- user-id create     Create user identity keypair
+|   +-- user-id inspect    Validate a user identity file (daemonless)
 |   +-- announce           Announce identity to network
 |
 +-- Network

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -265,7 +265,10 @@ fn shared_cache_dir() -> PathBuf {
 }
 
 fn default_log_level() -> String {
-    "info".to_string()
+    // Privacy by default for operators outside our fleet (issue #85): without
+    // an explicit RUST_LOG or config log_level override, x0xd logs warn/error
+    // only. Opt in to verbose logging with RUST_LOG=info.
+    "warn".to_string()
 }
 
 fn default_log_format() -> String {
@@ -788,6 +791,12 @@ struct AgentSignRequest {
     /// bytes verbatim — the caller is responsible for choosing a canonical
     /// serialization for any structured payload.
     payload_b64: String,
+    /// Optional domain-separation string. When present, the signature is
+    /// computed over `domain || 0x00 || payload` instead of the raw payload,
+    /// preventing cross-protocol signature replay (issue #90). Must not
+    /// contain NUL bytes.
+    #[serde(default)]
+    domain: Option<String>,
 }
 
 /// POST /announce request body.
@@ -4578,6 +4587,12 @@ async fn import_agent_card(
 /// envelope (≤1 KiB in practice) while still bounding worst-case work.
 const AGENT_SIGN_MAX_PAYLOAD_BYTES: usize = 256 * 1024;
 
+/// Maximum length of the optional `domain` separation string, in bytes.
+/// Domain strings are protocol identifiers (`x0x.<purpose>.<version>`
+/// convention) — far shorter in practice; the cap keeps the canonical
+/// bytes bounded by AGENT_SIGN_MAX_PAYLOAD_BYTES + 1 KiB + 1.
+const AGENT_SIGN_MAX_DOMAIN_BYTES: usize = 1024;
+
 /// Stable scheme identifier returned by `POST /agent/sign`.
 const AGENT_SIGN_SCHEME_ID: &str = "x0x.agent-sign.v1.ml-dsa-65";
 
@@ -4599,9 +4614,14 @@ const AGENT_SIGN_SCHEME_ID: &str = "x0x.agent-sign.v1.ml-dsa-65";
 /// Payload. `payload_b64` is base64-decoded and signed verbatim. The
 /// caller is responsible for choosing a canonical serialization of any
 /// structured payload (e.g. `serde_canonical_json`, `postcard`, or an
-/// explicit field-order convention). Callers should also domain-separate
-/// payloads (for example, with an application/type/version prefix) so a
-/// signature produced for one protocol cannot be replayed as another.
+/// explicit field-order convention).
+///
+/// Domain separation. The optional `domain` field, when present, changes
+/// the signed bytes to `domain || 0x00 || payload` and is echoed back in
+/// the response, so a signature produced for one protocol cannot be
+/// replayed as another (`x0x.<purpose>.<version>` is the conventional
+/// shape for x0x's own protocols). When omitted, the raw payload is
+/// signed — unchanged pre-#90 behavior.
 ///
 /// Response. Returns the agent_id (hex, 32 bytes), the agent's public
 /// key (base64), the signature (base64), and the stable signing scheme
@@ -4647,12 +4667,57 @@ async fn agent_sign(
         );
     }
 
+    // Optional domain separation (issue #90): sign `domain || 0x00 || payload`
+    // so a signature issued for one protocol context cannot be replayed in
+    // another. The NUL separator is rejected inside the domain itself so the
+    // framing stays unambiguous.
+    let canonical = match req.domain.as_deref() {
+        Some(domain) => {
+            if domain.is_empty() {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "ok": false,
+                        "error": "domain must be non-empty when provided",
+                    })),
+                );
+            }
+            if domain.as_bytes().contains(&0u8) {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "ok": false,
+                        "error": "domain must not contain NUL bytes",
+                    })),
+                );
+            }
+            if domain.len() > AGENT_SIGN_MAX_DOMAIN_BYTES {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "ok": false,
+                        "error": format!(
+                            "domain exceeds maximum length of {} bytes",
+                            AGENT_SIGN_MAX_DOMAIN_BYTES
+                        ),
+                    })),
+                );
+            }
+            let mut buf = Vec::with_capacity(domain.len() + 1 + payload.len());
+            buf.extend_from_slice(domain.as_bytes());
+            buf.push(0);
+            buf.extend_from_slice(&payload);
+            buf
+        }
+        None => payload,
+    };
+
     let identity = state.agent.identity();
     let keypair = identity.agent_keypair();
 
     let signature = match ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
         keypair.secret_key(),
-        &payload,
+        &canonical,
     ) {
         Ok(sig) => sig,
         Err(e) => {
@@ -4671,16 +4736,20 @@ async fn agent_sign(
         base64::engine::general_purpose::STANDARD.encode(keypair.public_key().as_bytes());
     let agent_id_hex = hex::encode(state.agent.agent_id().as_bytes());
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({
-            "ok": true,
-            "agent_id": agent_id_hex,
-            "public_key_b64": public_key_b64,
-            "signature_b64": signature_b64,
-            "algorithm": AGENT_SIGN_SCHEME_ID,
-        })),
-    )
+    let mut resp = serde_json::json!({
+        "ok": true,
+        "agent_id": agent_id_hex,
+        "public_key_b64": public_key_b64,
+        "signature_b64": signature_b64,
+        "algorithm": AGENT_SIGN_SCHEME_ID,
+    });
+    // Echo the domain back so a verifier knows the canonical-bytes shape
+    // (domain || 0x00 || payload) without out-of-band context.
+    if let Some(domain) = req.domain {
+        resp["domain"] = serde_json::Value::String(domain);
+    }
+
+    (StatusCode::OK, Json(resp))
 }
 
 /// GET /peers
@@ -18156,7 +18225,8 @@ fn init_logging(level: &str, format: &str) -> Result<()> {
     let fallback = level.to_lowercase();
     let fallback_directive = match fallback.as_str() {
         "trace" | "debug" | "info" | "warn" | "error" => fallback.as_str(),
-        _ => "info",
+        // Unknown values fall back to the privacy-preserving default (#85).
+        _ => "warn",
     };
 
     let (filter, source) = match std::env::var("RUST_LOG") {

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -129,12 +129,14 @@ pub async fn import_card(
 /// Reads bytes from `--file <PATH>` (or stdin when path is `-`) OR uses
 /// `--payload-b64 <BASE64>` directly, base64-encodes the bytes, and asks
 /// the daemon to produce a detached ML-DSA-65 signature. The daemon signs
-/// exact bytes; callers should canonicalize structured payloads and
-/// domain-separate them before signing.
+/// exact bytes; callers should canonicalize structured payloads. Pass
+/// `--domain <STRING>` to sign `domain || 0x00 || payload` for
+/// cross-protocol replay protection (issue #90).
 pub async fn sign(
     client: &DaemonClient,
     file: Option<&str>,
     payload_b64: Option<&str>,
+    domain: Option<&str>,
 ) -> Result<()> {
     client.ensure_running().await?;
 
@@ -156,7 +158,10 @@ pub async fn sign(
         (None, None) => bail!("pass either --file <PATH> or --payload-b64 <BASE64>"),
     };
 
-    let body = serde_json::json!({ "payload_b64": payload_b64 });
+    let mut body = serde_json::json!({ "payload_b64": payload_b64 });
+    if let Some(domain) = domain {
+        body["domain"] = serde_json::Value::String(domain.to_string());
+    }
     let resp = client.post("/agent/sign", &body).await?;
     print_value(client.format(), &resp);
     Ok(())
@@ -344,7 +349,7 @@ mod tests {
         let mock_resp = serde_json::json!({"signature_b64": "c2ln"});
         let (url, _shutdown) = start_mock_server(mock_resp).await;
         let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
-        let result = sign(&client, None, Some("aGVsbG8=")).await;
+        let result = sign(&client, None, Some("aGVsbG8="), None).await;
         assert!(result.is_ok(), "sign should succeed: {:?}", result);
     }
 
@@ -356,7 +361,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("payload.txt");
         std::fs::write(&path, b"hello").unwrap();
-        let result = sign(&client, path.to_str(), None).await;
+        let result = sign(&client, path.to_str(), None, None).await;
         assert!(result.is_ok(), "sign file should succeed: {:?}", result);
     }
 
@@ -366,11 +371,11 @@ mod tests {
         let (url, _shutdown) = start_mock_server(mock_resp).await;
         let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
 
-        let both = sign(&client, Some("-"), Some("aGVsbG8=")).await;
+        let both = sign(&client, Some("-"), Some("aGVsbG8="), None).await;
         assert!(both.is_err());
         assert!(both.unwrap_err().to_string().contains("pass either --file"));
 
-        let neither = sign(&client, None, None).await;
+        let neither = sign(&client, None, None, None).await;
         assert!(neither.is_err());
         assert!(neither
             .unwrap_err()

--- a/src/cli/commands/user_id.rs
+++ b/src/cli/commands/user_id.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use std::path::PathBuf;
 
 use crate::identity::UserKeypair;
-use crate::storage::save_user_keypair_to;
+use crate::storage::{load_user_keypair_from, save_user_keypair_to};
 
 /// Default user identity key path (`~/.x0x/user.key`).
 pub fn default_user_key_path() -> Result<PathBuf> {
@@ -28,10 +28,51 @@ pub async fn create(output: Option<PathBuf>) -> Result<PathBuf> {
     Ok(path)
 }
 
+/// Report produced by `x0x user-id inspect`.
+#[derive(Debug, serde::Serialize)]
+pub struct InspectReport {
+    /// Path of the inspected key file.
+    pub path: String,
+    /// Full hex-encoded UserId (SHA-256 of the ML-DSA-65 public key).
+    pub user_id: String,
+    /// Four-word speakable form of the UserId, when derivable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_words: Option<String>,
+    /// Always true on success; failures return an error (non-zero exit).
+    pub valid: bool,
+}
+
+/// `x0x user-id inspect [PATH]` — read and validate a user identity file.
+///
+/// Pure local file operation: deserialises the file as a [`UserKeypair`] and
+/// reports the derived `user_id` and four-word form. Never requires a running
+/// daemon — the symmetric counterpart of `x0x user-id create`.
+pub async fn inspect(input: Option<PathBuf>) -> Result<InspectReport> {
+    let path = match input {
+        Some(path) => path,
+        None => default_user_key_path()?,
+    };
+
+    let keypair = load_user_keypair_from(&path)
+        .await
+        .with_context(|| format!("invalid user identity file {}", path.display()))?;
+    let user_id = hex::encode(keypair.user_id().as_bytes());
+    let user_words = four_word_networking::IdentityEncoder::new()
+        .encode_hex(&user_id)
+        .ok()
+        .map(|w| w.to_string());
+
+    Ok(InspectReport {
+        path: path.display().to_string(),
+        user_id,
+        user_words,
+        valid: true,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::load_user_keypair_from;
     use anyhow::ensure;
 
     #[tokio::test]
@@ -54,5 +95,56 @@ mod tests {
         let _user_id = loaded.user_id();
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn inspect_reports_user_id_and_words_for_valid_file() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("user.key");
+        create(Some(path.clone())).await?;
+        let expected = hex::encode(load_user_keypair_from(&path).await?.user_id().as_bytes());
+
+        let report = inspect(Some(path.clone())).await?;
+
+        ensure!(report.valid, "valid file must report valid=true");
+        ensure!(
+            report.user_id == expected,
+            "inspect must derive the same user_id the storage layer loads"
+        );
+        ensure!(
+            report.user_words.is_some(),
+            "a 32-byte user_id must yield a four-word form"
+        );
+        ensure!(
+            report.path == path.display().to_string(),
+            "report must echo the inspected path"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn inspect_missing_file_fails_naming_the_path() {
+        let temp_dir = tempfile::tempdir().expect("tmpdir");
+        let path = temp_dir.path().join("nope.key");
+
+        let err = inspect(Some(path.clone()))
+            .await
+            .expect_err("missing file must fail");
+        assert!(
+            format!("{err:#}").contains(&path.display().to_string()),
+            "error must identify the offending file: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn inspect_malformed_file_fails() {
+        let temp_dir = tempfile::tempdir().expect("tmpdir");
+        let path = temp_dir.path().join("garbage.key");
+        std::fs::write(&path, b"not-a-bincode-user-keypair").expect("write");
+
+        assert!(
+            inspect(Some(path)).await.is_err(),
+            "malformed file must fail validation"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6214,9 +6214,12 @@ impl Agent {
         // this channel and republishes immediately on change.
         let upgraded =
             dm::DmCapabilities::pending().with_kem_public_key(kem_keypair.public_bytes.clone());
-        if self.dm_capabilities_tx.send(upgraded).is_err() {
-            tracing::debug!("dm_capabilities watch has no receivers; skipping upgrade broadcast");
-        }
+        // send_replace stores the value even when no receiver is subscribed
+        // yet; a plain send() drops the upgrade if this runs before the
+        // capability advert service subscribes, leaving peers cached on
+        // gossip_inbox=false and forcing the raw-QUIC fallback that fails
+        // across NAT (issue #101).
+        self.dm_capabilities_tx.send_replace(upgraded);
         tracing::info!("DM inbox service started");
         Ok(())
     }
@@ -9902,6 +9905,49 @@ fn sort_discovered_machine_sorts_fields() {
     assert_eq!(machine.agent_ids[1], identity::AgentId([2u8; 32]));
     assert_eq!(machine.user_ids[0], identity::UserId([1u8; 32]));
     assert_eq!(machine.user_ids[1], identity::UserId([2u8; 32]));
+}
+
+#[tokio::test]
+async fn dm_inbox_capability_upgrade_visible_to_late_subscriber() {
+    // Regression test for issue #101: x0xd starts the DM inbox before the
+    // capability advert service subscribes to the capabilities watch. The
+    // upgrade must be stored in the channel (send_replace), not merely
+    // broadcast to current receivers (send) — otherwise a late subscriber
+    // observes the stale pending state, advertises gossip_inbox=false for
+    // the process lifetime, and cross-NAT DMs fall back to the raw-QUIC
+    // path that black-holes.
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let agent = Agent::builder()
+        .with_machine_key(dir.path().join("machine.key"))
+        .with_agent_key_path(dir.path().join("agent.key"))
+        .with_peer_cache_dir(dir.path().join("peers"))
+        .with_network_config(network::NetworkConfig::default())
+        .build()
+        .await
+        .expect("agent");
+
+    let kem = std::sync::Arc::new(
+        groups::kem_envelope::AgentKemKeypair::generate().expect("kem keypair"),
+    );
+    agent
+        .start_dm_inbox(kem, dm_inbox::DmInboxConfig::default())
+        .await
+        .expect("start dm inbox");
+
+    // Subscribe only AFTER the inbox started — mirrors the x0xd startup
+    // order (start_dm_inbox_when_gossip_ready runs before
+    // start_capability_advert_service).
+    let late_rx = agent.dm_capabilities_tx.subscribe();
+    let caps = late_rx.borrow().clone();
+    assert!(
+        caps.gossip_inbox,
+        "DM capability upgrade must be visible to subscribers that attach after start_dm_inbox (issue #101)"
+    );
+    assert!(
+        !caps.kem_public_key.is_empty(),
+        "upgraded capabilities must carry the KEM public key"
+    );
+    agent.stop_dm_inbox().await;
 }
 
 #[test]

--- a/tests/daemon_api_integration.rs
+++ b/tests/daemon_api_integration.rs
@@ -151,6 +151,99 @@ async fn daemon_api_agent_sign_roundtrip() {
 
 #[tokio::test]
 #[ignore]
+async fn daemon_api_agent_sign_domain_separation_roundtrip() {
+    let d = daemon().await;
+
+    // Domain-separated signing (issue #90): the signature must verify over
+    // domain || 0x00 || payload, NOT over the raw payload — otherwise a
+    // signature issued in one protocol context could be replayed in another.
+    let payload = b"register envelope bytes";
+    let domain = "community.jams.pair.v1.register-pop";
+    let r: Value = ca(&d)
+        .post(d.url("/agent/sign"))
+        .json(&serde_json::json!({ "payload_b64": b64(payload), "domain": domain }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_eq!(r["ok"], true);
+    assert_eq!(
+        r["domain"].as_str().unwrap(),
+        domain,
+        "response must echo the domain so verifiers know the canonical-bytes shape"
+    );
+
+    let pk_bytes = base64::engine::general_purpose::STANDARD
+        .decode(r["public_key_b64"].as_str().unwrap())
+        .unwrap();
+    let sig_bytes = base64::engine::general_purpose::STANDARD
+        .decode(r["signature_b64"].as_str().unwrap())
+        .unwrap();
+    let public_key = ant_quic::MlDsaPublicKey::from_bytes(&pk_bytes).unwrap();
+    let signature =
+        ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(&sig_bytes).unwrap();
+
+    let mut canonical = Vec::new();
+    canonical.extend_from_slice(domain.as_bytes());
+    canonical.push(0);
+    canonical.extend_from_slice(payload);
+    ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(&public_key, &canonical, &signature)
+        .expect("signature verifies over domain || 0x00 || payload");
+
+    assert!(
+        ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+            &public_key,
+            payload,
+            &signature
+        )
+        .is_err(),
+        "domain-separated signature must NOT verify over the raw payload"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_sign_without_domain_omits_domain_field() {
+    let d = daemon().await;
+    // Pre-#90 behavior must be unchanged: no domain in, no domain out.
+    let r: Value = ca(&d)
+        .post(d.url("/agent/sign"))
+        .json(&serde_json::json!({ "payload_b64": b64(b"plain payload") }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(r["ok"], true);
+    assert!(
+        r.get("domain").is_none(),
+        "response must not contain a domain field when none was supplied"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_sign_rejects_nul_in_domain() {
+    let d = daemon().await;
+    let r = ca(&d)
+        .post(d.url("/agent/sign"))
+        .json(&serde_json::json!({ "payload_b64": b64(b"x"), "domain": "bad\u{0}domain" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        StatusCode::BAD_REQUEST,
+        "NUL bytes in domain would make the separator framing ambiguous"
+    );
+}
+
+#[tokio::test]
+#[ignore]
 async fn daemon_api_agent_sign_rejects_empty_payload() {
     let d = daemon().await;
     let r = ca(&d)


### PR DESCRIPTION
## Summary

First batch of the open-issue cleanup (#101, #93, #90, #85). All four verified locally: clippy `-D warnings` clean, `cargo doc -D warnings` clean, full workspace nextest **1680/1680**, plus daemon-backed sign tests 7/7.

### #101 — DM capability upgrade lost at startup (cross-NAT DM black-hole)
`start_dm_inbox` published the capability upgrade with `watch::Sender::send`, which **drops the value when no receiver is subscribed**. x0xd calls `start_dm_inbox` before `start_capability_advert_service` (x0xd.rs:2664-2668), so the upgrade vanished; peers cached `gossip_inbox=false` forever and used the raw-QUIC fallback that black-holes across NAT. Fixed with `send_replace`. The new regression test `dm_inbox_capability_upgrade_visible_to_late_subscriber` was verified to **fail on the pre-fix code** and pass post-fix.

### #93 — daemonless `x0x user-id inspect [PATH]`
Symmetric sibling of `user-id create`: validates the file via the existing storage primitive, prints `user_id` + `user_words` (four-word-networking), supports `--json`, exits non-zero naming the file on failure. Smoke-tested end-to-end (text, JSON, missing-file). 4 unit tests.

### #90 — optional `domain` on `POST /agent/sign`
Signs `domain || 0x00 || payload` when `domain` present; echoes it in the response. Rejects NUL bytes, empty domain, and >1 KiB domains with 400. Omitted = byte-for-byte pre-#90 behavior (`scheme` unchanged — presence of `domain` in the response is the signal, per the issue's default option). CLI: `x0x agent sign --domain`. Also documented `/agent/sign` in `docs/api-reference.md` — it was missing from the reference entirely. 3 new daemon integration tests, including a negative test that the domain-separated signature does NOT verify over the raw payload.

### #85 — warn-only default logging
`default_log_level()` `info` → `warn` (and the invalid-value fallback likewise), so an x0xd started without `RUST_LOG`/config override logs warn/error only. `RUST_LOG=info` restores verbosity. README gains a Logging section. `/health` + `/diagnostics/*` visibility unaffected.

## Test plan
- [x] `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`
- [x] `cargo doc` with `RUSTDOCFLAGS="-D warnings"`
- [x] Full workspace nextest 1680/1680
- [x] Daemon-backed `agent_sign` family with `--run-ignored` (7/7, includes 3 new #90 tests)
- [x] #101 regression test proven to fail pre-fix
- [x] `x0x user-id inspect` CLI smoke (text/JSON/error-exit)
- [ ] Testnet soak before merge (deploy + launch_soak windows) — running next

Closes #101. Closes #93. Closes #90. Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles four separate issue fixes: a cross-NAT DM \"black-hole\" caused by a lost watch channel send (#101), a new daemonless `user-id inspect` CLI command (#93), optional domain separation on `POST /agent/sign` (#90), and a `warn`-only default log level (#85).

- **#101 (critical correctness):** `start_dm_inbox` switched from `watch::Sender::send` to `send_replace`, which persists the capability upgrade in the channel even before any receiver subscribes — the root cause of peers advertising `gossip_inbox=false` forever across NAT. A regression test proving the pre-fix code fails is included.
- **#90 (domain separation):** `POST /agent/sign` accepts an optional `domain` string and signs `domain || 0x00 || payload`; the endpoint validates the domain (non-empty, NUL-free, ≤1 KiB) and echoes it back in the response. CLI and integration tests (including a negative replay test) are included.
- **#93 / #85:** New `user-id inspect` command and `warn`-default logging are clean, well-tested additions.

<h3>Confidence Score: 5/5</h3>

Safe to merge once the testnet soak window completes as noted in the PR checklist.

The core fix (send_replace) is a well-understood tokio::sync::watch API change with a regression test verified to fail on pre-fix code. Domain-separation logic is correct — NUL rejection, length capping, and the domain || 0x00 || payload construction are all sound, with integration tests verifying both happy path and negative replay. The remaining changes are self-contained and fully tested. No data-loss, auth, or correctness issues found.

No files require special attention; all changed paths are well-covered by the accompanying tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib.rs | Switches dm_capabilities_tx from send() to send_replace(), ensuring late subscribers see the capability upgrade; regression test included and proven to fail pre-fix. |
| src/bin/x0xd.rs | Adds domain-separation logic to agent_sign (with correct NUL/empty/length validation and domain || 0x00 || payload construction), changes default log level to warn, and updates the invalid-level fallback consistently. |
| src/cli/commands/user_id.rs | Adds inspect() function and InspectReport struct; four unit tests cover valid, missing, and malformed file paths. valid: bool is always true (failures return Err), documented and mirrors the ok: bool convention elsewhere. |
| src/cli/commands/identity.rs | Adds domain parameter to sign(), passes it as an optional JSON field; existing call sites updated to pass None; existing tests updated accordingly. |
| src/bin/x0x.rs | Wires up the new UserIdSub::Inspect variant and the --domain flag on AgentSub::Sign; both text and JSON output paths handled for inspect. |
| tests/daemon_api_integration.rs | Three new #[ignore] daemon integration tests covering domain-separated roundtrip, no-domain-field-in-response, and NUL-byte rejection; roundtrip test also verifies the signature does NOT verify over raw payload. |
| docs/api-reference.md | Documents POST /agent/sign endpoint and domain field that were previously missing from the API reference. |
| README.md | Adds a Logging section explaining the warn-only default and how to opt in to verbose output via RUST_LOG. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant xd as x0xd startup
    participant inbox as start_dm_inbox
    participant watch as watch::Sender<DmCapabilities>
    participant advert as capability_advert_service

    xd->>inbox: start_dm_inbox(kem_keypair)
    inbox->>watch: "send_replace(upgraded caps)<br/>gossip_inbox=true, kem_key=..."
    Note over watch: value stored in channel<br/>even with no subscribers yet
    xd->>advert: start_capability_advert_service (subscribes late)
    advert->>watch: subscribe() → borrow()
    watch-->>advert: "upgraded caps (gossip_inbox=true)"
    advert-->>advert: "advertise gossip_inbox=true to peers"

    Note over xd,advert: Pre-fix: send() dropped value<br/>advert saw gossip_inbox=false → NAT black-hole
```

<sub>Reviews (1): Last reviewed commit: ["fix(dm): store capability upgrade with s..."](https://github.com/saorsa-labs/x0x/commit/0b0a1a7bc2b5354873c339258c3a9147c8c00545) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36654750)</sub>

<!-- /greptile_comment -->