### PR TITLE
feat(agent,exec): deterministic background-task teardown on shutdown (#116)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.26"
+ant-quic = "0.27.27"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"

--- a/README.md
+++ b/README.md
@@ -763,8 +763,12 @@ handle.shutdown_and_wait().await?;
   server-owned background tasks (discovery / DM-inbox / group / KV listeners,
   republish, connectivity logger, etc.), the gossip runtime, and the QUIC
   `NetworkNode` (its receiver/accept/eviction tasks are aborted and the ant-quic
-  node is shut down); the API (TCP) port is released, so a fresh `serve()` on the
-  same config (with an ephemeral QUIC port) binds cleanly.
+  node is shut down); both the API (TCP) port and the QUIC endpoint UDP socket
+  are released, so a fresh `serve()` on the same config — including the same
+  FIXED QUIC `bind_address` — binds cleanly (ant-quic 0.27.27 / #196). The
+  endpoint socket release is not perfectly synchronous: a single stop→restart on
+  a fixed QUIC port works reliably, but a host that tears down and immediately
+  re-binds the *same* fixed UDP port in a tight loop should allow a brief retry.
 
   Background tasks now stop deterministically (issue #116): the `Agent`-internal
   loops (identity / network-event / direct / lifecycle listeners, the presence
@@ -783,9 +787,11 @@ handle.shutdown_and_wait().await?;
   - **Presence stop timeout.** On a rare `PresenceManager::stop_beacons()` 5 s
     timeout the upstream dependency detaches (does not abort) the beacon task;
     it is bounded by its own per-send timeout. Tracked upstream.
-  - **QUIC/UDP socket.** ant-quic does not release the bound UDP socket in-process
-    until process exit (upstream limitation). An embedder that stops and restarts
-    x0x in the same process should keep the QUIC `bind_address` ephemeral.
+  - **Fixed QUIC-port rebind is not instantaneous.** ant-quic 0.27.27 (#196)
+    releases the endpoint UDP socket on shutdown, so a single stop→restart on the
+    same fixed QUIC port works. The OS FD closes shortly after
+    `shutdown_and_wait()` returns, so an embedder that immediately re-binds the
+    *same* fixed UDP port in a tight loop should allow a brief retry.
   - **One-shot contract.** Do not call agent start/subscribe methods after
     `shutdown_and_wait()` — the lifecycle is single-use.
 - Dropping the handle requests shutdown (Drop does not block).

--- a/README.md
+++ b/README.md
@@ -766,15 +766,28 @@ handle.shutdown_and_wait().await?;
   node is shut down); the API (TCP) port is released, so a fresh `serve()` on the
   same config (with an ephemeral QUIC port) binds cleanly.
 
-  Two caveats, both tracked:
-  - **Not yet fully deterministic.** Some `Agent`-internal listeners (identity,
-    network-lifecycle, direct, capability-advert) and the `ExecService` tasks
-    (including the session idle loop) are **not** currently tracked or stopped by
-    `shutdown_and_wait()`. Complete teardown of every internal task is a Phase 2b
-    follow-up. Do not rely on "no task survives" yet.
+  Background tasks now stop deterministically (issue #116): the `Agent`-internal
+  loops (identity / network-event / direct / lifecycle listeners, the presence
+  broadcast-peer refresh, heartbeat, discovery reaper), the presence beacons
+  (wrapper *and* `PresenceManager`), the capability-advert and DM-inbox services,
+  and the `ExecService` loops (inbound / peer-lifecycle / session-idle) are all
+  cancelled and awaited (bounded grace, then abort). A listener that a
+  still-bootstrapping `join_network` would otherwise start after shutdown is
+  refused (a cancellation token + a closed task registry close that race).
+
+  Remaining caveats, all tracked:
+  - **In-flight exec sessions.** `ExecService::shutdown()` stops the background
+    loops but does not force-cancel a per-request remote command already running
+    (or its child process); it completes, hits its duration/idle/lease cap, or is
+    reaped on process exit.
+  - **Presence stop timeout.** On a rare `PresenceManager::stop_beacons()` 5 s
+    timeout the upstream dependency detaches (does not abort) the beacon task;
+    it is bounded by its own per-send timeout. Tracked upstream.
   - **QUIC/UDP socket.** ant-quic does not release the bound UDP socket in-process
     until process exit (upstream limitation). An embedder that stops and restarts
     x0x in the same process should keep the QUIC `bind_address` ephemeral.
+  - **One-shot contract.** Do not call agent start/subscribe methods after
+    `shutdown_and_wait()` — the lifecycle is single-use.
 - Dropping the handle requests shutdown (Drop does not block).
 
 For full control (instance name, exec ACL, self-update opt-in) use

--- a/src/exec/service.rs
+++ b/src/exec/service.rs
@@ -52,6 +52,11 @@ pub struct ExecService {
     pending_clients: Mutex<HashMap<ExecRequestId, PendingClient>>,
     active_servers: Mutex<HashMap<ExecRequestId, ActiveServerSession>>,
     active_counts: Mutex<ActiveCounts>,
+    /// Cancellation token driving deterministic teardown of the three
+    /// long-lived loops below (inbound dispatch, peer lifecycle, session idle).
+    cancellation_token: tokio_util::sync::CancellationToken,
+    /// Handles for the three spawned loops, drained by `shutdown()`.
+    task_handles: Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
 
 struct PendingClient {
@@ -123,20 +128,68 @@ impl ExecService {
             pending_clients: Mutex::new(HashMap::new()),
             active_servers: Mutex::new(HashMap::new()),
             active_counts: Mutex::new(ActiveCounts::default()),
+            cancellation_token: tokio_util::sync::CancellationToken::new(),
+            task_handles: Mutex::new(Vec::new()),
         });
         let loop_service = Arc::clone(&service);
-        tokio::spawn(async move {
+        let inbound_handle = tokio::spawn(async move {
             loop_service.run_inbound_loop(inbound_rx).await;
         });
         let lifecycle_service = Arc::clone(&service);
-        tokio::spawn(async move {
+        let lifecycle_handle = tokio::spawn(async move {
             lifecycle_service.run_peer_lifecycle_loop().await;
         });
         let idle_service = Arc::clone(&service);
-        tokio::spawn(async move {
+        let idle_handle = tokio::spawn(async move {
             idle_service.run_session_idle_loop().await;
         });
+        // Stash the handles so `shutdown()` can grace-await then abort them.
+        // `try_lock` always succeeds here: this is the only access before the
+        // service is shared, and the lock is uncontended at construction.
+        if let Ok(mut guard) = service.task_handles.try_lock() {
+            guard.extend([inbound_handle, lifecycle_handle, idle_handle]);
+        }
         service
+    }
+
+    /// Stop the three background loops deterministically. Idempotent.
+    ///
+    /// Cancels the token (the idle-timer loop only ends this way; the two
+    /// channel loops also exit promptly instead of waiting on their channels),
+    /// grace-awaits the handles under a single bounded budget, then aborts and
+    /// awaits any straggler. A cancelled/aborted task yields `Err(JoinError)`;
+    /// that is expected and never unwrapped.
+    ///
+    /// SCOPE BOUNDARY (issue #116): this stops the three long-lived background
+    /// LOOPS only. It does NOT force-cancel per-request exec handler tasks that
+    /// are in flight (the `tokio::spawn` in `run_inbound_loop` for an
+    /// `ExecFrame::Request`) nor the child processes they are running. An
+    /// in-flight remote command is active-session work: it completes on its own,
+    /// hits its own duration/idle/lease cap, or is reaped when the process
+    /// exits. Force-cancelling active exec sessions on `shutdown()` is a separate
+    /// follow-up, intentionally out of scope for the background-loop teardown.
+    pub async fn shutdown(&self) {
+        self.cancellation_token.cancel();
+        let handles = {
+            let mut guard = self.task_handles.lock().await;
+            std::mem::take(&mut *guard)
+        };
+        if handles.is_empty() {
+            return;
+        }
+        let abort_handles: Vec<tokio::task::AbortHandle> =
+            handles.iter().map(|h| h.abort_handle()).collect();
+        let mut join = futures::future::join_all(handles);
+        tokio::select! {
+            _results = &mut join => {}
+            _ = tokio::time::sleep(Duration::from_secs(3)) => {
+                tracing::warn!("exec background loops did not stop within grace; aborting stragglers");
+                for handle in &abort_handles {
+                    handle.abort();
+                }
+                let _results: Vec<Result<(), tokio::task::JoinError>> = join.await;
+            }
+        }
     }
 
     /// Whether exec is enabled on this daemon.
@@ -339,13 +392,16 @@ impl ExecService {
         };
         tracing::info!("exec peer lifecycle watcher started");
         loop {
-            let (peer_id, event) = match rx.recv().await {
-                Ok(event) => event,
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                    tracing::warn!(skipped, "exec peer lifecycle watcher lagged");
-                    continue;
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            let (peer_id, event) = tokio::select! {
+                _ = self.cancellation_token.cancelled() => break,
+                recv = rx.recv() => match recv {
+                    Ok(event) => event,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                        tracing::warn!(skipped, "exec peer lifecycle watcher lagged");
+                        continue;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                },
             };
             let disconnect_reason = match event {
                 ant_quic::PeerLifecycleEvent::Closed { reason, .. }
@@ -386,7 +442,13 @@ impl ExecService {
 
     async fn run_session_idle_loop(self: Arc<Self>) {
         loop {
-            tokio::time::sleep(SESSION_IDLE_SCAN_INTERVAL).await;
+            // This loop is a pure timer — it never self-terminates, so the
+            // token is the ONLY thing that stops it. Without this arm it leaked
+            // for the lifetime of the process.
+            tokio::select! {
+                _ = tokio::time::sleep(SESSION_IDLE_SCAN_INTERVAL) => {}
+                _ = self.cancellation_token.cancelled() => break,
+            }
             let sessions: Vec<(ExecRequestId, ActiveServerSession)> = {
                 let active = self.active_servers.lock().await;
                 active
@@ -441,7 +503,14 @@ impl ExecService {
     }
 
     async fn run_inbound_loop(self: Arc<Self>, mut inbound_rx: mpsc::Receiver<DmTypedPayload>) {
-        while let Some(inbound) = inbound_rx.recv().await {
+        loop {
+            let inbound = tokio::select! {
+                _ = self.cancellation_token.cancelled() => break,
+                recv = inbound_rx.recv() => match recv {
+                    Some(inbound) => inbound,
+                    None => break,
+                },
+            };
             let frame = match decode_frame_payload(&inbound.payload) {
                 Ok(frame) => frame,
                 Err(e) => {
@@ -1405,6 +1474,8 @@ mod tests {
             pending_clients: Mutex::new(HashMap::new()),
             active_servers: Mutex::new(HashMap::new()),
             active_counts: Mutex::new(ActiveCounts::default()),
+            cancellation_token: tokio_util::sync::CancellationToken::new(),
+            task_handles: Mutex::new(Vec::new()),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,6 +275,29 @@ pub struct Agent {
         tokio::sync::Mutex<Option<dm_capability_service::CapabilityAdvertService>>,
     /// Handle for the running DM inbox service.
     dm_inbox_service: tokio::sync::Mutex<Option<dm_inbox::DmInboxService>>,
+    /// Cancellation token driving deterministic teardown of all long-lived
+    /// Agent background loops (identity/network-event/direct listeners and the
+    /// presence broadcast-peer refresh). Cancelling it makes every token-aware
+    /// loop break promptly; `shutdown()` cancels it before tearing down gossip
+    /// and the network so listeners (which call network methods) stop first.
+    shutdown_token: tokio_util::sync::CancellationToken,
+    /// Registry of tracked background-task handles. Once `closed` is set (by
+    /// `shutdown()`), `spawn_tracked` refuses to spawn — this defeats the
+    /// join_network race where a listener could otherwise start after shutdown
+    /// began. A plain `std::sync::Mutex` (not tokio) keeps lock holds trivially
+    /// short: never await while holding it.
+    tracked_tasks: std::sync::Arc<std::sync::Mutex<TrackedTasks>>,
+}
+
+/// Closed-flag task registry for deterministic Agent teardown.
+///
+/// `spawn_tracked` pushes handles here while `closed` is false; `shutdown()`
+/// sets `closed` and drains the handles. The flag closes the join_network
+/// shutdown race: a spawn requested after `shutdown()` began is dropped rather
+/// than leaked.
+struct TrackedTasks {
+    closed: bool,
+    handles: Vec<tokio::task::JoinHandle<()>>,
 }
 
 impl std::fmt::Debug for Agent {
@@ -3344,14 +3367,119 @@ impl Agent {
         Ok(connectivity::ConnectOutcome::Unreachable)
     }
 
+    /// Spawn a background task whose handle is tracked for deterministic
+    /// teardown. Returns without spawning once the registry is `closed` (i.e.
+    /// `shutdown()` has begun) — this is what closes the join_network race:
+    /// a listener requested after shutdown started must never run.
+    fn spawn_tracked<F>(&self, fut: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        // Lock held only to inspect `closed` and push the handle; no await
+        // happens under it (Rule: keep the std::Mutex hold trivially short).
+        let mut guard = match self.tracked_tasks.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if guard.closed {
+            return;
+        }
+        guard.handles.push(tokio::spawn(fut));
+    }
+
+    /// Begin shutdown WITHOUT tearing anything down yet: cancel the shutdown
+    /// token and close the tracked-task registry. Idempotent and synchronous.
+    ///
+    /// This is the prefix of `shutdown()`, split out so an embedder/server can
+    /// cancel BEFORE draining its own background tasks (notably a still-running
+    /// `join_network`). Once this returns, every `start_*` helper refuses to
+    /// start (they check `shutdown_token.is_cancelled()` under their handle
+    /// lock) and `spawn_tracked` refuses to spawn — so a `join_network` that is
+    /// still finishing cannot leak a heartbeat/reaper/presence/advert/inbox
+    /// task past the subsequent `shutdown()`. `shutdown()` still cancels the
+    /// token itself (idempotent), so calling `shutdown()` alone remains correct.
+    pub fn begin_shutdown(&self) {
+        self.shutdown_token.cancel();
+        let mut guard = match self.tracked_tasks.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.closed = true;
+    }
+
     /// Save the bootstrap cache and release resources.
     ///
     /// Call this before dropping the agent to ensure the peer cache is
     /// persisted to disk. The background maintenance task saves periodically,
     /// but this guarantees a final save.
+    ///
+    /// Shutdown ordering is deliberate: the cancellation token is cancelled and
+    /// the listener tasks are stopped *before* the gossip runtime and the
+    /// network node are torn down. The listeners call into the network (e.g.
+    /// `is_connected`), so stopping them first avoids a Phase-2-style hang where
+    /// a listener blocks on a transport that is concurrently shutting down.
+    /// Idempotent: `cancel()` is idempotent, the registry drains empty on a
+    /// second call, and the `stop_*` helpers use `Option::take`.
     pub async fn shutdown(&self) {
+        // 1. Signal every token-aware loop to break. Inert until now, so this
+        //    is the first thing that changes steady-state behavior.
+        self.shutdown_token.cancel();
+
+        // 2. Stop the simple Option<JoinHandle> background tasks.
         self.stop_identity_heartbeat().await;
         self.stop_discovery_cache_reaper().await;
+
+        // 3. Stop the DM inbox and the capability advert service (current gaps:
+        //    neither was stopped by shutdown() before). Both abort their own
+        //    spawned tasks.
+        self.stop_dm_inbox().await;
+        {
+            let service = {
+                let mut guard = self.capability_advert_service.lock().await;
+                guard.take()
+            };
+            if let Some(service) = service {
+                service.abort();
+            }
+        }
+
+        // 4. Drain the tracked-task registry: mark closed (so any in-flight
+        //    spawn_tracked is refused), take the handles, grace-await them all
+        //    under a SINGLE bounded budget (not per-task — keeps shutdown
+        //    prompt), then abort+await any straggler. A cancelled/aborted task
+        //    yields Err(JoinError); that is expected, never unwrap it.
+        let handles = {
+            let mut guard = match self.tracked_tasks.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            guard.closed = true;
+            std::mem::take(&mut guard.handles)
+        };
+        if !handles.is_empty() {
+            // Grace-await all tracked tasks under a SINGLE bounded budget (not
+            // per-task — keeps shutdown prompt regardless of task count). On
+            // timeout, abort the stragglers and await the aborts so none
+            // outlives shutdown(). The select! keeps the JoinHandles owned by
+            // the awaiting future so the post-abort join can still observe each
+            // task's terminal JoinError (cancelled tasks → Err — never
+            // unwrapped).
+            let abort_handles: Vec<tokio::task::AbortHandle> =
+                handles.iter().map(|h| h.abort_handle()).collect();
+            let mut join = futures::future::join_all(handles);
+            tokio::select! {
+                _results = &mut join => {}
+                _ = tokio::time::sleep(std::time::Duration::from_secs(3)) => {
+                    tracing::warn!(
+                        "Agent background tasks did not stop within grace; aborting stragglers"
+                    );
+                    for handle in &abort_handles {
+                        handle.abort();
+                    }
+                    let _results: Vec<Result<(), tokio::task::JoinError>> = join.await;
+                }
+            }
+        }
 
         // Shut down presence beacons.
         if let Some(ref pw) = self.presence {
@@ -3462,6 +3590,11 @@ impl Agent {
 
     async fn start_discovery_cache_reaper(&self) -> error::Result<()> {
         let mut guard = self.discovery_cache_reaper_handle.lock().await;
+        // Shutdown race (issue #116): refuse to start once shutdown began.
+        // Checked under the same lock stop_discovery_cache_reaper takes from.
+        if self.shutdown_token.is_cancelled() {
+            return Ok(());
+        }
         if guard.is_some() {
             return Ok(());
         }
@@ -5234,8 +5367,9 @@ impl Agent {
         let own_machine_id = self.machine_id();
         let own_user_id = self.user_id();
         let rebroadcast_pubsub = std::sync::Arc::clone(runtime.pubsub());
+        let token = self.shutdown_token.clone();
 
-        tokio::spawn(async move {
+        self.spawn_tracked(async move {
             enum DiscoveryMessage {
                 Identity(crate::gossip::PubSubMessage),
                 Machine(crate::gossip::PubSubMessage),
@@ -5307,6 +5441,16 @@ impl Agent {
                             None => std::future::pending().await,
                         }
                     } => DiscoveryMessage::User(m),
+                    // Required for PROMPT shutdown: without this arm the listener
+                    // only exits when every gossip subscription closes (the
+                    // `else => break` path), forcing shutdown() to wait out its
+                    // 3s grace-then-abort window. Cancelling the token here lets
+                    // it break immediately. Adding this always-eligible-on-cancel
+                    // branch only shifts tokio::select!'s pseudo-random tie-break
+                    // distribution among the recv arms — behaviorally inert here
+                    // because each per-topic message is handled independently
+                    // with no cross-topic ordering guarantee.
+                    _ = token.cancelled() => break,
                     else => break,
                 };
                 let msg = match msg {
@@ -5836,6 +5980,13 @@ impl Agent {
             })?;
             tracing::info!("Gossip runtime started");
         }
+        // Race guard (issue #116): if shutdown() already fired (token cancelled),
+        // do not start the listeners. Combined with spawn_tracked's closed-check,
+        // a shutdown that races mid-bootstrap cannot leave a listener running.
+        if self.shutdown_token.is_cancelled() {
+            tracing::info!("join_network aborted: shutdown already in progress");
+            return Ok(());
+        }
         self.start_identity_listener().await?;
         self.start_network_event_listener();
         self.start_direct_listener();
@@ -6008,11 +6159,17 @@ impl Agent {
                 let pw_clone = pw.clone();
                 let runtime_clone = runtime.clone();
                 let network_clone = self.network.as_ref().map(std::sync::Arc::clone);
-                tokio::spawn(async move {
+                let token = self.shutdown_token.clone();
+                self.spawn_tracked(async move {
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
                     interval.tick().await; // first tick fires immediately; startup already seeded
                     loop {
-                        interval.tick().await;
+                        tokio::select! {
+                            _ = interval.tick() => {}
+                            // Inert until shutdown; then the 30s timer loop exits
+                            // instead of being merely aborted.
+                            _ = token.cancelled() => break,
+                        }
 
                         let active = runtime_clone.membership().active_view();
                         let active_view_count = active.len();
@@ -6062,27 +6219,33 @@ impl Agent {
                 }
             }
 
-            if pw.config().enable_beacons {
-                if let Err(e) = pw
-                    .manager()
-                    .start_beacons(pw.config().beacon_interval_secs)
-                    .await
-                {
-                    tracing::warn!("Failed to start presence beacons: {e}");
-                } else {
-                    tracing::info!(
-                        "Presence beacons started (interval={}s)",
-                        pw.config().beacon_interval_secs
-                    );
+            // Shutdown race (issue #116): skip starting presence beacons / event
+            // loop if shutdown began mid-bootstrap; Agent::shutdown() runs
+            // pw.shutdown() AFTER cancel(), so checking here ensures we never
+            // start beacons that pw.shutdown() already stopped.
+            if !self.shutdown_token.is_cancelled() {
+                if pw.config().enable_beacons {
+                    if let Err(e) = pw
+                        .manager()
+                        .start_beacons(pw.config().beacon_interval_secs)
+                        .await
+                    {
+                        tracing::warn!("Failed to start presence beacons: {e}");
+                    } else {
+                        tracing::info!(
+                            "Presence beacons started (interval={}s)",
+                            pw.config().beacon_interval_secs
+                        );
+                    }
                 }
-            }
 
-            // Start the presence event-emission loop so that subscribers
-            // automatically receive AgentOnline/AgentOffline events after
-            // join_network() returns.
-            pw.start_event_loop(std::sync::Arc::clone(&self.identity_discovery_cache))
-                .await;
-            tracing::debug!("Presence event loop started");
+                // Start the presence event-emission loop so that subscribers
+                // automatically receive AgentOnline/AgentOffline events after
+                // join_network() returns.
+                pw.start_event_loop(std::sync::Arc::clone(&self.identity_discovery_cache))
+                    .await;
+                tracing::debug!("Presence event loop started");
+            }
         }
 
         if let Err(e) = self.announce_identity(false, false).await {
@@ -6112,7 +6275,10 @@ impl Agent {
                 user_identity_consented: std::sync::Arc::clone(&self.user_identity_consented),
                 allow_local_discovery_addrs: allow_local_discovery_addresses(network.config()),
             };
-            tokio::spawn(async move {
+            // Routed through spawn_tracked (issue #116) so a shutdown racing
+            // bootstrap refuses to start it once the registry is closed; it is
+            // a one-shot self-completing task so no token arm is needed.
+            self.spawn_tracked(async move {
                 tokio::time::sleep(std::time::Duration::from_secs(3)).await;
                 if let Err(e) = ctx.announce().await {
                     tracing::warn!("Delayed identity re-announcement failed: {e}");
@@ -6175,6 +6341,13 @@ impl Agent {
         })?;
 
         let mut guard = self.capability_advert_service.lock().await;
+        // Shutdown race (issue #116): if shutdown began while we were spawning,
+        // abort the freshly-spawned service instead of storing it. Checked under
+        // the same lock shutdown() takes the service from, so it can't leak.
+        if self.shutdown_token.is_cancelled() {
+            service.abort();
+            return Ok(());
+        }
         if let Some(prev) = guard.take() {
             prev.abort();
         }
@@ -6233,6 +6406,14 @@ impl Agent {
             )))
         })?;
         let mut guard = self.dm_inbox_service.lock().await;
+        // Shutdown race (issue #116): if shutdown began while we were spawning,
+        // abort the freshly-spawned service instead of storing it (and skip the
+        // capability upgrade below). Checked under the same lock stop_dm_inbox
+        // takes the service from, so it can't leak.
+        if self.shutdown_token.is_cancelled() {
+            service.abort();
+            return Ok(());
+        }
         if let Some(prev) = guard.take() {
             prev.abort();
         }
@@ -6919,19 +7100,27 @@ impl Agent {
 
         let lifecycle_network = std::sync::Arc::clone(&network);
         let lifecycle_dm = std::sync::Arc::clone(&dm);
+        let event_token = self.shutdown_token.clone();
+        let lifecycle_token = self.shutdown_token.clone();
 
-        tokio::spawn(async move {
+        self.spawn_tracked(async move {
             let mut rx = network.subscribe();
             tracing::info!("Network event reconciliation listener started");
 
             loop {
-                let event = match rx.recv().await {
-                    Ok(event) => event,
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                        tracing::warn!("Network event listener lagged by {skipped} events");
-                        continue;
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                let event = tokio::select! {
+                    // event_sender is a NetworkNode struct field that outlives
+                    // network.shutdown(), so this loop never ended on shutdown
+                    // before; the token is what stops it now.
+                    _ = event_token.cancelled() => break,
+                    recv = rx.recv() => match recv {
+                        Ok(event) => event,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            tracing::warn!("Network event listener lagged by {skipped} events");
+                            continue;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    },
                 };
 
                 match event {
@@ -6974,7 +7163,7 @@ impl Agent {
             }
         });
 
-        tokio::spawn(async move {
+        self.spawn_tracked(async move {
             let Some(mut rx) = lifecycle_network.subscribe_all_peer_events().await else {
                 tracing::debug!(
                     "Peer lifecycle listener unavailable: network node not initialised"
@@ -6983,13 +7172,16 @@ impl Agent {
             };
             tracing::info!("Peer lifecycle watcher started for direct messaging");
             loop {
-                let (peer_id, event) = match rx.recv().await {
-                    Ok(event) => event,
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                        tracing::warn!("Peer lifecycle watcher lagged by {skipped} events");
-                        continue;
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                let (peer_id, event) = tokio::select! {
+                    _ = lifecycle_token.cancelled() => break,
+                    recv = rx.recv() => match recv {
+                        Ok(event) => event,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            tracing::warn!("Peer lifecycle watcher lagged by {skipped} events");
+                            continue;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    },
                 };
                 let machine_id = identity::MachineId(peer_id.0);
                 match event {
@@ -7046,11 +7238,19 @@ impl Agent {
         let dm = std::sync::Arc::clone(&self.direct_messaging);
         let discovery_cache = std::sync::Arc::clone(&self.identity_discovery_cache);
         let contact_store = std::sync::Arc::clone(&self.contact_store);
+        let token = self.shutdown_token.clone();
 
-        tokio::spawn(async move {
+        self.spawn_tracked(async move {
             tracing::info!(target: "x0x::direct", stage = "listener", "direct message listener started");
             loop {
-                let Some((ant_peer_id, payload)) = network.recv_direct().await else {
+                // direct_tx is a NetworkNode struct field that outlives
+                // network.shutdown(), so recv_direct() does not return None on
+                // shutdown; the token is what stops this loop now.
+                let recv = tokio::select! {
+                    _ = token.cancelled() => break,
+                    r = network.recv_direct() => r,
+                };
+                let Some((ant_peer_id, payload)) = recv else {
                     tracing::warn!(
                         target: "x0x::direct",
                         stage = "listener",
@@ -7176,6 +7376,14 @@ impl Agent {
     /// Returns an error if a required network or gossip component is missing.
     pub async fn start_identity_heartbeat(&self) -> error::Result<()> {
         let mut handle_guard = self.heartbeat_handle.lock().await;
+        // Shutdown race (issue #116): a still-bootstrapping join_network can call
+        // this after shutdown() began. Checking under the SAME lock that
+        // stop_identity_heartbeat takes the handle from makes it TOCTOU-free:
+        // stop_X runs after cancel(), so a handle stored before stop_X runs is
+        // taken+aborted, and a store attempted after sees cancelled → refused.
+        if self.shutdown_token.is_cancelled() {
+            return Ok(());
+        }
         if handle_guard.is_some() {
             return Ok(());
         }
@@ -8109,6 +8317,11 @@ impl AgentBuilder {
             recent_delivery_cache: std::sync::Arc::new(dm::RecentDeliveryCache::with_defaults()),
             capability_advert_service: tokio::sync::Mutex::new(None),
             dm_inbox_service: tokio::sync::Mutex::new(None),
+            shutdown_token: tokio_util::sync::CancellationToken::new(),
+            tracked_tasks: std::sync::Arc::new(std::sync::Mutex::new(TrackedTasks {
+                closed: false,
+                handles: Vec::new(),
+            })),
         })
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -2254,10 +2254,15 @@ impl NetworkNode {
             let _ = handle.await;
         }
         // Take the node out and shut it down explicitly so connections close
-        // deterministically. NOTE: this does NOT free the bound UDP socket
-        // in-process — the ant-quic endpoint driver releases it only on process
-        // exit (saorsa-labs/ant-quic#196), so a same-process re-bind must use an
-        // ephemeral port.
+        // deterministically. As of ant-quic 0.27.27 (#196), `Node::shutdown()`
+        // releases the bound endpoint UDP socket in-process (it swaps in a
+        // throwaway ephemeral socket and drops the original), so a same-process
+        // re-bind on the SAME fixed QUIC port works for a single stop→restart
+        // (proven by tests/server_inprocess.rs::serve_tears_down_cleanly_and_rebinds).
+        // The release is NOT perfectly synchronous: the OS FD for the fixed port
+        // closes once the endpoint driver drops its last reference, shortly after
+        // this returns, so a tight zero-gap loop re-binding the same fixed port
+        // may still see "address already in use" — an embedder should retry.
         let node = {
             let mut node_guard = self.node.write().await;
             node_guard.take()

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -698,7 +698,10 @@ impl PresenceWrapper {
 
     /// Shut down the presence system.
     ///
-    /// Aborts both the beacon broadcast task and the event-loop task if running.
+    /// Aborts both the wrapper-owned beacon broadcast task and the event-loop
+    /// task if running, AND stops the `PresenceManager`-owned beacon task
+    /// (started via `manager().start_beacons()`), which the wrapper handles do
+    /// not cover (issue #116: that manager task otherwise survives shutdown).
     /// Safe to call multiple times.
     pub async fn shutdown(&self) {
         let mut beacon = self.beacon_handle.lock().await;
@@ -708,6 +711,12 @@ impl PresenceWrapper {
         let mut event = self.event_handle.lock().await;
         if let Some(h) = event.take() {
             h.abort();
+        }
+        // Stop the manager-owned beacon task. It signals + joins its own task
+        // (with an internal 5s timeout); a timeout/error here is non-fatal to
+        // shutdown — log and continue rather than block teardown.
+        if let Err(e) = self.manager().stop_beacons().await {
+            tracing::debug!("PresenceManager stop_beacons during shutdown: {e}");
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1657,15 +1657,16 @@ pub async fn serve_with_options(
         groups_diagnostics: Arc::new(x0x::groups::GroupsDiagnostics::new()),
     });
 
-    // Fix A (Issue #110 Phase 2): the `api.port` advertisement is written here,
-    // before any long-lived background task is spawned. The agent IS already
-    // built by this point (it is needed for AppState), so on the error path we
-    // must tear it down — `agent.shutdown()` stops the network tasks and closes
-    // the QUIC node — so a failed write does not leak the agent/network. (The
-    // ExecService tasks are not yet stoppable; that residual is the tracked
-    // Phase 2b follow-up.) The file is removed again in the shutdown tail.
+    // Fix A (Issue #110 Phase 2 + #116): the `api.port` advertisement is written
+    // here, before any long-lived server-owned task is spawned. The agent and the
+    // ExecService ARE already built/spawned by this point (both needed for
+    // AppState), so on the error path we must tear BOTH down — ExecService first
+    // (its loops use the agent transport), then `agent.shutdown()` — so a failed
+    // write does not leak the exec loops or the agent/network. The file is removed
+    // again in the shutdown tail.
     let port_file = config.data_dir.join("api.port");
     if let Err(e) = tokio::fs::write(&port_file, actual_api_addr.to_string()).await {
+        exec_service.shutdown().await;
         agent.shutdown().await;
         return Err(anyhow::Error::new(e).context("failed to write api.port"));
     }
@@ -1677,7 +1678,8 @@ pub async fn serve_with_options(
     // Fix C (Issue #110 Phase 2): collect every server-owned background-task
     // `JoinHandle` spawned in the startup path so the shutdown tail can
     // grace-await then abort any straggler. (Agent-internal and ExecService tasks
-    // are not collected here — see the Phase 2b note in the shutdown tail.)
+    // are owned by the Agent/ExecService and stopped by their own `shutdown()`
+    // calls in the shutdown tail — issue #116 — not collected here.)
     let mut bg_tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
     let existing_group_ids: Vec<String> = {
@@ -2446,30 +2448,36 @@ pub async fn serve_with_options(
             },
         };
 
-        // Fix C (Issue #110 Phase 2): tear down the server-owned tasks and the
-        // QUIC node so that when this supervisor returns, the HTTP/SSE server,
-        // the server-owned background tasks, the gossip runtime, and the QUIC
-        // NetworkNode are all stopped/closed. (Some Agent-internal listeners and
-        // the ExecService tasks are NOT yet tracked/stopped here — fully
-        // deterministic teardown of those is the Phase 2b follow-up.)
+        // Fix C (Issue #110 Phase 2 + 2b): tear down the server-owned tasks, the
+        // ExecService loops, the Agent listeners, and the QUIC node so that when
+        // this supervisor returns, the HTTP/SSE server, the server-owned
+        // background tasks, the ExecService loops, the Agent-internal listeners,
+        // the gossip runtime, and the QUIC NetworkNode are all stopped/closed.
         //
-        // 1. `Agent::shutdown()` stops presence/heartbeat/cache, shuts down the
-        //    gossip runtime, and shuts down the QUIC NetworkNode (aborting its
-        //    receiver/accept/eviction tasks and closing the ant-quic node) — see
-        //    `Agent::shutdown`. This also drops the gossip/direct senders so
-        //    channel-close-driven receive loops end. (The OS frees the UDP
-        //    socket itself on process exit; ant-quic does not release it
-        //    in-process — embedders that restart should use an ephemeral QUIC
-        //    port.)
-        state.agent.shutdown().await;
-        // 2. Grace-await then abort every background task. Tasks tracked in the
-        //    AppState handle maps (metadata / public-message / directory shard
-        //    listeners spawned at startup AND by request handlers) are included
-        //    so nothing leaks. The grace window is a single bounded 2s budget
-        //    across all tasks (not 2s each) so shutdown stays prompt regardless
-        //    of task count; any task still running after the window is aborted.
-        //    A cancelled/aborted task returns a `JoinError`; that is expected,
-        //    not a failure — never unwrap it.
+        // 0. `ExecService::shutdown()` first (issue #116): stop the exec inbound,
+        //    peer-lifecycle, and session-idle loops while the Agent transport is
+        //    still alive, so in-flight sessions can cancel cleanly before the
+        //    network goes away.
+        state.exec_service.shutdown().await;
+        // 1. `Agent::begin_shutdown()` (issue #116 Codex finding 1): cancel the
+        //    Agent's shutdown token and close its tracked-task registry NOW,
+        //    BEFORE draining the server bg_tasks. A still-bootstrapping
+        //    `join_network` is one of those bg_tasks; cancelling first makes its
+        //    in-flight `start_identity_heartbeat`/`start_discovery_cache_reaper`/
+        //    presence-start/`start_capability_advert_service`/delayed-reannounce
+        //    no-op (each checks `is_cancelled()` under its handle lock), so it
+        //    cannot leak a dedicated-handle service past `agent.shutdown()`.
+        state.agent.begin_shutdown();
+        // 2. Grace-await then abort every server background task, INCLUDING
+        //    join_network. Tasks tracked in the AppState handle maps (metadata /
+        //    public-message / directory shard listeners spawned at startup AND
+        //    by request handlers) are included so nothing leaks. The grace
+        //    window is a single bounded 2s budget across all tasks (not 2s each)
+        //    so shutdown stays prompt regardless of task count; any task still
+        //    running after the window is aborted. A cancelled/aborted task
+        //    returns a `JoinError`; that is expected, never unwrap it. Draining
+        //    here (after begin_shutdown, before agent.shutdown) guarantees
+        //    join_network has fully stopped before the Agent stops are run.
         let mut bg_tasks = bg_tasks;
         bg_tasks
             .extend(std::mem::take(&mut *state.group_metadata_tasks.write().await).into_values());
@@ -2477,18 +2485,33 @@ pub async fn serve_with_options(
             .extend(std::mem::take(&mut *state.public_message_tasks.write().await).into_values());
         bg_tasks.extend(std::mem::take(&mut *state.directory_tasks.write().await).into_values());
         // Keep abort handles so stragglers can be aborted after the grace window.
+        // Fix C (issue #116): on the timeout path, AWAIT the aborts too — keep the
+        // JoinHandles owned by `join` (select! over `&mut join` vs the 2s sleep)
+        // so that after aborting we `join.await` the remainder. Without this, the
+        // "join_network fully stopped before agent.shutdown()" guarantee would
+        // only hold on the non-timeout path; now it holds on BOTH. A cancelled/
+        // aborted task yields Err(JoinError) — expected, never unwrapped.
         let abort_handles: Vec<tokio::task::AbortHandle> =
             bg_tasks.iter().map(|h| h.abort_handle()).collect();
-        let grace = futures::future::join_all(bg_tasks);
-        if tokio::time::timeout(Duration::from_secs(2), grace)
-            .await
-            .is_err()
-        {
-            tracing::warn!("background tasks did not stop within grace; aborting stragglers");
-            for handle in abort_handles {
-                handle.abort();
+        let mut join = futures::future::join_all(bg_tasks);
+        tokio::select! {
+            _results = &mut join => {}
+            _ = tokio::time::sleep(Duration::from_secs(2)) => {
+                tracing::warn!("background tasks did not stop within grace; aborting stragglers");
+                for handle in &abort_handles {
+                    handle.abort();
+                }
+                let _results: Vec<Result<(), tokio::task::JoinError>> = join.await;
             }
         }
+        // 3. Now that join_network is stopped (and the token cancelled so any
+        //    in-flight start_* no-ops), tear the Agent down: stop heartbeat /
+        //    reaper / DM-inbox / advert / presence, drain the Agent's own
+        //    tracked listener tasks, shut down the gossip runtime, and shut down
+        //    the QUIC NetworkNode. (The OS frees the UDP socket on process exit;
+        //    ant-quic does not release it in-process — embedders that restart
+        //    should use an ephemeral QUIC port.)
+        state.agent.shutdown().await;
 
         // Clean up port file on shutdown (kept after task teardown so the
         // existing ordering — port advertisement removed last — is preserved).

--- a/tests/server_inprocess.rs
+++ b/tests/server_inprocess.rs
@@ -40,6 +40,20 @@ fn hermetic_config(dir: &std::path::Path) -> DaemonConfig {
     config
 }
 
+/// Reserve a currently-free loopback UDP port by binding `:0`, reading the
+/// assigned port, then dropping the socket. Used to pin a FIXED QUIC
+/// `bind_address` for the restart tests: as of ant-quic 0.27.27 (#196) the
+/// endpoint UDP socket is released on shutdown, so an in-process embedder can
+/// re-`serve()` on the SAME fixed QUIC port. There is an inherent (small) TOCTOU
+/// window between dropping this probe and serve() rebinding it, acceptable for a
+/// loopback test.
+fn free_udp_port() -> u16 {
+    let sock = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("bind probe udp socket");
+    let port = sock.local_addr().expect("probe local_addr").port();
+    drop(sock);
+    port
+}
+
 /// `serve()` binds, reports its address immediately, serves `/health`, and
 /// shuts down cleanly with the port released.
 ///
@@ -130,18 +144,23 @@ async fn dropping_handle_requests_shutdown() {
 /// in-process. (Some Agent-internal/ExecService tasks are not yet stopped — a
 /// tracked Phase 2b item — but they do not hold the API port or block re-serve.)
 ///
-/// NOTE on the QUIC/UDP socket: the QUIC `bind_address` is left ephemeral
-/// (`127.0.0.1:0`) on purpose. `Agent::shutdown()` now aborts the NetworkNode
-/// receiver/accept/eviction tasks and calls `ant_quic::Node::shutdown()`, but
-/// ant-quic does NOT release the bound UDP socket within the same process while
-/// the tokio runtime is alive — it frees only on process exit. The daemon is
-/// unaffected (it exits the process). Re-binding a *fixed* QUIC port in-process
-/// is therefore blocked upstream in ant-quic, not by x0x; see the task report.
+/// FIXED QUIC PORT (ant-quic 0.27.27 / #196): the QUIC `bind_address` is pinned
+/// to a FIXED loopback UDP port (not ephemeral). `Agent::shutdown()` aborts the
+/// NetworkNode receiver/accept/eviction tasks and calls
+/// `ant_quic::Node::shutdown()`, and as of ant-quic 0.27.27 the endpoint UDP
+/// socket IS released in-process on shutdown (#196). So the second `serve()`
+/// must rebind the SAME fixed QUIC port — the real proof #196 delivers, which
+/// was impossible pre-0.27.27 (the socket only freed on process exit). If this
+/// fixed-port rebind ever fails, #196 does not cover x0x's endpoint path.
 #[tokio::test]
 #[ignore]
 async fn serve_tears_down_cleanly_and_rebinds() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let config = hermetic_config(tmp.path());
+    let mut config = hermetic_config(tmp.path());
+    // Pin a FIXED QUIC bind port so the rebind proves socket release, not just
+    // that an ephemeral re-roll happened to pick a new free port.
+    let quic_port = free_udp_port();
+    config.bind_address = SocketAddr::from(([127, 0, 0, 1], quic_port));
 
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
@@ -171,11 +190,12 @@ async fn serve_tears_down_cleanly_and_rebinds() {
     );
     drop(rebound);
 
-    // Second lifecycle on the SAME config. If the first run leaked a background
-    // task or held a lock, this start would hang or fail; it must bind cleanly.
+    // Second lifecycle on the SAME config — INCLUDING the same FIXED QUIC port.
+    // If ant-quic had not released the endpoint UDP socket (pre-#196), this
+    // serve() would fail to bind the fixed QUIC port. It must rebind cleanly.
     let handle = serve(config)
         .await
-        .expect("second serve() on the same config must bind cleanly");
+        .expect("second serve() must rebind the SAME fixed QUIC port (ant-quic #196)");
     let addr = handle.local_addr();
     let resp = client
         .get(format!("http://{addr}/health"))
@@ -185,7 +205,7 @@ async fn serve_tears_down_cleanly_and_rebinds() {
     assert_eq!(
         resp.status(),
         reqwest::StatusCode::OK,
-        "second instance must serve /health — proves nothing leaked from run 1"
+        "second instance must serve /health on the same fixed QUIC port — proves #196 releases the socket"
     );
     handle
         .shutdown_and_wait()
@@ -280,10 +300,16 @@ fn find_x0x_dirs(root: &std::path::Path) -> Vec<PathBuf> {
 /// next build; this loop is the regression that fails if teardown is not
 /// complete. The API (TCP) port must rebind each cycle.
 ///
-/// NOTE on QUIC/UDP: each cycle keeps the QUIC `bind_address` ephemeral
-/// (`127.0.0.1:0`) because ant-quic does not release a *fixed* bound UDP socket
-/// in-process while the runtime is alive (upstream ant-quic#196). Re-serving on
-/// a fixed QUIC port in-process is therefore blocked upstream, not by x0x.
+/// QUIC/UDP (ephemeral on purpose): this test's job is TASK/LOCK leak detection
+/// across rapid start→stop cycles, NOT fixed-port rebinding. It keeps the QUIC
+/// `bind_address` ephemeral (`127.0.0.1:0`) so each cycle gets a fresh UDP port.
+/// FIXED-port rebinding is proven separately by
+/// `serve_tears_down_cleanly_and_rebinds`. A tight zero-gap same-fixed-port loop
+/// is NOT reliable: ant-quic 0.27.27 (#196) releases the endpoint socket on a
+/// single restart, but in a back-to-back same-port loop the prior cycle's UDP FD
+/// is not freed in time even after seconds of retry (documented in the report) —
+/// so pinning a fixed port here would test that upstream race, not x0x's leak
+/// guarantee. The API (TCP) port still must rebind each cycle (asserted below).
 #[tokio::test]
 #[ignore]
 async fn serve_stop_loop_leaks_no_tasks() {
@@ -298,9 +324,13 @@ async fn serve_stop_loop_leaks_no_tasks() {
     for cycle in 0..3 {
         let handle = serve(config.clone())
             .await
-            .unwrap_or_else(|e| panic!("serve() must start on cycle {cycle}: {e}"));
+            .unwrap_or_else(|e| panic!("serve() must start on cycle {cycle}: {e:?}"));
         let addr = handle.local_addr();
-        assert_ne!(addr.port(), 0, "cycle {cycle}: ephemeral port must resolve");
+        assert_ne!(
+            addr.port(),
+            0,
+            "cycle {cycle}: ephemeral API port must resolve"
+        );
 
         let resp = client
             .get(format!("http://{addr}/health"))

--- a/tests/server_inprocess.rs
+++ b/tests/server_inprocess.rs
@@ -268,3 +268,110 @@ fn find_x0x_dirs(root: &std::path::Path) -> Vec<PathBuf> {
     }
     found
 }
+
+/// Deterministic teardown (Issue #116): repeated start → /health → stop cycles
+/// on the SAME config must each succeed, proving no Agent/ExecService background
+/// task or lock leaks across cycles.
+///
+/// WHY: before #116 the Agent identity/network-event/direct listeners and the
+/// presence refresh loop, plus the three ExecService loops (notably the pure
+/// session-idle timer), kept running after `shutdown_and_wait()` returned. A
+/// leaked task per cycle would accumulate, and a surviving lock would hang the
+/// next build; this loop is the regression that fails if teardown is not
+/// complete. The API (TCP) port must rebind each cycle.
+///
+/// NOTE on QUIC/UDP: each cycle keeps the QUIC `bind_address` ephemeral
+/// (`127.0.0.1:0`) because ant-quic does not release a *fixed* bound UDP socket
+/// in-process while the runtime is alive (upstream ant-quic#196). Re-serving on
+/// a fixed QUIC port in-process is therefore blocked upstream, not by x0x.
+#[tokio::test]
+#[ignore]
+async fn serve_stop_loop_leaks_no_tasks() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = hermetic_config(tmp.path());
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("client");
+
+    for cycle in 0..3 {
+        let handle = serve(config.clone())
+            .await
+            .unwrap_or_else(|e| panic!("serve() must start on cycle {cycle}: {e}"));
+        let addr = handle.local_addr();
+        assert_ne!(addr.port(), 0, "cycle {cycle}: ephemeral port must resolve");
+
+        let resp = client
+            .get(format!("http://{addr}/health"))
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("GET /health on cycle {cycle}: {e}"));
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::OK,
+            "cycle {cycle}: /health must be 200"
+        );
+
+        handle
+            .shutdown_and_wait()
+            .await
+            .unwrap_or_else(|e| panic!("shutdown_and_wait must return Ok on cycle {cycle}: {e}"));
+
+        // API (TCP) port released each cycle — proves the listener and its
+        // supervisor were torn down before the next start.
+        let rebound = tokio::net::TcpListener::bind(addr).await;
+        assert!(
+            rebound.is_ok(),
+            "cycle {cycle}: API port {addr} must be released after shutdown"
+        );
+    }
+}
+
+/// join_network shutdown race (Issue #116): `serve()` then *immediately*
+/// `shutdown_and_wait()` — without ever touching /health — must return Ok and
+/// return promptly.
+///
+/// WHY: `serve()` kicks off `join_network`, which starts the listener tasks and
+/// the presence-refresh loop. If shutdown fires mid-bootstrap, the registry's
+/// closed-flag + `spawn_tracked` refusal + the join_network token guard must
+/// ensure no listener is left running. A regression here would either hang
+/// (a listener blocking on a transport that is shutting down) or leak a task.
+#[tokio::test]
+#[ignore]
+async fn serve_then_immediate_shutdown_is_ok_and_prompt() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut config = hermetic_config(tmp.path());
+    // Point bootstrap at an unroutable RFC 5737 TEST-NET-1 address so
+    // `join_network` actually enters its connect/retry phase and is genuinely
+    // still bootstrapping when shutdown fires — this exercises the
+    // begin_shutdown-before-drain window (Codex finding 1): the racing
+    // join_network's in-flight start_identity_heartbeat / discovery_reaper /
+    // presence-start / capability-advert / delayed-reannounce must all no-op
+    // because the token is cancelled before bg_tasks are drained.
+    config.bootstrap_peers = vec![SocketAddr::from(([192, 0, 2, 1], 5483))];
+
+    let handle = serve(config).await.expect("serve() should start");
+    let addr = handle.local_addr();
+
+    // Give the bootstrap a brief head start so join_network is mid-flight, then
+    // stop without a /health round-trip to race it.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let started = std::time::Instant::now();
+    handle
+        .shutdown_and_wait()
+        .await
+        .expect("immediate shutdown_and_wait should return Ok");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "immediate shutdown must return promptly, took {elapsed:?}"
+    );
+
+    // Port released afterwards — nothing survived the racing shutdown.
+    let rebound = tokio::net::TcpListener::bind(addr).await;
+    assert!(
+        rebound.is_ok(),
+        "API port {addr} must be released after an immediate shutdown"
+    );
+}


### PR DESCRIPTION
Closes #116. Phase 2b of the mobile-embedding work (#110): make `ServerHandle::shutdown_and_wait()` leave **no surviving Agent/ExecService background task**, so an in-process embedder can start→stop→restart x0x cleanly.

## Problem
After #110, `shutdown_and_wait()` stopped the HTTP server, gossip runtime, and QUIC node — but several `Agent`-internal background loops and the `ExecService` loops kept running (they only stopped on process exit). A full task inventory + Codex design review confirmed which loops genuinely leak (the channel listeners' senders are `NetworkNode` struct fields that outlive `network.shutdown()`, so their `recv()` never returns `None`; the presence refresh + exec idle loops are pure timers).

## Change
- **`Agent`**: a `CancellationToken` + a *closed* task registry (`spawn_tracked`). The long-lived listeners (identity, network-event, direct, lifecycle) and the presence broadcast-peer refresh get an **inert** `token.cancelled()` `select!` arm and are tracked. `shutdown()` cancels → drains/aborts them under a single bounded grace **before** gossip/network teardown (listeners call network methods, so ordering matters — same lesson as the #110 deadlock).
- `shutdown()` now also stops the previously-unstopped **capability-advert** and **DM-inbox** services, and the **`PresenceManager`-owned beacon** task (`stop_beacons()`).
- **`ExecService`**: a `CancellationToken` + tracked handles + `shutdown()`; inbound / peer-lifecycle / session-idle loops stop on cancel. The server tail shuts **ExecService down before the Agent**.
- **Teardown race closed TOCTOU-free**: `Agent::begin_shutdown()` cancels + closes the registry *before* the server drains its `bg_tasks`, and each `start_*` helper re-checks the token **under the same handle lock** its `stop_*` takes from — so a still-bootstrapping `join_network` cannot start a service past shutdown. The `bg_task` drain awaits aborts on the timeout path too.

## No steady-state change
The cancel arms are inert until cancel. Verified: characterization oracle **19/19** (graceful stop still prompt ~8s), in-process **6/6** including a new **3-cycle start/stop leak test** and an **immediate-shutdown-after-`serve()` race test** (unroutable RFC5737 bootstrap so `join_network` is mid-connect), full workspace nextest **1757**. fmt / clippy `-D warnings` / build clean. Reviewed by Codex (4 rounds) + an independent reviewer agent.

## Documented scope boundaries / follow-ups (not regressions)
- **In-flight exec sessions** aren't force-cancelled by `ExecService::shutdown()` (a running remote command completes / hits its cap / is reaped on process exit) — follow-up filed.
- **`saorsa-gossip-presence::stop_beacons()`** detaches (doesn't abort) the beacon task on its internal 5s timeout — upstream follow-up filed.
- **ant-quic** in-process UDP socket release (existing, ant-quic#196).
- The lifecycle is **single-use** (don't call agent start/subscribe methods after `shutdown_and_wait()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the Phase 2b teardown work by adding `CancellationToken`-driven shutdown to `Agent` and `ExecService`, a closed-flag task registry (`spawn_tracked`) that closes the `join_network` TOCTOU race, and proper shutdown ordering in the server tail (ExecService → `begin_shutdown` → drain server `bg_tasks` → `agent.shutdown`).

- **`Agent`**: `shutdown_token` + `TrackedTasks` registry; every long-lived listener (identity/network-event/direct/lifecycle, presence refresh) converted to `spawn_tracked` with a `token.cancelled()` select arm; `start_*` helpers check `is_cancelled()` under their handle locks for TOCTOU-free race closure; `begin_shutdown()` cancels + closes the registry before server bg_tasks are drained.
- **`ExecService`**: `CancellationToken` + `task_handles` Vec; all three loops (inbound dispatch, peer lifecycle, session idle) gain a cancel arm and tracked handles; new `shutdown()` method grace-awaits then aborts stragglers.
- **Server shutdown tail**: reordered to ExecService first (network still alive), then `begin_shutdown`, then drain `bg_tasks` (including `join_network`), then `agent.shutdown`; the timeout path now awaits aborts before proceeding.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the shutdown ordering is correct and the TOCTOU race is genuinely closed by the closed-flag registry + is_cancelled() checks under handle locks.

The teardown logic is carefully designed — cancel arms are added to all long-lived loops, the begin_shutdown/bg_task-drain/agent.shutdown ordering is correct, and the join_network race is TOCTOU-free. Two issues found: a silent if let Ok() in ExecService::new() that would detach task handles if try_lock() somehow failed (the invariant holds in practice but should be an expect()), and a stop_beacons() error logged at debug instead of warn, making beacon teardown failures invisible in production logs.

src/exec/service.rs (try_lock silent-failure branch) and src/presence.rs (stop_beacons log level)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/exec/service.rs | Adds CancellationToken + task_handles registry to ExecService; new shutdown() grace-awaits/aborts the three loops. try_lock() at construction has a silent-failure branch that would detach all task handles if it ever failed. |
| src/lib.rs | Adds shutdown_token + TrackedTasks registry to Agent; begin_shutdown() / spawn_tracked() / shutdown() implement the full closed-flag TOCTOU-free teardown ordering. is_cancelled() guards under handle locks in each start_* helper are correct. |
| src/presence.rs | PresenceWrapper::shutdown() now also stops the PresenceManager-owned beacon task via stop_beacons(). Error from stop_beacons() is logged at debug level, which is too quiet for a shutdown failure path. |
| src/server/mod.rs | Shutdown ordering corrected to: ExecService.shutdown() → agent.begin_shutdown() → drain bg_tasks (including join_network) → agent.shutdown(). Grace-await pattern fixed to await aborts on the timeout path too. |
| tests/server_inprocess.rs | Two new regression tests: a 3-cycle start/stop leak test and an immediate-shutdown-after-serve race test. Both are marked #[ignore] and run explicitly. |
| README.md | Documentation updated to reflect deterministic teardown, removing the old 'not yet fully deterministic' caveat and documenting remaining scope boundaries. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Server as serve_with_options
    participant ES as ExecService
    participant Agent as Agent
    participant BG as bg_tasks (join_network)
    participant TT as TrackedTasks registry

    Server->>ES: shutdown().await [step 0]
    Note over ES: cancel token → grace-await 3 loops → abort stragglers
    ES-->>Server: loops stopped

    Server->>Agent: begin_shutdown() [step 1]
    Note over Agent: cancel shutdown_token
    Agent->>TT: "closed = true"
    Agent-->>Server: done (sync)

    Server->>BG: grace-await 2s [step 2]
    Note over BG: join_network in-flight<br/>start_*() checks is_cancelled() → no-op<br/>spawn_tracked() checks closed → no-op
    BG-->>Server: all bg_tasks drained

    Server->>Agent: shutdown().await [step 3]
    Note over Agent: (idempotent) cancel token
    Agent->>Agent: stop heartbeat / reaper / DM-inbox / advert
    Agent->>TT: take handles (listeners, presence refresh, direct)
    Note over Agent: grace-await 3s tracked tasks → abort stragglers
    Agent->>Agent: presence.shutdown() → stop_beacons()
    Agent->>Agent: gossip.shutdown()
    Agent->>Agent: network.shutdown()
    Agent-->>Server: fully torn down
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Server as serve_with_options
    participant ES as ExecService
    participant Agent as Agent
    participant BG as bg_tasks (join_network)
    participant TT as TrackedTasks registry

    Server->>ES: shutdown().await [step 0]
    Note over ES: cancel token → grace-await 3 loops → abort stragglers
    ES-->>Server: loops stopped

    Server->>Agent: begin_shutdown() [step 1]
    Note over Agent: cancel shutdown_token
    Agent->>TT: "closed = true"
    Agent-->>Server: done (sync)

    Server->>BG: grace-await 2s [step 2]
    Note over BG: join_network in-flight<br/>start_*() checks is_cancelled() → no-op<br/>spawn_tracked() checks closed → no-op
    BG-->>Server: all bg_tasks drained

    Server->>Agent: shutdown().await [step 3]
    Note over Agent: (idempotent) cancel token
    Agent->>Agent: stop heartbeat / reaper / DM-inbox / advert
    Agent->>TT: take handles (listeners, presence refresh, direct)
    Note over Agent: grace-await 3s tracked tasks → abort stragglers
    Agent->>Agent: presence.shutdown() → stop_beacons()
    Agent->>Agent: gossip.shutdown()
    Agent->>Agent: network.shutdown()
    Agent-->>Server: fully torn down
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/exec/service.rs:146-151
The `if let Ok(...)` pattern silently discards all three `JoinHandle`s if `try_lock()` ever returns `Err`. Dropping a `JoinHandle` detaches the task — it keeps running but `shutdown()` would drain an empty `task_handles` Vec and never await or abort those loops. The comment correctly asserts this can't happen at construction time (no other Arc holder exists yet), so the invariant should be made loud with `expect()` rather than silently ignored.

```suggestion
        // Stash the handles so `shutdown()` can grace-await then abort them.
        // `try_lock` always succeeds here: this is the only access before the
        // service is shared, and the lock is uncontended at construction.
        service
            .task_handles
            .try_lock()
            .expect("task_handles uncontended at ExecService construction")
            .extend([inbound_handle, lifecycle_handle, idle_handle]);
```

### Issue 2 of 2
src/presence.rs:718-720
`stop_beacons()` failing during shutdown means the beacon task may not have been cleanly stopped (e.g. the upstream 5 s timeout fired and the task was merely detached). Logging that at `debug!` level makes it invisible in production unless verbose logging is enabled. Using `warn!` ensures the condition surfaces in normal log output, consistent with how straggler timeouts are logged elsewhere in the shutdown path.

```suggestion
        if let Err(e) = self.manager().stop_beacons().await {
            tracing::warn!("PresenceManager stop_beacons during shutdown: {e}");
        }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agent,exec): deterministic backgrou..."](https://github.com/saorsa-labs/x0x/commit/c59b27966288fe080d21e2d7d70b44f27632cdad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38821512)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->