### PR TITLE
fix(cli): isolate upgrade daemon-discovery tests from live machine state

### DIFF
--- a/src/cli/commands/upgrade.rs
+++ b/src/cli/commands/upgrade.rs
@@ -251,7 +251,11 @@ async fn upgrade_binary_manual(
 
 /// Discover the daemon API address from the port file, if running.
 fn discover_daemon_api() -> Option<String> {
-    let data_dir = dirs::data_dir()?;
+    discover_daemon_api_in(&dirs::data_dir()?)
+}
+
+/// Discover the daemon API address from `<data_dir>/x0x/api.port`.
+fn discover_daemon_api_in(data_dir: &std::path::Path) -> Option<String> {
     let port_file = data_dir.join("x0x").join("api.port");
     std::fs::read_to_string(port_file)
         .ok()
@@ -261,7 +265,15 @@ fn discover_daemon_api() -> Option<String> {
 
 /// Stop the daemon if it's running. Returns true if it was running.
 async fn stop_daemon_if_running() -> bool {
-    let addr = match discover_daemon_api() {
+    match dirs::data_dir() {
+        Some(data_dir) => stop_daemon_if_running_in(&data_dir).await,
+        None => false,
+    }
+}
+
+/// Stop the daemon whose port file lives under `data_dir`, if it's running.
+async fn stop_daemon_if_running_in(data_dir: &std::path::Path) -> bool {
+    let addr = match discover_daemon_api_in(data_dir) {
         Some(a) => a,
         None => return false,
     };
@@ -281,7 +293,7 @@ async fn stop_daemon_if_running() -> bool {
     }
 
     // Read the API token for authenticated shutdown
-    let token = read_api_token();
+    let token = read_api_token_in(data_dir);
 
     // Send shutdown
     let shutdown_url = format!("http://{addr}/shutdown");
@@ -302,9 +314,8 @@ async fn stop_daemon_if_running() -> bool {
     true
 }
 
-/// Read the API token from the daemon's token file.
-fn read_api_token() -> Option<String> {
-    let data_dir = dirs::data_dir()?;
+/// Read the API token from `<data_dir>/x0x/api.token`.
+fn read_api_token_in(data_dir: &std::path::Path) -> Option<String> {
     let token_file = data_dir.join("x0x").join("api.token");
     std::fs::read_to_string(token_file)
         .ok()
@@ -484,9 +495,10 @@ mod tests {
     }
 
     #[test]
-    fn discover_daemon_api_returns_none_in_test_env() {
-        // In a test environment without a running daemon, this should return None
-        let result = discover_daemon_api();
+    fn discover_daemon_api_returns_none_without_port_file() {
+        // An isolated data dir with no port file means no daemon to talk to
+        let dir = tempfile::tempdir().expect("temp dir");
+        let result = discover_daemon_api_in(dir.path());
         assert!(
             result.is_none(),
             "should return None without a running daemon"
@@ -494,13 +506,36 @@ mod tests {
     }
 
     #[test]
-    fn read_api_token_returns_none_in_test_env() {
-        // In a test environment without a configured token, this should return None
-        let result = read_api_token();
+    fn discover_daemon_api_reads_trimmed_port_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let x0x_dir = dir.path().join("x0x");
+        std::fs::create_dir_all(&x0x_dir).expect("create x0x dir");
+        std::fs::write(x0x_dir.join("api.port"), "127.0.0.1:12700\n").expect("write port file");
+
+        let result = discover_daemon_api_in(dir.path());
+        assert_eq!(result.as_deref(), Some("127.0.0.1:12700"));
+    }
+
+    #[test]
+    fn read_api_token_returns_none_without_token_file() {
+        // An isolated data dir with no token file means no configured token
+        let dir = tempfile::tempdir().expect("temp dir");
+        let result = read_api_token_in(dir.path());
         assert!(
             result.is_none(),
             "should return None without a configured token"
         );
+    }
+
+    #[test]
+    fn read_api_token_ignores_empty_token_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let x0x_dir = dir.path().join("x0x");
+        std::fs::create_dir_all(&x0x_dir).expect("create x0x dir");
+        std::fs::write(x0x_dir.join("api.token"), "  \n").expect("write token file");
+
+        let result = read_api_token_in(dir.path());
+        assert!(result.is_none(), "whitespace-only token must be ignored");
     }
 
     #[tokio::test]
@@ -534,6 +569,7 @@ mod tests {
 
     #[tokio::test]
     async fn stop_daemon_if_running_returns_false_without_port_file() {
-        assert!(!stop_daemon_if_running().await);
+        let dir = tempfile::tempdir().expect("temp dir");
+        assert!(!stop_daemon_if_running_in(dir.path()).await);
     }
 }


### PR DESCRIPTION
## Problem

Two unit tests in `src/cli/commands/upgrade.rs` fail on any developer machine where a local x0xd daemon is (or was) running:

- `discover_daemon_api_returns_none_in_test_env`
- `stop_daemon_if_running_returns_false_without_port_file`

`discover_daemon_api()` reads the real global port file at `dirs::data_dir()/x0x/api.port` (`~/Library/Application Support/x0x/api.port` on macOS), so the tests asserted "no daemon" against live machine state. `read_api_token_returns_none_in_test_env` had the same hazard.

## Fix

Path injection: `discover_daemon_api_in(data_dir)`, `read_api_token_in(data_dir)`, and `stop_daemon_if_running_in(data_dir)` take the data directory as a parameter; the public fns delegate with `dirs::data_dir()`, so production behavior (including `restart_daemon` health polling) is unchanged. Tests drive the inner variants with a tempdir.

Also adds positive tests for port-file trimming and whitespace-only-token filtering so the parsing logic can actually fail under regression.

## Validation

- `cargo fmt --check` + `clippy --all-targets --all-features -D warnings` clean
- Upgrade test module passes 9/9 **with and without** a fake `api.port` present
- Full `cargo nextest run --all-features --workspace`: 1689/1689 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces path-injection variants (`_in` suffix) for `discover_daemon_api`, `stop_daemon_if_running`, and `read_api_token` so tests can drive those functions with an isolated `tempdir` instead of the real system data directory. Production call-sites are unchanged since the public functions continue to resolve `dirs::data_dir()` and delegate inward.

- Three new `_in` helpers accept a `&std::path::Path`, making the file-system side-effects fully controllable in tests.
- Two new positive tests (`discover_daemon_api_reads_trimmed_port_file`, `read_api_token_ignores_empty_token_file`) cover the trim-and-filter parsing path that was previously exercised only by coincidence.
- The `read_api_token()` public wrapper is dropped entirely (it was only ever called from inside `stop_daemon_if_running`, which now calls `read_api_token_in` directly).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactor is minimal and surgical, production call paths are unchanged, and the test suite now fully isolates daemon-discovery from live machine state.

The change is a straightforward path-injection refactor. All three helpers retain the same logic; only where they source the data directory differs. The new tests cover both the absence case and the trimming/filtering logic that was previously untestable in isolation. No production code paths are altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/cli/commands/upgrade.rs | Adds `_in` path-injection variants for daemon-discovery helpers; existing public API unchanged. New tests are properly isolated with `tempfile::tempdir()` and cover both absence and parsing of port/token files. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[stop_daemon_if_running] -->|resolve data dir| B{data_dir?}
    B -->|None| C[return false]
    B -->|Some| D[stop_daemon_if_running_in]
    D --> E[discover_daemon_api_in]
    E -->|read api.port| F{port file exists?}
    F -->|No| G[return false]
    F -->|Yes - trimmed non-empty| H[read_api_token_in]
    H -->|read api.token| I[POST /shutdown]
    I --> J[Poll /health until stopped]

    subgraph Tests["Isolated Tests using tempdir"]
        T1[no port file - returns None]
        T2[port file with newline - trimmed correctly]
        T3[no token file - returns None]
        T4[whitespace-only token - filtered out]
        T5[stop without port file - returns false]
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(cli): isolate upgrade daemon-discove..."](https://github.com/saorsa-labs/x0x/commit/6be3e8a21b753a70dfa7df2652617d136014fae6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36693782)</sub>

<!-- /greptile_comment -->