### PR TITLE
refactor(cli): replace dead unreachable!() arms with explicit errors (#129, WS1.8)

### DIFF
--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -1715,7 +1715,9 @@ async fn run(
                 commands::tasks::update(&client, &list_id, &task_id, "complete").await
             }
         },
-        Commands::Upgrade { .. } => unreachable!(),
+        Commands::Upgrade { .. } => {
+            anyhow::bail!("command dispatched earlier — dispatch table out of sync")
+        }
         Commands::Ws { sub } => match sub {
             None => commands::ws::general(&client).await,
             Some(WsSub::Sessions) => commands::ws::sessions(&client).await,
@@ -1752,7 +1754,9 @@ async fn run(
         | Commands::UserId { .. }
         | Commands::Start { .. }
         | Commands::Instances
-        | Commands::Autostart { .. } => unreachable!(),
+        | Commands::Autostart { .. } => {
+            anyhow::bail!("command dispatched earlier — dispatch table out of sync")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The only two compile-present panic sites in production code were `unreachable!()` exhaustiveness arms in `run()` (`src/bin/x0x.rs`), covering `Commands` variants that are dispatched by an early `return` in the same function's first match block. They are provably dead today, but a future refactor removing one early-return would silently turn an arm into a live panic (the #109 panic-scanner precedent: don't rely on dead code staying dead).

Replaced with `anyhow::bail!("command dispatched earlier — dispatch table out of sync")`, preserving exhaustiveness via the function's existing `anyhow::Result<()>` return type.

**Issue:** #129 · **Plan section:** WS1.8 — *Remove dead `unreachable!()` arms*

## Plan WS1.8 acceptance criteria

- [x] Zero `unreachable!()` in production code (`src/`, bins) — scanner-verifiable.
- [x] CLI behavior unchanged for all commands (existing CLI tests green).
- [x] fmt / clippy / nextest green.

## Verification

- `grep -rn 'unreachable!()' src/ src/bin/` → **no matches**.
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `parity_cli::every_endpoint_is_reachable_from_cli` + 262 CLI/routes/dispatch tests ✅

Closes #129.
EOF 2>&1 | tail -3

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces two `unreachable!()` exhaustiveness arms in `src/bin/x0x.rs` with `anyhow::bail!()` calls, converting potential silent panics into explicit errors. It also adds a comprehensive workplan document (`docs/plans/2026-07-production-hardening-and-tailnet.md`) for the team's production hardening and Tailnet Phase 1 effort.

- The two replaced arms cover `Commands::Upgrade` and the `Commands::UserId | Commands::Start | Commands::Instances | Commands::Autostart` group — all handled by early `return` in the preceding match block — so they are dead today but could become live in a future refactor.
- The workplan document (252 lines) describes two workstreams: 8 production-hardening tasks (WS1.1–WS1.9) and 8 Tailnet Phase 1 tasks (T1–T8), with sequencing, assignment, and acceptance criteria.

<h3>Confidence Score: 5/5</h3>

Tiny, isolated change to two exhaustiveness arms — no live code path is modified and the existing test suite covers all reachable variants.

Both changed arms are provably dead today because the preceding match block returns early for those variants. The substitution of anyhow::bail! preserves exhaustiveness without introducing any new behavior on the live paths. The workplan document is documentation only.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/bin/x0x.rs | Two unreachable!() arms in the second match command block replaced with anyhow::bail!() — minimal, correct change that converts provably-dead panic sites into propagating errors without altering any live code path. |
| docs/plans/2026-07-production-hardening-and-tailnet.md | New workplan document added; documentation-only, no executable code, no issues. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["run(command)"] --> B{"First match block\nno-daemon commands"}
    B -->|"Commands::Upgrade"| C["return upgrade::run()"]
    B -->|"Commands::UserId"| D["return user_id handler"]
    B -->|"Commands::Start"| E["return daemon::start()"]
    B -->|"Commands::Instances"| F["return daemon::instances()"]
    B -->|"Commands::Autostart"| G["return daemon::autostart()"]
    B -->|"_ => other"| H["DaemonClient::new()"]
    H --> I{"Second match block\ndaemon commands"}
    I -->|"Commands::Upgrade"| J["anyhow::bail!\nwas unreachable!()"]
    I -->|"UserId or Start\nor Instances\nor Autostart"| K["anyhow::bail!\nwas unreachable!()"]
    I -->|"all other commands"| L["execute with client"]
    style J fill:#ffcccc,stroke:#cc0000
    style K fill:#ffcccc,stroke:#cc0000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["run(command)"] --> B{"First match block\nno-daemon commands"}
    B -->|"Commands::Upgrade"| C["return upgrade::run()"]
    B -->|"Commands::UserId"| D["return user_id handler"]
    B -->|"Commands::Start"| E["return daemon::start()"]
    B -->|"Commands::Instances"| F["return daemon::instances()"]
    B -->|"Commands::Autostart"| G["return daemon::autostart()"]
    B -->|"_ => other"| H["DaemonClient::new()"]
    H --> I{"Second match block\ndaemon commands"}
    I -->|"Commands::Upgrade"| J["anyhow::bail!\nwas unreachable!()"]
    I -->|"UserId or Start\nor Instances\nor Autostart"| K["anyhow::bail!\nwas unreachable!()"]
    I -->|"all other commands"| L["execute with client"]
    style J fill:#ffcccc,stroke:#cc0000
    style K fill:#ffcccc,stroke:#cc0000
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(cli): replace dead unreachable!..."](https://github.com/saorsa-labs/x0x/commit/406e5b4d61928fdad316fff63361a2a5643a3047) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41317538)</sub>

<!-- /greptile_comment -->