### PR TITLE
fix(bootstrap): bound bootstrap dial with per-attempt timeout (#123, WS1.2)

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -7,7 +7,7 @@ use crate::error::{NetworkError, NetworkResult};
 use crate::network::NetworkNode;
 use std::net::SocketAddr;
 use std::time::Duration;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 
 /// Bootstrap configuration for connecting to initial peers.
 ///
@@ -22,6 +22,12 @@ pub struct BootstrapConfig {
     pub initial_backoff: Duration,
     /// Maximum backoff duration.
     pub max_backoff: Duration,
+    /// Per-attempt dial timeout (issue #123). Bounds each `connect_addr`
+    /// call so a black-holed bootstrap address fails fast and the retry
+    /// loop rotates to the next peer instead of stalling indefinitely.
+    /// Mirrors the timeout wrapper applied at every `connect_addr` /
+    /// `connect_cached_peer` call site in `lib.rs`.
+    pub dial_timeout: Duration,
 }
 
 impl Default for BootstrapConfig {
@@ -31,6 +37,7 @@ impl Default for BootstrapConfig {
             backoff_multiplier: 2.0,
             initial_backoff: Duration::from_millis(100),
             max_backoff: Duration::from_secs(5),
+            dial_timeout: Duration::from_secs(10),
         }
     }
 }
@@ -82,29 +89,57 @@ impl BootstrapConnector {
         let mut attempt = 0;
 
         loop {
-            match node.connect_addr(addr).await {
-                Ok(_peer_id) => {
+            // Issue #123: bound the dial. `connect_addr` has no reliable
+            // internal timeout (every lib.rs call site wraps it), so without
+            // this a single black-holed bootstrap address would stall the
+            // retry loop — the backoff `sleep` below only runs after a
+            // *returned* error. A timeout is treated as a retryable failure
+            // so the existing capped backoff proceeds to the next
+            // attempt/peer unchanged.
+            match timeout(self.config.dial_timeout, node.connect_addr(addr)).await {
+                Ok(Ok(_peer_id)) => {
                     return Ok(());
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     attempt += 1;
                     if attempt >= self.config.max_retries {
                         return Err(NetworkError::ConnectionFailed(format!(
-                            "Bootstrap connection failed after {} attempts: {}",
-                            attempt, e
+                            "Bootstrap connection to {addr} failed after {attempt} attempts: {e}"
                         )));
                     }
-
-                    // Apply exponential backoff
-                    sleep(backoff).await;
-                    backoff = std::cmp::min(
-                        Duration::from_secs_f64(
-                            backoff.as_secs_f64() * self.config.backoff_multiplier,
-                        ),
-                        self.config.max_backoff,
+                    tracing::debug!(
+                        target: "x0x::bootstrap",
+                        %addr,
+                        attempt,
+                        error = %e,
+                        "bootstrap dial failed; backing off"
+                    );
+                }
+                Err(_elapsed) => {
+                    attempt += 1;
+                    if attempt >= self.config.max_retries {
+                        return Err(NetworkError::ConnectionFailed(format!(
+                            "Bootstrap connection to {addr} timed out after {attempt} attempts \
+                             (dial timeout {:?})",
+                            self.config.dial_timeout
+                        )));
+                    }
+                    tracing::warn!(
+                        target: "x0x::bootstrap",
+                        %addr,
+                        attempt,
+                        dial_timeout = ?self.config.dial_timeout,
+                        "bootstrap dial timed out; backing off and retrying"
                     );
                 }
             }
+
+            // Apply exponential backoff (shared by both retryable outcomes).
+            sleep(backoff).await;
+            backoff = std::cmp::min(
+                Duration::from_secs_f64(backoff.as_secs_f64() * self.config.backoff_multiplier),
+                self.config.max_backoff,
+            );
         }
     }
 
@@ -159,6 +194,7 @@ mod tests {
         assert_eq!(config.backoff_multiplier, 2.0);
         assert_eq!(config.initial_backoff, Duration::from_millis(100));
         assert_eq!(config.max_backoff, Duration::from_secs(5));
+        assert_eq!(config.dial_timeout, Duration::from_secs(10));
     }
 
     #[test]
@@ -168,6 +204,7 @@ mod tests {
             backoff_multiplier: 1.5,
             initial_backoff: Duration::from_millis(50),
             max_backoff: Duration::from_secs(10),
+            dial_timeout: Duration::from_secs(10),
         };
         assert_eq!(config.max_retries, 5);
         assert_eq!(config.backoff_multiplier, 1.5);
@@ -186,6 +223,7 @@ mod tests {
             backoff_multiplier: 2.0,
             initial_backoff: Duration::from_millis(100),
             max_backoff: Duration::from_secs(5),
+            dial_timeout: Duration::from_secs(10),
         };
         let connector = BootstrapConnector::with_config(config.clone());
         assert_eq!(connector.config.max_retries, 2);
@@ -204,6 +242,7 @@ mod tests {
             backoff_multiplier: 2.0,
             initial_backoff: Duration::from_millis(100),
             max_backoff: Duration::from_secs(5),
+            dial_timeout: Duration::from_secs(10),
         };
 
         let mut backoff = config.initial_backoff;
@@ -229,6 +268,7 @@ mod tests {
             backoff_multiplier: 2.0,
             initial_backoff: Duration::from_millis(1000),
             max_backoff: Duration::from_secs(5),
+            dial_timeout: Duration::from_secs(10),
         };
 
         let mut backoff = config.initial_backoff;

--- a/tests/bootstrap_timeout.rs
+++ b/tests/bootstrap_timeout.rs
@@ -1,0 +1,59 @@
+#![allow(clippy::expect_used)]
+
+//! Bootstrap dial timeout — issue #123 / WS1.2.
+//!
+//! Proves `BootstrapConnector::connect_with_retry` bounds each dial with
+//! `dial_timeout` and advances through the capped backoff/retry loop instead
+//! of stalling on a black-holed address.
+//!
+//! The blackhole is a UDP socket bound on loopback: it absorbs the QUIC
+//! Initial packets the dial sends (so the kernel never returns ICMP
+//! port-unreachable) but never produces a QUIC handshake response, so the
+//! underlying `connect_addr` hangs until our timeout cuts it. Without the
+//! timeout wrapper added in #123, this test would hang for QUIC's far longer
+//! internal PTO and blow the wall-clock bound below.
+
+use std::net::UdpSocket;
+use std::time::{Duration, Instant};
+use x0x::bootstrap::{BootstrapConfig, BootstrapConnector};
+use x0x::network::{NetworkConfig, NetworkNode};
+
+#[tokio::test]
+async fn bootstrap_dial_timeout_is_bounded_and_advances() {
+    // Loopback blackhole: a socket that swallows QUIC Initials but never
+    // answers the handshake.
+    let blackhole = UdpSocket::bind("127.0.0.1:0").expect("bind blackhole socket");
+    let addr = blackhole.local_addr().expect("read blackhole local addr");
+
+    let network = NetworkNode::new(NetworkConfig::default(), None, None)
+        .await
+        .expect("create network node");
+
+    // Short dial timeout + a few retries with tiny backoff so the whole loop
+    // completes well under the bound even though each dial would otherwise hang.
+    let config = BootstrapConfig {
+        max_retries: 3,
+        backoff_multiplier: 1.0,
+        initial_backoff: Duration::from_millis(5),
+        max_backoff: Duration::from_millis(5),
+        dial_timeout: Duration::from_millis(150),
+    };
+
+    let start = Instant::now();
+    let result = BootstrapConnector::with_config(config)
+        .connect_with_retry(&network, addr)
+        .await;
+    let elapsed = start.elapsed();
+
+    // A black-holed dial must fail, never succeed.
+    assert!(result.is_err(), "black-holed bootstrap dial must fail");
+
+    // 3 attempts × 150 ms timeout + tiny backoff must stay well under this
+    // bound. If the per-attempt timeout wrapper were absent, a single hung
+    // attempt would stall the loop for QUIC's internal PTO (seconds) and this
+    // bound would be blown — which is exactly the regression #123 prevents.
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "bootstrap retry loop took {elapsed:?}; the dial timeout did not bound the attempts"
+    );
+}


### PR DESCRIPTION
## Summary

`BootstrapConnector::connect_with_retry` (`src/bootstrap.rs`) was the only dial site in the codebase **not** wrapped in `tokio::time::timeout`. `connect_addr` has no reliable internal timeout (all seven lib.rs call sites wrap it), so a single black-holed bootstrap address stalled the entire retry loop — the exponential-backoff `sleep` only runs after a *returned* error, so failover to the next peer never happened.

Fix: wrap each dial in `timeout(config.dial_timeout, …)` and treat the timeout as a retryable failure feeding the existing capped backoff (`max_retries=3`, backoff cap 5s).

**Issue:** #123 · **Plan section:** WS1.2 — *Timeout on bootstrap dial*

## Plan WS1.2 acceptance criteria

- [x] Bootstrap dial is bounded by an explicit timeout; timeout counts as a failed attempt feeding the existing capped backoff (max_retries=3, backoff cap 5s).
- [x] Test: a dial to a non-routable/blackhole address fails within the timeout and the loop proceeds to the next attempt/peer.
- [x] fmt / clippy (`-D warnings`) / nextest green.

## Design note (deviation flagged)

The plan suggested a `BOOTSTRAP_DIAL_TIMEOUT = 10s` constant. I implemented it as a `BootstrapConfig` field (`dial_timeout`, default `Duration::from_secs(10)`) instead. Reason: a bare `const` makes the timeout path untestable without a real 10s hang; a config field lets the test exercise the timeout with a short bound while every existing constructor keeps the 10s default. Same default value, same retry semantics — just injectable. The four in-module struct-literal constructions were updated to include the field.

## Test

New `tests/bootstrap_timeout.rs::bootstrap_dial_timeout_is_bounded_and_advances`: a UDP socket bound on loopback absorbs the QUIC Initials the dial sends (so no ICMP port-unreachable) but never answers the handshake — a deterministic blackhole. With a 150 ms / 3-retry config the loop completes in ~0.5 s and returns `Err`; without the timeout wrapper a single attempt would hang for QUIC's internal PTO and blow the wall-clock bound.

## Gates

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo nextest run --all-features --workspace` ✅ (one pre-existing flaky convergence test, `forged_member_joined_admin_role_or_secret_is_rejected` — documented in `ci.yml`/coverage as a gossip-convergence poll-counter flake — failed once under load and passes in isolation; unrelated to bootstrap.)

No `unwrap`/`expect`/`panic` in production code (the test file uses `expect` under `#![allow(clippy::expect_used)]`, matching `tests/network_timeout.rs`).

Closes #123.
EOF 2>&1 | tail -5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a per-attempt `dial_timeout` field to `BootstrapConfig` (default 10 s) and wraps each `connect_addr` call in `tokio::time::timeout`, fixing the only dial site in the codebase not bounded by an explicit timeout. Both timeout and ordinary connection failures now feed the same capped exponential-backoff path, and a new integration test verifies the loop completes within wall-clock bounds using a UDP blackhole.

- **`src/bootstrap.rs`**: adds `dial_timeout: Duration` to `BootstrapConfig`, wraps the dial in `timeout(self.config.dial_timeout, …)`, separates the `Ok(Ok)` / `Ok(Err)` / `Err(Elapsed)` match arms, and moves the backoff `sleep` outside the match so it is shared by both retryable outcomes — all four in-module struct literals updated.
- **`tests/bootstrap_timeout.rs`**: deterministic blackhole test (loopback UDP socket absorbs QUIC Initials, never answers the handshake) with a 150 ms / 3-retry config; asserts `Err` result and wall-clock < 3 s.
- **`docs/plans/…`**: new workplan document tracking the production-hardening and Tailnet Phase 1 workstreams.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is a focused, one-site fix that brings connect_with_retry in line with every other dial call in the codebase.

The retry-loop refactor is correct on all paths. Both retryable arms share the backoff logic correctly, the blackhole test is deterministic with adequate headroom, and no production panics are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/bootstrap.rs | Adds `dial_timeout` to `BootstrapConfig` and wraps each dial in `tokio::time::timeout`; backoff logic correctly moved outside the match so both error and elapsed arms share it. |
| tests/bootstrap_timeout.rs | Deterministic blackhole test using a bound `std::net::UdpSocket`; correctly proves both the `Err` outcome and the wall-clock bound with ~6x headroom. |
| docs/plans/2026-07-production-hardening-and-tailnet.md | New planning document covering Workstreams 1 and 2; no executable code. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(bootstrap): bound the bootstrap dial..."](https://github.com/saorsa-labs/x0x/commit/1c4b27d385485ff089c95bbf07f13fe257e05948) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41316991)</sub>

<!-- /greptile_comment -->