### PR TITLE
ci(coverage): exclude x0x_0041_prefer_newest_test from coverage gate (#148)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,11 @@ jobs:
         # instrumentation slowdown — a flake here must not abort the whole
         # coverage computation:
         #   * x0x_0041_synthetic_kill_restart — documented, matches Test Suite.
+        #   * x0x_0041_prefer_newest_test — sibling binary; the
+        #     direct_send_reissues_on_replaced_connection_within_500ms test's 2s
+        #     lifecycle_deadline is exceeded under coverage contention (#148).
+        #     Same class as #139; excluded here only — keeps running in the Test
+        #     Suite + integration tiers (binary()-scoped, not test()-scoped).
         #   * named_group_join_metadata_event — gossip-convergence forgery tests
         #     (e.g. forged_member_joined_*) poll a rejection counter that can
         #     exceed the wait window under coverage; the same code paths are
@@ -183,7 +188,7 @@ jobs:
         #   tranche 3 (#124): 65.6 → 65.7 (storage/identity errors; actual 66.70%)
         run: |
           cargo llvm-cov clean --workspace
-          cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --fail-under-lines 65.7 nextest -E '!binary(x0x_0041_synthetic_kill_restart) & !binary(named_group_join_metadata_event)'
+          cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --fail-under-lines 65.7 nextest -E '!binary(x0x_0041_synthetic_kill_restart) & !binary(x0x_0041_prefer_newest_test) & !binary(named_group_join_metadata_event)'
           python3 scripts/check-coverage-thresholds.py --lcov lcov.info --thresholds coverage-thresholds.toml --enforce-global
 
       - name: Upload LCOV report


### PR DESCRIPTION
## What

Excludes the `x0x_0041_prefer_newest_test` binary from the **Coverage Gate** nextest run, mirroring the existing `x0x_0041_synthetic_kill_restart` + `named_group_join_metadata_event` exclusions.

Closes #148.

## Why

`direct_send_reissues_on_replaced_connection_within_500ms` is a 2s-deadline integration test (two real Agents + network connect + lifecycle wait). Under `cargo llvm-cov`'s ~3× instrumentation slowdown with all 1936 tests contending for runner CPU, the 2s `lifecycle_deadline` is exceeded. It failed CI run [28626542274](https://github.com/saorsa-labs/x0x/actions/runs/28626542274) (PR #147, SHA `7c702f3`) and **passed on rerun** with no code change — environmental, same class as #139.

PR #147 bounds the per-WS **outbound** queue; it does not touch the direct-send / connection-replacement path under test. The variable is llvm-cov's slowdown, not the code.

## Scope

Mirrors the `named_group_join_metadata_event` precedent — **coverage-measurement-only** exclusion:

| Tier | Runs the test? |
|---|---|
| Test Suite job (no instrumentation) | ✅ yes |
| Coverage Gate (llvm-cov, ~3× slow) | ❌ excluded |
| Integration tier | ✅ yes |

A timing flake aborting the coverage run would mask a genuine coverage regression, so only the measurement skips it. `binary()`-scoped (not `test()`) per the documented convention — and defensible because both tests in the binary (`direct_send_reissues...` + `supersede_propagates_within_500ms_acceptance_budget`) are 500ms-deadline prefer-newest tests of the same flakiness class.

## Acceptance

- [x] One-line `ci.yml` change adds `& !binary(x0x_0041_prefer_newest_test)` to the Coverage Gate nextest filter (line 186)
- [x] Comment block updated to document the new exclusion + cross-ref #148
- [x] Test keeps running in Test Suite + integration tiers (binary-scoped, not removed)
- [x] Issue #148 filed with the full diagnosis + proposed follow-up (raise the wait budget)
- [x] Coverage Gate floor (65.7) still passes — verified by CI below

## Gates

fmt ✓ · clippy ✓ (no code change, ci.yml only) · Coverage Gate ✓

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows the coverage-gate test set for one flaky integration binary.

- Adds `x0x_0041_prefer_newest_test` to the `cargo llvm-cov nextest` exclusion filter.
- Documents why the binary is skipped only during coverage collection.
- Leaves the non-instrumented Test Suite filter unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Updates the Coverage Gate nextest filter and nearby documentation for the added binary exclusion. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(coverage): exclude x0x\_0041\_prefer\_ne..."](https://github.com/saorsa-labs/x0x/commit/5cd5380423812e69fafdb6ecf19c006aa5b2640a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41579708)</sub>

<!-- /greptile_comment -->