### PR TITLE
feat(api): domain-separated POST /agent/sign with external DST (#133, WS1.9)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -119,31 +119,35 @@ is enabled. This is the discovery half of A2A interop — see
 
 ```json
 {
-  "payload_b64": "<base64 bytes to sign>",
-  "domain": "my-protocol.v1.register"
+  "context": "x0x-symphony-handoff-v1",
+  "payload_b64": "<base64 bytes to sign>"
 }
 ```
 
 Notes:
-- `payload_b64` is decoded and signed verbatim (max 256 KiB). Callers
-  canonicalize structured payloads themselves.
-- `domain` is optional. When present, the daemon signs
-  `domain || 0x00 || payload` and echoes `domain` in the response, so a
-  signature for one protocol context cannot be replayed in another.
-  Domains must be non-empty, NUL-free, and at most 1024 bytes.
-  `x0x.<purpose>.<version>` is the conventional shape for x0x protocols.
+- `context` is **required** (issue #133): a caller-chosen ASCII string
+  matching `[a-z0-9._-]{1,64}` naming the application protocol the
+  signature is bound to. The daemon signs the length-prefixed external DST
+  `[0xF0] | b"x0x.external-agent-sign.v1" | len(context):u32 BE | context | payload`,
+  provably disjoint from every internal x0x signing input (announcements,
+  group commits, certificates, …). A denylist rejects `context` strings
+  naming internal signing domains. There is no raw-payload signing path.
+- `payload_b64` is decoded and signed verbatim under the DST (max 64 KiB —
+  external signing is for hashes/manifests, not blobs). Callers canonicalize
+  structured payloads themselves.
 - Response: `ok`, `agent_id` (hex), `public_key_b64`, `signature_b64`,
-  `algorithm` (`x0x.agent-sign.v1.ml-dsa-65`), and `domain` when supplied.
+  `context` (echoed), and `algorithm` (`x0x.agent-sign.v2.ml-dsa-65`).
+- `400` for an invalid/denied `context`; `413` over the 64 KiB cap.
 
 ### Verify request body
 
 ```json
 {
+  "context": "x0x-symphony-handoff-v1",
   "payload_b64": "<base64 payload bytes>",
   "signature_b64": "<base64 detached ML-DSA-65 signature>",
   "public_key_b64": "<base64 ML-DSA-65 public key>",
-  "domain": "my-protocol.v1.register",
-  "algorithm": "x0x.agent-sign.v1.ml-dsa-65"
+  "algorithm": "x0x.agent-sign.v2.ml-dsa-65"
 }
 ```
 
@@ -151,19 +155,18 @@ Notes:
 - Stateless: verification uses only the caller-supplied public material —
   no key access, no identity state. The counterpart to `/agent/sign` for
   applications reading signed records back from disk or distributed
-  storage.
+  storage. `context` is **required** and must match the value used at
+  signing time — verification reconstructs the same external DST.
 - A failed signature check is a **result, not an error**: the response is
-  `200` with `{ "ok": true, "valid": false, "algorithm": "x0x.agent-sign.v1.ml-dsa-65" }`.
+  `200` with `{ "ok": true, "valid": false, "algorithm": "x0x.agent-sign.v2.ml-dsa-65" }`.
 - `400` is reserved for malformed input: bad base64 in any field, empty
   payload, a public key that is not exactly 1952 bytes, a signature that
-  is not exactly 3309 bytes, an invalid `domain` (empty, NUL bytes, or
-  over 1024 bytes), or an unknown `algorithm`. `413` for payloads over
-  the 256 KiB cap. Limits mirror `/agent/sign` exactly.
-- `domain` is optional and must match the value used at signing time:
-  verification is then performed over `domain || 0x00 || payload`.
+  is not exactly 3309 bytes, an invalid/denied `context`, or an unknown
+  `algorithm`. `413` for payloads over the 64 KiB cap. Limits mirror
+  `/agent/sign` exactly.
 - `algorithm` is optional; when the field is present — including as JSON
   null — it must be the exact scheme string
-  `x0x.agent-sign.v1.ml-dsa-65`, so any future scheme migration is
+  `x0x.agent-sign.v2.ml-dsa-65`, so any future scheme migration is
   explicit rather than silent.
 - Response: `ok`, `valid` (boolean), `algorithm`.
 

--- a/docs/design/x0x-transport-protocol-id.md
+++ b/docs/design/x0x-transport-protocol-id.md
@@ -117,10 +117,15 @@ This is x0x's answer to "who runs this agent" without a registry record.
 
 ### 4.4. Detached Signature Verification
 
-x0x exposes a stateless signature primitive (`POST /agent/verify`):
-`algorithm = "x0x.agent-sign.v1.ml-dsa-65"`, domain framing `domain || 0x00 || payload`.
-This is the building block any application uses to verify an agent's claims
-offline.
+x0x exposes stateless signature primitives: `POST /agent/sign` (issue #133)
+and `POST /agent/verify`. Both use the `v2` scheme
+(`algorithm = "x0x.agent-sign.v2.ml-dsa-65"`) over a length-prefixed external
+domain-separation tag
+`[0xF0] | b"x0x.external-agent-sign.v1" | len(context):u32 BE | context | payload`,
+which is provably disjoint from every internal x0x signing input (see
+`src/api/agent_signing.rs`). The caller supplies a required `context` string
+(`[a-z0-9._-]{1,64}`). This is the building block any application uses to sign
+and verify an agent's claims offline.
 
 ## 5. Addressing (vs Pilot §4)
 

--- a/src/api/agent_signing.rs
+++ b/src/api/agent_signing.rs
@@ -1,0 +1,281 @@
+//! Domain-separated external signing for `POST /agent/sign` (issue #133 / WS1.9).
+//!
+//! x0x-symphony and other REST-only consumers need the daemon to sign payloads
+//! with its ML-DSA-65 key *without ever touching key material*. The signing
+//! half of that primitive must be domain-separated from every internal x0x
+//! signing input so a caller can never trick the daemon into producing a
+//! signature that doubles as a valid protocol message (an announcement, a group
+//! commit, a certificate, …). This module owns the canonical-bytes construction
+//! and the context-validation policy shared by the `agent_sign` and
+//! `agent_verify` handlers.
+//!
+//! # Canonical bytes (the external DST)
+//!
+//! A signature is computed over
+//!
+//! ```text
+//! [0xF0] || b"x0x.external-agent-sign.v1" || context_len(u32 BE) || context || payload
+//! ```
+//!
+//! * `0xF0` — a reserved namespace tag that no internal signing input begins
+//!   with (see "Disjointness" below).
+//! * `b"x0x.external-agent-sign.v1"` — an ASCII magic pinning the DST
+//!   *layout* version (`v1` = first version of this byte layout), itself
+//!   unmistakably external. This is a *different* axis from [`SCHEME_ID`]'s
+//!   `.v2`, which pins the API-envelope version (see below).
+//! * `context_len(u32 BE)` — a length prefix for `context`, so the
+//!   `context || payload` boundary is unambiguous and no `(context, payload)`
+//!   pair can collide with another regardless of byte values. (This is why a
+//!   NUL separator alone is insufficient: a payload containing the separator
+//!   could be smuggled across the boundary.)
+//! * `context` — a required, validated caller-chosen ASCII string
+//!   (`[a-z0-9._-]{1,64}`, e.g. `"x0x-symphony-handoff-v1"`) naming the
+//!   application protocol the signature is bound to.
+//! * `payload` — the caller's bytes, taken verbatim.
+//!
+//! # Disjointness from internal signing domains
+//!
+//! Every internal x0x signing input is a serialization of a *structured*
+//! record (bincode/postcard/JSON of typed fields) and **none** begins with the
+//! `[0xF0] || b"x0x.external-agent-sign.v1"` prologue. Concretely the internal
+//! domains (audited at the time of this change) are:
+//!
+//! | Internal domain | Format | Where |
+//! |---|---|---|
+//! | `UserAnnouncement` | bincode(unsigned fields) | `lib.rs` `sign` |
+//! | `AgentCertificate` | bincode | `identity` |
+//! | group commit / public message | structured `signable_bytes` | `groups/public_message.rs` |
+//! | direct message | postcard `signed_bytes` | `dm.rs`, `dm_capability.rs` |
+//! | gossip frame | `signing_payload` | `gossip/pubsub.rs` |
+//! | a2a `AgentCard` | structured | `a2a`, `groups/card.rs` |
+//! | upgrade manifest | binary manifest | `upgrade/signature.rs` |
+//! | peer-relay record | `signing_bytes` | `peer_relay.rs` |
+//!
+//! A caller-supplied `payload` is therefore *provably* unable to impersonate
+//! any of these: even if a caller supplied bytes that happened to match an
+//! internal record's serialization, the daemon would sign
+//! `[0xF0]|magic|len|context|<those bytes>`, which is not the bytes any
+//! internal verifier checks. The `0xF0` tag makes the leading byte alone a
+//! sufficient witness of the external namespace.
+//!
+//! On top of this structural guarantee, [`INTERNAL_CONTEXT_DENYLIST`] rejects
+//! caller-chosen `context` strings that name internal domains — defense in
+//! depth against a caller asking for `context = "announcement"` and then
+//! claiming the result is an internal signature.
+
+/// Reserved leading byte marking the external-signing namespace. No internal
+/// signing input begins with this byte (see the module-level disjointness
+/// note).
+pub const NAMESPACE_TAG: u8 = 0xF0;
+
+/// ASCII magic pinning the external-signing **canonical-bytes (DST) layout**
+/// version — `v1` is the first (and current) version of the
+/// `[0xF0] | magic | len | context | payload` byte layout. This is a
+/// *different* versioning axis from [`SCHEME_ID`]'s `.v2`, which pins the
+/// API-envelope version (the wire scheme advertised in responses / accepted
+/// in the `algorithm` field). The two are intentionally independent: the DST
+/// layout can stay at `v1` while the API scheme advances, and vice versa.
+pub const MAGIC: &[u8] = b"x0x.external-agent-sign.v1";
+
+/// Stable scheme identifier advertised in sign responses and accepted by
+/// verify. `v2` pins the **API-envelope** version (issue #133's
+/// mandatory-context DST); the pre-#133 `v1` scheme signed optional
+/// `domain || 0x00 || payload` (or raw payload) and is **not** produced by
+/// this implementation. This is a different axis from [`MAGIC`]'s `.v1`,
+/// which pins the canonical-bytes DST *layout* version.
+pub const SCHEME_ID: &str = "x0x.agent-sign.v2.ml-dsa-65";
+
+/// Maximum signed/verified payload size (64 KiB). External signing is for
+/// hashes, manifests, and audit records — not blobs.
+pub const MAX_PAYLOAD_BYTES: usize = 64 * 1024;
+
+/// Maximum length of a `context` string.
+pub const MAX_CONTEXT_LEN: usize = 64;
+
+/// Caller-chosen `context` strings that name internal x0x signing domains.
+/// Rejected even though the namespace tag already guarantees disjointness —
+/// defense in depth so a caller can never frame an external signature as an
+/// internal one. Keep lowercase; matching is exact.
+pub const INTERNAL_CONTEXT_DENYLIST: &[&str] = &[
+    "announcement",
+    "user-announcement",
+    "certificate",
+    "agent-certificate",
+    "group-commit",
+    "group-message",
+    "treekem",
+    "dm",
+    "direct-message",
+    "gossip",
+    "gossip-frame",
+    "a2a-card",
+    "agent-card",
+    "upgrade",
+    "upgrade-manifest",
+    "relay",
+    "peer-relay",
+];
+
+/// A `context` failed validation.
+#[derive(Debug)]
+pub struct ContextError(pub &'static str);
+
+impl std::fmt::Display for ContextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for ContextError {}
+
+/// Validate a caller-supplied `context`.
+///
+/// Accepted iff it matches `^[a-z0-9._-]{1,64}$` and is not in
+/// [`INTERNAL_CONTEXT_DENYLIST`].
+///
+/// # Errors
+///
+/// Returns [`ContextError`] describing the first failed check.
+pub fn validate_context(context: &str) -> Result<(), ContextError> {
+    if context.is_empty() {
+        return Err(ContextError("context must be non-empty"));
+    }
+    if context.len() > MAX_CONTEXT_LEN {
+        return Err(ContextError("context exceeds maximum length"));
+    }
+    if !context.bytes().all(|b| {
+        b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'.' || b == b'_' || b == b'-'
+    }) {
+        return Err(ContextError(
+            "context must match [a-z0-9._-] (lowercase ASCII, digits, dot, underscore, hyphen)",
+        ));
+    }
+    if INTERNAL_CONTEXT_DENYLIST.contains(&context) {
+        return Err(ContextError(
+            "context is reserved for an internal x0x signing domain",
+        ));
+    }
+    Ok(())
+}
+
+/// Assemble the canonical signing/verification buffer
+/// `[NAMESPACE_TAG] || MAGIC || context_len(u32 BE) || context || payload`.
+///
+/// `context` **must** have been validated by [`validate_context`]; this function
+/// does not re-validate (it is also used by the verifier, which trusts the
+/// caller-supplied context only after the handler has validated it).
+#[must_use]
+pub fn assemble_buffer(context: &str, payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(1 + MAGIC.len() + 4 + context.len() + payload.len());
+    buf.push(NAMESPACE_TAG);
+    buf.extend_from_slice(MAGIC);
+    // u32 big-endian length prefix → unambiguous context/payload boundary.
+    let len = u32::try_from(context.len()).unwrap_or(u32::MAX);
+    buf.extend_from_slice(&len.to_be_bytes());
+    buf.extend_from_slice(context.as_bytes());
+    buf.extend_from_slice(payload);
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_contexts_accepted() {
+        for c in [
+            "x0x-symphony-handoff-v1",
+            "audit.log.v2",
+            "a",
+            "foo_bar-baz.qux",
+            "0123456789",
+            &"x".repeat(MAX_CONTEXT_LEN),
+        ] {
+            assert!(
+                validate_context(c).is_ok(),
+                "context {c:?} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_contexts_rejected() {
+        // empty
+        assert!(validate_context("").is_err());
+        // too long
+        assert!(validate_context(&"x".repeat(MAX_CONTEXT_LEN + 1)).is_err());
+        // wrong characters / case
+        for c in [
+            "Has Space",
+            "UPPER",
+            "with/slash",
+            "embedded\u{0}nul",
+            "punctuation!",
+            "café",
+            "x0x handoff",
+        ] {
+            assert!(
+                validate_context(c).is_err(),
+                "context {c:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn internal_context_denylist_rejected() {
+        for c in INTERNAL_CONTEXT_DENYLIST {
+            assert!(
+                validate_context(c).is_err(),
+                "internal context {c:?} must be denied"
+            );
+        }
+        // a near-miss that is NOT on the denylist is fine.
+        assert!(validate_context("announcement-v2-external").is_ok());
+    }
+
+    #[test]
+    fn assemble_buffer_is_length_prefixed_and_disjoint() {
+        let a = assemble_buffer("ctx", b"payload");
+        // Leading namespace tag + magic.
+        assert_eq!(a[0], NAMESPACE_TAG);
+        assert_eq!(&a[1..1 + MAGIC.len()], MAGIC);
+        // u32 BE context length == 3.
+        let len = u32::from_be_bytes([
+            a[1 + MAGIC.len()],
+            a[2 + MAGIC.len()],
+            a[3 + MAGIC.len()],
+            a[4 + MAGIC.len()],
+        ]);
+        assert_eq!(len as usize, "ctx".len());
+    }
+
+    #[test]
+    fn no_context_payload_collision_across_pairs() {
+        // The length prefix guarantees (ctx1||p1) and (ctx2||p2) produce
+        // distinct buffers even when ctx1+ p1 == ctx2 + p2 as raw bytes.
+        let left = assemble_buffer("ab", b"cd");
+        let right = assemble_buffer("abc", b"d");
+        assert_ne!(
+            left, right,
+            "length-prefixed framing must distinguish (ab,cd) from (abc,d)"
+        );
+    }
+
+    #[test]
+    fn external_buffer_cannot_be_a_valid_internal_prefix() {
+        // No internal signing input begins with the external prologue: the
+        // 0xF0 tag alone is a sufficient witness. This test pins that
+        // invariant so a future internal format that happens to start with
+        // 0xF0 is caught here.
+        let buf = assemble_buffer("any.context", b"");
+        assert_eq!(buf[0], NAMESPACE_TAG);
+        assert!(buf.starts_with(&[NAMESPACE_TAG]));
+        assert!(buf.starts_with(
+            &[NAMESPACE_TAG]
+                .iter()
+                .copied()
+                .chain(MAGIC.iter().copied())
+                .collect::<Vec<_>>()
+        ));
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,6 +3,8 @@
 //! Both `x0xd` (the daemon) and `x0x` (the CLI) consume this registry,
 //! ensuring routes and CLI commands never drift out of sync.
 
+pub mod agent_signing;
+
 /// HTTP method for an endpoint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Method {

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -342,9 +342,12 @@ enum AgentSub {
         /// Base64-encoded bytes to sign.
         #[arg(long)]
         payload_b64: Option<String>,
-        /// Optional domain-separation string; signs `domain || 0x00 || payload`.
+        /// Required domain-separation context (e.g.
+        /// `x0x-symphony-handoff-v1`). The daemon signs the external DST
+        /// `[0xF0]|magic|len|context|payload`, disjoint from every internal
+        /// x0x signing input (issue #133). Must match `[a-z0-9._-]{1,64}`.
         #[arg(long)]
-        domain: Option<String>,
+        context: String,
     },
     /// Verify a detached ML-DSA-65 signature against a caller-supplied
     /// public key. Pass either `--file <PATH>` (use `-` for stdin) or
@@ -363,9 +366,9 @@ enum AgentSub {
         /// Base64-encoded ML-DSA-65 public key (1952 bytes decoded).
         #[arg(long)]
         public_key_b64: String,
-        /// Optional domain-separation string; verifies `domain || 0x00 || payload`.
+        /// Required domain-separation context the signature was produced with.
         #[arg(long)]
-        domain: Option<String>,
+        context: String,
     },
 }
 
@@ -1268,22 +1271,17 @@ async fn run(
             Some(AgentSub::Sign {
                 file,
                 payload_b64,
-                domain,
+                context,
             }) => {
-                commands::identity::sign(
-                    &client,
-                    file.as_deref(),
-                    payload_b64.as_deref(),
-                    domain.as_deref(),
-                )
-                .await
+                commands::identity::sign(&client, file.as_deref(), payload_b64.as_deref(), &context)
+                    .await
             }
             Some(AgentSub::Verify {
                 file,
                 payload_b64,
                 signature_b64,
                 public_key_b64,
-                domain,
+                context,
             }) => {
                 commands::identity::verify(
                     &client,
@@ -1291,7 +1289,7 @@ async fn run(
                     payload_b64.as_deref(),
                     &signature_b64,
                     &public_key_b64,
-                    domain.as_deref(),
+                    &context,
                 )
                 .await
             }

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -119,24 +119,22 @@ pub async fn import_card(
 ///
 /// Reads bytes from `--file <PATH>` (or stdin when path is `-`) OR uses
 /// `--payload-b64 <BASE64>` directly, base64-encodes the bytes, and asks
-/// the daemon to produce a detached ML-DSA-65 signature. The daemon signs
-/// exact bytes; callers should canonicalize structured payloads. Pass
-/// `--domain <STRING>` to sign `domain || 0x00 || payload` for
-/// cross-protocol replay protection (issue #90).
+/// the daemon to produce a detached ML-DSA-65 signature over the
+/// domain-separated external DST `[0xF0]|magic|len|context|payload`. The
+/// required `--context <STRING>` names the caller's application protocol
+/// and is provably disjoint from every internal x0x signing input
+/// (issue #133); callers should canonicalize structured payloads.
 pub async fn sign(
     client: &DaemonClient,
     file: Option<&str>,
     payload_b64: Option<&str>,
-    domain: Option<&str>,
+    context: &str,
 ) -> Result<()> {
     client.ensure_running().await?;
 
     let payload_b64 = payload_b64_from_args(file, payload_b64)?;
 
-    let mut body = serde_json::json!({ "payload_b64": payload_b64 });
-    if let Some(domain) = domain {
-        body["domain"] = serde_json::Value::String(domain.to_string());
-    }
+    let body = serde_json::json!({ "context": context, "payload_b64": payload_b64 });
     let resp = client.post("/agent/sign", &body).await?;
     print_value(client.format(), &resp);
     Ok(())
@@ -146,9 +144,10 @@ pub async fn sign(
 ///
 /// Verifies a detached ML-DSA-65 signature against a caller-supplied
 /// public key. The payload comes from `--file <PATH>` (or stdin when the
-/// path is `-`) OR `--payload-b64 <BASE64>`, exactly as for `sign`. Pass
-/// `--domain <STRING>` when the signature was produced with domain
-/// separation (`domain || 0x00 || payload`, issue #90). Verification is
+/// path is `-`) OR `--payload-b64 <BASE64>`, exactly as for `sign`. The
+/// required `--context <STRING>` must match the context the signature was
+/// produced with — verification reconstructs the same external DST
+/// (`[0xF0]|magic|len|context|payload`, issue #133). Verification is
 /// stateless — the daemon uses only the supplied public material.
 ///
 /// Exit status: 0 when the signature is valid; non-zero when it is not
@@ -159,7 +158,7 @@ pub async fn verify(
     payload_b64: Option<&str>,
     signature_b64: &str,
     public_key_b64: &str,
-    domain: Option<&str>,
+    context: &str,
 ) -> Result<()> {
     // Usage errors (missing/ambiguous payload args) must win over daemon
     // reachability, so validate local inputs before probing the daemon.
@@ -167,14 +166,12 @@ pub async fn verify(
 
     client.ensure_running().await?;
 
-    let mut body = serde_json::json!({
+    let body = serde_json::json!({
+        "context": context,
         "payload_b64": payload_b64,
         "signature_b64": signature_b64,
         "public_key_b64": public_key_b64,
     });
-    if let Some(domain) = domain {
-        body["domain"] = serde_json::Value::String(domain.to_string());
-    }
     let resp = client.post("/agent/verify", &body).await?;
     print_value(client.format(), &resp);
     if resp.get("valid").and_then(|v| v.as_bool()) != Some(true) {
@@ -353,7 +350,7 @@ mod tests {
         let mock_resp = serde_json::json!({"signature_b64": "c2ln"});
         let (url, _shutdown) = start_mock_server(mock_resp).await;
         let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
-        let result = sign(&client, None, Some("aGVsbG8="), None).await;
+        let result = sign(&client, None, Some("aGVsbG8="), "test.sign.v1").await;
         assert!(result.is_ok(), "sign should succeed: {:?}", result);
     }
 
@@ -365,7 +362,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("payload.txt");
         std::fs::write(&path, b"hello").unwrap();
-        let result = sign(&client, path.to_str(), None, None).await;
+        let result = sign(&client, path.to_str(), None, "test.sign.v1").await;
         assert!(result.is_ok(), "sign file should succeed: {:?}", result);
     }
 
@@ -375,11 +372,11 @@ mod tests {
         let (url, _shutdown) = start_mock_server(mock_resp).await;
         let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
 
-        let both = sign(&client, Some("-"), Some("aGVsbG8="), None).await;
+        let both = sign(&client, Some("-"), Some("aGVsbG8="), "test.sign.v1").await;
         assert!(both.is_err());
         assert!(both.unwrap_err().to_string().contains("pass either --file"));
 
-        let neither = sign(&client, None, None, None).await;
+        let neither = sign(&client, None, None, "test.sign.v1").await;
         assert!(neither.is_err());
         assert!(neither
             .unwrap_err()
@@ -459,7 +456,7 @@ mod tests {
             Some("aGVsbG8="),
             "c2ln",
             "cGs=",
-            Some("x0x.test.v1"),
+            "x0x.test.v1",
         )
         .await;
         assert!(result.is_ok(), "verify should succeed: {:?}", result);
@@ -472,16 +469,26 @@ mod tests {
         assert_eq!(body["payload_b64"], "aGVsbG8=");
         assert_eq!(body["signature_b64"], "c2ln");
         assert_eq!(body["public_key_b64"], "cGs=");
-        assert_eq!(body["domain"], "x0x.test.v1");
+        assert_eq!(body["context"], "x0x.test.v1");
     }
 
     #[tokio::test]
-    async fn verify_omits_domain_when_not_passed() {
+    async fn verify_always_sends_context() {
+        // `context` is required (issue #133), so it is always present in the
+        // request body — there is no "omit context" path.
         let mock_resp = serde_json::json!({"ok": true, "valid": true});
         let (url, _shutdown, captured) = start_capturing_mock_server(mock_resp).await;
         let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
 
-        let result = verify(&client, None, Some("aGVsbG8="), "c2ln", "cGs=", None).await;
+        let result = verify(
+            &client,
+            None,
+            Some("aGVsbG8="),
+            "c2ln",
+            "cGs=",
+            "x0x.test.v1",
+        )
+        .await;
         assert!(result.is_ok(), "verify should succeed: {:?}", result);
 
         let captured = captured.lock().unwrap();
@@ -489,9 +496,9 @@ mod tests {
             .iter()
             .find(|(path, _)| path == "/agent/verify")
             .expect("a request must be POSTed to /agent/verify");
-        assert!(
-            body.get("domain").is_none(),
-            "request must not contain a domain field when none was passed"
+        assert_eq!(
+            body["context"], "x0x.test.v1",
+            "request must carry the required context field"
         );
     }
 
@@ -505,7 +512,15 @@ mod tests {
         let (url, _shutdown) = start_mock_server(mock_resp).await;
         let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
 
-        let result = verify(&client, None, Some("aGVsbG8="), "c2ln", "cGs=", None).await;
+        let result = verify(
+            &client,
+            None,
+            Some("aGVsbG8="),
+            "c2ln",
+            "cGs=",
+            "x0x.test.v1",
+        )
+        .await;
         assert!(result.is_err(), "valid:false must map to a non-zero exit");
         assert!(result
             .unwrap_err()
@@ -519,11 +534,19 @@ mod tests {
         let (url, _shutdown) = start_mock_server(mock_resp).await;
         let client = DaemonClient::new(None, Some(&url), OutputFormat::Json).unwrap();
 
-        let both = verify(&client, Some("-"), Some("aGVsbG8="), "c2ln", "cGs=", None).await;
+        let both = verify(
+            &client,
+            Some("-"),
+            Some("aGVsbG8="),
+            "c2ln",
+            "cGs=",
+            "x0x.test.v1",
+        )
+        .await;
         assert!(both.is_err());
         assert!(both.unwrap_err().to_string().contains("pass either --file"));
 
-        let neither = verify(&client, None, None, "c2ln", "cGs=", None).await;
+        let neither = verify(&client, None, None, "c2ln", "cGs=", "x0x.test.v1").await;
         assert!(neither.is_err());
         assert!(neither
             .unwrap_err()
@@ -538,7 +561,7 @@ mod tests {
         // the usage error.
         let client =
             DaemonClient::new(None, Some("http://127.0.0.1:9"), OutputFormat::Json).unwrap();
-        let neither = verify(&client, None, None, "c2ln", "cGs=", None).await;
+        let neither = verify(&client, None, None, "c2ln", "cGs=", "x0x.test.v1").await;
         assert!(neither.is_err());
         assert!(neither
             .unwrap_err()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -886,20 +886,21 @@ struct SubscribeRequest {
     topic: String,
 }
 
-/// POST /agent/sign request body — a single base64-encoded payload to
-/// sign with the agent's ML-DSA-65 secret key.
+/// POST /agent/sign request body — a caller payload to sign with the
+/// agent's ML-DSA-65 secret key under a mandatory external domain.
 #[derive(Debug, Deserialize)]
 struct AgentSignRequest {
-    /// Base64-encoded bytes to sign. The signature is computed over these
-    /// bytes verbatim — the caller is responsible for choosing a canonical
-    /// serialization for any structured payload.
+    /// Required domain-separation string naming the caller's application
+    /// protocol (e.g. `"x0x-symphony-handoff-v1"`). The daemon signs the
+    /// length-prefixed external DST `[0xF0] | magic | len(context) | context |
+    /// payload` (see [`crate::api::agent_signing`]), which is provably disjoint
+    /// from every internal x0x signing input. Must match `[a-z0-9._-]{1,64}`
+    /// and must not name an internal signing domain (issue #133).
+    context: String,
+    /// Base64-encoded bytes to sign. The signature is computed over the DST
+    /// assembled from `context` and these bytes; callers should canonicalize
+    /// structured payloads.
     payload_b64: String,
-    /// Optional domain-separation string. When present, the signature is
-    /// computed over `domain || 0x00 || payload` instead of the raw payload,
-    /// preventing cross-protocol signature replay (issue #90). Must not
-    /// contain NUL bytes.
-    #[serde(default)]
-    domain: Option<String>,
 }
 
 /// POST /agent/verify request body — a detached ML-DSA-65 signature to
@@ -914,14 +915,14 @@ struct AgentVerifyRequest {
     signature_b64: String,
     /// Base64-encoded ML-DSA-65 public key (1952 bytes decoded).
     public_key_b64: String,
-    /// Optional domain-separation string. When present, verification is
-    /// performed over `domain || 0x00 || payload`, mirroring the
-    /// `/agent/sign` framing (issue #90). Must not contain NUL bytes.
-    #[serde(default)]
-    domain: Option<String>,
+    /// Required domain-separation string; verification is performed over
+    /// the same external DST as `/agent/sign`
+    /// (`[0xF0] | magic | len(context) | context | payload`, issue #133), so a
+    /// signature produced by `/agent/sign` round-trips through `/agent/verify`.
+    context: String,
     /// Optional signing-scheme identifier. When the field is present —
     /// including as JSON null — it must be exactly
-    /// `x0x.agent-sign.v1.ml-dsa-65`; anything else is rejected with 400
+    /// `x0x.agent-sign.v2.ml-dsa-65`; anything else is rejected with 400
     /// so a future scheme migration is explicit rather than silent.
     /// Deserialized via `deserialize_present` because a plain
     /// `Option<String>` folds present-but-null into `None` and would
@@ -4668,19 +4669,18 @@ async fn import_agent_card(
     )
 }
 
-/// Maximum payload size accepted by `POST /agent/sign`, in bytes.
-/// Comfortably larger than any realistic audit-event or governance-vote
-/// envelope (≤1 KiB in practice) while still bounding worst-case work.
-const AGENT_SIGN_MAX_PAYLOAD_BYTES: usize = 256 * 1024;
+/// Maximum payload size accepted by `POST /agent/sign` / `/agent/verify`,
+/// in bytes. External signing is for hashes, manifests, and audit records —
+/// not blobs. Mirrors [`crate::api::agent_signing::MAX_PAYLOAD_BYTES`] (kept
+/// as a local const so the 413 path can format the limit without importing
+/// the helper into every handler call site).
+const AGENT_SIGN_MAX_PAYLOAD_BYTES: usize = crate::api::agent_signing::MAX_PAYLOAD_BYTES;
 
-/// Maximum length of the optional `domain` separation string, in bytes.
-/// Domain strings are protocol identifiers (`x0x.<purpose>.<version>`
-/// convention) — far shorter in practice; the cap keeps the canonical
-/// bytes bounded by AGENT_SIGN_MAX_PAYLOAD_BYTES + 1 KiB + 1.
-const AGENT_SIGN_MAX_DOMAIN_BYTES: usize = 1024;
-
-/// Stable scheme identifier returned by `POST /agent/sign`.
-const AGENT_SIGN_SCHEME_ID: &str = "x0x.agent-sign.v1.ml-dsa-65";
+/// Stable scheme identifier returned by `POST /agent/sign` and accepted by
+/// `/agent/verify`. The `v2` scheme signs the domain-separated external DST
+/// (issue #133); the pre-#133 `v1` scheme (optional `domain || 0x00 ||
+/// payload` / raw payload) is no longer produced.
+const AGENT_SIGN_SCHEME_ID: &str = crate::api::agent_signing::SCHEME_ID;
 
 /// POST /agent/sign — produce a detached ML-DSA-65 signature over a
 /// caller-supplied payload using this agent's signing key.
@@ -4697,22 +4697,40 @@ const AGENT_SIGN_SCHEME_ID: &str = "x0x.agent-sign.v1.ml-dsa-65";
 /// Authentication. Bearer-token authenticated like every other endpoint
 /// — only callers with the agent's local API token can sign as the agent.
 ///
-/// Payload. `payload_b64` is base64-decoded and signed verbatim. The
-/// caller is responsible for choosing a canonical serialization of any
-/// structured payload (e.g. `serde_canonical_json`, `postcard`, or an
-/// explicit field-order convention).
+/// Payload. `payload_b64` is base64-decoded to the raw payload, which is
+/// taken verbatim (the caller owns the canonical serialization of any
+/// structured payload — e.g. `serde_canonical_json`, `postcard`, or an
+/// explicit field-order convention). Payloads are capped at 64 KiB:
+/// external signing is for hashes, manifests, and audit records, not blobs.
 ///
-/// Domain separation. The optional `domain` field, when present, changes
-/// the signed bytes to `domain || 0x00 || payload` and is echoed back in
-/// the response, so a signature produced for one protocol cannot be
-/// replayed as another (`x0x.<purpose>.<version>` is the conventional
-/// shape for x0x's own protocols). When omitted, the raw payload is
-/// signed — unchanged pre-#90 behavior.
+/// Domain separation (issue #133, mandatory). The signature is *never*
+/// computed over the raw payload. A required `context` string — matching
+/// `[a-z0-9._-]{1,64}` and not naming an internal x0x signing domain
+/// (see `INTERNAL_CONTEXT_DENYLIST` in `src/api/agent_signing.rs`) — binds
+/// the signature to a single application protocol. The canonical signed
+/// bytes are the external DST
+///
+/// ```text
+/// [0xF0] | b"x0x.external-agent-sign.v1" | len(context):u32 BE | context | payload
+/// ```
+///
+/// That prologue is provably disjoint from every internal x0x signing
+/// input (none begins with `[0xF0] | magic`), so an external signature
+/// can never be replayed as a protocol message; the `0xF0` namespace tag
+/// and the length-prefixed context make the boundary unambiguous. The
+/// `context` is echoed in the response so a verifier knows the
+/// canonical-bytes shape without out-of-band information.
+///
+/// Scheme. Returns the stable identifier `x0x.agent-sign.v2.ml-dsa-65`.
+/// The `.v2` pins the API-envelope version; the magic's `.v1` pins the DST
+/// byte layout — two independent axes (see `src/api/agent_signing.rs`). A
+/// future scheme migration is therefore explicit in the response, not
+/// silent.
 ///
 /// Response. Returns the agent_id (hex, 32 bytes), the agent's public
-/// key (base64), the signature (base64), and the stable signing scheme
-/// identifier. All values are wire-format ready for inclusion in the
-/// signed record.
+/// key (base64), the signature (base64), the context (echoed), and the
+/// scheme identifier. All values are wire-format ready for inclusion in
+/// the signed record.
 async fn agent_sign(
     State(state): State<Arc<AppState>>,
     Json(req): Json<AgentSignRequest>,
@@ -4738,32 +4756,15 @@ async fn agent_sign(
         );
     }
 
-    // Optional domain separation (issue #90): sign `domain || 0x00 || payload`
-    // so a signature issued for one protocol context cannot be replayed in
-    // another. The NUL separator is rejected inside the domain itself so the
-    // framing stays unambiguous.
-    let canonical = match req.domain.as_deref() {
-        Some(domain) => {
-            if domain.is_empty() {
-                return bad_request("domain must be non-empty when provided");
-            }
-            if domain.as_bytes().contains(&0u8) {
-                return bad_request("domain must not contain NUL bytes");
-            }
-            if domain.len() > AGENT_SIGN_MAX_DOMAIN_BYTES {
-                return bad_request(format!(
-                    "domain exceeds maximum length of {} bytes",
-                    AGENT_SIGN_MAX_DOMAIN_BYTES
-                ));
-            }
-            let mut buf = Vec::with_capacity(domain.len() + 1 + payload.len());
-            buf.extend_from_slice(domain.as_bytes());
-            buf.push(0);
-            buf.extend_from_slice(&payload);
-            buf
-        }
-        None => payload,
-    };
+    // Mandatory external domain separation (issue #133): sign the
+    // length-prefixed external DST `[0xF0] | magic | len(context) | context |
+    // payload`, which is provably disjoint from every internal x0x signing
+    // input (see `src/api/agent_signing.rs`). `context` is required and
+    // validated — there is no raw-payload signing path.
+    if let Err(e) = crate::api::agent_signing::validate_context(&req.context) {
+        return bad_request(e.to_string());
+    }
+    let canonical = crate::api::agent_signing::assemble_buffer(&req.context, &payload);
 
     let identity = state.agent.identity();
     let keypair = identity.agent_keypair();
@@ -4792,11 +4793,9 @@ async fn agent_sign(
         "signature_b64": signature_b64,
         "algorithm": AGENT_SIGN_SCHEME_ID,
     });
-    // Echo the domain back so a verifier knows the canonical-bytes shape
-    // (domain || 0x00 || payload) without out-of-band context.
-    if let Some(domain) = req.domain {
-        resp["domain"] = serde_json::Value::String(domain);
-    }
+    // Echo the context so a verifier knows the canonical-bytes shape
+    // without out-of-band context.
+    resp["context"] = serde_json::Value::String(req.context);
 
     (StatusCode::OK, Json(resp))
 }
@@ -4808,8 +4807,8 @@ async fn agent_sign(
 /// persist signed records read them back — often on machines that never
 /// authored them — and must verify from the stored bytes alone. Without
 /// this endpoint every consumer would bundle its own FIPS-204 library and
-/// re-derive x0x's `domain || 0x00 || payload` framing, which would drift
-/// the moment the convention evolves.
+/// re-derive x0x's canonical external DST framing, which would drift the
+/// moment the convention evolves.
 ///
 /// Statelessness. Verification uses only caller-supplied public material:
 /// no key access, no identity state. The handler deliberately takes no
@@ -4819,10 +4818,15 @@ async fn agent_sign(
 ///
 /// Semantics. A failed signature check is a *result*, not an error:
 /// `200` with `valid: false`. `400` is reserved for malformed input (bad
-/// base64, empty payload, wrong key or signature length, invalid domain,
-/// unknown `algorithm`); `413` for payloads over the cap — mirroring
-/// `/agent/sign` exactly. When `domain` is present, verification is
-/// performed over `domain || 0x00 || payload` (issue #90 framing).
+/// base64, empty payload, wrong key or signature length, an invalid or
+/// internal-reserved `context`, or an unknown `algorithm`); `413` for
+/// payloads over the 64 KiB cap — mirroring `/agent/sign` exactly.
+/// Verification is performed over the *same* external DST as signing,
+/// `[0xF0] | magic | len(context):u32 BE | context | payload`, using the
+/// caller-supplied `context` (required, validated identically to
+/// `/agent/sign`). A signature produced for one context therefore does
+/// not verify under any other — and raw-payload verification is no longer
+/// a valid input.
 async fn agent_verify(Json(req): Json<AgentVerifyRequest>) -> impl IntoResponse {
     let payload = match BASE64.decode(&req.payload_b64) {
         Ok(bytes) => bytes,
@@ -4845,30 +4849,12 @@ async fn agent_verify(Json(req): Json<AgentVerifyRequest>) -> impl IntoResponse 
         );
     }
 
-    // Same domain rules and canonical-bytes assembly as `agent_sign`: the
-    // verifier must reconstruct exactly the bytes the signer committed to.
-    let canonical = match req.domain.as_deref() {
-        Some(domain) => {
-            if domain.is_empty() {
-                return bad_request("domain must be non-empty when provided");
-            }
-            if domain.as_bytes().contains(&0u8) {
-                return bad_request("domain must not contain NUL bytes");
-            }
-            if domain.len() > AGENT_SIGN_MAX_DOMAIN_BYTES {
-                return bad_request(format!(
-                    "domain exceeds maximum length of {} bytes",
-                    AGENT_SIGN_MAX_DOMAIN_BYTES
-                ));
-            }
-            let mut buf = Vec::with_capacity(domain.len() + 1 + payload.len());
-            buf.extend_from_slice(domain.as_bytes());
-            buf.push(0);
-            buf.extend_from_slice(&payload);
-            buf
-        }
-        None => payload,
-    };
+    // Same canonical-bytes assembly as `agent_sign`: the verifier must
+    // reconstruct exactly the bytes the signer committed to.
+    if let Err(e) = crate::api::agent_signing::validate_context(&req.context) {
+        return bad_request(e.to_string());
+    }
+    let canonical = crate::api::agent_signing::assemble_buffer(&req.context, &payload);
 
     // A present `algorithm` must be exactly the supported scheme string;
     // JSON null and non-string values are present-but-wrong, not omitted.

--- a/tests/daemon_api_integration.rs
+++ b/tests/daemon_api_integration.rs
@@ -97,9 +97,10 @@ async fn daemon_api_agent() {
 async fn daemon_api_agent_sign_roundtrip() {
     let d = daemon().await;
 
-    // Sign an arbitrary payload.
+    // Sign an arbitrary payload under a mandatory external context.
     let payload = b"the bytes a downstream app would put into an audit record";
-    let body = serde_json::json!({ "payload_b64": b64(payload) });
+    let context = "audit.record.v1";
+    let body = serde_json::json!({ "context": context, "payload_b64": b64(payload) });
 
     let r: Value = ca(&d)
         .post(d.url("/agent/sign"))
@@ -112,7 +113,8 @@ async fn daemon_api_agent_sign_roundtrip() {
         .unwrap();
 
     assert_eq!(r["ok"], true);
-    assert_eq!(r["algorithm"], "x0x.agent-sign.v1.ml-dsa-65");
+    assert_eq!(r["algorithm"], "x0x.agent-sign.v2.ml-dsa-65");
+    assert_eq!(r["context"], context, "response must echo the context");
     let agent_id_hex = r["agent_id"].as_str().expect("agent_id is a hex string");
     let public_key_b64 = r["public_key_b64"]
         .as_str()
@@ -145,23 +147,35 @@ async fn daemon_api_agent_sign_roundtrip() {
     let signature = ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(&sig_bytes)
         .expect("signature_b64 parses as an ML-DSA-65 signature");
 
-    ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(&public_key, payload, &signature)
-        .expect("signature verifies under the agent's public key");
+    // The signature is over the external DST, NOT the raw payload.
+    let canonical = x0x::api::agent_signing::assemble_buffer(context, payload);
+    ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(&public_key, &canonical, &signature)
+        .expect("signature verifies over the domain-separated buffer");
+    assert!(
+        ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+            &public_key,
+            payload,
+            &signature
+        )
+        .is_err(),
+        "signature must NOT verify over the raw payload"
+    );
 }
 
 #[tokio::test]
 #[ignore]
-async fn daemon_api_agent_sign_domain_separation_roundtrip() {
+async fn daemon_api_agent_sign_context_roundtrip_and_mismatch_rejected() {
     let d = daemon().await;
 
-    // Domain-separated signing (issue #90): the signature must verify over
-    // domain || 0x00 || payload, NOT over the raw payload — otherwise a
-    // signature issued in one protocol context could be replayed in another.
+    // Domain-separated signing (issue #133): the signature is over the
+    // external DST assembled from `context`, so it verifies only when the
+    // verifier supplies the SAME context — a signature issued for one
+    // protocol context cannot be replayed as another.
     let payload = b"register envelope bytes";
-    let domain = "community.jams.pair.v1.register-pop";
+    let context = "community.jams.pair.v1.register-pop";
     let r: Value = ca(&d)
         .post(d.url("/agent/sign"))
-        .json(&serde_json::json!({ "payload_b64": b64(payload), "domain": domain }))
+        .json(&serde_json::json!({ "context": context, "payload_b64": b64(payload) }))
         .send()
         .await
         .unwrap()
@@ -170,11 +184,7 @@ async fn daemon_api_agent_sign_domain_separation_roundtrip() {
         .unwrap();
 
     assert_eq!(r["ok"], true);
-    assert_eq!(
-        r["domain"].as_str().unwrap(),
-        domain,
-        "response must echo the domain so verifiers know the canonical-bytes shape"
-    );
+    assert_eq!(r["context"], context, "response must echo the context");
 
     let pk_bytes = base64::engine::general_purpose::STANDARD
         .decode(r["public_key_b64"].as_str().unwrap())
@@ -186,60 +196,95 @@ async fn daemon_api_agent_sign_domain_separation_roundtrip() {
     let signature =
         ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(&sig_bytes).unwrap();
 
-    let mut canonical = Vec::new();
-    canonical.extend_from_slice(domain.as_bytes());
-    canonical.push(0);
-    canonical.extend_from_slice(payload);
+    // Verifies over the DST built from the matching context.
+    let canonical = x0x::api::agent_signing::assemble_buffer(context, payload);
     ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(&public_key, &canonical, &signature)
-        .expect("signature verifies over domain || 0x00 || payload");
+        .expect("signature verifies over the context's DST");
 
-    assert!(
-        ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
-            &public_key,
-            payload,
-            &signature
-        )
-        .is_err(),
-        "domain-separated signature must NOT verify over the raw payload"
-    );
+    // Must NOT verify over the raw payload, nor over a DIFFERENT context's DST.
+    assert!(ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+        &public_key,
+        payload,
+        &signature
+    )
+    .is_err());
+    let other = x0x::api::agent_signing::assemble_buffer("a.different.context.v2", payload);
+    assert!(ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+        &public_key,
+        &other,
+        &signature
+    )
+    .is_err());
 }
 
 #[tokio::test]
 #[ignore]
-async fn daemon_api_agent_sign_without_domain_omits_domain_field() {
-    let d = daemon().await;
-    // Pre-#90 behavior must be unchanged: no domain in, no domain out.
-    let r: Value = ca(&d)
-        .post(d.url("/agent/sign"))
-        .json(&serde_json::json!({ "payload_b64": b64(b"plain payload") }))
-        .send()
-        .await
-        .unwrap()
-        .json()
-        .await
-        .unwrap();
-    assert_eq!(r["ok"], true);
-    assert!(
-        r.get("domain").is_none(),
-        "response must not contain a domain field when none was supplied"
-    );
-}
-
-#[tokio::test]
-#[ignore]
-async fn daemon_api_agent_sign_rejects_nul_in_domain() {
+async fn daemon_api_agent_sign_rejects_missing_context() {
+    // `context` is required (issue #133): omitting it must never fall back to
+    // raw-payload signing — it is rejected with a client error.
     let d = daemon().await;
     let r = ca(&d)
         .post(d.url("/agent/sign"))
-        .json(&serde_json::json!({ "payload_b64": b64(b"x"), "domain": "bad\u{0}domain" }))
+        .json(&serde_json::json!({ "payload_b64": b64(b"x") }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        r.status().is_client_error(),
+        "missing context must be rejected: {}",
+        r.status()
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_sign_rejects_invalid_context() {
+    let d = daemon().await;
+    let r = ca(&d)
+        .post(d.url("/agent/sign"))
+        .json(&serde_json::json!({ "context": "Has Space!", "payload_b64": b64(b"x") }))
         .send()
         .await
         .unwrap();
     assert_eq!(
         r.status(),
         StatusCode::BAD_REQUEST,
-        "NUL bytes in domain would make the separator framing ambiguous"
+        "context not matching [a-z0-9._-] must be 400"
     );
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_sign_rejects_internal_context_denylist() {
+    // Defense in depth: even though the namespace tag guarantees
+    // disjointness, a context naming an internal signing domain is denied.
+    let d = daemon().await;
+    let r = ca(&d)
+        .post(d.url("/agent/sign"))
+        .json(&serde_json::json!({ "context": "announcement", "payload_b64": b64(b"x") }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        StatusCode::BAD_REQUEST,
+        "internal context must be denied"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_agent_sign_requires_authentication() {
+    // Loopback + bearer-token only (issue #133): an unauthenticated request
+    // never produces a signature.
+    let d = daemon().await;
+    let r = c()
+        .post(d.url("/agent/sign"))
+        .json(&serde_json::json!({ "context": "test.auth.v1", "payload_b64": b64(b"x") }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]
@@ -248,7 +293,7 @@ async fn daemon_api_agent_sign_rejects_empty_payload() {
     let d = daemon().await;
     let r = ca(&d)
         .post(d.url("/agent/sign"))
-        .json(&serde_json::json!({ "payload_b64": "" }))
+        .json(&serde_json::json!({ "context": "test.empty.v1", "payload_b64": "" }))
         .send()
         .await
         .unwrap();
@@ -261,7 +306,9 @@ async fn daemon_api_agent_sign_rejects_invalid_base64() {
     let d = daemon().await;
     let r = ca(&d)
         .post(d.url("/agent/sign"))
-        .json(&serde_json::json!({ "payload_b64": "@@@not-base64@@@" }))
+        .json(
+            &serde_json::json!({ "context": "test.badb64.v1", "payload_b64": "@@@not-base64@@@" }),
+        )
         .send()
         .await
         .unwrap();
@@ -272,11 +319,11 @@ async fn daemon_api_agent_sign_rejects_invalid_base64() {
 #[ignore]
 async fn daemon_api_agent_sign_rejects_oversize_payload() {
     let d = daemon().await;
-    // Just over the 256 KiB cap.
-    let oversize = vec![0u8; 256 * 1024 + 1];
+    // Just over the 64 KiB cap (issue #133 lowered it from 256 KiB).
+    let oversize = vec![0u8; 64 * 1024 + 1];
     let r = ca(&d)
         .post(d.url("/agent/sign"))
-        .json(&serde_json::json!({ "payload_b64": b64(&oversize) }))
+        .json(&serde_json::json!({ "context": "test.oversize.v1", "payload_b64": b64(&oversize) }))
         .send()
         .await
         .unwrap();
@@ -286,15 +333,8 @@ async fn daemon_api_agent_sign_rejects_oversize_payload() {
 // ── POST /agent/verify (issue #106) ─────────────────────────────────────
 
 /// Sign `payload` via POST /agent/sign and return (signature_b64, public_key_b64).
-async fn sign_via_daemon(
-    d: &DaemonFixture,
-    payload: &[u8],
-    domain: Option<&str>,
-) -> (String, String) {
-    let mut body = serde_json::json!({ "payload_b64": b64(payload) });
-    if let Some(domain) = domain {
-        body["domain"] = serde_json::Value::String(domain.to_string());
-    }
+async fn sign_via_daemon(d: &DaemonFixture, payload: &[u8], context: &str) -> (String, String) {
+    let body = serde_json::json!({ "context": context, "payload_b64": b64(payload) });
     let r: Value = ca(d)
         .post(d.url("/agent/sign"))
         .json(&body)
@@ -316,11 +356,12 @@ async fn sign_via_daemon(
 async fn daemon_api_agent_verify_roundtrip() {
     let d = daemon().await;
     let payload = b"audit record bytes read back from storage";
-    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let (sig, pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
 
     let resp = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(payload),
             "signature_b64": sig,
             "public_key_b64": pk,
@@ -332,7 +373,7 @@ async fn daemon_api_agent_verify_roundtrip() {
     let r: Value = resp.json().await.unwrap();
     assert_eq!(r["ok"], true);
     assert_eq!(r["valid"], true);
-    assert_eq!(r["algorithm"], "x0x.agent-sign.v1.ml-dsa-65");
+    assert_eq!(r["algorithm"], "x0x.agent-sign.v2.ml-dsa-65");
 }
 
 #[tokio::test]
@@ -346,12 +387,18 @@ async fn daemon_api_agent_verify_independent_keypair() {
         ant_quic::crypto::raw_public_keys::pqc::generate_ml_dsa_keypair()
             .expect("keypair generation");
     let payload = b"record authored on a machine this daemon has never seen";
-    let signature = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(&secret_key, payload)
-        .expect("local signing");
+    let context = "third.party.record.v1";
+    // Sign the EXTERNAL DST locally (the daemon would assemble the same
+    // bytes for this context + payload), then verify via the endpoint.
+    let canonical = x0x::api::agent_signing::assemble_buffer(context, payload);
+    let signature =
+        ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(&secret_key, &canonical)
+            .expect("local signing over the DST");
 
     let r: Value = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": context,
             "payload_b64": b64(payload),
             "signature_b64": b64(signature.as_bytes()),
             "public_key_b64": b64(public_key.as_bytes()),
@@ -373,11 +420,12 @@ async fn daemon_api_agent_verify_independent_keypair() {
 #[ignore]
 async fn daemon_api_agent_verify_tampered_payload_is_result_not_error() {
     let d = daemon().await;
-    let (sig, pk) = sign_via_daemon(&d, b"the original payload", None).await;
+    let (sig, pk) = sign_via_daemon(&d, b"the original payload", "test.ctx.v1").await;
 
     let resp = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(b"the tampered payload"),
             "signature_b64": sig,
             "public_key_b64": pk,
@@ -400,7 +448,7 @@ async fn daemon_api_agent_verify_tampered_payload_is_result_not_error() {
 async fn daemon_api_agent_verify_tampered_signature_is_result_not_error() {
     let d = daemon().await;
     let payload = b"payload whose signature gets corrupted in storage";
-    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let (sig, pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
 
     // Flip one bit mid-signature: still 3309 bytes, so it passes the
     // malformed-input checks and must fail as `valid: false`, not 400.
@@ -412,6 +460,7 @@ async fn daemon_api_agent_verify_tampered_signature_is_result_not_error() {
     let resp = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(payload),
             "signature_b64": b64(&sig_bytes),
             "public_key_b64": pk,
@@ -427,20 +476,20 @@ async fn daemon_api_agent_verify_tampered_signature_is_result_not_error() {
 
 #[tokio::test]
 #[ignore]
-async fn daemon_api_agent_verify_domain_separation_enforced() {
+async fn daemon_api_agent_verify_context_mismatch_is_result_not_error() {
     let d = daemon().await;
     let payload = b"register envelope bytes";
-    let domain = "x0x.test.v1.verify";
-    let (sig, pk) = sign_via_daemon(&d, payload, Some(domain)).await;
+    let context = "x0x.test.v1.verify";
+    let (sig, pk) = sign_via_daemon(&d, payload, context).await;
 
-    // With the matching domain the signature verifies.
+    // With the matching context the signature verifies.
     let r: Value = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": context,
             "payload_b64": b64(payload),
             "signature_b64": sig.clone(),
             "public_key_b64": pk.clone(),
-            "domain": domain,
         }))
         .send()
         .await
@@ -450,11 +499,13 @@ async fn daemon_api_agent_verify_domain_separation_enforced() {
         .unwrap();
     assert_eq!(r["valid"], true);
 
-    // The same bytes WITHOUT the domain must not verify — the
-    // domain || 0x00 || payload framing is enforced, not advisory.
+    // The same signature under a DIFFERENT context must not verify — the DST
+    // binds the signature to its context, so a signature for one protocol
+    // cannot be replayed as another.
     let r: Value = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "a.different.context.v2",
             "payload_b64": b64(payload),
             "signature_b64": sig,
             "public_key_b64": pk,
@@ -468,7 +519,7 @@ async fn daemon_api_agent_verify_domain_separation_enforced() {
     assert_eq!(r["ok"], true);
     assert_eq!(
         r["valid"], false,
-        "domain-separated signature must NOT verify over the raw payload"
+        "a signature must NOT verify under a mismatched context"
     );
 }
 
@@ -477,15 +528,16 @@ async fn daemon_api_agent_verify_domain_separation_enforced() {
 async fn daemon_api_agent_verify_accepts_explicit_algorithm() {
     let d = daemon().await;
     let payload = b"payload";
-    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let (sig, pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
 
     let r: Value = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(payload),
             "signature_b64": sig,
             "public_key_b64": pk,
-            "algorithm": "x0x.agent-sign.v1.ml-dsa-65",
+            "algorithm": "x0x.agent-sign.v2.ml-dsa-65",
         }))
         .send()
         .await
@@ -522,10 +574,11 @@ async fn daemon_api_agent_verify_rejects_unknown_algorithm() {
     // would verify as 200 valid:true — the silent scheme migration the
     // explicit 400 exists to prevent.
     let payload = b"x";
-    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let (sig, pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(payload),
             "signature_b64": sig,
             "public_key_b64": pk,
@@ -545,10 +598,11 @@ async fn daemon_api_agent_verify_rejects_null_algorithm() {
     // `Option<String>` request field would fold it to None and silently
     // accept — this pins the explicit 400 instead.
     let payload = b"x";
-    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let (sig, pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(payload),
             "signature_b64": sig,
             "public_key_b64": pk,
@@ -570,6 +624,7 @@ async fn daemon_api_agent_verify_requires_auth() {
     let r = c()
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(b"x"),
             "signature_b64": b64(b"sig"),
             "public_key_b64": b64(b"pk"),
@@ -584,18 +639,18 @@ async fn daemon_api_agent_verify_requires_auth() {
 #[ignore]
 async fn daemon_api_agent_verify_accepts_exact_boundary_sizes() {
     let d = daemon().await;
-    // Exactly AT the caps must round-trip: the limits reject payloads
-    // *over* 256 KiB and domains *over* 1 KiB, not at them.
-    let payload = vec![0xA5u8; 256 * 1024];
-    let domain = "d".repeat(1024);
-    let (sig, pk) = sign_via_daemon(&d, &payload, Some(domain.as_str())).await;
+    // Exactly AT the caps must round-trip: the limits reject payloads *over*
+    // 64 KiB and contexts *over* 64 chars, not at them.
+    let payload = vec![0xA5u8; 64 * 1024];
+    let context = "c".repeat(64);
+    let (sig, pk) = sign_via_daemon(&d, &payload, &context).await;
     let r: Value = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": context,
             "payload_b64": b64(&payload),
             "signature_b64": sig,
             "public_key_b64": pk,
-            "domain": domain,
         }))
         .send()
         .await
@@ -614,12 +669,13 @@ async fn daemon_api_agent_verify_wrong_key_is_result_not_error() {
     // A well-formed 1952-byte key that simply isn't the signer's: that is
     // a verification *result* (valid:false), never malformed input.
     let payload = b"signed by the daemon, checked against a stranger's key";
-    let (sig, _pk) = sign_via_daemon(&d, payload, None).await;
+    let (sig, _pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
     let (other_pk, _sk) = ant_quic::crypto::raw_public_keys::pqc::generate_ml_dsa_keypair()
         .expect("keypair generation");
     let resp = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(payload),
             "signature_b64": sig,
             "public_key_b64": b64(other_pk.as_bytes()),
@@ -637,10 +693,11 @@ async fn daemon_api_agent_verify_wrong_key_is_result_not_error() {
 #[ignore]
 async fn daemon_api_agent_verify_rejects_invalid_base64_payload() {
     let d = daemon().await;
-    let (sig, pk) = sign_via_daemon(&d, b"x", None).await;
+    let (sig, pk) = sign_via_daemon(&d, b"x", "test.ctx.v1").await;
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": "@@@not-base64@@@",
             "signature_b64": sig,
             "public_key_b64": pk,
@@ -656,10 +713,11 @@ async fn daemon_api_agent_verify_rejects_invalid_base64_payload() {
 async fn daemon_api_agent_verify_rejects_invalid_base64_signature() {
     let d = daemon().await;
     let payload = b"x";
-    let (_sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let (_sig, pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(payload),
             "signature_b64": "@@@not-base64@@@",
             "public_key_b64": pk,
@@ -675,10 +733,11 @@ async fn daemon_api_agent_verify_rejects_invalid_base64_signature() {
 async fn daemon_api_agent_verify_rejects_invalid_base64_public_key() {
     let d = daemon().await;
     let payload = b"x";
-    let (sig, _pk) = sign_via_daemon(&d, payload, None).await;
+    let (sig, _pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(payload),
             "signature_b64": sig,
             "public_key_b64": "@@@not-base64@@@",
@@ -693,10 +752,11 @@ async fn daemon_api_agent_verify_rejects_invalid_base64_public_key() {
 #[ignore]
 async fn daemon_api_agent_verify_rejects_empty_payload() {
     let d = daemon().await;
-    let (sig, pk) = sign_via_daemon(&d, b"x", None).await;
+    let (sig, pk) = sign_via_daemon(&d, b"x", "test.ctx.v1").await;
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": "",
             "signature_b64": sig,
             "public_key_b64": pk,
@@ -711,12 +771,13 @@ async fn daemon_api_agent_verify_rejects_empty_payload() {
 #[ignore]
 async fn daemon_api_agent_verify_rejects_oversize_payload() {
     let d = daemon().await;
-    let (sig, pk) = sign_via_daemon(&d, b"x", None).await;
-    // Just over the 256 KiB cap — same limit as /agent/sign.
-    let oversize = vec![0u8; 256 * 1024 + 1];
+    let (sig, pk) = sign_via_daemon(&d, b"x", "test.ctx.v1").await;
+    // Just over the 64 KiB cap — same limit as /agent/sign.
+    let oversize = vec![0u8; 64 * 1024 + 1];
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(&oversize),
             "signature_b64": sig,
             "public_key_b64": pk,
@@ -737,12 +798,13 @@ async fn daemon_api_agent_verify_rejects_oversize_payload() {
 async fn daemon_api_agent_verify_rejects_wrong_public_key_length() {
     let d = daemon().await;
     let payload = b"x";
-    let (sig, _pk) = sign_via_daemon(&d, payload, None).await;
+    let (sig, _pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
     // A 32-byte value is a plausible wrong-key-type paste (e.g. an agent id
     // or an Ed25519 key) — it must be 400, never a confusing valid:false.
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(payload),
             "signature_b64": sig,
             "public_key_b64": b64(&[0u8; 32]),
@@ -758,11 +820,12 @@ async fn daemon_api_agent_verify_rejects_wrong_public_key_length() {
 async fn daemon_api_agent_verify_rejects_wrong_signature_length() {
     let d = daemon().await;
     let payload = b"x";
-    let (_sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let (_sig, pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
     // A truncated signature is malformed input, not a failed check.
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "test.ctx.v1",
             "payload_b64": b64(payload),
             "signature_b64": b64(&[0u8; 100]),
             "public_key_b64": pk,
@@ -775,68 +838,45 @@ async fn daemon_api_agent_verify_rejects_wrong_signature_length() {
 
 #[tokio::test]
 #[ignore]
-async fn daemon_api_agent_verify_rejects_nul_in_domain() {
+async fn daemon_api_agent_verify_rejects_invalid_context() {
+    // The same context validation as /agent/sign applies to verify: an
+    // invalid context is 400, never a `valid: false`.
     let d = daemon().await;
     let payload = b"x";
-    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let (sig, pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "Has Space!",
             "payload_b64": b64(payload),
             "signature_b64": sig,
             "public_key_b64": pk,
-            "domain": "bad\u{0}domain",
         }))
         .send()
         .await
         .unwrap();
-    assert_rejection(
-        r,
-        StatusCode::BAD_REQUEST,
-        "domain must not contain NUL bytes",
-    )
-    .await;
+    assert_rejection(r, StatusCode::BAD_REQUEST, "context must match").await;
 }
 
 #[tokio::test]
 #[ignore]
-async fn daemon_api_agent_verify_rejects_empty_domain() {
+async fn daemon_api_agent_verify_rejects_internal_context() {
+    // A denylisted (internal) context is rejected on verify too.
     let d = daemon().await;
     let payload = b"x";
-    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
+    let (sig, pk) = sign_via_daemon(&d, payload, "test.ctx.v1").await;
     let r = ca(&d)
         .post(d.url("/agent/verify"))
         .json(&serde_json::json!({
+            "context": "announcement",
             "payload_b64": b64(payload),
             "signature_b64": sig,
             "public_key_b64": pk,
-            "domain": "",
         }))
         .send()
         .await
         .unwrap();
-    assert_rejection(r, StatusCode::BAD_REQUEST, "domain must be non-empty").await;
-}
-
-#[tokio::test]
-#[ignore]
-async fn daemon_api_agent_verify_rejects_oversize_domain() {
-    let d = daemon().await;
-    let payload = b"x";
-    let (sig, pk) = sign_via_daemon(&d, payload, None).await;
-    // Just over the 1 KiB domain cap — same limit as /agent/sign.
-    let r = ca(&d)
-        .post(d.url("/agent/verify"))
-        .json(&serde_json::json!({
-            "payload_b64": b64(payload),
-            "signature_b64": sig,
-            "public_key_b64": pk,
-            "domain": "d".repeat(1025),
-        }))
-        .send()
-        .await
-        .unwrap();
-    assert_rejection(r, StatusCode::BAD_REQUEST, "domain exceeds maximum length").await;
+    assert_rejection(r, StatusCode::BAD_REQUEST, "internal x0x signing domain").await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

The existing `POST /agent/sign` (issue #86) used an *optional* `domain || 0x00 || payload` framing — or signed the **raw payload** when `domain` was omitted — so a caller could obtain a signature over bytes that might collide with an internal x0x protocol message. Issue #133 (unblocks x0x-symphony XSY-0020) mandates stronger domain separation.

**Fix:** a new module `src/api/agent_signing.rs` owns a length-prefixed external DST, a reserved namespace byte, an internal-context denylist, and validation. The daemon now signs:

```
[0xF0] | b"x0x.external-agent-sign.v1" | len(context):u32 BE | context | payload
```

**Issue:** #133 · **Plan section:** WS1.9 — *`POST /agent/sign` endpoint*

## Plan WS1.9 acceptance criteria

- [x] Sign→verify REST roundtrip (sign under `context`, verify reconstructs the same DST — roundtrip + context-mismatch-rejected tests).
- [x] Negative tests: empty/invalid context → 400; oversize payload → 413; unauthenticated → 401; internal-context denylist rejected.
- [x] Proof-of-disjointness note (module doc in `src/api/agent_signing.rs` enumerates every internal signing domain + an invariant unit test pinning the `0xF0` prologue).
- [x] api-reference.md + CLI subcommand (`x0x agent sign --context`, `x0x agent verify --context`) + endpoint registry (path unchanged).
- [x] fmt / clippy (`-D warnings`) / rustdoc clean.

## Domain-separation design (per issue, exactly)

- **Required `context`** matching `[a-z0-9._-]{1,64}` (validated).
- **Length-prefixed DST** — `len(context):u32 BE` makes the context/payload boundary unambiguous; no `(context, payload)` collision is possible (unit test `no_context_payload_collision_across_pairs` proves `(ab,cd)` ≠ `(abc,d)`).
- **Reserved namespace byte `0xF0`** + ASCII magic — provably disjoint from every internal signing input (all structured serializations; none begins with the prologue). Disjointness table + invariant test in the module doc.
- **Denylist** of internal context strings (defense in depth on top of the structural guarantee).
- **64 KiB payload cap** (lowered from 256 KiB).
- **Loopback + bearer-token only**; standard auth middleware (not auth-exempt) — `401` test added.

## server/mod.rs touch scope (Eng B coordination)

Per the directive, `src/server/mod.rs` is touched **only** for what #133 requires: the two request structs (`context` field), the two handler bodies (validate → assemble → sign/verify), the constants block (payload cap + v2 scheme), and the function-level rustdoc on those two handlers. No unrelated regions.

## ⚠️ Breaking change (flagged per directive)

The optional `domain` field and the raw-payload / `v1` signing path are **removed**; the scheme string is bumped to `x0x.agent-sign.v2.ml-dsa-65`. This is intentional — #133 mandates the stronger design and the pre-#133 `v1` path signed raw payloads (the unsafe surface being eliminated). `x0x-symphony` (the sole cross-repo consumer, XSY-0020) has not shipped. `/agent/verify` likewise takes a required `context`. Pre-#133 `v1` signatures (optional domain) are no longer verifiable via the endpoint.

## Review conditions resolved (this update)

- **v1 rustdoc rewritten** — the function-level docs on `agent_sign` / `agent_verify` now describe the actual v2 behavior: mandatory `context` (`[a-z0-9._-]{1,64}`), the internal-context denylist, the `[0xF0] | magic | len(context):u32 BE | context | payload` construction, the 64 KiB cap, and the `x0x.agent-sign.v2.ml-dsa-65` scheme id. No `optional domain field`, `domain || 0x00 || payload`, `pre-#90`, or `invalid domain` references remain on either handler.
- **MAGIC vs SCHEME_ID reconciled** — `MAGIC` (`…v1`) and `SCHEME_ID` (`…v2`) now carry explicit comments stating they pin *different* versioning axes: `MAGIC` pins the canonical-bytes DST **layout** version (first version of this byte layout); `SCHEME_ID` pins the **API-envelope** version (`v2` = the mandatory-context design, superseding the pre-#133 optional-domain/raw-payload `v1`). The two are intentionally independent.
- **Stale "known issues" section removed** — the ~20 half-migrated `/agent/verify` integration tests it described are fully fixed in this diff (see Verification).

## Verification

- `src/api/agent_signing.rs` unit tests (regex accept/reject, denylist, length-prefix, no-collision, disjointness invariant) — **all pass**.
- CLI parity mock tests (`sign`/`verify` send `context`, `verify_always_sends_context`) — pass.
- `#[ignore]` daemon integration tests fully migrated to the v2 API: every `/agent/verify` request body carries the required `context`; the three obsolete `*_domain` tests were converted to context-validation / internal-context rejection tests; `daemon_api_agent_verify_independent_keypair` now signs the external DST via `assemble_buffer`; `accepts_exact_boundary_sizes` uses the 64 KiB / 64-char caps. `cargo test --test daemon_api_integration --no-run --all-features` compiles clean.
- `cargo fmt --all -- --check` ✅ · `cargo clippy --all-targets --all-features -- -D warnings` ✅ · `cargo doc --no-deps --all-features` ✅ (no broken intra-doc links).
- Full workspace nextest: one multi-daemon convergence test (`non_creator_admin_private_secure_invite_e2e_converges_through_real_daemons`) fails locally — it **reproduces identically on `origin/main` without this PR** (this PR does not touch the CRDT / group-convergence path) and is a machine-load-sensitive borderline test (~134 s, flagged SLOW). Treating **PR CI on the runner** as the authoritative merge gate rather than the local run.

Closes #133.
