### PR TITLE
Batch 2: KvStore first-join bootstrap (#96), local: topics (#89), seeded user keygen (#95), logging redaction module (#83 groundwork)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -85,6 +85,10 @@ jobs:
         run: cargo nextest run --all-features --test gui_smoke
       - name: Run WebSocket tests
         run: cargo nextest run --all-features --test ws_integration -- --ignored
+      - name: Run KvStore first-join bootstrap tests (issue 96)
+        run: cargo nextest run --all-features --test kv_first_join_bootstrap --test-threads 1 -- --ignored
+      - name: Run local-topic routing tests (issue 89)
+        run: cargo nextest run --all-features --test local_topics --test-threads 1 -- --ignored
 
   # ── Soak test (weekly, ~90min) ────────────────────────────────────────
   soak:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -134,6 +134,16 @@ Notes:
 }
 ```
 
+### `local:` topics (same-daemon IPC)
+
+Topics whose name starts with `local:` (e.g. `local:my-app/events`) are
+never gossipped: messages are delivered only to subscribers attached to
+the same `x0xd` instance — they never enter the PlumTree EAGER set or
+IHAVE digests. All primitives work unchanged (`/publish`, `/subscribe`,
+`/events`, WebSocket subscribe, bearer-token auth). Use them as a local
+pub/sub substrate for multi-process applications sharing one daemon,
+without leaking events to the mesh.
+
 ## Discovery
 
 | Method | Endpoint | CLI | Purpose |

--- a/src/bin/x0x-user-keygen.rs
+++ b/src/bin/x0x-user-keygen.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
         .map(PathBuf::from)
         .context("usage: x0x-user-keygen <output-path>")?;
 
-    let resolved = x0x::cli::commands::user_id::create(Some(output)).await?;
+    let resolved = x0x::cli::commands::user_id::create(Some(output), None).await?;
     println!("{}", resolved.display());
     Ok(())
 }

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -344,6 +344,10 @@ enum UserIdSub {
     Create {
         /// Output path. Existing file at this path is overwritten.
         path: Option<PathBuf>,
+        /// Derive the keypair deterministically from a 32-byte hex seed
+        /// (64 hex chars) via FIPS 204 seeded KeyGen. Same seed, same keypair.
+        #[arg(long, value_name = "HEX")]
+        from_seed: Option<String>,
     },
     /// Read and validate a user identity file (no daemon needed).
     /// Defaults to ~/.x0x/user.key.
@@ -1109,8 +1113,9 @@ async fn run(
             };
         }
         Commands::UserId { sub } => match sub {
-            UserIdSub::Create { path } => {
-                let resolved = commands::user_id::create(path.clone()).await?;
+            UserIdSub::Create { path, from_seed } => {
+                let resolved =
+                    commands::user_id::create(path.clone(), from_seed.as_deref()).await?;
                 match format {
                     OutputFormat::Json => x0x::cli::print_value(
                         format,

--- a/src/cli/commands/user_id.rs
+++ b/src/cli/commands/user_id.rs
@@ -13,14 +13,32 @@ pub fn default_user_key_path() -> Result<PathBuf> {
 }
 
 /// `x0x user-id create [PATH]` — create a user identity keypair on disk.
-pub async fn create(output: Option<PathBuf>) -> Result<PathBuf> {
+///
+/// With `from_seed_hex` (issue #95), the keypair is derived
+/// deterministically from the 32-byte seed via FIPS 204 seeded KeyGen:
+/// same seed → same keypair on any machine. Without it, random keygen.
+pub async fn create(output: Option<PathBuf>, from_seed_hex: Option<&str>) -> Result<PathBuf> {
     let path = match output {
         Some(path) => path,
         None => default_user_key_path()?,
     };
 
-    let keypair = UserKeypair::generate()
-        .map_err(|e| anyhow::anyhow!("failed to generate user keypair: {e}"))?;
+    let keypair = match from_seed_hex {
+        Some(hex_seed) => {
+            let bytes = hex::decode(hex_seed.trim())
+                .context("--from-seed must be hex (64 hex chars encoding 32 bytes)")?;
+            let seed: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+                anyhow::anyhow!(
+                    "--from-seed must encode exactly 32 bytes (64 hex chars), got {} bytes",
+                    bytes.len()
+                )
+            })?;
+            UserKeypair::from_seed(&seed)
+                .map_err(|e| anyhow::anyhow!("failed to derive user keypair from seed: {e}"))?
+        }
+        None => UserKeypair::generate()
+            .map_err(|e| anyhow::anyhow!("failed to generate user keypair: {e}"))?,
+    };
     save_user_keypair_to(&keypair, &path)
         .await
         .with_context(|| format!("failed to write user keypair to {}", path.display()))?;
@@ -80,7 +98,7 @@ mod tests {
         let temp_dir = tempfile::tempdir()?;
         let path = temp_dir.path().join("user.key");
 
-        let resolved = create(Some(path.clone())).await?;
+        let resolved = create(Some(path.clone()), None).await?;
 
         ensure!(
             resolved == path,
@@ -101,7 +119,7 @@ mod tests {
     async fn inspect_reports_user_id_and_words_for_valid_file() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let path = temp_dir.path().join("user.key");
-        create(Some(path.clone())).await?;
+        create(Some(path.clone()), None).await?;
         let expected = hex::encode(load_user_keypair_from(&path).await?.user_id().as_bytes());
 
         let report = inspect(Some(path.clone())).await?;
@@ -120,6 +138,52 @@ mod tests {
             "report must echo the inspected path"
         );
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_from_seed_is_deterministic_across_machines() -> Result<()> {
+        // Issue #95: same seed must yield the same UserKeypair every time —
+        // this is the contract mnemonic-based identity portability rests on.
+        let temp_dir = tempfile::tempdir()?;
+        let seed_hex = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+
+        let path_a = temp_dir.path().join("a.key");
+        let path_b = temp_dir.path().join("b.key");
+        create(Some(path_a.clone()), Some(seed_hex)).await?;
+        create(Some(path_b.clone()), Some(seed_hex)).await?;
+
+        let id_a = load_user_keypair_from(&path_a).await?.user_id();
+        let id_b = load_user_keypair_from(&path_b).await?.user_id();
+        ensure!(id_a == id_b, "same seed must derive the same user_id");
+
+        let path_c = temp_dir.path().join("c.key");
+        let other_seed = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        create(Some(path_c.clone()), Some(other_seed)).await?;
+        let id_c = load_user_keypair_from(&path_c).await?.user_id();
+        ensure!(
+            id_a != id_c,
+            "different seeds must derive different user_ids"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_from_seed_rejects_bad_seed_encoding() {
+        let temp_dir = tempfile::tempdir().expect("tmpdir");
+        let path = temp_dir.path().join("user.key");
+
+        assert!(
+            create(Some(path.clone()), Some("not-hex")).await.is_err(),
+            "non-hex seed must be rejected"
+        );
+        assert!(
+            create(Some(path.clone()), Some("aabb")).await.is_err(),
+            "short seed must be rejected"
+        );
+        assert!(
+            !path.exists(),
+            "no key file may be written when the seed is invalid"
+        );
     }
 
     #[tokio::test]

--- a/src/gossip/pubsub.rs
+++ b/src/gossip/pubsub.rs
@@ -256,6 +256,25 @@ pub struct PubSubManager {
     contacts: std::sync::OnceLock<Arc<tokio::sync::RwLock<ContactStore>>>,
     /// Drop-detection counters exposed at `GET /diagnostics/gossip`.
     stats: Arc<PubSubStats>,
+    /// Subscriber channels for `local:` topics (issue #89). These topics
+    /// are same-daemon IPC: delivered only to local subscribers, never
+    /// handed to PlumTree, never gossipped to remote peers.
+    local_topics: Arc<RwLock<HashMap<String, Vec<mpsc::Sender<PubSubMessage>>>>>,
+}
+
+/// Topic-name prefix marking a topic as local-only (issue #89).
+///
+/// Topics starting with this prefix are delivered exclusively to
+/// subscribers on the same daemon — they never enter the PlumTree EAGER
+/// set, IHAVE digests, or any other remote relay path. Because such
+/// topics are never registered with PlumTree, an inbound gossip frame
+/// referencing one has no subscription to deliver into and is dropped.
+pub const LOCAL_TOPIC_PREFIX: &str = "local:";
+
+/// True when `topic` is a same-daemon-only topic (issue #89).
+#[must_use]
+pub fn is_local_topic(topic: &str) -> bool {
+    topic.starts_with(LOCAL_TOPIC_PREFIX)
 }
 
 impl std::fmt::Debug for PubSubManager {
@@ -324,6 +343,7 @@ impl PubSubManager {
             signing,
             contacts: std::sync::OnceLock::new(),
             stats: Arc::new(PubSubStats::default()),
+            local_topics: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 
@@ -372,6 +392,27 @@ impl PubSubManager {
     /// domain-separated `TopicId`s, while still carrying a stable string topic
     /// name inside the signed x0x payload.
     pub async fn subscribe_topic_id(&self, topic: String, topic_id: TopicId) -> Subscription {
+        // `local:` topics never touch PlumTree — same-daemon delivery only
+        // (issue #89).
+        if is_local_topic(&topic) {
+            let (tx, rx) = mpsc::channel(10_000);
+            self.local_topics
+                .write()
+                .await
+                .entry(topic.clone())
+                .or_default()
+                .push(tx);
+            {
+                let mut counts = self.topic_ref_counts.write().await;
+                *counts.entry(topic.clone()).or_insert(0) += 1;
+            }
+            return Subscription {
+                topic,
+                receiver: rx,
+                topic_ref_counts: Arc::clone(&self.topic_ref_counts),
+            };
+        }
+
         self.register_dynamic_topic_priority(&topic, topic_id);
         self.initialize_topic_peers(topic_id).await;
 
@@ -472,6 +513,44 @@ impl PubSubManager {
         topic_id: TopicId,
         payload: Bytes,
     ) -> NetworkResult<()> {
+        // `local:` topics fan out to same-daemon subscribers only — the
+        // payload never reaches PlumTree or any remote peer (issue #89).
+        if is_local_topic(&topic) {
+            let message = PubSubMessage {
+                topic: topic.clone(),
+                payload,
+                sender: self.signing.as_ref().map(|ctx| ctx.agent_id),
+                sender_public_key: self
+                    .signing
+                    .as_ref()
+                    .map(|ctx| ctx.public_key_bytes.clone()),
+                // Local publishes come from a bearer-token-authenticated
+                // API caller on this daemon — trusted by construction.
+                verified: true,
+                trust_level: None,
+            };
+            let mut topics = self.local_topics.write().await;
+            if let Some(senders) = topics.get_mut(&topic) {
+                senders.retain(|tx| match tx.try_send(message.clone()) {
+                    Ok(()) => {
+                        self.stats
+                            .delivered_to_subscriber
+                            .fetch_add(1, Ordering::Relaxed);
+                        true
+                    }
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        self.stats
+                            .slow_subscriber_dropped
+                            .fetch_add(1, Ordering::Relaxed);
+                        true
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => false,
+                });
+            }
+            self.stats.publish_total.fetch_add(1, Ordering::Relaxed);
+            return Ok(());
+        }
+
         let encoded_result = if let Some(ref ctx) = self.signing {
             let signing_payload =
                 build_signing_payload(ctx.agent_id.as_bytes(), topic.as_bytes(), &payload);
@@ -531,6 +610,10 @@ impl PubSubManager {
     /// Unsubscribe from a topic, removing all subscriptions.
     pub async fn unsubscribe(&self, topic: &str) {
         self.topic_ref_counts.write().await.remove(topic);
+        if is_local_topic(topic) {
+            self.local_topics.write().await.remove(topic);
+            return;
+        }
         let topic_id = TopicId::from_entity(topic.as_bytes());
         if let Err(e) = self.plumtree.unsubscribe(topic_id).await {
             tracing::debug!("PlumTree unsubscribe failed for topic '{topic}': {e}");

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -334,6 +334,35 @@ impl UserKeypair {
             secret_key,
         })
     }
+
+    /// Generate a UserKeypair deterministically from a 32-byte seed.
+    ///
+    /// Uses the FIPS 204 seeded KeyGen (the ξ input), so the same seed
+    /// produces the same ML-DSA-65 keypair on any machine, every time —
+    /// the foundation for mnemonic-based identity portability (issue #95).
+    /// Mnemonic ↔ seed encoding (e.g. BIP-39) is the consumer
+    /// application's responsibility; x0x performs only the
+    /// seed → keypair step.
+    ///
+    /// The seed must be high-entropy (32 random bytes). Anyone who learns
+    /// the seed can reconstruct the secret key.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the generated key bytes cannot be converted
+    /// into the transport key types (never expected for a valid seed).
+    pub fn from_seed(seed: &[u8; 32]) -> Result<Self, crate::error::IdentityError> {
+        use fips204::traits::{KeyGen, SerDes};
+        let (pk, sk) = fips204::ml_dsa_65::KG::keygen_from_seed(seed);
+        let public_key = MlDsaPublicKey::from_bytes(&pk.into_bytes())
+            .map_err(|e| crate::error::IdentityError::KeyGeneration(format!("{e:?}")))?;
+        let secret_key = MlDsaSecretKey::from_bytes(&sk.into_bytes())
+            .map_err(|e| crate::error::IdentityError::KeyGeneration(format!("{e:?}")))?;
+        Ok(Self {
+            public_key,
+            secret_key,
+        })
+    }
     /// Get a reference to the public key.
     #[inline]
     #[must_use]
@@ -875,6 +904,34 @@ mod tests {
         let keypair = MachineKeypair::generate().unwrap();
         let machine_id = MachineId::from_public_key(keypair.public_key());
         machine_id.verify(keypair.public_key()).unwrap();
+    }
+    #[test]
+    fn user_keypair_from_seed_is_deterministic_and_functional() {
+        // Issue #95: identical seeds must yield byte-identical keypairs
+        // (the portability contract), and the derived keypair must be a
+        // working ML-DSA-65 signer — not just stable bytes.
+        let seed = [7u8; 32];
+        let kp1 = UserKeypair::from_seed(&seed).unwrap();
+        let kp2 = UserKeypair::from_seed(&seed).unwrap();
+        assert_eq!(
+            kp1.public_key().as_bytes(),
+            kp2.public_key().as_bytes(),
+            "same seed must derive the same public key"
+        );
+        assert_eq!(kp1.user_id(), kp2.user_id());
+
+        let kp3 = UserKeypair::from_seed(&[8u8; 32]).unwrap();
+        assert_ne!(kp1.user_id(), kp3.user_id());
+
+        // UserId binds to the derived public key.
+        kp1.user_id().verify(kp1.public_key()).unwrap();
+
+        // Derived secret key signs; derived public key verifies.
+        let msg = b"seeded keypair must be usable";
+        let sig = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(kp1.secret_key(), msg)
+            .unwrap();
+        ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(kp1.public_key(), msg, &sig)
+            .unwrap();
     }
     #[test]
     fn test_agent_id_from_public_key() {

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -7,8 +7,29 @@ use crate::gossip::PubSubManager;
 use crate::kv::{KvStore, KvStoreDelta, Result};
 use saorsa_gossip_crdt_sync::AntiEntropyManager;
 use saorsa_gossip_types::PeerId;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+
+/// Suffix appended to a store topic to form its state-sync side channel.
+///
+/// State requests travel on a separate topic so the main topic keeps its
+/// existing `(PeerId, KvStoreDelta)` wire format — pre-#96 nodes simply
+/// never subscribe to the side channel and are unaffected.
+const STATE_SYNC_TOPIC_SUFFIX: &str = "/state-sync";
+
+/// Delays between state-request retries for a first-time joiner whose
+/// store is still empty. Spread out so a slow mesh (peer discovery,
+/// subscription propagation) still converges without flooding.
+const STATE_REQUEST_RETRY_SECS: [u64; 4] = [1, 5, 15, 30];
+
+/// Message exchanged on the state-sync side topic.
+#[derive(Debug, Serialize, Deserialize)]
+enum KvSyncMessage {
+    /// A peer with no local state for the store asks holders to republish
+    /// their full state (as a regular delta) on the main topic.
+    StateRequest { requester: PeerId },
+}
 
 /// Synchronization wrapper for a KvStore.
 ///
@@ -27,6 +48,10 @@ pub struct KvStoreSync {
 
     /// Topic name for this store.
     topic: String,
+
+    /// This node's gossip peer id — identifies our deltas and state
+    /// requests on the wire.
+    local_peer_id: PeerId,
 }
 
 impl KvStoreSync {
@@ -38,11 +63,13 @@ impl KvStoreSync {
     /// * `pubsub` - Pub/sub manager for gossip messaging.
     /// * `topic` - Topic name for pub/sub.
     /// * `sync_interval_secs` - How often to run anti-entropy.
+    /// * `local_peer_id` - This node's gossip peer id.
     pub fn new(
         store: KvStore,
         pubsub: Arc<PubSubManager>,
         topic: String,
         sync_interval_secs: u64,
+        local_peer_id: PeerId,
     ) -> Result<Self> {
         let store = Arc::new(RwLock::new(store));
         let anti_entropy = AntiEntropyManager::new(Arc::clone(&store), sync_interval_secs);
@@ -52,12 +79,23 @@ impl KvStoreSync {
             anti_entropy,
             pubsub,
             topic,
+            local_peer_id,
         })
+    }
+
+    /// The state-sync side topic for this store.
+    fn state_sync_topic(&self) -> String {
+        format!("{}{}", self.topic, STATE_SYNC_TOPIC_SUFFIX)
     }
 
     /// Start background synchronization.
     ///
     /// Subscribes to the gossip topic and begins receiving remote deltas.
+    /// Also joins the state-sync side channel: holders answer state
+    /// requests by republishing their full state, and — issue #96 — a
+    /// first-time joiner (empty local store) requests that state so it
+    /// bootstraps keys written before it joined. Without this, only
+    /// deltas published *after* subscribing ever arrive.
     pub async fn start(&self) -> Result<()> {
         let mut sub = self.pubsub.subscribe(self.topic.clone()).await;
         let store = Arc::clone(&self.store);
@@ -89,12 +127,85 @@ impl KvStoreSync {
             }
         });
 
+        // Responder: holders with non-empty state answer StateRequests by
+        // republishing their full state as a regular delta on the main
+        // topic. CRDT merge makes duplicate responses from multiple
+        // holders harmless (idempotent), so no response suppression is
+        // needed at current mesh sizes.
+        let mut sync_sub = self.pubsub.subscribe(self.state_sync_topic()).await;
+        let responder_store = Arc::clone(&self.store);
+        let responder_pubsub = Arc::clone(&self.pubsub);
+        let responder_topic = self.topic.clone();
+        let local_peer_id = self.local_peer_id;
+        tokio::spawn(async move {
+            while let Some(msg) = sync_sub.recv().await {
+                let Ok(KvSyncMessage::StateRequest { requester }) =
+                    bincode::deserialize::<KvSyncMessage>(&msg.payload)
+                else {
+                    continue;
+                };
+                if requester == local_peer_id {
+                    continue;
+                }
+                let full = {
+                    let s = responder_store.read().await;
+                    if s.is_empty() {
+                        continue;
+                    }
+                    s.full_delta()
+                };
+                let Ok(serialized) = bincode::serialize(&(local_peer_id, full)) else {
+                    continue;
+                };
+                if let Err(e) = responder_pubsub
+                    .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
+                    .await
+                {
+                    tracing::warn!("KvStore state-response publish failed: {e}");
+                }
+            }
+        });
+
+        // Bootstrap requester: a first-time joiner starts with an empty
+        // store and has no other way to learn keys written before it
+        // subscribed (the gossip message cache only replays ~60s, and
+        // pruning on busy topics removes older deltas entirely). Ask
+        // holders to republish over a short retry schedule. The full
+        // schedule always runs — a partial state arriving early (for
+        // example fresh keys via cache replay) must not stop the
+        // request for the complete historical state. Requests and the
+        // full-delta responses they trigger are idempotent CRDT merges,
+        // so the extra chatter is bounded and harmless. A creator of a
+        // genuinely new store also sends these — nobody answers.
+        if self.store.read().await.is_empty() {
+            let requester_pubsub = Arc::clone(&self.pubsub);
+            let sync_topic = self.state_sync_topic();
+            tokio::spawn(async move {
+                for delay_secs in STATE_REQUEST_RETRY_SECS {
+                    tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                    let request = KvSyncMessage::StateRequest {
+                        requester: local_peer_id,
+                    };
+                    let Ok(serialized) = bincode::serialize(&request) else {
+                        return;
+                    };
+                    if let Err(e) = requester_pubsub
+                        .publish(sync_topic.clone(), bytes::Bytes::from(serialized))
+                        .await
+                    {
+                        tracing::debug!("KvStore state-request publish failed: {e}");
+                    }
+                }
+            });
+        }
+
         Ok(())
     }
 
     /// Stop background synchronization.
     pub async fn stop(&self) -> Result<()> {
         self.pubsub.unsubscribe(&self.topic).await;
+        self.pubsub.unsubscribe(&self.state_sync_topic()).await;
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,9 @@ pub mod exec;
 /// The x0x Constitution — The Four Laws of Intelligent Coexistence — embedded at compile time.
 pub mod constitution;
 
+/// Privacy-preserving log identifier wrappers (salted-hash redaction).
+pub mod logging;
+
 /// Shared API endpoint registry consumed by both x0xd and the x0x CLI.
 pub mod api;
 
@@ -8317,6 +8320,7 @@ impl Agent {
             std::sync::Arc::clone(runtime.pubsub()),
             topic.to_string(),
             30,
+            peer_id,
         )
         .map_err(|e| {
             error::IdentityError::Storage(std::io::Error::other(format!(
@@ -8372,6 +8376,7 @@ impl Agent {
             std::sync::Arc::clone(runtime.pubsub()),
             topic.to_string(),
             30,
+            peer_id,
         )
         .map_err(|e| {
             error::IdentityError::Storage(std::io::Error::other(format!(

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,226 @@
+//! Privacy-preserving log identifiers (issue #83, privacy Layer 2).
+//!
+//! Mirrors `saorsa_gossip_types::logging` (their issue #13): a
+//! per-process random salt plus BLAKE3 keyed hashing turn stable
+//! identifiers into opaque, daemon-local tokens in `warn!`/`error!`
+//! lines — `agent_a1b2c3d4` instead of a 64-char hex AgentId.
+//! Properties:
+//!
+//! - Within one daemon run, the same identifier always shows the same
+//!   token, so operators can still correlate log lines while debugging.
+//! - After restart, and across daemons, the same real identifier hashes
+//!   differently — logs alone cannot reconstruct a social graph.
+//!
+//! The salt is 32 random bytes in a `OnceLock`: memory-only, never
+//! persisted, never exposed. For `PeerId`/`TopicId` use the re-exported
+//! upstream wrappers; for x0x's own identifier shapes use the wrappers
+//! below.
+//!
+//! ## Usage
+//!
+//! ```
+//! use x0x::logging::{LogAgentId, LogHexId};
+//! use x0x::identity::AgentId;
+//!
+//! let agent = AgentId([0xAA; 32]);
+//! tracing::warn!(agent = %LogAgentId::from(&agent), "rejected");
+//! // group ids and similar identifiers often travel as hex strings:
+//! let group_hex = "a1b2c3";
+//! tracing::warn!(group = %LogHexId::group(group_hex), "commit failed");
+//! ```
+
+use std::fmt;
+use std::sync::OnceLock;
+
+use crate::identity::{AgentId, MachineId, UserId};
+
+pub use saorsa_gossip_types::{LogPeerId, LogTopicId};
+
+/// Per-process random salt for keyed hashing of log identifiers.
+static LOG_SALT: OnceLock<[u8; 32]> = OnceLock::new();
+
+/// Return the per-process salt, initialising it on first call.
+fn salt() -> &'static [u8; 32] {
+    LOG_SALT.get_or_init(|| {
+        use rand::RngCore;
+        let mut s = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut s);
+        s
+    })
+}
+
+/// **Test-only:** seed the process-global log salt deterministically.
+///
+/// Returns `true` if this call performed the initialisation, `false`
+/// if the salt was already set. Exposed unconditionally so downstream
+/// crate tests can produce deterministic log fixtures.
+#[doc(hidden)]
+pub fn init_log_salt_for_tests(seed: [u8; 32]) -> bool {
+    LOG_SALT.set(seed).is_ok()
+}
+
+/// 8-hex-char opaque token for an identifier of any length under the
+/// process-global salt.
+fn opaque_token(bytes: &[u8]) -> String {
+    let mut hasher = blake3::Hasher::new_keyed(salt());
+    hasher.update(bytes);
+    hex::encode(&hasher.finalize().as_bytes()[..4])
+}
+
+macro_rules! log_id_wrapper {
+    ($(#[$doc:meta])* $name:ident, $inner:ty, $prefix:literal) => {
+        $(#[$doc])*
+        #[derive(Clone, Copy)]
+        pub struct $name([u8; 32]);
+
+        impl From<&$inner> for $name {
+            fn from(id: &$inner) -> Self {
+                Self(id.0)
+            }
+        }
+
+        impl From<$inner> for $name {
+            fn from(id: $inner) -> Self {
+                Self(id.0)
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, concat!($prefix, "_{}"), opaque_token(&self.0))
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                // Mirror Display — the `?` formatter must not leak either.
+                fmt::Display::fmt(self, f)
+            }
+        }
+    };
+}
+
+log_id_wrapper!(
+    /// Displays an [`AgentId`] as `agent_xxxxxxxx`.
+    LogAgentId,
+    AgentId,
+    "agent"
+);
+log_id_wrapper!(
+    /// Displays a [`MachineId`] as `machine_xxxxxxxx`.
+    LogMachineId,
+    MachineId,
+    "machine"
+);
+log_id_wrapper!(
+    /// Displays a [`UserId`] as `user_xxxxxxxx`.
+    LogUserId,
+    UserId,
+    "user"
+);
+
+/// Privacy wrapper for identifiers that travel as strings (hex group
+/// ids, topic names, addresses). Displays as `<prefix>_xxxxxxxx`.
+#[derive(Clone, Copy)]
+pub struct LogHexId<'a> {
+    prefix: &'static str,
+    id: &'a str,
+}
+
+impl<'a> LogHexId<'a> {
+    /// Wrap an arbitrary string identifier with a custom prefix.
+    #[must_use]
+    pub fn new(prefix: &'static str, id: &'a str) -> Self {
+        Self { prefix, id }
+    }
+
+    /// Wrap a hex group id → `group_xxxxxxxx`.
+    #[must_use]
+    pub fn group(id: &'a str) -> Self {
+        Self::new("group", id)
+    }
+
+    /// Wrap a topic name → `topic_xxxxxxxx`.
+    #[must_use]
+    pub fn topic(id: &'a str) -> Self {
+        Self::new("topic", id)
+    }
+
+    /// Wrap a hex agent id string → `agent_xxxxxxxx`.
+    #[must_use]
+    pub fn agent(id: &'a str) -> Self {
+        Self::new("agent", id)
+    }
+
+    /// Wrap a network address → `addr_xxxxxxxx`.
+    #[must_use]
+    pub fn addr(id: &'a str) -> Self {
+        Self::new("addr", id)
+    }
+}
+
+impl fmt::Display for LogHexId<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}_{}", self.prefix, opaque_token(self.id.as_bytes()))
+    }
+}
+
+impl fmt::Debug for LogHexId<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokens_are_stable_within_process_and_leak_nothing() {
+        // Within one process the same id must map to the same token
+        // (operators correlate lines), and the rendered form must not
+        // contain the real identifier (the privacy property).
+        init_log_salt_for_tests([42u8; 32]);
+        let agent = AgentId([0xAB; 32]);
+        let a1 = format!("{}", LogAgentId::from(&agent));
+        let a2 = format!("{}", LogAgentId::from(&agent));
+        assert_eq!(a1, a2, "same id must render the same token in-process");
+        assert!(a1.starts_with("agent_"), "prefixed for readability: {a1}");
+        assert_eq!(a1.len(), "agent_".len() + 8, "8 hex chars: {a1}");
+        let real_hex = hex::encode([0xAB; 32]);
+        assert!(
+            !a1.contains(&real_hex[..8]),
+            "token must not embed the real id"
+        );
+    }
+
+    #[test]
+    fn different_ids_get_different_tokens() {
+        init_log_salt_for_tests([42u8; 32]);
+        let a = format!("{}", LogAgentId::from(AgentId([1u8; 32])));
+        let b = format!("{}", LogAgentId::from(AgentId([2u8; 32])));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn debug_formatter_does_not_leak() {
+        init_log_salt_for_tests([42u8; 32]);
+        let agent = AgentId([0xCD; 32]);
+        assert_eq!(
+            format!("{:?}", LogAgentId::from(&agent)),
+            format!("{}", LogAgentId::from(&agent)),
+            "Debug must mirror Display so tracing's ? sigil cannot leak"
+        );
+    }
+
+    #[test]
+    fn string_identifier_wrapper_redacts_groups_and_topics() {
+        init_log_salt_for_tests([42u8; 32]);
+        let group_hex = "deadbeefdeadbeefdeadbeefdeadbeef";
+        let g = format!("{}", LogHexId::group(group_hex));
+        assert!(g.starts_with("group_"));
+        assert!(!g.contains("deadbeef"), "must not leak the group id: {g}");
+        let t = format!("{}", LogHexId::topic("secret-team-channel"));
+        assert!(!t.contains("secret"), "must not leak the topic name: {t}");
+    }
+}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -28,6 +28,8 @@ covers project-wide rules and architecture.
 | `presence_wiring_test.rs` | PresenceWrapper lifecycle, config defaults, shutdown |
 | `presence_integration.rs` | Presence API surface: subscribe, cached_agent, foaf_peer_candidates |
 | `kv_store_integration.rs` | KV store CRUD, access policies, CRDT sync |
+| `kv_first_join_bootstrap.rs` | Issue #96: cold first-join state bootstrap via state-sync side topic (daemon-backed, `--ignored`) |
+| `local_topics.rs` | Issue #89: `local:` topics deliver same-daemon only, never gossipped (daemon-backed, `--ignored`) |
 | `named_group_integration.rs` | Named groups, invites, join/leave, display names |
 | `bootstrap_cache_integration.rs` | Bootstrap cache persistence, quality scoring |
 | `constitution_integration.rs` | Constitution embedding and serving |

--- a/tests/harness/src/cluster.rs
+++ b/tests/harness/src/cluster.rs
@@ -52,7 +52,11 @@ impl AgentInstance {
 
     async fn refresh_runtime_state(&mut self) {
         let api_addr = self.api_addr.clone();
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        // 90s, not 30s: debug-build daemons doing ML-DSA keygen plus
+        // hard-coded internet bootstrap rounds come healthy anywhere from
+        // ~15s to >30s depending on machine load — the old deadline was a
+        // flakiness knife-edge for the first daemon of a run.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(90);
         let client = reqwest::Client::new();
         loop {
             if let Ok(resp) = client.get(format!("http://{api_addr}/health")).send().await {
@@ -61,7 +65,7 @@ impl AgentInstance {
                 }
             }
             if tokio::time::Instant::now() > deadline {
-                panic!("x0xd {} did not become healthy within 30s", self.name);
+                panic!("x0xd {} did not become healthy within 90s", self.name);
             }
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
@@ -219,6 +223,41 @@ pub async fn cluster() -> &'static AgentCluster {
 /// Start a fresh two-daemon pair with Bob bootstrapping to Alice.
 pub async fn pair() -> AgentPair {
     pair_with_extra_config("").await
+}
+
+/// Start a single daemon with no bootstrap peers. Returns the instance
+/// and its UDP bind port so a later daemon can bootstrap to it — the
+/// staggered-start primitive for cold-late-join tests (issue #96), where
+/// state must exist before the second daemon's process does.
+pub async fn solo() -> (AgentInstance, u16) {
+    let binary = find_x0xd_binary();
+    let suffix = rand::random::<u16>();
+    let api = allocate_unused_tcp_port();
+    let bind = allocate_unused_udp_port();
+    let instance = start_instance(&binary, &format!("solo-{suffix}"), api, bind, "", "").await;
+    (instance, bind)
+}
+
+/// Start a daemon that bootstraps to an already-running instance's UDP
+/// bind port (as returned by [`solo`]). Waits for the mesh to settle and
+/// asserts the two nodes actually peered, mirroring [`pair`]'s guarantees.
+pub async fn join_peer(anchor: &AgentInstance, anchor_bind: u16) -> AgentInstance {
+    let binary = find_x0xd_binary();
+    let suffix = rand::random::<u16>();
+    let api = allocate_unused_tcp_port();
+    let bind = allocate_unused_udp_port();
+    let instance = start_instance(
+        &binary,
+        &format!("late-{suffix}"),
+        api,
+        bind,
+        &format!("bootstrap_peers = [\"127.0.0.1:{anchor_bind}\"]"),
+        "",
+    )
+    .await;
+    tokio::time::sleep(MESH_SETTLE_TIME).await;
+    assert_nodes_connected(&[anchor, &instance]).await;
+    instance
 }
 
 pub async fn trio_with_extra_config(extra_config: &str) -> AgentCluster {
@@ -401,6 +440,19 @@ async fn assert_nodes_connected(nodes: &[&AgentInstance]) {
 }
 
 fn find_x0xd_binary() -> PathBuf {
+    // Runtime override — lets a test run pin the daemon build (e.g. to
+    // prove a regression test fails against a pre-fix binary while the
+    // test code itself compiles from the current tree).
+    if let Ok(path) = std::env::var("X0XD_TEST_BINARY") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return path;
+        }
+        panic!(
+            "X0XD_TEST_BINARY set but does not exist: {}",
+            path.display()
+        );
+    }
     if let Some(path) = option_env!("CARGO_BIN_EXE_x0xd") {
         let path = PathBuf::from(path);
         if path.exists() {

--- a/tests/kv_first_join_bootstrap.rs
+++ b/tests/kv_first_join_bootstrap.rs
@@ -1,0 +1,160 @@
+//! Regression test for issue #96 — KvStore first-time late join must
+//! bootstrap pre-existing keys.
+//!
+//! A first-time joiner of a KvStore topic previously received only deltas
+//! published *after* it subscribed: keys written before the join never
+//! arrived (polled for 10 minutes in the issue repro), even though future
+//! writes replicated fine. The fix adds a state-sync side channel — an
+//! empty-store joiner requests state, holders respond by republishing
+//! their full state as a regular CRDT delta.
+//!
+//! All tests are `#[ignore]` — they boot real x0xd daemons.
+//! Run with: cargo nextest run --test kv_first_join_bootstrap -- --ignored
+//! Before running: cargo build --release --bin x0xd
+
+use base64::Engine;
+use std::time::{Duration, Instant};
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+fn b64(s: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(s)
+}
+
+#[tokio::test]
+#[ignore]
+async fn first_time_late_joiner_bootstraps_historical_keys() {
+    // True cold first-join (issue #96): alice creates the store and
+    // writes a key while bob's daemon DOES NOT EXIST YET. This defeats
+    // both fallback paths that can mask the gap on a warm pair — the
+    // per-write direct-DM delta delivery (bob is nobody's contact at
+    // write time) and short-window gossip cache replay.
+    let (alice, alice_bind) = cluster::solo().await;
+    let topic = format!("kv-bootstrap-{}", rand::random::<u32>());
+
+    let r = alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "party", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates store");
+    let r = alice
+        .put(
+            &format!("/stores/{topic}/party-historical"),
+            serde_json::json!({ "value": b64(b"written-before-bob-existed") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice writes historical key");
+
+    // Let the write age past the gossip message-cache window (60s in
+    // saorsa-gossip-pubsub), then keep the topic busy with fresh writes.
+    // Cache pruning is lazy (runs on insert), so on a quiet topic the
+    // expired historical delta lingers and anti-entropy can still
+    // redeliver it by luck; the fresh inserts force the prune, which is
+    // the issue's real-world shape — scenario 3 of #96 observed exactly
+    // this (future writes arrived, the historical key never did).
+    tokio::time::sleep(Duration::from_secs(70)).await;
+    for n in 0..3 {
+        let r = alice
+            .put(
+                &format!("/stores/{topic}/fresh-{n}"),
+                serde_json::json!({ "value": b64(b"fresh-write") }),
+            )
+            .await;
+        assert!(r.status().is_success(), "alice fresh write {n}");
+    }
+
+    // Only now does bob's daemon boot and connect.
+    let bob = cluster::join_peer(&alice, alice_bind).await;
+
+    // Bob joins the store topic for the first time, after the write.
+    let r = bob
+        .post(&format!("/stores/{topic}/join"), serde_json::json!({}))
+        .await;
+    assert!(r.status().is_success(), "bob joins store");
+    let pair = cluster::AgentPair { alice, bob };
+
+    // The historical key must arrive via the state-sync bootstrap. The
+    // requester retries at 1/5/15/30s; allow the full schedule plus
+    // propagation slack.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let r = pair.bob.get(&format!("/stores/{topic}/keys")).await;
+        let body: serde_json::Value = r.json().await.expect("keys response is json");
+        let last_keys = body.to_string();
+        let found = body["keys"]
+            .as_array()
+            .map(|keys| keys.iter().any(|k| k == "party-historical"))
+            .unwrap_or(false)
+            || last_keys.contains("party-historical");
+        if found {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "bob never bootstrapped the historical key written before his \
+             first join (issue #96); last keys response: {last_keys}"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // And the value itself must be readable.
+    let r = pair
+        .bob
+        .get(&format!("/stores/{topic}/party-historical"))
+        .await;
+    assert!(
+        r.status().is_success(),
+        "bob reads the bootstrapped historical value"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn live_replication_still_works_after_bootstrap_change() {
+    // Guard: the state-sync side channel must not disturb the existing
+    // join-before-write replication path (issue #96 scenario 1).
+    let pair = cluster::pair().await;
+    let topic = format!("kv-live-{}", rand::random::<u32>());
+
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "live", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates store");
+    let r = pair
+        .bob
+        .post(&format!("/stores/{topic}/join"), serde_json::json!({}))
+        .await;
+    assert!(r.status().is_success(), "bob joins before the write");
+
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/party-control"),
+            serde_json::json!({ "value": b64(b"live-write") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice writes after bob joined");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let r = pair
+            .bob
+            .get(&format!("/stores/{topic}/party-control"))
+            .await;
+        if r.status().is_success() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "live replication regressed: bob never saw a write made after he joined"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}

--- a/tests/local_topics.rs
+++ b/tests/local_topics.rs
@@ -1,0 +1,146 @@
+//! Tests for `local:` topic routing (issue #89).
+//!
+//! Topics prefixed `local:` are same-daemon IPC: delivered to subscribers
+//! attached to the same x0xd instance, never gossipped to remote mesh
+//! peers. These tests prove both halves — local delivery works through
+//! the public daemon surfaces, and a connected remote peer subscribed to
+//! the same topic name receives nothing.
+//!
+//! All tests are `#[ignore]` — they boot real x0xd daemons.
+//! Run with: cargo nextest run --test local_topics -- --ignored
+//! Before running: cargo build --release --bin x0xd
+
+use base64::Engine;
+use futures::{SinkExt, StreamExt};
+use std::time::Duration;
+use tokio_tungstenite::tungstenite::Message;
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+type Ws =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn ws_connect(instance: &cluster::AgentInstance) -> Ws {
+    let (ws, _) = tokio_tungstenite::connect_async(&instance.ws_url("/ws"))
+        .await
+        .expect("WS connect failed");
+    ws
+}
+
+async fn ws_send(ws: &mut Ws, msg: &str) {
+    ws.send(Message::Text(msg.into()))
+        .await
+        .expect("WS send failed");
+}
+
+async fn ws_recv_text(ws: &mut Ws, timeout_secs: u64) -> Option<String> {
+    match tokio::time::timeout(Duration::from_secs(timeout_secs), ws.next()).await {
+        Ok(Some(Ok(Message::Text(t)))) => Some(t.to_string()),
+        _ => None,
+    }
+}
+
+/// Subscribe to a topic over WS and wait for the confirmation frame.
+async fn ws_subscribe(ws: &mut Ws, topic: &str) {
+    ws_send(
+        ws,
+        &format!(r#"{{"type":"subscribe","topics":["{topic}"]}}"#),
+    )
+    .await;
+    for _ in 0..5 {
+        if let Some(frame) = ws_recv_text(ws, 5).await {
+            let v: serde_json::Value = serde_json::from_str(&frame).unwrap_or_default();
+            if v["type"] == "subscribed" {
+                return;
+            }
+        }
+    }
+    panic!("did not receive subscribed confirmation for {topic}");
+}
+
+/// Wait until a WS frame mentioning `needle` arrives, or time out.
+async fn ws_saw(ws: &mut Ws, needle: &str, timeout_secs: u64) -> bool {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+    while tokio::time::Instant::now() < deadline {
+        if let Some(frame) = ws_recv_text(ws, 2).await {
+            if frame.contains(needle) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[tokio::test]
+#[ignore]
+async fn local_topic_delivers_to_same_daemon_subscriber_only() {
+    let pair = cluster::pair().await;
+    let topic = "local:my-app/events";
+    let marker = format!("local-marker-{}", rand::random::<u32>());
+    let payload_b64 = base64::engine::general_purpose::STANDARD.encode(marker.as_bytes());
+
+    // Both daemons subscribe to the SAME local: topic name.
+    let mut alice_ws = ws_connect(&pair.alice).await;
+    let mut bob_ws = ws_connect(&pair.bob).await;
+    ws_subscribe(&mut alice_ws, topic).await;
+    ws_subscribe(&mut bob_ws, topic).await;
+
+    // Alice publishes on the local topic.
+    let r = pair
+        .alice
+        .post(
+            "/publish",
+            serde_json::json!({ "topic": topic, "payload": payload_b64 }),
+        )
+        .await;
+    assert!(r.status().is_success(), "publish on local: topic succeeds");
+
+    // Alice's own subscriber receives it...
+    assert!(
+        ws_saw(&mut alice_ws, &payload_b64, 10).await,
+        "same-daemon subscriber must receive the local: message"
+    );
+
+    // ...but Bob — a connected remote peer subscribed to the identical
+    // topic name — must receive nothing: local: topics are never
+    // gossipped (issue #89).
+    assert!(
+        !ws_saw(&mut bob_ws, &payload_b64, 8).await,
+        "local: message leaked to a remote mesh peer"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn local_topic_fans_out_to_multiple_local_subscribers() {
+    let pair = cluster::pair().await;
+    let topic = "local:fanout/check";
+    let marker = format!("fanout-{}", rand::random::<u32>());
+    let payload_b64 = base64::engine::general_purpose::STANDARD.encode(marker.as_bytes());
+
+    // Two independent subscribers on the same daemon (the multi-process
+    // app pattern local: topics exist for).
+    let mut sub1 = ws_connect(&pair.alice).await;
+    let mut sub2 = ws_connect(&pair.alice).await;
+    ws_subscribe(&mut sub1, topic).await;
+    ws_subscribe(&mut sub2, topic).await;
+
+    let r = pair
+        .alice
+        .post(
+            "/publish",
+            serde_json::json!({ "topic": topic, "payload": payload_b64 }),
+        )
+        .await;
+    assert!(r.status().is_success());
+
+    assert!(
+        ws_saw(&mut sub1, &payload_b64, 10).await,
+        "first local subscriber must receive the message"
+    );
+    assert!(
+        ws_saw(&mut sub2, &payload_b64, 10).await,
+        "second local subscriber must receive the message (fan-out)"
+    );
+}


### PR DESCRIPTION
## Summary

Second batch of the open-issue cleanup. Stacked on #102 (Batch 1) — contains its commits; merge #102 first and this rebases to just the Batch-2 commit.

### #96 — KvStore first-time late join never bootstraps pre-existing keys
Root cause: a first-time joiner only ever received deltas published after it subscribed. The gossip message cache replays ~60s, and its lazy pruning (runs on insert) means *busy* topics lose older deltas entirely — matching the issue's scenario 3 exactly (future writes arrived in ~1s, the historical key never did).

Fix: a `<topic>/state-sync` side channel. Empty-store joiners publish `StateRequest`s on a 1/5/15/30s schedule; any holder with state responds by republishing `full_delta()` as a normal CRDT delta on the main topic (idempotent merge, multi-holder safe). Backward compatible: the main-topic wire format is untouched and pre-fix nodes simply never subscribe to the side channel.

**Proof**: new cold-join daemon test (alice writes while bob's daemon does not exist; 70s cache-expiry wait; busy-topic writes force the prune; bob boots, connects, joins) — **fails against the pre-fix binary** (`X0XD_TEST_BINARY` override: bob receives the fresh keys, never the historical one — the issue's exact signature) and **passes post-fix** in ~20s. A second test guards the join-before-write live path.

### #89 — `local:` topics (same-daemon pub/sub IPC)
Topics prefixed `local:` are handled in `PubSubManager` with a local subscriber registry and never touch PlumTree — no EAGER set, no IHAVE digests, and inbound gossip cannot deliver to local subscribers because no PlumTree subscription ever exists. `/publish`, `/subscribe`, WS subscribe, SSE, bearer auth all unchanged. Documented in the API reference.

**Tests**: daemon-pair WS tests prove same-daemon delivery, two-subscriber fan-out, and that a *connected remote peer subscribed to the identical topic name receives nothing*.

### #95 — `x0x user-id create --from-seed <hex>`
Deterministic UserKeypair via FIPS 204 seeded KeyGen — `fips204::ml_dsa_65::KG::keygen_from_seed` (the ξ input; the crate was already a direct dependency, so no upstream work was needed). Same 32-byte seed → same keypair on any machine; BIP-39 mnemonic encoding intentionally stays in consumer apps per the issue's separation-of-concerns table. Validation: hex/length checks (no file written on bad seed), determinism + distinct-seed + sign/verify tests.

### #83 — groundwork only
`src/logging.rs`: salted-BLAKE3 identifier wrappers (`LogAgentId`/`LogMachineId`/`LogUserId`/`LogHexId`, re-exported upstream `LogPeerId`/`LogTopicId`), per-process memory-only salt, Debug mirrors Display so `?` can't leak. The ~48-site warn!/error! call-site migration ships as its own follow-up PR for reviewability.

### Test-harness hardening
- `solo()` / `join_peer()` staggered-start helpers (state-before-the-joiner-exists scenarios)
- `X0XD_TEST_BINARY` runtime override (lets a regression test run against a pinned pre-fix daemon)
- daemon health deadline 30s→90s (debug builds + hard-coded internet bootstrap rounds made 30s a first-daemon flakiness knife-edge)
- new test files wired into `integration.yml` (single-threaded)

## Test plan
- [x] fmt / clippy `-D warnings` / `cargo doc -D warnings` clean
- [x] Full workspace nextest **1687/1687**
- [x] 4/4 daemon-backed tests (serial)
- [x] #96 test proven to fail on pre-fix binary
- [ ] Testnet soak after #102 merges (note: fleet-wide degradation today affects prod 0.21.4 equally — A/B drop-rate comparison on the same host shows the new build at *less than half* prod's drop rate)

Closes #96. Closes #89. Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This batch closes issues #96 (KvStore cold-join bootstrap via a state-sync side channel), #89 (`local:` topics for same-daemon pub/sub IPC), and #95 (deterministic `UserKeypair` from a 32-byte seed), plus groundwork for #83 (salted-BLAKE3 log-identifier redaction) and a domain-separation field on the agent-sign endpoint.

- **#96 / `src/kv/sync.rs`**: Empty-store joiners publish `StateRequest`s on `<topic>/state-sync` at 1/5/15/30 s; any holder with non-empty state responds by republishing `full_delta()` as a regular CRDT delta on the main topic. Backward-compatible wire format; the 70 s cache-expiry integration test and pre-fix binary regression proof are solid, but the access-control interaction between `merge_delta`'s `writer` check and non-owner responders is a gap for `Signed`/`Allowlisted` stores (see inline comment).
- **#89 / `src/gossip/pubsub.rs`**: `local:` topics are routed through a per-`PubSubManager` `HashMap<String, Vec<Sender>>`, bypassing PlumTree entirely; fan-out, lazy dead-sender cleanup, and isolation from remote peers are all verified by new daemon-pair WS tests.
- **#95 / `src/identity.rs` + `src/cli/commands/user_id.rs`**: `UserKeypair::from_seed` wraps `fips204::ml_dsa_65::KG::keygen_from_seed`; determinism, distinct-seed, and sign/verify properties are unit-tested; the CLI validates hex/length before writing any file.

<h3>Confidence Score: 3/5</h3>

The local-topic routing, seeded keygen, domain-separation signing, and test-harness changes are solid. The state-sync bootstrap works for the tested 2-node owner-is-online scenario but silently breaks for Signed and Allowlisted stores when only non-owner replicas can respond.

The state-sync responder publishes full_delta() signed with its own agent keypair, but merge_delta on the receiving side runs the same is_authorized() check used for live writes. For Signed stores (the default policy), only the owner's agent_id passes that check — responses from every other replica are silently dropped. The integration test only exercises Alice-as-owner responding to Bob, so the failure mode does not appear in CI.

src/kv/sync.rs — how merge_delta writer-authorization interacts with state-sync responses from non-owner holders. src/logging.rs — init_log_salt_for_tests needs a cfg(test) guard.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/kv/sync.rs | Adds state-sync side channel (#96): responder and bootstrap-requester tasks are correct for the 2-node owner-is-online case but silently fail for non-owner responders on Signed/Allowlisted stores, and the requester task is not cancelled on stop(). |
| src/gossip/pubsub.rs | Adds local: topic routing with a centralized sender-Vec registry; fan-out, lazy dead-sender cleanup via retain, and unsubscribe semantics look correct and consistent with the existing PlumTree subscriber pattern. |
| src/logging.rs | New privacy-preserving log-identifier module: per-process BLAKE3-keyed salt, correct Debug=Display guard, well-tested — init_log_salt_for_tests needs a cfg(test) guard to prevent production exposure. |
| src/identity.rs | Adds UserKeypair::from_seed using fips204 seeded KeyGen; deterministic, sign/verify tested, error path is clean. |
| src/cli/commands/user_id.rs | Adds --from-seed hex validation (length + decode), inspect subcommand, and determinism/rejection/malformed-file tests — all paths are well-covered and no file is written on invalid input. |
| src/bin/x0xd.rs | Domain-separation signing (#90): empty/NUL/length checks are correct, canonical bytes construction is unambiguous, domain echoed in response, and send_replace fix for #101 prevents the DM capability race. |
| tests/harness/src/cluster.rs | Adds solo()/join_peer() staggered-start helpers, X0XD_TEST_BINARY override for pre-fix regression proofs, and bumps the health deadline to 90s. |
| tests/kv_first_join_bootstrap.rs | Regression test for issue #96 using solo/join_peer and a 70s cache-expiry wait; proves the failure scenario. Only covers the 2-node, owner-is-online path. |
| tests/local_topics.rs | Daemon-backed tests prove same-daemon delivery, two-subscriber fan-out, and non-leakage to a connected remote peer — complete coverage of the local: topic contract. |
| src/lib.rs | Adds local logging module export, fixes DM capability upgrade to send_replace (#101), and passes local_peer_id to KvStoreSync::new. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Alice as Alice (owner daemon)
    participant Mesh as PlumTree Mesh
    participant Bob as Bob (late-joiner daemon)

    Alice->>Mesh: PUT /stores/topic/key (publish KvStoreDelta)
    Note over Mesh: >60s pass, cache pruned

    Bob->>Mesh: subscribe(topic) + subscribe(topic/state-sync)
    Note over Bob: store is_empty() == true, spawn requester

    loop STATE_REQUEST_RETRY_SECS 1,5,15,30
        Bob->>Mesh: publish(topic/state-sync, StateRequest)
        Mesh->>Alice: deliver StateRequest
        Alice-->>Mesh: publish(topic, full_delta)
        Mesh-->>Bob: deliver full_delta
        Bob->>Bob: "merge_delta writer=alice_agent_id"
        Note over Bob: is_authorized(alice) true for Signed store
    end

    Note over Bob: local:topic messages stay on-daemon only
    Bob->>Bob: subscribe local:events to local_topics map
    Bob->>Bob: publish local:events via retain try_send
    Note over Bob: PlumTree never sees local: frames
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/kv/sync.rs:157-165
**State-sync bootstrap silently rejected for non-owner responders**

When a holder republishes `full_delta()` as a state-sync response it signs the gossip message with its own agent keypair. On the joiner's side, `merge_delta` uses `msg.sender` (the responder's `AgentId`) as the `writer` parameter. For `AccessPolicy::Signed` stores (the default), `is_authorized` only returns true for the store owner — so a full-delta republished by any non-owner replica is silently rejected (`return Ok(())` in `KvStore::merge_delta`). Bootstrap therefore works only if the store owner happens to be among the responding holders. In a scenario where the owner is offline but replicas are available, the joiner never bootstraps, which is precisely the failure mode issue #96 aimed to fix.

### Issue 2 of 3
src/kv/sync.rs:180-200
**Requester task outlives `stop()` and can double-fire if `start()` is re-called**

The requester task captures only `Arc<PubSubManager>` and the sync topic string, so it is not cancelled when `stop()` calls `unsubscribe`. The task continues sleeping and publishing for up to 51 s (1+5+15+30) after the store is torn down. If the same `KvStoreSync` (or a replacement for the same topic) calls `start()` again before the old task finishes, two requester tasks run concurrently, doubling request volume during the overlap window.

### Issue 3 of 3
src/logging.rs:57-60
**Test helper exposed in production builds**

`init_log_salt_for_tests` is `pub` without a `#[cfg(any(test, feature = "testing"))]` guard. Any code that imports `x0x::logging` and runs in the same process can call it before the first log emission, fixing the `OnceLock` salt to a known value. After that, every identifier hashes to a predictable token, defeating the per-session privacy guarantee the module provides. Consider gating this behind `#[cfg(test)]` or a dedicated `testing` feature flag.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(kv,pubsub,cli): KvStore first-join ..."](https://github.com/saorsa-labs/x0x/commit/7f07733627efbeaffab0b0c1cc931b9d622dbf70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36668123)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->