### PR TITLE
fix(agent): track crdt/kv sync tasks with Agent shutdown (#126, WS1.5)

### DIFF
--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -129,11 +129,32 @@ impl TaskListSync {
     ///
     /// Returns an error if subscription startup fails.
     pub async fn start(&self) -> Result<()> {
+        self.start_with_spawner(|fut| {
+            tokio::spawn(fut);
+        })
+        .await
+    }
+
+    /// Start background synchronization with a caller-supplied spawner.
+    ///
+    /// Identical to [`start`](Self::start), but routes the background loops
+    /// (delta-merge listener, state-request responder, and the bounded
+    /// bootstrap requester) through `spawn` instead of detaching them with
+    /// `tokio::spawn`. The `Agent` passes its tracked-task spawner so these
+    /// loops are registered with the `Agent::shutdown()` drain and aborted on
+    /// teardown (issue #126); callers without an `Agent` use
+    /// [`start`](Self::start), which detaches via `tokio::spawn` as before.
+    pub async fn start_with_spawner<S>(&self, spawn: S) -> Result<()>
+    where
+        S: Fn(std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>)
+            + Send
+            + Sync,
+    {
         // Subscribe to topic — received messages will contain serialized deltas.
         let mut sub = self.pubsub.subscribe(self.topic.clone()).await;
         let task_list = Arc::clone(&self.task_list);
 
-        tokio::spawn(async move {
+        spawn(Box::pin(async move {
             while let Some(msg) = sub.recv().await {
                 match decode_delta::<TaskListDelta>(&msg.payload) {
                     Ok((peer_id, delta)) => {
@@ -147,7 +168,7 @@ impl TaskListSync {
                     }
                 }
             }
-        });
+        }));
 
         // Responder: holders with non-empty state answer StateRequests by
         // republishing their full state as a regular delta on the main topic.
@@ -159,7 +180,7 @@ impl TaskListSync {
         let responder_pubsub = Arc::clone(&self.pubsub);
         let responder_topic = self.topic.clone();
         let local_peer_id = self.local_peer_id;
-        tokio::spawn(async move {
+        spawn(Box::pin(async move {
             while let Some(msg) = sync_sub.recv().await {
                 let Ok(TaskListSyncMessage::StateRequest { requester }) =
                     bincode::deserialize::<TaskListSyncMessage>(&msg.payload)
@@ -186,7 +207,7 @@ impl TaskListSync {
                     tracing::warn!("TaskList state-response publish failed: {e}");
                 }
             }
-        });
+        }));
 
         // Bootstrap requester: a first-time joiner starts with an empty list
         // and has no other way to learn tasks written before it subscribed
@@ -198,7 +219,7 @@ impl TaskListSync {
         if self.task_list.read().await.task_count() == 0 {
             let requester_pubsub = Arc::clone(&self.pubsub);
             let sync_topic = self.state_sync_topic();
-            tokio::spawn(async move {
+            spawn(Box::pin(async move {
                 for delay_secs in STATE_REQUEST_RETRY_SECS {
                     tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
                     let request = TaskListSyncMessage::StateRequest {
@@ -214,7 +235,7 @@ impl TaskListSync {
                         tracing::debug!("TaskList state-request publish failed: {e}");
                     }
                 }
-            });
+            }));
         }
 
         Ok(())

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -89,10 +89,31 @@ impl KvStoreSync {
     /// bootstraps keys written before it joined. Without this, only
     /// deltas published *after* subscribing ever arrive.
     pub async fn start(&self) -> Result<()> {
+        self.start_with_spawner(|fut| {
+            tokio::spawn(fut);
+        })
+        .await
+    }
+
+    /// Start background synchronization with a caller-supplied spawner.
+    ///
+    /// Identical to [`start`](Self::start), but routes the background loops
+    /// (delta-merge listener, state-request responder, and the bounded
+    /// bootstrap requester) through `spawn` instead of detaching them with
+    /// `tokio::spawn`. The `Agent` passes its tracked-task spawner so these
+    /// loops are registered with the `Agent::shutdown()` drain and aborted on
+    /// teardown (issue #126); callers without an `Agent` use
+    /// [`start`](Self::start), which detaches via `tokio::spawn` as before.
+    pub async fn start_with_spawner<S>(&self, spawn: S) -> Result<()>
+    where
+        S: Fn(std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>)
+            + Send
+            + Sync,
+    {
         let mut sub = self.pubsub.subscribe(self.topic.clone()).await;
         let store = Arc::clone(&self.store);
 
-        tokio::spawn(async move {
+        spawn(Box::pin(async move {
             while let Some(msg) = sub.recv().await {
                 let decoded = decode_delta::<KvStoreDelta>(&msg.payload);
                 match decoded {
@@ -110,7 +131,7 @@ impl KvStoreSync {
                     }
                 }
             }
-        });
+        }));
 
         // Responder: holders with non-empty state answer StateRequests by
         // republishing their full state as a regular delta on the main
@@ -122,7 +143,7 @@ impl KvStoreSync {
         let responder_pubsub = Arc::clone(&self.pubsub);
         let responder_topic = self.topic.clone();
         let local_peer_id = self.local_peer_id;
-        tokio::spawn(async move {
+        spawn(Box::pin(async move {
             while let Some(msg) = sync_sub.recv().await {
                 let Ok(KvSyncMessage::StateRequest { requester }) =
                     bincode::deserialize::<KvSyncMessage>(&msg.payload)
@@ -149,7 +170,7 @@ impl KvStoreSync {
                     tracing::warn!("KvStore state-response publish failed: {e}");
                 }
             }
-        });
+        }));
 
         // Bootstrap requester: a first-time joiner starts with an empty
         // store and has no other way to learn keys written before it
@@ -165,7 +186,7 @@ impl KvStoreSync {
         if self.store.read().await.is_empty() {
             let requester_pubsub = Arc::clone(&self.pubsub);
             let sync_topic = self.state_sync_topic();
-            tokio::spawn(async move {
+            spawn(Box::pin(async move {
                 for delay_secs in STATE_REQUEST_RETRY_SECS {
                     tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
                     let request = KvSyncMessage::StateRequest {
@@ -181,7 +202,7 @@ impl KvStoreSync {
                         tracing::debug!("KvStore state-request publish failed: {e}");
                     }
                 }
-            });
+            }));
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7670,12 +7670,14 @@ impl Agent {
         })?;
 
         let sync = std::sync::Arc::new(sync);
-        sync.start().await.map_err(|e| {
-            error::IdentityError::Storage(std::io::Error::other(format!(
-                "task list sync start failed: {}",
-                e
-            )))
-        })?;
+        sync.start_with_spawner(|fut| self.spawn_tracked(fut))
+            .await
+            .map_err(|e| {
+                error::IdentityError::Storage(std::io::Error::other(format!(
+                    "task list sync start failed: {}",
+                    e
+                )))
+            })?;
 
         Ok(TaskListHandle {
             sync,
@@ -7732,12 +7734,14 @@ impl Agent {
         })?;
 
         let sync = std::sync::Arc::new(sync);
-        sync.start().await.map_err(|e| {
-            error::IdentityError::Storage(std::io::Error::other(format!(
-                "task list sync start failed: {}",
-                e
-            )))
-        })?;
+        sync.start_with_spawner(|fut| self.spawn_tracked(fut))
+            .await
+            .map_err(|e| {
+                error::IdentityError::Storage(std::io::Error::other(format!(
+                    "task list sync start failed: {}",
+                    e
+                )))
+            })?;
 
         Ok(TaskListHandle {
             sync,
@@ -8572,11 +8576,13 @@ impl Agent {
         })?;
 
         let sync = std::sync::Arc::new(sync);
-        sync.start().await.map_err(|e| {
-            error::IdentityError::Storage(std::io::Error::other(format!(
-                "kv store sync start failed: {e}",
-            )))
-        })?;
+        sync.start_with_spawner(|fut| self.spawn_tracked(fut))
+            .await
+            .map_err(|e| {
+                error::IdentityError::Storage(std::io::Error::other(format!(
+                    "kv store sync start failed: {e}",
+                )))
+            })?;
 
         Ok(KvStoreHandle {
             sync,
@@ -8627,11 +8633,13 @@ impl Agent {
         })?;
 
         let sync = std::sync::Arc::new(sync);
-        sync.start().await.map_err(|e| {
-            error::IdentityError::Storage(std::io::Error::other(format!(
-                "kv store sync start failed: {e}",
-            )))
-        })?;
+        sync.start_with_spawner(|fut| self.spawn_tracked(fut))
+            .await
+            .map_err(|e| {
+                error::IdentityError::Storage(std::io::Error::other(format!(
+                    "kv store sync start failed: {e}",
+                )))
+            })?;
 
         Ok(KvStoreHandle {
             sync,
@@ -9353,6 +9361,82 @@ mod tests {
         agent.shutdown().await;
         assert!(agent.heartbeat_handle.lock().await.is_none());
         assert!(dropped.load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    /// Issue #126 / WS1.5: the delta-merge + state-request subscription loops
+    /// spawned by `create_kv_store` / `create_task_list` must be routed through
+    /// `spawn_tracked` so `Agent::shutdown()` drains and aborts them. Previously
+    /// they detached via bare `tokio::spawn` and only ended when the gossip
+    /// runtime later dropped its topic sender.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn shutdown_drains_crdt_kv_sync_tasks() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("agent");
+
+        // Build() constructs the gossip runtime, so creating a store + a list
+        // works without join_network. Each creation spawns the delta-merge and
+        // state-request subscription loops (plus a bounded bootstrap requester
+        // for an empty store/list).
+        let baseline = agent
+            .tracked_tasks
+            .lock()
+            .expect("tracked_tasks")
+            .handles
+            .len();
+
+        agent
+            .create_kv_store("ws15-store", "ws15-store-topic")
+            .await
+            .expect("create kv store");
+        agent
+            .create_task_list("ws15-list", "ws15-list-topic")
+            .await
+            .expect("create task list");
+
+        // The loops must now be registered with spawn_tracked. With the old bare
+        // tokio::spawn this count would NOT have moved.
+        let (registered, abort_handles): (usize, Vec<tokio::task::AbortHandle>) = {
+            let guard = agent.tracked_tasks.lock().expect("tracked_tasks");
+            let aborts = guard.handles.iter().map(|h| h.abort_handle()).collect();
+            (guard.handles.len(), aborts)
+        };
+        assert!(
+            registered > baseline,
+            "CRDT/KV sync loops must register with spawn_tracked \
+             (registry {registered}, baseline {baseline})"
+        );
+
+        agent.shutdown().await;
+
+        // shutdown() closes the registry and drains it (handles taken, grace-
+        // awaited, stragglers aborted).
+        let after = agent.tracked_tasks.lock().expect("tracked_tasks");
+        assert!(
+            after.closed,
+            "tracked-task registry must be closed after shutdown"
+        );
+        assert!(
+            after.handles.is_empty(),
+            "tracked-task registry must be drained after shutdown ({} left)",
+            after.handles.len()
+        );
+        drop(after);
+
+        // Every formerly-tracked sync loop terminated.
+        for handle in &abort_handles {
+            assert!(
+                handle.is_finished(),
+                "a CRDT/KV sync task did not terminate after shutdown"
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
## Summary

`TaskListSync::start` / `KvStoreSync::start` spawned their long-lived subscription loops (delta-merge listener + state-request responder) with bare `tokio::spawn` and dropped the JoinHandles. They were registered in **neither** the Agent's `spawn_tracked` registry nor the server `bg_tasks` vector, so `Agent::shutdown()` never aborted them — they only ended when the gossip runtime later dropped the topic sender. This was the one class of background task outside the otherwise-thorough (issue-#116-hardened) shutdown path, leaking per store/list — risky for embedded `serve()` (#110) restart-in-process scenarios.

**Fix:** add `start_with_spawner(spawn)` to both sync types, routing the background loops through a caller-supplied spawner instead of detaching via `tokio::spawn`. The four Agent-owned call sites (`create_task_list`, `join_task_list`, `create_kv_store`, `join_kv_store`) now pass `|fut| self.spawn_tracked(fut)`, so the loops land in the tracked registry and are drained + aborted by `Agent::shutdown()`.

**Issue:** #126 · **Plan section:** WS1.5 — *Track crdt/kv sync tasks in shutdown*

## Plan WS1.5 acceptance criteria

- [x] All four spawn sites tracked and aborted on `Agent::shutdown()`.
- [x] Test: create store/list, shut agent down, assert the subscription tasks terminate.
- [x] fmt / clippy / nextest green.

## Mechanism choice (per plan Rule 8)

The plan preferred `spawn_tracked` (Agent-owned) with a fallback to owned handles if the dependency direction was awkward. `spawn_tracked` worked cleanly: the four call sites are all `&self` methods on `Agent` with `spawn_tracked` in scope, so I added a `start_with_spawner<S>(spawn: S)` seam to the sync types and passed `|fut| self.spawn_tracked(fut)` from each Agent call site. `start()` is preserved (delegates via `tokio::spawn`) for non-Agent callers.

## Test

`shutdown_drains_crdt_kv_sync_tasks` (`src/lib.rs` test module — can observe the private `tracked_tasks` registry): build an agent, create a kv store + task list, **assert the registry grew** (proving the spawns went through `spawn_tracked` — they would not have with bare `tokio::spawn`), shut down, then assert the registry is `closed` + `handles` empty and every formerly-tracked sync loop reports terminated via `AbortHandle::is_finished()`.

## Gates

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- 170 crdt/kv/sync/shutdown tests ✅ including the new `shutdown_drains_crdt_kv_sync_tasks`.

No `unwrap`/`expect`/`panic` added to production code (the sync structs use no panicking APIs; the `Box::pin` + trait-object spawner is panic-free).

Closes #126.
EOF 2>&1 | tail -3

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes #126 (WS1.5) by routing the long-lived delta-merge and state-request subscription loops in `TaskListSync` and `KvStoreSync` through `Agent::spawn_tracked` instead of detaching them with bare `tokio::spawn`. Previously these loops fell outside the shutdown drain, leaving up to three untracked tasks per store/list that only terminated when the gossip runtime dropped its topic sender.

- Adds `start_with_spawner<S>(spawn: S)` to both sync types; `start()` delegates through it with a `tokio::spawn` wrapper, preserving the non-Agent API unchanged.
- All four `Agent` call sites (`create_task_list`, `join_task_list`, `create_kv_store`, `join_kv_store`) now pass `|fut| self.spawn_tracked(fut)`, placing the loops in the tracked registry so `Agent::shutdown()` drains and aborts them.
- Adds `shutdown_drains_crdt_kv_sync_tasks` test that verifies the registry grows after store/list creation and is fully drained and closed after `shutdown()`.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge. It closes a real gap in the shutdown path by routing all four previously-untracked sync loops through spawn_tracked, and the new test verifies both registration and teardown end-to-end.

The implementation is mechanically correct and symmetric across both sync types. The only finding is an overly tight Sync bound on the spawner type parameter in both start_with_spawner methods — the bound is not needed since the closure is called sequentially, never shared across threads, and it makes the API unnecessarily restrictive for future non-Agent callers. All current call sites satisfy it, so there is no runtime impact today.

The Sync bound in src/crdt/sync.rs and src/kv/sync.rs is the only item worth a second look before merge.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/crdt/sync.rs | Adds start_with_spawner to TaskListSync; start() delegates through it. All three spawn sites converted. The Sync bound on the spawner type parameter is unnecessary (spawner is called sequentially, never shared across threads). |
| src/kv/sync.rs | Mirrors the crdt/sync.rs change for KvStoreSync. Same start_with_spawner pattern, same unnecessary Sync bound on the spawner. |
| src/lib.rs | Four Agent call sites updated from sync.start() to sync.start_with_spawner(|fut| self.spawn_tracked(fut)). New shutdown_drains_crdt_kv_sync_tasks test verifies registry growth and full drain. Changes are mechanical and correct. |
| docs/plans/2026-07-production-hardening-and-tailnet.md | New workplan document; doc-only addition, no code impact. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent
    participant SyncType as TaskListSync/KvStoreSync
    participant TrackedRegistry
    participant SyncLoop

    Note over Agent: create_kv_store / join_kv_store
    Note over Agent: create_task_list / join_task_list

    Agent->>SyncType: "start_with_spawner(|fut| self.spawn_tracked(fut))"
    SyncType->>TrackedRegistry: spawn_tracked(delta-merge loop)
    TrackedRegistry-->>SyncLoop: tokio::spawn → JoinHandle stored
    SyncType->>TrackedRegistry: spawn_tracked(state-request responder)
    TrackedRegistry-->>SyncLoop: tokio::spawn → JoinHandle stored
    SyncType->>TrackedRegistry: spawn_tracked(bootstrap requester) [if empty]
    TrackedRegistry-->>SyncLoop: tokio::spawn → JoinHandle stored

    Note over Agent: Agent::shutdown()
    Agent->>TrackedRegistry: close registry + drain handles
    TrackedRegistry->>SyncLoop: abort / await grace period
    SyncLoop-->>TrackedRegistry: finished
    TrackedRegistry-->>Agent: all handles drained
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent
    participant SyncType as TaskListSync/KvStoreSync
    participant TrackedRegistry
    participant SyncLoop

    Note over Agent: create_kv_store / join_kv_store
    Note over Agent: create_task_list / join_task_list

    Agent->>SyncType: "start_with_spawner(|fut| self.spawn_tracked(fut))"
    SyncType->>TrackedRegistry: spawn_tracked(delta-merge loop)
    TrackedRegistry-->>SyncLoop: tokio::spawn → JoinHandle stored
    SyncType->>TrackedRegistry: spawn_tracked(state-request responder)
    TrackedRegistry-->>SyncLoop: tokio::spawn → JoinHandle stored
    SyncType->>TrackedRegistry: spawn_tracked(bootstrap requester) [if empty]
    TrackedRegistry-->>SyncLoop: tokio::spawn → JoinHandle stored

    Note over Agent: Agent::shutdown()
    Agent->>TrackedRegistry: close registry + drain handles
    TrackedRegistry->>SyncLoop: abort / await grace period
    SyncLoop-->>TrackedRegistry: finished
    TrackedRegistry-->>Agent: all handles drained
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/crdt/sync.rs:148-154
The `Sync` bound on the spawner is unnecessary. `start_with_spawner` calls `spawn` sequentially — there is no concurrent sharing of the closure across threads — so `Fn(...) + Send` is sufficient. Requiring `Sync` unnecessarily restricts callers whose spawner captures non-`Sync` interior-mutable state (e.g. `Cell<...>`). The `kv/sync.rs` counterpart has the same issue.

```suggestion
    where
        S: Fn(std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>)
            + Send,
    {
        // Subscribe to topic — received messages will contain serialized deltas.
        let mut sub = self.pubsub.subscribe(self.topic.clone()).await;
```

### Issue 2 of 2
src/kv/sync.rs:108-113
Same unnecessary `Sync` bound as in `crdt/sync.rs` — dropping it makes the API consistent and equally permissive for future callers.

```suggestion
    where
        S: Fn(std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>)
            + Send,
    {
        let mut sub = self.pubsub.subscribe(self.topic.clone()).await;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): track crdt/kv sync tasks wit..."](https://github.com/saorsa-labs/x0x/commit/be43bfa7d394a0bd321112685ba1b9bd644065ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41319854)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->