### PR TITLE
refactor: codebase simplification (tranches 1+3) + review fixes

### DIFF
--- a/.planning/reviews/code-simplifier-core.md
+++ b/.planning/reviews/code-simplifier-core.md
@@ -1,0 +1,335 @@
+# Core Library Simplification Review
+
+Scope: `src/lib.rs` (9,980 lines), `src/identity.rs` (1,232), `src/storage.rs` (682),
+`src/error.rs` (540), `src/bootstrap.rs` (247), `src/connectivity.rs` (701),
+`src/contacts.rs` (1,040).
+
+Findings only — no code changes made. Severity/risk per CLAUDE.md Rule 2 (Simplicity
+First) and Rule 3 (Surgical Changes). Each fix below is independently shippable; none
+require a behavioural change. Verify with `just check` after any applied fix.
+
+---
+
+## Structural overview
+
+`lib.rs` is dominated by a single `impl Agent` block spanning **lines 1980–7516
+(~5,500 lines, 94 methods)**. The `Agent` struct has **27 fields**. This is the
+central readability problem: a new reader cannot form a mental model of the public API
+because connection management, identity announcement/discovery, direct messaging,
+gossip pub/sub, presence, and lifecycle are all flattened into one impl block with no
+visual or module seam between them.
+
+The five largest methods alone account for ~2,080 lines:
+
+| Method | Line | Approx length |
+|---|---|---|
+| `connect_to_agent` | 2381 | 603 |
+| `start_identity_listener` | 5161 | 501 |
+| `connect_to_machine` | 2996 | 344 |
+| `send_direct_raw_quic` | 3794 | 324 |
+| `join_network` | 5799 | 308 |
+
+---
+
+## Top 10 highest-value findings
+
+### 1. `impl Agent` is a 5,500-line god-object with no module seams
+- **Location:** `src/lib.rs:1980–7516`
+- **What's wrong:** 94 methods in one impl block, 27 struct fields. Six clearly
+  separable concern-clusters share no organizational boundary: (a) identity accessors
+  + builder glue, (b) connection establishment (`connect_to_agent`,
+  `connect_to_machine`, `reachability`, `seed_transport_peer_hints_for_target`),
+  (c) direct messaging (`send_direct*`, `recv_direct*`, DM inbox lifecycle), (d)
+  identity announcement + discovery cache (`announce_identity`, `discovered_*`,
+  `find_*`, `start_identity_listener`), (e) gossip pub/sub (`subscribe`, `publish`,
+  `peers`), (f) presence + FOAF.
+- **Proposed fix:** Split `impl Agent` across `agent/` submodules using the multiple-
+  `impl Agent` blocks Rust allows: `agent/connect.rs`, `agent/direct.rs`,
+  `agent/discovery.rs`, `agent/announce.rs`, `agent/gossip.rs`, `agent/lifecycle.rs`.
+  The struct definition stays in one place; each module carries one `impl Agent { … }`.
+  No API changes, purely file-level moves. This is the single biggest clarity win.
+- **Risk:** Low (mechanical move; private helpers may need `pub(crate)`).
+- **Impact:** Major readability gain; no efficiency change.
+
+### 2. `connect_to_agent` is 603 lines in a single method
+- **Location:** `src/lib.rs:2381` (603 lines)
+- **What's wrong:** Single method orchestrating cache lookup, address resolution,
+  multi-stage discovery, coordinator selection, hole-punch, and raw-QUIC fallback. Far
+  past the "senior engineer would call this overcomplicated" bar (Rule 2).
+- **Proposed fix:** Extract named private stages: `resolve_agent_endpoint`,
+  `attempt_direct_dial`, `attempt_coordinated_dial`, `attempt_relay_dial`. The public
+  method becomes a readable strategy sequence. Mirror the same decomposition in
+  `connect_to_machine` (344 lines, 2996) which shares the structure.
+- **Risk:** Medium (control-flow heavy; needs the existing tests green to verify).
+- **Impact:** Large readability gain; no efficiency change.
+
+### 3. Three `Id` types have byte-identical impls
+- **Location:** `src/identity.rs:44–133` (`MachineId`, `AgentId`, `UserId`)
+- **What's wrong:** `from_public_key`, `as_bytes`, `to_vec`, `verify`, and `Display`
+  are copy-pasted three times. ~90 lines of pure duplication that drift independently.
+- **Proposed fix:** A declarative macro `peer_id_newtype!(MachineId);` emitting the
+  newtype + the five identical methods + `Display`. Keeps each type nominally distinct
+  (the type-safety reason they're separate) while removing the triplication. Document
+  the macro once.
+- **Risk:** Low (identical bodies; macro is a faithful expansion).
+- **Impact:** ~60-line reduction; eliminates drift risk.
+
+### 4. Three keypair serialize/deserialize fn pairs are identical
+- **Location:** `src/storage.rs:36–101` and `383–417`
+  (`serialize_machine_keypair`/`deserialize_*` for machine/agent/user)
+- **What's wrong:** Six functions, all with the identical body
+  `SerializedKeypair { public_key, secret_key } → bincode`. Only the keypair type
+  name differs.
+- **Proposed fix:** Generic over a small trait, e.g.
+  `fn serialize_keypair<K: KeypairBytes>(kp: &K) -> Result<Vec<u8>>` plus
+  `deserialize_keypair<K: KeypairBytes>(bytes) -> Result<K>`, where `KeypairBytes`
+  exposes `public_key().as_bytes()` / `from_bytes(...)`. Keep the named wrappers only
+  if external callers depend on the exact symbol names; otherwise drop them.
+- **Risk:** Low (the three keypair types already share the same accessor shape).
+- **Impact:** ~80-line reduction; one serialization codepath to test.
+
+### 5. Announcement Unsigned/signed struct pairs duplicate every field + `to_unsigned`
+- **Location:** `src/lib.rs:679–770` (IdentityAnnouncement), `855–970`
+  (MachineAnnouncement), `972–1136` (UserAnnouncement); 6 `to_unsigned` sites total
+- **What's wrong:** Each announcement defines an `…Unsigned` struct mirroring the signed
+  struct (14 fields for identity), plus a hand-written `to_unsigned()` that copies and
+  clones every field. The signed struct then re-declares the same fields with longer
+  doc comments. The sign-payload is `bincode::serialize(&self.to_unsigned())`.
+- **Proposed fix:** Flatten to one struct holding the payload fields plus
+  `machine_signature: Vec<u8>`, and serialize the payload by serializing the struct
+  with the signature field skipped via `#[serde(skip)]` during the canonical pass — or
+  factor a shared `SignedAnnouncement<T>` wrapper `{ payload: T, machine_signature }`
+  so the Unsigned/signed split exists once, generically. Removes 3 mirror structs and 3
+  hand-copied `to_unsigned` bodies.
+- **Risk:** Medium (touches the wire/signing format — must keep the serialized bytes
+  bit-identical so existing announcements still verify; gate behind the announcement
+  round-trip tests).
+- **Impact:** ~150-line reduction; removes a whole class of "added a field to one
+  struct but not its mirror" bugs.
+
+### 6. Crypto verify boilerplate repeated across 3 announcements + IntroductionCard
+- **Location:** `src/lib.rs:788–854` plus the Machine/User `verify` bodies;
+  `MlDsaPublicKey::from_bytes` ×4, `MlDsaSignature::from_bytes` ×3,
+  `verify_with_ml_dsa` ×3
+- **What's wrong:** Each `verify()` repeats: parse machine pubkey → derive id → compare
+  → serialize unsigned → parse signature → `verify_with_ml_dsa` → map 4 distinct error
+  strings. ~40 lines duplicated per announcement type.
+- **Proposed fix:** A free helper
+  `fn verify_ml_dsa_attestation(pubkey_bytes, expected_machine_id, unsigned_bytes,
+  signature_bytes) -> error::Result<()>` consolidating the parse/derive/compare/verify
+  chain. Each announcement's `verify()` calls it then does only its type-specific cert
+  checks.
+- **Risk:** Low–medium (security-sensitive path; keep error variants identical and add
+  a test that a tampered signature still fails).
+- **Impact:** ~90-line reduction; single audited verification routine.
+
+### 7. Discovery accessors duplicate the "read cache → TTL filter → clone → sort" shape
+- **Location:** `src/lib.rs:4815–4960` (`discovered_agents`,
+  `discovered_agents_unfiltered`, `discovered_machines`,
+  `discovered_machines_unfiltered`) + `find_agents_by_user` (6777)
+- **What's wrong:** Five+ methods repeat `start_identity_listener().await?` →
+  `cache.read().await.values()` → optional `discovery_record_is_live` filter →
+  `.cloned().collect()` → `sort_by_key`. The agent and machine variants are structurally
+  identical over different caches.
+- **Proposed fix:** A generic private helper
+  `async fn snapshot_cache<K, V: Clone>(cache, ttl_filter, sort_key) -> Vec<V>` (or two
+  thin helpers `live_records` / `all_records`). The public methods shrink to one call
+  each. Note: `start_identity_listener().await?` is repeated **18 times** across the
+  impl — see finding #9.
+- **Risk:** Low.
+- **Impact:** ~80-line reduction; the cache-access policy lives in one place.
+
+### 8. `start_identity_listener` is a 501-line method
+- **Location:** `src/lib.rs:5161` (501 lines)
+- **What's wrong:** Single method spawns the listener and inlines all
+  per-announcement-type handling (identity/machine/user decode, verify, trust-gate,
+  cache upsert). Hard to follow and the `AtomicBool` once-guard + spawn boilerplate is
+  buried in it.
+- **Proposed fix:** Extract `handle_identity_announcement`, `handle_machine_announcement`,
+  `handle_user_announcement` as free functions taking the relevant `Arc<RwLock<…>>`
+  caches; the listener loop dispatches by message kind. The `upsert_discovered_agent`
+  helper (already exists, used 16×) shows the pattern is amenable to extraction.
+- **Risk:** Medium (background task; verify discovery integration tests).
+- **Impact:** Large readability gain.
+
+### 9. `start_identity_listener().await?` guard repeated 18×; `gossip_runtime.as_ref()` 19×
+- **Location:** throughout `impl Agent`
+- **What's wrong:** Nearly every discovery/find method opens with
+  `self.start_identity_listener().await?;` and many re-implement the
+  `match self.gossip_runtime.as_ref() { Some(r) => r, None => return … }` guard inline.
+- **Proposed fix:** (a) Keep the `start_identity_listener` call but make the lazy-start
+  idempotent guard cheaper to read by giving it a `ensure_discovery_started()` alias
+  used consistently. (b) Add `fn runtime(&self) -> error::Result<&Arc<GossipRuntime>>`
+  returning the "not initialized" error once, replacing the 19 inline matches.
+- **Risk:** Low.
+- **Impact:** Removes ~19 repeated guard blocks; intent ("requires runtime") becomes
+  explicit in one place.
+
+### 10. Inline UNIX-timestamp computation duplicated alongside an existing helper
+- **Location:** `src/lib.rs:5310, 5390, 5500, 6628, 6665, 6741` (7 inline
+  `SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs())` sites),
+  while `Self::unix_timestamp_secs()` (5663) already exists and is referenced 18×
+- **What's wrong:** Two ways to get "now in seconds" coexist; the inline form is copied
+  6–7 times.
+- **Proposed fix:** Replace every inline `SystemTime::now()…as_secs()` with
+  `Self::unix_timestamp_secs()` (or a free `unix_timestamp_secs()` fn so non-method
+  callers/free helpers can use it too).
+- **Risk:** Low (pure substitution).
+- **Impact:** Small but removes a copy-paste hazard; one definition of "now".
+
+---
+
+## Longer tail
+
+### 11. `NetworkError` has ~30 variants with heavy overlap
+- **Location:** `src/error.rs:169–318`
+- **What's wrong:** Variants like `ConnectionFailed`, `ConnectionClosed`,
+  `ConnectionReset`, `ConnectionError`, `NotConnected`, `AlreadyConnected`,
+  `AgentNotConnected`, plus duplicated `Serialization`/`SerializationError` and
+  `ConfigError`/`ConfigError`-style string variants. Several carry `[u8; 32]` peer ids
+  and overlap semantically.
+- **Proposed fix:** Audit which variants are actually constructed and matched-on
+  distinctly (grep for each). Collapse the string-wrapping near-duplicates
+  (`Serialization` vs `SerializationError`, `ConnectionError` vs `ConnectionFailed`)
+  into one each. Don't over-merge variants that callers branch on.
+- **Risk:** Medium (callers may match specific variants; check `map_raw_quic_dm_error`
+  and CLI/API error mapping first — Rule 8).
+- **Impact:** Smaller, clearer error surface.
+
+### 12. `Agent` struct's 27 fields mix lifecycle handles, caches, and config
+- **Location:** `src/lib.rs:201–272`
+- **What's wrong:** Three `Arc<RwLock<HashMap…>>` discovery caches, four `AtomicBool`
+  once-guards, two `Mutex<Option<JoinHandle>>`, and DM/capability infra all sit flat.
+  The three discovery caches in particular are always used together.
+- **Proposed fix:** Group the three discovery caches into a `DiscoveryCaches` struct
+  (identity/machine/user), and the once-guards into a small `ListenerGuards` struct.
+  Reduces the top-level field count and makes the "discovery subsystem" legible.
+- **Risk:** Low–medium (field accesses change `self.x` → `self.discovery.x`).
+- **Impact:** Struct becomes scannable; supports the #1 module split.
+
+### 13. `Drop for Agent` only aborts two of several background tasks
+- **Location:** `src/lib.rs:286–298`
+- **What's wrong:** `Drop` aborts `heartbeat_handle` and
+  `discovery_cache_reaper_handle`, but the capability advert service, DM inbox service,
+  and listener spawns are not handled here. Either they're owned elsewhere (then the
+  asymmetry is confusing) or they leak. Worth a comment or consolidation.
+- **Proposed fix:** Collect all abortable `JoinHandle`s into one
+  `Vec<JoinHandle<()>>`/struct and abort uniformly in `Drop`; or document why only two
+  need explicit abort.
+- **Risk:** Low (verify shutdown tests).
+- **Impact:** Clarifies lifecycle ownership.
+
+### 14. `find_agent` / `find_machine` / `find_agent_rendezvous` share a multi-stage
+  cache→subscribe→timeout shape
+- **Location:** `src/lib.rs:6587 (find_agent), 6701 (find_machine), 7288
+  (find_agent_rendezvous)`
+- **What's wrong:** Each does "stage 1 cache hit; stage 2 subscribe to shard topic and
+  `tokio::select!` against a 5s deadline; stage 3 cache result." The deadline-loop +
+  verify + upsert block is near-identical.
+- **Proposed fix:** Extract `wait_for_announcement_on(topic, deadline, predicate)`
+  returning the first verified matching announcement. Each `find_*` keeps only its
+  cache lookup + predicate.
+- **Risk:** Medium (async select / timeout semantics must be preserved exactly).
+- **Impact:** Removes a substantial duplicated async block.
+
+### 15. `discovered_agent`/`discovered_machine`/`discovered_user` single-key lookups
+  are identical
+- **Location:** `src/lib.rs:4904, 4970, 5112`
+- **What's wrong:** All three are
+  `start_listener; Ok(cache.read().await.get(&id).cloned())`.
+- **Proposed fix:** Folds out naturally once #7's `snapshot_cache`/lookup helper exists;
+  add a `get_record(cache, id)` one-liner helper.
+- **Risk:** Low.
+- **Impact:** Minor.
+
+### 16. `connectivity.rs` `ReachabilityInfo` re-declares fields already on
+  `DiscoveredAgent` and clones them
+- **Location:** `src/connectivity.rs` `ReachabilityInfo` + `from_discovered`
+- **What's wrong:** `ReachabilityInfo` mirrors `addresses`, `nat_type`,
+  `can_receive_direct`, `is_relay`, `is_coordinator`, `reachable_via`,
+  `relay_candidates` from `DiscoveredAgent`, and `from_discovered` clones each. It's a
+  near-copy of the same field set that also appears on the announcement structs
+  (finding #5).
+- **Proposed fix:** Either make `ReachabilityInfo<'a>` borrow from `&DiscoveredAgent`
+  (no clones) if its lifetime allows, or have `DiscoveredAgent` expose a
+  `reachability(&self) -> ReachabilityView<'_>` that borrows. If a separate owned type
+  is genuinely needed, derive it via `From<&DiscoveredAgent>` and document why the copy
+  exists.
+- **Risk:** Low–medium (lifetime threading if borrowed).
+- **Impact:** Removes a 7-field clone per reachability decision.
+
+### 17. Repeated `.read().await` / `.write().await` (34 / 23 sites) — verify no
+  lock-held-across-await hazards and no double-lock
+- **Location:** throughout `impl Agent`
+- **What's wrong:** Not a duplication bug per se, but several discovery methods take a
+  read lock, clone out, then in `machine_for_agent` take a second lock — re-locking
+  patterns are easy to get subtly wrong, and a few methods clone the whole cache value
+  set under the lock.
+- **Proposed fix:** Audit each `.write().await` site for "compute under lock then drop";
+  prefer cloning the minimal key/value out and releasing before further awaits. Confirm
+  `online_agents` (holds `cache` read guard across an `await` on
+  `pw.manager().get_group_presence`) doesn't risk reader starvation — consider dropping
+  the guard before the presence await and re-reading, or snapshotting first.
+- **Risk:** Medium (concurrency semantics — needs care + the existing soak tests).
+- **Impact:** Efficiency + correctness clarity; `online_agents` at 4840 is the specific
+  one holding a read guard across an await.
+
+### 18. 120 `.clone()` sites in lib.rs — several are avoidable
+- **Location:** lib.rs broadly; notably the announcement `to_unsigned` bodies (#5), the
+  discovery `from_discovered` (#16), and `find_agent` stage-1 `addresses.clone()`
+- **What's wrong:** Many clones are structurally forced by the duplicated types above;
+  removing the duplication (#5, #16) removes the clones for free.
+- **Proposed fix:** Treat as a follow-on benefit of #5/#7/#16 rather than a standalone
+  pass. For the remainder, prefer returning references or `Arc` clones over deep
+  `Vec`/`String` clones where the caller only reads.
+- **Risk:** Low.
+- **Impact:** Modest allocation reduction on hot discovery/announce paths.
+
+### 19. `bincode::serialize` appears 22× with the same error-map closure
+- **Location:** lib.rs (announcement signing/verifying), storage.rs, others
+- **What's wrong:** `bincode::serialize(&x).map_err(|e| Error::Serialization(
+  format!("…: {e}")))` is copied repeatedly with slightly varying messages.
+- **Proposed fix:** A small `fn ser<T: Serialize>(t: &T, ctx: &str) -> Result<Vec<u8>>`
+  and matching `de` helper in a `wire`/`codec` module. Centralizes the error mapping.
+- **Risk:** Low.
+- **Impact:** ~1 line per call site removed; consistent error messages.
+
+### 20. Snapshot types (`KvEntrySnapshot`, `TaskSnapshot`) and handles
+  (`TaskListHandle`, `KvStoreHandle`) sit at the bottom of lib.rs and belong in their
+  modules
+- **Location:** `src/lib.rs:8104 (TaskListHandle), 8407 (KvStoreHandle), 8604
+  (KvEntrySnapshot), 8626 (TaskSnapshot)`, plus the `impl Agent` blocks at 8293 that
+  create them
+- **What's wrong:** `TaskListHandle`/`KvStoreHandle` are thin wrappers over `crdt`/`kv`
+  yet live in the top-level crate file, inflating lib.rs and splitting their logic from
+  the modules they wrap.
+- **Proposed fix:** Move `TaskListHandle` into `crdt/` (or a `handles` module) and
+  `KvStoreHandle` into `kv/`; re-export from lib.rs so the public path is unchanged.
+  The `create_task_list`/`join_task_list`/KV `impl Agent` methods move with #1's split.
+- **Risk:** Low (move + `pub use` re-export keeps API stable).
+- **Impact:** ~600 lines out of lib.rs; handles colocate with their backing types.
+
+---
+
+## Counts summary
+
+- **Top findings:** 10 (1 god-object split, 2 oversized methods, 4 duplication
+  families, plus guards/timestamps).
+- **Tail findings:** 10 (#11–#20).
+- **Total:** 20 findings.
+- **Largest single win:** #1 (split the 5,500-line `impl Agent`), enabling #2, #8, #12,
+  #20.
+- **Lowest-risk quick wins:** #3 (Id macro), #4 (keypair serde generic), #9 (runtime
+  guard helper), #10 (timestamp helper), #19 (bincode codec helpers).
+- **Risk-flagged (touch wire/security/concurrency — gate behind tests):** #5
+  (announcement format), #6 (verify path), #11 (error variants), #14 (async find),
+  #17 (lock-across-await).
+
+### Public-API coherence verdict
+The public surface is *capable* but not *legible*: a new user faces 94 methods on one
+`Agent` type with overlapping names (`discovered_agents` vs `discovered_agents_unfiltered`
+vs `online_agents`; `find_agent` vs `discovered_agent` vs `cached_agent`). The biggest
+new-user clarity improvements are (a) the module split (#1/#20) so methods cluster by
+concern, and (b) a short doc note distinguishing the three "get an agent" families
+(live-filtered cache view / unfiltered cache view / single lookup) — they currently look
+interchangeable but differ in TTL and network behaviour.

--- a/.planning/reviews/code-simplifier-data.md
+++ b/.planning/reviews/code-simplifier-data.md
@@ -1,0 +1,133 @@
+# Code-Simplifier Review — Data-Structures Slice
+
+Scope: `src/crdt/`, `src/kv/`, `src/mls/`, `src/groups/`.
+Date: 2026-06-10. Findings only — no code changed.
+
+Constraints honored:
+- Group-admin flows (invite issuance/consumption, ban, role changes, KeyPackage handling) → marked **DEFERRED** (#106/#107).
+- `mls/` crypto → structural/clarity only, marked **risk=high**, no wire-format change proposed.
+
+---
+
+## Top 10 highest-value findings
+
+### 1. `crdt/` and `kv/` are near-duplicate delta/sync stacks that should share a generic CRDT-store scaffold
+**Location:** `src/crdt/{delta.rs,sync.rs,task_list.rs}` vs `src/kv/{delta.rs,sync.rs,store.rs}`
+**What's wrong:** The two modules are structural mirror images:
+- Both back a collection with `OrSet<K>` (membership) + `HashMap<K,V>` (content) + `LwwRegister` (metadata) + a `version: u64` + `seq_counter: Arc<AtomicU64>`.
+- Both define a `*Delta` struct with `added`/`removed`/`updated`/`name_update`/`version` and constructor helpers (`for_add`/`for_put`, `for_state_change`/`for_update`, `new`, `is_empty`).
+- Both define a `*Sync` wrapper holding `Arc<RwLock<T>>`, a `PubSubManager`, a `topic`, an unused `AntiEntropyManager` (see #3), and a `tokio::spawn` recv loop that does the identical bincode decode (`with_fixint_encoding().with_limit(MAX_MESSAGE_DESERIALIZE_SIZE).allow_trailing_bytes().deserialize::<(PeerId, Delta)>`), `merge_delta`, warn-on-error.
+- Both implement `DeltaCrdt` with the same `delta()` = "full_delta if version moved" body and a `version()` accessor.
+**Proposed fix:** Extract a generic `CrdtStore` scaffold (the OrSet+HashMap+Lww+version+seq pattern) and a generic `GossipSync<T: DeltaCrdt>` wrapper that owns the `Arc<RwLock<T>>`, topic, decode loop, and publish path. KvStore adds only the access-control/allowlist hook; TaskList adds only ordering. Start by unifying the *sync* layer (lowest risk — the decode/merge/publish loop is byte-identical) before the store layer.
+**Risk:** medium (touches replication hot path; must keep wire format `(PeerId, Delta)` and bincode options byte-identical — KvStore and TaskList deltas stay distinct types).
+**Impact:** high — removes ~2 of the largest near-duplicated files; one decode/merge loop to test and harden instead of two.
+
+### 2. `TaskList::delta(since_version)` is a dead, misleading abstraction (production never calls it)
+**Location:** `src/crdt/delta.rs:140-167` (`delta`), `:253-269` (`DeltaCrdt for TaskList`)
+**What's wrong:** `delta()` claims to produce changes "since a version" but always emits a **full-state** delta with **placeholder OR-Set tags** `(PeerId::new([0u8;32]), 0)` and self-admits via comments ("Note: placeholder implementation", "In a real implementation, we'd only include tasks added since the version"). Production code (`lib.rs:8153/8192/8228/8280`) exclusively uses `for_add`/`for_state_change`/`for_reorder`. The only callers of `delta()`/`DeltaCrdt::delta` are tests.
+**Proposed fix:** Either (a) delete `TaskList::delta()` + the `DeltaCrdt for TaskList` impl if the gossip infra doesn't actually invoke the trait at runtime (confirm `AntiEntropyManager`/`DeltaCrdt` is never driven — see #3), or (b) if the trait must stay for type bounds, rename to `full_delta()` to match `KvStore` and drop the false "since_version" semantics and placeholder-tag comments. Do NOT leave a method whose doc contradicts its body.
+**Risk:** low (dead in production; verify no trait-object dispatch first).
+**Impact:** high — removes a self-described fake implementation that misleads every future reader of the CRDT layer.
+
+### 3. `AntiEntropyManager` is dead weight in both sync wrappers
+**Location:** `src/crdt/sync.rs:32-33,81-85` and `src/kv/sync.rs` (`anti_entropy` field, both `#[allow(dead_code)]`)
+**What's wrong:** Both `*Sync` structs construct and store an `AntiEntropyManager<T>` that is never started, polled, or read — explicitly silenced with `#[allow(dead_code)]`. The constructors take a `sync_interval_secs` param purely to feed this dead manager. Actual convergence comes from the gossip recv loop + (in kv) the `StateRequest` side channel, not from `AntiEntropyManager`.
+**Proposed fix:** Remove the `anti_entropy` field, the `AntiEntropyManager` import, and the `sync_interval_secs` constructor parameter from both sync wrappers (update the 1-2 call sites). If periodic anti-entropy is genuinely planned, leave a single `// TODO(anti-entropy)` rather than a half-wired field.
+**Risk:** low (field is provably unused).
+**Impact:** medium — removes a misleading "we do anti-entropy" signal and a vestigial constructor arg from the public-ish sync API.
+
+### 4. kv has a `StateRequest` first-join catch-up path that crdt lacks — divergence, not deduplication
+**Location:** `src/kv/sync.rs:18-45` (`STATE_SYNC_TOPIC_SUFFIX`, `STATE_REQUEST_RETRY_SECS`, `KvSyncMessage::StateRequest`, responder loop ~`:140-160`); absent in `src/crdt/sync.rs`.
+**What's wrong:** KvStoreSync gained a state-sync side channel so empty first-time joiners converge; TaskListSync has no equivalent, so a fresh TaskList subscriber only converges on the next publish. This is a real behavioral gap masked by the otherwise-parallel structure. (Relevant if #1 is done — the catch-up belongs in the shared layer.)
+**Proposed fix:** When unifying sync (#1), lift the `StateRequest`/responder pattern into the generic `GossipSync` so both task lists and kv stores get first-join catch-up. If not unifying, at minimum document on `TaskListSync` that it has no cold-start catch-up.
+**Risk:** low-medium (adds a side topic to the task-list path; CRDT merge idempotency makes duplicate responses safe, as the kv comment already notes).
+**Impact:** medium — closes a silent convergence gap and removes the "why does kv have this and crdt doesn't" puzzle.
+
+### 5. Two live `MlsGroup` planes (`group.rs` GSS vs `treekem.rs`) — legacy plane still wired into 4 daemon paths
+**Location:** `src/mls/group.rs` (`MlsGroup`, GSS) vs `src/mls/treekem.rs` (`TreeKemMlsGroup`); legacy used at `bin/x0xd.rs:459,1526,9875,10880,15781,18187`, `crdt/encrypted.rs`, `mls/keys.rs`.
+**What's wrong:** `mls/group.rs::MlsGroup` is the legacy Group-Shared-Secret plane (no FS/PCS) and is still the default for several daemon endpoints and the entire `crdt/encrypted.rs` delta-encryption path, while `TreeKemMlsGroup` is the real RFC-9420 default for new groups (ADR-0012). Two parallel group APIs (`add_member`/`remove_member`/`commit`/`encrypt_message`) with overlapping names is a clarity hazard and a migration risk.
+**Proposed fix:** **Observation only — DEFERRED + risk=high.** Do not collapse the planes here. The right vehicle is the ADR-0012 migration, not a simplification pass. Action item for that work: make every daemon call site name the plane explicitly (e.g. via `SecureGroupPlane`) so no path silently constructs a GSS group; audit whether `crdt/encrypted.rs` should move to `TreeKemMlsGroup`.
+**Risk:** high (crypto semantics + persisted plane discriminator + wire/welcome formats).
+**Impact:** high if/when addressed under ADR-0012; flagged so it isn't mistaken for dead code and deleted.
+
+### 6. `KvStore::merge_delta` mixes access-control, allowlist mutation, and three apply loops in one 90-line function
+**Location:** `src/kv/store.rs:357-443`
+**What's wrong:** One function does: (a) writer authorization with a nested `match` on policy for the anonymous case, (b) allowlist add/remove gated on owner check (duplicated `writer.is_some_and(|w| self.owner.as_ref().is_some_and(|o| o == w))` twice), (c) added-entries loop, (d) removed-keys loop, (e) updated-entries upsert loop, (f) name LWW. High cyclomatic complexity for a security-sensitive path.
+**Proposed fix:** Extract `fn authorize_writer(&self, writer) -> bool` (collapses a/the anonymous-`match`), `fn is_owner(&self, w) -> bool` (kills the duplicated owner predicate), and `fn apply_allowlist_changes(&mut self, delta, writer)`. Leave the three apply loops inline but after the gate. Keeps behavior identical, makes the security gate independently testable.
+**Risk:** low-medium (security path — keep the silent-Ok rejection semantics exactly).
+**Impact:** medium — the access-control decision becomes one named, unit-testable predicate instead of inline boolean soup.
+
+### 7. `full_delta()` / `delta()` re-derive the active-key set and clone every entry on every cold-start response
+**Location:** `src/kv/store.rs:475-494` (`full_delta`), `src/crdt/delta.rs:148-166`; called from `kv/sync.rs:155` responder loop per `StateRequest`.
+**What's wrong:** `full_delta` builds `let active: HashSet<String> = self.keys.elements().into_iter().cloned().collect();` (clones every key) then clones every `KvEntry` (incl. its `Vec<u8>` value) into the delta. The crdt `delta()` similarly `task.clone()`s every item and walks `tasks_ordered()` **twice**. Under repeated `StateRequest`s from multiple joiners this is O(state) allocation churn per request with no caching.
+**Proposed fix:** (a) In `full_delta`, iterate `self.keys.elements()` directly and look up entries instead of building an intermediate `HashSet` clone of all keys. (b) In crdt `delta()`, compute `tasks_ordered()` once and reuse for both the `added_tasks` and `ordering_update`. (c) Optional: cache the serialized full-state bytes keyed by `version` in the responder so N concurrent joiners share one serialization (idempotent today, so safe).
+**Risk:** low (pure refactor of a producer; output unchanged).
+**Impact:** medium — removes per-request whole-state re-clone + double traversal on the cold-start hot path.
+
+### 8. `KvStore::get` does a redundant `String` allocation and an O(n) `elements()` scan per read
+**Location:** `src/kv/store.rs:306-313`
+**What's wrong:** `get` allocates `key.to_string()`, then calls `self.keys.elements().contains(&&key_string)` — `elements()` materializes the whole active set and scans it linearly, just to gate a `HashMap` lookup. Every read pays an allocation + O(active-keys) scan.
+**Proposed fix:** Gate on the `HashMap` directly: `self.entries.get(key)` already returns `None` for absent keys; if tombstone-hiding is required, check membership via an OR-Set `contains(&str)` if available, or keep an `active_keys: HashSet` invariant updated on put/remove. At minimum drop the `to_string()` and use a borrowed lookup.
+**Risk:** low (verify OR-Set tombstone semantics: a removed-then-present entry must still be hidden — confirm `entries.remove` already runs on remove, which `remove()` at `:324` does, so `entries.get` alone is likely sufficient).
+**Impact:** medium — `get` is the most-called KvStore method; removes alloc + linear scan from every read.
+
+### 9. Duplicated bincode-decode incantation repeated verbatim across sync paths
+**Location:** `src/crdt/sync.rs:~115-122`, `src/kv/sync.rs:~110-119`, mirrored by the publish-side `bincode::serialize(&(peer,delta))` in both.
+**What's wrong:** The exact builder chain `bincode::options().with_fixint_encoding().with_limit(MAX_MESSAGE_DESERIALIZE_SIZE).allow_trailing_bytes().deserialize::<(PeerId, Delta)>(&payload)` and its serialize counterpart are copy-pasted. A future change to limits/encoding must be made in ≥3 places consistently or the wire format silently forks.
+**Proposed fix:** Add `fn decode_delta<D: DeserializeOwned>(payload: &[u8]) -> Result<(PeerId, D)>` and `fn encode_delta<D: Serialize>(peer, &D) -> Result<Bytes>` in a shared module (e.g. `network` or a new `gossip::wire`), used by both sync loops. Folds naturally into #1.
+**Risk:** low (mechanical; must keep the option chain byte-identical).
+**Impact:** medium — single source of truth for the on-wire delta envelope.
+
+### 10. `tasks_ordered()` builds a full `HashSet` clone and does a linear `current_order.contains` per task
+**Location:** `src/crdt/task_list.rs:349-372`
+**What's wrong:** Allocates `or_set_tasks: HashSet<TaskId>` from `elements()` every call, then for the append phase does `current_order.contains(task_id)` — an O(n) `Vec::contains` inside a loop over the set, i.e. O(n·m). Called on every render/read and twice inside `delta()`.
+**Proposed fix:** Build one `ordered_set: HashSet<&TaskId>` from `current_order` once and use it for the "already placed" check, replacing the per-iteration `Vec::contains`. Keeps the single `or_set_tasks` allocation but drops the quadratic term. Cache nothing; just fix the inner scan.
+**Risk:** low (pure read-path refactor; ordering result identical).
+**Impact:** medium — removes quadratic behavior on a frequently-called accessor.
+
+---
+
+## Tail (lower-value but worth noting)
+
+### T1. `KvStoreId`/`TaskListId`/`AgentId`-style newtype boilerplate is copy-pasted
+**Location:** `kv/store.rs:59-93`, `crdt/task_list.rs:~30-60`, `crdt/task_item.rs` (`TaskId`).
+Each 32-byte newtype re-implements `new`/`as_bytes`/`Display(hex)`/`from_content(blake3)`. A small `id_newtype!` declarative macro (or shared `Hash32` wrapper) would remove ~4 identical blocks.
+Risk: low. Impact: low-medium (cosmetic, but removes real duplication).
+
+### T2. `default_seq_counter()` + `#[serde(skip, default=...)]` pattern duplicated
+**Location:** `kv/store.rs:97` and `crdt/task_list.rs:71`. Same free function, same skip-serialize `Arc<AtomicU64>` field. Folds into the shared scaffold of #1.
+Risk: low. Impact: low.
+
+### T3. `merge_delta` "updated" upsert uses placeholder seq `(peer_id, 0)` in both kv and crdt
+**Location:** `kv/store.rs:429-431`, `crdt/delta.rs:222`. Both insert a synthetic OR-Set tag with seq `0` for out-of-order upserts. The reasoning is sound and commented, but the magic `0` and the two near-identical upsert branches are another shared-scaffold candidate. Note only.
+Risk: low (CRDT semantics — leave behavior). Impact: low.
+
+### T4. `KvEntry::merge` LWW tiebreak by `content_hash >` is subtle and undocumented at the field
+**Location:** `kv/entry.rs:89-95`. Tie-break on `updated_at` equal → higher `content_hash` wins. Correct and deterministic, but the rule lives only in the struct doc-comment, not at `merge`. Add a one-line comment at the comparison so the next reader doesn't think it's arbitrary.
+Risk: low. Impact: low (clarity).
+
+### T5. `get`-style "to_string then contains(&&x)" double-reference pattern
+**Location:** `kv/store.rs:308` `contains(&&key_string)`. The `&&` is a readability snag. Resolved by #8's borrowed-lookup fix.
+Risk: low. Impact: low.
+
+### T6. `groups/` administration code — DEFERRED
+**Location:** `groups/mod.rs` (`record_issued_invite`, `consume_issued_invite`, `add_member*`, `ban_member`, `set_member_role`, `set_member_treekem_key_package`, `kem_envelope.rs`, `invite.rs`).
+Per instructions these are being reworked under #106/#107. Observation: `GroupInfo` in `mod.rs` (1,152 lines) carries both the state-commit/roster machinery and the invite/ban/role mutators in one struct — when #106/#107 lands, consider splitting roster-mutation from discovery/card projection. **No refactor proposed now.**
+Risk: n/a. Impact: deferred.
+
+### T7. `groups/state_commit.rs` hashing helpers are well-factored — note, no action
+**Location:** `state_commit.rs:63-186` (`blake3_hex`, `compute_roster_root`, `push_len_prefixed`, `role_byte`, `state_byte`). This module is the *good* pattern (length-prefixed canonical encoding, per-component hashes). Flagged as a positive reference for how the crdt/kv hashing could be organized. The signable-bytes/sign/verify path is crypto — risk=high, no change proposed.
+Risk: high (crypto). Impact: none (commendation).
+
+### T8. `mls/group.rs` `add_member`/`remove_member`/`commit` clone `group_id` + both tree hashes repeatedly
+**Location:** `mls/group.rs:375-379,433-437,475-482,532-533`. Multiple `.clone()` of `group_id`/`new_tree_hash`/`new_transcript_hash` per commit. Structural only.
+**Risk:** high (crypto path — do NOT alter what gets hashed/signed). Observation only; if touched, confirm clones aren't load-bearing for the borrow checker before removing.
+Impact: low.
+
+---
+
+## Summary of dependencies between findings
+- #1 is the umbrella; #3, #4, #9, T2, T3 all fold into it naturally.
+- #2 and #3 should be verified together (is `DeltaCrdt` ever dispatched at runtime? If not, both the trait impl and the manager are removable).
+- #7, #8, #10 are independent, low-risk efficiency wins doable today without the #1 refactor.
+- #5 and T6 are explicitly DEFERRED (crypto / #106-#107).

--- a/.planning/reviews/code-simplifier-network.md
+++ b/.planning/reviews/code-simplifier-network.md
@@ -1,0 +1,218 @@
+# Code Simplifier Review — Networking Slice
+
+Scope: `src/network.rs`, `src/gossip/`, `src/presence.rs`, `src/direct.rs`,
+`src/dm.rs`, `src/dm_send.rs`, `src/dm_inbox.rs`, `src/peer_relay.rs`.
+
+**Overall assessment.** This slice is in good shape for code of its size and
+history. The PeerId-conversion concern is already solved (two named helpers,
+used consistently). The dm/direct family has clean responsibility boundaries.
+The receive-channel paths are already de-duplicated behind a shared helper.
+Findings below are mostly small clarity/duplication cleanups; none change
+behavior, and I have flagged the one or two that come anywhere near runtime
+semantics as `risk=high` per the constraints. There is **no large structural
+consolidation that is both safe and worthwhile** here — the dm family
+separation is intentional and load-bearing (legacy raw-QUIC vs gossip path,
+overlap release).
+
+---
+
+## Top findings (highest value first)
+
+### 1. `now_unix_ms` time helper duplicated 3× with subtly different fallbacks
+- **Location:** `dm.rs:951` (`now_unix_ms` → `unwrap_or_default()`),
+  `direct.rs:240` (`now_unix_ms_lossy` → `unwrap_or(0)`), plus an inline
+  `SystemTime::now().duration_since(UNIX_EPOCH)` at `direct.rs:218`.
+- **What's wrong:** Three copies of the same "millis since epoch, lossy on
+  pre-epoch clock" computation. `unwrap_or_default()` and `unwrap_or(0)` are
+  identical for `u64` but the divergence invites drift. `direct.rs` even has a
+  4th inline copy at line 218 that bypasses its own helper.
+- **Proposed fix:** Keep the single canonical `dm::now_unix_ms()` (already
+  `pub`), delete `direct::now_unix_ms_lossy`, re-point its callers, and replace
+  the inline `direct.rs:218` block with the helper.
+- **Risk:** low (pure function, same result for all reachable inputs).
+- **Impact:** Removes ~10 lines and one named-helper, single source of truth
+  for DM timestamps.
+
+### 2. `decode_v2` repeats the same length-prefix bounds-check stanza 4×
+- **Location:** `gossip/pubsub.rs:974-1040` (`decode_v2`).
+- **What's wrong:** The pattern `if data.len() < pos + 2 { err } let n =
+  u16::from_be_bytes([data[pos], data[pos+1]]); pos += 2; if data.len() < pos +
+  n { err } let field = &data[pos..pos+n]; pos += n;` is copy-pasted four times
+  (pubkey, signature, topic, with topic adding a UTF-8 step). This is the
+  densest duplication in the slice.
+- **Proposed fix:** Add a small local `fn take_lp<'a>(data: &'a [u8], pos: &mut
+  usize, what: &str) -> NetworkResult<&'a [u8]>` that does the two bounds checks
+  + slice + advance, returning a borrowed slice. The four sites collapse to one
+  line each; the distinct error strings become the `what` argument.
+- **Risk:** low (mechanical extraction; identical bounds math and error
+  variants preserved). Keep the existing per-field error message text via the
+  `what` parameter so wire-error diagnostics don't change.
+- **Impact:** ~40 lines → ~12, materially easier to audit the wire parser
+  (which is security-sensitive).
+
+### 3. `direct.rs` is doing two jobs: wire codec + lifecycle/registry/diagnostics
+- **Location:** `direct.rs` (1,562 lines): `DirectMessage`/`encode_message`/
+  `decode_message` (wire) vs `DirectMessaging` registry, lifecycle generations,
+  per-peer diagnostics, subscriber fan-out.
+- **What's wrong:** The file mixes the small stable wire format (`0x10` framing,
+  ~30 lines at 1255-1300) with the large stateful `DirectMessaging` service
+  (registry, lifecycle, diagnostics, subscriber queues). Readers chasing the
+  supersede/lifecycle logic wade through codec helpers and vice-versa.
+- **Proposed fix:** Optional module split — move `DirectMessage`,
+  `DirectMessageReceiver`, `encode_message`/`decode_message`, `dm_path_label`,
+  `dm_payload_digest_hex` into a `direct/wire.rs` (or leave codec in `dm.rs`
+  alongside the other wire types), leaving `direct.rs` as the service. No logic
+  moves, only declarations.
+- **Risk:** low (pure code-movement; `pub(crate)` re-exports keep call sites
+  working). Flag: do NOT touch `handle_incoming`'s internal_tx best-effort
+  enqueue comment/logic (lines ~1100-1120) — that is a hard-won back-pressure
+  fix.
+- **Impact:** Two files of clear single responsibility; reduces the cognitive
+  load of the largest non-network file.
+
+### 4. Manual `pos`-cursor wire codecs duplicate a pattern that exists 3×
+- **Location:** `gossip/pubsub.rs` `encode_v1/decode_v1/encode_v2/decode_v2`
+  (883-1040) and `direct.rs` `encode_message/decode_message` (1255-1300), and
+  the DM envelope codec in `dm.rs`.
+- **What's wrong:** Each module hand-rolls big-endian `u16` length-prefix
+  framing. Three independent implementations of the same primitive.
+- **Proposed fix:** Introduce a tiny crate-internal `wire` helper module with
+  `put_lp(buf, &[u8])` / `take_lp(data, &mut pos)` and `put_u16`/`take_u16`.
+  Migrate the three codecs incrementally. (Subsumes finding #2.)
+- **Risk:** medium — touches three serializers that produce on-wire bytes. The
+  refactor must be byte-for-byte identical; verify with the existing round-trip
+  tests (`pubsub.rs` has encode/decode tests; `direct.rs:1255+` likewise).
+  Because it spans wire formats, do it as a separate reviewed PR, not bundled.
+- **Impact:** One audited framing primitive instead of three; future format
+  bumps touch one place.
+
+### 5. `send_via_gossip` has 10 positional args (`#[allow(too_many_arguments)]`)
+- **Location:** `dm_send.rs:38-50`.
+- **What's wrong:** Ten positional params (pubsub, signing, self_agent_id,
+  self_machine_id, recipient_agent_id, recipient_kem_public_key, payload,
+  config, inflight, lifecycle_hint). The `#[allow]` silences clippy but call
+  sites are error-prone (two `AgentId` and a `MachineId` adjacent — easy to
+  transpose).
+- **Proposed fix:** Group the stable identity/context params into a
+  `DmSendContext<'a>` borrow struct (`pubsub`, `signing`, `self_agent_id`,
+  `self_machine_id`, `inflight`) passed by reference; keep per-call params
+  (`recipient_*`, `payload`, `config`, `lifecycle_hint`) as args. Drops to 5-6
+  args and removes the `#[allow]`.
+- **Risk:** low (signature-only change; no control-flow change). Internal
+  function, single primary caller.
+- **Impact:** Safer call sites, removes a lint suppression.
+
+### 6. `recv_direct` internal pull-channel is a parallel delivery surface to the subscriber fan-out
+- **Location:** `direct.rs:1026-1120` (`handle_incoming`) + `network.rs:2294`
+  (`recv_direct`).
+- **What's wrong:** Every inbound direct message is delivered twice — to the
+  per-subscriber queues AND best-effort to `internal_tx` for the legacy
+  `recv_direct()` pull API. The comment explains this is a convenience for
+  library users. It is dead weight for the daemon (the dominant deployment),
+  doubling the per-message bookkeeping and keeping a second channel alive.
+- **Proposed fix:** Do **not** change now. Document as a candidate for removal
+  once no in-tree caller depends on `recv_direct()` pull semantics (audit
+  `lib.rs`/tests). If kept, leave exactly as-is.
+- **Risk:** high (removing the internal channel changes the library-facing
+  delivery contract and could mask a back-pressure interaction the comment
+  explicitly warns about). Listed for awareness, not action.
+- **Impact:** Awareness only; potential future simplification of the direct
+  delivery path.
+
+### 7. `local:` publish branch in `publish_topic_id` is a large inline block
+- **Location:** `gossip/pubsub.rs:516-552`.
+- **What's wrong:** The same-daemon `local:` fan-out (build message, lock
+  `local_topics`, retain-with-try_send + stats accounting) is ~36 lines inlined
+  at the top of `publish_topic_id`, before the unrelated remote-publish path.
+  It mixes two distinct delivery mechanisms in one function body.
+- **Proposed fix:** Extract `async fn publish_local(&self, topic: String,
+  payload: Bytes) -> NetworkResult<()>` and early-`return` to it from the
+  `is_local_topic` guard. The retain/try_send stats logic moves verbatim.
+- **Risk:** low (verbatim move behind the existing guard; same locking order and
+  `try_send` semantics — preserve the `Full` vs `Closed` arms exactly, they
+  encode the slow-subscriber-drop fix).
+- **Impact:** `publish_topic_id` reads as "local vs remote" at a glance;
+  isolates the issue-#89 local path.
+
+### 8. `DmInboxConfig` hand-written `Debug` impl to print a `Vec` length
+- **Location:** `dm_inbox.rs` (`impl std::fmt::Debug for DmInboxConfig`).
+- **What's wrong:** A full manual `Debug` impl exists solely to print
+  `typed_payload_routes.len()` instead of the contents (because
+  `DmTypedPayloadRoute` holds an `mpsc::Sender`, which isn't `Debug`).
+- **Proposed fix:** Either `#[derive(Debug)]` on `DmInboxConfig` after making
+  `DmTypedPayloadRoute` derive `Debug` with `#[debug(skip)]`-style handling, or
+  — simpler and zero-dep — keep the manual impl but it is genuinely the minimal
+  form already. Lowest-effort real win: annotate why (one comment) and leave.
+  Net: this is near-optimal; only flag is that the `Debug` field name
+  `typed_payload_routes` prints a number, which can confuse logs.
+- **Risk:** low.
+- **Impact:** Marginal. Included for completeness; safe to skip.
+
+### 9. Triple `receive_*_message` wrappers — already factored, leave as-is (anti-finding)
+- **Location:** `network.rs:2299-2345`.
+- **What's wrong:** Nothing. `receive_pubsub_message`/`receive_membership_message`/
+  `receive_bulk_message` already delegate to a shared
+  `receive_from_gossip_channel(rx, diagnostics, stream_type, stream_name)`.
+- **Proposed fix:** None. Recorded so a future reviewer doesn't "consolidate"
+  what is already minimal and clear (three named public entry points over one
+  generic helper is the right altitude).
+- **Risk:** n/a.
+- **Impact:** Prevents a churny non-improvement.
+
+### 10. PeerId conversion — already solved, leave as-is (anti-finding)
+- **Location:** `network.rs:2642-2648` (`ant_to_gossip_peer_id` /
+  `gossip_to_ant_peer_id`), ~45 conversion sites.
+- **What's wrong:** Nothing structural. Conversions go through the two named
+  helpers (or the trivial `.0` tuple access for logging). There is no scattered
+  ad-hoc `PeerId::new(x.0)` to consolidate.
+- **Minor note:** A handful of sites use `peer_id.0` directly for `NetworkEvent`
+  construction and hex logging (e.g. `network.rs:1599,1617,1639,1923`). These
+  are the raw `[u8;32]` for the event payload, not a type conversion — correct
+  as written. No change.
+- **Risk:** n/a.
+- **Impact:** Confirms the headline concern is not actionable; avoids
+  introducing a needless newtype-wrapper layer.
+
+---
+
+## Tail (lower value)
+
+- **`direct.rs:251` `dm_path_label` + `dm_payload_digest_hex`** are small free
+  functions that belong with the wire codec move in finding #3. risk=low.
+
+- **`presence.rs` free functions (60-244)** — `global_presence_topic`,
+  `peer_to_agent_id`, `parse_addr_hints`, `presence_record_to_discovered_agent`,
+  `filter_by_trust`, `foaf_peer_score` — are a clean pure-function layer under
+  the `PresenceWrapper` service. Well-organized; no change. (anti-finding)
+
+- **`peer_relay.rs`** — zero `.clone()`, clear `RelayHeader`/`RelayPolicy`/
+  `PeerRelay` separation, sign/verify symmetric. Cleanest file in the slice;
+  no findings. (anti-finding)
+
+- **Inline `hex_prefix(&peer_id.0, 4)` for logging** repeats across
+  `network.rs` (~10 sites). Already a shared helper; the repetition is just
+  call sites. Could be a `LogTransportPeerId` newtype (one already exists and is
+  used at 1060/1570) applied uniformly, but this is cosmetic. risk=low,
+  impact=low.
+
+- **`GossipDispatchStats` / `DispatchStreamStats` / `DispatchQueueStats`**
+  (`runtime.rs:97-257`) — three stats structs each with a `snapshot()`. Some
+  boilerplate, but each tracks a distinct dispatch stage; consolidating would
+  reduce clarity. Leave. (anti-finding)
+
+- **`gossip/pubsub.rs` `encode_v1`/`encode_v2`** share the topic-length
+  `u16::try_from(...).map_err("Topic too long")` stanza. Folds into the finding
+  #4 wire helper. risk=low until done as part of #4.
+
+---
+
+## Recommended sequencing
+
+1. Findings #1, #5, #7, #8 — independent, low-risk, no wire-format impact. Safe
+   to bundle in one cleanup PR with the existing test suite as the gate.
+2. Findings #2 then #4 — wire-codec consolidation, separate reviewed PR, must
+   pass the encode/decode round-trip tests byte-for-byte. Do #2 (local to
+   `decode_v2`) first as a contained warm-up before the cross-module #4.
+3. Finding #3 — module split, mechanical but large diff; do alone so review is
+   "moved, not modified."
+4. Findings #6, #9, #10 — no action (awareness / anti-findings).

--- a/.planning/reviews/code-simplifier-tooling.md
+++ b/.planning/reviews/code-simplifier-tooling.md
@@ -1,0 +1,264 @@
+# Code Simplifier Review — Tooling Slice
+
+Scope: `src/bin/x0x.rs`, `src/cli/`, `src/api/mod.rs`, `src/exec/`, `src/upgrade/`, `src/gui/`.
+Date: 2026-06-10. Findings only — no code changed.
+
+## Context: how a command flows today
+
+Adding one endpoint (e.g. the upcoming `x0x agent verify`, issue #106) currently
+requires edits in **5 separate places**, none of which the compiler links together:
+
+1. `src/api/mod.rs` — append an `EndpointDef` to `ENDPOINTS`.
+2. `src/bin/x0x.rs` — add a variant to the relevant clap `*Sub` enum.
+3. `src/bin/x0x.rs` — add a `match` arm in `run()` dispatching to the command fn.
+4. `src/cli/commands/<area>.rs` — write the `ensure_running -> client.X -> print_value` wrapper.
+5. `src/gui/coverage-whitelist.txt` — add an entry if the GUI will not call it.
+
+The `ENDPOINTS` registry is **documentation/coverage-only**: it is consumed by
+`cli/commands/mod.rs::routes()` (the `x0x routes` table) and `bin/gui_coverage.rs`
+(the `just gui-coverage` check). It is **not** used at runtime to dispatch CLI
+subcommands or build HTTP requests — there is no link between an `EndpointDef`
+and the function that calls its path. So the registry's promise ("routes and CLI
+commands never drift out of sync") is only enforced for *naming/coverage*, not for
+*behavior*: you can add a working CLI command and forget the registry, or vice
+versa, and nothing fails to compile. The per-command wrapper functions are almost
+entirely mechanical and near-identical across ~100 functions.
+
+---
+
+## Top 10 findings (highest value first)
+
+### 1. ~100 near-identical command wrappers — the dominant duplication
+- **Location:** all of `src/cli/commands/*.rs` (e.g. `contacts.rs`, `presence.rs:11-19`,
+  `network.rs:43-160`, `group.rs` — 15 of 36 fns are pure wrappers; `discovery.rs`,
+  `machines.rs`, `store.rs`, `tasks.rs`, `files.rs`, etc.).
+- **What's wrong:** The overwhelmingly common shape is literally:
+  ```rust
+  pub async fn foo(client: &DaemonClient) -> Result<()> {
+      client.ensure_running().await?;
+      let resp = client.get("/path").await?;
+      print_value(client.format(), &resp);
+      Ok(())
+  }
+  ```
+  `ensure_running().await?` appears 130+ times; `print_value(client.format(), &resp)`
+  appears once per wrapper. This is the project's largest source of mechanical
+  boilerplate and the main reason adding an endpoint feels heavy.
+- **Proposed fix:** Add convenience methods on `DaemonClient` that fold the three
+  steps into one, returning the JSON so callers stay flexible:
+  ```rust
+  // in cli/mod.rs
+  pub async fn run_get(&self, path: &str) -> Result<()> {
+      self.ensure_running().await?;
+      let resp = self.get(path).await?;
+      print_value(self.format(), &resp);
+      Ok(())
+  }
+  pub async fn run_post<T: Serialize + ?Sized>(&self, path: &str, body: &T) -> Result<()> { ... }
+  // ...run_patch / run_put / run_delete / run_post_empty / run_get_query
+  ```
+  A pure GET wrapper collapses to `client.run_get("/contacts").await` at the call
+  site, eliminating the per-fn module wrapper entirely for the trivial majority.
+  Wrappers that mutate the response (e.g. `identity::agent` injecting
+  `identity_words`) keep their bespoke body and use the existing granular `get`/`post`.
+- **Risk:** low. Pure additive helpers; existing fns can migrate incrementally.
+- **Impact:** high. Removes hundreds of lines, makes the trivial case a one-liner,
+  and makes `agent verify` a single `client.run_post("/agent/verify", &body).await`.
+
+### 2. `start_mock_server` copy-pasted into many test modules
+- **Location:** `grep` finds `fn start_mock_server` defined independently in
+  `contacts.rs`, `presence.rs`, `identity.rs`, and several more command test modules
+  (each ~25 identical lines: axum fallback router returning fixed JSON + oneshot shutdown).
+- **What's wrong:** The same axum mock-server helper is duplicated verbatim across
+  command test modules. Any change (e.g. asserting request bodies, returning error
+  status) must be made in every copy.
+- **Proposed fix:** Hoist one `start_mock_server` into a shared test-support module
+  (e.g. `cli/commands/test_support.rs` gated `#[cfg(test)]`, or a
+  `mod test_util` re-exported under `#[cfg(test)]`) and `use` it from each module's tests.
+- **Risk:** low. Test-only.
+- **Impact:** medium-high. Removes a large block of duplicated test code; makes the
+  test harness extensible (the current copies all only assert "returns Ok").
+
+### 3. Registry is doc-only and not wired to dispatch — drift is invisible
+- **Location:** `src/api/mod.rs` (`ENDPOINTS`), consumers `cli/commands/mod.rs:37-77`
+  and `bin/gui_coverage.rs:407-421`; dispatch in `bin/x0x.rs:1089-1400`.
+- **What's wrong:** The doc comment claims the registry keeps "routes and CLI commands
+  never drift out of sync," but nothing connects an `EndpointDef` to the function that
+  serves its path. A new CLI command with no registry entry compiles and runs fine;
+  a registry entry with no command also compiles. The only guard is the `gui-coverage`
+  job and the `x0x routes` listing — both cosmetic.
+- **Proposed fix (structural, choose one):**
+  - (a) Add a CI/test that asserts every `EndpointDef.cli_name` resolves to a reachable
+    clap subcommand path and vice-versa (parse `Cli::command()` and walk subcommands).
+    This makes the "no drift" promise real without restructuring.
+  - (b) Longer-term: drive the request path from the registry — give `EndpointDef` an
+    optional handler key so command fns look up their path/method from the registry
+    instead of hardcoding string literals, removing the literal-string duplication
+    between registry and wrapper.
+- **Risk:** low for (a), medium for (b).
+- **Impact:** high. Turns a documented-but-unenforced invariant into a compile/CI-enforced
+  one; directly de-risks adding `agent verify` and future endpoints.
+
+### 4. `exec/service.rs::run_child` is 291 lines
+- **Location:** `src/exec/service.rs` `run_child` (~291 lines), `handle_request` (~129),
+  `run_remote` (~109), `stream_output` (~102).
+- **What's wrong:** `run_child` is by far the largest function in the slice and mixes
+  process spawning, stdout/stderr stream pumping, output caps/truncation, lease/idle
+  tracking, and termination/signal handling. Hard to read, test in isolation, and extend.
+- **Proposed fix:** Extract cohesive helpers: `spawn_child(...)`, the stream-pump loop
+  (already partly in `stream_output`), the cap/truncation accounting, and the
+  wait/terminate path. Each becomes independently unit-testable.
+- **Risk:** medium — this is live exec behavior with ACL/timeout/cap semantics; extract
+  mechanically without changing control flow, lean on the existing exec tests
+  (`output_caps_warn_truncate_and_keep_draining`, `duration_cap_terminates_child_promptly`).
+- **Impact:** medium-high. Improves the largest readability hotspot in `exec/`.
+
+### 5. `x0x exec` positional overloading is clever and fragile
+- **Location:** `src/bin/x0x.rs` `Commands::Exec { agent_id, timeout, stdin_file, cancel, argv }`
+  dispatch (~lines 1330-1356).
+- **What's wrong:** The first positional (`agent_id`) is overloaded as a pseudo-subcommand:
+  `agent_id == Some("sessions")` means "list sessions", `agent_id == Some("cancel")` means
+  "cancel", otherwise it's a real agent id — disambiguated by also inspecting `cancel`
+  and `argv.is_empty()`. This string-sentinel routing inside the handler is exactly the
+  kind of "clever" logic that is hard to extend and surprises users (an agent literally
+  named `sessions` or `cancel` is unreachable). Error strings (`usage: ...`) are also
+  hand-maintained instead of clap-generated.
+- **Proposed fix:** Model these as real clap subcommands: `ExecSub::Sessions`,
+  `ExecSub::Cancel { request_id, agent_id }`, `ExecSub::Run { agent_id, argv, ... }`.
+  clap then generates help/usage and removes the sentinel checks.
+- **Risk:** medium — changes the CLI surface/argument grammar; needs a check that the
+  `exec <agent> -- <argv>` form documented in CLAUDE.md still parses (likely via a
+  default/`Run` subcommand or `trailing_var_arg`). Coordinate with `docs/exec.md`.
+- **Impact:** medium. Removes the cleverest routing in the CLI; makes exec sub-actions
+  discoverable in `--help`.
+
+### 6. `cli/commands/mod.rs::routes(json)` hand-rolls JSON serialization
+- **Location:** `src/cli/commands/mod.rs:30-110` — `routes()` builds a JSON array by hand
+  with a custom `json_escape()` (handles quotes, control chars, `\uXXXX`).
+- **What's wrong:** A bespoke JSON serializer + escaper reimplements what `serde_json`
+  already does correctly, and is a latent correctness risk (the project depends on
+  `serde_json` everywhere else). The text branch's column-width formatting is fine.
+- **Proposed fix:** Derive/build a `serde_json::Value` (or a small `#[derive(Serialize)]`
+  struct mirroring `EndpointDef`) and `serde_json::to_string_pretty`. Delete `json_escape`
+  and its four unit tests.
+- **Risk:** low. Output is consumed by `just gui-coverage` tooling — keep field names
+  (`method`, `path`, `cli_name`, `description`, `category`) identical; a golden-output
+  test pins the contract.
+- **Impact:** medium. Removes a custom serializer + tests; eliminates an escaping-bug class.
+
+### 7. Ad-hoc query-string building duplicated across commands
+- **Location:** `presence.rs` (`get_query` with `ttl`/`timeout_ms`, values pre-stringified
+  via `.to_string()` into locals), `identity.rs::card` (manual `params.push("k=v")` +
+  `format!("?{}", join("&"))`), and similar elsewhere.
+- **What's wrong:** Two different idioms for the same job (typed `get_query(&[(k,&v)])`
+  vs manual string assembly with no URL-encoding). The manual path in `card` does not
+  URL-encode `display_name`, so a name with `&`/`=`/spaces corrupts the query.
+- **Proposed fix:** Standardize on `get_query`/a `query: &[(&str, Option<String>)]` helper
+  that skips `None` and percent-encodes values. Migrate `card` to it. Drop the
+  `ttl.to_string()` locals by having the helper accept `&[(&str, String)]`.
+- **Risk:** low-medium (behavior fix for encoding — verify daemon-side parsing unaffected).
+- **Impact:** medium. Removes an inconsistency and a real encoding bug.
+
+### 8. `DaemonClient` error-extraction logic duplicated three times
+- **Location:** `cli/mod.rs` — the `if !status.is_success() { body.get("error")... bail! }`
+  block appears in `get_stream` and twice inside `handle_response` (post-send check and
+  post-parse check), plus the empty-body `json!({"ok": ...})` shim.
+- **What's wrong:** The HTTP-error-to-anyhow translation is copy-pasted. `get_stream`
+  re-implements it instead of sharing.
+- **Proposed fix:** Extract `fn error_from_body(status, body) -> anyhow::Error` and a
+  small `async fn check_status(resp) -> Result<reqwest::Response>` used by both the
+  streaming and JSON paths.
+- **Risk:** low.
+- **Impact:** medium. Single source of truth for daemon error formatting.
+
+### 9. `print_value_text` recursion has subtle, untested array spacing
+- **Location:** `cli/mod.rs` `print_value_text` — arrays print a trailing blank line only
+  when `indent == 0 && !arr.is_empty()`, scalars/objects/arrays each branch separately.
+- **What's wrong:** The top-level-only blank-line rule is an implicit formatting
+  convention with no test pinning it; it is easy to break during future edits, and the
+  human-readable text format is what most users see. Not broken, but unprotected.
+- **Proposed fix:** Add a couple of golden-string tests for nested object/array rendering
+  so the text format is locked. Optionally factor the indent/`pad` handling.
+- **Risk:** low (tests only).
+- **Impact:** medium. Protects the primary user-facing output format.
+
+### 10. Dispatch `match` in `x0x.rs` is ~310 lines of mechanical mapping
+- **Location:** `src/bin/x0x.rs` `run()` ~1089-1400.
+- **What's wrong:** A very long flat `match` where most arms are a 1:1
+  `Sub::Variant { .. } => commands::area::fn(&client, ..).await`. It is not *complex*,
+  but it is a third place (after the clap enum and the command module) that must be
+  edited per endpoint, and the bulk obscures the few arms that carry real logic
+  (the `Exec` overloading in finding 5, the `UserId` pre-client branch).
+- **Proposed fix:** Keep the match (clap-derived dispatch is idiomatic), but (a) move the
+  non-trivial arms — `Exec`, `UserId` local-only handling — into small named fns so the
+  match body is uniformly one line per arm, and (b) consider splitting the per-area
+  sub-matches (`AgentsSub`, `ContactsSub`, ...) into `fn dispatch_contacts(sub, &client)`
+  helpers to shrink `run()`.
+- **Risk:** low. Pure code movement.
+- **Impact:** medium. Makes `run()` skimmable and isolates the logic-bearing arms.
+
+---
+
+## Tail findings (lower value / smaller)
+
+### 11. `discover_api` / token-resolution string juggling
+- **Location:** `cli/mod.rs::new` / `discover_api`.
+- The `http://` prefix check, port-file read, and default-port fallback are readable but
+  spread across `new` and `discover_api`. Minor: the `format!("http://{addr}")` logic is
+  duplicated between the two. Fold address normalization into one `normalize_base_url(&str)`.
+- Risk: low. Impact: low.
+
+### 12. `Method` enum has a hand-written `Display` impl
+- **Location:** `api/mod.rs:21-33`.
+- Five-arm match mapping to uppercase string. Fine, but `strum`/a `const fn as_str` would
+  remove the boilerplate if a dependency is acceptable. Low priority — leave unless
+  touching the file anyway. Risk: low. Impact: low.
+
+### 13. `routes()` text formatting uses magic column widths
+- **Location:** `cli/commands/mod.rs:55-75` — `method_width=6`, `path_width=50`,
+  `cmd_width=24`, and a `+30` fudge in the separator length.
+- The `+30` is unexplained and the widths can truncate long paths silently. Compute widths
+  from the data or add a comment. Risk: low. Impact: low.
+
+### 14. exec `agent_id`-as-sentinel also blocks valid help
+- Related to finding 5: because routing happens after clap, `x0x exec --help` cannot
+  describe `sessions`/`cancel`. Folded into the finding-5 fix.
+
+### 15. `upgrade/` — structural only (per constraint)
+- **Location:** `upgrade/apply.rs` (`apply_upgrade_from_manifest` ~lines 92-225,
+  `TempDirGuard`, `download_to_file`, archive extraction), `upgrade/mod.rs`,
+  `upgrade/monitor.rs`.
+- The Windows-specific hardening (`TempDirGuard` Drop-based cleanup, sideline replace,
+  startup sweep) is deliberately defensive and **must not be behavior-changed**.
+  Structural-only observations:
+  - `apply.rs` mixes manifest validation, download, extraction, and restart in one module;
+    `extract_from_tar_gz` / `extract_from_zip` are already nicely separated and well-tested
+    — good pattern, leave as-is.
+  - `apply_upgrade_from_manifest` is moderately long; if ever touched, the
+    validate / download / verify / swap phases could be named sub-steps **without**
+    altering the guard/sideline ordering. **Risk: high** for any change here — flag only,
+    do not refactor speculatively.
+- Impact: n/a (no action recommended now).
+
+### 16. `gui/` is a single 259 KB embedded `x0x-gui.html`
+- **Location:** `src/gui/x0x-gui.html` (264 KB) + `coverage-whitelist.txt`.
+- No `.rs` in `src/gui/` (served via `include_str!` from elsewhere). Nothing to simplify
+  structurally on the Rust side; the whitelist is well-documented with inline rationale
+  (good practice). The only note: the HTML is a large monolith, but splitting it is out of
+  scope for the tooling/Rust review and would complicate the `include_str!` embed.
+  Risk: n/a. Impact: n/a.
+
+---
+
+## Recommended sequencing for `agent verify` (issue #106) and beyond
+
+1. Land finding #1 (`run_get`/`run_post` helpers) and #2 (shared `start_mock_server`)
+   first — they are low-risk and immediately make the new command trivial.
+2. Land finding #3(a) (registry↔clap consistency test) so `agent verify` cannot silently
+   skip the registry.
+3. Then `agent verify` is: one `EndpointDef`, one `AgentSub::Verify` variant, one
+   one-line dispatch arm, one `client.run_post("/agent/verify", &body).await` (or a
+   bespoke fn if it injects `identity_words` like `agent`), whitelist entry if needed.
+
+The biggest leverage is finding #1: it converts the dominant per-command boilerplate into
+a single call and is the difference between "easy to extend" and "copy the nearest neighbor."

--- a/.planning/reviews/code-simplifier-x0xd.md
+++ b/.planning/reviews/code-simplifier-x0xd.md
@@ -1,0 +1,197 @@
+# Code-Simplifier Review — `src/bin/x0xd.rs`
+
+**File:** `/Users/davidirvine/Desktop/Devel/projects/x0x/src/bin/x0xd.rs`
+**Size:** 21,322 lines (≈19,960 non-test + ≈1,360 test module starting L19963)
+**Reviewed:** 2026-06-10
+**Constraint:** Report only — no code changes. Group-admin surfaces under issues #106/#107 are marked **DEFERRED**.
+
+## Headline metrics
+
+| Metric | Count |
+|---|---|
+| Top-level functions | 336 |
+| Internal modules (non-test) | **0** |
+| Axum handlers (`-> impl IntoResponse`) | 115 |
+| `.route(...)` registrations | 130 |
+| `(StatusCode::X, Json(json!({"ok": false, "error": ...})))` error literals | ~350 |
+| `StatusCode::` usages | 499 |
+| Full-path `base64::engine::general_purpose::STANDARD` | 73 |
+| `.clone()` calls | 512 |
+| `save_named_groups()` (full-map persist) calls | 43 |
+| Functions > 100 lines | 41 |
+| Functions > 200 lines | 5 |
+| Largest function | `apply_named_group_metadata_event_inner` — **1,663 lines** |
+| 2nd largest | `main` — **1,183 lines** |
+
+The dominant structural issue is that **this is a single flat 21k-line file with no module boundaries**. Everything — config structs, identity, file transfer, group metadata state machine, TreeKEM, the HTTP router, 115 handlers, the WebSocket layer, diagnostics, and the test module — lives in one translation unit. That is the single biggest barrier to contributor comprehension, and several smaller findings below are symptoms of it.
+
+---
+
+# TOP 10 HIGHEST-VALUE FINDINGS
+
+## 1. Split the monolith into modules (highest-value structural change)
+
+- **Location:** whole file (21,322 lines), 0 internal modules besides `mod tests` at L19963.
+- **What's wrong:** A 21k-line `main.rs` with 336 top-level functions and zero module seams. New contributors cannot form a mental map; tooling (rust-analyzer, grep, diff review) is slow; merge conflicts are guaranteed because every concern shares one file. The natural seams already exist as comment-delimited regions but are not enforced as modules.
+- **Proposed fix:** Carve `src/bin/x0xd.rs` into a thin binary entrypoint plus a `x0xd/` submodule tree. Natural seams visible from the function map:
+  - `config.rs` — `DaemonConfig`, `DaemonUpdateConfig`, the ~20 `default_*` functions (L229–L360), `impl Default`.
+  - `state.rs` — `AppState` (L423, ~50 fields) + its constructor.
+  - `responses.rs` — the error/JSON-response helpers (finding #2) + request/response DTOs (59 `Deserialize` + 27 `Serialize` derives).
+  - `router.rs` — the `Build router` block (L2089–L2298, 130 routes).
+  - `handlers/` — group handlers, contact handlers, file-transfer handlers, presence, diagnostics, etc. (115 handlers).
+  - `group_metadata.rs` — `apply_named_group_metadata_event_inner` + helpers (see #3).
+  - `ws.rs` — `handle_ws_connection`, `handle_ws_command`, `WsInbound`/`WsOutbound`.
+  - `file_transfer.rs` — `handle_file_complete`, `stream_file_chunks`, `file_send_handler`, `FileChunkAckSlot`.
+  - `persistence.rs` — `save_named_groups`, `save_mls_groups`, `write_named_groups_json_atomic`, etc.
+- **Risk:** Medium. Mechanical move-and-`pub(crate)` work; the danger is volume of churn and visibility-of-helpers. Do it incrementally (one module per PR), `cargo check` between each. Coordinate ordering with the #106/#107 contributor to avoid collisions in the group-admin region.
+- **Impact:** Very high readability. Each file becomes independently reviewable; grep/blame/diff scope shrinks 10–20×. No runtime change.
+
+## 2. Introduce error-response helpers — ~350 duplicated `(StatusCode, Json(json!({"ok":false,"error":...})))` literals
+
+- **Location:** ~350 sites file-wide. Shapes: `BAD_REQUEST` ×82, `INTERNAL_SERVER_ERROR` ×77, `NOT_FOUND` ×63, `FORBIDDEN` ×20, `SERVICE_UNAVAILABLE` ×14, `CONFLICT` ×10, plus 84 with no adjacent status. Examples: L91, L100, L2403, L2883, L2911, L2921, L2931.
+- **What's wrong:** Every handler hand-rolls the same `{ "ok": false, "error": <msg> }` JSON body paired with a status code, typically as a 5-line block. No helper exists (`grep` for `err_response`/`json_err`/`ApiError`/`bad_request` → 0 hits). This is ~1,500+ lines of boilerplate and a consistency hazard (some bodies include `"ok": false`, some only `"error"`, one variant at L2403 uses `axum::Json` and omits `"ok"`).
+- **Proposed fix:** Add small helpers in a `responses` module, e.g.
+  ```rust
+  fn api_error(status: StatusCode, msg: impl Into<String>) -> (StatusCode, Json<serde_json::Value>) {
+      (status, Json(serde_json::json!({ "ok": false, "error": msg.into() })))
+  }
+  fn bad_request(msg: impl Into<String>) -> ... { api_error(StatusCode::BAD_REQUEST, msg) }
+  // not_found, internal_error, forbidden, conflict, unavailable ...
+  ```
+  Optionally a `JsonError` newtype implementing `IntoResponse`. Collapses each 5-line block to one line and forces a single body shape.
+- **Risk:** Low. Pure refactor; the JSON shape is preserved. Verify the handful of non-`"ok"` variants (e.g. L2403 auth) are intentionally distinct and either fold them in or keep a dedicated helper.
+- **Impact:** High readability (−1,000+ lines), high consistency. Eliminates the most-repeated pattern in the file.
+
+## 3. Decompose `apply_named_group_metadata_event_inner` (1,663 lines, 16 event-variant arms)
+
+- **Location:** L8095–L9758. Single `match` over `NamedGroupMetadataEvent` with 16 arms (MemberAdded L8256, MemberRemoved L8475, GroupDeleted L8607, PolicyUpdated L8662, MemberRoleUpdated L8704, MemberBanned L8760, MemberUnbanned L8871, JoinRequest{Created/Approved/Rejected/Cancelled} L8914–L9232, GroupCardPublished L9269, GroupMetadataUpdated L9288, SecureShareDelivered L9330, MemberJoined L9418). Max brace depth 8.
+- **What's wrong:** One function holds the entire group-membership state machine. Arms run 40–300 lines each. Brace depth 8 makes control flow hard to follow; the shared validation prologue (L8151–L8165 guards `group_id` across all variants) is interleaved with per-variant logic. This is the single hardest function in the codebase to understand or modify safely.
+- **Proposed fix:** Keep the `match` as a thin dispatcher that extracts the shared prologue (group_id resolution, frontier/verified gating) once, then delegates each arm to a dedicated `apply_member_added(...)`, `apply_member_removed(...)`, `apply_group_deleted(...)`, etc., colocated in a `group_metadata` module. Each becomes independently testable.
+  - **Note / partial DEFERRAL:** several arms (`MemberBanned`, `MemberRemoved`, role updates) overlap the #106/#107 rework. Do the *extract-arm-to-function* split only for arms NOT touched by #106/#107 (e.g. GroupCardPublished, GroupMetadataUpdated, JoinRequest*, SecureShareDelivered), and coordinate the ban/remove/role arms with that contributor.
+- **Risk:** Medium-high (this is the most behaviorally sensitive code in the daemon; see MEMORY entries on TreeKEM/verified-gate races). Each extracted arm must preserve exact lock ordering and the verified-gate semantics. Extract one arm at a time behind the existing test suite.
+- **Impact:** Very high readability; enables per-variant unit tests (currently impossible). No behavior change if done carefully.
+
+## 4. Decompose `main` (1,183 lines)
+
+- **Location:** L1163–L2346. Sections (from inline comments): startup banner, GitHub fallback check, shared-state build (L1552), shard subscriptions (L1654), DM inbox (L1715), router build (L2089), server start (L2299).
+- **What's wrong:** `main` does config load, identity/agent setup, ~10 background-task spawns, the full 130-route router construction, and server bind in one body. The router block alone (L2089–L2298) is ~210 lines of `.route(...)` chaining inline.
+- **Proposed fix:** Extract `build_router(state) -> Router` (moves with finding #1's `router.rs`), `spawn_background_tasks(state)`, `load_or_init_state(config) -> AppState`, and `print_startup_banner(...)`. `main` shrinks to a readable orchestration sequence (~60 lines).
+- **Risk:** Low-medium. Spawn ordering and the "build state before join_network" comment (L1552) must be preserved — keep the call sequence identical.
+- **Impact:** High readability. `main` becomes a table of contents for daemon startup.
+
+## 5. Alias base64 STANDARD engine — 73 full-path `base64::engine::general_purpose::STANDARD`
+
+- **Location:** 73 sites file-wide (e.g. L2907, L4106, L4635, L4735, L17631). `use base64::Engine;` already exists at L34 but no engine alias.
+- **What's wrong:** `base64::engine::general_purpose::STANDARD.encode(...)` / `.decode(...)` is spelled out in full at every call site. Noise that obscures the actual data being encoded.
+- **Proposed fix:** Add `use base64::engine::general_purpose::STANDARD as B64;` (or `STANDARD_B64`) and use `B64.encode(...)` / `B64.decode(...)`. Further, the decode+match+error-response blocks (e.g. L2907, L4635) recur ~33 times paired with finding #2 — a `fn decode_b64(field: &str, value: &str) -> Result<Vec<u8>, (StatusCode, Json<..>)>` helper collapses each to a `?`-style early return.
+- **Risk:** Low (alias) / low-medium (decode helper, touches handler control flow).
+- **Impact:** Medium readability; removes ~73 noisy paths and ~33 decode boilerplate blocks.
+
+## 6. Extract the lock → mutate → persist trio for named groups
+
+- **Location:** `save_named_groups()` called 43×, `save_mls_groups()` 19×, frequently together (e.g. L8470, L8559). Pattern: `store_named_group_info(...)` → `refresh_group_card_cache_from_info(...)` → `save_named_groups(state)` → `save_mls_groups(state)`.
+- **What's wrong:** The "commit a roster change and persist" sequence is repeated verbatim across many membership mutations, each manually chaining the same 3–4 calls in the same order. Easy to get the order wrong or forget one (the codebase history shows real bugs from missed persists/cache-refreshes).
+- **Proposed fix:** A single `commit_group_update(state, group_key, next_info) -> bool` helper that does store_info → refresh_card_cache → save_named_groups → save_mls_groups in the canonical order and returns success. Mutation sites call one function.
+  - **Partial DEFERRAL:** several callers are inside the #106/#107 ban/remove/role functions — introduce the helper for the non-deferred callers; the deferred functions adopt it during their rework.
+- **Risk:** Medium (ordering of persistence vs. cache refresh is behaviorally load-bearing per MEMORY entries). Preserve exact ordering inside the helper.
+- **Impact:** High consistency; removes a class of "forgot to persist/refresh" bugs.
+
+## 7. `save_named_groups` rewrites the entire group map on every mutation — efficiency
+
+- **Location:** `save_named_groups` L18131–L18144; called 43×.
+- **What's wrong:** Each call takes `named_groups.read()`, `serde_json::to_string_pretty(&*groups)` over the **whole** map, then atomically rewrites the entire file (`write_named_groups_json_atomic`, L18146 — temp file + rename + uuid). On a busy daemon with many groups, every single-group membership change re-serializes and re-writes all groups. Under the metadata listener firing repeatedly (gossip), this is O(total_groups) disk work per event and `to_string_pretty` (pretty-printing) adds avoidable CPU.
+- **Proposed fix:** (a) Use compact `to_vec`/`to_string` instead of `to_string_pretty` for the on-disk format (it's machine-read, not human-edited). (b) Consider debouncing/coalescing saves (e.g. a dirty flag + periodic flush, or per-group files keyed by group_id like the existing `treekem_dir/*.snap` scheme) so a burst of metadata events produces one write, not N. (c) At minimum, document why full-map rewrite is acceptable if group counts are bounded.
+- **Risk:** Low for the pretty→compact change; medium for debouncing (must guarantee durability on shutdown — flush on the graceful-stop path).
+- **Impact:** Medium-high efficiency on group-heavy / high-churn daemons; reduces disk and CPU on the hot metadata path.
+
+## 8. `handle_file_complete` (1,423 lines) — second-largest function
+
+- **Location:** L19899 onward (note: extends into the test region boundary; the brace-accurate body is large regardless). `stream_file_chunks` (136 L19355), `file_send_handler` (162 L2864), `FileChunkAckSlot` (L2760).
+- **What's wrong:** The file-transfer completion path is a single very large function mixing chunk reassembly, ack handling, validation (sha256/size — see L2911–L2931), and delivery. The base64 + sha256 + size-match validation block (L2907–L2931) is itself a self-contained, reusable unit.
+- **Proposed fix:** Extract the file-transfer concern into a `file_transfer` module (finding #1) and split `handle_file_complete` into `reassemble_chunks`, `validate_payload` (b64 decode + size check + sha256 check, currently inline at L2907–L2931 and likely duplicated), and `deliver_completed_file`.
+- **Risk:** Medium (file-transfer correctness; ack-slot synchronization). Behind the e2e file-transfer tests.
+- **Impact:** High readability for a self-contained subsystem; the validation extraction also removes duplication.
+
+## 9. Centralize ID hex-encoding for logging — 143 `hex::encode` + 85 `LogHexId::`
+
+- **Location:** `hex::encode(...)` 143×, `LogHexId::` 85×, `hex::decode` 22×, file-wide.
+- **What's wrong:** Two parallel conventions coexist for turning IDs into log/JSON strings: a `LogHexId::group(...)`-style abstraction (85 uses) and raw `hex::encode(id.as_bytes())` (143 uses). Mixed conventions for the same operation make it unclear which to use and produce inconsistent log formatting (some truncated via `LogHexId`, some full hex). Per Rule 7 (surface conflicts), pick one.
+- **Proposed fix:** Standardize on `LogHexId` (or a single `id_hex(&id)` helper) for all ID-to-string in logs and JSON responses; reserve raw `hex::encode` only for wire payloads that genuinely need full hex. Audit the 143 raw sites and convert log/response uses.
+- **Risk:** Low-medium (changes log/response string formatting — confirm no consumer parses the full-hex form where truncated would appear; API responses should keep full hex, logs can truncate).
+- **Impact:** Medium readability + consistency; clearer logs.
+
+## 10. `handle_ws_command` (215 lines) — inline WS dispatch with per-arm gossip wiring
+
+- **Location:** L17574–L17789. Single `match cmd` over `WsInbound`; the `Subscribe` arm alone (L17595+) inlines shared-fanout channel creation, gossip subscription, and a spawned forwarder task (~70 lines).
+- **What's wrong:** Command parsing, per-command business logic, and the gossip-subscription/forwarder machinery are interleaved in one function. The `Subscribe` arm's broadcast-channel setup + forwarder spawn is a reusable unit buried inside a match arm.
+- **Proposed fix:** Extract `fn ensure_topic_fanout(state, topic) -> broadcast::Receiver<WsOutbound>` for the shared-channel/forwarder logic, and give each non-trivial `WsInbound` variant its own `handle_ws_subscribe`, `handle_ws_unsubscribe`, etc. Move to a `ws` module (finding #1).
+- **Risk:** Low-medium (WS reconnection/receive paths are flagged fragile in MEMORY — keep behavior identical, lean on round-trip tests).
+- **Impact:** Medium readability; isolates the fan-out logic for reuse and testing.
+
+---
+
+# LONGER TAIL
+
+## 11. `connectivity_diagnostics` (199 L16842) + `augment_pubsub_stage_diagnostics` (159 L16671)
+- Large diagnostics builders that assemble big JSON objects inline. Candidates to move into a `diagnostics` module and split per-section. **Risk:** low. **Impact:** medium readability.
+
+## 12. `run_doctor` (154 L3197), `run_gossip_update_listener` (187 L3536)
+- Self-contained subsystems (doctor checks; upgrade listener) embedded in the main file. Move to `doctor.rs` / belongs with `upgrade/`. **Risk:** low. **Impact:** medium.
+
+## 13. `import_group_card` (165 L13859), `import_agent_card` (132 L4453), `introduction` (159 L4129)
+- Card import/handshake handlers in the 100–165 line range with repeated decode→validate→cache→persist shapes. Benefit from findings #2/#5/#6 helpers. **Risk:** low. **Impact:** medium.
+
+## 14. `send_group_public_message` (176 L10203) + `public_messages` ring-buffer handling
+- Long handler; the validate→append-to-ring-buffer→gossip-publish sequence likely overlaps other public-message paths. Extract a `record_public_message` helper. **Risk:** low. **Impact:** medium.
+
+## 15. `direct_send` (165 L15505)
+- Large DM handler; per MEMORY, DM paths have had several regressions. Splitting validation from send would aid future debugging, but defer aggressive changes given fragility. **Risk:** medium. **Impact:** medium.
+
+## 16. `.clone()` density hotspots — 512 total, concentrated in group region
+- Densest buckets: L13001–14000 (62), L10001–11000 (52), L9001–10000 (46), L8001–9000 (44) — i.e. the group metadata / join / TreeKEM code. Many are `group_id.clone()` / `card.clone()` / `signed_card.clone()` repeated to satisfy the borrow checker across the lock-load-mutate-save dance. After the #3/#6 refactors, many clones can be eliminated by passing references or moving once. **Risk:** low-medium (borrow-checker driven; verify each). **Impact:** medium efficiency in the hottest code paths. Suggest a targeted clone audit *after* the structural splits, not before.
+
+## 17. `named_group_metadata_event_kind` (293 reported / brace-accurate smaller, L6066)
+- A classifier mapping events to a kind; large due to one arm per variant. Once the event enum is handled in a dedicated module (#3), this dispatcher colocates there. **Risk:** low. **Impact:** low-medium.
+
+## 18. Request/Response DTO sprawl — 59 `Deserialize` + 27 `Serialize` structs inline
+- 86 DTO derives scattered among logic. Moving them to a `dto`/`responses` module (per #1) declutters the logic files and makes the API surface greppable in one place. Several `default_*` serde-default fns (20 total, L229–L5975) belong next to their structs. **Risk:** low. **Impact:** medium readability.
+
+## 19. Bearer-token auth checked inline (15 sites)
+- Auth/token logic appears at ~15 sites with no single `require_bearer(headers) -> Result<...>` guard (e.g. L2403). An axum extractor or middleware would remove repetition and centralize the auth policy. **Risk:** medium (security-sensitive — must preserve exact reject behavior). **Impact:** medium.
+
+## 20. `read()`-then-`write()` re-lock on the same field (4 sites)
+- 4 places acquire a read lock, drop it, then acquire a write lock on the same `state.<field>` within ~15 lines — a check-then-act that re-locks and re-reads. Where the read result drives the write, fold into a single `write()` guard to avoid the redundant lock round-trip and the TOCTOU window. **Risk:** low-medium (must confirm no intentional await-point between them releasing the lock). **Impact:** low-medium efficiency + correctness.
+
+## 21. `to_string_pretty` for machine-read on-disk JSON (also #7)
+- Beyond `save_named_groups`, audit other persistence writers for `to_string_pretty` where compact `to_string`/`to_vec` suffices (disk files not meant for human editing). **Risk:** low. **Impact:** low efficiency.
+
+## 22. Inline section comments (`// Phase C.2`, `// Phase E`) as module markers
+- The code is already mentally organized by "Phase" comments (C.2, D.2, D.3, E) inside `main` and the router. These are exactly the seams for finding #1's module split — use them as the partition guide. **Risk:** n/a (observation). **Impact:** guides #1.
+
+---
+
+# DEFERRED — group-administration surfaces (issues #106/#107)
+
+Observations only; **do not refactor** — external contributor reworking these.
+
+- `create_group_invite` (L10723) and `CreateInviteRequest`/`impl Default` (L5967).
+- `add_treekem_named_group_member` (L11287, 173 lines).
+- `remove_treekem_named_group_member` (L11716, 187 lines).
+- `update_member_role` (L12432).
+- `ban_treekem_group_member` (L12685, 157 lines) and `ban_group_member` (L12538, 146 lines).
+- Their corresponding arms inside `apply_named_group_metadata_event_inner` (#3): `MemberAdded`, `MemberRemoved`, `MemberRoleUpdated`, `MemberBanned`, `MemberUnbanned`.
+
+These share the same anti-patterns flagged above (error-literal duplication #2, lock→mutate→persist trio #6, clone density #16). When the contributor reworks them, the helpers from #2/#5/#6 should be adopted there — flag this in the #106/#107 PR review rather than touching the code now.
+
+---
+
+# Suggested sequencing (lowest-risk first)
+
+1. **#5 base64 alias** + **#2 error-response helpers** — pure, mechanical, removes the most lines, zero behavior change.
+2. **#9 ID-hex standardization** + **#18/#19 DTO/auth consolidation** — low risk, sets up module split.
+3. **#1 module split** — incremental, one module per PR, `cargo check` between; coordinate group region with #106/#107.
+4. **#4 `main` decomposition** + **#10 WS split** + **#8 file-transfer split** — medium risk, behind e2e tests.
+5. **#3 metadata-event decomposition** + **#6 commit helper** — highest behavioral sensitivity, one arm at a time, full TreeKEM/soak test coverage.
+6. **#7 persist efficiency** + **#16 clone audit** + **#20 re-lock** — efficiency pass after structure is in place.
+
+All findings preserve external behavior; none change the REST/WS API surface, persisted formats (except #7's pretty→compact, which is an internal on-disk change), or wire protocol.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.23.0] - 2026-06-10
+
+### Fixed
+
+- **CRDT delta apply bypassed the LWW vector clock** (PR #108). `merge_delta` applied list name (kv + task lists) and task ordering via `LwwRegister::set()`, which bumps the local clock and adopts the value *unconditionally* — while the full-state merge path already resolved by causality. A redelivered or stale full-state snapshot could therefore overwrite a newer local name/ordering. Deltas now carry the whole `LwwRegister` (value + vector clock) and receivers resolve the winner via `LwwRegister::merge()`.
+- **`KvStore::get` could resurrect a deleted key.** A simplification assumed `entries` and the active-key OR-Set stay in lockstep, but `KvStore::merge` applies a remote tombstone without pruning `entries`. `get` now re-checks active-key membership (O(1) via `OrSet::contains`).
+- **`x0x contacts card` did not URL-encode `display_name`** — a name with spaces or `&` corrupted the query.
+
+### Added
+
+- **Task lists get cold-start bootstrap.** A first-time joiner of a task-list topic now requests state on a 1/5/15/30s schedule and holders republish full state (mirrors the kv-store side channel from #96), so tasks added before the join arrive instead of being lost. Daemon-backed e2e test included.
+
+### Changed
+
+- **Wire-format change (minor bump):** `TaskListDelta.{name_update,ordering_update}` and `KvStoreDelta.name_update` now carry an `LwwRegister<value>` instead of a bare value on the CRDT sync topics. Deltas are transient (not persisted), but mixed-version daemons cannot exchange task-list/kv deltas during rollout — coordinate the upgrade for apps using these features. The gossip relay layer is unaffected.
+- **Codebase simplification (PR #108, ~−1,300 lines):** consolidated daemon error-response and base64 boilerplate, CLI command wrappers and a `routes --json`/`exec` cleanup, a shared gossip delta codec, and dead-code removal. No REST/WebSocket API changes.
+
 ## [v0.22.1] - 2026-06-10
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.22.1"
+version = "0.23.0"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -92,8 +92,9 @@ x0x exec <agent_id> --timeout 30 -- journalctl -u x0xd -n 100
 # Send stdin from a local file.
 x0x exec <agent_id> --stdin-file payload.bin -- some-tool --consume-stdin
 
-# Cancel a local in-flight request.
+# Cancel a local in-flight request (flag form, or the `cancel` subcommand).
 x0x exec <agent_id> --cancel <request_id>
+x0x exec cancel <request_id>
 
 # List local pending and remote active sessions.
 x0x exec sessions
@@ -101,6 +102,11 @@ x0x exec sessions
 # Local exec diagnostics.
 x0x diagnostics exec
 ```
+
+`sessions` and `cancel` are real `exec` subcommands (see `x0x exec --help`),
+not positional sentinels. They never shadow a real target: agent IDs are
+64-char hex strings, so the bare words `sessions`/`cancel` can never be a valid
+`<agent_id>`.
 
 For binary output, use `--json` and decode `stdout_b64` / `stderr_b64`.
 

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -173,8 +173,16 @@ enum Commands {
     /// Stream all gossip events to stdout.
     Events,
     /// Remote non-interactive exec over the x0x mesh.
+    ///
+    /// Run a command:   `x0x exec <agent_id> -- <argv...>`
+    /// List sessions:   `x0x exec sessions`
+    /// Cancel a request: `x0x exec cancel <request_id>` (or `--cancel <id>`)
+    ///
+    /// Note: `sessions` and `cancel` are reserved sub-actions. They never
+    /// collide with a real target because agent IDs are 64-char hex strings.
+    #[command(args_conflicts_with_subcommands = true, subcommand_negates_reqs = true)]
     Exec {
-        /// Target agent ID, or the literal `sessions` to list sessions.
+        /// Target agent ID (64-char hex).
         agent_id: Option<String>,
         /// Remote timeout in seconds (remote ACL caps apply).
         #[arg(long)]
@@ -188,6 +196,9 @@ enum Commands {
         /// Command argv. Use `--` before argv to preserve flags.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         argv: Vec<String>,
+        /// `sessions` / `cancel` sub-actions.
+        #[command(subcommand)]
+        sub: Option<ExecSub>,
     },
     /// Direct messaging.
     Direct {
@@ -399,6 +410,21 @@ enum DiagnosticsSub {
     Groups,
     /// Print remote exec counters, warnings, and ACL summary.
     Exec,
+}
+
+/// Remote exec sub-actions (`x0x exec sessions`, `x0x exec cancel <id>`).
+#[derive(Subcommand)]
+enum ExecSub {
+    /// List exec sessions originated by this local daemon.
+    Sessions,
+    /// Cancel an in-flight exec request by id.
+    Cancel {
+        /// Request id to cancel.
+        request_id: String,
+        /// Optional target agent id the request was sent to.
+        #[arg(long)]
+        agent_id: Option<String>,
+    },
 }
 
 /// Presence subcommands.
@@ -1363,23 +1389,25 @@ async fn run(
             stdin_file,
             cancel,
             argv,
-        } => {
-            if agent_id.as_deref() == Some("sessions") && cancel.is_none() && argv.is_empty() {
-                commands::exec::sessions(&client).await
-            } else if agent_id.as_deref() == Some("cancel") && cancel.is_none() {
-                let Some(request_id) = argv.first() else {
-                    anyhow::bail!("usage: x0x exec cancel <request_id>");
-                };
-                commands::exec::cancel(&client, request_id, None).await
-            } else if let Some(request_id) = cancel {
-                commands::exec::cancel(&client, &request_id, agent_id.as_deref()).await
-            } else {
-                let Some(agent_id) = agent_id else {
-                    anyhow::bail!("usage: x0x exec <agent_id> [--timeout <secs>] [--stdin-file <path>] -- <argv...>");
-                };
-                commands::exec::run(&client, &agent_id, &argv, timeout, stdin_file.as_deref()).await
+            sub,
+        } => match sub {
+            Some(ExecSub::Sessions) => commands::exec::sessions(&client).await,
+            Some(ExecSub::Cancel {
+                request_id,
+                agent_id,
+            }) => commands::exec::cancel(&client, &request_id, agent_id.as_deref()).await,
+            None => {
+                if let Some(request_id) = cancel {
+                    commands::exec::cancel(&client, &request_id, agent_id.as_deref()).await
+                } else {
+                    let Some(agent_id) = agent_id else {
+                        anyhow::bail!("usage: x0x exec <agent_id> [--timeout <secs>] [--stdin-file <path>] -- <argv...>");
+                    };
+                    commands::exec::run(&client, &agent_id, &argv, timeout, stdin_file.as_deref())
+                        .await
+                }
             }
-        }
+        },
         Commands::Direct { sub } => match sub {
             DirectSub::Connect { agent_id } => commands::direct::connect(&client, &agent_id).await,
             DirectSub::Send {

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -31,6 +31,7 @@ use axum::response::sse::{Event, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, patch, post, put};
 use axum::{Json, Router};
+use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -87,23 +88,12 @@ fn parse_optional_json<T: serde::de::DeserializeOwned + Default>(
         .unwrap_or(false);
     if !is_json {
         // Non-JSON content type with a body — reject
-        return Err((
+        return Err(api_error(
             StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "Content-Type must be application/json"
-            })),
+            "Content-Type must be application/json",
         ));
     }
-    serde_json::from_slice(body).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": format!("invalid JSON: {e}")
-            })),
-        )
-    })
+    serde_json::from_slice(body).map_err(|e| bad_request(format!("invalid JSON: {e}")))
 }
 
 // ---------------------------------------------------------------------------
@@ -2879,10 +2869,7 @@ async fn file_send_handler(
         .to_string();
 
     if agent_id_hex.is_empty() || sha256.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"ok": false, "error": "agent_id and sha256 are required"})),
-        );
+        return bad_request("agent_id and sha256 are required");
     }
 
     let agent_id = match parse_agent_id_hex(agent_id_hex) {
@@ -2904,54 +2891,30 @@ async fn file_send_handler(
             .or_else(|| body.get("data_base64"))
             .and_then(|v| v.as_str())
         {
-            let data = match base64::engine::general_purpose::STANDARD.decode(data_b64) {
+            let data = match BASE64.decode(data_b64) {
                 Ok(data) => data,
                 Err(e) => {
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Json(serde_json::json!({
-                            "ok": false,
-                            "error": format!("invalid data_b64: {e}")
-                        })),
-                    );
+                    return bad_request(format!("invalid data_b64: {e}"));
                 }
             };
             if data.len() as u64 != size {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "data_b64 length does not match size"
-                    })),
-                );
+                return bad_request("data_b64 length does not match size");
             }
             let actual_sha = hex::encode(Sha256::digest(&data));
             if !sha256.eq_ignore_ascii_case(&actual_sha) {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "data_b64 sha256 mismatch"
-                    })),
-                );
+                return bad_request("data_b64 sha256 mismatch");
             }
             if let Err(e) = tokio::fs::create_dir_all(&state.transfers_dir).await {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": format!("failed to create transfer spool: {e}")
-                    })),
+                    format!("failed to create transfer spool: {e}"),
                 );
             }
             let spool_path = state.transfers_dir.join(format!("{transfer_id}.send"));
             if let Err(e) = tokio::fs::write(&spool_path, data).await {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": format!("failed to spool upload: {e}")
-                    })),
+                    format!("failed to spool upload: {e}"),
                 );
             }
             source_path = spool_path.to_string_lossy().into_owned();
@@ -3016,9 +2979,9 @@ async fn file_send_handler(
                 t.error = Some(format!("Failed to send offer: {e}"));
                 t.completed_at_unix_ms = Some(file_transfer_now().1);
             }
-            (
+            api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"ok": false, "error": format!("send offer failed: {e}")})),
+                format!("send offer failed: {e}"),
             )
         }
     }
@@ -3045,10 +3008,7 @@ async fn file_transfer_status_handler(
             StatusCode::OK,
             Json(serde_json::json!({"ok": true, "transfer": t})),
         ),
-        None => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"ok": false, "error": "transfer not found"})),
-        ),
+        None => not_found("transfer not found"),
     }
 }
 
@@ -3069,18 +3029,10 @@ async fn file_accept_handler(
                 remote_agent_hex = t.remote_agent_id.clone();
             }
             Some(_) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(
-                        serde_json::json!({"ok": false, "error": "transfer is not a pending receive"}),
-                    ),
-                );
+                return bad_request("transfer is not a pending receive");
             }
             None => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({"ok": false, "error": "transfer not found"})),
-                );
+                return not_found("transfer not found");
             }
         }
     }
@@ -3116,11 +3068,9 @@ async fn file_accept_handler(
         if let Some(t) = transfers.get_mut(&id) {
             t.status = x0x::files::TransferStatus::Pending;
         }
-        (
+        api_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(
-                serde_json::json!({"ok": false, "error": "accepted but failed to notify sender — reverted to pending"}),
-            ),
+            "accepted but failed to notify sender — reverted to pending",
         )
     } else {
         (StatusCode::OK, Json(serde_json::json!({"ok": true})))
@@ -3151,16 +3101,10 @@ async fn file_reject_handler(
                 remote_agent_hex = t.remote_agent_id.clone();
             }
             Some(_) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({"ok": false, "error": "transfer is not pending"})),
-                );
+                return bad_request("transfer is not pending");
             }
             None => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({"ok": false, "error": "transfer not found"})),
-                );
+                return not_found("transfer not found");
             }
         }
     }
@@ -4002,17 +3946,11 @@ async fn status(State(state): State<Arc<AppState>>) -> Json<ApiResponse<StatusDa
 /// GET /network/status — NAT traversal diagnostics and connection stats.
 async fn network_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let Some(network) = state.agent.network() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "network not initialized" })),
-        );
+        return api_error(StatusCode::SERVICE_UNAVAILABLE, "network not initialized");
     };
 
     let Some(status) = network.node_status().await else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "node not available" })),
-        );
+        return api_error(StatusCode::SERVICE_UNAVAILABLE, "node not available");
     };
 
     let nat_type_str = format!("{:?}", status.nat_type);
@@ -4103,8 +4041,7 @@ async fn agent_info(State(state): State<Arc<AppState>>) -> Json<ApiResponse<Agen
             agent_id: hex::encode(state.agent.agent_id().as_bytes()),
             machine_id: hex::encode(state.agent.machine_id().as_bytes()),
             user_id: state.agent.user_id().map(|u| hex::encode(u.as_bytes())),
-            kem_public_key_b64: base64::engine::general_purpose::STANDARD
-                .encode(&state.agent_kem_keypair.public_bytes),
+            kem_public_key_b64: BASE64.encode(&state.agent_kem_keypair.public_bytes),
         },
     })
 }
@@ -4309,11 +4246,7 @@ async fn announce_identity(
             })),
         )
             .into_response(),
-        Err(e) => (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        )
-            .into_response(),
+        Err(e) => bad_request(format!("{e}")).into_response(),
     }
 }
 
@@ -4458,10 +4391,7 @@ async fn import_agent_card(
     let card = match x0x::groups::card::AgentCard::from_link(&req.card) {
         Ok(c) => c,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": format!("invalid card: {e}") })),
-            );
+            return bad_request(format!("invalid card: {e}"));
         }
     };
 
@@ -4485,10 +4415,7 @@ async fn import_agent_card(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "invalid agent_id in card" })),
-            );
+            return bad_request("invalid agent_id in card");
         }
     };
     let agent_id = x0x::identity::AgentId(agent_id_bytes);
@@ -4632,39 +4559,24 @@ async fn agent_sign(
     State(state): State<Arc<AppState>>,
     Json(req): Json<AgentSignRequest>,
 ) -> impl IntoResponse {
-    let payload = match base64::engine::general_purpose::STANDARD.decode(&req.payload_b64) {
+    let payload = match BASE64.decode(&req.payload_b64) {
         Ok(bytes) => bytes,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": format!("invalid base64 payload: {e}"),
-                })),
-            );
+            return bad_request(format!("invalid base64 payload: {e}"));
         }
     };
 
     if payload.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "payload must be non-empty",
-            })),
-        );
+        return bad_request("payload must be non-empty");
     }
 
     if payload.len() > AGENT_SIGN_MAX_PAYLOAD_BYTES {
-        return (
+        return api_error(
             StatusCode::PAYLOAD_TOO_LARGE,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": format!(
-                    "payload exceeds maximum signable size of {} bytes",
-                    AGENT_SIGN_MAX_PAYLOAD_BYTES
-                ),
-            })),
+            format!(
+                "payload exceeds maximum signable size of {} bytes",
+                AGENT_SIGN_MAX_PAYLOAD_BYTES
+            ),
         );
     }
 
@@ -4675,34 +4587,16 @@ async fn agent_sign(
     let canonical = match req.domain.as_deref() {
         Some(domain) => {
             if domain.is_empty() {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "domain must be non-empty when provided",
-                    })),
-                );
+                return bad_request("domain must be non-empty when provided");
             }
             if domain.as_bytes().contains(&0u8) {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "domain must not contain NUL bytes",
-                    })),
-                );
+                return bad_request("domain must not contain NUL bytes");
             }
             if domain.len() > AGENT_SIGN_MAX_DOMAIN_BYTES {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": format!(
-                            "domain exceeds maximum length of {} bytes",
-                            AGENT_SIGN_MAX_DOMAIN_BYTES
-                        ),
-                    })),
-                );
+                return bad_request(format!(
+                    "domain exceeds maximum length of {} bytes",
+                    AGENT_SIGN_MAX_DOMAIN_BYTES
+                ));
             }
             let mut buf = Vec::with_capacity(domain.len() + 1 + payload.len());
             buf.extend_from_slice(domain.as_bytes());
@@ -4722,19 +4616,15 @@ async fn agent_sign(
     ) {
         Ok(sig) => sig,
         Err(e) => {
-            return (
+            return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": format!("signing failed: {e:?}"),
-                })),
+                format!("signing failed: {e:?}"),
             );
         }
     };
 
-    let signature_b64 = base64::engine::general_purpose::STANDARD.encode(signature.as_bytes());
-    let public_key_b64 =
-        base64::engine::general_purpose::STANDARD.encode(keypair.public_key().as_bytes());
+    let signature_b64 = BASE64.encode(signature.as_bytes());
+    let public_key_b64 = BASE64.encode(keypair.public_key().as_bytes());
     let agent_id_hex = hex::encode(state.agent.agent_id().as_bytes());
 
     let mut resp = serde_json::json!({
@@ -4768,10 +4658,7 @@ async fn peers(State(state): State<Arc<AppState>>) -> impl IntoResponse {
                 Json(serde_json::json!({ "ok": true, "peers": entries })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -4782,36 +4669,24 @@ async fn publish(
 ) -> impl IntoResponse {
     // Reject empty topic
     if req.topic.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "ok": false, "error": "topic must not be empty" })),
-        );
+        return bad_request("topic must not be empty");
     }
 
     // Decode base64 payload
-    let payload = match base64::engine::general_purpose::STANDARD.decode(&req.payload) {
+    let payload = match BASE64.decode(&req.payload) {
         Ok(p) => p,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": format!(
-                        "invalid base64 in payload field: {e}. \
+            return bad_request(format!(
+                "invalid base64 in payload field: {e}. \
                          The payload must be base64-encoded \
                          (e.g., use `echo -n \"hello\" | base64`)"
-                    )
-                })),
-            );
+            ));
         }
     };
 
     match state.agent.publish(&req.topic, payload).await {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -4841,7 +4716,7 @@ async fn subscribe(
                         data: serde_json::json!({
                             "subscription_id": sub_id,
                             "topic": topic,
-                            "payload": base64::engine::general_purpose::STANDARD.encode(&msg.payload),
+                            "payload": BASE64.encode(&msg.payload),
                             "sender": msg.sender.map(|s| hex::encode(s.0)),
                             "verified": msg.verified,
                             "trust_level": msg.trust_level.map(|t| t.to_string()),
@@ -4878,10 +4753,7 @@ async fn subscribe(
                 Json(serde_json::json!({ "ok": true, "subscription_id": id })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -4902,10 +4774,7 @@ async fn unsubscribe(
         );
         (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
     } else {
-        (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "subscription not found" })),
-        )
+        not_found("subscription not found")
     }
 }
 
@@ -4955,10 +4824,7 @@ async fn presence(State(state): State<Arc<AppState>>) -> impl IntoResponse {
                 Json(serde_json::json!({ "ok": true, "agents": entries })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5000,10 +4866,7 @@ async fn presence_online(State(state): State<Arc<AppState>>) -> impl IntoRespons
                 Json(serde_json::json!({ "ok": true, "agents": entries })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5032,10 +4895,7 @@ async fn presence_foaf(
                 Json(serde_json::json!({ "ok": true, "agents": entries })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5054,12 +4914,7 @@ async fn presence_find(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(
-                    serde_json::json!({ "ok": false, "error": "invalid agent id (expected 64 hex chars)" }),
-                ),
-            );
+            return bad_request("invalid agent id (expected 64 hex chars)");
         }
     };
     let agent_id = x0x::identity::AgentId(bytes);
@@ -5076,10 +4931,7 @@ async fn presence_find(
             StatusCode::OK,
             Json(serde_json::json!({ "ok": true, "agent": null })),
         ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5097,12 +4949,7 @@ async fn presence_status(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(
-                    serde_json::json!({ "ok": false, "error": "invalid agent id (expected 64 hex chars)" }),
-                ),
-            );
+            return bad_request("invalid agent id (expected 64 hex chars)");
         }
     };
     let agent_id = x0x::identity::AgentId(bytes);
@@ -5248,10 +5095,7 @@ async fn discovered_agents(
                 Json(serde_json::json!({ "ok": true, "agents": entries })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5308,18 +5152,10 @@ async fn discovered_agent(
                 };
             }
             Ok(None) => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(
-                        serde_json::json!({ "ok": false, "error": "agent not found within timeout" }),
-                    ),
-                );
+                return not_found("agent not found within timeout");
             }
             Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-                );
+                return api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"));
             }
         }
     }
@@ -5332,14 +5168,8 @@ async fn discovered_agent(
                 "agent": discovered_agent_entry(agent),
             })),
         ),
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "agent not found" })),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Ok(None) => not_found("agent not found"),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5362,10 +5192,7 @@ async fn discovered_machines(
                 Json(serde_json::json!({ "ok": true, "machines": entries })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5397,19 +5224,10 @@ async fn discovered_machine(
                 );
             }
             Ok(None) => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "machine not found within timeout"
-                    })),
-                );
+                return not_found("machine not found within timeout");
             }
             Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-                );
+                return api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"));
             }
         }
     }
@@ -5422,14 +5240,8 @@ async fn discovered_machine(
                 "machine": discovered_machine_entry(machine),
             })),
         ),
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "machine not found" })),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Ok(None) => not_found("machine not found"),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5457,14 +5269,8 @@ async fn machine_for_agent_handler(
                 "machine": discovered_machine_entry(machine),
             })),
         ),
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "agent machine not found" })),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Ok(None) => not_found("agent machine not found"),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5480,13 +5286,7 @@ async fn agents_by_user_handler(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "invalid user_id: expected 64 hex characters"
-                })),
-            );
+            return bad_request("invalid user_id: expected 64 hex characters");
         }
     };
     let user_id = x0x::identity::UserId(user_id_bytes);
@@ -5503,10 +5303,7 @@ async fn agents_by_user_handler(
                 })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5522,13 +5319,7 @@ async fn machines_by_user_handler(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "invalid user_id: expected 64 hex characters"
-                })),
-            );
+            return bad_request("invalid user_id: expected 64 hex characters");
         }
     };
     let user_id = x0x::identity::UserId(user_id_bytes);
@@ -5545,10 +5336,7 @@ async fn machines_by_user_handler(
                 })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -5766,14 +5554,7 @@ async fn add_machine(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "machine_id must be a 64-character hex string"
-                })),
-            )
-                .into_response();
+            return bad_request("machine_id must be a 64-character hex string").into_response();
         }
     };
     let machine_id = MachineId(machine_bytes);
@@ -5839,14 +5620,7 @@ async fn delete_machine(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "machine_id must be a 64-character hex string"
-                })),
-            )
-                .into_response();
+            return bad_request("machine_id must be a 64-character hex string").into_response();
         }
     };
     let machine_id = MachineId(machine_bytes);
@@ -5859,11 +5633,7 @@ async fn delete_machine(
     if removed {
         (StatusCode::NO_CONTENT, Json(serde_json::json!({}))).into_response()
     } else {
-        (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "machine not found" })),
-        )
-            .into_response()
+        not_found("machine not found").into_response()
     }
 }
 
@@ -5886,10 +5656,7 @@ async fn delete_contact(
     if removed.is_some() {
         (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
     } else {
-        (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "contact not found" })),
-        )
+        not_found("contact not found")
     }
 }
 
@@ -6385,17 +6152,16 @@ async fn publish_secure_share(
     secret_epoch: u64,
 ) -> bool {
     use base64::Engine as _;
-    let recipient_kem_public =
-        match base64::engine::general_purpose::STANDARD.decode(recipient_kem_public_b64) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::warn!(
-                    recipient = %LogHexId::agent(&recipient_hex),
-                    "publish_secure_share: recipient KEM public key not valid base64: {e}"
-                );
-                return false;
-            }
-        };
+    let recipient_kem_public = match BASE64.decode(recipient_kem_public_b64) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(
+                recipient = %LogHexId::agent(&recipient_hex),
+                "publish_secure_share: recipient KEM public key not valid base64: {e}"
+            );
+            return false;
+        }
+    };
     let aad = secure_share_aad(group_id, recipient_hex, secret_epoch);
     let (kem_ct, aead_nonce, aead_ct) =
         match x0x::groups::kem_envelope::seal_group_secret_to_recipient(
@@ -6413,9 +6179,9 @@ async fn publish_secure_share(
         group_id: group_id.to_string(),
         recipient: recipient_hex.to_string(),
         secret_epoch,
-        kem_ciphertext_b64: base64::engine::general_purpose::STANDARD.encode(&kem_ct),
-        aead_nonce_b64: base64::engine::general_purpose::STANDARD.encode(aead_nonce),
-        aead_ciphertext_b64: base64::engine::general_purpose::STANDARD.encode(&aead_ct),
+        kem_ciphertext_b64: BASE64.encode(&kem_ct),
+        aead_nonce_b64: BASE64.encode(aead_nonce),
+        aead_ciphertext_b64: BASE64.encode(&aead_ct),
         actor: actor_hex.to_string(),
     };
     publish_named_group_metadata_event(state, metadata_topic, &event).await;
@@ -8329,14 +8095,13 @@ async fn apply_named_group_metadata_event_inner(
             };
             if let Some((commit_b64, welcome_b64, welcome_ref, epoch)) = treekem_payload {
                 use base64::Engine as _;
-                let commit_bytes =
-                    match base64::engine::general_purpose::STANDARD.decode(commit_b64) {
-                        Ok(bytes) => bytes,
-                        Err(_) => return false,
-                    };
+                let commit_bytes = match BASE64.decode(commit_b64) {
+                    Ok(bytes) => bytes,
+                    Err(_) => return false,
+                };
                 if agent_id == local_agent_hex {
                     let welcome_bytes = if let Some(welcome_b64) = welcome_b64 {
-                        match base64::engine::general_purpose::STANDARD.decode(welcome_b64) {
+                        match BASE64.decode(welcome_b64) {
                             Ok(bytes) => bytes,
                             Err(_) => return false,
                         }
@@ -8562,11 +8327,10 @@ async fn apply_named_group_metadata_event_inner(
             }
             if let Some((commit_b64, _epoch)) = treekem_payload {
                 use base64::Engine as _;
-                let commit_bytes =
-                    match base64::engine::general_purpose::STANDARD.decode(commit_b64) {
-                        Ok(bytes) => bytes,
-                        Err(_) => return false,
-                    };
+                let commit_bytes = match BASE64.decode(commit_b64) {
+                    Ok(bytes) => bytes,
+                    Err(_) => return false,
+                };
                 let group = {
                     let map = state.treekem_groups.read().await;
                     map.get(&resolved_group_key).cloned()
@@ -8828,11 +8592,10 @@ async fn apply_named_group_metadata_event_inner(
                 }
             } else if let Some((commit_b64, epoch)) = treekem_payload {
                 use base64::Engine as _;
-                let commit_bytes =
-                    match base64::engine::general_purpose::STANDARD.decode(commit_b64) {
-                        Ok(bytes) => bytes,
-                        Err(_) => return false,
-                    };
+                let commit_bytes = match BASE64.decode(commit_b64) {
+                    Ok(bytes) => bytes,
+                    Err(_) => return false,
+                };
                 let group = {
                     let map = state.treekem_groups.read().await;
                     map.get(&resolved_group_key).cloned()
@@ -9079,14 +8842,13 @@ async fn apply_named_group_metadata_event_inner(
             };
             if let Some((commit_b64, welcome_b64, welcome_ref, _epoch)) = treekem_payload {
                 use base64::Engine as _;
-                let commit_bytes =
-                    match base64::engine::general_purpose::STANDARD.decode(commit_b64) {
-                        Ok(bytes) => bytes,
-                        Err(_) => return false,
-                    };
+                let commit_bytes = match BASE64.decode(commit_b64) {
+                    Ok(bytes) => bytes,
+                    Err(_) => return false,
+                };
                 if requester_agent_id == local_agent_hex {
                     let welcome_bytes = if let Some(welcome_b64) = welcome_b64 {
-                        match base64::engine::general_purpose::STANDARD.decode(welcome_b64) {
+                        match BASE64.decode(welcome_b64) {
                             Ok(bytes) => bytes,
                             Err(_) => return false,
                         }
@@ -9362,13 +9124,11 @@ async fn apply_named_group_metadata_event_inner(
                 return false;
             }
             use base64::Engine as _;
-            let kem_ct = match base64::engine::general_purpose::STANDARD.decode(&kem_ciphertext_b64)
-            {
+            let kem_ct = match BASE64.decode(&kem_ciphertext_b64) {
                 Ok(b) => b,
                 Err(_) => return false,
             };
-            let aead_nonce = match base64::engine::general_purpose::STANDARD.decode(&aead_nonce_b64)
-            {
+            let aead_nonce = match BASE64.decode(&aead_nonce_b64) {
                 Ok(b) => b,
                 Err(_) => return false,
             };
@@ -9377,11 +9137,10 @@ async fn apply_named_group_metadata_event_inner(
             }
             let mut nonce_bytes = [0u8; 12];
             nonce_bytes.copy_from_slice(&aead_nonce);
-            let aead_ct =
-                match base64::engine::general_purpose::STANDARD.decode(&aead_ciphertext_b64) {
-                    Ok(b) => b,
-                    Err(_) => return false,
-                };
+            let aead_ct = match BASE64.decode(&aead_ciphertext_b64) {
+                Ok(b) => b,
+                Err(_) => return false,
+            };
             let aad = secure_share_aad(ev_group_id, &recipient, secret_epoch);
             let opened = x0x::groups::kem_envelope::open_group_secret(
                 &state.agent_kem_keypair,
@@ -9442,17 +9201,16 @@ async fn apply_named_group_metadata_event_inner(
 
             // 2. Decode the joiner's published public key + signature.
             use base64::Engine as _;
-            let pubkey_bytes =
-                match base64::engine::general_purpose::STANDARD.decode(&member_public_key_b64) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        tracing::debug!(
-                            group_id = %resolved_group_key,
-                            "MemberJoined: bad public key base64: {e}"
-                        );
-                        return false;
-                    }
-                };
+            let pubkey_bytes = match BASE64.decode(&member_public_key_b64) {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::debug!(
+                        group_id = %resolved_group_key,
+                        "MemberJoined: bad public key base64: {e}"
+                    );
+                    return false;
+                }
+            };
             let pubkey = match ant_quic::MlDsaPublicKey::from_bytes(&pubkey_bytes) {
                 Ok(p) => p,
                 Err(e) => {
@@ -9463,7 +9221,7 @@ async fn apply_named_group_metadata_event_inner(
                     return false;
                 }
             };
-            let sig_bytes = match base64::engine::general_purpose::STANDARD.decode(&signature_b64) {
+            let sig_bytes = match BASE64.decode(&signature_b64) {
                 Ok(b) => b,
                 Err(e) => {
                     tracing::debug!(
@@ -9601,7 +9359,7 @@ async fn apply_named_group_metadata_event_inner(
                     let Some(kp_b64) = treekem_key_package_b64.clone() else {
                         return false;
                     };
-                    match base64::engine::general_purpose::STANDARD.decode(kp_b64) {
+                    match BASE64.decode(kp_b64) {
                         Ok(bytes) => Some(bytes),
                         Err(_) => return false,
                     }
@@ -9728,8 +9486,7 @@ async fn apply_named_group_metadata_event_inner(
                 actor: inviter_agent_id.clone(),
                 agent_id: member_agent_id.clone(),
                 display_name: display_name.clone(),
-                treekem_commit_b64: treekem_commit
-                    .map(|c| base64::engine::general_purpose::STANDARD.encode(c)),
+                treekem_commit_b64: treekem_commit.map(|c| BASE64.encode(c)),
                 treekem_welcome_b64: None,
                 welcome_ref,
                 treekem_epoch,
@@ -9860,10 +9617,7 @@ async fn create_named_group(
         Some(name) => match x0x::groups::GroupPolicyPreset::from_name(name) {
             Some(preset) => preset.to_policy(),
             None => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({ "ok": false, "error": "unknown preset" })),
-                );
+                return bad_request("unknown preset");
             }
         },
         None => x0x::groups::GroupPolicy::default(),
@@ -9887,8 +9641,7 @@ async fn create_named_group(
             {
                 use base64::Engine as _;
                 let owner_hex = hex::encode(agent_id.as_bytes());
-                let owner_kem_b64 = base64::engine::general_purpose::STANDARD
-                    .encode(&state.agent_kem_keypair.public_bytes);
+                let owner_kem_b64 = BASE64.encode(&state.agent_kem_keypair.public_bytes);
                 info.set_member_kem_public_key(&owner_hex, owner_kem_b64);
             }
 
@@ -9924,12 +9677,9 @@ async fn create_named_group(
                     Ok(tk) => tk,
                     Err(e) => {
                         tracing::error!(group_id = %group_id_hex, "failed to create TreeKEM group: {e}");
-                        return (
+                        return api_error(
                             StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(serde_json::json!({
-                                "ok": false,
-                                "error": format!("failed to create secure group: {e}")
-                            })),
+                            format!("failed to create secure group: {e}"),
                         );
                     }
                 };
@@ -9972,12 +9722,9 @@ async fn create_named_group(
                         persist_treekem_and_named_groups_atomic(&state, &group_id_hex, &guard).await
                     {
                         tracing::error!(group_id = %group_id_hex, "failed to atomically persist TreeKEM group create: {e}");
-                        return (
+                        return api_error(
                             StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(serde_json::json!({
-                                "ok": false,
-                                "error": format!("failed to persist secure group: {e}")
-                            })),
+                            format!("failed to persist secure group: {e}"),
                         );
                     }
                 }
@@ -10070,10 +9817,7 @@ async fn create_named_group(
                 })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -10104,10 +9848,7 @@ async fn get_named_group(
 ) -> impl IntoResponse {
     let groups = state.named_groups.read().await;
     let Some(info) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     let members = named_group_member_values(info);
 
@@ -10139,10 +9880,7 @@ async fn get_named_group_members(
 ) -> impl IntoResponse {
     let groups = state.named_groups.read().await;
     let Some(info) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     let members = named_group_member_values(info);
     (
@@ -10209,23 +9947,16 @@ async fn send_group_public_message(
         "chat" => x0x::groups::GroupPublicMessageKind::Chat,
         "announcement" => x0x::groups::GroupPublicMessageKind::Announcement,
         other => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": format!("unknown kind '{other}' (expected 'chat' or 'announcement')")
-                })),
-            );
+            return bad_request(format!(
+                "unknown kind '{other}' (expected 'chat' or 'announcement')"
+            ));
         }
     };
 
     if req.body.len() > x0x::groups::MAX_PUBLIC_MESSAGE_BYTES {
-        return (
+        return api_error(
             StatusCode::PAYLOAD_TOO_LARGE,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "body exceeds MAX_PUBLIC_MESSAGE_BYTES"
-            })),
+            "body exceeds MAX_PUBLIC_MESSAGE_BYTES",
         );
     }
 
@@ -10241,25 +9972,13 @@ async fn send_group_public_message(
     let (msg, direct_recipients) = {
         let groups = state.named_groups.read().await;
         let Some(info) = groups.get(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-            );
+            return not_found("group not found");
         };
         if info.policy.confidentiality != x0x::groups::GroupConfidentiality::SignedPublic {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "group is not SignedPublic — use /groups/:id/secure/encrypt"
-                })),
-            );
+            return bad_request("group is not SignedPublic — use /groups/:id/secure/encrypt");
         }
         if info.is_banned(&local_hex) {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({ "ok": false, "error": "you are banned" })),
-            );
+            return forbidden("you are banned");
         }
         // Endpoint-side write-access enforcement. Mirror the ingest
         // validator so we reject locally rather than trust receivers.
@@ -10267,13 +9986,7 @@ async fn send_group_public_message(
         match info.policy.write_access {
             x0x::groups::GroupWriteAccess::MembersOnly => {
                 if caller_role.is_none() {
-                    return (
-                        StatusCode::FORBIDDEN,
-                        Json(serde_json::json!({
-                            "ok": false,
-                            "error": "members-only write policy"
-                        })),
-                    );
+                    return forbidden("members-only write policy");
                 }
             }
             x0x::groups::GroupWriteAccess::ModeratedPublic => { /* any non-banned */ }
@@ -10282,13 +9995,7 @@ async fn send_group_public_message(
                     .map(|r| r.at_least(x0x::groups::GroupRole::Admin))
                     .unwrap_or(false);
                 if !ok {
-                    return (
-                        StatusCode::FORBIDDEN,
-                        Json(serde_json::json!({
-                            "ok": false,
-                            "error": "admin-only write policy"
-                        })),
-                    );
+                    return forbidden("admin-only write policy");
                 }
             }
         }
@@ -10310,12 +10017,9 @@ async fn send_group_public_message(
         ) {
             Ok(m) => (m, direct_recipients),
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": format!("sign failed: {e}")
-                    })),
+                    format!("sign failed: {e}"),
                 );
             }
         }
@@ -10330,23 +10034,17 @@ async fn send_group_public_message(
     let bytes = match serde_json::to_vec(&msg) {
         Ok(b) => b,
         Err(e) => {
-            return (
+            return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": format!("serialize failed: {e}")
-                })),
+                format!("serialize failed: {e}"),
             );
         }
     };
     if let Err(e) = state.agent.publish(&topic, bytes.clone()).await {
         tracing::warn!(topic = %LogHexId::topic(&topic), "E: public-send publish failed: {e}");
-        return (
+        return api_error(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": format!("publish failed: {e}")
-            })),
+            format!("publish failed: {e}"),
         );
     }
     if let Err(e) = state
@@ -10414,22 +10112,10 @@ async fn get_group_public_messages(
         }
     };
     if confidentiality == x0x::groups::GroupConfidentiality::MlsEncrypted {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "MlsEncrypted groups do not publish a plaintext message history"
-            })),
-        );
+        return bad_request("MlsEncrypted groups do not publish a plaintext message history");
     }
     if read_access == x0x::groups::GroupReadAccess::MembersOnly && !is_member {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "members-only read policy"
-            })),
-        );
+        return forbidden("members-only read policy");
     }
 
     // Ensure the listener is live on the stable-id topic.
@@ -10814,19 +10500,13 @@ async fn join_group_via_invite(
     let invite = match x0x::groups::invite::SignedInvite::from_link(&req.invite) {
         Ok(inv) => inv,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": format!("invalid invite: {e}") })),
-            );
+            return bad_request(format!("invalid invite: {e}"));
         }
     };
 
     // Check expiry
     if invite.is_expired() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "ok": false, "error": "invite has expired" })),
-        );
+        return bad_request("invite has expired");
     }
     let invite_is_treekem = invite.secure_plane == Some(x0x::mls::SecureGroupPlane::TreeKem);
 
@@ -10835,10 +10515,7 @@ async fn join_group_via_invite(
     let creator = match parse_agent_id_hex(&invite.inviter) {
         Ok(id) => id,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": format!("invalid inviter: {e}") })),
-            );
+            return bad_request(format!("invalid inviter: {e}"));
         }
     };
 
@@ -10848,12 +10525,7 @@ async fn join_group_via_invite(
     let group_id_bytes = match hex::decode(&group_id_hex) {
         Ok(bytes) => bytes,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(
-                    serde_json::json!({ "ok": false, "error": format!("invalid group_id hex: {e}") }),
-                ),
-            );
+            return bad_request(format!("invalid group_id hex: {e}"));
         }
     };
 
@@ -10863,16 +10535,13 @@ async fn join_group_via_invite(
         let prepared = match x0x::mls::TreeKemMlsGroup::prepare_member(agent_id, &seed) {
             Ok(prepared) => prepared,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": format!("failed to prepare TreeKEM KeyPackage: {e}")
-                    })),
+                    format!("failed to prepare TreeKEM KeyPackage: {e}"),
                 );
             }
         };
-        Some(base64::engine::general_purpose::STANDARD.encode(prepared.key_package_bytes()))
+        Some(BASE64.encode(prepared.key_package_bytes()))
     } else {
         None
     };
@@ -10976,7 +10645,7 @@ async fn join_group_via_invite(
             let now_ms = now_millis_u64();
             let member_pubkey_b64 = {
                 use base64::Engine as _;
-                base64::engine::general_purpose::STANDARD.encode(signing_kp.public_key().as_bytes())
+                BASE64.encode(signing_kp.public_key().as_bytes())
             };
             let stable_id_for_event = info.stable_group_id().to_string();
             let display_name_for_event = req.display_name.clone();
@@ -10998,8 +10667,7 @@ async fn join_group_via_invite(
             ) {
                 Ok(sig) => {
                     use base64::Engine as _;
-                    let signature_b64 =
-                        base64::engine::general_purpose::STANDARD.encode(sig.as_bytes());
+                    let signature_b64 = BASE64.encode(sig.as_bytes());
                     let event = NamedGroupMetadataEvent::MemberJoined {
                         group_id: info.mls_group_id.clone(),
                         stable_group_id: Some(stable_id_for_event),
@@ -11127,10 +10795,7 @@ async fn join_group_via_invite(
                 })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -11142,10 +10807,7 @@ async fn set_group_display_name(
 ) -> impl IntoResponse {
     let mut groups = state.named_groups.write().await;
     let Some(info) = groups.get_mut(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
 
     let agent_hex = hex::encode(state.agent.agent_id().as_bytes());
@@ -11187,18 +10849,10 @@ async fn add_named_group_member(
     let (metadata_topic, event, members, epoch) = {
         let mut named_groups = state.named_groups.write().await;
         let Some(info) = named_groups.get_mut(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-            );
+            return not_found("group not found");
         };
         if local_agent != info.creator {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(
-                    serde_json::json!({ "ok": false, "error": "only the creator can add members" }),
-                ),
-            );
+            return forbidden("only the creator can add members");
         }
         if info.secure_plane == x0x::mls::SecureGroupPlane::TreeKem {
             drop(named_groups);
@@ -11207,10 +10861,7 @@ async fn add_named_group_member(
 
         let agent_hex = hex::encode(agent_id.as_bytes());
         if info.has_member(&agent_hex) {
-            return (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({ "ok": false, "error": "member already present" })),
-            );
+            return api_error(StatusCode::CONFLICT, "member already present");
         }
         info.roster_revision = info.roster_revision.saturating_add(1);
         let actor_hex = hex::encode(local_agent.as_bytes());
@@ -11227,9 +10878,9 @@ async fn add_named_group_member(
         let commit = match info.seal_commit(signing_kp, now_ms) {
             Ok(c) => c,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                    format!("seal failed: {e}"),
                 );
             }
         };
@@ -11501,33 +11152,17 @@ async fn remove_named_group_member(
     let (metadata_topic, event, members, epoch) = {
         let mut named_groups = state.named_groups.write().await;
         let Some(info) = named_groups.get_mut(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-            );
+            return not_found("group not found");
         };
 
         if agent_id_hex == hex::encode(info.creator.as_bytes()) {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(
-                    serde_json::json!({ "ok": false, "error": "cannot remove creator via member API; delete the group instead" }),
-                ),
-            );
+            return bad_request("cannot remove creator via member API; delete the group instead");
         }
         if local_agent != info.creator {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(
-                    serde_json::json!({ "ok": false, "error": "only the creator can remove other members" }),
-                ),
-            );
+            return forbidden("only the creator can remove other members");
         }
         if !info.has_member(&agent_id_hex) {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "member not found" })),
-            );
+            return not_found("member not found");
         }
 
         info.roster_revision = info.roster_revision.saturating_add(1);
@@ -11536,9 +11171,9 @@ async fn remove_named_group_member(
         let commit = match info.seal_commit(signing_kp, now_ms) {
             Ok(c) => c,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                    format!("seal failed: {e}"),
                 );
             }
         };
@@ -11926,10 +11561,7 @@ async fn get_group_state(
 ) -> impl IntoResponse {
     let groups = state.named_groups.read().await;
     let Some(info) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     let roster_root = x0x::groups::compute_roster_root(&info.members_v2);
     let policy_hash = x0x::groups::compute_policy_hash(&info.policy);
@@ -11966,31 +11598,19 @@ async fn seal_group_state(
     {
         let groups = state.named_groups.read().await;
         let Some(info) = groups.get(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-            );
+            return not_found("group not found");
         };
         let role = info.caller_role(&local_hex);
         if !role
             .map(|r| r.at_least(x0x::groups::GroupRole::Admin))
             .unwrap_or(false)
         {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "owner or admin required to seal state"
-                })),
-            );
+            return forbidden("owner or admin required to seal state");
         }
     }
     let commit = publish_group_card_with_reseal(&state, &id).await;
     let Some(commit) = commit else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": "seal failed" })),
-        );
+        return api_error(StatusCode::INTERNAL_SERVER_ERROR, "seal failed");
     };
     (
         StatusCode::OK,
@@ -12021,29 +11641,17 @@ async fn withdraw_group_state(
     let commit = {
         let mut groups = state.named_groups.write().await;
         let Some(info) = groups.get_mut(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-            );
+            return not_found("group not found");
         };
         if info.caller_role(&local_hex) != Some(x0x::groups::GroupRole::Owner) {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "owner required to withdraw"
-                })),
-            );
+            return forbidden("owner required to withdraw");
         }
         match info.seal_withdrawal(signing_kp, now_ms) {
             Ok(c) => c,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": format!("withdrawal seal failed: {e}")
-                    })),
+                    format!("withdrawal seal failed: {e}"),
                 );
             }
         }
@@ -12082,10 +11690,7 @@ async fn leave_group(
 
     let mut groups = state.named_groups.write().await;
     let Some(info) = groups.get_mut(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
 
     let is_creator = local_agent == info.creator;
@@ -12101,11 +11706,9 @@ async fn leave_group(
         let commit = match info.seal_withdrawal(signing_kp, now_ms) {
             Ok(c) => c,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(
-                        serde_json::json!({ "ok": false, "error": format!("withdrawal seal failed: {e}") }),
-                    ),
+                    format!("withdrawal seal failed: {e}"),
                 );
             }
         };
@@ -12125,9 +11728,9 @@ async fn leave_group(
         let commit = match info.seal_commit(signing_kp, now_ms) {
             Ok(c) => c,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                    format!("seal failed: {e}"),
                 );
             }
         };
@@ -12238,10 +11841,7 @@ fn require_admin_or_above(
 ) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
     match info.caller_role(caller_hex) {
         Some(role) if role.at_least(x0x::groups::GroupRole::Admin) => Ok(()),
-        _ => Err((
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({ "ok": false, "error": "admin role required" })),
-        )),
+        _ => Err(forbidden("admin role required")),
     }
 }
 
@@ -12251,10 +11851,7 @@ fn require_owner(
 ) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
     match info.caller_role(caller_hex) {
         Some(x0x::groups::GroupRole::Owner) => Ok(()),
-        _ => Err((
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({ "ok": false, "error": "owner role required" })),
-        )),
+        _ => Err(forbidden("owner role required")),
     }
 }
 
@@ -12273,10 +11870,7 @@ async fn update_named_group(
     let _membership_guard = membership_lock.lock().await;
     let mut groups = state.named_groups.write().await;
     let Some(info) = groups.get_mut(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     if let Err(e) = require_admin_or_above(info, &caller_hex) {
         return e;
@@ -12295,9 +11889,9 @@ async fn update_named_group(
     let commit = match info.seal_commit(signing_kp, now_ms) {
         Ok(c) => c,
         Err(e) => {
-            return (
+            return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                format!("seal failed: {e}"),
             );
         }
     };
@@ -12343,10 +11937,7 @@ async fn update_group_policy(
     let now_ms = now_millis_u64();
     let mut groups = state.named_groups.write().await;
     let Some(info) = groups.get_mut(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     if let Err(e) = require_owner(info, &caller_hex) {
         return e;
@@ -12357,10 +11948,7 @@ async fn update_group_policy(
         match x0x::groups::GroupPolicyPreset::from_name(preset_name) {
             Some(preset) => new_policy = preset.to_policy(),
             None => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({ "ok": false, "error": "unknown preset" })),
-                );
+                return bad_request("unknown preset");
             }
         }
     }
@@ -12398,9 +11986,9 @@ async fn update_group_policy(
     let commit = match info.seal_commit(signing_kp, now_ms) {
         Ok(c) => c,
         Err(e) => {
-            return (
+            return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                format!("seal failed: {e}"),
             );
         }
     };
@@ -12549,10 +12137,7 @@ async fn ban_group_member(
     let _membership_guard = membership_lock.lock().await;
     let mut groups = state.named_groups.write().await;
     let Some(info) = groups.get_mut(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     if let Err(e) = require_admin_or_above(info, &caller_hex) {
         return e;
@@ -12562,10 +12147,7 @@ async fn ban_group_member(
         return ban_treekem_group_member(state, id, agent_id_hex, caller_hex).await;
     }
     if info.caller_role(&agent_id_hex) == Some(x0x::groups::GroupRole::Owner) {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({ "ok": false, "error": "cannot ban owner" })),
-        );
+        return forbidden("cannot ban owner");
     }
     info.ban_member(&agent_id_hex, Some(caller_hex.clone()));
     info.roster_revision = info.roster_revision.saturating_add(1);
@@ -12596,9 +12178,9 @@ async fn ban_group_member(
     let commit = match info.seal_commit(signing_kp, now_ms) {
         Ok(c) => c,
         Err(e) => {
-            return (
+            return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                format!("seal failed: {e}"),
             );
         }
     };
@@ -12850,19 +12432,13 @@ async fn unban_group_member(
     let now_ms = now_millis_u64();
     let mut groups = state.named_groups.write().await;
     let Some(info) = groups.get_mut(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     if let Err(e) = require_admin_or_above(info, &caller_hex) {
         return e;
     }
     if !info.is_banned(&agent_id_hex) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "ok": false, "error": "member is not banned" })),
-        );
+        return bad_request("member is not banned");
     }
     if info.secure_plane == x0x::mls::SecureGroupPlane::TreeKem {
         if let Some(member) = info.members_v2.get_mut(&agent_id_hex) {
@@ -12878,9 +12454,9 @@ async fn unban_group_member(
     let commit = match info.seal_commit(signing_kp, now_ms) {
         Ok(c) => c,
         Err(e) => {
-            return (
+            return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                format!("seal failed: {e}"),
             );
         }
     };
@@ -12913,10 +12489,7 @@ async fn list_join_requests(
     let caller_hex = hex::encode(state.agent.agent_id().as_bytes());
     let groups = state.named_groups.read().await;
     let Some(info) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     if let Err(e) = require_admin_or_above(info, &caller_hex) {
         return e;
@@ -12947,40 +12520,23 @@ async fn create_join_request(
     let (metadata_topic, event_group_id, request, creator_hex, commit) = {
         let mut groups = state.named_groups.write().await;
         let Some(info) = groups.get_mut(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-            );
+            return not_found("group not found");
         };
         if info.policy.admission != x0x::groups::GroupAdmission::RequestAccess {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(
-                    serde_json::json!({ "ok": false, "error": "group admission is not request_access" }),
-                ),
-            );
+            return forbidden("group admission is not request_access");
         }
         if info.is_banned(&caller_hex) {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({ "ok": false, "error": "banned" })),
-            );
+            return forbidden("banned");
         }
         if info.has_active_member(&caller_hex) {
-            return (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({ "ok": false, "error": "already a member" })),
-            );
+            return api_error(StatusCode::CONFLICT, "already a member");
         }
         if info
             .join_requests
             .values()
             .any(|r| r.requester_agent_id == caller_hex && r.is_pending())
         {
-            return (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({ "ok": false, "error": "pending request already exists" })),
-            );
+            return api_error(StatusCode::CONFLICT, "pending request already exists");
         }
 
         let mut request = x0x::groups::JoinRequest::new(
@@ -12994,41 +12550,33 @@ async fn create_join_request(
             let group_id_bytes = match hex::decode(&info.mls_group_id) {
                 Ok(bytes) => bytes,
                 Err(e) => {
-                    return (
+                    return api_error(
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(
-                            serde_json::json!({ "ok": false, "error": format!("invalid TreeKEM group id: {e}") }),
-                        ),
+                        format!("invalid TreeKEM group id: {e}"),
                     );
                 }
             };
             let seed = agent_treekem_seed(state.agent.as_ref(), &group_id_bytes);
-            let prepared = match x0x::mls::TreeKemMlsGroup::prepare_member(
-                state.agent.agent_id(),
-                &seed,
-            ) {
-                Ok(prepared) => prepared,
-                Err(e) => {
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(
-                            serde_json::json!({ "ok": false, "error": format!("failed to prepare TreeKEM KeyPackage: {e}") }),
-                        ),
-                    );
-                }
-            };
-            request.treekem_key_package_b64 = Some(
-                base64::engine::general_purpose::STANDARD.encode(prepared.key_package_bytes()),
-            );
+            let prepared =
+                match x0x::mls::TreeKemMlsGroup::prepare_member(state.agent.agent_id(), &seed) {
+                    Ok(prepared) => prepared,
+                    Err(e) => {
+                        return api_error(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("failed to prepare TreeKEM KeyPackage: {e}"),
+                        );
+                    }
+                };
+            request.treekem_key_package_b64 = Some(BASE64.encode(prepared.key_package_bytes()));
         }
         info.join_requests
             .insert(request.request_id.clone(), request.clone());
         let commit = match info.seal_commit(signing_kp, now_ms) {
             Ok(c) => c,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                    format!("seal failed: {e}"),
                 );
             }
         };
@@ -13044,8 +12592,7 @@ async fn create_join_request(
     // Include our ML-KEM-768 public key so the approver can seal the group
     // shared secret directly to us on approval.
     use base64::Engine as _;
-    let requester_kem_b64 =
-        base64::engine::general_purpose::STANDARD.encode(&state.agent_kem_keypair.public_bytes);
+    let requester_kem_b64 = BASE64.encode(&state.agent_kem_keypair.public_bytes);
     let event = NamedGroupMetadataEvent::JoinRequestCreated {
         group_id: event_group_id,
         request_id: request.request_id.clone(),
@@ -13096,10 +12643,7 @@ async fn approve_join_request(
     let (metadata_topic, event_group_id, requester_hex, revision, commit) = {
         let mut groups = state.named_groups.write().await;
         let Some(info) = groups.get_mut(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-            );
+            return not_found("group not found");
         };
         if let Err(e) = require_admin_or_above(info, &caller_hex) {
             return e;
@@ -13108,16 +12652,10 @@ async fn approve_join_request(
             return resp;
         }
         let Some(req) = info.join_requests.get_mut(&request_id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "request not found" })),
-            );
+            return not_found("request not found");
         };
         if !req.is_pending() {
-            return (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({ "ok": false, "error": "request is not pending" })),
-            );
+            return api_error(StatusCode::CONFLICT, "request is not pending");
         }
         req.status = x0x::groups::JoinRequestStatus::Approved;
         req.reviewed_by = Some(caller_hex.clone());
@@ -13133,9 +12671,9 @@ async fn approve_join_request(
         let commit = match info.seal_commit(signing_kp, now_ms) {
             Ok(c) => c,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                    format!("seal failed: {e}"),
                 );
             }
         };
@@ -13277,31 +12815,19 @@ async fn approve_treekem_join_request(
     let (mut next, metadata_topic, event_group_id, requester_hex, requester_id, kp_bytes) = {
         let groups = state.named_groups.read().await;
         let Some(info) = groups.get(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-            );
+            return not_found("group not found");
         };
         if let Err(e) = require_admin_or_above(info, &caller_hex) {
             return e;
         }
         let Some(req) = info.join_requests.get(&request_id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "request not found" })),
-            );
+            return not_found("request not found");
         };
         if !req.is_pending() {
-            return (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({ "ok": false, "error": "request is not pending" })),
-            );
+            return api_error(StatusCode::CONFLICT, "request is not pending");
         }
         if info.is_banned(&req.requester_agent_id) {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({ "ok": false, "error": "requester is banned" })),
-            );
+            return forbidden("requester is banned");
         }
         let requester_id = match parse_agent_id_hex(&req.requester_agent_id) {
             Ok(id) => id,
@@ -13313,24 +12839,15 @@ async fn approve_treekem_join_request(
             }
         };
         let Some(kp_b64) = req.treekem_key_package_b64.clone() else {
-            return (
+            return api_error(
                 StatusCode::FAILED_DEPENDENCY,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "request is missing TreeKEM KeyPackage"
-                })),
+                "request is missing TreeKEM KeyPackage",
             );
         };
-        let kp_bytes = match base64::engine::general_purpose::STANDARD.decode(kp_b64) {
+        let kp_bytes = match BASE64.decode(kp_b64) {
             Ok(bytes) => bytes,
             Err(_) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "request TreeKEM KeyPackage is not valid base64"
-                    })),
-                );
+                return bad_request("request TreeKEM KeyPackage is not valid base64");
             }
         };
         (
@@ -13348,12 +12865,9 @@ async fn approve_treekem_join_request(
         map.get(&id).cloned()
     };
     let Some(group) = group else {
-        return (
+        return api_error(
             StatusCode::FAILED_DEPENDENCY,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "TreeKEM group not loaded — restart or re-share required"
-            })),
+            "TreeKEM group not loaded — restart or re-share required",
         );
     };
     let mut guard = group.lock().await;
@@ -13370,53 +12884,41 @@ async fn approve_treekem_join_request(
         Some(caller_hex.clone()),
         None,
     );
-    next.set_member_treekem_key_package(
-        &requester_hex,
-        base64::engine::general_purpose::STANDARD.encode(&kp_bytes),
-    );
+    next.set_member_treekem_key_package(&requester_hex, BASE64.encode(&kp_bytes));
     next.secret_epoch = treekem_epoch;
     next.security_binding = Some(format!("treekem:epoch={treekem_epoch}"));
     let revision = next.roster_revision;
     let commit = match next.seal_commit(signing_kp, now_ms) {
         Ok(c) => c,
         Err(e) => {
-            return (
+            return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                format!("seal failed: {e}"),
             );
         }
     };
     let out = match guard.add_member(requester_id, &kp_bytes) {
         Ok(out) => out,
         Err(e) => {
-            return (
+            return api_error(
                 StatusCode::CONFLICT,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": format!("TreeKEM add_member failed: {e}")
-                })),
+                format!("TreeKEM add_member failed: {e}"),
             );
         }
     };
     if guard.epoch() != treekem_epoch {
-        return (
+        return api_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "TreeKEM epoch did not advance as expected"
-            })),
+            "TreeKEM epoch did not advance as expected",
         );
     }
     if let Err(e) =
         persist_treekem_and_named_groups_atomic_with_info(&state, &id, next.clone(), &guard).await
     {
         tracing::error!(group_id = %LogHexId::group(&id), "failed to persist TreeKEM snapshot after approval: {e}");
-        return (
+        return api_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "failed to persist secure group state"
-            })),
+            "failed to persist secure group state",
         );
     }
     let treekem_commit = out.commit;
@@ -13436,7 +12938,7 @@ async fn approve_treekem_join_request(
         revision,
         actor: caller_hex,
         requester_agent_id: requester_hex.clone(),
-        treekem_commit_b64: Some(base64::engine::general_purpose::STANDARD.encode(treekem_commit)),
+        treekem_commit_b64: Some(BASE64.encode(treekem_commit)),
         treekem_welcome_b64: None,
         welcome_ref: Some(welcome_ref),
         treekem_epoch: Some(treekem_epoch),
@@ -13470,25 +12972,16 @@ async fn reject_join_request(
     let (metadata_topic, event_group_id, requester_hex, commit) = {
         let mut groups = state.named_groups.write().await;
         let Some(info) = groups.get_mut(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-            );
+            return not_found("group not found");
         };
         if let Err(e) = require_admin_or_above(info, &caller_hex) {
             return e;
         }
         let Some(req) = info.join_requests.get_mut(&request_id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "request not found" })),
-            );
+            return not_found("request not found");
         };
         if !req.is_pending() {
-            return (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({ "ok": false, "error": "request is not pending" })),
-            );
+            return api_error(StatusCode::CONFLICT, "request is not pending");
         }
         req.status = x0x::groups::JoinRequestStatus::Rejected;
         req.reviewed_by = Some(caller_hex.clone());
@@ -13497,9 +12990,9 @@ async fn reject_join_request(
         let commit = match info.seal_commit(signing_kp, now_ms) {
             Ok(c) => c,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                    format!("seal failed: {e}"),
                 );
             }
         };
@@ -13537,37 +13030,25 @@ async fn cancel_join_request(
     let (metadata_topic, event_group_id, requester_hex, commit) = {
         let mut groups = state.named_groups.write().await;
         let Some(info) = groups.get_mut(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-            );
+            return not_found("group not found");
         };
         let Some(req) = info.join_requests.get_mut(&request_id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "request not found" })),
-            );
+            return not_found("request not found");
         };
         if req.requester_agent_id != caller_hex {
-            return (
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({ "ok": false, "error": "not your request" })),
-            );
+            return forbidden("not your request");
         }
         if !req.is_pending() {
-            return (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({ "ok": false, "error": "request is not pending" })),
-            );
+            return api_error(StatusCode::CONFLICT, "request is not pending");
         }
         req.status = x0x::groups::JoinRequestStatus::Cancelled;
         let requester_hex = req.requester_agent_id.clone();
         let commit = match info.seal_commit(signing_kp, now_ms) {
             Ok(c) => c,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": format!("seal failed: {e}") })),
+                    format!("seal failed: {e}"),
                 );
             }
         };
@@ -13723,13 +13204,7 @@ async fn create_discovery_subscription(
     Json(req): Json<SubscribeDiscoveryRequest>,
 ) -> impl IntoResponse {
     let Some(kind) = x0x::groups::ShardKind::from_str(&req.kind) else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "kind must be 'tag', 'name', or 'id'"
-            })),
-        );
+        return bad_request("kind must be 'tag', 'name', or 'id'");
     };
     let (shard, key) = match (req.shard, req.key.as_deref()) {
         (Some(s), k) => (s, k.map(str::to_string)),
@@ -13742,23 +13217,11 @@ async fn create_discovery_subscription(
             (x0x::groups::shard_of(kind, &normalised), Some(normalised))
         }
         (None, None) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "either 'shard' or 'key' is required"
-                })),
-            );
+            return bad_request("either 'shard' or 'key' is required");
         }
     };
     if state.directory_subscriptions.read().await.len() >= x0x::groups::DEFAULT_MAX_SUBSCRIPTIONS {
-        return (
-            StatusCode::PAYLOAD_TOO_LARGE,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "subscription limit reached"
-            })),
-        );
+        return api_error(StatusCode::PAYLOAD_TOO_LARGE, "subscription limit reached");
     }
     let rec = x0x::groups::SubscriptionRecord {
         kind,
@@ -13790,13 +13253,7 @@ async fn delete_discovery_subscription(
     Path((kind_str, shard)): Path<(String, u32)>,
 ) -> impl IntoResponse {
     let Some(kind) = x0x::groups::ShardKind::from_str(&kind_str) else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "kind must be 'tag', 'name', or 'id'"
-            })),
-        );
+        return bad_request("kind must be 'tag', 'name', or 'id'");
     };
     let existed = state
         .directory_subscriptions
@@ -13834,19 +13291,15 @@ async fn get_group_card(
             }
             Ok(None) => {}
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "ok": false, "error": format!("card sign failed: {e}") })),
+                    format!("card sign failed: {e}"),
                 )
-                    .into_response();
+                .into_response();
             }
         }
     }
-    (
-        StatusCode::NOT_FOUND,
-        Json(serde_json::json!({ "ok": false, "error": "card not found" })),
-    )
-        .into_response()
+    not_found("card not found").into_response()
 }
 
 /// POST /groups/cards/import — accept a discoverable card into the local cache.
@@ -13861,16 +13314,10 @@ async fn import_group_card(
     Json(card): Json<x0x::groups::GroupCard>,
 ) -> impl IntoResponse {
     if card.policy_summary.discoverability == x0x::groups::GroupDiscoverability::Hidden {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "ok": false, "error": "card is hidden" })),
-        );
+        return bad_request("card is hidden");
     }
     if let Err(e) = card.verify_signature() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "ok": false, "error": format!("invalid signed card: {e}") })),
-        );
+        return bad_request(format!("invalid signed card: {e}"));
     }
     let group_id = card.group_id.clone();
 
@@ -13899,10 +13346,7 @@ async fn import_group_card(
     let creator = match parse_agent_id_hex(&card.owner_agent_id) {
         Ok(id) => id,
         Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "invalid owner_agent_id" })),
-            );
+            return bad_request("invalid owner_agent_id");
         }
     };
 
@@ -14065,13 +13509,7 @@ fn treekem_membership_unsupported(
     info: &x0x::groups::GroupInfo,
 ) -> Option<(StatusCode, Json<serde_json::Value>)> {
     if info.secure_plane == x0x::mls::SecureGroupPlane::TreeKem {
-        Some((
-            StatusCode::NOT_IMPLEMENTED,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "TreeKEM secure-group membership flow is not supported by this endpoint; use request-access approval/removal transport"
-            })),
-        ))
+        Some(api_error(StatusCode::NOT_IMPLEMENTED, "TreeKEM secure-group membership flow is not supported by this endpoint; use request-access approval/removal transport"))
     } else {
         None
     }
@@ -14091,13 +13529,10 @@ async fn treekem_group_encrypt(
     payload_b64: &str,
 ) -> (StatusCode, Json<serde_json::Value>) {
     use base64::Engine as _;
-    let plaintext = match base64::engine::general_purpose::STANDARD.decode(payload_b64) {
+    let plaintext = match BASE64.decode(payload_b64) {
         Ok(p) => p,
         Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "invalid base64 payload" })),
-            );
+            return bad_request("invalid base64 payload");
         }
     };
     let group = {
@@ -14105,12 +13540,9 @@ async fn treekem_group_encrypt(
         match map.get(group_id_hex) {
             Some(g) => Arc::clone(g),
             None => {
-                return (
+                return api_error(
                     StatusCode::FAILED_DEPENDENCY,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "TreeKEM group not loaded — restart or re-share required"
-                    })),
+                    "TreeKEM group not loaded — restart or re-share required",
                 );
             }
         }
@@ -14119,11 +13551,9 @@ async fn treekem_group_encrypt(
     let ciphertext = match guard.encrypt_message(&plaintext) {
         Ok(c) => c,
         Err(e) => {
-            return (
+            return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(
-                    serde_json::json!({ "ok": false, "error": format!("treekem encrypt failed: {e}") }),
-                ),
+                format!("treekem encrypt failed: {e}"),
             );
         }
     };
@@ -14132,11 +13562,9 @@ async fn treekem_group_encrypt(
     // not, so a persist failure fails the request.
     if let Err(e) = persist_treekem_snapshot_bound(state, group_id_hex, &guard).await {
         tracing::error!(group_id = %group_id_hex, "failed to persist TreeKEM snapshot after encrypt: {e}");
-        return (
+        return api_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(
-                serde_json::json!({ "ok": false, "error": "failed to persist secure group state" }),
-            ),
+            "failed to persist secure group state",
         );
     }
     let epoch = guard.epoch();
@@ -14145,7 +13573,7 @@ async fn treekem_group_encrypt(
         StatusCode::OK,
         Json(serde_json::json!({
             "ok": true,
-            "ciphertext_b64": base64::engine::general_purpose::STANDARD.encode(&ciphertext),
+            "ciphertext_b64": BASE64.encode(&ciphertext),
             "secret_epoch": epoch,
             "secure_plane": "treekem",
         })),
@@ -14162,13 +13590,10 @@ async fn treekem_group_decrypt(
     ciphertext_b64: &str,
 ) -> (StatusCode, Json<serde_json::Value>) {
     use base64::Engine as _;
-    let ciphertext = match base64::engine::general_purpose::STANDARD.decode(ciphertext_b64) {
+    let ciphertext = match BASE64.decode(ciphertext_b64) {
         Ok(c) => c,
         Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "invalid base64 ciphertext" })),
-            );
+            return bad_request("invalid base64 ciphertext");
         }
     };
     let group = {
@@ -14176,12 +13601,9 @@ async fn treekem_group_decrypt(
         match map.get(group_id_hex) {
             Some(g) => Arc::clone(g),
             None => {
-                return (
+                return api_error(
                     StatusCode::FAILED_DEPENDENCY,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "TreeKEM group not loaded — restart or re-share required"
-                    })),
+                    "TreeKEM group not loaded — restart or re-share required",
                 );
             }
         }
@@ -14190,12 +13612,7 @@ async fn treekem_group_decrypt(
     let plaintext = match guard.decrypt_message(&ciphertext) {
         Ok(p) => p,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(
-                    serde_json::json!({ "ok": false, "error": format!("treekem decrypt failed: {e}") }),
-                ),
-            );
+            return bad_request(format!("treekem decrypt failed: {e}"));
         }
     };
     // Persisting the receive replay window is best-effort. A failure here may
@@ -14213,7 +13630,7 @@ async fn treekem_group_decrypt(
         StatusCode::OK,
         Json(serde_json::json!({
             "ok": true,
-            "payload_b64": base64::engine::general_purpose::STANDARD.encode(&plaintext),
+            "payload_b64": BASE64.encode(&plaintext),
             "secret_epoch": epoch,
             "secure_plane": "treekem",
         })),
@@ -14228,25 +13645,13 @@ async fn secure_group_encrypt(
     let caller_hex = hex::encode(state.agent.agent_id().as_bytes());
     let groups = state.named_groups.read().await;
     let Some(info) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     if !info.has_active_member(&caller_hex) {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({ "ok": false, "error": "not a member" })),
-        );
+        return forbidden("not a member");
     }
     if info.policy.confidentiality != x0x::groups::GroupConfidentiality::MlsEncrypted {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "group is not MlsEncrypted — use public send instead"
-            })),
-        );
+        return bad_request("group is not MlsEncrypted — use public send instead");
     }
     // ADR-0012: real-TreeKEM groups encrypt via the live group's ratchet, not
     // the GSS shared secret. Dispatch on the group's plane.
@@ -14255,12 +13660,9 @@ async fn secure_group_encrypt(
         return treekem_group_encrypt(state.as_ref(), &id, &req.payload_b64).await;
     }
     let Some(key) = info.secure_message_key() else {
-        return (
+        return api_error(
             StatusCode::FAILED_DEPENDENCY,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "no shared secret available — await welcome or ask admin to re-share"
-            })),
+            "no shared secret available — await welcome or ask admin to re-share",
         );
     };
     let epoch = info.secret_epoch;
@@ -14268,13 +13670,10 @@ async fn secure_group_encrypt(
     drop(groups);
 
     use base64::Engine as _;
-    let plaintext = match base64::engine::general_purpose::STANDARD.decode(&req.payload_b64) {
+    let plaintext = match BASE64.decode(&req.payload_b64) {
         Ok(p) => p,
         Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "invalid base64 payload" })),
-            );
+            return bad_request("invalid base64 payload");
         }
     };
 
@@ -14288,10 +13687,7 @@ async fn secure_group_encrypt(
     let cipher = match chacha20poly1305::ChaCha20Poly1305::new_from_slice(&key) {
         Ok(c) => c,
         Err(_) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "cipher init failed" })),
-            );
+            return api_error(StatusCode::INTERNAL_SERVER_ERROR, "cipher init failed");
         }
     };
     let aad = format!("x0x.group.secure|{}|{}", group_id_clone, epoch);
@@ -14305,9 +13701,9 @@ async fn secure_group_encrypt(
     ) {
         Ok(c) => c,
         Err(e) => {
-            return (
+            return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": format!("encrypt failed: {e}") })),
+                format!("encrypt failed: {e}"),
             );
         }
     };
@@ -14316,8 +13712,8 @@ async fn secure_group_encrypt(
         StatusCode::OK,
         Json(serde_json::json!({
             "ok": true,
-            "ciphertext_b64": base64::engine::general_purpose::STANDARD.encode(&ciphertext),
-            "nonce_b64": base64::engine::general_purpose::STANDARD.encode(nonce_bytes),
+            "ciphertext_b64": BASE64.encode(&ciphertext),
+            "nonce_b64": BASE64.encode(nonce_bytes),
             "secret_epoch": epoch,
         })),
     )
@@ -14338,17 +13734,11 @@ async fn secure_group_decrypt(
     let caller_hex = hex::encode(state.agent.agent_id().as_bytes());
     let groups = state.named_groups.read().await;
     let Some(info) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     if !info.has_active_member(&caller_hex) && !info.is_banned(&caller_hex) {
         // Removed/never-member callers can't decrypt.
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({ "ok": false, "error": "not a member" })),
-        );
+        return forbidden("not a member");
     }
     // ADR-0012: real-TreeKEM groups decrypt via the live group's ratchet. A
     // removed member's leaf is gone from the live group, so decryption of a
@@ -14358,13 +13748,7 @@ async fn secure_group_decrypt(
         return treekem_group_decrypt(state.as_ref(), &id, &req.ciphertext_b64).await;
     }
     let Some(local_secret) = info.shared_secret.clone() else {
-        return (
-            StatusCode::FAILED_DEPENDENCY,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "no shared secret available"
-            })),
-        );
+        return api_error(StatusCode::FAILED_DEPENDENCY, "no shared secret available");
     };
     let local_epoch = info.secret_epoch;
     let group_id_clone = info.stable_group_id().to_string();
@@ -14386,29 +13770,20 @@ async fn secure_group_decrypt(
     }
 
     use base64::Engine as _;
-    let ciphertext = match base64::engine::general_purpose::STANDARD.decode(&req.ciphertext_b64) {
+    let ciphertext = match BASE64.decode(&req.ciphertext_b64) {
         Ok(c) => c,
         Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "invalid base64 ciphertext" })),
-            );
+            return bad_request("invalid base64 ciphertext");
         }
     };
-    let nonce_bytes = match base64::engine::general_purpose::STANDARD.decode(&req.nonce_b64) {
+    let nonce_bytes = match BASE64.decode(&req.nonce_b64) {
         Ok(n) => n,
         Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "invalid base64 nonce" })),
-            );
+            return bad_request("invalid base64 nonce");
         }
     };
     if nonce_bytes.len() != 12 {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "ok": false, "error": "nonce must be 12 bytes" })),
-        );
+        return bad_request("nonce must be 12 bytes");
     }
 
     let key = x0x::groups::GroupInfo::derive_message_key(
@@ -14420,10 +13795,7 @@ async fn secure_group_decrypt(
     let cipher = match chacha20poly1305::ChaCha20Poly1305::new_from_slice(&key) {
         Ok(c) => c,
         Err(_) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "cipher init failed" })),
-            );
+            return api_error(StatusCode::INTERNAL_SERVER_ERROR, "cipher init failed");
         }
     };
     let nonce = chacha20poly1305::Nonce::from_slice(&nonce_bytes);
@@ -14439,14 +13811,11 @@ async fn secure_group_decrypt(
             StatusCode::OK,
             Json(serde_json::json!({
                 "ok": true,
-                "payload_b64": base64::engine::general_purpose::STANDARD.encode(&plaintext),
+                "payload_b64": BASE64.encode(&plaintext),
                 "secret_epoch": req.secret_epoch,
             })),
         ),
-        Err(_) => (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({ "ok": false, "error": "decryption failed" })),
-        ),
+        Err(_) => forbidden("decryption failed"),
     }
 }
 
@@ -14492,40 +13861,25 @@ async fn secure_group_reseal(
     let caller_hex = hex::encode(state.agent.agent_id().as_bytes());
     let groups = state.named_groups.read().await;
     let Some(info) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
     if !info.has_active_member(&caller_hex) {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({ "ok": false, "error": "not a member" })),
-        );
+        return forbidden("not a member");
     }
     // Recipient must be a known member with a KEM pubkey.
     let Some(recipient_member) = info.members_v2.get(&req.recipient) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "recipient is not a member" })),
-        );
+        return not_found("recipient is not a member");
     };
     let Some(recipient_kem_b64) = recipient_member.kem_public_key_b64.clone() else {
-        return (
+        return api_error(
             StatusCode::FAILED_DEPENDENCY,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "recipient has no published KEM public key"
-            })),
+            "recipient has no published KEM public key",
         );
     };
     let Some(secret_vec) = info.shared_secret.clone() else {
-        return (
+        return api_error(
             StatusCode::FAILED_DEPENDENCY,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "no shared secret available on this daemon"
-            })),
+            "no shared secret available on this daemon",
         );
     };
     let epoch = info.secret_epoch;
@@ -14533,31 +13887,21 @@ async fn secure_group_reseal(
     drop(groups);
 
     if secret_vec.len() != 32 {
-        return (
+        return api_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": "shared secret has unexpected length"
-            })),
+            "shared secret has unexpected length",
         );
     }
     let mut secret = [0u8; 32];
     secret.copy_from_slice(&secret_vec);
 
     use base64::Engine as _;
-    let recipient_kem_bytes =
-        match base64::engine::general_purpose::STANDARD.decode(&recipient_kem_b64) {
-            Ok(b) => b,
-            Err(_) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "recipient KEM public key is not valid base64"
-                    })),
-                );
-            }
-        };
+    let recipient_kem_bytes = match BASE64.decode(&recipient_kem_b64) {
+        Ok(b) => b,
+        Err(_) => {
+            return bad_request("recipient KEM public key is not valid base64");
+        }
+    };
     let aad = secure_share_aad(&group_id_wire, &req.recipient, epoch);
     let (kem_ct, aead_nonce, aead_ct) =
         match x0x::groups::kem_envelope::seal_group_secret_to_recipient(
@@ -14567,12 +13911,9 @@ async fn secure_group_reseal(
         ) {
             Ok(t) => t,
             Err(e) => {
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": format!("seal failed: {e}")
-                    })),
+                    format!("seal failed: {e}"),
                 );
             }
         };
@@ -14584,9 +13925,9 @@ async fn secure_group_reseal(
             "group_id": group_id_wire,
             "recipient": req.recipient,
             "secret_epoch": epoch,
-            "kem_ciphertext_b64": base64::engine::general_purpose::STANDARD.encode(&kem_ct),
-            "aead_nonce_b64": base64::engine::general_purpose::STANDARD.encode(aead_nonce),
-            "aead_ciphertext_b64": base64::engine::general_purpose::STANDARD.encode(&aead_ct),
+            "kem_ciphertext_b64": BASE64.encode(&kem_ct),
+            "aead_nonce_b64": BASE64.encode(aead_nonce),
+            "aead_ciphertext_b64": BASE64.encode(&aead_ct),
         })),
     )
 }
@@ -14613,39 +13954,27 @@ async fn secure_open_envelope_adversarial(
     Json(req): Json<OpenEnvelopeRequest>,
 ) -> impl IntoResponse {
     use base64::Engine as _;
-    let kem_ct = match base64::engine::general_purpose::STANDARD.decode(&req.kem_ciphertext_b64) {
+    let kem_ct = match BASE64.decode(&req.kem_ciphertext_b64) {
         Ok(b) => b,
         Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "bad kem_ciphertext_b64" })),
-            );
+            return bad_request("bad kem_ciphertext_b64");
         }
     };
-    let nonce = match base64::engine::general_purpose::STANDARD.decode(&req.aead_nonce_b64) {
+    let nonce = match BASE64.decode(&req.aead_nonce_b64) {
         Ok(b) => b,
         Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "bad aead_nonce_b64" })),
-            );
+            return bad_request("bad aead_nonce_b64");
         }
     };
     if nonce.len() != 12 {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "ok": false, "error": "nonce must be 12 bytes" })),
-        );
+        return bad_request("nonce must be 12 bytes");
     }
     let mut nonce_bytes = [0u8; 12];
     nonce_bytes.copy_from_slice(&nonce);
-    let aead_ct = match base64::engine::general_purpose::STANDARD.decode(&req.aead_ciphertext_b64) {
+    let aead_ct = match BASE64.decode(&req.aead_ciphertext_b64) {
         Ok(b) => b,
         Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "bad aead_ciphertext_b64" })),
-            );
+            return bad_request("bad aead_ciphertext_b64");
         }
     };
     let aad = secure_share_aad(&req.group_id, &req.recipient, req.secret_epoch);
@@ -14661,7 +13990,7 @@ async fn secure_open_envelope_adversarial(
             Json(serde_json::json!({
                 "ok": true,
                 "opened": true,
-                "secret_b64": base64::engine::general_purpose::STANDARD.encode(secret),
+                "secret_b64": BASE64.encode(secret),
             })),
         ),
         Err(_) => (
@@ -14706,10 +14035,7 @@ async fn create_task_list(
                 Json(serde_json::json!({ "ok": true, "id": id })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -14720,10 +14046,7 @@ async fn list_tasks(
 ) -> impl IntoResponse {
     let lists = state.task_lists.read().await;
     let Some(handle) = lists.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "task list not found" })),
-        );
+        return not_found("task list not found");
     };
 
     match handle.list_tasks().await {
@@ -14744,10 +14067,7 @@ async fn list_tasks(
                 Json(serde_json::json!({ "ok": true, "tasks": entries })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -14759,10 +14079,7 @@ async fn add_task(
 ) -> impl IntoResponse {
     let lists = state.task_lists.read().await;
     let Some(handle) = lists.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "task list not found" })),
-        );
+        return not_found("task list not found");
     };
 
     match handle
@@ -14773,10 +14090,7 @@ async fn add_task(
             StatusCode::CREATED,
             Json(serde_json::json!({ "ok": true, "task_id": format!("{task_id}") })),
         ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -14788,10 +14102,7 @@ async fn update_task(
 ) -> impl IntoResponse {
     let lists = state.task_lists.read().await;
     let Some(handle) = lists.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "task list not found" })),
-        );
+        return not_found("task list not found");
     };
 
     // Parse task ID from hex
@@ -14802,12 +14113,7 @@ async fn update_task(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(
-                    serde_json::json!({ "ok": false, "error": "invalid task ID (expected 64 hex chars)" }),
-                ),
-            );
+            return bad_request("invalid task ID (expected 64 hex chars)");
         }
     };
     let task_id = x0x::crdt::TaskId::from_bytes(task_id_bytes);
@@ -14816,21 +14122,13 @@ async fn update_task(
         "claim" => handle.claim_task(task_id).await,
         "complete" => handle.complete_task(task_id).await,
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(
-                    serde_json::json!({ "ok": false, "error": "action must be 'claim' or 'complete'" }),
-                ),
-            );
+            return bad_request("action must be 'claim' or 'complete'");
         }
     };
 
     match result {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -15044,10 +14342,7 @@ async fn create_kv_store(
                 Json(serde_json::json!({ "ok": true, "id": id })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -15064,10 +14359,7 @@ async fn join_kv_store(
                 Json(serde_json::json!({ "ok": true, "id": id })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -15078,10 +14370,7 @@ async fn list_kv_keys(
 ) -> impl IntoResponse {
     let stores = state.kv_stores.read().await;
     let Some(handle) = stores.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "store not found" })),
-        );
+        return not_found("store not found");
     };
 
     match handle.keys().await {
@@ -15103,10 +14392,7 @@ async fn list_kv_keys(
                 Json(serde_json::json!({ "ok": true, "keys": keys })),
             )
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -15119,22 +14405,16 @@ async fn put_kv_value(
     let handle = {
         let stores = state.kv_stores.read().await;
         let Some(handle) = stores.get(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "store not found" })),
-            );
+            return not_found("store not found");
         };
         handle.clone()
     };
 
     use base64::Engine;
-    let value = match base64::engine::general_purpose::STANDARD.decode(&req.value) {
+    let value = match BASE64.decode(&req.value) {
         Ok(v) => v,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": format!("invalid base64: {e}") })),
-            );
+            return bad_request(format!("invalid base64: {e}"));
         }
     };
 
@@ -15169,16 +14449,13 @@ async fn get_kv_value(
 ) -> impl IntoResponse {
     let stores = state.kv_stores.read().await;
     let Some(handle) = stores.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "store not found" })),
-        );
+        return not_found("store not found");
     };
 
     match handle.get(&key).await {
         Ok(Some(entry)) => {
             use base64::Engine;
-            let value_b64 = base64::engine::general_purpose::STANDARD.encode(&entry.value);
+            let value_b64 = BASE64.encode(&entry.value);
             (
                 StatusCode::OK,
                 Json(serde_json::json!({
@@ -15193,14 +14470,8 @@ async fn get_kv_value(
                 })),
             )
         }
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "key not found" })),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Ok(None) => not_found("key not found"),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -15212,10 +14483,7 @@ async fn delete_kv_value(
     let handle = {
         let stores = state.kv_stores.read().await;
         let Some(handle) = stores.get(&id) else {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({ "ok": false, "error": "store not found" })),
-            );
+            return not_found("store not found");
         };
         handle.clone()
     };
@@ -15226,10 +14494,7 @@ async fn delete_kv_value(
             spawn_kv_store_delta_delivery(&state, recipients, &id, handle.peer_id(), &delta);
             (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": format!("{e}") })),
-        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }
 
@@ -15283,10 +14548,7 @@ async fn connect_agent(
         }
         Ok(Err(e)) => {
             tracing::error!("connect_agent failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "connection failed" })),
-            )
+            api_error(StatusCode::INTERNAL_SERVER_ERROR, "connection failed")
         }
         Err(_elapsed) => {
             tracing::warn!(
@@ -15348,10 +14610,7 @@ async fn connect_machine(
         }
         Ok(Err(e)) => {
             tracing::error!("connect_machine failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "connection failed" })),
-            )
+            api_error(StatusCode::INTERNAL_SERVER_ERROR, "connection failed")
         }
         Err(_elapsed) => {
             tracing::warn!(
@@ -15386,21 +14645,13 @@ async fn exec_run(
         }
     };
     if req.argv.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "ok": false, "error": "argv must not be empty" })),
-        )
-            .into_response();
+        return bad_request("argv must not be empty").into_response();
     }
     let stdin = match req.stdin_b64.as_deref() {
-        Some(encoded) => match base64::engine::general_purpose::STANDARD.decode(encoded) {
+        Some(encoded) => match BASE64.decode(encoded) {
             Ok(bytes) => Some(bytes),
             Err(e) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({ "ok": false, "error": format!("invalid stdin_b64: {e}") })),
-                )
-                    .into_response();
+                return bad_request(format!("invalid stdin_b64: {e}")).into_response();
             }
         },
         None => None,
@@ -15423,8 +14674,8 @@ async fn exec_run(
                     "code": result.code,
                     "signal": result.signal,
                     "duration_ms": result.duration_ms,
-                    "stdout_b64": base64::engine::general_purpose::STANDARD.encode(&result.stdout),
-                    "stderr_b64": base64::engine::general_purpose::STANDARD.encode(&result.stderr),
+                    "stdout_b64": BASE64.encode(&result.stdout),
+                    "stderr_b64": BASE64.encode(&result.stderr),
                     "stdout_bytes_total": result.stdout_bytes_total,
                     "stderr_bytes_total": result.stderr_bytes_total,
                     "truncated": result.truncated,
@@ -15461,11 +14712,7 @@ async fn exec_cancel(
     let request_id = match x0x::exec::ExecRequestId::from_hex(&req.request_id) {
         Ok(id) => id,
         Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": e.to_string() })),
-            )
-                .into_response();
+            return bad_request(e.to_string()).into_response();
         }
     };
     let target = match req.agent_id.as_deref() {
@@ -15483,11 +14730,7 @@ async fn exec_cancel(
     };
     match state.exec_service.cancel_remote(request_id, target).await {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response(),
-        Err(e) => (
-            StatusCode::BAD_GATEWAY,
-            Json(serde_json::json!({ "ok": false, "error": e.to_string() })),
-        )
-            .into_response(),
+        Err(e) => api_error(StatusCode::BAD_GATEWAY, e.to_string()).into_response(),
     }
 }
 
@@ -15521,10 +14764,7 @@ async fn direct_send(
         let contacts = state.contacts.read().await;
         if let Some(contact) = contacts.get(&agent_id) {
             if contact.trust_level == TrustLevel::Blocked {
-                return (
-                    StatusCode::FORBIDDEN,
-                    Json(serde_json::json!({ "ok": false, "error": "agent is blocked" })),
-                );
+                return forbidden("agent is blocked");
             }
         }
     }
@@ -15720,7 +14960,7 @@ async fn direct_events_sse(
                     let data = serde_json::json!({
                         "sender": hex::encode(msg.sender.as_bytes()),
                         "machine_id": hex::encode(msg.machine_id.as_bytes()),
-                        "payload": base64::engine::general_purpose::STANDARD.encode(&msg.payload),
+                        "payload": BASE64.encode(&msg.payload),
                         "received_at": msg.received_at,
                         "verified": msg.verified,
                         "trust_decision": msg.trust_decision.map(|d| d.to_string())
@@ -15761,10 +15001,7 @@ async fn create_mls_group(
         Some(hex_str) => match hex::decode(&hex_str) {
             Ok(bytes) => bytes,
             Err(e) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({ "ok": false, "error": format!("invalid hex: {e}") })),
-                );
+                return bad_request(format!("invalid hex: {e}"));
             }
         },
         None => {
@@ -15806,10 +15043,7 @@ async fn create_mls_group(
         }
         Err(e) => {
             tracing::error!("operation failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "internal error" })),
-            )
+            api_error(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
         }
     }
 }
@@ -15841,10 +15075,7 @@ async fn get_mls_group(
 ) -> impl IntoResponse {
     let groups = state.mls_groups.read().await;
     let Some(group) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
 
     let members: Vec<String> = group
@@ -15882,10 +15113,7 @@ async fn add_mls_member(
 
     let mut groups = state.mls_groups.write().await;
     let Some(group) = groups.get_mut(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
 
     // add_member() auto-applies the commit internally (increments epoch).
@@ -15906,10 +15134,7 @@ async fn add_mls_member(
         }
         Err(e) => {
             tracing::error!("add_mls_member failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "operation failed" })),
-            )
+            api_error(StatusCode::INTERNAL_SERVER_ERROR, "operation failed")
         }
     }
 }
@@ -15931,10 +15156,7 @@ async fn remove_mls_member(
 
     let mut groups = state.mls_groups.write().await;
     let Some(group) = groups.get_mut(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
 
     // remove_member() auto-applies the commit internally.
@@ -15954,10 +15176,7 @@ async fn remove_mls_member(
         }
         Err(e) => {
             tracing::error!("remove_mls_member failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "internal error" })),
-            )
+            api_error(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
         }
     }
 }
@@ -15975,10 +15194,7 @@ async fn mls_encrypt(
 
     let groups = state.mls_groups.read().await;
     let Some(group) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
 
     let (cipher, epoch) = match make_mls_cipher(group) {
@@ -15991,16 +15207,13 @@ async fn mls_encrypt(
             StatusCode::OK,
             Json(serde_json::json!({
                 "ok": true,
-                "ciphertext": base64::engine::general_purpose::STANDARD.encode(&ciphertext),
+                "ciphertext": BASE64.encode(&ciphertext),
                 "epoch": epoch
             })),
         ),
         Err(e) => {
             tracing::error!("mls_encrypt failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "encryption failed" })),
-            )
+            api_error(StatusCode::INTERNAL_SERVER_ERROR, "encryption failed")
         }
     }
 }
@@ -16018,10 +15231,7 @@ async fn mls_decrypt(
 
     let groups = state.mls_groups.read().await;
     let Some(group) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
 
     let (cipher, _epoch) = match make_mls_cipher(group) {
@@ -16034,15 +15244,12 @@ async fn mls_decrypt(
             StatusCode::OK,
             Json(serde_json::json!({
                 "ok": true,
-                "payload": base64::engine::general_purpose::STANDARD.encode(&plaintext)
+                "payload": BASE64.encode(&plaintext)
             })),
         ),
         Err(e) => {
             tracing::error!("mls_decrypt failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "decryption failed" })),
-            )
+            api_error(StatusCode::INTERNAL_SERVER_ERROR, "decryption failed")
         }
     }
 }
@@ -16080,10 +15287,7 @@ async fn find_agent(
         ),
         Err(e) => {
             tracing::error!("find_agent failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "search failed" })),
-            )
+            api_error(StatusCode::INTERNAL_SERVER_ERROR, "search failed")
         }
     }
 }
@@ -16115,10 +15319,7 @@ async fn agent_reachability(
                 "addresses": info.addresses.iter().map(|a| a.to_string()).collect::<Vec<_>>()
             })),
         ),
-        None => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "agent not in discovery cache" })),
-        ),
+        None => not_found("agent not in discovery cache"),
     }
 }
 
@@ -16191,10 +15392,7 @@ async fn pin_machine(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "invalid machine_id hex" })),
-            );
+            return bad_request("invalid machine_id hex");
         }
     };
     let machine_id = MachineId(machine_bytes);
@@ -16230,10 +15428,7 @@ async fn unpin_machine(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "invalid machine_id hex" })),
-            );
+            return bad_request("invalid machine_id hex");
         }
     };
     let machine_id = MachineId(machine_bytes);
@@ -16269,10 +15464,7 @@ async fn evaluate_trust(
             arr
         }
         _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": "invalid machine_id hex" })),
-            );
+            return bad_request("invalid machine_id hex");
         }
     };
     let machine_id = MachineId(machine_bytes);
@@ -16318,10 +15510,7 @@ async fn create_mls_welcome(
 
     let groups = state.mls_groups.read().await;
     let Some(group) = groups.get(&id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "ok": false, "error": "group not found" })),
-        );
+        return not_found("group not found");
     };
 
     match x0x::mls::MlsWelcome::create(group, &invitee) {
@@ -16330,10 +15519,7 @@ async fn create_mls_welcome(
                 Ok(b) => b,
                 Err(e) => {
                     tracing::error!("welcome serialization failed: {e}");
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(serde_json::json!({ "ok": false, "error": "serialization failed" })),
-                    );
+                    return api_error(StatusCode::INTERNAL_SERVER_ERROR, "serialization failed");
                 }
             };
 
@@ -16341,7 +15527,7 @@ async fn create_mls_welcome(
                 StatusCode::OK,
                 Json(serde_json::json!({
                     "ok": true,
-                    "welcome": base64::engine::general_purpose::STANDARD.encode(&welcome_bytes),
+                    "welcome": BASE64.encode(&welcome_bytes),
                     "group_id": id,
                     "epoch": welcome.epoch()
                 })),
@@ -16349,10 +15535,7 @@ async fn create_mls_welcome(
         }
         Err(e) => {
             tracing::error!("create_mls_welcome failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "welcome creation failed" })),
-            )
+            api_error(StatusCode::INTERNAL_SERVER_ERROR, "welcome creation failed")
         }
     }
 }
@@ -16531,11 +15714,9 @@ async fn apply_upgrade(State(state): State<Arc<AppState>>) -> impl IntoResponse 
             Ok(m) => m.with_include_prereleases(state.update_config.include_prereleases),
             Err(e) => {
                 tracing::error!("upgrade monitor creation failed: {e}");
-                return (
+                return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(
-                        serde_json::json!({ "ok": false, "error": "upgrade monitor unavailable" }),
-                    ),
+                    "upgrade monitor unavailable",
                 );
             }
         };
@@ -16555,10 +15736,7 @@ async fn apply_upgrade(State(state): State<Arc<AppState>>) -> impl IntoResponse 
         }
         Err(e) => {
             tracing::error!("upgrade check failed: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "ok": false, "error": "upgrade check failed" })),
-            );
+            return api_error(StatusCode::INTERNAL_SERVER_ERROR, "upgrade check failed");
         }
     };
 
@@ -16649,10 +15827,7 @@ async fn bootstrap_cache_stats(State(state): State<Arc<AppState>>) -> impl IntoR
                 })),
             )
         }
-        None => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "network not initialized" })),
-        ),
+        None => api_error(StatusCode::SERVICE_UNAVAILABLE, "network not initialized"),
     }
 }
 
@@ -16841,10 +16016,7 @@ where
 /// guarantee ant-quic is responsible for.
 async fn connectivity_diagnostics(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let Some(network) = state.agent.network() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "network not initialized" })),
-        );
+        return api_error(StatusCode::SERVICE_UNAVAILABLE, "network not initialized");
     };
 
     match network.node_status().await {
@@ -17032,20 +16204,14 @@ async fn connectivity_diagnostics(State(state): State<Arc<AppState>>) -> impl In
             });
             (StatusCode::OK, Json(snapshot))
         }
-        None => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "node status unavailable" })),
-        ),
+        None => api_error(StatusCode::SERVICE_UNAVAILABLE, "node status unavailable"),
     }
 }
 
 /// GET /diagnostics/ack — ACK-v2 per-stage latency and outcome diagnostics.
 async fn ack_diagnostics(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let Some(network) = state.agent.network() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "network not initialized" })),
-        );
+        return api_error(StatusCode::SERVICE_UNAVAILABLE, "network not initialized");
     };
 
     match network.ack_diagnostics().await {
@@ -17056,9 +16222,9 @@ async fn ack_diagnostics(State(state): State<Arc<AppState>>) -> impl IntoRespons
                 "ack": snapshot,
             })),
         ),
-        None => (
+        None => api_error(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "ACK diagnostics unavailable" })),
+            "ACK diagnostics unavailable",
         ),
     }
 }
@@ -17090,9 +16256,9 @@ async fn gossip_diagnostics(State(state): State<Arc<AppState>>) -> impl IntoResp
                 })),
             )
         }
-        None => (
+        None => api_error(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "gossip runtime not initialized" })),
+            "gossip runtime not initialized",
         ),
     }
 }
@@ -17163,23 +16329,13 @@ async fn dm_diagnostics(State(state): State<Arc<AppState>>) -> impl IntoResponse
 
 /// Parse a hex `peer_id` path segment into an ant-quic `PeerId` (32 bytes).
 fn parse_peer_id(hex_str: &str) -> Result<ant_quic::PeerId, (StatusCode, Json<serde_json::Value>)> {
-    let bytes = hex::decode(hex_str).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": format!("invalid hex peer_id: {e}")
-            })),
-        )
-    })?;
+    let bytes =
+        hex::decode(hex_str).map_err(|e| bad_request(format!("invalid hex peer_id: {e}")))?;
     if bytes.len() != 32 {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": format!("peer_id must be 32 bytes, got {}", bytes.len())
-            })),
-        ));
+        return Err(bad_request(format!(
+            "peer_id must be 32 bytes, got {}",
+            bytes.len()
+        )));
     }
     let mut arr = [0u8; 32];
     arr.copy_from_slice(&bytes);
@@ -17209,10 +16365,7 @@ async fn probe_peer_handler(
         Err(e) => return e.into_response(),
     };
     let Some(network) = state.agent.network() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "network not initialized" })),
-        )
+        return api_error(StatusCode::SERVICE_UNAVAILABLE, "network not initialized")
             .into_response();
     };
     let timeout_ms = q.timeout_ms.unwrap_or(2_000).clamp(100, 30_000);
@@ -17229,19 +16382,14 @@ async fn probe_peer_handler(
             })),
         )
             .into_response(),
-        Some(Err(e)) => (
+        Some(Err(e)) => api_error(
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({
-                "ok": false,
-                "error": format!("probe failed: {e}"),
-            })),
+            format!("probe failed: {e}"),
         )
-            .into_response(),
-        None => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "network node not running" })),
-        )
-            .into_response(),
+        .into_response(),
+        None => {
+            api_error(StatusCode::SERVICE_UNAVAILABLE, "network node not running").into_response()
+        }
     }
 }
 
@@ -17267,10 +16415,7 @@ async fn peer_health_handler(
         Err(e) => return e.into_response(),
     };
     let Some(network) = state.agent.network() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "network not initialized" })),
-        )
+        return api_error(StatusCode::SERVICE_UNAVAILABLE, "network not initialized")
             .into_response();
     };
     match network.connection_health(peer_id).await {
@@ -17303,11 +16448,9 @@ async fn peer_health_handler(
             )
                 .into_response()
         }
-        None => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "network node not running" })),
-        )
-            .into_response(),
+        None => {
+            api_error(StatusCode::SERVICE_UNAVAILABLE, "network node not running").into_response()
+        }
     }
 }
 
@@ -17319,17 +16462,11 @@ async fn peer_health_handler(
 async fn peer_events_handler(State(state): State<Arc<AppState>>) -> axum::response::Response {
     use axum::response::IntoResponse;
     let Some(network) = state.agent.network() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "network not initialized" })),
-        )
+        return api_error(StatusCode::SERVICE_UNAVAILABLE, "network not initialized")
             .into_response();
     };
     let Some(mut rx) = network.subscribe_all_peer_events().await else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({ "ok": false, "error": "network node not running" })),
-        )
+        return api_error(StatusCode::SERVICE_UNAVAILABLE, "network node not running")
             .into_response();
     };
     let mut shutdown_rx = state.shutdown_notify.subscribe();
@@ -17473,7 +16610,7 @@ async fn handle_ws_connection(
                 let out = WsOutbound::DirectMessage {
                     sender: hex::encode(msg.sender.as_bytes()),
                     machine_id: hex::encode(msg.machine_id.as_bytes()),
-                    payload: base64::engine::general_purpose::STANDARD.encode(&msg.payload),
+                    payload: BASE64.encode(&msg.payload),
                     received_at: msg.received_at,
                     verified: msg.verified,
                     trust_decision: msg.trust_decision.map(|d| d.to_string()),
@@ -17628,8 +16765,7 @@ async fn handle_ws_command(
                                     while let Some(msg) = gossip_sub.recv().await {
                                         let out = WsOutbound::Message {
                                             topic: topic_clone.clone(),
-                                            payload: base64::engine::general_purpose::STANDARD
-                                                .encode(&msg.payload),
+                                            payload: BASE64.encode(&msg.payload),
                                             origin: msg.sender.map(|s| hex::encode(s.as_bytes())),
                                         };
                                         let _ = btx.send(out);
@@ -18131,7 +17267,7 @@ async fn load_named_groups(
 async fn save_named_groups(state: &AppState) {
     let json = {
         let groups = state.named_groups.read().await;
-        serde_json::to_string_pretty(&*groups)
+        serde_json::to_string(&*groups)
     };
     match json {
         Ok(json) => {
@@ -18170,16 +17306,35 @@ async fn write_named_groups_json_atomic(path: &FsPath, json: &str) -> std::io::R
     write_result
 }
 
+/// Build a uniform `{ "ok": false, "error": <msg> }` JSON error response paired
+/// with the given status code. Used by handlers in place of hand-rolled literals.
+fn api_error(status: StatusCode, msg: impl Into<String>) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        status,
+        Json(serde_json::json!({ "ok": false, "error": msg.into() })),
+    )
+}
+
+/// `400 Bad Request` error response.
+fn bad_request(msg: impl Into<String>) -> (StatusCode, Json<serde_json::Value>) {
+    api_error(StatusCode::BAD_REQUEST, msg)
+}
+
+/// `404 Not Found` error response.
+fn not_found(msg: impl Into<String>) -> (StatusCode, Json<serde_json::Value>) {
+    api_error(StatusCode::NOT_FOUND, msg)
+}
+
+/// `403 Forbidden` error response.
+fn forbidden(msg: impl Into<String>) -> (StatusCode, Json<serde_json::Value>) {
+    api_error(StatusCode::FORBIDDEN, msg)
+}
+
 /// Decode a base64-encoded payload from a request field.
 fn decode_base64_payload(encoded: &str) -> Result<Vec<u8>, (StatusCode, Json<serde_json::Value>)> {
-    base64::engine::general_purpose::STANDARD
+    BASE64
         .decode(encoded)
-        .map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "ok": false, "error": format!("invalid base64: {e}") })),
-            )
-        })
+        .map_err(|e| bad_request(format!("invalid base64: {e}")))
 }
 
 /// Derive an MLS cipher from a group's current key schedule.
@@ -18188,10 +17343,7 @@ fn make_mls_cipher(
 ) -> Result<(x0x::mls::MlsCipher, u64), (StatusCode, Json<serde_json::Value>)> {
     let key_schedule = x0x::mls::MlsKeySchedule::from_group(group).map_err(|e| {
         tracing::error!("MLS key derivation failed: {e}");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "ok": false, "error": "key derivation failed" })),
-        )
+        api_error(StatusCode::INTERNAL_SERVER_ERROR, "key derivation failed")
     })?;
     let cipher = x0x::mls::MlsCipher::new(
         key_schedule.encryption_key().to_vec(),
@@ -18996,7 +18148,7 @@ async fn stream_welcome_blob(
         let msg = WelcomeBlobMessage::Chunk {
             welcome_id: welcome_id.to_string(),
             sequence,
-            data: base64::engine::general_purpose::STANDARD.encode(chunk),
+            data: BASE64.encode(chunk),
         };
         if let Err(e) = send_welcome_blob_message(state, recipient, &msg).await {
             tracing::warn!(
@@ -19037,7 +18189,7 @@ async fn handle_welcome_blob_chunk(
     data: String,
 ) {
     let sender_hex = hex::encode(sender.as_bytes());
-    let decoded = match base64::engine::general_purpose::STANDARD.decode(data) {
+    let decoded = match BASE64.decode(data) {
         Ok(bytes) => bytes,
         Err(e) => {
             notify_welcome_waiters(
@@ -19419,7 +18571,7 @@ async fn stream_file_chunks(
             return;
         }
 
-        let chunk_data = base64::engine::general_purpose::STANDARD.encode(&buf[..n]);
+        let chunk_data = BASE64.encode(&buf[..n]);
         let chunk_msg = x0x::files::FileMessage::Chunk(x0x::files::FileChunk {
             transfer_id: transfer_id.to_string(),
             sequence,
@@ -19602,7 +18754,7 @@ async fn handle_file_chunk(state: &Arc<AppState>, sender: &AgentId, chunk: x0x::
         }
     };
 
-    let data = match base64::engine::general_purpose::STANDARD.decode(&chunk.data) {
+    let data = match BASE64.decode(&chunk.data) {
         Ok(d) => d,
         Err(e) => {
             tracing::error!("Chunk decode error for {}: {e}", chunk.transfer_id);

--- a/src/cli/commands/connect.rs
+++ b/src/cli/commands/connect.rs
@@ -81,44 +81,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn connect_rejects_wrong_word_count() {
         let mock_resp = serde_json::json!({"agents": []});

--- a/src/cli/commands/contacts.rs
+++ b/src/cli/commands/contacts.rs
@@ -5,10 +5,7 @@ use anyhow::Result;
 
 /// `x0x contacts [list]` — GET /contacts
 pub async fn list(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/contacts").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/contacts").await
 }
 
 /// `x0x contacts add` — POST /contacts
@@ -61,10 +58,7 @@ pub async fn update(
 
 /// `x0x contacts remove` — DELETE /contacts/:agent_id
 pub async fn remove(client: &DaemonClient, agent_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.delete(&format!("/contacts/{agent_id}")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_delete(&format!("/contacts/{agent_id}")).await
 }
 
 /// `x0x contacts revoke` — POST /contacts/:agent_id/revoke
@@ -118,44 +112,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn list_returns_mock_response() {
         let mock_resp =

--- a/src/cli/commands/daemon.rs
+++ b/src/cli/commands/daemon.rs
@@ -483,44 +483,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn stop_sends_shutdown_request() {
         let mock_resp = serde_json::json!({"ok": true});

--- a/src/cli/commands/direct.rs
+++ b/src/cli/commands/direct.rs
@@ -43,10 +43,7 @@ pub async fn send(
 
 /// `x0x direct connections` — GET /direct/connections
 pub async fn connections(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/direct/connections").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/direct/connections").await
 }
 
 /// `x0x direct events` — stream GET /direct/events
@@ -94,44 +91,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn connect_returns_mock_response() {
         let mock_resp = serde_json::json!({"outcome": "Connected"});

--- a/src/cli/commands/discovery.rs
+++ b/src/cli/commands/discovery.rs
@@ -54,18 +54,12 @@ pub async fn reachability(client: &DaemonClient, agent_id: &str) -> Result<()> {
 
 /// `x0x agents machine` — GET /agents/:agent_id/machine
 pub async fn machine(client: &DaemonClient, agent_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/agents/{agent_id}/machine")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/agents/{agent_id}/machine")).await
 }
 
 /// `x0x agents by-user` — GET /users/:user_id/agents
 pub async fn by_user(client: &DaemonClient, user_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/users/{user_id}/agents")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/users/{user_id}/agents")).await
 }
 
 #[cfg(test)]
@@ -74,44 +68,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn list_returns_mock_response() {
         let mock_resp =

--- a/src/cli/commands/exec.rs
+++ b/src/cli/commands/exec.rs
@@ -112,44 +112,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn run_rejects_empty_argv_before_http() {
         let mock_resp = serde_json::json!({"status": "unused"});

--- a/src/cli/commands/files.rs
+++ b/src/cli/commands/files.rs
@@ -85,10 +85,7 @@ pub async fn receive_file(
 
 /// `x0x transfers` — GET /files/transfers
 pub async fn transfers(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/files/transfers").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/files/transfers").await
 }
 
 /// `x0x transfer-status` — GET /files/transfers/:id
@@ -134,44 +131,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn send_file_posts_metadata_for_existing_file() {
         let mock_resp = serde_json::json!({"transfer_id": "tx-1", "status": "queued"});

--- a/src/cli/commands/find.rs
+++ b/src/cli/commands/find.rs
@@ -111,44 +111,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn find_rejects_wrong_word_count() {
         let mock_resp = serde_json::json!({"agents": [{"agent_id": "abc123"}]});

--- a/src/cli/commands/group.rs
+++ b/src/cli/commands/group.rs
@@ -13,10 +13,7 @@ use serde_json::{json, Value};
 
 /// `x0x group list` — GET /groups.
 pub async fn list(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/groups").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/groups").await
 }
 
 /// `x0x group create` — POST /groups.
@@ -45,10 +42,7 @@ pub async fn create(
 
 /// `x0x group info` — GET /groups/:id.
 pub async fn info(client: &DaemonClient, group_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/groups/{group_id}")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/groups/{group_id}")).await
 }
 
 /// `x0x group update` — PATCH /groups/:id.
@@ -77,10 +71,7 @@ pub async fn update(
 
 /// `x0x group members` — GET /groups/:id/members.
 pub async fn members(client: &DaemonClient, group_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/groups/{group_id}/members")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/groups/{group_id}/members")).await
 }
 
 /// `x0x group add-member` — POST /groups/:id/members.
@@ -152,10 +143,7 @@ pub async fn set_name(client: &DaemonClient, group_id: &str, name: &str) -> Resu
 
 /// `x0x group leave` — DELETE /groups/:id.
 pub async fn leave(client: &DaemonClient, group_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.delete(&format!("/groups/{group_id}")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_delete(&format!("/groups/{group_id}")).await
 }
 
 // ── Policy / roles / bans ───────────────────────────────────────────────
@@ -256,10 +244,9 @@ pub async fn unban(client: &DaemonClient, group_id: &str, agent_id: &str) -> Res
 
 /// `x0x group requests` — GET /groups/:id/requests.
 pub async fn requests(client: &DaemonClient, group_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/groups/{group_id}/requests")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client
+        .run_get(&format!("/groups/{group_id}/requests"))
+        .await
 }
 
 /// `x0x group request-access` — POST /groups/:id/requests.
@@ -329,18 +316,12 @@ pub async fn discover(client: &DaemonClient, query: Option<&str>) -> Result<()> 
 
 /// `x0x group discover-nearby` — GET /groups/discover/nearby.
 pub async fn discover_nearby(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/groups/discover/nearby").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/groups/discover/nearby").await
 }
 
 /// `x0x group discover-subscriptions` — GET /groups/discover/subscriptions.
 pub async fn discover_subscriptions(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/groups/discover/subscriptions").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/groups/discover/subscriptions").await
 }
 
 /// `x0x group discover-subscribe` — POST /groups/discover/subscribe.
@@ -375,10 +356,7 @@ pub async fn discover_unsubscribe(client: &DaemonClient, kind: &str, shard: u32)
 
 /// `x0x group card` — GET /groups/cards/:id.
 pub async fn card(client: &DaemonClient, group_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/groups/cards/{group_id}")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/groups/cards/{group_id}")).await
 }
 
 /// `x0x group card-import` — POST /groups/cards/import.
@@ -426,20 +404,16 @@ pub async fn send(
 
 /// `x0x group messages` — GET /groups/:id/messages.
 pub async fn messages(client: &DaemonClient, group_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/groups/{group_id}/messages")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client
+        .run_get(&format!("/groups/{group_id}/messages"))
+        .await
 }
 
 // ── State-commit chain (Phase D.3) ──────────────────────────────────────
 
 /// `x0x group state` — GET /groups/:id/state.
 pub async fn state(client: &DaemonClient, group_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/groups/{group_id}/state")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/groups/{group_id}/state")).await
 }
 
 /// `x0x group state-seal` — POST /groups/:id/state/seal.
@@ -542,44 +516,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn list_returns_mock_response() {
         let mock_resp = serde_json::json!({"status": "ok"});

--- a/src/cli/commands/groups.rs
+++ b/src/cli/commands/groups.rs
@@ -6,10 +6,7 @@ use base64::Engine;
 
 /// `x0x groups [list]` — GET /mls/groups
 pub async fn list(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/mls/groups").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/mls/groups").await
 }
 
 /// `x0x groups create` — POST /mls/groups
@@ -26,10 +23,7 @@ pub async fn create(client: &DaemonClient, id: Option<&str>) -> Result<()> {
 
 /// `x0x groups get` — GET /mls/groups/:id
 pub async fn get(client: &DaemonClient, group_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/mls/groups/{group_id}")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/mls/groups/{group_id}")).await
 }
 
 /// `x0x groups add-member` — POST /mls/groups/:id/members
@@ -101,44 +95,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn list_returns_mock_response() {
         let mock_resp = serde_json::json!({"status": "ok"});

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -50,10 +50,7 @@ pub async fn agent(client: &DaemonClient) -> Result<()> {
 
 /// `x0x agent user-id` — GET /agent/user-id
 pub async fn user_id(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/agent/user-id").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/agent/user-id").await
 }
 
 /// `x0x announce` — POST /announce
@@ -75,19 +72,16 @@ pub async fn card(
     include_groups: bool,
 ) -> Result<()> {
     client.ensure_running().await?;
-    let mut params = Vec::new();
+    // Build the query with reqwest's encoder so a `display_name` containing
+    // spaces, `&`, or `=` is percent-encoded rather than corrupting the query.
+    let mut query: Vec<(&str, &str)> = Vec::new();
     if let Some(name) = display_name {
-        params.push(format!("display_name={name}"));
+        query.push(("display_name", name));
     }
     if include_groups {
-        params.push("include_groups=true".to_string());
+        query.push(("include_groups", "true"));
     }
-    let query = if params.is_empty() {
-        String::new()
-    } else {
-        format!("?{}", params.join("&"))
-    };
-    let resp = client.get(&format!("/agent/card{query}")).await?;
+    let resp = client.get_query("/agent/card", &query).await?;
 
     // Print the link prominently
     if let Some(link) = resp.get("link").and_then(|v| v.as_str()) {
@@ -102,10 +96,7 @@ pub async fn card(
 
 /// `x0x agent introduction` — GET /introduction
 pub async fn introduction(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/introduction").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/introduction").await
 }
 
 /// `x0x agent import` — POST /agent/card/import
@@ -173,41 +164,7 @@ mod tests {
     use super::*;
     use crate::cli::{DaemonClient, OutputFormat};
 
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[test]
     fn identity_words_encodes_known_hex() {
         let encoder = IdentityEncoder::new();
@@ -381,5 +338,63 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("pass either --file <PATH>"));
+    }
+
+    /// Regression: `card` must percent-encode `display_name`, so a name with
+    /// spaces and `&` cannot corrupt the query string. Captures the raw
+    /// request URI on a mock server and asserts the value round-trips.
+    #[tokio::test]
+    async fn card_url_encodes_display_name() {
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let captured_for_handler = Arc::clone(&captured);
+
+        let app = axum::Router::new().fallback(move |req: axum::extract::Request| {
+            let captured = Arc::clone(&captured_for_handler);
+            async move {
+                *captured.lock().await = Some(req.uri().to_string());
+                axum::response::Response::builder()
+                    .status(200)
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from("{\"ok\":true}"))
+                    .unwrap()
+            }
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app.into_make_service())
+                .with_graceful_shutdown(async {
+                    rx.await.ok();
+                })
+                .await
+                .ok();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let url = format!("http://{addr}");
+        let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
+        let result = card(&client, Some("Alice & Bob"), false).await;
+        assert!(result.is_ok(), "card should succeed: {result:?}");
+
+        let uri = captured.lock().await.clone().expect("request captured");
+        // The literal "Alice & Bob" must be encoded, never appearing raw with
+        // a bare `&` that would split into a second query parameter.
+        assert!(
+            uri.contains("display_name=Alice"),
+            "expected encoded display_name in {uri}"
+        );
+        assert!(
+            !uri.contains("display_name=Alice & Bob"),
+            "raw space/ampersand leaked into query: {uri}"
+        );
+        assert!(
+            uri.contains("%26") || uri.contains("Alice%20%26%20Bob") || uri.contains("Alice+%26"),
+            "ampersand was not percent-encoded: {uri}"
+        );
+        drop(tx);
     }
 }

--- a/src/cli/commands/machines.rs
+++ b/src/cli/commands/machines.rs
@@ -32,10 +32,7 @@ pub async fn get_discovered(client: &DaemonClient, machine_id: &str, wait: bool)
 
 /// `x0x machines by-user` — GET /users/:user_id/machines
 pub async fn by_user(client: &DaemonClient, user_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/users/{user_id}/machines")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/users/{user_id}/machines")).await
 }
 
 /// `x0x machines connect` — POST /machines/connect
@@ -107,44 +104,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn discovered_returns_mock_response() {
         let mock_resp = serde_json::json!({"machines": [{"machine_id": "abc123"}]});

--- a/src/cli/commands/messaging.rs
+++ b/src/cli/commands/messaging.rs
@@ -40,10 +40,7 @@ pub async fn subscribe(client: &DaemonClient, topic: &str) -> Result<()> {
 
 /// `x0x unsubscribe` — DELETE /subscribe/:id
 pub async fn unsubscribe(client: &DaemonClient, id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.delete(&format!("/subscribe/{id}")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_delete(&format!("/subscribe/{id}")).await
 }
 
 /// `x0x events` — stream GET /events
@@ -96,44 +93,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     async fn start_sse_server(body: &'static str) -> (String, tokio::sync::oneshot::Sender<()>) {
         let app = axum::Router::new().fallback(move |_req: axum::extract::Request| async move {
             axum::response::Response::builder()

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -23,34 +23,44 @@ pub mod upgrade;
 pub mod user_id;
 pub mod ws;
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 use crate::api;
+use serde::Serialize;
+
+/// JSON shape of one endpoint in `routes --json`.
+///
+/// Field order/names are the public contract consumed by `just routes-json`
+/// and other tooling: `method`, `path`, `cli_name`, `description`, `category`.
+#[derive(Serialize)]
+struct RouteEntry<'a> {
+    method: String,
+    path: &'a str,
+    cli_name: &'a str,
+    description: &'a str,
+    category: &'a str,
+}
 
 /// Print the full API route table.
 ///
 /// When `json` is true, emits a JSON array — one object per endpoint with
 /// `method`, `path`, `cli_name`, `description`, `category` fields. Used by
-/// `just gui-coverage` and other downstream tooling to treat the registry as
+/// `just routes-json` and other downstream tooling to treat the registry as
 /// the source of truth.
 pub fn routes(json: bool) -> anyhow::Result<()> {
     if json {
-        let mut out = String::from("[\n");
-        let total = api::ENDPOINTS.len();
-        for (i, ep) in api::ENDPOINTS.iter().enumerate() {
-            out.push_str(&format!(
-                "  {{\"method\":\"{}\",\"path\":{},\"cli_name\":{},\"description\":{},\"category\":{}}}",
-                ep.method,
-                json_escape(ep.path),
-                json_escape(ep.cli_name),
-                json_escape(ep.description),
-                json_escape(ep.category),
-            ));
-            if i + 1 < total {
-                out.push(',');
-            }
-            out.push('\n');
-        }
-        out.push(']');
-        println!("{out}");
+        let entries: Vec<RouteEntry<'_>> = api::ENDPOINTS
+            .iter()
+            .map(|ep| RouteEntry {
+                method: ep.method.to_string(),
+                path: ep.path,
+                cli_name: ep.cli_name,
+                description: ep.description,
+                category: ep.category,
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&entries)?);
         return Ok(());
     }
 
@@ -78,57 +88,58 @@ pub fn routes(json: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn json_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('"');
-    for ch in s.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
-            c => out.push(c),
-        }
-    }
-    out.push('"');
-    out
-}
-
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
     use crate::cli::OutputFormat;
 
+    /// The `routes --json` payload is a public contract: tooling parses it and
+    /// keys off `method`/`path`/`cli_name`/`description`/`category`. Pin the
+    /// serialized shape so a serializer change cannot silently break it.
     #[test]
-    fn json_escape_simple_string() {
-        assert_eq!(json_escape("hello"), r#""hello""#);
+    fn routes_json_contract_is_stable() {
+        let entries: Vec<RouteEntry<'_>> = api::ENDPOINTS
+            .iter()
+            .map(|ep| RouteEntry {
+                method: ep.method.to_string(),
+                path: ep.path,
+                cli_name: ep.cli_name,
+                description: ep.description,
+                category: ep.category,
+            })
+            .collect();
+        let json = serde_json::to_string_pretty(&entries).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().expect("routes json is an array");
+        assert_eq!(arr.len(), api::ENDPOINTS.len());
+        for (entry, ep) in arr.iter().zip(api::ENDPOINTS.iter()) {
+            let obj = entry.as_object().expect("each entry is an object");
+            for field in ["method", "path", "cli_name", "description", "category"] {
+                assert!(obj.contains_key(field), "missing field {field}");
+            }
+            assert_eq!(obj["method"], serde_json::json!(ep.method.to_string()));
+            assert_eq!(obj["path"], serde_json::json!(ep.path));
+            assert_eq!(obj["cli_name"], serde_json::json!(ep.cli_name));
+        }
     }
 
+    /// Special characters must survive serialization — this is what the old
+    /// hand-rolled escaper guarded. A `"`/newline/tab in a description must
+    /// round-trip without producing invalid JSON.
     #[test]
-    fn json_escape_escapes_quotes() {
-        assert_eq!(json_escape("say \"hi\""), r#""say \"hi\"""#);
-    }
-
-    #[test]
-    fn json_escape_escapes_backslash() {
-        assert_eq!(json_escape("a\\b"), r#""a\\b""#);
-    }
-
-    #[test]
-    fn json_escape_escapes_newline() {
-        assert_eq!(json_escape("a\nb"), r#""a\nb""#);
-    }
-
-    #[test]
-    fn json_escape_escapes_tab() {
-        assert_eq!(json_escape("a\tb"), r#""a\tb""#);
-    }
-
-    #[test]
-    fn json_escape_escapes_control_chars() {
-        assert_eq!(json_escape("a\x00b"), r#""a\u0000b""#);
+    fn routes_json_escapes_special_characters() {
+        let entries = vec![RouteEntry {
+            method: "GET".to_string(),
+            path: "/x",
+            cli_name: "x",
+            description: "say \"hi\"\nand\ttab",
+            category: "test",
+        }];
+        let json = serde_json::to_string(&entries).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed[0]["description"], "say \"hi\"\nand\ttab");
     }
 
     #[test]

--- a/src/cli/commands/network.rs
+++ b/src/cli/commands/network.rs
@@ -41,10 +41,7 @@ fn inject_location_words(value: &mut serde_json::Value) {
 
 /// `x0x health` — GET /health
 pub async fn health(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/health").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/health").await
 }
 
 /// `x0x status` — GET /status
@@ -60,34 +57,22 @@ pub async fn status(client: &DaemonClient) -> Result<()> {
 
 /// `x0x peers` — GET /peers
 pub async fn peers(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/peers").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/peers").await
 }
 
 /// `x0x presence` — GET /presence
 pub async fn presence(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/presence").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/presence").await
 }
 
 /// `x0x network status` — GET /network/status
 pub async fn network_status(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/network/status").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/network/status").await
 }
 
 /// `x0x network cache` — GET /network/bootstrap-cache
 pub async fn bootstrap_cache(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/network/bootstrap-cache").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/network/bootstrap-cache").await
 }
 
 /// `x0x diagnostics connectivity` — GET /diagnostics/connectivity
@@ -97,10 +82,7 @@ pub async fn bootstrap_cache(client: &DaemonClient) -> Result<()> {
 /// hole-punch success rate, and advertised external addresses. Primary tool
 /// for answering "is ant-quic's 100%-connectivity promise holding?".
 pub async fn diagnostics_connectivity(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/diagnostics/connectivity").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/diagnostics/connectivity").await
 }
 
 /// `x0x diagnostics ack` — GET /diagnostics/ack
@@ -109,10 +91,7 @@ pub async fn diagnostics_connectivity(client: &DaemonClient) -> Result<()> {
 /// the old opaque "ACK timeout" class into sender open/write/finish/read and
 /// receiver demux/admission/response-write stages.
 pub async fn diagnostics_ack(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/diagnostics/ack").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/diagnostics/ack").await
 }
 
 /// `x0x diagnostics gossip` — GET /diagnostics/gossip
@@ -122,10 +101,7 @@ pub async fn diagnostics_ack(client: &DaemonClient) -> Result<()> {
 /// subscriber channel (buffer full or dropped subscription). Primary tool
 /// for the 100%-delivery proof under stress.
 pub async fn diagnostics_gossip(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/diagnostics/gossip").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/diagnostics/gossip").await
 }
 
 /// `x0x diagnostics dm` — GET /diagnostics/dm
@@ -133,10 +109,7 @@ pub async fn diagnostics_gossip(client: &DaemonClient) -> Result<()> {
 /// Prints direct-message send/receive counters, subscriber fan-out health, and
 /// per-peer timing/path state.
 pub async fn diagnostics_dm(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/diagnostics/dm").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/diagnostics/dm").await
 }
 
 /// `x0x diagnostics groups` — GET /diagnostics/groups
@@ -150,10 +123,7 @@ pub async fn diagnostics_dm(client: &DaemonClient) -> Result<()> {
 /// joiners' messages reached the listener but the owner's `members_v2`
 /// view is missing them.
 pub async fn diagnostics_groups(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/diagnostics/groups").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/diagnostics/groups").await
 }
 
 /// `x0x peers probe <peer_id>` — POST /peers/:peer_id/probe
@@ -183,10 +153,7 @@ pub async fn peers_probe(
 /// lifecycle state, generation, directional activity timestamps, and the
 /// most-recent close reason.
 pub async fn peers_health(client: &DaemonClient, peer_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/peers/{peer_id}/health")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/peers/{peer_id}/health")).await
 }
 
 /// `x0x peers events` — GET /peers/events (SSE).
@@ -244,44 +211,8 @@ mod tests {
     }
 }
 
-/// Start a mock axum server that returns the given JSON for any request.
-/// Returns the base URL and a shutdown sender.
-#[allow(dead_code)]
-async fn start_mock_server(
-    response_json: serde_json::Value,
-) -> (String, tokio::sync::oneshot::Sender<()>) {
-    use std::sync::Arc;
-
-    let json = Arc::new(response_json);
-    let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-        let json = Arc::clone(&json);
-        async move {
-            let body = serde_json::to_vec(&*json).unwrap();
-            axum::response::Response::builder()
-                .status(200)
-                .header("content-type", "application/json")
-                .body(axum::body::Body::from(body))
-                .unwrap()
-        }
-    });
-
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-    tokio::spawn(async move {
-        axum::serve(listener, app.into_make_service())
-            .with_graceful_shutdown(async {
-                rx.await.ok();
-            })
-            .await
-            .ok();
-    });
-
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-    (format!("http://{}", addr), tx)
-}
+#[cfg(test)]
+use crate::cli::commands::test_support::start_mock_server;
 
 #[tokio::test]
 async fn health_returns_mock_response() {

--- a/src/cli/commands/presence.rs
+++ b/src/cli/commands/presence.rs
@@ -1,6 +1,6 @@
 //! Presence CLI commands — wrappers around the `/presence/*` REST endpoints.
 
-use crate::cli::{print_value, DaemonClient};
+use crate::cli::DaemonClient;
 use anyhow::Result;
 
 /// `x0x presence online` — GET /presence/online
@@ -8,10 +8,7 @@ use anyhow::Result;
 /// Lists all online agents from the local discovery cache (network view:
 /// includes all non-blocked agents).
 pub async fn online(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/presence/online").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/presence/online").await
 }
 
 /// `x0x presence foaf` — GET /presence/foaf?ttl=N&timeout_ms=N
@@ -19,44 +16,35 @@ pub async fn online(client: &DaemonClient) -> Result<()> {
 /// Performs a FOAF random-walk query and returns the social view (Trusted +
 /// Known contacts only).
 pub async fn foaf(client: &DaemonClient, ttl: u8, timeout_ms: u64) -> Result<()> {
-    client.ensure_running().await?;
     let ttl_str = ttl.to_string();
     let timeout_str = timeout_ms.to_string();
-    let resp = client
-        .get_query(
+    client
+        .run_get_query(
             "/presence/foaf",
             &[("ttl", &ttl_str), ("timeout_ms", &timeout_str)],
         )
-        .await?;
-    print_value(client.format(), &resp);
-    Ok(())
+        .await
 }
 
 /// `x0x presence find <id>` — GET /presence/find/:id
 ///
 /// Locates a specific agent by hex-encoded AgentId via FOAF random walk.
 pub async fn find(client: &DaemonClient, id: &str, ttl: u8, timeout_ms: u64) -> Result<()> {
-    client.ensure_running().await?;
     let ttl_str = ttl.to_string();
     let timeout_str = timeout_ms.to_string();
-    let resp = client
-        .get_query(
+    client
+        .run_get_query(
             &format!("/presence/find/{id}"),
             &[("ttl", &ttl_str), ("timeout_ms", &timeout_str)],
         )
-        .await?;
-    print_value(client.format(), &resp);
-    Ok(())
+        .await
 }
 
 /// `x0x presence status <id>` — GET /presence/status/:id
 ///
 /// Checks local cache for an agent by hex-encoded AgentId. No network I/O.
 pub async fn status(client: &DaemonClient, id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/presence/status/{id}")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/presence/status/{id}")).await
 }
 
 /// `x0x presence events` — GET /presence/events (SSE stream).
@@ -83,44 +71,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn online_returns_mock_response() {
         let mock_resp = serde_json::json!({"agents": [{"agent_id": "abc123", "online": true}]});

--- a/src/cli/commands/store.rs
+++ b/src/cli/commands/store.rs
@@ -5,10 +5,7 @@ use anyhow::Result;
 
 /// `x0x store list` — GET /stores.
 pub async fn list(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/stores").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/stores").await
 }
 
 /// `x0x store create` — POST /stores.
@@ -31,10 +28,7 @@ pub async fn join(client: &DaemonClient, topic: &str) -> Result<()> {
 
 /// `x0x store keys` — GET /stores/:id/keys.
 pub async fn keys(client: &DaemonClient, store_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/stores/{store_id}/keys")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/stores/{store_id}/keys")).await
 }
 
 /// `x0x store put` — PUT /stores/:id/:key.
@@ -61,18 +55,14 @@ pub async fn put(
 
 /// `x0x store get` — GET /stores/:id/:key.
 pub async fn get(client: &DaemonClient, store_id: &str, key: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/stores/{store_id}/{key}")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get(&format!("/stores/{store_id}/{key}")).await
 }
 
 /// `x0x store rm` — DELETE /stores/:id/:key.
 pub async fn rm(client: &DaemonClient, store_id: &str, key: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.delete(&format!("/stores/{store_id}/{key}")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client
+        .run_delete(&format!("/stores/{store_id}/{key}"))
+        .await
 }
 
 #[cfg(test)]
@@ -81,44 +71,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn list_returns_mock_response() {
         let mock_resp = serde_json::json!({"stores": [{"name": "test-store"}]});

--- a/src/cli/commands/tasks.rs
+++ b/src/cli/commands/tasks.rs
@@ -5,10 +5,7 @@ use anyhow::Result;
 
 /// `x0x tasks [list]` — GET /task-lists
 pub async fn list(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/task-lists").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/task-lists").await
 }
 
 /// `x0x tasks create` — POST /task-lists
@@ -25,10 +22,9 @@ pub async fn create(client: &DaemonClient, name: &str, topic: &str) -> Result<()
 
 /// `x0x tasks show` — GET /task-lists/:id/tasks
 pub async fn show(client: &DaemonClient, list_id: &str) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get(&format!("/task-lists/{list_id}/tasks")).await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client
+        .run_get(&format!("/task-lists/{list_id}/tasks"))
+        .await
 }
 
 /// `x0x tasks add` — POST /task-lists/:id/tasks
@@ -72,44 +68,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn list_returns_mock_response() {
         let mock_resp = serde_json::json!({"task_lists": [{"name": "test-list"}]});

--- a/src/cli/commands/test_support.rs
+++ b/src/cli/commands/test_support.rs
@@ -1,0 +1,47 @@
+//! Shared test helpers for command modules.
+//!
+//! Hoists the previously copy-pasted `start_mock_server` helper into one place
+//! so every command test module shares a single implementation.
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+/// Start a mock axum server that returns the given JSON for any request.
+///
+/// Returns the base URL and a oneshot sender that shuts the server down when
+/// dropped or signalled.
+pub async fn start_mock_server(
+    response_json: serde_json::Value,
+) -> (String, tokio::sync::oneshot::Sender<()>) {
+    use std::sync::Arc;
+
+    let json = Arc::new(response_json);
+    let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
+        let json = Arc::clone(&json);
+        async move {
+            let body = serde_json::to_vec(&*json).unwrap();
+            axum::response::Response::builder()
+                .status(200)
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
+                .unwrap()
+        }
+    });
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .with_graceful_shutdown(async {
+                rx.await.ok();
+            })
+            .await
+            .ok();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    (format!("http://{addr}"), tx)
+}

--- a/src/cli/commands/ws.rs
+++ b/src/cli/commands/ws.rs
@@ -36,10 +36,7 @@ pub async fn general(client: &DaemonClient) -> Result<()> {
 
 /// `x0x ws sessions` — GET /ws/sessions
 pub async fn sessions(client: &DaemonClient) -> Result<()> {
-    client.ensure_running().await?;
-    let resp = client.get("/ws/sessions").await?;
-    print_value(client.format(), &resp);
-    Ok(())
+    client.run_get("/ws/sessions").await
 }
 
 /// `x0x ws direct` — GET /ws/direct (diagnostic: prints the WebSocket URL).
@@ -81,44 +78,7 @@ mod tests {
     use super::*;
     use crate::cli::DaemonClient;
 
-    /// Start a mock axum server that returns the given JSON for any request.
-    #[allow(dead_code)]
-    async fn start_mock_server(
-        response_json: serde_json::Value,
-    ) -> (String, tokio::sync::oneshot::Sender<()>) {
-        use std::sync::Arc;
-
-        let json = Arc::new(response_json);
-        let app = axum::Router::new().fallback(move |_req: axum::extract::Request| {
-            let json = Arc::clone(&json);
-            async move {
-                let body = serde_json::to_vec(&*json).unwrap();
-                axum::response::Response::builder()
-                    .status(200)
-                    .header("content-type", "application/json")
-                    .body(axum::body::Body::from(body))
-                    .unwrap()
-            }
-        });
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            axum::serve(listener, app.into_make_service())
-                .with_graceful_shutdown(async {
-                    rx.await.ok();
-                })
-                .await
-                .ok();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        (format!("http://{}", addr), tx)
-    }
-
+    use crate::cli::commands::test_support::start_mock_server;
     #[tokio::test]
     async fn sessions_returns_mock_response() {
         let mock_resp = serde_json::json!({"sessions": [{"id": "session-1"}]});

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -243,11 +243,7 @@ impl DaemonClient {
         if !resp.status().is_success() {
             let status = resp.status();
             let body: serde_json::Value = resp.json().await.unwrap_or_default();
-            let msg = body
-                .get("error")
-                .and_then(|e| e.as_str())
-                .unwrap_or("unknown error");
-            anyhow::bail!("{} (HTTP {})", msg, status.as_u16());
+            return Err(error_from_body(status, &body));
         }
         Ok(resp)
     }
@@ -262,14 +258,69 @@ impl DaemonClient {
         };
 
         if !status.is_success() {
-            let msg = body
-                .get("error")
-                .and_then(|e| e.as_str())
-                .unwrap_or("unknown error");
-            anyhow::bail!("{} (HTTP {})", msg, status.as_u16());
+            return Err(error_from_body(status, &body));
         }
 
         Ok(body)
+    }
+
+    /// Ensure the daemon is running, send a GET, and print the response.
+    ///
+    /// Collapses the `ensure_running -> get -> print_value` shape shared by the
+    /// trivial read-only commands into a single call.
+    pub async fn run_get(&self, path: &str) -> Result<()> {
+        self.ensure_running().await?;
+        let resp = self.get(path).await?;
+        print_value(self.format, &resp);
+        Ok(())
+    }
+
+    /// Ensure the daemon is running, send a GET with query params, and print.
+    pub async fn run_get_query(&self, path: &str, query: &[(&str, &str)]) -> Result<()> {
+        self.ensure_running().await?;
+        let resp = self.get_query(path, query).await?;
+        print_value(self.format, &resp);
+        Ok(())
+    }
+
+    /// Ensure the daemon is running, send a POST with a JSON body, and print.
+    pub async fn run_post<T: Serialize + ?Sized>(&self, path: &str, body: &T) -> Result<()> {
+        self.ensure_running().await?;
+        let resp = self.post(path, body).await?;
+        print_value(self.format, &resp);
+        Ok(())
+    }
+
+    /// Ensure the daemon is running, send a POST with no body, and print.
+    pub async fn run_post_empty(&self, path: &str) -> Result<()> {
+        self.ensure_running().await?;
+        let resp = self.post_empty(path).await?;
+        print_value(self.format, &resp);
+        Ok(())
+    }
+
+    /// Ensure the daemon is running, send a PATCH with a JSON body, and print.
+    pub async fn run_patch<T: Serialize + ?Sized>(&self, path: &str, body: &T) -> Result<()> {
+        self.ensure_running().await?;
+        let resp = self.patch(path, body).await?;
+        print_value(self.format, &resp);
+        Ok(())
+    }
+
+    /// Ensure the daemon is running, send a PUT with a JSON body, and print.
+    pub async fn run_put<T: Serialize + ?Sized>(&self, path: &str, body: &T) -> Result<()> {
+        self.ensure_running().await?;
+        let resp = self.put(path, body).await?;
+        print_value(self.format, &resp);
+        Ok(())
+    }
+
+    /// Ensure the daemon is running, send a DELETE, and print the response.
+    pub async fn run_delete(&self, path: &str) -> Result<()> {
+        self.ensure_running().await?;
+        let resp = self.delete(path).await?;
+        print_value(self.format, &resp);
+        Ok(())
     }
 
     /// Get the output format.
@@ -286,6 +337,18 @@ impl DaemonClient {
     pub fn api_token(&self) -> Option<&str> {
         self.api_token.as_deref()
     }
+}
+
+/// Build an `anyhow::Error` from a non-success HTTP status and its JSON body.
+///
+/// Reads the `error` field from the body when present, falling back to
+/// `"unknown error"`, and appends the numeric status code.
+fn error_from_body(status: reqwest::StatusCode, body: &serde_json::Value) -> anyhow::Error {
+    let msg = body
+        .get("error")
+        .and_then(|e| e.as_str())
+        .unwrap_or("unknown error");
+    anyhow::anyhow!("{} (HTTP {})", msg, status.as_u16())
 }
 
 /// Print a JSON value according to the output format.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -283,38 +283,6 @@ impl DaemonClient {
         Ok(())
     }
 
-    /// Ensure the daemon is running, send a POST with a JSON body, and print.
-    pub async fn run_post<T: Serialize + ?Sized>(&self, path: &str, body: &T) -> Result<()> {
-        self.ensure_running().await?;
-        let resp = self.post(path, body).await?;
-        print_value(self.format, &resp);
-        Ok(())
-    }
-
-    /// Ensure the daemon is running, send a POST with no body, and print.
-    pub async fn run_post_empty(&self, path: &str) -> Result<()> {
-        self.ensure_running().await?;
-        let resp = self.post_empty(path).await?;
-        print_value(self.format, &resp);
-        Ok(())
-    }
-
-    /// Ensure the daemon is running, send a PATCH with a JSON body, and print.
-    pub async fn run_patch<T: Serialize + ?Sized>(&self, path: &str, body: &T) -> Result<()> {
-        self.ensure_running().await?;
-        let resp = self.patch(path, body).await?;
-        print_value(self.format, &resp);
-        Ok(())
-    }
-
-    /// Ensure the daemon is running, send a PUT with a JSON body, and print.
-    pub async fn run_put<T: Serialize + ?Sized>(&self, path: &str, body: &T) -> Result<()> {
-        self.ensure_running().await?;
-        let resp = self.put(path, body).await?;
-        print_value(self.format, &resp);
-        Ok(())
-    }
-
     /// Ensure the daemon is running, send a DELETE, and print the response.
     pub async fn run_delete(&self, path: &str) -> Result<()> {
         self.ensure_running().await?;

--- a/src/crdt/delta.rs
+++ b/src/crdt/delta.rs
@@ -122,48 +122,29 @@ impl TaskList {
         self.current_version()
     }
 
-    /// Generate a delta containing changes since a given version.
+    /// Generate a delta containing the task list's entire current state.
     ///
-    /// Returns None if no changes have occurred since the specified version.
-    ///
-    /// # Arguments
-    ///
-    /// * `since_version` - The version to generate delta from
-    ///
-    /// # Returns
-    ///
-    /// Some(delta) if there are changes, None otherwise.
-    ///
-    /// Note: This is a simplified implementation. A production version would
-    /// maintain a changelog to generate accurate deltas.
+    /// Mirrors `KvStore::full_delta`: every active task is emitted as an
+    /// "added" entry plus the current ordering and name. Receivers apply it
+    /// with `merge_delta`, whose upsert/LWW semantics make a full snapshot a
+    /// safe superset of any incremental change — this is the producer used to
+    /// answer cold-start state requests (see `TaskListSync`). The OR-Set tags
+    /// are synthetic because the receiver re-derives membership on merge.
     #[must_use]
-    pub fn delta(&self, since_version: u64) -> Option<TaskListDelta> {
-        let current_version = self.version();
+    pub fn full_delta(&self) -> TaskListDelta {
+        let mut delta = TaskListDelta::new(self.version());
 
-        // If versions match, no changes
-        if since_version >= current_version {
-            return None;
-        }
-
-        // For simplicity, we generate a full-state delta
-        // A production implementation would track actual changes
-        let mut delta = TaskListDelta::new(current_version);
-
-        // Add all current tasks as "added"
-        // In a real implementation, we'd only include tasks added since the version
-        for task in self.tasks_ordered() {
+        let ordered = self.tasks_ordered();
+        for task in &ordered {
             let task_id = *task.id();
-            let tag = (PeerId::new([0u8; 32]), 0); // Placeholder tag
-            delta.added_tasks.insert(task_id, (task.clone(), tag));
+            let tag = (PeerId::new([0u8; 32]), 0);
+            delta.added_tasks.insert(task_id, ((*task).clone(), tag));
         }
 
-        // Include current ordering
-        delta.ordering_update = Some(self.tasks_ordered().iter().map(|t| *t.id()).collect());
-
-        // Include current name
+        delta.ordering_update = Some(ordered.iter().map(|t| *t.id()).collect());
         delta.name_update = Some(self.name().to_string());
 
-        Some(delta)
+        delta
     }
 
     /// Merge a delta into this TaskList.
@@ -262,7 +243,14 @@ impl DeltaCrdt for TaskList {
     }
 
     fn delta(&self, since_version: u64) -> Option<Self::Delta> {
-        self.delta(since_version)
+        // A full-state delta is a sound conservative answer to "changes since
+        // version N": merge_delta is idempotent and LWW/upsert-based, so the
+        // receiver converges regardless of how much extra state we include.
+        if since_version >= self.version() {
+            None
+        } else {
+            Some(self.full_delta())
+        }
     }
 
     fn version(&self) -> u64 {
@@ -348,11 +336,8 @@ mod tests {
         let task = make_task(1, peer);
         list.add_task(task, peer, 1).ok().unwrap();
 
-        // Generate delta from version 0
-        let delta = list.delta(0);
-        assert!(delta.is_some());
-
-        let delta = delta.unwrap();
+        // A full-state delta carries every active task.
+        let delta = list.full_delta();
         assert!(!delta.is_empty());
         assert!(!delta.added_tasks.is_empty());
     }
@@ -365,8 +350,9 @@ mod tests {
 
         let current_version = list.version();
 
-        // Delta from current version should be None
-        let delta = list.delta(current_version);
+        // Asking the DeltaCrdt trait for changes since the current version
+        // yields nothing.
+        let delta = DeltaCrdt::delta(&list, current_version);
         assert!(delta.is_none());
     }
 
@@ -383,8 +369,8 @@ mod tests {
         let task = make_task(1, peer2);
         list2.add_task(task, peer2, 1).ok().unwrap();
 
-        // Generate delta from list2
-        let delta = list2.delta(0).unwrap();
+        // Generate a full-state delta from list2
+        let delta = list2.full_delta();
 
         // Merge delta into list1
         let result = list1.merge_delta(&delta, peer1);
@@ -392,6 +378,42 @@ mod tests {
 
         // list1 should now have the task
         assert_eq!(list1.task_count(), 1);
+    }
+
+    #[test]
+    fn full_delta_lets_a_late_joiner_converge() {
+        // WHY: a peer that subscribes after tasks were already added has no
+        // organic deltas to replay. The cold-start path (TaskListSync's
+        // StateRequest) answers with `full_delta()`; merging it must reproduce
+        // the holder's complete state — every task, the ordering, and the name
+        // — or a late joiner would converge to a partial list.
+        let holder_peer = peer(1);
+        let joiner_peer = peer(2);
+        let id = list_id(1);
+
+        let mut holder = TaskList::new(id, "Sprint".to_string(), holder_peer);
+        let t1 = make_task(1, holder_peer);
+        let t2 = make_task(2, holder_peer);
+        let t3 = make_task(3, holder_peer);
+        let (id1, id2, id3) = (*t1.id(), *t2.id(), *t3.id());
+        holder.add_task(t1, holder_peer, 1).expect("add t1");
+        holder.add_task(t2, holder_peer, 2).expect("add t2");
+        holder.add_task(t3, holder_peer, 3).expect("add t3");
+        holder
+            .reorder(vec![id3, id1, id2], holder_peer)
+            .expect("reorder");
+        holder.update_name("Sprint Backlog".to_string(), holder_peer);
+
+        // Fresh joiner with an empty list applies only the cold-start snapshot.
+        let mut joiner = TaskList::new(id, String::new(), joiner_peer);
+        let snapshot = holder.full_delta();
+        joiner.merge_delta(&snapshot, holder_peer).expect("merge");
+
+        assert_eq!(joiner.task_count(), 3, "all tasks transferred");
+        assert_eq!(joiner.name(), "Sprint Backlog", "name transferred");
+        let joiner_order: Vec<_> = joiner.tasks_ordered().iter().map(|t| *t.id()).collect();
+        let holder_order: Vec<_> = holder.tasks_ordered().iter().map(|t| *t.id()).collect();
+        assert_eq!(joiner_order, holder_order, "ordering converged");
     }
 
     #[test]

--- a/src/crdt/delta.rs
+++ b/src/crdt/delta.rs
@@ -13,7 +13,7 @@
 //! This significantly reduces bandwidth usage in collaborative scenarios.
 
 use crate::crdt::{Result, TaskId, TaskItem, TaskList};
-use saorsa_gossip_crdt_sync::DeltaCrdt;
+use saorsa_gossip_crdt_sync::{DeltaCrdt, LwwRegister};
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -39,15 +39,14 @@ pub struct TaskListDelta {
     /// A future optimization could implement TaskItemDelta for finer-grained updates.
     pub task_updates: HashMap<TaskId, TaskItem>,
 
-    /// Update to task ordering (new_order, timestamp)
-    ///
-    /// If Some, the ordering changed. The receiver should merge this using LWW semantics.
-    pub ordering_update: Option<Vec<TaskId>>,
+    /// Update to task ordering, carried as the full LWW register (value +
+    /// vector clock) so the receiver resolves it by causality rather than
+    /// adopting it unconditionally.
+    pub ordering_update: Option<LwwRegister<Vec<TaskId>>>,
 
-    /// Update to list name (new_name)
-    ///
-    /// If Some, the name changed. The receiver should merge this using LWW semantics.
-    pub name_update: Option<String>,
+    /// Update to list name, carried as the full LWW register (value + vector
+    /// clock) so the receiver resolves it by causality.
+    pub name_update: Option<LwwRegister<String>>,
 
     /// Version number of this delta
     pub version: u64,
@@ -87,10 +86,13 @@ impl TaskListDelta {
     }
 
     /// Create a delta for a reorder operation.
+    ///
+    /// Takes the post-reorder ordering register (with its vector clock) so the
+    /// change merges by causality on the receiver.
     #[must_use]
-    pub fn for_reorder(new_order: Vec<TaskId>, version: u64) -> Self {
+    pub fn for_reorder(order_register: LwwRegister<Vec<TaskId>>, version: u64) -> Self {
         let mut delta = Self::new(version);
-        delta.ordering_update = Some(new_order);
+        delta.ordering_update = Some(order_register);
         delta
     }
 
@@ -141,8 +143,11 @@ impl TaskList {
             delta.added_tasks.insert(task_id, ((*task).clone(), tag));
         }
 
-        delta.ordering_update = Some(ordered.iter().map(|t| *t.id()).collect());
-        delta.name_update = Some(self.name().to_string());
+        // Carry the registers themselves (value + clock) so a cold-start
+        // snapshot merges by causality and cannot clobber a newer local
+        // ordering/name on an already-populated peer.
+        delta.ordering_update = Some(self.ordering_register().clone());
+        delta.name_update = Some(self.name_register().clone());
 
         delta
     }
@@ -204,23 +209,16 @@ impl TaskList {
             }
         }
 
-        // Apply ordering update (LWW semantics via merge)
-        if let Some(ref new_order) = delta.ordering_update {
-            // Validate all task IDs exist before reordering
-            let valid_order: Vec<TaskId> = new_order
-                .iter()
-                .filter(|id| self.get_task(id).is_some())
-                .copied()
-                .collect();
-
-            if !valid_order.is_empty() {
-                let _ = self.reorder(valid_order, peer_id);
-            }
+        // Apply ordering update via LWW (vector-clock) merge. The merged
+        // ordering may reference task IDs not yet present (out-of-order
+        // delivery); tasks_ordered filters those at read time.
+        if let Some(ref order_register) = delta.ordering_update {
+            self.merge_ordering(order_register);
         }
 
-        // Apply name update (LWW semantics via merge)
-        if let Some(ref new_name) = delta.name_update {
-            self.update_name(new_name.clone(), peer_id);
+        // Apply name update via LWW (vector-clock) merge.
+        if let Some(ref name_register) = delta.name_update {
+            self.merge_name(name_register);
         }
 
         Ok(())
@@ -468,9 +466,13 @@ mod tests {
         list.add_task(task1, peer, 1).ok().unwrap();
         list.add_task(task2, peer, 2).ok().unwrap();
 
-        // Create delta with ordering update
+        // Build an ordering register that causally dominates the local one
+        // (a peer that reversed the order on top of the shared history), so
+        // the LWW merge adopts it.
+        let mut order_register = list.ordering_register().clone();
+        order_register.set(vec![id2, id1], peer); // Reversed order, newer clock
         let mut delta = TaskListDelta::new(10);
-        delta.ordering_update = Some(vec![id2, id1]); // Reversed order
+        delta.ordering_update = Some(order_register);
 
         // Merge delta
         list.merge_delta(&delta, peer).ok().unwrap();
@@ -482,14 +484,43 @@ mod tests {
     }
 
     #[test]
+    fn stale_name_delta_does_not_clobber_newer_local_name() {
+        // WHY: a cold-start responder broadcasts its full state on the main
+        // topic, reaching established peers. A peer that renamed the list more
+        // recently must not have its name reverted by an older holder's
+        // snapshot — the register's vector clock decides the winner.
+        let local = peer(1);
+        let remote = peer(2);
+        let id = list_id(1);
+        let mut list = TaskList::new(id, "Original".to_string(), local);
+
+        // `remote` renames the list; capture that register as the "stale" one.
+        list.update_name("FromRemote".to_string(), remote);
+        let stale = list.name_register().clone();
+
+        // `local` then renames on top — causally newer (its clock includes the
+        // remote rename), so a later redelivery of the stale register loses.
+        list.update_name("Newest".to_string(), local);
+
+        let mut delta = TaskListDelta::new(7);
+        delta.name_update = Some(stale);
+        list.merge_delta(&delta, remote).ok().unwrap();
+
+        assert_eq!(list.name(), "Newest", "stale name must not clobber newer");
+    }
+
+    #[test]
     fn test_merge_delta_with_name_update() {
         let peer = peer(1);
         let id = list_id(1);
         let mut list = TaskList::new(id, "Original".to_string(), peer);
 
-        // Create delta with name update
+        // A peer renames on top of the shared initial state; its register
+        // causally dominates ours, so the LWW merge adopts it.
+        let mut other = TaskList::new(id, "Original".to_string(), peer);
+        other.update_name("Updated".to_string(), peer);
         let mut delta = TaskListDelta::new(5);
-        delta.name_update = Some("Updated".to_string());
+        delta.name_update = Some(other.name_register().clone());
 
         // Merge delta
         list.merge_delta(&delta, peer).ok().unwrap();

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -1,42 +1,63 @@
-//! Task list synchronization using anti-entropy gossip.
+//! Task list synchronization using gossip pub/sub.
 //!
 //! This module provides automatic synchronization of TaskLists across peers
-//! using saorsa-gossip's anti-entropy mechanism combined with pub/sub.
+//! using saorsa-gossip's pub/sub delta propagation.
 //!
 //! ## Architecture
 //!
 //! - `TaskListSync` wraps a TaskList in Arc<RwLock<>> for concurrent access
-//! - Uses `AntiEntropyManager` for periodic background synchronization
 //! - Publishes deltas to a gossip topic when local changes occur
 //! - Subscribes to the topic to receive and apply remote deltas
+//! - Runs a `StateRequest` cold-start side channel so a first-time joiner
+//!   bootstraps tasks written before it subscribed (mirrors `KvStoreSync`)
 //!
 //! This provides eventual consistency across all peers sharing the same topic.
 
 use crate::crdt::{Result, TaskList, TaskListDelta};
+use crate::gossip::wire::{decode_delta, encode_delta};
 use crate::gossip::PubSubManager;
-use saorsa_gossip_crdt_sync::AntiEntropyManager;
 use saorsa_gossip_types::PeerId;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+/// Suffix appended to a task-list topic to form its state-sync side channel.
+///
+/// State requests travel on a separate topic so the main topic keeps its
+/// existing `(PeerId, TaskListDelta)` wire format — peers that predate this
+/// channel simply never subscribe to it and are unaffected.
+const STATE_SYNC_TOPIC_SUFFIX: &str = "/state-sync";
+
+/// Delays between state-request retries for a first-time joiner whose task
+/// list is still empty. Spread out so a slow mesh still converges without
+/// flooding.
+const STATE_REQUEST_RETRY_SECS: [u64; 4] = [1, 5, 15, 30];
+
+/// Message exchanged on the state-sync side topic.
+#[derive(Debug, Serialize, Deserialize)]
+enum TaskListSyncMessage {
+    /// A peer with no local state for the list asks holders to republish
+    /// their full state (as a regular delta) on the main topic.
+    StateRequest { requester: PeerId },
+}
+
 /// Synchronization wrapper for a TaskList.
 ///
-/// Manages automatic background synchronization of a TaskList using
-/// anti-entropy gossip. Changes are propagated via deltas published
-/// to a gossip topic.
+/// Manages automatic background synchronization of a TaskList using gossip
+/// pub/sub. Changes are propagated via deltas published to a gossip topic.
 pub struct TaskListSync {
     /// The task list being synchronized (wrapped for concurrent access).
     task_list: Arc<RwLock<TaskList>>,
-
-    /// Anti-entropy manager for periodic sync.
-    #[allow(dead_code)]
-    anti_entropy: AntiEntropyManager<TaskList>,
 
     /// Pub/sub manager for topic-based messaging.
     pubsub: Arc<PubSubManager>,
 
     /// Topic name for this task list.
     topic: String,
+
+    /// This node's gossip peer id — identifies our deltas and state
+    /// requests on the wire.
+    local_peer_id: PeerId,
 }
 
 impl TaskListSync {
@@ -47,7 +68,7 @@ impl TaskListSync {
     /// * `task_list` - The TaskList to synchronize
     /// * `pubsub` - Pub/sub manager for gossip messaging
     /// * `topic` - Topic name for pub/sub (typically task list ID)
-    /// * `sync_interval_secs` - How often to run anti-entropy (seconds)
+    /// * `local_peer_id` - This node's gossip peer id
     ///
     /// # Returns
     ///
@@ -65,33 +86,40 @@ impl TaskListSync {
     ///     task_list,
     ///     pubsub,
     ///     "tasklist-abc123".to_string(),
-    ///     30, // Sync every 30 seconds
+    ///     peer_id,
     /// )?;
     /// ```
     pub fn new(
         task_list: TaskList,
         pubsub: Arc<PubSubManager>,
         topic: String,
-        sync_interval_secs: u64,
+        local_peer_id: PeerId,
     ) -> Result<Self> {
         // Wrap task list for concurrent access
         let task_list = Arc::new(RwLock::new(task_list));
 
-        // Create anti-entropy manager
-        let anti_entropy = AntiEntropyManager::new(Arc::clone(&task_list), sync_interval_secs);
-
         Ok(Self {
             task_list,
-            anti_entropy,
             pubsub,
             topic,
+            local_peer_id,
         })
+    }
+
+    /// The state-sync side topic for this task list.
+    fn state_sync_topic(&self) -> String {
+        format!("{}{}", self.topic, STATE_SYNC_TOPIC_SUFFIX)
     }
 
     /// Start background synchronization.
     ///
     /// Subscribes to the gossip topic and begins receiving remote deltas.
-    /// This method returns immediately; synchronization runs in the background.
+    /// Also joins the state-sync side channel: holders answer state requests
+    /// by republishing their full state, and a first-time joiner (empty local
+    /// list) requests that state so it bootstraps tasks written before it
+    /// subscribed. Without this, only deltas published *after* subscribing
+    /// ever arrive. This method returns immediately; synchronization runs in
+    /// the background.
     ///
     /// # Returns
     ///
@@ -99,24 +127,15 @@ impl TaskListSync {
     ///
     /// # Errors
     ///
-    /// Returns an error if subscription or anti-entropy startup fails.
+    /// Returns an error if subscription startup fails.
     pub async fn start(&self) -> Result<()> {
         // Subscribe to topic — received messages will contain serialized deltas.
-        // The background task applies them via apply_remote_delta.
         let mut sub = self.pubsub.subscribe(self.topic.clone()).await;
         let task_list = Arc::clone(&self.task_list);
 
         tokio::spawn(async move {
             while let Some(msg) = sub.recv().await {
-                let decoded = {
-                    use bincode::Options;
-                    bincode::options()
-                        .with_fixint_encoding()
-                        .with_limit(crate::network::MAX_MESSAGE_DESERIALIZE_SIZE)
-                        .allow_trailing_bytes()
-                        .deserialize::<(PeerId, TaskListDelta)>(&msg.payload)
-                };
-                match decoded {
+                match decode_delta::<TaskListDelta>(&msg.payload) {
                     Ok((peer_id, delta)) => {
                         let mut list = task_list.write().await;
                         if let Err(e) = list.merge_delta(&delta, peer_id) {
@@ -130,12 +149,80 @@ impl TaskListSync {
             }
         });
 
+        // Responder: holders with non-empty state answer StateRequests by
+        // republishing their full state as a regular delta on the main topic.
+        // CRDT merge makes duplicate responses from multiple holders harmless
+        // (idempotent), so no response suppression is needed at current mesh
+        // sizes.
+        let mut sync_sub = self.pubsub.subscribe(self.state_sync_topic()).await;
+        let responder_list = Arc::clone(&self.task_list);
+        let responder_pubsub = Arc::clone(&self.pubsub);
+        let responder_topic = self.topic.clone();
+        let local_peer_id = self.local_peer_id;
+        tokio::spawn(async move {
+            while let Some(msg) = sync_sub.recv().await {
+                let Ok(TaskListSyncMessage::StateRequest { requester }) =
+                    bincode::deserialize::<TaskListSyncMessage>(&msg.payload)
+                else {
+                    continue;
+                };
+                if requester == local_peer_id {
+                    continue;
+                }
+                let full = {
+                    let list = responder_list.read().await;
+                    if list.task_count() == 0 {
+                        continue;
+                    }
+                    list.full_delta()
+                };
+                let Ok(serialized) = encode_delta(local_peer_id, &full) else {
+                    continue;
+                };
+                if let Err(e) = responder_pubsub
+                    .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
+                    .await
+                {
+                    tracing::warn!("TaskList state-response publish failed: {e}");
+                }
+            }
+        });
+
+        // Bootstrap requester: a first-time joiner starts with an empty list
+        // and has no other way to learn tasks written before it subscribed
+        // (the gossip message cache only replays recent deltas). Ask holders
+        // to republish over a short retry schedule. Requests and the
+        // full-delta responses they trigger are idempotent CRDT merges, so the
+        // extra chatter is bounded and harmless. A creator of a genuinely new
+        // list also sends these — nobody answers.
+        if self.task_list.read().await.task_count() == 0 {
+            let requester_pubsub = Arc::clone(&self.pubsub);
+            let sync_topic = self.state_sync_topic();
+            tokio::spawn(async move {
+                for delay_secs in STATE_REQUEST_RETRY_SECS {
+                    tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                    let request = TaskListSyncMessage::StateRequest {
+                        requester: local_peer_id,
+                    };
+                    let Ok(serialized) = bincode::serialize(&request) else {
+                        return;
+                    };
+                    if let Err(e) = requester_pubsub
+                        .publish(sync_topic.clone(), bytes::Bytes::from(serialized))
+                        .await
+                    {
+                        tracing::debug!("TaskList state-request publish failed: {e}");
+                    }
+                }
+            });
+        }
+
         Ok(())
     }
 
     /// Stop background synchronization.
     ///
-    /// Unsubscribes from the gossip topic.
+    /// Unsubscribes from the gossip topic and its state-sync side channel.
     ///
     /// # Returns
     ///
@@ -146,6 +233,7 @@ impl TaskListSync {
     /// Returns an error if operations fail.
     pub async fn stop(&self) -> Result<()> {
         self.pubsub.unsubscribe(&self.topic).await;
+        self.pubsub.unsubscribe(&self.state_sync_topic()).await;
         Ok(())
     }
 
@@ -189,7 +277,7 @@ impl TaskListSync {
     ///
     /// Returns an error if serialization or publishing fails.
     pub async fn publish_delta(&self, local_peer_id: PeerId, delta: TaskListDelta) -> Result<()> {
-        let serialized = bincode::serialize(&(local_peer_id, delta)).map_err(|e| {
+        let serialized = encode_delta(local_peer_id, &delta).map_err(|e| {
             crate::crdt::CrdtError::Gossip(format!("failed to serialize delta: {e}"))
         })?;
 

--- a/src/crdt/task_list.rs
+++ b/src/crdt/task_list.rs
@@ -351,6 +351,9 @@ impl TaskList {
 
         let current_order = self.ordering.get();
         let or_set_tasks: HashSet<TaskId> = self.tasks.elements().into_iter().copied().collect();
+        // Membership set over the ordering vector so the append phase below is
+        // O(1) per task instead of an O(n) `Vec::contains` inside the loop.
+        let ordered_ids: HashSet<&TaskId> = current_order.iter().collect();
 
         // Start with tasks in the ordering vector, but only if they're in the OR-Set
         let mut ordered: Vec<&TaskItem> = current_order
@@ -361,7 +364,7 @@ impl TaskList {
 
         // Append tasks that are in OR-Set but not in ordering
         for task_id in &or_set_tasks {
-            if !current_order.contains(task_id) {
+            if !ordered_ids.contains(task_id) {
                 if let Some(task) = self.task_data.get(task_id) {
                     ordered.push(task);
                 }

--- a/src/crdt/task_list.rs
+++ b/src/crdt/task_list.rs
@@ -434,6 +434,40 @@ impl TaskList {
         self.version += 1;
     }
 
+    /// The name register, including its vector clock.
+    ///
+    /// Deltas carry this whole register (not just the value) so receivers can
+    /// resolve a remote name change by causality via [`Self::merge_name`].
+    #[must_use]
+    pub fn name_register(&self) -> &LwwRegister<String> {
+        &self.name
+    }
+
+    /// The ordering register, including its vector clock.
+    #[must_use]
+    pub fn ordering_register(&self) -> &LwwRegister<Vec<TaskId>> {
+        &self.ordering
+    }
+
+    /// Merge a remote name register using LWW (vector-clock) semantics.
+    ///
+    /// Unlike `update_name`, which records a local edit, this resolves the
+    /// winner by causality so a stale delta cannot overwrite a newer local
+    /// name. Mirrors what the full-state [`TaskList::merge`] already does.
+    pub fn merge_name(&mut self, other: &LwwRegister<String>) {
+        self.name.merge(other);
+        self.version += 1;
+    }
+
+    /// Merge a remote ordering register using LWW (vector-clock) semantics.
+    ///
+    /// The merged ordering may reference task IDs not yet known locally
+    /// (out-of-order delivery); `tasks_ordered` filters those at read time.
+    pub fn merge_ordering(&mut self, other: &LwwRegister<Vec<TaskId>>) {
+        self.ordering.merge(other);
+        self.version += 1;
+    }
+
     /// Get the number of tasks in the list.
     #[must_use]
     pub fn task_count(&self) -> usize {

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -64,7 +64,6 @@ use serde::Serialize;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc, Notify, RwLock};
 
 /// Stream type byte for direct messages (distinct from gossip: 0, 1, 2).
@@ -215,10 +214,7 @@ impl DirectMessage {
         verified: bool,
         trust_decision: Option<TrustDecision>,
     ) -> Self {
-        let received_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
+        let received_at = crate::dm::now_unix_ms();
 
         Self {
             sender,
@@ -237,12 +233,7 @@ impl DirectMessage {
     }
 }
 
-fn now_unix_ms_lossy() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
-}
+use crate::dm::now_unix_ms as now_unix_ms_lossy;
 
 fn direct_diagnostics_retain_limit(connected_len: usize) -> usize {
     DIRECT_DIAGNOSTICS_MIN_RETAIN.max(connected_len.saturating_mul(2))

--- a/src/dm_send.rs
+++ b/src/dm_send.rs
@@ -35,19 +35,40 @@ pub const DEFAULT_ENVELOPE_LIFETIME_MS: u64 = 120_000;
 const PUBLISH_ONLY_REDUNDANT_REPUBLISH_DELAY: Duration = Duration::from_millis(250);
 const ACK_LEGACY_BUS_FALLBACK_DELAY: Duration = Duration::from_millis(250);
 
-#[allow(clippy::too_many_arguments)]
+/// Stable per-sender context for [`send_via_gossip`].
+///
+/// Groups the identity/runtime handles that are constant for a given sending
+/// agent, separating them from the per-call message parameters. This keeps the
+/// two adjacent `AgentId`/`MachineId` self-identity fields off the call site's
+/// positional argument list, where they were easy to transpose.
+pub struct DmSendContext<'a> {
+    /// PlumTree pub/sub manager used to publish the envelope.
+    pub pubsub: Arc<PubSubManager>,
+    /// Sender signing context (ML-DSA-65).
+    pub signing: &'a SigningContext,
+    /// This agent's `AgentId`.
+    pub self_agent_id: AgentId,
+    /// This agent's `MachineId`.
+    pub self_machine_id: MachineId,
+    /// Shared in-flight ACK registry.
+    pub inflight: Arc<InFlightAcks>,
+}
+
 pub async fn send_via_gossip(
-    pubsub: Arc<PubSubManager>,
-    signing: &SigningContext,
-    self_agent_id: AgentId,
-    self_machine_id: MachineId,
+    ctx: DmSendContext<'_>,
     recipient_agent_id: AgentId,
     recipient_kem_public_key: &[u8],
     payload: Vec<u8>,
     config: &DmSendConfig,
-    inflight: Arc<InFlightAcks>,
     lifecycle_hint: Option<DmLifecycleHint>,
 ) -> Result<DmReceipt, DmError> {
+    let DmSendContext {
+        pubsub,
+        signing,
+        self_agent_id,
+        self_machine_id,
+        inflight,
+    } = ctx;
     if payload.len() > MAX_PAYLOAD_BYTES {
         return Err(DmError::EnvelopeConstruction(format!(
             "payload exceeds MAX_PAYLOAD_BYTES ({} > {})",

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -6,6 +6,7 @@
 pub mod config;
 pub mod pubsub;
 pub mod runtime;
+pub(crate) mod wire;
 
 pub use config::GossipConfig;
 pub use pubsub::{

--- a/src/gossip/pubsub.rs
+++ b/src/gossip/pubsub.rs
@@ -516,39 +516,7 @@ impl PubSubManager {
         // `local:` topics fan out to same-daemon subscribers only — the
         // payload never reaches PlumTree or any remote peer (issue #89).
         if is_local_topic(&topic) {
-            let message = PubSubMessage {
-                topic: topic.clone(),
-                payload,
-                sender: self.signing.as_ref().map(|ctx| ctx.agent_id),
-                sender_public_key: self
-                    .signing
-                    .as_ref()
-                    .map(|ctx| ctx.public_key_bytes.clone()),
-                // Local publishes come from a bearer-token-authenticated
-                // API caller on this daemon — trusted by construction.
-                verified: true,
-                trust_level: None,
-            };
-            let mut topics = self.local_topics.write().await;
-            if let Some(senders) = topics.get_mut(&topic) {
-                senders.retain(|tx| match tx.try_send(message.clone()) {
-                    Ok(()) => {
-                        self.stats
-                            .delivered_to_subscriber
-                            .fetch_add(1, Ordering::Relaxed);
-                        true
-                    }
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        self.stats
-                            .slow_subscriber_dropped
-                            .fetch_add(1, Ordering::Relaxed);
-                        true
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => false,
-                });
-            }
-            self.stats.publish_total.fetch_add(1, Ordering::Relaxed);
-            return Ok(());
+            return self.publish_local(topic, payload).await;
         }
 
         let encoded_result = if let Some(ref ctx) = self.signing {
@@ -590,6 +558,48 @@ impl PubSubManager {
                 )))
             }
         }
+    }
+
+    /// Fan out a `local:` publish to same-daemon subscribers only.
+    ///
+    /// The payload never reaches PlumTree or any remote peer (issue #89). The
+    /// `Full` vs `Closed` arms encode the slow-subscriber-drop behaviour:
+    /// `Full` keeps the subscriber (the message is dropped, not the queue),
+    /// `Closed` evicts it.
+    async fn publish_local(&self, topic: String, payload: Bytes) -> NetworkResult<()> {
+        let message = PubSubMessage {
+            topic: topic.clone(),
+            payload,
+            sender: self.signing.as_ref().map(|ctx| ctx.agent_id),
+            sender_public_key: self
+                .signing
+                .as_ref()
+                .map(|ctx| ctx.public_key_bytes.clone()),
+            // Local publishes come from a bearer-token-authenticated
+            // API caller on this daemon — trusted by construction.
+            verified: true,
+            trust_level: None,
+        };
+        let mut topics = self.local_topics.write().await;
+        if let Some(senders) = topics.get_mut(&topic) {
+            senders.retain(|tx| match tx.try_send(message.clone()) {
+                Ok(()) => {
+                    self.stats
+                        .delivered_to_subscriber
+                        .fetch_add(1, Ordering::Relaxed);
+                    true
+                }
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    self.stats
+                        .slow_subscriber_dropped
+                        .fetch_add(1, Ordering::Relaxed);
+                    true
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => false,
+            });
+        }
+        self.stats.publish_total.fetch_add(1, Ordering::Relaxed);
+        Ok(())
     }
 
     /// Handle an incoming message from a peer.
@@ -970,6 +980,32 @@ fn encode_v2(
     Ok(Bytes::from(buf))
 }
 
+/// Read a `u16_be` length-prefixed field at `*pos`, advancing the cursor past
+/// both the prefix and the field.
+///
+/// Returns a borrowed slice of the field bytes. `what` names the field so the
+/// per-field error diagnostics (`"Truncated <what> length"` / `"Truncated
+/// <what>"`) match the original hand-written checks. Performs the two bounds
+/// checks the v2 decoder relies on: that the length prefix is present, and
+/// that the buffer holds the full claimed field.
+fn take_lp<'a>(data: &'a [u8], pos: &mut usize, what: &str) -> NetworkResult<&'a [u8]> {
+    if data.len() < *pos + 2 {
+        return Err(NetworkError::SerializationError(format!(
+            "Truncated {what} length"
+        )));
+    }
+    let len = u16::from_be_bytes([data[*pos], data[*pos + 1]]) as usize;
+    *pos += 2;
+    if data.len() < *pos + len {
+        return Err(NetworkError::SerializationError(format!(
+            "Truncated {what}"
+        )));
+    }
+    let field = &data[*pos..*pos + len];
+    *pos += len;
+    Ok(field)
+}
+
 /// Decode a v2 (signed) message, verifying the ML-DSA-65 signature.
 fn decode_v2(data: &[u8]) -> NetworkResult<PubSubMessage> {
     // Minimum: 1 (version) + 32 (agent_id) + 2 (pk_len) + 2 (sig_len) + 2 (topic_len)
@@ -987,54 +1023,19 @@ fn decode_v2(data: &[u8]) -> NetworkResult<PubSubMessage> {
     let agent_id = AgentId(agent_id_bytes);
     pos += 32;
 
-    // Public key
-    if data.len() < pos + 2 {
-        return Err(NetworkError::SerializationError(
-            "Truncated pubkey length".to_string(),
-        ));
-    }
-    let pk_len = u16::from_be_bytes([data[pos], data[pos + 1]]) as usize;
-    pos += 2;
-    if data.len() < pos + pk_len {
-        return Err(NetworkError::SerializationError(
-            "Truncated public key".to_string(),
-        ));
-    }
-    let public_key_bytes = data[pos..pos + pk_len].to_vec();
-    pos += pk_len;
+    let public_key_bytes = take_lp(data, &mut pos, "public key").map_err(|e| match e {
+        NetworkError::SerializationError(msg) if msg == "Truncated public key length" => {
+            NetworkError::SerializationError("Truncated pubkey length".to_string())
+        }
+        other => other,
+    })?;
+    let public_key_bytes = public_key_bytes.to_vec();
 
-    // Signature
-    if data.len() < pos + 2 {
-        return Err(NetworkError::SerializationError(
-            "Truncated signature length".to_string(),
-        ));
-    }
-    let sig_len = u16::from_be_bytes([data[pos], data[pos + 1]]) as usize;
-    pos += 2;
-    if data.len() < pos + sig_len {
-        return Err(NetworkError::SerializationError(
-            "Truncated signature".to_string(),
-        ));
-    }
-    let signature_bytes = &data[pos..pos + sig_len];
-    pos += sig_len;
+    let signature_bytes = take_lp(data, &mut pos, "signature")?;
 
-    // Topic
-    if data.len() < pos + 2 {
-        return Err(NetworkError::SerializationError(
-            "Truncated topic length".to_string(),
-        ));
-    }
-    let topic_len = u16::from_be_bytes([data[pos], data[pos + 1]]) as usize;
-    pos += 2;
-    if data.len() < pos + topic_len {
-        return Err(NetworkError::SerializationError(
-            "Truncated topic".to_string(),
-        ));
-    }
-    let topic = String::from_utf8(data[pos..pos + topic_len].to_vec())
+    let topic_bytes = take_lp(data, &mut pos, "topic")?;
+    let topic = String::from_utf8(topic_bytes.to_vec())
         .map_err(|e| NetworkError::SerializationError(format!("Invalid UTF-8: {}", e)))?;
-    pos += topic_len;
 
     // Payload (remaining bytes)
     let payload = Bytes::copy_from_slice(&data[pos..]);
@@ -1454,6 +1455,120 @@ mod tests {
     fn test_v2_truncated_data() {
         // Just version byte + a few bytes — should fail
         assert!(decode_v2(&[VERSION_V2, 0, 0, 0]).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // V2 decode bounds-check tests (pin the `take_lp` extraction in finding #2)
+    // -----------------------------------------------------------------------
+
+    /// Produce a known-good encoded v2 buffer for slicing in the bounds tests.
+    fn valid_v2_buffer() -> Bytes {
+        let kp = AgentKeypair::generate().expect("keygen");
+        let ctx = SigningContext::from_keypair(&kp);
+        let topic = "bounds-check";
+        let payload = Bytes::from("payload bytes");
+        let signing_payload =
+            build_signing_payload(ctx.agent_id.as_bytes(), topic.as_bytes(), &payload);
+        let signature = ctx.sign(&signing_payload).expect("sign");
+        encode_v2(
+            &ctx.agent_id,
+            &ctx.public_key_bytes,
+            &signature,
+            topic,
+            &payload,
+        )
+        .expect("encode")
+    }
+
+    #[test]
+    fn test_v2_full_buffer_decodes_and_verifies() {
+        // Baseline: the unmodified buffer round-trips and verifies. This pins
+        // the happy path so the bounds tests below isolate truncation.
+        let buf = valid_v2_buffer();
+        let msg = decode_v2(&buf).expect("decode");
+        assert_eq!(msg.topic, "bounds-check");
+        assert_eq!(msg.payload, Bytes::from("payload bytes"));
+        assert!(msg.verified);
+    }
+
+    /// Byte offset where the trailing payload (the "remaining bytes" field)
+    /// begins in a v2 buffer. Truncations before this offset hit a length-
+    /// prefix bounds check; truncations at/after it just shorten the payload
+    /// and remain valid.
+    fn v2_payload_start(buf: &[u8]) -> usize {
+        let pk_len = u16::from_be_bytes([buf[33], buf[34]]) as usize;
+        let sig_len_pos = 35 + pk_len;
+        let sig_len = u16::from_be_bytes([buf[sig_len_pos], buf[sig_len_pos + 1]]) as usize;
+        let topic_len_pos = sig_len_pos + 2 + sig_len;
+        let topic_len = u16::from_be_bytes([buf[topic_len_pos], buf[topic_len_pos + 1]]) as usize;
+        topic_len_pos + 2 + topic_len
+    }
+
+    #[test]
+    fn test_v2_truncated_in_header_region_is_err() {
+        // Truncating anywhere inside the framed header (version → end of topic)
+        // must be rejected, never panic. This walks every length-prefix bounds
+        // check in decode_v2.
+        let buf = valid_v2_buffer();
+        let payload_start = v2_payload_start(&buf);
+        for cut in 1..payload_start {
+            assert!(
+                decode_v2(&buf[..cut]).is_err(),
+                "truncating to {cut} of {} bytes (payload_start={payload_start}) must be an error",
+                buf.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_v2_truncation_into_payload_region_still_decodes() {
+        // The payload is the trailing "remaining bytes" field with no length
+        // prefix, so cutting into it yields a shorter (still valid) payload.
+        // This pins the boundary that test_v2_truncated_in_header_region_is_err
+        // stops at.
+        let buf = valid_v2_buffer();
+        let payload_start = v2_payload_start(&buf);
+        for cut in payload_start..=buf.len() {
+            assert!(
+                decode_v2(&buf[..cut]).is_ok(),
+                "truncating to {cut} (>= payload_start {payload_start}) must still decode"
+            );
+        }
+    }
+
+    #[test]
+    fn test_v2_oversized_pubkey_len_is_err() {
+        // Overwrite the pubkey length prefix (bytes 33..35) with 0xFFFF so the
+        // claimed field overruns the buffer — must be a clean error.
+        let mut buf = valid_v2_buffer().to_vec();
+        buf[33] = 0xFF;
+        buf[34] = 0xFF;
+        assert!(decode_v2(&buf).is_err());
+    }
+
+    #[test]
+    fn test_v2_oversized_sig_len_is_err() {
+        // The signature length prefix sits right after the public key. Decode
+        // the real pubkey length to locate it, then poison it.
+        let mut buf = valid_v2_buffer().to_vec();
+        let pk_len = u16::from_be_bytes([buf[33], buf[34]]) as usize;
+        let sig_len_pos = 35 + pk_len;
+        buf[sig_len_pos] = 0xFF;
+        buf[sig_len_pos + 1] = 0xFF;
+        assert!(decode_v2(&buf).is_err());
+    }
+
+    #[test]
+    fn test_v2_oversized_topic_len_is_err() {
+        // The topic length prefix sits after pubkey and signature.
+        let mut buf = valid_v2_buffer().to_vec();
+        let pk_len = u16::from_be_bytes([buf[33], buf[34]]) as usize;
+        let sig_len_pos = 35 + pk_len;
+        let sig_len = u16::from_be_bytes([buf[sig_len_pos], buf[sig_len_pos + 1]]) as usize;
+        let topic_len_pos = sig_len_pos + 2 + sig_len;
+        buf[topic_len_pos] = 0xFF;
+        buf[topic_len_pos + 1] = 0xFF;
+        assert!(decode_v2(&buf).is_err());
     }
 
     // -----------------------------------------------------------------------

--- a/src/gossip/wire.rs
+++ b/src/gossip/wire.rs
@@ -5,33 +5,39 @@
 //! options in one place means the on-wire format cannot silently fork between
 //! the two stacks.
 
+use bincode::Options;
 use saorsa_gossip_types::PeerId;
 use serde::{de::DeserializeOwned, Serialize};
 
+/// The single source of truth for the encoding of the `(PeerId, Delta)`
+/// envelope: fixint, trailing-byte tolerant. Both the encode and decode paths
+/// derive from this so the format cannot fork between them — the decode side
+/// additionally bounds the input size (see [`decode_delta`]). Fixint matches
+/// the legacy inline `bincode::serialize`, so existing peers and persisted
+/// payloads stay compatible.
+fn envelope_opts() -> impl Options {
+    bincode::options()
+        .with_fixint_encoding()
+        .allow_trailing_bytes()
+}
+
 /// Serialize a `(sender, delta)` pair for publication on a CRDT sync topic.
-///
-/// Uses `bincode::serialize` (fixint encoding), matching the decode side in
-/// [`decode_delta`].
 pub(crate) fn encode_delta<D: Serialize>(
     sender: PeerId,
     delta: &D,
 ) -> Result<Vec<u8>, bincode::Error> {
-    bincode::serialize(&(sender, delta))
+    envelope_opts().serialize(&(sender, delta))
 }
 
 /// Decode a `(sender, delta)` pair received on a CRDT sync topic.
 ///
-/// Fixint encoding with a hard size limit, tolerating trailing bytes — the
-/// single definition of the inbound delta envelope shared by every CRDT sync
-/// loop.
+/// Adds a hard size limit on top of [`envelope_opts`] so an oversized inbound
+/// payload is rejected rather than allocated.
 pub(crate) fn decode_delta<D: DeserializeOwned>(
     payload: &[u8],
 ) -> Result<(PeerId, D), bincode::Error> {
-    use bincode::Options;
-    bincode::options()
-        .with_fixint_encoding()
+    envelope_opts()
         .with_limit(crate::network::MAX_MESSAGE_DESERIALIZE_SIZE)
-        .allow_trailing_bytes()
         .deserialize::<(PeerId, D)>(payload)
 }
 

--- a/src/gossip/wire.rs
+++ b/src/gossip/wire.rs
@@ -1,0 +1,78 @@
+//! Shared wire codec for the `(PeerId, Delta)` envelope used by CRDT gossip sync.
+//!
+//! The task-list and kv-store sync loops both publish and receive deltas as a
+//! bincode-encoded `(sender_peer_id, delta)` tuple. Keeping the encode/decode
+//! options in one place means the on-wire format cannot silently fork between
+//! the two stacks.
+
+use saorsa_gossip_types::PeerId;
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Serialize a `(sender, delta)` pair for publication on a CRDT sync topic.
+///
+/// Uses `bincode::serialize` (fixint encoding), matching the decode side in
+/// [`decode_delta`].
+pub(crate) fn encode_delta<D: Serialize>(
+    sender: PeerId,
+    delta: &D,
+) -> Result<Vec<u8>, bincode::Error> {
+    bincode::serialize(&(sender, delta))
+}
+
+/// Decode a `(sender, delta)` pair received on a CRDT sync topic.
+///
+/// Fixint encoding with a hard size limit, tolerating trailing bytes — the
+/// single definition of the inbound delta envelope shared by every CRDT sync
+/// loop.
+pub(crate) fn decode_delta<D: DeserializeOwned>(
+    payload: &[u8],
+) -> Result<(PeerId, D), bincode::Error> {
+    use bincode::Options;
+    bincode::options()
+        .with_fixint_encoding()
+        .with_limit(crate::network::MAX_MESSAGE_DESERIALIZE_SIZE)
+        .allow_trailing_bytes()
+        .deserialize::<(PeerId, D)>(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Sample {
+        a: u64,
+        b: String,
+    }
+
+    fn peer(n: u8) -> PeerId {
+        PeerId::new([n; 32])
+    }
+
+    #[test]
+    fn round_trips_sender_and_delta() {
+        let delta = Sample {
+            a: 42,
+            b: "hello".to_string(),
+        };
+        let bytes = encode_delta(peer(7), &delta).expect("encode");
+        let (sender, decoded): (PeerId, Sample) = decode_delta(&bytes).expect("decode");
+        assert_eq!(sender, peer(7));
+        assert_eq!(decoded, delta);
+    }
+
+    #[test]
+    fn encode_matches_legacy_inline_serialization() {
+        // The helper must produce bytes identical to the previous inline
+        // `bincode::serialize(&(peer, delta))` call so existing peers and
+        // persisted payloads stay compatible.
+        let delta = Sample {
+            a: 9,
+            b: "x".to_string(),
+        };
+        let helper = encode_delta(peer(3), &delta).expect("encode");
+        let inline = bincode::serialize(&(peer(3), &delta)).expect("inline");
+        assert_eq!(helper, inline);
+    }
+}

--- a/src/kv/delta.rs
+++ b/src/kv/delta.rs
@@ -5,7 +5,7 @@
 
 use crate::identity::AgentId;
 use crate::kv::{KvEntry, KvStore};
-use saorsa_gossip_crdt_sync::DeltaCrdt;
+use saorsa_gossip_crdt_sync::{DeltaCrdt, LwwRegister};
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -25,8 +25,10 @@ pub struct KvStoreDelta {
     /// Value updates to existing keys (key -> full entry).
     pub updated: HashMap<String, KvEntry>,
 
-    /// Name update (LWW semantics).
-    pub name_update: Option<String>,
+    /// Name update, carried as the full LWW register (value + vector clock)
+    /// so the receiver resolves it by causality rather than adopting it
+    /// unconditionally.
+    pub name_update: Option<LwwRegister<String>>,
 
     /// Agents added to the allowlist (owner-only, propagated via delta).
     pub allowlist_additions: Option<Vec<AgentId>>,
@@ -181,8 +183,13 @@ mod tests {
         let id = store_id(1);
         let mut store = KvStore::new(id, "Original".to_string(), owner, AccessPolicy::Signed);
 
+        // A peer renames the store on top of the shared initial state; its
+        // name register causally dominates ours, so the LWW merge adopts it.
+        let mut other = KvStore::new(id, "Original".to_string(), owner, AccessPolicy::Signed);
+        other.update_name("Updated".to_string(), peer(1));
+
         let mut delta = KvStoreDelta::new(1);
-        delta.name_update = Some("Updated".to_string());
+        delta.name_update = Some(other.name_register().clone());
 
         store
             .merge_delta(&delta, peer(1), Some(&owner))

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -181,6 +181,16 @@ impl KvStore {
         self.name.get()
     }
 
+    /// The name register, including its vector clock.
+    ///
+    /// Deltas carry this whole register (not just the value) so receivers can
+    /// resolve a remote name change by causality rather than adopting it
+    /// unconditionally.
+    #[must_use]
+    pub fn name_register(&self) -> &LwwRegister<String> {
+        &self.name
+    }
+
     /// Get the access policy.
     #[must_use]
     pub fn policy(&self) -> &AccessPolicy {
@@ -439,9 +449,10 @@ impl KvStore {
             }
         }
 
-        // Apply name update
-        if let Some(ref new_name) = delta.name_update {
-            self.name.set(new_name.clone(), peer_id);
+        // Apply name update via LWW (vector-clock) merge so a stale delta
+        // cannot overwrite a newer local name; mirrors the full-state merge.
+        if let Some(ref name_register) = delta.name_update {
+            self.name.merge(name_register);
         }
 
         self.version += 1;
@@ -490,7 +501,7 @@ impl KvStore {
             }
         }
 
-        delta.name_update = Some(self.name().to_string());
+        delta.name_update = Some(self.name.clone());
 
         // Include allowlist in full delta
         if !self.allowed_writers.is_empty() {

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -302,14 +302,14 @@ impl KvStore {
     }
 
     /// Get an entry by key.
+    ///
+    /// `entries` and the active-key OR-Set are kept in lockstep by `put`,
+    /// `remove`, `merge`, and `merge_delta` (a tombstoned key is removed from
+    /// both), so a direct `entries` lookup already excludes inactive keys
+    /// without materializing and scanning the OR-Set on every read.
     #[must_use]
     pub fn get(&self, key: &str) -> Option<&KvEntry> {
-        let key_string = key.to_string();
-        if self.keys.elements().contains(&&key_string) {
-            self.entries.get(key)
-        } else {
-            None
-        }
+        self.entries.get(key)
     }
 
     /// Remove a key from the store.
@@ -474,10 +474,11 @@ impl KvStore {
     #[must_use]
     pub fn full_delta(&self) -> KvStoreDelta {
         let mut delta = KvStoreDelta::new(self.version);
-        let active: HashSet<String> = self.keys.elements().into_iter().cloned().collect();
 
-        for (key, entry) in &self.entries {
-            if active.contains(key) {
+        // Walk the active-key OR-Set directly and look entries up, rather than
+        // cloning the whole key set into an intermediate HashSet first.
+        for key in self.keys.elements() {
+            if let Some(entry) = self.entries.get(key) {
                 let tag = (PeerId::new([0u8; 32]), 0);
                 delta.added.insert(key.clone(), (entry.clone(), tag));
             }

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -303,13 +303,19 @@ impl KvStore {
 
     /// Get an entry by key.
     ///
-    /// `entries` and the active-key OR-Set are kept in lockstep by `put`,
-    /// `remove`, `merge`, and `merge_delta` (a tombstoned key is removed from
-    /// both), so a direct `entries` lookup already excludes inactive keys
-    /// without materializing and scanning the OR-Set on every read.
+    /// Gated on active-key membership so a tombstoned key never reads back.
+    /// `entries` is not a reliable proxy for the active set: `merge` applies a
+    /// remote OR-Set tombstone via `merge_state` without pruning `entries`, so
+    /// a key can linger in `entries` after it leaves the active set. We query
+    /// the OR-Set directly (an O(1) membership check) rather than materializing
+    /// and linearly scanning `elements()` as the previous implementation did.
     #[must_use]
     pub fn get(&self, key: &str) -> Option<&KvEntry> {
-        self.entries.get(key)
+        if self.keys.contains(&key.to_string()) {
+            self.entries.get(key)
+        } else {
+            None
+        }
     }
 
     /// Remove a key from the store.

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -3,9 +3,9 @@
 //! Wraps a KvStore in `Arc<RwLock<>>` for concurrent access and
 //! synchronizes it via gossip pub/sub delta propagation.
 
+use crate::gossip::wire::{decode_delta, encode_delta};
 use crate::gossip::PubSubManager;
 use crate::kv::{KvStore, KvStoreDelta, Result};
-use saorsa_gossip_crdt_sync::AntiEntropyManager;
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -39,10 +39,6 @@ pub struct KvStoreSync {
     /// The store being synchronized.
     store: Arc<RwLock<KvStore>>,
 
-    /// Anti-entropy manager for periodic sync.
-    #[allow(dead_code)]
-    anti_entropy: AntiEntropyManager<KvStore>,
-
     /// Pub/sub manager for topic-based messaging.
     pubsub: Arc<PubSubManager>,
 
@@ -62,21 +58,17 @@ impl KvStoreSync {
     /// * `store` - The KvStore to synchronize.
     /// * `pubsub` - Pub/sub manager for gossip messaging.
     /// * `topic` - Topic name for pub/sub.
-    /// * `sync_interval_secs` - How often to run anti-entropy.
     /// * `local_peer_id` - This node's gossip peer id.
     pub fn new(
         store: KvStore,
         pubsub: Arc<PubSubManager>,
         topic: String,
-        sync_interval_secs: u64,
         local_peer_id: PeerId,
     ) -> Result<Self> {
         let store = Arc::new(RwLock::new(store));
-        let anti_entropy = AntiEntropyManager::new(Arc::clone(&store), sync_interval_secs);
 
         Ok(Self {
             store,
-            anti_entropy,
             pubsub,
             topic,
             local_peer_id,
@@ -102,14 +94,7 @@ impl KvStoreSync {
 
         tokio::spawn(async move {
             while let Some(msg) = sub.recv().await {
-                let decoded = {
-                    use bincode::Options;
-                    bincode::options()
-                        .with_fixint_encoding()
-                        .with_limit(crate::network::MAX_MESSAGE_DESERIALIZE_SIZE)
-                        .allow_trailing_bytes()
-                        .deserialize::<(PeerId, KvStoreDelta)>(&msg.payload)
-                };
+                let decoded = decode_delta::<KvStoreDelta>(&msg.payload);
                 match decoded {
                     Ok((peer_id, delta)) => {
                         let mut s = store.write().await;
@@ -154,7 +139,7 @@ impl KvStoreSync {
                     }
                     s.full_delta()
                 };
-                let Ok(serialized) = bincode::serialize(&(local_peer_id, full)) else {
+                let Ok(serialized) = encode_delta(local_peer_id, &full) else {
                     continue;
                 };
                 if let Err(e) = responder_pubsub
@@ -211,7 +196,7 @@ impl KvStoreSync {
 
     /// Publish a local delta to the gossip network.
     pub async fn publish_delta(&self, local_peer_id: PeerId, delta: KvStoreDelta) -> Result<()> {
-        let serialized = bincode::serialize(&(local_peer_id, delta))
+        let serialized = encode_delta(local_peer_id, &delta)
             .map_err(|e| crate::kv::KvError::Gossip(format!("serialize delta failed: {e}")))?;
 
         self.pubsub

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8279,7 +8279,12 @@ impl TaskListHandle {
                     e
                 )))
             })?;
-            crdt::TaskListDelta::for_reorder(task_ids, list.current_version())
+            // Carry the post-reorder ordering register (value + clock) so the
+            // change merges by causality on receivers.
+            crdt::TaskListDelta::for_reorder(
+                list.ordering_register().clone(),
+                list.current_version(),
+            )
         };
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
             tracing::warn!("failed to publish reorder delta: {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3727,15 +3727,17 @@ impl Agent {
                     // the full backoff window.
                     let lifecycle_hint = self.dm_lifecycle_hint(to).await;
                     dm_send::send_via_gossip(
-                        std::sync::Arc::clone(runtime.pubsub()),
-                        &signing,
-                        self.identity.agent_id(),
-                        self.identity.machine_id(),
+                        dm_send::DmSendContext {
+                            pubsub: std::sync::Arc::clone(runtime.pubsub()),
+                            signing: &signing,
+                            self_agent_id: self.identity.agent_id(),
+                            self_machine_id: self.identity.machine_id(),
+                            inflight: std::sync::Arc::clone(&self.dm_inflight_acks),
+                        },
                         *to,
                         &kem_pub,
                         payload,
                         &config,
-                        std::sync::Arc::clone(&self.dm_inflight_acks),
                         lifecycle_hint,
                     )
                     .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7428,7 +7428,7 @@ impl Agent {
             task_list,
             std::sync::Arc::clone(runtime.pubsub()),
             topic.to_string(),
-            30,
+            peer_id,
         )
         .map_err(|e| {
             error::IdentityError::Storage(std::io::Error::other(format!(
@@ -7490,7 +7490,7 @@ impl Agent {
             task_list,
             std::sync::Arc::clone(runtime.pubsub()),
             topic.to_string(),
-            30,
+            peer_id,
         )
         .map_err(|e| {
             error::IdentityError::Storage(std::io::Error::other(format!(
@@ -8321,7 +8321,6 @@ impl Agent {
             store,
             std::sync::Arc::clone(runtime.pubsub()),
             topic.to_string(),
-            30,
             peer_id,
         )
         .map_err(|e| {
@@ -8377,7 +8376,6 @@ impl Agent {
             store,
             std::sync::Arc::clone(runtime.pubsub()),
             topic.to_string(),
-            30,
             peer_id,
         )
         .map_err(|e| {

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -29,6 +29,7 @@ covers project-wide rules and architecture.
 | `presence_integration.rs` | Presence API surface: subscribe, cached_agent, foaf_peer_candidates |
 | `kv_store_integration.rs` | KV store CRUD, access policies, CRDT sync |
 | `kv_first_join_bootstrap.rs` | Issue #96: cold first-join state bootstrap via state-sync side topic (daemon-backed, `--ignored`) |
+| `tasklist_first_join_bootstrap.rs` | Task-list cold first-join bootstrap via state-sync side topic + LWW-clock delta merge (daemon-backed, `--ignored`) |
 | `local_topics.rs` | Issue #89: `local:` topics deliver same-daemon only, never gossipped (daemon-backed, `--ignored`) |
 | `named_group_integration.rs` | Named groups, invites, join/leave, display names |
 | `bootstrap_cache_integration.rs` | Bootstrap cache persistence, quality scoring |

--- a/tests/crdt_integration.rs
+++ b/tests/crdt_integration.rs
@@ -267,10 +267,7 @@ fn test_delta_generation() {
     let task = TaskItem::new(task_id, metadata, peer_id);
     task_list.add_task(task, peer_id, 1).expect("Failed to add");
 
-    let delta = task_list.delta(0);
-    assert!(delta.is_some());
-
-    let delta = delta.unwrap();
+    let delta = task_list.full_delta();
     assert!(!delta.added_tasks.is_empty());
 }
 

--- a/tests/parity_cli.rs
+++ b/tests/parity_cli.rs
@@ -99,6 +99,46 @@ fn group_update_rejects_empty_patch_before_daemon_check() {
     );
 }
 
+/// `x0x exec` exposes `sessions` and `cancel` as real, discoverable
+/// subcommands (not magic first-positional sentinels), while the
+/// `x0x exec <agent> -- <argv>` run form still parses. These assert the
+/// documented invocation shapes keep working after the clap restructure.
+#[test]
+fn exec_sub_actions_are_discoverable_subcommands() {
+    let help = run_cli(&["exec", "--help"]).expect("spawn x0x exec --help");
+    assert!(help.status.success(), "exec --help should succeed");
+    let text = String::from_utf8_lossy(&help.stdout);
+    assert!(
+        text.contains("sessions") && text.contains("cancel"),
+        "exec --help must list the sessions/cancel subcommands:\n{text}"
+    );
+
+    // `sessions` and `cancel <id>` must parse (they fail later only because no
+    // daemon is running, never with a clap usage error).
+    for args in [vec!["exec", "sessions"], vec!["exec", "cancel", "req-1"]] {
+        let out = run_cli(&args).expect("spawn x0x exec sub-action");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !stderr.contains("Usage:") && !stderr.contains("unexpected argument"),
+            "`x0x {}` should parse as a subcommand, got clap error:\n{stderr}",
+            args.join(" ")
+        );
+    }
+}
+
+#[test]
+fn exec_run_form_still_parses_with_flags() {
+    let agent = "a".repeat(64);
+    // run form with `--` argv and a typed `--timeout` flag must parse.
+    let out = run_cli(&["exec", &agent, "--timeout", "5", "--", "echo", "hi"])
+        .expect("spawn x0x exec run form");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("Usage:") && !stderr.contains("unexpected argument"),
+        "exec run form with --timeout should parse, got clap error:\n{stderr}"
+    );
+}
+
 #[test]
 fn group_policy_rejects_empty_patch_before_daemon_check() {
     let output = run_cli(&["group", "policy", "deadbeef"]).expect("spawn x0x group policy");

--- a/tests/tasklist_first_join_bootstrap.rs
+++ b/tests/tasklist_first_join_bootstrap.rs
@@ -1,0 +1,152 @@
+//! Cold-start bootstrap for collaborative task lists.
+//!
+//! A first-time joiner of a task-list topic previously received only deltas
+//! published *after* it subscribed: tasks added before the join never
+//! arrived, even though future adds replicated fine. The state-sync side
+//! channel (mirrored from the kv-store cold-start, issue #96) closes that
+//! gap — an empty-list joiner requests state, holders respond by
+//! republishing their full state as a regular CRDT delta whose name/ordering
+//! registers merge by vector-clock causality.
+//!
+//! All tests are `#[ignore]` — they boot real x0xd daemons.
+//! Run with: cargo nextest run --test tasklist_first_join_bootstrap -- --ignored
+//! Before running: cargo build --release --bin x0xd
+
+use std::time::{Duration, Instant};
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+/// Collect the task titles currently visible on a daemon's task list.
+async fn task_titles(node: &cluster::AgentInstance, topic: &str) -> Vec<String> {
+    let r = node.get(&format!("/task-lists/{topic}/tasks")).await;
+    let body: serde_json::Value = r.json().await.expect("tasks response is json");
+    body["tasks"]
+        .as_array()
+        .map(|tasks| {
+            tasks
+                .iter()
+                .filter_map(|t| t["title"].as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tokio::test]
+#[ignore]
+async fn first_time_late_joiner_bootstraps_historical_tasks() {
+    // True cold first-join: alice creates the list and adds a task while
+    // bob's daemon DOES NOT EXIST YET. This defeats both fallback paths
+    // that can mask the gap on a warm pair — per-write direct delivery
+    // (bob is unknown at add time) and short-window gossip cache replay.
+    let (alice, alice_bind) = cluster::solo().await;
+    let topic = format!("tasklist-bootstrap-{}", rand::random::<u32>());
+
+    let r = alice
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "sprint", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates task list");
+    let r = alice
+        .post(
+            &format!("/task-lists/{topic}/tasks"),
+            serde_json::json!({ "title": "written-before-bob-existed" }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice adds historical task");
+
+    // Age the add past the gossip message-cache window (60s in
+    // saorsa-gossip-pubsub), then force a cache prune with fresh adds so the
+    // expired historical delta can't be redelivered by luck — the issue's
+    // real-world shape (future adds arrive, the historical task never does).
+    tokio::time::sleep(Duration::from_secs(70)).await;
+    for n in 0..3 {
+        let r = alice
+            .post(
+                &format!("/task-lists/{topic}/tasks"),
+                serde_json::json!({ "title": format!("fresh-{n}") }),
+            )
+            .await;
+        assert!(r.status().is_success(), "alice fresh add {n}");
+    }
+
+    // Only now does bob's daemon boot and connect.
+    let bob = cluster::join_peer(&alice, alice_bind).await;
+
+    // Bob subscribes to the topic for the first time, after the add. There is
+    // no REST "join" for task lists; creating on the same topic subscribes an
+    // empty list, which triggers the cold-start StateRequest.
+    let r = bob
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "sprint", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob subscribes to the task list");
+
+    // The historical task must arrive via the state-sync bootstrap. The
+    // requester retries at 1/5/15/30s; allow the full schedule plus slack.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let titles = task_titles(&bob, &topic).await;
+        if titles.iter().any(|t| t == "written-before-bob-existed") {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "bob never bootstrapped the task added before his first join; \
+             last titles: {titles:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn live_replication_still_works_after_bootstrap_change() {
+    // Guard: the state-sync side channel must not disturb the existing
+    // join-before-add replication path.
+    let pair = cluster::pair().await;
+    let topic = format!("tasklist-live-{}", rand::random::<u32>());
+
+    let r = pair
+        .alice
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "live", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates task list");
+    let r = pair
+        .bob
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "live", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob subscribes before the add");
+
+    let r = pair
+        .alice
+        .post(
+            &format!("/task-lists/{topic}/tasks"),
+            serde_json::json!({ "title": "live-task" }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice adds after bob joined");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let titles = task_titles(&pair.bob, &topic).await;
+        if titles.iter().any(|t| t == "live-task") {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "live replication regressed: bob never saw a task added after he joined"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}


### PR DESCRIPTION
## Summary

Codebase-wide simplification pass (tranches 1 + 3 of the deep-dive review), plus the fixes that came out of a multi-angle `/code-review` of the branch itself. Net **~−1,300 lines** across the daemon, CLI, gossip wire codec, and crdt/kv sync — behavior-preserving except where explicitly noted, with two genuine correctness fixes the review surfaced.

The five review reports that drove this are included under `.planning/reviews/` (88 findings across 5 slices).

## What's in it

**Daemon (`x0xd`)** — `e5e29e2`
- 258 hand-rolled `(StatusCode, Json(json!({"ok":false,"error":…})))` literals collapsed onto `api_error`/`bad_request`/`not_found`/`forbidden` helpers (byte-identical JSON). 67 base64 paths aliased. `save_named_groups` persistence switched pretty→compact. **−848 lines.** Group-administration handlers deliberately untouched (pending #106/#107).

**CLI / tooling** — `ee2ada8`
- `DaemonClient::run_get`/`run_get_query`/`run_delete` collapse 44 wrapper bodies; 18 duplicated `start_mock_server` copies hoisted to one test-support module; `routes --json` via serde derive instead of hand-rolled JSON; `exec sessions`/`cancel` modeled as real clap subcommands; **fixed a real bug** — `identity card` now URL-encodes `display_name`. **−583 lines.**

**Gossip wire** — `8648d01`
- `take_lp` length-prefix helper in `decode_v2` (+6 new bounds/round-trip tests added *before* the refactor), `now_unix_ms` deduped, `send_via_gossip`'s 10 args grouped into `DmSendContext`, `publish_local` extracted. Wire bytes unchanged.

**crdt / kv** — `a257194`
- Shared `gossip::wire::{encode_delta,decode_delta}` as the single definition of the `(PeerId, Delta)` envelope; removed the never-driven `AntiEntropyManager`; renamed the misleading `TaskList::delta(since_version)` → `full_delta()`; **lifted kv's `StateRequest` cold-start catch-up into task lists** so a late-joining replica converges on state written before it subscribed. Plus three efficiency fixes (`KvStore::get`, `full_delta`, `tasks_ordered`).

## Fixes from the branch's own code review

**`d86632e`**
- 🔴 **`KvStore::get` could resurrect deleted keys.** The earlier `get()` simplification assumed `entries` and the active-key OR-Set stay in lockstep, but `KvStore::merge()` applies a remote tombstone via `merge_state()` without pruning `entries`. Restored the active-key guard via `OrSet::contains()` (O(1)), keeping the win of dropping the old O(n) `elements()` scan.
- `gossip::wire` encode/decode now derive from one `envelope_opts()` so the format genuinely can't fork (was agreeing only because bincode's default is fixint).
- Removed 4 dead `run_*` helpers (zero call sites).

**`968430a` — LWW name/ordering deltas applied by clock, not bare `set()`**
- `merge_delta` was applying name (kv + task lists) and ordering (task lists) via `update_name()`/`reorder()` → `LwwRegister::set()`, which bumps the local clock and adopts the value **unconditionally**. The full-state `TaskList::merge()` already used `LwwRegister::merge()` (causal LWW); only the delta path regressed. The new cold-start responder (which rebroadcasts `full_delta` on the main topic to all members) made a stale snapshot able to clobber a newer local name/ordering on every join.
- Fix: deltas now carry the whole `LwwRegister` (value + vector clock); receivers resolve the winner by causality via `LwwRegister::merge()`. New test `stale_name_delta_does_not_clobber_newer_local_name` pins it.

> ⚠️ **Wire-format change (needs a coordinated rollout).** `TaskListDelta.{name_update,ordering_update}` and `KvStoreDelta.name_update` change from bare value → `LwwRegister<value>` on the CRDT sync topics. Deltas are transient (not persisted), but mixed-version daemons cannot exchange task-list/kv deltas during rollout. This warrants a **minor version bump** and a coordinated app-tier upgrade. The bootstrap fleet (gossip relay) is unaffected — only apps using task lists / kv stores.

## Deferred (tracked follow-ups, intentionally not in this PR)

- **`GossipSync<T>` unification** — the ~90 lines of `StateRequest` machinery are now duplicated across `crdt/sync.rs` and `kv/sync.rs` (including parallel `*SyncMessage` enums). The right altitude is a shared generic, but it's high blast-radius on the replication wire types and belongs in its own reviewed PR.
- Minor cold-start edges shared with kv: oversized `full_delta` (>4 MiB) silently dropped by the decode size cap; one-shot empty-gate skips bootstrap if a single delta lands first; name-only lists don't bootstrap.
- `exec sessions`/`cancel` rest on the "agent IDs are 64-char hex" invariant (an agent literally named `sessions` is unaddressable) — accepted tradeoff, documented in `docs/exec.md`.
- 138 `{ok:true,…}` success literals in `x0xd` got no builder while errors did — future cleanup.

## Validation

`cargo fmt`, `clippy --all-targets --all-features -D warnings`, full `nextest`, and `cargo doc` under `RUSTDOCFLAGS="-D warnings"` all clean. 1,697+ tests pass (new tests: wire round-trip, late-joiner convergence, stale-name clobber resistance). No changes to the REST/WS API surface or the group-admin handlers under active development in #106/#107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Large behavior-preserving simplification pass (−1,300 lines) across the daemon, CLI, gossip wire codec, and CRDT/kv sync, plus two genuine correctness fixes surfaced by an in-branch code review. The refactors are mechanical and low-risk; the correctness fixes — `KvStore::get()` resurrecting deleted keys and delta paths applying LWW name/ordering unconditionally instead of causally — are important and are tested.

- **CRDT / kv correctness**: `TaskListDelta` and `KvStoreDelta` now carry full `LwwRegister` objects for name and ordering so receivers resolve conflicts by vector-clock causality; `KvStore::get()` is gated on OR-Set membership to prevent deleted-key resurrection; a new cold-start `StateRequest` bootstrap in both sync modules lets late-joining replicas converge on pre-subscription state.
- **Wire codec unification**: `gossip::wire::{encode_delta, decode_delta}` is the single definition of the `(PeerId, Delta)` envelope (fixint, trailing-byte-tolerant, size-limited on decode) with a wire-compatibility test; `take_lp` in `pubsub.rs` DRYs the six length-prefix bounds checks with six new fuzz-like truncation tests.
- **CLI / daemon cleanup**: 258 inline error literals collapsed onto `api_error`/`bad_request`/`not_found` helpers; `identity card` URL-encoding bug fixed with a regression test; `DmSendContext` struct removes the 10-positional-arg footgun on `send_via_gossip`; `start_mock_server` deduped from 18 copies to one shared helper.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the simplification and CLI fixes; the CRDT correctness path warrants a follow-up to align `len()`/`is_empty()` with the OR-Set gate already applied to `get()`.

The `get()` fix explicitly documents that `entries` and the OR-Set can diverge after a remote `merge()`, but `len()` and `is_empty()` still count from `entries`. A store where all keys were tombstoned via `merge()` reports `is_empty() == false`, silently suppressing the cold-start bootstrap request that `kv/sync.rs` depends on.

src/kv/store.rs (`len()` and `is_empty()` still use `entries` after the `get()` OR-Set fix); src/crdt/task_list.rs (`task_count()` uses `task_data.len()` which can include zombie entries after full-state `merge()`)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/kv/store.rs | Restores OR-Set gate on `get()` to prevent deleted-key resurrection; introduces `name_register()` accessor. `len()`/`is_empty()` still count from `entries` and can overcount after tombstone merges via `merge()`. |
| src/crdt/task_list.rs | Adds `name_register()`, `ordering_register()`, `merge_name()`, `merge_ordering()` for causal LWW; O(1) set lookup in `tasks_ordered()`. `task_count()` uses `task_data.len()` which can overcount after full-state `merge()` applies tombstones. |
| src/crdt/delta.rs | Promotes `ordering_update`/`name_update` from bare values to full `LwwRegister`s; adds `full_delta()`, `merge_ordering`/`merge_name` paths with new causal-correctness and late-joiner convergence tests. |
| src/crdt/sync.rs | New cold-start StateRequest bootstrap (mirrors kv/sync.rs) with fixed 4-retry schedule; switches to shared `encode_delta`/`decode_delta`. Bootstrap retry loop intentionally runs to completion even after state arrives. |
| src/gossip/wire.rs | New module canonicalises the `(PeerId, Delta)` bincode envelope; wire-compatibility test verifies `encode_delta` produces identical bytes to the legacy `bincode::serialize`. |
| src/gossip/pubsub.rs | Extracts `publish_local()` helper and `take_lp()` length-prefix reader; adds six bounds/round-trip tests. The `map_err` error-string remap for 'pubkey length' is fragile but cosmetically only. |
| src/kv/sync.rs | Removes dead `AntiEntropyManager` and `sync_interval_secs`; switches to shared `encode_delta`/`decode_delta`. |
| src/bin/x0xd.rs | 258 inline error literals collapsed onto helpers; `save_named_groups` switched to compact JSON. Large mechanical change. |
| src/cli/commands/identity.rs | Fixes real URL-encoding bug in `card` with regression test. |
| src/cli/commands/test_support.rs | New module centralising the 18× copy-pasted `start_mock_server` helper. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Joiner
    participant SyncTopic as Gossip: main topic
    participant SideTopic as Gossip: /state-sync topic
    participant Holder

    Note over Joiner: start() with empty list/store
    Joiner->>SyncTopic: subscribe
    Joiner->>SideTopic: subscribe (responder loop)

    loop STATE_REQUEST_RETRY_SECS [1,5,15,30]
        Joiner->>SideTopic: "StateRequest{requester}"
        SideTopic->>Holder: "StateRequest{requester}"
        Holder->>Holder: if non-empty → full_delta()
        Holder->>SyncTopic: encode_delta(peer_id, full_delta)
        SyncTopic->>Joiner: (PeerId, Delta)
        Joiner->>Joiner: merge_delta() — LwwRegister merge for name/ordering
    end

    Note over Joiner,Holder: Joiner converges on pre-subscription state
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/kv/store.rs`, line 214-222 ([link](https://github.com/saorsa-labs/x0x/blob/968430af66fa78248cb648f0dbce2513ef398183/src/kv/store.rs#L214-L222)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`len()` / `is_empty()` report stale counts after tombstone merges**

   The `get()` fix in this PR explicitly documents that `entries` and the OR-Set can diverge after `merge()` applies remote tombstones without pruning `entries`. But `len()` and `is_empty()` still count from `entries`, creating the same inconsistency. Concretely, after a remote `merge()` removes a key from the OR-Set, `is_empty()` can return `false` while all `get()` calls return `None`. The bootstrap gate in `kv/sync.rs` — `if self.store.read().await.is_empty()` — would silently skip the cold-start state request for a store that has only zombie entries, leaving a late joiner without any live data. Both methods should count via `self.keys.elements().count()` (same source `active_keys()` already uses).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/kv/store.rs
   Line: 214-222

   Comment:
   **`len()` / `is_empty()` report stale counts after tombstone merges**

   The `get()` fix in this PR explicitly documents that `entries` and the OR-Set can diverge after `merge()` applies remote tombstones without pruning `entries`. But `len()` and `is_empty()` still count from `entries`, creating the same inconsistency. Concretely, after a remote `merge()` removes a key from the OR-Set, `is_empty()` can return `false` while all `get()` calls return `None`. The bootstrap gate in `kv/sync.rs` — `if self.store.read().await.is_empty()` — would silently skip the cold-start state request for a store that has only zombie entries, leaving a late joiner without any live data. Both methods should count via `self.keys.elements().count()` (same source `active_keys()` already uses).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/crdt/task_list.rs`, line 473-475 ([link](https://github.com/saorsa-labs/x0x/blob/968430af66fa78248cb648f0dbce2513ef398183/src/crdt/task_list.rs#L473-L475)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`task_count()` can overcount after `TaskList::merge()` applies tombstones**

   `task_count()` returns `task_data.len()`, but `TaskList::merge()` inserts all entries from `other.task_data` without removing tasks that are tombstoned in `other.tasks` (the OR-Set). A task removed on a remote peer and propagated via `merge()` stays in `task_data` while leaving the OR-Set, making `task_count()` exceed the true active count. The bootstrap check `if self.task_list.read().await.task_count() == 0` in `crdt/sync.rs` is not materially affected (delta merges clean up `task_data` via `remove_task()`), but callers expecting an accurate live count should use `self.tasks.elements().count()` instead.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/crdt/task_list.rs
   Line: 473-475

   Comment:
   **`task_count()` can overcount after `TaskList::merge()` applies tombstones**

   `task_count()` returns `task_data.len()`, but `TaskList::merge()` inserts all entries from `other.task_data` without removing tasks that are tombstoned in `other.tasks` (the OR-Set). A task removed on a remote peer and propagated via `merge()` stays in `task_data` while leaving the OR-Set, making `task_count()` exceed the true active count. The bootstrap check `if self.task_list.read().await.task_count() == 0` in `crdt/sync.rs` is not materially affected (delta merges clean up `task_data` via `remove_task()`), but callers expecting an accurate live count should use `self.tasks.elements().count()` instead.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/kv/store.rs:214-222
**`len()` / `is_empty()` report stale counts after tombstone merges**

The `get()` fix in this PR explicitly documents that `entries` and the OR-Set can diverge after `merge()` applies remote tombstones without pruning `entries`. But `len()` and `is_empty()` still count from `entries`, creating the same inconsistency. Concretely, after a remote `merge()` removes a key from the OR-Set, `is_empty()` can return `false` while all `get()` calls return `None`. The bootstrap gate in `kv/sync.rs` — `if self.store.read().await.is_empty()` — would silently skip the cold-start state request for a store that has only zombie entries, leaving a late joiner without any live data. Both methods should count via `self.keys.elements().count()` (same source `active_keys()` already uses).

### Issue 2 of 3
src/crdt/task_list.rs:473-475
**`task_count()` can overcount after `TaskList::merge()` applies tombstones**

`task_count()` returns `task_data.len()`, but `TaskList::merge()` inserts all entries from `other.task_data` without removing tasks that are tombstoned in `other.tasks` (the OR-Set). A task removed on a remote peer and propagated via `merge()` stays in `task_data` while leaving the OR-Set, making `task_count()` exceed the true active count. The bootstrap check `if self.task_list.read().await.task_count() == 0` in `crdt/sync.rs` is not materially affected (delta merges clean up `task_data` via `remove_task()`), but callers expecting an accurate live count should use `self.tasks.elements().count()` instead.

### Issue 3 of 3
src/gossip/pubsub.rs:1023-1034
**Error-string comparison is fragile for `take_lp` remapping**

The `map_err` arm matches on the literal string `"Truncated public key length"` to remap it to `"Truncated pubkey length"`. If `take_lp`'s format string or the `what` argument ever changes, this match silently stops firing and callers that relied on the `"pubkey length"` wording would see the new message. No existing test matches these strings (all tests check `is_err()` only), so the remapping is buying backward compatibility that nothing currently depends on. Consider removing the `map_err` and letting the canonical `"Truncated public key length"` propagate.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(crdt/kv): apply name/ordering deltas..."](https://github.com/saorsa-labs/x0x/commit/968430af66fa78248cb648f0dbce2513ef398183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36802513)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->