### PR TITLE
feat(api,cli): add POST /agent/verify + x0x agent verify — detached-signature verification (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`POST /agent/verify` + `x0x agent verify` — signature-verify counterpart to `/agent/sign`** (#106). Stateless detached ML-DSA-65 signature verification using only caller-supplied public material: applications that persist signed records no longer need to bundle their own FIPS-204 library or re-derive the `domain || 0x00 || payload` framing when reading records back. A failed check is a result (`200` + `valid: false`), not an error; `400`/`413` mirror `/agent/sign`'s malformed-input and size rules, with explicit key-length (1952) and signature-length (3309) validation and an optional `algorithm` field rejecting unknown schemes (including present-but-null). Proposed by @JimCollinson.
+
 ## [v0.23.0] - 2026-06-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **`POST /agent/verify` + `x0x agent verify` — signature-verify counterpart to `/agent/sign`** (#106). Stateless detached ML-DSA-65 signature verification using only caller-supplied public material: applications that persist signed records no longer need to bundle their own FIPS-204 library or re-derive the `domain || 0x00 || payload` framing when reading records back. A failed check is a result (`200` + `valid: false`), not an error; `400`/`413` mirror `/agent/sign`'s malformed-input and size rules, with explicit key-length (1952) and signature-length (3309) validation and an optional `algorithm` field rejecting unknown schemes (including present-but-null). Proposed by @JimCollinson.
+- **`POST /agent/verify` + `x0x agent verify` — signature-verify counterpart to `/agent/sign`** (#106, PR #109). Stateless detached ML-DSA-65 signature verification using only caller-supplied public material: applications that persist signed records no longer need to bundle their own FIPS-204 library or re-derive the `domain || 0x00 || payload` framing when reading records back. A failed check is a result (`200` + `valid: false`), not an error; `400`/`413` mirror `/agent/sign`'s malformed-input and size rules, with explicit key-length (1952) and signature-length (3309) validation and an optional `algorithm` field rejecting unknown schemes (including present-but-null). Proposed by @JimCollinson.
 
 ## [v0.23.0] - 2026-06-10
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -69,6 +69,7 @@ curl http://127.0.0.1:12700/status
 | GET | `/agent/card` | `x0x agent card` | Generate a shareable identity card |
 | POST | `/agent/card/import` | `x0x agent import` | Import a card into contacts |
 | POST | `/agent/sign` | `x0x agent sign` | Detached ML-DSA-65 signature over caller-supplied bytes |
+| POST | `/agent/verify` | `x0x agent verify` | Verify a detached ML-DSA-65 signature against a caller-supplied public key |
 
 ### Announce request body
 
@@ -106,6 +107,38 @@ Notes:
   `x0x.<purpose>.<version>` is the conventional shape for x0x protocols.
 - Response: `ok`, `agent_id` (hex), `public_key_b64`, `signature_b64`,
   `algorithm` (`x0x.agent-sign.v1.ml-dsa-65`), and `domain` when supplied.
+
+### Verify request body
+
+```json
+{
+  "payload_b64": "<base64 payload bytes>",
+  "signature_b64": "<base64 detached ML-DSA-65 signature>",
+  "public_key_b64": "<base64 ML-DSA-65 public key>",
+  "domain": "my-protocol.v1.register",
+  "algorithm": "x0x.agent-sign.v1.ml-dsa-65"
+}
+```
+
+Notes:
+- Stateless: verification uses only the caller-supplied public material —
+  no key access, no identity state. The counterpart to `/agent/sign` for
+  applications reading signed records back from disk or distributed
+  storage.
+- A failed signature check is a **result, not an error**: the response is
+  `200` with `{ "ok": true, "valid": false, "algorithm": "x0x.agent-sign.v1.ml-dsa-65" }`.
+- `400` is reserved for malformed input: bad base64 in any field, empty
+  payload, a public key that is not exactly 1952 bytes, a signature that
+  is not exactly 3309 bytes, an invalid `domain` (empty, NUL bytes, or
+  over 1024 bytes), or an unknown `algorithm`. `413` for payloads over
+  the 256 KiB cap. Limits mirror `/agent/sign` exactly.
+- `domain` is optional and must match the value used at signing time:
+  verification is then performed over `domain || 0x00 || payload`.
+- `algorithm` is optional; when the field is present — including as JSON
+  null — it must be the exact scheme string
+  `x0x.agent-sign.v1.ml-dsa-65`, so any future scheme migration is
+  explicit rather than silent.
+- Response: `ok`, `valid` (boolean), `algorithm`.
 
 ## Network
 

--- a/docs/design/api-manifest.json
+++ b/docs/design/api-manifest.json
@@ -1,5 +1,5 @@
 {
-  "endpoint_count": 131,
+  "endpoint_count": 132,
   "endpoints": [
     {
       "category": "status",
@@ -70,6 +70,13 @@
       "description": "Detached ML-DSA-65 signature over a caller-supplied payload",
       "method": "POST",
       "path": "/agent/sign"
+    },
+    {
+      "category": "identity",
+      "cli_name": "agent verify",
+      "description": "Verify a detached ML-DSA-65 signature against a caller-supplied public key",
+      "method": "POST",
+      "path": "/agent/verify"
     },
     {
       "category": "network",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -119,6 +119,13 @@ pub const ENDPOINTS: &[EndpointDef] = &[
         description: "Detached ML-DSA-65 signature over a caller-supplied payload",
         category: "identity",
     },
+    EndpointDef {
+        method: Method::Post,
+        path: "/agent/verify",
+        cli_name: "agent verify",
+        description: "Verify a detached ML-DSA-65 signature against a caller-supplied public key",
+        category: "identity",
+    },
     // ── Network ─────────────────────────────────────────────────────────
     EndpointDef {
         method: Method::Get,

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -346,6 +346,27 @@ enum AgentSub {
         #[arg(long)]
         domain: Option<String>,
     },
+    /// Verify a detached ML-DSA-65 signature against a caller-supplied
+    /// public key. Pass either `--file <PATH>` (use `-` for stdin) or
+    /// `--payload-b64 <BASE64>`. Exits 0 when the signature is valid,
+    /// non-zero when it is not.
+    Verify {
+        /// Path to a file whose bytes were signed verbatim. Use `-` for stdin.
+        #[arg(long, conflicts_with = "payload_b64")]
+        file: Option<String>,
+        /// Base64-encoded bytes the signature was computed over.
+        #[arg(long)]
+        payload_b64: Option<String>,
+        /// Base64-encoded detached ML-DSA-65 signature.
+        #[arg(long)]
+        signature_b64: String,
+        /// Base64-encoded ML-DSA-65 public key (1952 bytes decoded).
+        #[arg(long)]
+        public_key_b64: String,
+        /// Optional domain-separation string; verifies `domain || 0x00 || payload`.
+        #[arg(long)]
+        domain: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1238,6 +1259,23 @@ async fn run(
                     &client,
                     file.as_deref(),
                     payload_b64.as_deref(),
+                    domain.as_deref(),
+                )
+                .await
+            }
+            Some(AgentSub::Verify {
+                file,
+                payload_b64,
+                signature_b64,
+                public_key_b64,
+                domain,
+            }) => {
+                commands::identity::verify(
+                    &client,
+                    file.as_deref(),
+                    payload_b64.as_deref(),
+                    &signature_b64,
+                    &public_key_b64,
                     domain.as_deref(),
                 )
                 .await

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -790,6 +790,46 @@ struct AgentSignRequest {
     domain: Option<String>,
 }
 
+/// POST /agent/verify request body — a detached ML-DSA-65 signature to
+/// verify against caller-supplied public key material.
+#[derive(Debug, Deserialize)]
+struct AgentVerifyRequest {
+    /// Base64-encoded bytes the signature was computed over. Same caveat
+    /// as `/agent/sign`: the bytes are taken verbatim, so the caller must
+    /// reproduce the exact canonical serialization that was signed.
+    payload_b64: String,
+    /// Base64-encoded detached ML-DSA-65 signature (3309 bytes decoded).
+    signature_b64: String,
+    /// Base64-encoded ML-DSA-65 public key (1952 bytes decoded).
+    public_key_b64: String,
+    /// Optional domain-separation string. When present, verification is
+    /// performed over `domain || 0x00 || payload`, mirroring the
+    /// `/agent/sign` framing (issue #90). Must not contain NUL bytes.
+    #[serde(default)]
+    domain: Option<String>,
+    /// Optional signing-scheme identifier. When the field is present —
+    /// including as JSON null — it must be exactly
+    /// `x0x.agent-sign.v1.ml-dsa-65`; anything else is rejected with 400
+    /// so a future scheme migration is explicit rather than silent.
+    /// Deserialized via `deserialize_present` because a plain
+    /// `Option<String>` folds present-but-null into `None` and would
+    /// silently accept `"algorithm": null`.
+    #[serde(default, deserialize_with = "deserialize_present")]
+    algorithm: Option<serde_json::Value>,
+}
+
+/// Deserialize a field as `Some(value)` whenever the field is present —
+/// even when the value is JSON null — so present-but-null can be
+/// distinguished from an omitted field (serde's `Option<T>` maps both
+/// to `None`).
+fn deserialize_present<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: serde::Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    T::deserialize(deserializer).map(Some)
+}
+
 /// POST /announce request body.
 #[derive(Debug, Default, Deserialize)]
 struct AnnounceIdentityRequest {
@@ -2085,6 +2125,7 @@ async fn main() -> Result<()> {
         .route("/agent/card", get(get_agent_card))
         .route("/agent/card/import", post(import_agent_card))
         .route("/agent/sign", post(agent_sign))
+        .route("/agent/verify", post(agent_verify))
         .route("/announce", post(announce_identity))
         .route("/peers", get(peers))
         .route("/network/status", get(network_status))
@@ -4641,6 +4682,154 @@ async fn agent_sign(
     }
 
     (StatusCode::OK, Json(resp))
+}
+
+/// POST /agent/verify — verify a detached ML-DSA-65 signature against a
+/// caller-supplied public key (issue #106).
+///
+/// Rationale. The counterpart to `POST /agent/sign`: applications that
+/// persist signed records read them back — often on machines that never
+/// authored them — and must verify from the stored bytes alone. Without
+/// this endpoint every consumer would bundle its own FIPS-204 library and
+/// re-derive x0x's `domain || 0x00 || payload` framing, which would drift
+/// the moment the convention evolves.
+///
+/// Statelessness. Verification uses only caller-supplied public material:
+/// no key access, no identity state. The handler deliberately takes no
+/// `State` extractor so this property is enforced at compile time.
+///
+/// Authentication. Bearer-token authenticated like every other endpoint.
+///
+/// Semantics. A failed signature check is a *result*, not an error:
+/// `200` with `valid: false`. `400` is reserved for malformed input (bad
+/// base64, empty payload, wrong key or signature length, invalid domain,
+/// unknown `algorithm`); `413` for payloads over the cap — mirroring
+/// `/agent/sign` exactly. When `domain` is present, verification is
+/// performed over `domain || 0x00 || payload` (issue #90 framing).
+async fn agent_verify(Json(req): Json<AgentVerifyRequest>) -> impl IntoResponse {
+    let payload = match BASE64.decode(&req.payload_b64) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return bad_request(format!("invalid base64 payload: {e}"));
+        }
+    };
+
+    if payload.is_empty() {
+        return bad_request("payload must be non-empty");
+    }
+
+    if payload.len() > AGENT_SIGN_MAX_PAYLOAD_BYTES {
+        return api_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!(
+                "payload exceeds maximum verifiable size of {} bytes",
+                AGENT_SIGN_MAX_PAYLOAD_BYTES
+            ),
+        );
+    }
+
+    // Same domain rules and canonical-bytes assembly as `agent_sign`: the
+    // verifier must reconstruct exactly the bytes the signer committed to.
+    let canonical = match req.domain.as_deref() {
+        Some(domain) => {
+            if domain.is_empty() {
+                return bad_request("domain must be non-empty when provided");
+            }
+            if domain.as_bytes().contains(&0u8) {
+                return bad_request("domain must not contain NUL bytes");
+            }
+            if domain.len() > AGENT_SIGN_MAX_DOMAIN_BYTES {
+                return bad_request(format!(
+                    "domain exceeds maximum length of {} bytes",
+                    AGENT_SIGN_MAX_DOMAIN_BYTES
+                ));
+            }
+            let mut buf = Vec::with_capacity(domain.len() + 1 + payload.len());
+            buf.extend_from_slice(domain.as_bytes());
+            buf.push(0);
+            buf.extend_from_slice(&payload);
+            buf
+        }
+        None => payload,
+    };
+
+    // A present `algorithm` must be exactly the supported scheme string;
+    // JSON null and non-string values are present-but-wrong, not omitted.
+    if let Some(algorithm) = req.algorithm.as_ref() {
+        if algorithm.as_str() != Some(AGENT_SIGN_SCHEME_ID) {
+            return bad_request(format!(
+                "unsupported algorithm: {algorithm} (expected {AGENT_SIGN_SCHEME_ID})"
+            ));
+        }
+    }
+
+    let signature_bytes = match BASE64.decode(&req.signature_b64) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return bad_request(format!("invalid base64 signature: {e}"));
+        }
+    };
+
+    // A wrong-length signature is malformed input, not a failed check —
+    // reject it with 400 so a truncated paste never reads as `valid: false`.
+    if signature_bytes.len() != ant_quic::crypto::raw_public_keys::pqc::ML_DSA_65_SIGNATURE_SIZE {
+        return bad_request(format!(
+            "signature must be exactly {} bytes for ML-DSA-65, got {}",
+            ant_quic::crypto::raw_public_keys::pqc::ML_DSA_65_SIGNATURE_SIZE,
+            signature_bytes.len()
+        ));
+    }
+
+    let signature = match ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(
+        &signature_bytes,
+    ) {
+        Ok(sig) => sig,
+        Err(e) => {
+            return bad_request(format!("invalid signature format: {e:?}"));
+        }
+    };
+
+    let public_key_bytes = match BASE64.decode(&req.public_key_b64) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return bad_request(format!("invalid base64 public key: {e}"));
+        }
+    };
+
+    // An ML-DSA-65 public key is exactly 1952 bytes; anything else is a
+    // wrong-key-type paste and gets 400, never a confusing `valid: false`.
+    if public_key_bytes.len() != ant_quic::crypto::raw_public_keys::pqc::ML_DSA_65_PUBLIC_KEY_SIZE {
+        return bad_request(format!(
+            "public key must be exactly {} bytes for ML-DSA-65, got {}",
+            ant_quic::crypto::raw_public_keys::pqc::ML_DSA_65_PUBLIC_KEY_SIZE,
+            public_key_bytes.len()
+        ));
+    }
+
+    let public_key =
+        match ant_quic::crypto::raw_public_keys::pqc::MlDsaPublicKey::from_bytes(&public_key_bytes)
+        {
+            Ok(pk) => pk,
+            Err(e) => {
+                return bad_request(format!("invalid public key format: {e:?}"));
+            }
+        };
+
+    let valid = ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+        &public_key,
+        &canonical,
+        &signature,
+    )
+    .is_ok();
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "ok": true,
+            "valid": valid,
+            "algorithm": AGENT_SIGN_SCHEME_ID,
+        })),
+    )
 }
 
 /// GET /peers

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -131,23 +131,7 @@ pub async fn sign(
 ) -> Result<()> {
     client.ensure_running().await?;
 
-    let payload_b64 = match (file, payload_b64) {
-        (Some(path), None) => {
-            let bytes = if path == "-" {
-                let mut buf = Vec::new();
-                std::io::stdin()
-                    .read_to_end(&mut buf)
-                    .context("failed to read stdin")?;
-                buf
-            } else {
-                std::fs::read(path).with_context(|| format!("failed to read file: {path}"))?
-            };
-            base64::engine::general_purpose::STANDARD.encode(bytes)
-        }
-        (None, Some(b64)) => b64.to_string(),
-        (Some(_), Some(_)) => bail!("pass either --file or --payload-b64, not both"),
-        (None, None) => bail!("pass either --file <PATH> or --payload-b64 <BASE64>"),
-    };
+    let payload_b64 = payload_b64_from_args(file, payload_b64)?;
 
     let mut body = serde_json::json!({ "payload_b64": payload_b64 });
     if let Some(domain) = domain {
@@ -158,13 +142,76 @@ pub async fn sign(
     Ok(())
 }
 
+/// `x0x agent verify` — POST /agent/verify
+///
+/// Verifies a detached ML-DSA-65 signature against a caller-supplied
+/// public key. The payload comes from `--file <PATH>` (or stdin when the
+/// path is `-`) OR `--payload-b64 <BASE64>`, exactly as for `sign`. Pass
+/// `--domain <STRING>` when the signature was produced with domain
+/// separation (`domain || 0x00 || payload`, issue #90). Verification is
+/// stateless — the daemon uses only the supplied public material.
+///
+/// Exit status: 0 when the signature is valid; non-zero when it is not
+/// (the daemon reports `valid: false`) or on malformed input.
+pub async fn verify(
+    client: &DaemonClient,
+    file: Option<&str>,
+    payload_b64: Option<&str>,
+    signature_b64: &str,
+    public_key_b64: &str,
+    domain: Option<&str>,
+) -> Result<()> {
+    // Usage errors (missing/ambiguous payload args) must win over daemon
+    // reachability, so validate local inputs before probing the daemon.
+    let payload_b64 = payload_b64_from_args(file, payload_b64)?;
+
+    client.ensure_running().await?;
+
+    let mut body = serde_json::json!({
+        "payload_b64": payload_b64,
+        "signature_b64": signature_b64,
+        "public_key_b64": public_key_b64,
+    });
+    if let Some(domain) = domain {
+        body["domain"] = serde_json::Value::String(domain.to_string());
+    }
+    let resp = client.post("/agent/verify", &body).await?;
+    print_value(client.format(), &resp);
+    if resp.get("valid").and_then(|v| v.as_bool()) != Some(true) {
+        bail!("signature verification failed");
+    }
+    Ok(())
+}
+
+/// Resolve the payload for `sign`/`verify` from `--file <PATH>` (with `-`
+/// meaning stdin) or `--payload-b64 <BASE64>`, returning base64 bytes.
+fn payload_b64_from_args(file: Option<&str>, payload_b64: Option<&str>) -> Result<String> {
+    match (file, payload_b64) {
+        (Some(path), None) => {
+            let bytes = if path == "-" {
+                let mut buf = Vec::new();
+                std::io::stdin()
+                    .read_to_end(&mut buf)
+                    .context("failed to read stdin")?;
+                buf
+            } else {
+                std::fs::read(path).with_context(|| format!("failed to read file: {path}"))?
+            };
+            Ok(base64::engine::general_purpose::STANDARD.encode(bytes))
+        }
+        (None, Some(b64)) => Ok(b64.to_string()),
+        (Some(_), Some(_)) => bail!("pass either --file or --payload-b64, not both"),
+        (None, None) => bail!("pass either --file <PATH> or --payload-b64 <BASE64>"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;
     use crate::cli::{DaemonClient, OutputFormat};
 
-    use crate::cli::commands::test_support::start_mock_server;
+    use crate::cli::commands::test_support::{start_capturing_mock_server, start_mock_server};
     #[test]
     fn identity_words_encodes_known_hex() {
         let encoder = IdentityEncoder::new();
@@ -396,5 +443,106 @@ mod tests {
             "ampersand was not percent-encoded: {uri}"
         );
         drop(tx);
+    }
+
+    #[tokio::test]
+    async fn verify_posts_full_body_to_verify_endpoint() {
+        let mock_resp = serde_json::json!({
+            "ok": true, "valid": true, "algorithm": "x0x.agent-sign.v1.ml-dsa-65"
+        });
+        let (url, _shutdown, captured) = start_capturing_mock_server(mock_resp).await;
+        let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
+
+        let result = verify(
+            &client,
+            None,
+            Some("aGVsbG8="),
+            "c2ln",
+            "cGs=",
+            Some("x0x.test.v1"),
+        )
+        .await;
+        assert!(result.is_ok(), "verify should succeed: {:?}", result);
+
+        let captured = captured.lock().unwrap();
+        let (_, body) = captured
+            .iter()
+            .find(|(path, _)| path == "/agent/verify")
+            .expect("a request must be POSTed to /agent/verify");
+        assert_eq!(body["payload_b64"], "aGVsbG8=");
+        assert_eq!(body["signature_b64"], "c2ln");
+        assert_eq!(body["public_key_b64"], "cGs=");
+        assert_eq!(body["domain"], "x0x.test.v1");
+    }
+
+    #[tokio::test]
+    async fn verify_omits_domain_when_not_passed() {
+        let mock_resp = serde_json::json!({"ok": true, "valid": true});
+        let (url, _shutdown, captured) = start_capturing_mock_server(mock_resp).await;
+        let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
+
+        let result = verify(&client, None, Some("aGVsbG8="), "c2ln", "cGs=", None).await;
+        assert!(result.is_ok(), "verify should succeed: {:?}", result);
+
+        let captured = captured.lock().unwrap();
+        let (_, body) = captured
+            .iter()
+            .find(|(path, _)| path == "/agent/verify")
+            .expect("a request must be POSTed to /agent/verify");
+        assert!(
+            body.get("domain").is_none(),
+            "request must not contain a domain field when none was passed"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_fails_when_daemon_reports_invalid() {
+        // The daemon's 200 + valid:false is a result, not an HTTP error —
+        // but for scripts the CLI exit code must still reflect it.
+        let mock_resp = serde_json::json!({
+            "ok": true, "valid": false, "algorithm": "x0x.agent-sign.v1.ml-dsa-65"
+        });
+        let (url, _shutdown) = start_mock_server(mock_resp).await;
+        let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
+
+        let result = verify(&client, None, Some("aGVsbG8="), "c2ln", "cGs=", None).await;
+        assert!(result.is_err(), "valid:false must map to a non-zero exit");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("signature verification failed"));
+    }
+
+    #[tokio::test]
+    async fn verify_rejects_ambiguous_or_missing_payload() {
+        let mock_resp = serde_json::json!({"unused": true});
+        let (url, _shutdown) = start_mock_server(mock_resp).await;
+        let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
+
+        let both = verify(&client, Some("-"), Some("aGVsbG8="), "c2ln", "cGs=", None).await;
+        assert!(both.is_err());
+        assert!(both.unwrap_err().to_string().contains("pass either --file"));
+
+        let neither = verify(&client, None, None, "c2ln", "cGs=", None).await;
+        assert!(neither.is_err());
+        assert!(neither
+            .unwrap_err()
+            .to_string()
+            .contains("pass either --file <PATH>"));
+    }
+
+    #[tokio::test]
+    async fn verify_arg_errors_win_over_unreachable_daemon() {
+        // No server listening: if verify probed the daemon before validating
+        // its arguments, this would surface a connectivity error instead of
+        // the usage error.
+        let client =
+            DaemonClient::new(None, Some("http://127.0.0.1:9"), OutputFormat::Json).unwrap();
+        let neither = verify(&client, None, None, "c2ln", "cGs=", None).await;
+        assert!(neither.is_err());
+        assert!(neither
+            .unwrap_err()
+            .to_string()
+            .contains("pass either --file <PATH>"));
     }
 }

--- a/src/cli/commands/test_support.rs
+++ b/src/cli/commands/test_support.rs
@@ -45,3 +45,56 @@ pub async fn start_mock_server(
 
     (format!("http://{addr}"), tx)
 }
+
+/// Like [`start_mock_server`], but records every `(path, JSON body)` the
+/// client sends, so tests can assert the request actually hit the expected
+/// endpoint with the expected fields.
+pub async fn start_capturing_mock_server(
+    response_json: serde_json::Value,
+) -> (
+    String,
+    tokio::sync::oneshot::Sender<()>,
+    std::sync::Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>>,
+) {
+    use std::sync::{Arc, Mutex};
+
+    let json = Arc::new(response_json);
+    let captured: Arc<Mutex<Vec<(String, serde_json::Value)>>> = Arc::new(Mutex::new(Vec::new()));
+    let cap = Arc::clone(&captured);
+    let app = axum::Router::new().fallback(move |req: axum::extract::Request| {
+        let json = Arc::clone(&json);
+        let cap = Arc::clone(&cap);
+        async move {
+            let path = req.uri().path().to_string();
+            let bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
+                .await
+                .unwrap_or_default();
+            let body: serde_json::Value =
+                serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+            cap.lock().unwrap().push((path, body));
+            let resp = serde_json::to_vec(&*json).unwrap();
+            axum::response::Response::builder()
+                .status(200)
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(resp))
+                .unwrap()
+        }
+    });
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .with_graceful_shutdown(async {
+                rx.await.ok();
+            })
+            .await
+            .ok();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    (format!("http://{addr}"), tx, captured)
+}

--- a/tests/api_coverage.rs
+++ b/tests/api_coverage.rs
@@ -59,6 +59,7 @@ const COVERED: &[CoveredEndpoint] = &[
         daemon_api_import_card_invalid_trust_level_rejected
     ),
     covered!(Post, "/agent/sign", daemon_api_agent_sign_roundtrip),
+    covered!(Post, "/agent/verify", daemon_api_agent_verify_roundtrip),
     // ── Network ─────────────────────────────────────────────────────────
     covered!(Get, "/peers", daemon_api_peers),
     // ── Presence ────────────────────────────────────────────────────────

--- a/tests/daemon_api_integration.rs
+++ b/tests/daemon_api_integration.rs
@@ -283,6 +283,562 @@ async fn daemon_api_agent_sign_rejects_oversize_payload() {
     assert_eq!(r.status(), StatusCode::PAYLOAD_TOO_LARGE);
 }
 
+// ── POST /agent/verify (issue #106) ─────────────────────────────────────
+
+/// Sign `payload` via POST /agent/sign and return (signature_b64, public_key_b64).
+async fn sign_via_daemon(
+    d: &DaemonFixture,
+    payload: &[u8],
+    domain: Option<&str>,
+) -> (String, String) {
+    let mut body = serde_json::json!({ "payload_b64": b64(payload) });
+    if let Some(domain) = domain {
+        body["domain"] = serde_json::Value::String(domain.to_string());
+    }
+    let r: Value = ca(d)
+        .post(d.url("/agent/sign"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(r["ok"], true, "sign must succeed before verify: {r}");
+    (
+        r["signature_b64"].as_str().unwrap().to_string(),
+        r["public_key_b64"].as_str().unwrap().to_string(),
+    )
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_roundtrip() {
+    let d = daemon().await;
+    let payload = b"audit record bytes read back from storage";
+    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+
+    let resp = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let r: Value = resp.json().await.unwrap();
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["valid"], true);
+    assert_eq!(r["algorithm"], "x0x.agent-sign.v1.ml-dsa-65");
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_independent_keypair() {
+    // The primary third-party use case: the verifying daemon never authored
+    // the signature and holds none of the key material — a record signed by
+    // an arbitrary ML-DSA-65 keypair must verify from the supplied bytes alone.
+    let d = daemon().await;
+    let (public_key, secret_key) =
+        ant_quic::crypto::raw_public_keys::pqc::generate_ml_dsa_keypair()
+            .expect("keypair generation");
+    let payload = b"record authored on a machine this daemon has never seen";
+    let signature = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(&secret_key, payload)
+        .expect("local signing");
+
+    let r: Value = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": b64(signature.as_bytes()),
+            "public_key_b64": b64(public_key.as_bytes()),
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(r["ok"], true);
+    assert_eq!(
+        r["valid"], true,
+        "a signature from a caller-supplied keypair must verify"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_tampered_payload_is_result_not_error() {
+    let d = daemon().await;
+    let (sig, pk) = sign_via_daemon(&d, b"the original payload", None).await;
+
+    let resp = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(b"the tampered payload"),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a failed signature check is a result, not an error"
+    );
+    let r: Value = resp.json().await.unwrap();
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["valid"], false);
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_tampered_signature_is_result_not_error() {
+    let d = daemon().await;
+    let payload = b"payload whose signature gets corrupted in storage";
+    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+
+    // Flip one bit mid-signature: still 3309 bytes, so it passes the
+    // malformed-input checks and must fail as `valid: false`, not 400.
+    let mut sig_bytes = base64::engine::general_purpose::STANDARD
+        .decode(&sig)
+        .unwrap();
+    sig_bytes[100] ^= 0x01;
+
+    let resp = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": b64(&sig_bytes),
+            "public_key_b64": pk,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let r: Value = resp.json().await.unwrap();
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["valid"], false);
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_domain_separation_enforced() {
+    let d = daemon().await;
+    let payload = b"register envelope bytes";
+    let domain = "x0x.test.v1.verify";
+    let (sig, pk) = sign_via_daemon(&d, payload, Some(domain)).await;
+
+    // With the matching domain the signature verifies.
+    let r: Value = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig.clone(),
+            "public_key_b64": pk.clone(),
+            "domain": domain,
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(r["valid"], true);
+
+    // The same bytes WITHOUT the domain must not verify — the
+    // domain || 0x00 || payload framing is enforced, not advisory.
+    let r: Value = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(r["ok"], true);
+    assert_eq!(
+        r["valid"], false,
+        "domain-separated signature must NOT verify over the raw payload"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_accepts_explicit_algorithm() {
+    let d = daemon().await;
+    let payload = b"payload";
+    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+
+    let r: Value = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+            "algorithm": "x0x.agent-sign.v1.ml-dsa-65",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(r["valid"], true);
+}
+
+/// Assert a rejection response: expected status, `ok: false`, and an error
+/// string naming the gate that fired.
+///
+/// The substring assertion is load-bearing: every rejection test sends a
+/// request that is fully valid except for the one field under test, so
+/// without it a deleted guard could go unnoticed when a *different* check
+/// downstream happens to return the same status.
+async fn assert_rejection(resp: reqwest::Response, status: StatusCode, needle: &str) {
+    assert_eq!(resp.status(), status);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["ok"], false);
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains(needle),
+        "error must identify the failing gate: expected substring {needle:?}, got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_unknown_algorithm() {
+    let d = daemon().await;
+    // Real signature and key: with the algorithm gate removed this request
+    // would verify as 200 valid:true — the silent scheme migration the
+    // explicit 400 exists to prevent.
+    let payload = b"x";
+    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+            "algorithm": "x0x.agent-sign.v2.something-else",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(r, StatusCode::BAD_REQUEST, "unsupported algorithm").await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_null_algorithm() {
+    let d = daemon().await;
+    // JSON null is a *present* algorithm field, not an omitted one: an
+    // `Option<String>` request field would fold it to None and silently
+    // accept — this pins the explicit 400 instead.
+    let payload = b"x";
+    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+            "algorithm": null,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(r, StatusCode::BAD_REQUEST, "unsupported algorithm").await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_requires_auth() {
+    let d = daemon().await;
+    // Bearer-token like every other endpoint — stateless or not, an
+    // unauthenticated carve-out isn't worth the inconsistency (issue #106,
+    // maintainer refinement 6).
+    let r = c()
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(b"x"),
+            "signature_b64": b64(b"sig"),
+            "public_key_b64": b64(b"pk"),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_accepts_exact_boundary_sizes() {
+    let d = daemon().await;
+    // Exactly AT the caps must round-trip: the limits reject payloads
+    // *over* 256 KiB and domains *over* 1 KiB, not at them.
+    let payload = vec![0xA5u8; 256 * 1024];
+    let domain = "d".repeat(1024);
+    let (sig, pk) = sign_via_daemon(&d, &payload, Some(domain.as_str())).await;
+    let r: Value = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(&payload),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+            "domain": domain,
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["valid"], true);
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_wrong_key_is_result_not_error() {
+    let d = daemon().await;
+    // A well-formed 1952-byte key that simply isn't the signer's: that is
+    // a verification *result* (valid:false), never malformed input.
+    let payload = b"signed by the daemon, checked against a stranger's key";
+    let (sig, _pk) = sign_via_daemon(&d, payload, None).await;
+    let (other_pk, _sk) = ant_quic::crypto::raw_public_keys::pqc::generate_ml_dsa_keypair()
+        .expect("keypair generation");
+    let resp = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": b64(other_pk.as_bytes()),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let r: Value = resp.json().await.unwrap();
+    assert_eq!(r["ok"], true);
+    assert_eq!(r["valid"], false);
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_invalid_base64_payload() {
+    let d = daemon().await;
+    let (sig, pk) = sign_via_daemon(&d, b"x", None).await;
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": "@@@not-base64@@@",
+            "signature_b64": sig,
+            "public_key_b64": pk,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(r, StatusCode::BAD_REQUEST, "invalid base64 payload").await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_invalid_base64_signature() {
+    let d = daemon().await;
+    let payload = b"x";
+    let (_sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": "@@@not-base64@@@",
+            "public_key_b64": pk,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(r, StatusCode::BAD_REQUEST, "invalid base64 signature").await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_invalid_base64_public_key() {
+    let d = daemon().await;
+    let payload = b"x";
+    let (sig, _pk) = sign_via_daemon(&d, payload, None).await;
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": "@@@not-base64@@@",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(r, StatusCode::BAD_REQUEST, "invalid base64 public key").await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_empty_payload() {
+    let d = daemon().await;
+    let (sig, pk) = sign_via_daemon(&d, b"x", None).await;
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": "",
+            "signature_b64": sig,
+            "public_key_b64": pk,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(r, StatusCode::BAD_REQUEST, "payload must be non-empty").await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_oversize_payload() {
+    let d = daemon().await;
+    let (sig, pk) = sign_via_daemon(&d, b"x", None).await;
+    // Just over the 256 KiB cap — same limit as /agent/sign.
+    let oversize = vec![0u8; 256 * 1024 + 1];
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(&oversize),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(
+        r,
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "exceeds maximum verifiable size",
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_wrong_public_key_length() {
+    let d = daemon().await;
+    let payload = b"x";
+    let (sig, _pk) = sign_via_daemon(&d, payload, None).await;
+    // A 32-byte value is a plausible wrong-key-type paste (e.g. an agent id
+    // or an Ed25519 key) — it must be 400, never a confusing valid:false.
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": b64(&[0u8; 32]),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(r, StatusCode::BAD_REQUEST, "public key must be exactly").await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_wrong_signature_length() {
+    let d = daemon().await;
+    let payload = b"x";
+    let (_sig, pk) = sign_via_daemon(&d, payload, None).await;
+    // A truncated signature is malformed input, not a failed check.
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": b64(&[0u8; 100]),
+            "public_key_b64": pk,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(r, StatusCode::BAD_REQUEST, "signature must be exactly").await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_nul_in_domain() {
+    let d = daemon().await;
+    let payload = b"x";
+    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+            "domain": "bad\u{0}domain",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(
+        r,
+        StatusCode::BAD_REQUEST,
+        "domain must not contain NUL bytes",
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_empty_domain() {
+    let d = daemon().await;
+    let payload = b"x";
+    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+            "domain": "",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(r, StatusCode::BAD_REQUEST, "domain must be non-empty").await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_verify_rejects_oversize_domain() {
+    let d = daemon().await;
+    let payload = b"x";
+    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    // Just over the 1 KiB domain cap — same limit as /agent/sign.
+    let r = ca(&d)
+        .post(d.url("/agent/verify"))
+        .json(&serde_json::json!({
+            "payload_b64": b64(payload),
+            "signature_b64": sig,
+            "public_key_b64": pk,
+            "domain": "d".repeat(1025),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_rejection(r, StatusCode::BAD_REQUEST, "domain exceeds maximum length").await;
+}
+
 #[tokio::test]
 #[ignore]
 async fn daemon_api_peers() {


### PR DESCRIPTION
## Summary

Implements #106 as accepted: `POST /agent/verify`, the stateless signature-verify counterpart to `POST /agent/sign`, plus the `x0x agent verify` CLI sibling via the shared endpoint registry. Applications that persist detached-signed records — the use-case `/agent/sign` was built for — can now verify them on read-back, including on machines that never authored them, without bundling their own FIPS-204 library or re-deriving the `domain || 0x00 || payload` framing.

Verified locally: clippy `-D warnings` clean, `cargo doc -D warnings` clean, workspace nextest **1698/1703** (the 5 failures are pre-existing environmental cluster-mesh tests in `named_group_join_metadata_event` — reproduced identically on unmodified main `5f086cf` in the same environment), daemon-backed API suite **89/89** including 21 new `/agent/verify` tests.

### Design notes

`algorithm` is deserialized through a small custom deserializer into `Option<serde_json::Value>` rather than a plain `Option<String>`, because serde folds a present JSON `null` into `None` — indistinguishable from an omitted field — and the endpoint would silently accept `"algorithm": null`. Since the field exists precisely to make any future scheme migration explicit rather than silent, present-but-null is rejected with the same `unsupported algorithm` 400 as any other wrong value.

A wrong-length signature (≠ 3309 bytes) is a `400`, never `valid: false`: a truncated or mis-pasted signature is bad input, not a legitimate "this signature doesn't match", and conflating the two would hide caller bugs behind a normal-looking negative result. This is the same reasoning as the accepted wrong-length-key rule, applied symmetrically.

### The seven accepted refinements (from the maintainer comment on #106)

1. **Failed verification is a result, not an error** — `200` + `{"ok": true, "valid": false}`. `400` is reserved for malformed input (bad base64 in any field, empty payload, NUL/empty/oversize domain, wrong key or signature length, unknown `algorithm`); `413` for payloads over the cap — mirroring `/agent/sign` exactly.
2. **Public key length validated** — exactly 1952 bytes (`ML_DSA_65_PUBLIC_KEY_SIZE` from ant-quic), rejected with a 400 naming the expected length, never a confusing `valid: false`. The same logic is applied to wrong-length signatures (3309 bytes): a truncated paste is malformed input, not a failed check.
3. **Optional `algorithm` field** — accepted only as the exact string `x0x.agent-sign.v1.ml-dsa-65`; anything else, **including present-but-JSON-null**, is a 400 (see Design notes).
4. **Sign-handler limits and domain rules mirrored verbatim** — 256 KiB payload cap, 1 KiB domain cap, non-empty NUL-free domain, verification over `domain || 0x00 || payload` when domain is present. Exact-boundary (at-cap) sizes round-trip.
5. **CLI sibling in the same PR** — `x0x agent verify --file <PATH>|-` / `--payload-b64`, `--signature-b64`, `--public-key-b64`, `[--domain]`, wired through the shared endpoint registry in `src/api/mod.rs`. Exit 0 when valid, non-zero when not; usage errors are validated before the daemon probe so they win over connectivity errors.
6. **Bearer-token auth like every other endpoint** — the route sits behind the standard auth middleware; a 401 test pins it.
7. **Batch verify out of scope** — not included.

Statelessness is compile-enforced: `agent_verify` takes no `State` extractor at all — verification uses only caller-supplied public material. The handler follows the post-#108 idioms (`bad_request`/`api_error` helpers, `BASE64` alias).

### Tests

- Round-trips: sign→verify; an **independent caller-supplied keypair** (generated in-test, signed locally, never seen by the daemon — the third-party-verification case the issue is about); domain round-trip plus the negative proof that a domain-separated signature does NOT verify without the domain; exact-boundary payload/domain sizes.
- Results-not-errors: tampered payload, bit-flipped signature, and a well-formed stranger key each return `200` + `valid: false`.
- Every 400/413 case is individually pinned: each rejection test sends a request that is fully valid except the single field under test, and asserts the error-message substring naming the failing gate — so a deleted guard cannot hide behind a different gate's 400.
- CLI tests against a request-capturing mock (request path and body fields, domain omission, `valid: false` → non-zero exit, argument validation), plus the `api_coverage` registry entry.

### Notes

- `x0x agent sign` shares a small quirk this PR fixes only on the verify side: it probes the daemon before validating its payload arguments, so usage errors can surface as connectivity errors. Fixing `sign` is out of #106's scope — happy to follow up with a small PR if wanted.
- `docs/api-reference.md` documents the endpoint including the 200-vs-400 semantics; CHANGELOG entry under Unreleased; `docs/design/api-manifest.json` regenerated from the registry.

## Test plan

- [x] `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo doc` with `RUSTDOCFLAGS="-D warnings"`
- [x] Workspace nextest 1698/1703 — the 5 failures are pre-existing environmental (`named_group_join_metadata_event` cluster tests; identical failures reproduced on clean main `5f086cf` in the same environment)
- [x] Daemon-backed API suite (`-- --ignored`): 89/89, including the 21 new `/agent/verify` tests
- [x] Live CLI end-to-end against a local daemon: valid → exit 0; tampered → `valid: false`, exit 1; domain mismatch → `valid: false`; wrong-length key → 400

Closes #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements `POST /agent/verify` and `x0x agent verify` — the stateless signature-verification counterpart to the existing `/agent/sign` endpoint — using caller-supplied public material and ML-DSA-65 (FIPS-204). A failed verification is a result (`200` + `valid: false`), while malformed input yields 400/413, mirroring the sign handler exactly.

- New `agent_verify` handler in `x0xd.rs` with thorough input validation: base64 decoding, exact key/signature length checks (1952/3309 bytes), domain rules mirrored from `agent_sign`, and a custom `deserialize_present` serde shim that distinguishes a present-but-JSON-null `algorithm` field from an omitted one.
- CLI `verify` subcommand validates payload args (file vs. base64) before probing the daemon, fixing an ordering quirk that still exists in `agent sign`; exits non-zero on `valid: false` or errors.
- 21 new daemon-backed integration tests cover: sign→verify round-trips, independent-keypair third-party verification, domain-separation enforcement, every 400/413 gate pinned individually, auth, and exact-boundary sizes.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the new endpoint is stateless, compile-enforced, and fully covered by 21 new integration tests plus unit tests; no existing behaviour is altered.

The implementation is thorough and follows every established pattern in the codebase. All validation gates have individually-pinned rejection tests, domain-separation enforcement is verified both positively and negatively, and auth is confirmed. The only non-trivial novelty is the `deserialize_present` serde shim — its logic is correct and the null-algorithm rejection test pins the exact behaviour it was written to enforce. A small amount of caution is warranted given the new crypto validation path and the fact that `MlDsaSignature::from_bytes` / `MlDsaPublicKey::from_bytes` results after the explicit length checks are untested (those branches may be unreachable in practice, but if `ant_quic` ever adds structural checks they would silently return 400 rather than `valid: false`).

No files require special attention; `src/bin/x0xd.rs` carries the most new logic but is well-tested.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/bin/x0xd.rs | Adds `AgentVerifyRequest`, `deserialize_present` serde helper, and `agent_verify` handler; input validation mirrors `agent_sign` exactly; statelessness enforced at compile time via absent `State` extractor. |
| src/cli/commands/identity.rs | Adds `verify()` CLI function and extracts `payload_b64_from_args` helper; `verify` validates payload args before probing daemon (fixing ordering quirk that remains in `sign`); exits non-zero on `valid: false`. |
| src/cli/commands/test_support.rs | Adds `start_capturing_mock_server` to record (path, body) pairs from client requests; clean parallel of the existing `start_mock_server`. |
| tests/daemon_api_integration.rs | Adds 21 ignored integration tests covering round-trips, independent-keypair verification, domain separation, all 400/413 gates individually, auth, and boundary sizes; each rejection test pins the error substring so a deleted guard can't hide. |
| src/bin/x0x.rs | Adds `AgentSub::Verify` enum variant with correct `conflicts_with` for `--file`/`--payload-b64` and dispatches to `commands::identity::verify`. |
| src/api/mod.rs | Adds `EndpointDef` for `POST /agent/verify` to the shared endpoint registry. |
| tests/api_coverage.rs | Registers `daemon_api_agent_verify_roundtrip` as the coverage anchor for `POST /agent/verify`. |
| docs/api-reference.md | Documents the new endpoint including request body, 200-vs-400 semantics, domain framing, and algorithm field behaviour. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant x0xd as x0xd (daemon)
    participant PQC as ant_quic PQC

    Caller->>x0xd: "POST /agent/verify<br/>{payload_b64, signature_b64, public_key_b64, [domain], [algorithm]}"

    x0xd->>x0xd: BASE64.decode(payload_b64) → payload
    x0xd->>x0xd: Validate payload (non-empty, ≤ 256 KiB)

    alt domain present
        x0xd->>x0xd: Validate domain (non-empty, no NUL, ≤ 1 KiB)
        x0xd->>x0xd: "canonical = domain || 0x00 || payload"
    else no domain
        x0xd->>x0xd: "canonical = payload"
    end

    alt algorithm present
        x0xd->>x0xd: "algorithm == supported scheme string?"
        alt wrong or null
            x0xd-->>Caller: 400 unsupported algorithm
        end
    end

    x0xd->>x0xd: BASE64.decode(signature_b64) → sig_bytes
    x0xd->>x0xd: "sig_bytes.len() == 3309?"
    alt wrong length
        x0xd-->>Caller: 400 signature must be exactly N bytes
    end

    x0xd->>x0xd: BASE64.decode(public_key_b64) → pk_bytes
    x0xd->>x0xd: "pk_bytes.len() == 1952?"
    alt wrong length
        x0xd-->>Caller: 400 public key must be exactly N bytes
    end

    x0xd->>PQC: verify_with_ml_dsa(public_key, canonical, signature)
    PQC-->>x0xd: Ok(()) or Err

    x0xd-->>Caller: "200 {ok: true, valid: true|false, algorithm}"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/bin/x0xd.rs:4783-4790
**`from_bytes` failure after the length check may silently violate the stated contract**

The PR's stated invariant is: wrong-length → `400`, right-length wrong-signature → `200 valid: false`. The explicit length check at line 4775 enforces the first half. However, if `MlDsaSignature::from_bytes` (and likewise `MlDsaPublicKey::from_bytes` at line 4810) can fail for reasons other than length — e.g., if a future version of `ant_quic` adds coefficient-range checks — a correctly-sized but structurally invalid blob would get `400 invalid signature format` rather than `valid: false`, silently breaking the contract without any failing test to catch it. If `from_bytes` is guaranteed to be infallible after a length check (as is typical for PQ signature wrappers that are just byte arrays), the `Err` branches are dead and could be replaced with `unwrap()`/`expect()` to make that assumption explicit and auditable.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): reference PR #109 in th..."](https://github.com/saorsa-labs/x0x/commit/1ec8aea2b7a7bc2ee7803996b44b09cc7501849b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36960865)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->