### PR TITLE
feat(groups): retain state-commit history + GET /groups/:id/state/commits (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.25.0] - 2026-06-19
+
+### Added
+
+- **Retained named-group state-commit history + `GET /groups/:id/state/commits` (members-only, paged) — a verifiable role/roster audit trail ([#111](https://github.com/saorsa-labs/x0x/issues/111), proposed by @nkoteskey).** Every authored or applied `GroupStateCommit` is now retained in-struct alongside an independently-verifiable roster projection: recomputing the BLAKE3 `roster_root` from the stored `{agent_id → (role, state)}` snapshot must equal the signed `commit.roster_root`. This makes "who held which role at revision N" auditable after the fact — closing the verification gap that [ADR-0016](docs/adr/0016-role-based-group-authority-flat-admin.md)'s flat Admin/Member delegated authority left open. The endpoint serves the chain to members with pagination (`from_revision`, `limit`) and reports `roster_root_verified` per entry. Retention rides the existing atomic group writes through the two methods every commit-production path funnels through (`seal_commit` for the authoring committer, `finalize_applied_commit` for commits applied over gossip), bounded by `COMMIT_LOG_CAP`. CLI: `x0x group state-commits <group_id>`. Verified on the live 6-node testnet across both the authored (committer) and applied-over-gossip (TreeKEM joiner) paths.
+
 ## [v0.24.0] - 2026-06-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.24.0
+version: 0.25.0
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -329,6 +329,7 @@ Identity types: `anonymous`, `known`, `trusted`, `pinned`
 | POST | `/groups/join` | `x0x group join <invite>` | Join via invite |
 | PUT | `/groups/:id/display-name` | `x0x group set-name <group_id> <name>` | Set your display name |
 | GET | `/groups/:id/state` | `x0x group state <group_id>` | **Phase D.3**: inspect the signed state-commit chain |
+| GET | `/groups/:id/state/commits` | `x0x group state-commits <group_id>` | **issue #111**: read retained state-commit history (members only, paged) |
 | POST | `/groups/:id/state/seal` | `x0x group state-seal <group_id>` | **Phase D.3**: advance the chain + republish signed card |
 | POST | `/groups/:id/state/withdraw` | `x0x group state-withdraw <group_id>` | **Phase D.3**: seal terminal withdrawal; evicts public card on peers |
 | POST | `/groups/:id/send` | `x0x group send` | **Phase E**: publish a signed message to a SignedPublic group |
@@ -418,6 +419,37 @@ Each named group maintains a signed commit chain:
   higher-revision commit with `withdrawn=true` and broadcasts the
   withdrawal card. Peers evict stale listings on receipt regardless of
   TTL.
+
+#### Retained commit history (issue #111)
+
+`GET /groups/:id/state` exposes only the chain **head**. To answer
+"what did the signed roster say at revision N" long after the fact (for
+verification and group-governance integrators per ADR-0016), each daemon
+retains every commit it applies — from both local authorship and peer
+commits — paired with the roster projection it effected:
+
+- `GET /groups/:id/state/commits?from_revision=0&limit=100` —
+  **members only** (retained roster projections are member content, so
+  this does *not* use `/state`'s public-projection gate). Returns
+  `{ ok, group_id, state_revision, total_retained,
+  first_available_revision, latest_retained_revision, from_revision,
+  limit, count, has_more, next_from_revision, commits }`, where each
+  `commits[]` entry is `{ commit, roster, roster_root_verified }`.
+  `roster` is the `{ agent_id: { role, state } }` projection of `Active` +
+  `Banned` members; `roster_root_verified` recomputes the root over that
+  projection and compares it to the commit's signed `roster_root`, so any
+  at-rest corruption surfaces rather than serving silently-wrong history.
+  `limit` is capped at 500.
+
+Scope and honest limits: retention is **not retroactive** — history begins
+at the first release that retains it, and each daemon holds only the suffix
+it witnessed (a member who joined at revision 50 has no earlier entries;
+`first_available_revision` lets callers distinguish a real gap from an empty
+result). Each retained entry is independently verifiable against its
+commit's `roster_root` with no dependence on the prior chain. Storage is
+bounded per group (`COMMIT_LOG_CAP`, oldest dropped past the cap with a
+logged warning — never silent); checkpoint-and-truncate and cross-peer
+backfill are deferred.
 
 Cards and commits carry ML-DSA-65 signatures. Peers verify both the
 signature and the chain link (`prev_state_hash`) before accepting; stale

--- a/docs/design/api-manifest.json
+++ b/docs/design/api-manifest.json
@@ -1,5 +1,5 @@
 {
-  "endpoint_count": 132,
+  "endpoint_count": 133,
   "endpoints": [
     {
       "category": "status",
@@ -588,6 +588,13 @@
       "description": "Inspect the signed state-commit chain for a group",
       "method": "GET",
       "path": "/groups/:id/state"
+    },
+    {
+      "category": "named-groups",
+      "cli_name": "group state-commits",
+      "description": "Read retained state-commit history (members only, paged)",
+      "method": "GET",
+      "path": "/groups/:id/state/commits"
     },
     {
       "category": "named-groups",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -651,6 +651,13 @@ pub const ENDPOINTS: &[EndpointDef] = &[
         category: "named-groups",
     },
     EndpointDef {
+        method: Method::Get,
+        path: "/groups/:id/state/commits",
+        cli_name: "group state-commits",
+        description: "Read retained state-commit history (members only, paged)",
+        category: "named-groups",
+    },
+    EndpointDef {
         method: Method::Post,
         path: "/groups/:id/state/seal",
         cli_name: "group state-seal",

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -950,6 +950,17 @@ enum GroupSub {
         /// Group ID.
         group_id: String,
     },
+    /// Read retained state-commit history (members only, paged).
+    StateCommits {
+        /// Group ID.
+        group_id: String,
+        /// Only return commits with revision >= this value.
+        #[arg(long, default_value_t = 0)]
+        from_revision: u64,
+        /// Page size (daemon caps at 500).
+        #[arg(long)]
+        limit: Option<usize>,
+    },
     /// Advance the state-commit chain and republish the signed card.
     StateSeal {
         /// Group ID.
@@ -1614,6 +1625,11 @@ async fn run(
                 commands::group::messages(&client, &group_id).await
             }
             Some(GroupSub::State { group_id }) => commands::group::state(&client, &group_id).await,
+            Some(GroupSub::StateCommits {
+                group_id,
+                from_revision,
+                limit,
+            }) => commands::group::state_commits(&client, &group_id, from_revision, limit).await,
             Some(GroupSub::StateSeal { group_id }) => {
                 commands::group::state_seal(&client, &group_id).await
             }

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -2233,6 +2233,7 @@ async fn main() -> Result<()> {
         .route("/groups/:id/display-name", put(set_group_display_name))
         // Phase D.3 — state-commit chain endpoints.
         .route("/groups/:id/state", get(get_group_state))
+        .route("/groups/:id/state/commits", get(get_group_state_commits))
         .route("/groups/:id/state/seal", post(seal_group_state))
         .route("/groups/:id/state/withdraw", post(withdraw_group_state))
         .route("/groups/:id", delete(leave_group))
@@ -11848,6 +11849,111 @@ async fn get_group_state(
             "roster_root": roster_root,
             "policy_hash": policy_hash,
             "public_meta_hash": public_meta_hash,
+        })),
+    )
+}
+
+/// Query parameters for [`get_group_state_commits`].
+#[derive(Debug, Deserialize)]
+struct StateCommitsQuery {
+    /// Only return retained commits with `revision >= from_revision`.
+    #[serde(default)]
+    from_revision: u64,
+    /// Page size (clamped to `[1, STATE_COMMITS_MAX_LIMIT]`).
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+/// GET /groups/:id/state/commits — issue #111: paged read over the retained
+/// state-commit history (ADR-0016 verification / governance use-cases).
+///
+/// **Members-only.** Unlike `/groups/:id/state` (which serves the public
+/// projection even to non-member card-importers), retained roster projections
+/// are member content, so this endpoint requires the local agent to be an
+/// **active member** of the group — it deliberately does NOT reuse the
+/// public-projection gate.
+///
+/// Each entry is `{ commit, roster, roster_root_verified }`, ordered by
+/// ascending revision. `roster_root_verified` recomputes the roster root over
+/// the retained projection and compares it to the commit's signed
+/// `roster_root`, so on-disk corruption surfaces loudly rather than serving
+/// silently-wrong history. `first_available_revision` lets callers distinguish
+/// a real gap (history began after their `from_revision`, because each daemon
+/// retains only the suffix it witnessed) from an empty result.
+async fn get_group_state_commits(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Query(q): Query<StateCommitsQuery>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    const STATE_COMMITS_DEFAULT_LIMIT: usize = 100;
+    const STATE_COMMITS_MAX_LIMIT: usize = 500;
+    let limit = q
+        .limit
+        .unwrap_or(STATE_COMMITS_DEFAULT_LIMIT)
+        .clamp(1, STATE_COMMITS_MAX_LIMIT);
+
+    let groups = state.named_groups.read().await;
+    let Some(info) = groups.get(&id) else {
+        return not_found("group not found");
+    };
+
+    // Members-only gate: retained roster projections are member content.
+    let local_agent_hex = hex::encode(state.agent.agent_id().as_bytes());
+    if !info.has_active_member(&local_agent_hex) {
+        return api_error(
+            StatusCode::FORBIDDEN,
+            "members only: retained state-commit history is member content",
+        );
+    }
+
+    let matched = info
+        .commit_log
+        .iter()
+        .filter(|rc| rc.commit.revision >= q.from_revision)
+        .count();
+    let entries: Vec<serde_json::Value> = info
+        .commit_log
+        .iter()
+        .filter(|rc| rc.commit.revision >= q.from_revision)
+        .take(limit)
+        .map(|rc| {
+            serde_json::json!({
+                "commit": rc.commit,
+                "roster": rc.roster,
+                "roster_root_verified": rc.roster_root_consistent(),
+            })
+        })
+        .collect();
+
+    let has_more = matched > entries.len();
+    // Cursor for the next page: one past the last returned revision. Safe
+    // because the log is monotonic in revision and truncated only from the
+    // front, so `last()` is the highest revision on this page.
+    let next_from_revision = if has_more {
+        info.commit_log
+            .iter()
+            .filter(|rc| rc.commit.revision >= q.from_revision)
+            .nth(entries.len().saturating_sub(1))
+            .map(|rc| rc.commit.revision + 1)
+    } else {
+        None
+    };
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "ok": true,
+            "group_id": info.stable_group_id(),
+            "state_revision": info.state_revision,
+            "total_retained": info.commit_log.len(),
+            "first_available_revision": info.commit_log.first().map(|rc| rc.commit.revision),
+            "latest_retained_revision": info.commit_log.last().map(|rc| rc.commit.revision),
+            "from_revision": q.from_revision,
+            "limit": limit,
+            "count": entries.len(),
+            "has_more": has_more,
+            "next_from_revision": next_from_revision,
+            "commits": entries,
         })),
     )
 }

--- a/src/cli/commands/group.rs
+++ b/src/cli/commands/group.rs
@@ -416,6 +416,23 @@ pub async fn state(client: &DaemonClient, group_id: &str) -> Result<()> {
     client.run_get(&format!("/groups/{group_id}/state")).await
 }
 
+/// `x0x group state-commits` — GET /groups/:id/state/commits.
+///
+/// Reads the retained state-commit history (members only). `from_revision`
+/// and `limit` page the result; the daemon caps `limit` at 500.
+pub async fn state_commits(
+    client: &DaemonClient,
+    group_id: &str,
+    from_revision: u64,
+    limit: Option<usize>,
+) -> Result<()> {
+    let mut path = format!("/groups/{group_id}/state/commits?from_revision={from_revision}");
+    if let Some(limit) = limit {
+        path.push_str(&format!("&limit={limit}"));
+    }
+    client.run_get(&path).await
+}
+
 /// `x0x group state-seal` — POST /groups/:id/state/seal.
 pub async fn state_seal(client: &DaemonClient, group_id: &str) -> Result<()> {
     client.ensure_running().await?;

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -50,7 +50,8 @@ pub use self::public_message::{
 pub use self::request::{JoinRequest, JoinRequestStatus};
 pub use self::state_commit::{
     compute_policy_hash, compute_public_meta_hash, compute_roster_root, compute_state_hash,
-    ActionKind, ApplyContext, ApplyError, GroupGenesis, GroupPublicMeta, GroupStateCommit,
+    roster_projection, roster_root_of_projection, ActionKind, ApplyContext, ApplyError,
+    GroupGenesis, GroupPublicMeta, GroupStateCommit, RetainedCommit, RosterMemberSnapshot,
     CARD_SIGNATURE_DOMAIN, DEFAULT_CARD_TTL_SECS, EVENT_SIGNATURE_DOMAIN, STATE_COMMIT_DOMAIN,
 };
 
@@ -195,6 +196,22 @@ pub struct GroupInfo {
     #[serde(default)]
     pub withdrawn: bool,
 
+    /// Retained, applied state-commit history (issue #111, follow-up to
+    /// ADR-0016). Each entry pairs a signed
+    /// [`state_commit::GroupStateCommit`] with the roster projection it
+    /// effected, so "what did the signed roster say at revision N" is
+    /// answerable and independently verifiable long after the fact — the
+    /// head-only chain fields above cannot do this. Appended by
+    /// [`GroupInfo::seal_commit`] (local authorship) and
+    /// [`GroupInfo::finalize_applied_commit`] (peer commits); it therefore
+    /// captures every commit this daemon applied, from either path, with no
+    /// per-call-site wiring. Bounded by [`COMMIT_LOG_CAP`]: past the cap the
+    /// oldest entries are dropped and the loss is logged (never silent).
+    /// History begins at the first retaining release and each daemon retains
+    /// only the suffix it witnessed.
+    #[serde(default)]
+    pub commit_log: Vec<state_commit::RetainedCommit>,
+
     /// Legacy pre-v1.1 invite-secret set. Retained for JSON compatibility
     /// with already-persisted group blobs, but new admission checks use
     /// `issued_invites` so expiry, role cap, and one-time consumption can be
@@ -218,6 +235,13 @@ pub struct GroupInfo {
 fn secure_plane_legacy_default() -> SecureGroupPlane {
     SecureGroupPlane::Gss
 }
+
+/// Hard cap on retained state-commits per group (issue #111). Private-group
+/// roster churn is low-frequency, so this bounds `named_groups.json` growth
+/// while keeping a deep history. Past the cap the oldest entries are dropped
+/// (checkpoint-and-truncate is deferred — see issue #111); the drop is logged
+/// so history loss can never be silent.
+pub const COMMIT_LOG_CAP: usize = 4096;
 
 impl GroupInfo {
     /// Create a new `GroupInfo` with the given policy (defaults to `private_secure`).
@@ -310,6 +334,7 @@ impl GroupInfo {
             members_v2,
             join_requests: BTreeMap::new(),
             discovery_card_topic,
+            commit_log: Vec::new(),
             shared_secret,
             secret_epoch: 0,
             // Generic constructor stays on the legacy GSS plane (matching the
@@ -446,7 +471,7 @@ impl GroupInfo {
         let policy_hash = state_commit::compute_policy_hash(&self.policy);
         let meta_hash = state_commit::compute_public_meta_hash(&self.public_meta());
 
-        state_commit::GroupStateCommit::sign(
+        let commit = state_commit::GroupStateCommit::sign(
             self.stable_group_id().to_string(),
             self.state_revision,
             Some(prev),
@@ -457,7 +482,33 @@ impl GroupInfo {
             self.withdrawn,
             now_ms,
             keypair,
-        )
+        )?;
+        // issue #111: retain the locally-authored commit + the roster it
+        // committed. `self` already reflects the committed state here.
+        self.retain_commit(&commit);
+        Ok(commit)
+    }
+
+    /// Append a retained commit for the just-committed state and enforce
+    /// [`COMMIT_LOG_CAP`]. `self` must already reflect the committed roster
+    /// (callers mutate then seal/finalize, so this holds). The single
+    /// chokepoint both commit-production paths route through, so retention
+    /// cannot be forgotten at an individual apply site.
+    fn retain_commit(&mut self, commit: &state_commit::GroupStateCommit) {
+        self.commit_log.push(state_commit::RetainedCommit::capture(
+            commit.clone(),
+            &self.members_v2,
+        ));
+        if self.commit_log.len() > COMMIT_LOG_CAP {
+            let overflow = self.commit_log.len() - COMMIT_LOG_CAP;
+            self.commit_log.drain(0..overflow);
+            tracing::warn!(
+                group_id = %self.stable_group_id(),
+                dropped = overflow,
+                cap = COMMIT_LOG_CAP,
+                "commit_log exceeded cap; dropped oldest retained commits",
+            );
+        }
     }
 
     /// Mark the group as withdrawn and seal the terminal higher-revision
@@ -522,6 +573,10 @@ impl GroupInfo {
                 got: self.state_hash.clone(),
             });
         }
+        // issue #111: retain the peer-authored commit only after it has
+        // validated and applied cleanly (post hash-match), so rejected
+        // commits never enter the history.
+        self.retain_commit(commit);
         Ok(())
     }
 
@@ -979,6 +1034,49 @@ mod tests {
         assert!(owner.is_active());
         assert_eq!(info.policy, GroupPolicy::default());
         assert_eq!(info.active_member_count(), 1);
+    }
+
+    #[test]
+    fn seal_commit_retains_verifiable_history() {
+        // issue #111: every locally-authored commit is retained in-struct,
+        // paired with a roster projection that re-derives its signed root.
+        let mut info = GroupInfo::new("Test".into(), String::new(), agent(1), "aabb".repeat(8));
+        let kp = crate::identity::AgentKeypair::generate().unwrap();
+        assert!(
+            info.commit_log.is_empty(),
+            "fresh group has no retained commits"
+        );
+
+        let c1 = info.seal_commit(&kp, 1_000).unwrap();
+        info.add_member(
+            hex::encode([2u8; 32]),
+            GroupRole::Member,
+            Some("alice".into()),
+            None,
+        );
+        let c2 = info.seal_commit(&kp, 2_000).unwrap();
+
+        assert_eq!(
+            info.commit_log.len(),
+            2,
+            "each seal retains exactly one entry"
+        );
+        assert_eq!(info.commit_log[0].commit.revision, c1.revision);
+        assert_eq!(info.commit_log[1].commit.revision, c2.revision);
+        assert!(c2.revision > c1.revision, "revisions are monotonic");
+
+        for entry in &info.commit_log {
+            assert!(
+                entry.roster_root_consistent(),
+                "retained entry must re-derive its signed roster_root"
+            );
+        }
+        assert!(
+            info.commit_log[1]
+                .roster
+                .contains_key(&hex::encode([2u8; 32])),
+            "newly added member must appear in the latest retained projection"
+        );
     }
 
     #[test]

--- a/src/groups/state_commit.rs
+++ b/src/groups/state_commit.rs
@@ -72,22 +72,107 @@ fn blake3_hex(input: &[u8]) -> String {
 /// currently affect effective access.
 #[must_use]
 pub fn compute_roster_root(members_v2: &BTreeMap<String, GroupMember>) -> String {
-    let mut entries: Vec<(&String, &GroupMember)> = members_v2
+    let mut entries: Vec<(&str, GroupRole, GroupMemberState)> = members_v2
         .iter()
         .filter(|(_, m)| matches!(m.state, GroupMemberState::Active | GroupMemberState::Banned))
+        .map(|(id, m)| (id.as_str(), m.role, m.state))
         .collect();
-    entries.sort_by(|a, b| a.0.cmp(b.0));
+    roster_root_from_entries(&mut entries)
+}
 
+/// Shared hashing core for the roster root. Sorts `entries` by id and folds
+/// `(id, role, state)` into the canonical `x0x.roster-root.v1` digest. Both
+/// [`compute_roster_root`] (over a live roster) and
+/// [`roster_root_of_projection`] (over a retained projection) route through
+/// this so a retained projection re-derives the exact root its commit signed.
+fn roster_root_from_entries(entries: &mut [(&str, GroupRole, GroupMemberState)]) -> String {
+    entries.sort_by(|a, b| a.0.cmp(b.0));
     let mut buf = Vec::with_capacity(entries.len() * 48 + 16);
     buf.extend_from_slice(b"x0x.roster-root.v1");
-    for (id, m) in entries {
+    for (id, role, state) in entries.iter() {
         buf.push(b'|');
         buf.extend_from_slice(id.as_bytes());
         buf.push(b':');
-        buf.push(role_byte(m.role));
-        buf.push(state_byte(m.state));
+        buf.push(role_byte(*role));
+        buf.push(state_byte(*state));
     }
     blake3_hex(&buf)
+}
+
+/// Minimal, verifiable roster projection captured alongside a retained commit:
+/// exactly the `(role, state)` tuples that feed [`compute_roster_root`]
+/// (`Active` + `Banned` members). Sufficient to answer "what did the signed
+/// roster say at revision N" and to re-derive the commit's `roster_root`
+/// independently — without having witnessed every prior commit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RosterMemberSnapshot {
+    pub role: GroupRole,
+    pub state: GroupMemberState,
+}
+
+/// Project the roster-root-relevant view of a roster: `Active` + `Banned`
+/// members with their `(role, state)`. Mirrors [`compute_roster_root`]'s
+/// filter exactly so [`roster_root_of_projection`] re-derives the same root.
+#[must_use]
+pub fn roster_projection(
+    members_v2: &BTreeMap<String, GroupMember>,
+) -> BTreeMap<String, RosterMemberSnapshot> {
+    members_v2
+        .iter()
+        .filter(|(_, m)| matches!(m.state, GroupMemberState::Active | GroupMemberState::Banned))
+        .map(|(id, m)| {
+            (
+                id.clone(),
+                RosterMemberSnapshot {
+                    role: m.role,
+                    state: m.state,
+                },
+            )
+        })
+        .collect()
+}
+
+/// Re-derive the roster root from a projection (see [`roster_projection`]).
+#[must_use]
+pub fn roster_root_of_projection(projection: &BTreeMap<String, RosterMemberSnapshot>) -> String {
+    let mut entries: Vec<(&str, GroupRole, GroupMemberState)> = projection
+        .iter()
+        .map(|(id, s)| (id.as_str(), s.role, s.state))
+        .collect();
+    roster_root_from_entries(&mut entries)
+}
+
+/// A retained, applied state commit paired with the roster projection it
+/// effected (issue #111). Each entry is independently verifiable: recomputing
+/// the root over `roster` yields `commit.roster_root` (see
+/// [`RetainedCommit::roster_root_consistent`]). Retained entries let
+/// verification and governance integrators answer roster-at-revision questions
+/// long after the fact, which the head-only `GroupInfo` snapshot cannot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetainedCommit {
+    pub commit: GroupStateCommit,
+    pub roster: BTreeMap<String, RosterMemberSnapshot>,
+}
+
+impl RetainedCommit {
+    /// Capture a retained entry from a just-committed roster and the signed
+    /// commit that produced it. `members_v2` must already reflect the
+    /// committed state.
+    #[must_use]
+    pub fn capture(commit: GroupStateCommit, members_v2: &BTreeMap<String, GroupMember>) -> Self {
+        Self {
+            roster: roster_projection(members_v2),
+            commit,
+        }
+    }
+
+    /// True iff the retained roster projection re-derives the commit's signed
+    /// `roster_root` — i.e. the entry is internally consistent and was not
+    /// corrupted at rest.
+    #[must_use]
+    pub fn roster_root_consistent(&self) -> bool {
+        roster_root_of_projection(&self.roster) == self.commit.roster_root
+    }
 }
 
 /// Compute the canonical policy hash.
@@ -624,6 +709,78 @@ mod tests {
         // Different nonce => different id even with same creator/time.
         let g2 = GroupGenesis::new("aa".repeat(32), 1_000);
         assert_ne!(g.group_id, g2.group_id);
+    }
+
+    #[test]
+    fn roster_projection_rederives_roster_root() {
+        // issue #111: a retained roster projection must hash to the exact root
+        // its commit signed — that is what makes a single retained entry
+        // independently verifiable without the prior chain.
+        let mut m = BTreeMap::new();
+        m.insert("aa".repeat(32), make_owner(&"aa".repeat(32)));
+        m.insert(
+            "bb".repeat(32),
+            make_member(&"bb".repeat(32), GroupRole::Admin),
+        );
+        m.insert("cc".repeat(32), make_banned(&"cc".repeat(32)));
+        // Excluded from the root: Removed + Pending must not appear in the
+        // projection (mirrors compute_roster_root's filter exactly).
+        m.insert("dd".repeat(32), make_removed(&"dd".repeat(32)));
+
+        let projection = roster_projection(&m);
+        assert!(
+            projection.contains_key(&"cc".repeat(32)),
+            "banned members are part of the root and must be projected"
+        );
+        assert!(
+            !projection.contains_key(&"dd".repeat(32)),
+            "removed members are excluded from the root and the projection"
+        );
+        assert_eq!(
+            roster_root_of_projection(&projection),
+            compute_roster_root(&m),
+            "projection must re-derive the live roster root"
+        );
+    }
+
+    #[test]
+    fn retained_commit_capture_is_self_consistent() {
+        let mut m = BTreeMap::new();
+        m.insert("aa".repeat(32), make_owner(&"aa".repeat(32)));
+        m.insert(
+            "bb".repeat(32),
+            make_member(&"bb".repeat(32), GroupRole::Member),
+        );
+
+        let kp = AgentKeypair::generate().unwrap();
+        let commit = GroupStateCommit::sign(
+            "gid".into(),
+            1,
+            Some("prev".into()),
+            compute_roster_root(&m),
+            compute_policy_hash(&GroupPolicy::default()),
+            compute_public_meta_hash(&GroupPublicMeta::default()),
+            None,
+            false,
+            5_000,
+            &kp,
+        )
+        .unwrap();
+
+        let retained = RetainedCommit::capture(commit, &m);
+        assert!(
+            retained.roster_root_consistent(),
+            "captured projection must re-derive the commit's signed roster_root"
+        );
+
+        // A tampered projection must fail the consistency check (this is the
+        // on-disk-corruption guard the endpoint surfaces as roster_root_verified).
+        let mut tampered = retained.clone();
+        tampered.roster.get_mut(&"bb".repeat(32)).unwrap().role = GroupRole::Admin;
+        assert!(
+            !tampered.roster_root_consistent(),
+            "a mutated projection must no longer match the signed root"
+        );
     }
 
     #[test]

--- a/tests/api_coverage.rs
+++ b/tests/api_coverage.rs
@@ -375,6 +375,11 @@ const COVERED: &[CoveredEndpoint] = &[
         d4_stateful_events_converge_via_signed_commits
     ),
     covered!(
+        Get,
+        "/groups/:id/state/commits",
+        state_commits_endpoint_serves_retained_history
+    ),
+    covered!(
         Post,
         "/groups/:id/state/seal",
         d4_stateful_events_converge_via_signed_commits

--- a/tests/e2e_vps_groups.py
+++ b/tests/e2e_vps_groups.py
@@ -206,6 +206,14 @@ class X0xClient:
             return self._req(
                 "GET", f"/groups/{params['group_id']}/messages",
             )
+        if action == "group_state_commits":
+            path = (
+                f"/groups/{params['group_id']}/state/commits"
+                f"?from_revision={params.get('from_revision', 0)}"
+            )
+            if params.get("limit") is not None:
+                path += f"&limit={params['limit']}"
+            return self._req("GET", path)
         raise ValueError(f"unhandled action: {action}")
 
     def open_sse(self, path: str, timeout: float = 3600 * 6):
@@ -823,6 +831,210 @@ class FleetHarness:
                 f"bodies={list(anchor_bodies)[:5]}",
             )
 
+        # 7. Retained state-commit history (issue #111) — committer path.
+        # The public_open creator is the deterministic committer (ADR-0014):
+        # it authors GroupCreated + one MemberAdded per joiner via seal_commit
+        # and retains each. Every retained commit must independently verify —
+        # recomputing roster_root from the stored projection equals the signed
+        # commit.roster_root (the ADR-0016 "who held which role at revision N"
+        # audit property). public_open JOINERS are intentionally NOT checked
+        # here: a GSS joiner bootstraps at state_revision=0 WITHOUT the
+        # authority base-state (only TreeKEM invites seed it — see x0xd.rs
+        # group-join handler), so it cannot replay the signed chain. The
+        # applied-over-gossip retention path (finalize_applied_commit) is
+        # exercised against a TreeKEM group in run_treekem_state_commit_audit().
+        ok, details, commits = self._fetch_state_commits(self.anchor_name, gid)
+        self.assert_pass(
+            f"{self.anchor_name} reads retained state-commits (authored)",
+            ok and len(commits) >= 1,
+            f"ok={ok} state_revision={details.get('state_revision')} "
+            f"total_retained={details.get('total_retained')}",
+        )
+        if commits:
+            self._assert_chain_consistent(
+                self.anchor_name, commits, "authored",
+            )
+
+    def run_treekem_state_commit_audit(self) -> None:
+        """Issue #111 — applied-over-gossip retention on a TreeKEM group.
+
+        Unlike public_open, a private_secure (TreeKEM) invite seeds the
+        joiner's authority base-state, so joiners CAN apply later members'
+        signed MemberAdded commits via finalize_applied_commit and retain
+        them. This is the cross-region proof of the #111 *applied* path.
+
+        A joiner's OWN join seeds base-state but does not retain a commit; a
+        retained commit only appears once a LATER member's commit reaches and
+        applies on it. So the first joiner accumulates commits and the last
+        may have none — we assert correctness (ascending + every commit
+        re-derives its signed roster_root) on whatever chain each joiner has,
+        and liveness as ">=1 joiner retains a verified applied commit".
+        """
+        members = [n for n in self.runners if n != self.anchor_name]
+        self.log.info(
+            "[treekem #111] anchor=%s creates private_secure group",
+            self.anchor_name,
+        )
+        create = self.call(
+            self.anchor_name, "group_create",
+            {"name": "Phase-B TreeKEM #111 Audit",
+             "description": "applied-over-gossip state-commit retention",
+             "preset": "private_secure"},
+        )
+        if create.get("outcome") != "ok":
+            self.failures.append("anchor failed to create TreeKEM group")
+            return
+        details = create.get("details") or {}
+        gid = (
+            details.get("group_id")
+            or (details.get("group") or {}).get("id")
+        )
+        if not gid:
+            self.failures.append("anchor failed to extract TreeKEM group_id")
+            return
+
+        joined: List[str] = []
+        for member in members:
+            inv = self.call(
+                self.anchor_name, "group_invite", {"group_id": gid},
+            )
+            invite = (inv.get("details") or {}).get("invite_link")
+            if not invite or not invite.startswith("x0x://invite/"):
+                self.failures.append(f"TreeKEM invite for {member} missing")
+                continue
+            try:
+                resp = self.call(member, "group_join", {"invite": invite})
+            except Exception as exc:
+                if self.allow_skips:
+                    self.log.warning("  SKIP %s TreeKEM join: %s", member, exc)
+                    continue
+                self.failures.append(
+                    f"{member} TreeKEM join unreachable: {exc}"
+                )
+                continue
+            if resp.get("outcome") == "ok":
+                joined.append(member)
+            else:
+                self.assert_pass(
+                    f"{member} joins TreeKEM group", False,
+                    f"outcome={resp.get('outcome')}",
+                )
+
+        self.assert_pass(
+            "TreeKEM group has >=2 joiners (needed to exercise applied path)",
+            len(joined) >= 2,
+            f"joined={joined}",
+        )
+        if len(joined) < 2:
+            return
+
+        # Wait for the anchor (committer) to seal a commit per joiner.
+        deadline = time.time() + 30.0
+        anchor_commits: List[Dict[str, Any]] = []
+        while time.time() < deadline:
+            ok, _d, anchor_commits = self._fetch_state_commits(
+                self.anchor_name, gid,
+            )
+            if ok and len(anchor_commits) >= len(joined):
+                break
+            time.sleep(1.0)
+        self.assert_pass(
+            f"{self.anchor_name} authored a TreeKEM commit per joiner",
+            len(anchor_commits) >= len(joined),
+            f"commits={len(anchor_commits)} joined={len(joined)}",
+        )
+        if anchor_commits:
+            self._assert_chain_consistent(
+                self.anchor_name, anchor_commits, "treekem-authored",
+            )
+
+        # Liveness: poll until >=1 joiner has applied + retained a verified
+        # commit over gossip. A base-state seed alone does NOT count — a real
+        # retained applied commit must be present. Correctness is asserted on
+        # whatever each joiner already has, every poll (never flaky).
+        deadline = time.time() + 90.0
+        applied_joiner: Optional[str] = None
+        while time.time() < deadline and applied_joiner is None:
+            for m in joined:
+                ok, _d, commits = self._fetch_state_commits(m, gid)
+                if ok and commits:
+                    self._assert_chain_consistent(m, commits, "treekem-applied")
+                    applied_joiner = m
+                    break
+            if applied_joiner is None:
+                time.sleep(3.0)
+        self.assert_pass(
+            "a TreeKEM joiner applied + retained a verified state-commit over "
+            "gossip (issue #111 applied path)",
+            applied_joiner is not None,
+            f"checked joiners={joined}",
+        )
+
+    def _fetch_state_commits(
+        self, node: str, gid: str,
+    ) -> Tuple[bool, Dict[str, Any], List[Dict[str, Any]]]:
+        """(ok, details, commits) — (False, {}, []) on error/unreachable."""
+        try:
+            resp = self.call(node, "group_state_commits", {"group_id": gid})
+        except Exception as exc:
+            self.log.warning("  %s state-commits call failed: %s", node, exc)
+            return (False, {}, [])
+        if resp.get("outcome") != "ok":
+            return (False, {}, [])
+        details = resp.get("details") or {}
+        return (True, details, self._state_commits(details))
+
+    def _assert_chain_consistent(
+        self, node: str, commits: List[Dict[str, Any]], path_kind: str,
+    ) -> None:
+        """Correctness invariants for ANY non-empty chain (never flaky)."""
+        revisions = [c.get("revision") for c in commits]
+        ascending = all(
+            isinstance(a, int) and isinstance(b, int) and a < b
+            for a, b in zip(revisions, revisions[1:])
+        )
+        self.assert_pass(
+            f"{node} commit revisions strictly ascending ({path_kind})",
+            ascending,
+            f"revisions={revisions[:8]}",
+        )
+        unverified = [
+            c.get("revision")
+            for c in commits
+            if not c.get("roster_root_verified")
+        ]
+        self.assert_pass(
+            f"{node} every retained commit re-derives its signed roster_root "
+            f"({path_kind})",
+            not unverified,
+            f"unverified_revisions={unverified[:8]}",
+        )
+
+    @staticmethod
+    def _state_commits(payload: Any) -> List[Dict[str, Any]]:
+        if not isinstance(payload, dict):
+            return []
+        raw = payload.get("commits")
+        if not isinstance(raw, list):
+            return []
+        out: List[Dict[str, Any]] = []
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            commit = entry.get("commit")
+            revision = (
+                commit.get("revision") if isinstance(commit, dict) else None
+            )
+            out.append(
+                {
+                    "revision": revision,
+                    "roster_root_verified": bool(
+                        entry.get("roster_root_verified")
+                    ),
+                }
+            )
+        return out
+
     @staticmethod
     def _member_aids(payload: Any) -> List[str]:
         if not isinstance(payload, dict):
@@ -1029,6 +1241,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         try:
             harness.run_contacts_lifecycle()
             harness.run_group_lifecycle()
+            harness.run_treekem_state_commit_audit()
         except Exception as exc:
             log.exception("scenario crashed: %s", exc)
             harness.failures.append(f"scenario crash: {exc}")

--- a/tests/gui_named_group_parity.rs
+++ b/tests/gui_named_group_parity.rs
@@ -31,6 +31,15 @@ const GUI_HTML: &str = include_str!("../src/gui/x0x-gui.html");
 /// Adding an entry here is a downgrade that must show up in
 /// `docs/proof/NAMED_GROUPS_PARITY_SIGNOFF.md`.
 const DEFERRED: &[(Method, &str, &str)] = &[
+    // issue #111: retained state-commit history is a verification / governance
+    // read surface (audit, dispute evidence), not a routine browser action.
+    // Exposed via the CLI (`x0x group state-commits`) and the REST API; a GUI
+    // history viewer is deferred until there is a product need.
+    (
+        Method::Get,
+        "/groups/:id/state/commits",
+        "verification/audit read surface; exposed via CLI + REST, GUI viewer deferred",
+    ),
     // The adversarial test endpoint is only meaningful as a CLI /
     // harness probe; exposing it in the browser UI would be confusing
     // and has no product use case.

--- a/tests/named_group_d4_apply.rs
+++ b/tests/named_group_d4_apply.rs
@@ -676,3 +676,112 @@ async fn d4_mls_ban_commit_advances_binding_and_converges() {
         .send()
         .await;
 }
+
+/// issue #111: the retained state-commit history endpoint serves applied
+/// commits paired with independently-verifiable roster projections, ordered by
+/// revision, with working pagination. Members-only (the local owner is a
+/// member, so it is served here).
+#[tokio::test]
+#[ignore = "requires spawning real x0xd daemons"]
+async fn state_commits_endpoint_serves_retained_history() {
+    let _guard = suite_lock().await;
+    let pair = pair().await;
+    let alice = &pair.alice;
+
+    let group_id =
+        create_group_preset(alice, "Issue111", "retained history", "private_secure").await;
+
+    // Advance the signed chain a few times via owner-authored metadata edits;
+    // each distinct edit reseals a new commit.
+    for name in ["rev-a", "rev-b", "rev-c"] {
+        let resp = authed_client(alice)
+            .patch(alice.url(&format!("/groups/{group_id}")))
+            .json(&serde_json::json!({ "name": name }))
+            .send()
+            .await
+            .expect("patch group");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "metadata patch should succeed"
+        );
+    }
+
+    let head = get_state(alice, &group_id).await;
+    let head_rev = head["state_revision"].as_u64().expect("head revision");
+    assert!(head_rev >= 3, "expected >=3 commits, head at {head_rev}");
+
+    // Full history.
+    let body: Value = authed_client(alice)
+        .get(alice.url(&format!("/groups/{group_id}/state/commits")))
+        .send()
+        .await
+        .expect("get commits")
+        .json()
+        .await
+        .expect("commits json");
+    assert_eq!(body["ok"], true, "commits response: {body:?}");
+
+    let commits = body["commits"].as_array().expect("commits array");
+    assert!(
+        commits.len() as u64 >= head_rev,
+        "retained {} commits but head at {head_rev}",
+        commits.len()
+    );
+
+    // Each retained entry must self-verify and be strictly revision-ordered.
+    let mut prev_rev = 0u64;
+    for entry in commits {
+        assert_eq!(
+            entry["roster_root_verified"], true,
+            "retained roster must re-derive the signed roster_root: {entry:?}"
+        );
+        let rev = entry["commit"]["revision"]
+            .as_u64()
+            .expect("commit revision");
+        assert!(
+            rev > prev_rev,
+            "commits must be strictly ascending in revision"
+        );
+        prev_rev = rev;
+        assert!(
+            entry["roster"].as_object().is_some_and(|r| !r.is_empty()),
+            "roster projection should be non-empty (owner present): {entry:?}"
+        );
+    }
+
+    // Pagination: limit + from_revision cursor must advance across pages.
+    let page1: Value = authed_client(alice)
+        .get(alice.url(&format!("/groups/{group_id}/state/commits?limit=1")))
+        .send()
+        .await
+        .expect("page1")
+        .json()
+        .await
+        .expect("page1 json");
+    assert_eq!(page1["count"], 1, "limit=1 returns one entry: {page1:?}");
+    assert_eq!(page1["has_more"], true, "more pages expected: {page1:?}");
+    let next = page1["next_from_revision"].as_u64().expect("cursor");
+    let page2: Value = authed_client(alice)
+        .get(alice.url(&format!(
+            "/groups/{group_id}/state/commits?from_revision={next}&limit=1"
+        )))
+        .send()
+        .await
+        .expect("page2")
+        .json()
+        .await
+        .expect("page2 json");
+    let p1_rev = page1["commits"][0]["commit"]["revision"]
+        .as_u64()
+        .expect("p1 rev");
+    let p2_rev = page2["commits"][0]["commit"]["revision"]
+        .as_u64()
+        .expect("p2 rev");
+    assert!(p2_rev > p1_rev, "cursor must advance past the first page");
+
+    let _ = authed_client(alice)
+        .delete(alice.url(&format!("/groups/{group_id}")))
+        .send()
+        .await;
+}

--- a/tests/proof-reports/parity/gui-named-groups-coverage.txt
+++ b/tests/proof-reports/parity/gui-named-groups-coverage.txt
@@ -1,4 +1,4 @@
-# GUI named-groups parity report — 36 endpoints total
+# GUI named-groups parity report — 37 endpoints total
   WIRED     POST /groups
   WIRED     GET /groups
   WIRED     GET /groups/:id
@@ -12,6 +12,7 @@
   WIRED     PUT /groups/:id/display-name
   WIRED     DELETE /groups/:id
   WIRED     GET /groups/:id/state
+  DEFERRED  GET /groups/:id/state/commits  // verification/audit read surface; exposed via CLI + REST, GUI viewer deferred
   WIRED     POST /groups/:id/state/seal
   WIRED     POST /groups/:id/state/withdraw
   WIRED     PATCH /groups/:id
@@ -36,4 +37,4 @@
   DEFERRED  POST /groups/:id/secure/reseal  // secure-plane primitive; server-side rekey on approve/ban
   DEFERRED  POST /groups/secure/open-envelope  // adversarial test endpoint, not a user-facing action
 
-Coverage: 25/36 wired; 11 deferred; 0 missing
+Coverage: 25/37 wired; 12 deferred; 0 missing

--- a/tests/runners/x0x_test_runner.py
+++ b/tests/runners/x0x_test_runner.py
@@ -252,6 +252,14 @@ class X0xClient:
     def groups_messages(self, gid: str) -> Dict[str, Any]:
         return self._request("GET", f"/groups/{gid}/messages")
 
+    def groups_state_commits(
+        self, gid: str, from_revision: int = 0, limit: Optional[int] = None
+    ) -> Dict[str, Any]:
+        path = f"/groups/{gid}/state/commits?from_revision={from_revision}"
+        if limit is not None:
+            path += f"&limit={limit}"
+        return self._request("GET", path)
+
     def groups_set_display_name(self, gid: str, name: str) -> Dict[str, Any]:
         return self._request(
             "PUT", f"/groups/{gid}/display-name", body={"name": name},
@@ -845,6 +853,7 @@ class TestRunner:
                 "group_members",
                 "group_send_message",
                 "group_messages",
+                "group_state_commits",
                 "group_set_display_name",
                 "group_leave",
             ):
@@ -1139,6 +1148,12 @@ class TestRunner:
             )
         if action == "group_messages":
             return self.client.groups_messages(params["group_id"])
+        if action == "group_state_commits":
+            return self.client.groups_state_commits(
+                params["group_id"],
+                params.get("from_revision", 0),
+                params.get("limit"),
+            )
         if action == "group_set_display_name":
             return self.client.groups_set_display_name(
                 params["group_id"], params["name"]


### PR DESCRIPTION
Closes #111.

## What

Retain every authored or applied `GroupStateCommit` in-struct, alongside an **independently-verifiable** roster projection. Recomputing the BLAKE3 `roster_root` from the stored `{agent_id → (role, state)}` snapshot must equal the signed `commit.roster_root` — so "who held which role at revision N" is auditable after the fact. This closes the verification gap that [ADR-0016](docs/adr/0016-role-based-group-authority-flat-admin.md)'s flat Admin/Member delegated authority left open.

Proposed by @nkoteskey in #111.

## How (design)

- **`src/groups/state_commit.rs`** — roster projection + `RetainedCommit` (`capture`, `roster_root_consistent`) over a shared `roster_root` core, so the stored snapshot re-derives the exact signed root.
- **`src/groups/mod.rs`** — `GroupInfo.commit_log` (`#[serde(default)]`, back-compat) bounded by `COMMIT_LOG_CAP`. Retention is wired through the **two** methods every commit-production path funnels through:
  - `seal_commit` — the authoring committer (ADR-0014 deterministic committer)
  - `finalize_applied_commit` — commits applied over gossip
  No new persistence wiring; retention rides the existing atomic group writes.
- **`GET /groups/:id/state/commits`** — members-only, paged (`from_revision`, `limit`); each entry reports `roster_root_verified`. CLI: `x0x group state-commits <group_id>`.
- Endpoint registry + manifest + coverage/parity tests updated.

## Why snapshot-projection (not deltas)

Neither commit-production method has the pre-mutation roster, so true deltas aren't available without extra state. A post-commit snapshot is computable from the committed state alone **and** is independently verifiable per-revision (recompute root == signed root) — no delta-fold, no before/after needed.

## Verification

- `just check` green: fmt, clippy `-D warnings`, build, **nextest 1715 passed**, doc.
- **Live 6-node testnet** (`tests/e2e_vps_groups.py`, 4 continents): both paths proven —
  - authored (public_open committer): 4 commits, ascending, every `roster_root` re-derived;
  - applied-over-gossip (private_secure / TreeKEM joiner): joiner applied + retained verified commits received over gossip.

> Note: public_open *joiners* intentionally sit at `state_revision=0` (a GSS joiner isn't seeded the authority base-state — only TreeKEM invites are), so the applied-path audit is exercised against a TreeKEM group, where it genuinely occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes #111 by retaining every `GroupStateCommit` (authored and applied-over-gossip) in a bounded `commit_log` on `GroupInfo`, paired with a roster projection that can independently re-derive the commit's signed `roster_root`. It exposes this history via `GET /groups/:id/state/commits` (members-only, paged by `from_revision`/`limit`) and a matching `x0x group state-commits` CLI command.

- **Retention chokepoint** (`retain_commit`) is wired into both `seal_commit` and `finalize_applied_commit`, making it structurally impossible for a commit-production path to skip retention; the cap (4 096) is enforced with a logged drain so history loss is never silent.
- **Independent verifiability** is guaranteed by routing both the live `compute_roster_root` and the stored-projection `roster_root_of_projection` through the same `roster_root_from_entries` core; because `state_hash` commits to `roster_root`, a passing `finalize_applied_commit` guarantees `roster_root_consistent()` is true for every retained applied commit.
- **Pagination cursor** (`next_from_revision`) is revision-based and monotonically safe; the endpoint iterates `commit_log` three times per request rather than one, and cap-overflow eviction uses a front-drain on a `Vec` (O(n) shift) rather than a `VecDeque`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the two write paths and the read endpoint are all correct. The only findings are efficiency observations that don't affect correctness or security.

The retention chokepoint design is sound, the roster-root re-derivation is byte-identical to the commit-time computation, and the members-only gate is consistent with the rest of the daemon. The front-drain on a Vec and the triple iteration over commit_log in the endpoint handler are the two things worth revisiting before this pattern is copied — neither breaks anything today but both become more noticeable as groups accumulate commits near the cap.

src/groups/mod.rs (retain_commit drain pattern) and src/bin/x0xd.rs (get_group_state_commits iterator structure) are the two places that would benefit from a follow-up pass.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/groups/state_commit.rs | Adds RosterMemberSnapshot, roster_projection, roster_root_of_projection, and RetainedCommit. The shared roster_root_from_entries core correctly makes live-roster and projection re-derivation byte-identical. Consistency check is sound because state_hash already commits to roster_root. |
| src/groups/mod.rs | Adds commit_log Vec and retain_commit chokepoint called from both seal_commit and finalize_applied_commit; cap enforcement uses drain(0..) from Vec front which is O(n) per eviction. |
| src/bin/x0xd.rs | Adds GET /groups/:id/state/commits handler with members-only gate and revision-based pagination; iterates commit_log three times per request unnecessarily, but is correct. |
| src/cli/commands/group.rs | Adds state_commits CLI command that correctly appends from_revision and limit query params to the GET path. |
| src/bin/x0x.rs | Wires StateCommits subcommand into the CLI dispatch table; defaults and types match the daemon handler. |
| tests/named_group_d4_apply.rs | Adds integration test for the endpoint covering full history, per-entry roster_root_verified, and two-page cursor pagination. |
| src/api/mod.rs | Adds endpoint registration entry for GET /groups/:id/state/commits in the correct position relative to existing state-chain endpoints. |
| tests/gui_named_group_parity.rs | Correctly defers GUI parity for the new endpoint with a documented rationale; pattern matches existing deferred entries. |
| tests/runners/x0x_test_runner.py | Adds groups_state_commits helper and wires it into the action dispatch table; matches CLI and daemon query-param conventions. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant GroupInfo
    participant state_commit

    Note over Caller,state_commit: Authoring path (seal_commit)
    Caller->>GroupInfo: seal_commit(keypair, now_ms)
    GroupInfo->>GroupInfo: increment state_revision, recompute_state_hash
    GroupInfo->>state_commit: compute_roster_root(members_v2)
    GroupInfo->>state_commit: GroupStateCommit::sign(revision, roster_root, ...)
    state_commit-->>GroupInfo: commit
    GroupInfo->>GroupInfo: "retain_commit(&commit) — capture + enforce COMMIT_LOG_CAP"
    GroupInfo-->>Caller: Ok(commit)

    Note over Caller,state_commit: Gossip apply path (finalize_applied_commit)
    Caller->>GroupInfo: mutate members_v2
    Caller->>GroupInfo: "finalize_applied_commit(&commit)"
    GroupInfo->>GroupInfo: apply revision/withdrawn, recompute_state_hash
    GroupInfo->>GroupInfo: "assert state_hash == commit.state_hash"
    GroupInfo->>GroupInfo: "retain_commit(&commit) — capture projection"
    GroupInfo-->>Caller: Ok(())

    Note over Caller,state_commit: Read path
    Caller->>GroupInfo: "GET /groups/:id/state/commits?from_revision=N&limit=M"
    GroupInfo-->>Caller: "[{commit, roster, roster_root_verified}] + has_more + next_from_revision"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant GroupInfo
    participant state_commit

    Note over Caller,state_commit: Authoring path (seal_commit)
    Caller->>GroupInfo: seal_commit(keypair, now_ms)
    GroupInfo->>GroupInfo: increment state_revision, recompute_state_hash
    GroupInfo->>state_commit: compute_roster_root(members_v2)
    GroupInfo->>state_commit: GroupStateCommit::sign(revision, roster_root, ...)
    state_commit-->>GroupInfo: commit
    GroupInfo->>GroupInfo: "retain_commit(&commit) — capture + enforce COMMIT_LOG_CAP"
    GroupInfo-->>Caller: Ok(commit)

    Note over Caller,state_commit: Gossip apply path (finalize_applied_commit)
    Caller->>GroupInfo: mutate members_v2
    Caller->>GroupInfo: "finalize_applied_commit(&commit)"
    GroupInfo->>GroupInfo: apply revision/withdrawn, recompute_state_hash
    GroupInfo->>GroupInfo: "assert state_hash == commit.state_hash"
    GroupInfo->>GroupInfo: "retain_commit(&commit) — capture projection"
    GroupInfo-->>Caller: Ok(())

    Note over Caller,state_commit: Read path
    Caller->>GroupInfo: "GET /groups/:id/state/commits?from_revision=N&limit=M"
    GroupInfo-->>Caller: "[{commit, roster, roster_root_verified}] + has_more + next_from_revision"
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/bin/x0xd.rs:11909-11940
**Triple pass over `commit_log` per request**

`commit_log` is iterated three times: once to count `matched`, once to collect `entries`, and once again to derive `next_from_revision`. Because the cursor revision is available on `RetainedCommit` directly, a single `Peekable` pass can replace all three, and `entries.last()` replaces the third re-scan. With the 4 096-entry cap this is harmless today, but the pattern also makes `next_from_revision` structurally dependent on `entries.len()` staying in sync across two separate iterator chains, which is subtle. A `Peekable` iterator collects the page, checks `peek().is_some()` for `has_more`, and reads the cursor from the last typed element — no re-scan needed.

### Issue 2 of 2
src/groups/mod.rs:497-511
**O(n) `drain` from Vec front on every cap-overflow commit**

`commit_log.drain(0..overflow)` on a `Vec` shifts all remaining entries left — O(n) per eviction. After 4 096 commits every subsequent `retain_commit` call copies ~4 096 `RetainedCommit` entries (each containing a cloned `GroupStateCommit` + a `BTreeMap`). For high-churn groups that reach the cap this becomes a noticeable per-commit cost on the write path. Replacing `Vec` with `VecDeque` makes front removal O(1); the endpoint already iterates it linearly, and `VecDeque` supports range iteration the same way.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(groups): retain state-commit histor..."](https://github.com/saorsa-labs/x0x/commit/398abcf0584be0f380011b4aafa9a91a4f6d5235) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38731755)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->