### PR TITLE
chore(125/WS1.4-P0): snapshot x0x routes for decomposition characterization

### DIFF
--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -1,0 +1,49 @@
+# Server decomposition characterization guard (#125 / WS1.4 P0)
+
+This directory holds the **byte-exact snapshots** that prove every extraction
+PR in the `src/server/mod.rs` decomposition series (#125) is behavior-preserving.
+The series must keep these identical; any deviation is a regression, not a move.
+
+## Snapshots
+
+| File | Source command | What it pins |
+|---|---|---|
+| `server-routes.txt` | `x0x routes` | Full endpoint table (method/path/CLI/description) from the registry |
+| `server-routes.json` | `x0x routes --json` | Structured form (135 endpoints) |
+
+After each extraction PR, re-run both commands and `diff` against the committed
+files — output must be **byte-identical**.
+
+## Automated guards (already in CI)
+
+The snapshots are the human-readable rendering; the runtime parity chain is
+enforced by existing tests:
+
+- `tests/api_manifest.rs::manifest_matches_registry` — committed
+  `docs/design/api-manifest.json` ⟷ live `ENDPOINTS` registry.
+- `tests/api_coverage.rs::route_set_matches_registry` — live `ENDPOINTS`
+  registry ⟷ the actual router's route set (runs the real `build_router()`).
+
+A mechanical move that drops or renames a route breaks `route_set_matches_registry`
+even if the snapshot text is unchanged (the snapshot reads the registry, not the
+router; the test closes that gap).
+
+## Public API surface to preserve
+
+`src/server/` is a `pub mod`. The public items reachable as `x0x::server::*`
+must not move or change signature across the series:
+
+- Structs: `ServeOptions`, `ServerHandle`, `DaemonConfig` (+ public methods/fields).
+- Consts: `DEFAULT_QUIC_PORT`.
+- Free functions: `default_bind_address`, `default_api_address`,
+  `default_data_dir`, `run`, `run_update_check_and_report`, `serve`,
+  `serve_with_options`, `validate_instance_name`, `list_instances`.
+
+Handlers, middleware, and helpers are private and move freely between submodules.
+`cargo doc --no-deps` building cleanly is the public-API compile guard.
+
+## Methodology
+
+Each extraction PR is **moves + `use` fixes only**. Never fold a behavior change
+into a move. If a behavior change is warranted, it lands as a separate PR before
+or after the move, never inside one.

--- a/tests/snapshots/server-routes.json
+++ b/tests/snapshots/server-routes.json
@@ -1,0 +1,947 @@
+[
+  {
+    "method": "GET",
+    "path": "/health",
+    "cli_name": "health",
+    "description": "Health check",
+    "category": "status"
+  },
+  {
+    "method": "GET",
+    "path": "/status",
+    "cli_name": "status",
+    "description": "Runtime status with uptime",
+    "category": "status"
+  },
+  {
+    "method": "POST",
+    "path": "/shutdown",
+    "cli_name": "stop",
+    "description": "Gracefully stop the daemon",
+    "category": "status"
+  },
+  {
+    "method": "POST",
+    "path": "/auth/session",
+    "cli_name": "auth session",
+    "description": "Exchange the durable API token for a short-lived browser session token",
+    "category": "status"
+  },
+  {
+    "method": "GET",
+    "path": "/agent",
+    "cli_name": "agent",
+    "description": "Agent identity info",
+    "category": "identity"
+  },
+  {
+    "method": "POST",
+    "path": "/announce",
+    "cli_name": "announce",
+    "description": "Announce identity to network",
+    "category": "identity"
+  },
+  {
+    "method": "GET",
+    "path": "/agent/user-id",
+    "cli_name": "agent user-id",
+    "description": "Current agent user ID",
+    "category": "identity"
+  },
+  {
+    "method": "GET",
+    "path": "/agent/card",
+    "cli_name": "agent card",
+    "description": "Generate shareable identity card",
+    "category": "identity"
+  },
+  {
+    "method": "GET",
+    "path": "/introduction",
+    "cli_name": "agent introduction",
+    "description": "Introduction card with trust-scoped disclosure",
+    "category": "identity"
+  },
+  {
+    "method": "POST",
+    "path": "/agent/card/import",
+    "cli_name": "agent import",
+    "description": "Import agent card to contacts",
+    "category": "identity"
+  },
+  {
+    "method": "POST",
+    "path": "/agent/sign",
+    "cli_name": "agent sign",
+    "description": "Detached ML-DSA-65 signature over a caller-supplied payload",
+    "category": "identity"
+  },
+  {
+    "method": "POST",
+    "path": "/agent/verify",
+    "cli_name": "agent verify",
+    "description": "Verify a detached ML-DSA-65 signature against a caller-supplied public key",
+    "category": "identity"
+  },
+  {
+    "method": "GET",
+    "path": "/peers",
+    "cli_name": "peers",
+    "description": "Connected gossip peers",
+    "category": "network"
+  },
+  {
+    "method": "GET",
+    "path": "/presence",
+    "cli_name": "presence",
+    "description": "Online agents (alias for /presence/online)",
+    "category": "presence"
+  },
+  {
+    "method": "GET",
+    "path": "/presence/online",
+    "cli_name": "presence online",
+    "description": "List all currently online agents (network view, non-blocked)",
+    "category": "presence"
+  },
+  {
+    "method": "GET",
+    "path": "/presence/foaf",
+    "cli_name": "presence foaf",
+    "description": "FOAF random-walk discovery of nearby agents (social view)",
+    "category": "presence"
+  },
+  {
+    "method": "GET",
+    "path": "/presence/find/:id",
+    "cli_name": "presence find",
+    "description": "Find a specific agent by ID via FOAF random walk",
+    "category": "presence"
+  },
+  {
+    "method": "GET",
+    "path": "/presence/status/:id",
+    "cli_name": "presence status",
+    "description": "Get local cache presence status for an agent",
+    "category": "presence"
+  },
+  {
+    "method": "GET",
+    "path": "/presence/events",
+    "cli_name": "presence events",
+    "description": "Server-Sent Events stream of presence online/offline events",
+    "category": "presence"
+  },
+  {
+    "method": "GET",
+    "path": "/network/status",
+    "cli_name": "network status",
+    "description": "Network connectivity details",
+    "category": "network"
+  },
+  {
+    "method": "GET",
+    "path": "/network/bootstrap-cache",
+    "cli_name": "network cache",
+    "description": "Bootstrap peer cache stats",
+    "category": "network"
+  },
+  {
+    "method": "GET",
+    "path": "/diagnostics/connectivity",
+    "cli_name": "diagnostics connectivity",
+    "description": "Connectivity snapshot (NodeStatus + transport_environment VPN/MTU assessment)",
+    "category": "network"
+  },
+  {
+    "method": "GET",
+    "path": "/diagnostics/ack",
+    "cli_name": "diagnostics ack",
+    "description": "ACK-v2 per-stage latency buckets and outcome counters",
+    "category": "network"
+  },
+  {
+    "method": "GET",
+    "path": "/diagnostics/gossip",
+    "cli_name": "diagnostics gossip",
+    "description": "PubSub drop-detection counters (publish/deliver deltas)",
+    "category": "network"
+  },
+  {
+    "method": "GET",
+    "path": "/diagnostics/dm",
+    "cli_name": "diagnostics dm",
+    "description": "Direct-message send/receive counters and per-peer health",
+    "category": "network"
+  },
+  {
+    "method": "GET",
+    "path": "/diagnostics/groups",
+    "cli_name": "diagnostics groups",
+    "description": "Per-group ingest counters, listener state, and drop buckets",
+    "category": "network"
+  },
+  {
+    "method": "GET",
+    "path": "/diagnostics/exec",
+    "cli_name": "diagnostics exec",
+    "description": "Remote exec counters, warnings, active sessions, and ACL summary",
+    "category": "exec"
+  },
+  {
+    "method": "GET",
+    "path": "/diagnostics/ws",
+    "cli_name": "diagnostics ws",
+    "description": "WebSocket outbound-queue health: capacity and drop/slow-consumer-close counters",
+    "category": "network"
+  },
+  {
+    "method": "POST",
+    "path": "/peers/:peer_id/probe",
+    "cli_name": "peer probe",
+    "description": "Active ant-quic probe_peer liveness + RTT (ant-quic 0.27.2 #173)",
+    "category": "network"
+  },
+  {
+    "method": "GET",
+    "path": "/peers/:peer_id/health",
+    "cli_name": "peer health",
+    "description": "Connection health snapshot for a peer (ant-quic 0.27.1 #170)",
+    "category": "network"
+  },
+  {
+    "method": "GET",
+    "path": "/peers/events",
+    "cli_name": "peer events",
+    "description": "SSE stream of peer lifecycle events (ant-quic 0.27.1 #171)",
+    "category": "network"
+  },
+  {
+    "method": "POST",
+    "path": "/publish",
+    "cli_name": "publish",
+    "description": "Publish message to topic",
+    "category": "messaging"
+  },
+  {
+    "method": "POST",
+    "path": "/subscribe",
+    "cli_name": "subscribe",
+    "description": "Subscribe to topic",
+    "category": "messaging"
+  },
+  {
+    "method": "DELETE",
+    "path": "/subscribe/:id",
+    "cli_name": "unsubscribe",
+    "description": "Unsubscribe by ID",
+    "category": "messaging"
+  },
+  {
+    "method": "GET",
+    "path": "/events",
+    "cli_name": "events",
+    "description": "SSE event stream",
+    "category": "messaging"
+  },
+  {
+    "method": "GET",
+    "path": "/agents/discovered",
+    "cli_name": "agents list",
+    "description": "List discovered agents",
+    "category": "discovery"
+  },
+  {
+    "method": "GET",
+    "path": "/agents/discovered/:agent_id",
+    "cli_name": "agents get",
+    "description": "Get discovered agent details",
+    "category": "discovery"
+  },
+  {
+    "method": "GET",
+    "path": "/agents/:agent_id/machine",
+    "cli_name": "agents machine",
+    "description": "Resolve agent to current machine endpoint",
+    "category": "discovery"
+  },
+  {
+    "method": "GET",
+    "path": "/machines/discovered",
+    "cli_name": "machines discovered",
+    "description": "List discovered machine endpoints",
+    "category": "machines"
+  },
+  {
+    "method": "GET",
+    "path": "/machines/discovered/:machine_id",
+    "cli_name": "machines get",
+    "description": "Get discovered machine endpoint details",
+    "category": "machines"
+  },
+  {
+    "method": "POST",
+    "path": "/agents/find/:agent_id",
+    "cli_name": "agents find",
+    "description": "Find agent on network",
+    "category": "discovery"
+  },
+  {
+    "method": "GET",
+    "path": "/agents/reachability/:agent_id",
+    "cli_name": "agents reachability",
+    "description": "Agent reachability info",
+    "category": "discovery"
+  },
+  {
+    "method": "GET",
+    "path": "/users/:user_id/agents",
+    "cli_name": "agents by-user",
+    "description": "Agents by user ID",
+    "category": "discovery"
+  },
+  {
+    "method": "GET",
+    "path": "/users/:user_id/machines",
+    "cli_name": "machines by-user",
+    "description": "Machine endpoints by user ID",
+    "category": "machines"
+  },
+  {
+    "method": "GET",
+    "path": "/contacts",
+    "cli_name": "contacts list",
+    "description": "List contacts",
+    "category": "contacts"
+  },
+  {
+    "method": "POST",
+    "path": "/contacts",
+    "cli_name": "contacts add",
+    "description": "Add contact",
+    "category": "contacts"
+  },
+  {
+    "method": "POST",
+    "path": "/contacts/trust",
+    "cli_name": "trust set",
+    "description": "Quick trust/block",
+    "category": "contacts"
+  },
+  {
+    "method": "PATCH",
+    "path": "/contacts/:agent_id",
+    "cli_name": "contacts update",
+    "description": "Update contact trust",
+    "category": "contacts"
+  },
+  {
+    "method": "DELETE",
+    "path": "/contacts/:agent_id",
+    "cli_name": "contacts remove",
+    "description": "Remove contact",
+    "category": "contacts"
+  },
+  {
+    "method": "POST",
+    "path": "/contacts/:agent_id/revoke",
+    "cli_name": "contacts revoke",
+    "description": "Revoke contact",
+    "category": "contacts"
+  },
+  {
+    "method": "GET",
+    "path": "/contacts/:agent_id/revocations",
+    "cli_name": "contacts revocations",
+    "description": "List revocations",
+    "category": "contacts"
+  },
+  {
+    "method": "GET",
+    "path": "/contacts/:agent_id/machines",
+    "cli_name": "machines list",
+    "description": "List machines for contact",
+    "category": "machines"
+  },
+  {
+    "method": "POST",
+    "path": "/contacts/:agent_id/machines",
+    "cli_name": "machines add",
+    "description": "Add machine record",
+    "category": "machines"
+  },
+  {
+    "method": "DELETE",
+    "path": "/contacts/:agent_id/machines/:machine_id",
+    "cli_name": "machines remove",
+    "description": "Remove machine record",
+    "category": "machines"
+  },
+  {
+    "method": "POST",
+    "path": "/contacts/:agent_id/machines/:machine_id/pin",
+    "cli_name": "machines pin",
+    "description": "Pin machine",
+    "category": "machines"
+  },
+  {
+    "method": "DELETE",
+    "path": "/contacts/:agent_id/machines/:machine_id/pin",
+    "cli_name": "machines unpin",
+    "description": "Unpin machine",
+    "category": "machines"
+  },
+  {
+    "method": "POST",
+    "path": "/trust/evaluate",
+    "cli_name": "trust evaluate",
+    "description": "Evaluate trust for agent+machine",
+    "category": "trust"
+  },
+  {
+    "method": "POST",
+    "path": "/agents/connect",
+    "cli_name": "direct connect",
+    "description": "Connect to agent",
+    "category": "direct"
+  },
+  {
+    "method": "POST",
+    "path": "/machines/connect",
+    "cli_name": "machines connect",
+    "description": "Connect to machine",
+    "category": "direct"
+  },
+  {
+    "method": "POST",
+    "path": "/direct/send",
+    "cli_name": "direct send",
+    "description": "Send direct message",
+    "category": "direct"
+  },
+  {
+    "method": "GET",
+    "path": "/direct/connections",
+    "cli_name": "direct connections",
+    "description": "List direct connections",
+    "category": "direct"
+  },
+  {
+    "method": "GET",
+    "path": "/direct/events",
+    "cli_name": "direct events",
+    "description": "Stream direct messages",
+    "category": "direct"
+  },
+  {
+    "method": "POST",
+    "path": "/exec/run",
+    "cli_name": "exec",
+    "description": "Run a strictly allowlisted non-interactive command on a remote daemon",
+    "category": "exec"
+  },
+  {
+    "method": "POST",
+    "path": "/exec/cancel",
+    "cli_name": "exec cancel",
+    "description": "Cancel an in-flight remote exec request",
+    "category": "exec"
+  },
+  {
+    "method": "GET",
+    "path": "/exec/sessions",
+    "cli_name": "exec sessions",
+    "description": "List local pending and remote active exec sessions",
+    "category": "exec"
+  },
+  {
+    "method": "POST",
+    "path": "/mls/groups",
+    "cli_name": "groups create",
+    "description": "Create encrypted group",
+    "category": "groups"
+  },
+  {
+    "method": "GET",
+    "path": "/mls/groups",
+    "cli_name": "groups list",
+    "description": "List groups",
+    "category": "groups"
+  },
+  {
+    "method": "GET",
+    "path": "/mls/groups/:id",
+    "cli_name": "groups get",
+    "description": "Get group details",
+    "category": "groups"
+  },
+  {
+    "method": "POST",
+    "path": "/mls/groups/:id/members",
+    "cli_name": "groups add-member",
+    "description": "Add member to group",
+    "category": "groups"
+  },
+  {
+    "method": "DELETE",
+    "path": "/mls/groups/:id/members/:agent_id",
+    "cli_name": "groups remove-member",
+    "description": "Remove member",
+    "category": "groups"
+  },
+  {
+    "method": "POST",
+    "path": "/mls/groups/:id/encrypt",
+    "cli_name": "groups encrypt",
+    "description": "Encrypt for group",
+    "category": "groups"
+  },
+  {
+    "method": "POST",
+    "path": "/mls/groups/:id/decrypt",
+    "cli_name": "groups decrypt",
+    "description": "Decrypt from group",
+    "category": "groups"
+  },
+  {
+    "method": "POST",
+    "path": "/mls/groups/:id/welcome",
+    "cli_name": "groups welcome",
+    "description": "Create welcome for member",
+    "category": "groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups",
+    "cli_name": "group create",
+    "description": "Create named group",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups",
+    "cli_name": "group list",
+    "description": "List groups",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups/:id",
+    "cli_name": "group info",
+    "description": "Get group info",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups/:id/members",
+    "cli_name": "group members",
+    "description": "List named-group members",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/members",
+    "cli_name": "group add-member",
+    "description": "Add named-group member",
+    "category": "named-groups"
+  },
+  {
+    "method": "DELETE",
+    "path": "/groups/:id/members/:agent_id",
+    "cli_name": "group remove-member",
+    "description": "Remove named-group member",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/send",
+    "cli_name": "group send",
+    "description": "Publish a signed message to a SignedPublic group",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups/:id/messages",
+    "cli_name": "group messages",
+    "description": "Retrieve cached public messages (non-members on Public read)",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/invite",
+    "cli_name": "group invite",
+    "description": "Generate invite link",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/join",
+    "cli_name": "group join",
+    "description": "Join group via invite",
+    "category": "named-groups"
+  },
+  {
+    "method": "PUT",
+    "path": "/groups/:id/display-name",
+    "cli_name": "group set-name",
+    "description": "Set display name in group",
+    "category": "named-groups"
+  },
+  {
+    "method": "DELETE",
+    "path": "/groups/:id",
+    "cli_name": "group leave",
+    "description": "Leave a group",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups/:id/state",
+    "cli_name": "group state",
+    "description": "Inspect the signed state-commit chain for a group",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups/:id/state/commits",
+    "cli_name": "group state-commits",
+    "description": "Read retained state-commit history (members only, paged)",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/state/seal",
+    "cli_name": "group state-seal",
+    "description": "Advance the state-commit chain and republish signed card",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/state/withdraw",
+    "cli_name": "group delete",
+    "description": "Delete a group with a terminal withdrawal commit",
+    "category": "named-groups"
+  },
+  {
+    "method": "PATCH",
+    "path": "/groups/:id",
+    "cli_name": "group update",
+    "description": "Update group name/description (admin+)",
+    "category": "named-groups"
+  },
+  {
+    "method": "PATCH",
+    "path": "/groups/:id/policy",
+    "cli_name": "group policy",
+    "description": "Update group policy (admin+)",
+    "category": "named-groups"
+  },
+  {
+    "method": "PATCH",
+    "path": "/groups/:id/members/:agent_id/role",
+    "cli_name": "group set-role",
+    "description": "Change a member's role (admin+)",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/ban/:agent_id",
+    "cli_name": "group ban",
+    "description": "Ban a member (admin+)",
+    "category": "named-groups"
+  },
+  {
+    "method": "DELETE",
+    "path": "/groups/:id/ban/:agent_id",
+    "cli_name": "group unban",
+    "description": "Unban a member (admin+)",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups/:id/requests",
+    "cli_name": "group requests",
+    "description": "List join requests (admin+)",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/requests",
+    "cli_name": "group request-access",
+    "description": "Submit a join request",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/requests/:request_id/approve",
+    "cli_name": "group approve-request",
+    "description": "Approve a join request (admin+)",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/requests/:request_id/reject",
+    "cli_name": "group reject-request",
+    "description": "Reject a join request (admin+)",
+    "category": "named-groups"
+  },
+  {
+    "method": "DELETE",
+    "path": "/groups/:id/requests/:request_id",
+    "cli_name": "group cancel-request",
+    "description": "Cancel own pending join request",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups/discover",
+    "cli_name": "group discover",
+    "description": "List locally known discoverable groups",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups/discover/nearby",
+    "cli_name": "group discover-nearby",
+    "description": "Presence-social browse of PublicDirectory groups",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups/discover/subscriptions",
+    "cli_name": "group discover-subscriptions",
+    "description": "List active shard subscriptions",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/discover/subscribe",
+    "cli_name": "group discover-subscribe",
+    "description": "Subscribe to a tag/name/id directory shard",
+    "category": "named-groups"
+  },
+  {
+    "method": "DELETE",
+    "path": "/groups/discover/subscribe/:kind/:shard",
+    "cli_name": "group discover-unsubscribe",
+    "description": "Unsubscribe from a directory shard",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/groups/cards/:id",
+    "cli_name": "group card",
+    "description": "Fetch a single group card",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/cards/import",
+    "cli_name": "group card-import",
+    "description": "Import a group card into local cache",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/secure/encrypt",
+    "cli_name": "group secure-encrypt",
+    "description": "Encrypt content with the group's shared secret (member-only)",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/secure/decrypt",
+    "cli_name": "group secure-decrypt",
+    "description": "Decrypt content with the group's shared secret (member-only, epoch must match)",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/:id/secure/reseal",
+    "cli_name": "group secure-reseal",
+    "description": "Re-seal the current group shared secret to a named recipient (produces a real SecureShareDelivered-format envelope)",
+    "category": "named-groups"
+  },
+  {
+    "method": "POST",
+    "path": "/groups/secure/open-envelope",
+    "cli_name": "group secure-open-envelope",
+    "description": "Attempt to open a SecureShareDelivered envelope with this daemon's KEM key (adversarial test)",
+    "category": "named-groups"
+  },
+  {
+    "method": "GET",
+    "path": "/task-lists",
+    "cli_name": "tasks list",
+    "description": "List task lists",
+    "category": "tasks"
+  },
+  {
+    "method": "POST",
+    "path": "/task-lists",
+    "cli_name": "tasks create",
+    "description": "Create task list",
+    "category": "tasks"
+  },
+  {
+    "method": "GET",
+    "path": "/task-lists/:id/tasks",
+    "cli_name": "tasks show",
+    "description": "Show tasks in list",
+    "category": "tasks"
+  },
+  {
+    "method": "POST",
+    "path": "/task-lists/:id/tasks",
+    "cli_name": "tasks add",
+    "description": "Add task to list",
+    "category": "tasks"
+  },
+  {
+    "method": "PATCH",
+    "path": "/task-lists/:id/tasks/:tid",
+    "cli_name": "tasks claim / tasks complete",
+    "description": "Claim or complete a task (action: claim|complete)",
+    "category": "tasks"
+  },
+  {
+    "method": "GET",
+    "path": "/stores",
+    "cli_name": "store list",
+    "description": "List key-value stores",
+    "category": "stores"
+  },
+  {
+    "method": "POST",
+    "path": "/stores",
+    "cli_name": "store create",
+    "description": "Create key-value store",
+    "category": "stores"
+  },
+  {
+    "method": "POST",
+    "path": "/stores/:id/join",
+    "cli_name": "store join",
+    "description": "Join existing store",
+    "category": "stores"
+  },
+  {
+    "method": "GET",
+    "path": "/stores/:id/keys",
+    "cli_name": "store keys",
+    "description": "List keys in store",
+    "category": "stores"
+  },
+  {
+    "method": "PUT",
+    "path": "/stores/:id/:key",
+    "cli_name": "store put",
+    "description": "Put value in store",
+    "category": "stores"
+  },
+  {
+    "method": "GET",
+    "path": "/stores/:id/:key",
+    "cli_name": "store get",
+    "description": "Get value from store",
+    "category": "stores"
+  },
+  {
+    "method": "DELETE",
+    "path": "/stores/:id/:key",
+    "cli_name": "store rm",
+    "description": "Remove key from store",
+    "category": "stores"
+  },
+  {
+    "method": "POST",
+    "path": "/files/send",
+    "cli_name": "send-file",
+    "description": "Send file to agent",
+    "category": "files"
+  },
+  {
+    "method": "GET",
+    "path": "/files/transfers",
+    "cli_name": "transfers",
+    "description": "List file transfers",
+    "category": "files"
+  },
+  {
+    "method": "GET",
+    "path": "/files/transfers/:id",
+    "cli_name": "transfer-status",
+    "description": "Transfer status",
+    "category": "files"
+  },
+  {
+    "method": "POST",
+    "path": "/files/accept/:id",
+    "cli_name": "accept-file",
+    "description": "Accept incoming transfer",
+    "category": "files"
+  },
+  {
+    "method": "POST",
+    "path": "/files/reject/:id",
+    "cli_name": "reject-file",
+    "description": "Reject incoming transfer",
+    "category": "files"
+  },
+  {
+    "method": "GET",
+    "path": "/constitution",
+    "cli_name": "constitution",
+    "description": "Display the x0x Constitution (Markdown)",
+    "category": "status"
+  },
+  {
+    "method": "GET",
+    "path": "/constitution/json",
+    "cli_name": "constitution --json",
+    "description": "Constitution with version metadata (JSON)",
+    "category": "status"
+  },
+  {
+    "method": "GET",
+    "path": "/upgrade",
+    "cli_name": "upgrade",
+    "description": "Check for updates",
+    "category": "upgrade"
+  },
+  {
+    "method": "POST",
+    "path": "/upgrade/apply",
+    "cli_name": "upgrade --apply",
+    "description": "Apply the latest verified release manifest",
+    "category": "upgrade"
+  },
+  {
+    "method": "GET",
+    "path": "/ws",
+    "cli_name": "ws",
+    "description": "General-purpose WebSocket session",
+    "category": "websocket"
+  },
+  {
+    "method": "GET",
+    "path": "/ws/direct",
+    "cli_name": "ws direct",
+    "description": "WebSocket session for direct messaging",
+    "category": "websocket"
+  },
+  {
+    "method": "GET",
+    "path": "/ws/sessions",
+    "cli_name": "ws sessions",
+    "description": "List WebSocket sessions",
+    "category": "websocket"
+  },
+  {
+    "method": "GET",
+    "path": "/gui",
+    "cli_name": "gui",
+    "description": "Open the embedded GUI",
+    "category": "websocket"
+  }
+]

--- a/tests/snapshots/server-routes.txt
+++ b/tests/snapshots/server-routes.txt
@@ -1,0 +1,139 @@
+METHOD  PATH                                                CLI COMMAND               DESCRIPTION
+--------------------------------------------------------------------------------------------------------------
+GET  /health                                             health                    Health check
+GET  /status                                             status                    Runtime status with uptime
+POST  /shutdown                                           stop                      Gracefully stop the daemon
+POST  /auth/session                                       auth session              Exchange the durable API token for a short-lived browser session token
+GET  /constitution                                       constitution              Display the x0x Constitution (Markdown)
+GET  /constitution/json                                  constitution --json       Constitution with version metadata (JSON)
+GET  /agent                                              agent                     Agent identity info
+POST  /announce                                           announce                  Announce identity to network
+GET  /agent/user-id                                      agent user-id             Current agent user ID
+GET  /agent/card                                         agent card                Generate shareable identity card
+GET  /introduction                                       agent introduction        Introduction card with trust-scoped disclosure
+POST  /agent/card/import                                  agent import              Import agent card to contacts
+POST  /agent/sign                                         agent sign                Detached ML-DSA-65 signature over a caller-supplied payload
+POST  /agent/verify                                       agent verify              Verify a detached ML-DSA-65 signature against a caller-supplied public key
+GET  /peers                                              peers                     Connected gossip peers
+GET  /network/status                                     network status            Network connectivity details
+GET  /network/bootstrap-cache                            network cache             Bootstrap peer cache stats
+GET  /diagnostics/connectivity                           diagnostics connectivity  Connectivity snapshot (NodeStatus + transport_environment VPN/MTU assessment)
+GET  /diagnostics/ack                                    diagnostics ack           ACK-v2 per-stage latency buckets and outcome counters
+GET  /diagnostics/gossip                                 diagnostics gossip        PubSub drop-detection counters (publish/deliver deltas)
+GET  /diagnostics/dm                                     diagnostics dm            Direct-message send/receive counters and per-peer health
+GET  /diagnostics/groups                                 diagnostics groups        Per-group ingest counters, listener state, and drop buckets
+GET  /diagnostics/ws                                     diagnostics ws            WebSocket outbound-queue health: capacity and drop/slow-consumer-close counters
+POST  /peers/:peer_id/probe                               peer probe                Active ant-quic probe_peer liveness + RTT (ant-quic 0.27.2 #173)
+GET  /peers/:peer_id/health                              peer health               Connection health snapshot for a peer (ant-quic 0.27.1 #170)
+GET  /peers/events                                       peer events               SSE stream of peer lifecycle events (ant-quic 0.27.1 #171)
+GET  /presence                                           presence                  Online agents (alias for /presence/online)
+GET  /presence/online                                    presence online           List all currently online agents (network view, non-blocked)
+GET  /presence/foaf                                      presence foaf             FOAF random-walk discovery of nearby agents (social view)
+GET  /presence/find/:id                                  presence find             Find a specific agent by ID via FOAF random walk
+GET  /presence/status/:id                                presence status           Get local cache presence status for an agent
+GET  /presence/events                                    presence events           Server-Sent Events stream of presence online/offline events
+GET  /diagnostics/exec                                   diagnostics exec          Remote exec counters, warnings, active sessions, and ACL summary
+POST  /exec/run                                           exec                      Run a strictly allowlisted non-interactive command on a remote daemon
+POST  /exec/cancel                                        exec cancel               Cancel an in-flight remote exec request
+GET  /exec/sessions                                      exec sessions             List local pending and remote active exec sessions
+POST  /publish                                            publish                   Publish message to topic
+POST  /subscribe                                          subscribe                 Subscribe to topic
+DELETE  /subscribe/:id                                      unsubscribe               Unsubscribe by ID
+GET  /events                                             events                    SSE event stream
+GET  /agents/discovered                                  agents list               List discovered agents
+GET  /agents/discovered/:agent_id                        agents get                Get discovered agent details
+GET  /agents/:agent_id/machine                           agents machine            Resolve agent to current machine endpoint
+POST  /agents/find/:agent_id                              agents find               Find agent on network
+GET  /agents/reachability/:agent_id                      agents reachability       Agent reachability info
+GET  /users/:user_id/agents                              agents by-user            Agents by user ID
+GET  /machines/discovered                                machines discovered       List discovered machine endpoints
+GET  /machines/discovered/:machine_id                    machines get              Get discovered machine endpoint details
+GET  /users/:user_id/machines                            machines by-user          Machine endpoints by user ID
+GET  /contacts/:agent_id/machines                        machines list             List machines for contact
+POST  /contacts/:agent_id/machines                        machines add              Add machine record
+DELETE  /contacts/:agent_id/machines/:machine_id            machines remove           Remove machine record
+POST  /contacts/:agent_id/machines/:machine_id/pin        machines pin              Pin machine
+DELETE  /contacts/:agent_id/machines/:machine_id/pin        machines unpin            Unpin machine
+GET  /contacts                                           contacts list             List contacts
+POST  /contacts                                           contacts add              Add contact
+POST  /contacts/trust                                     trust set                 Quick trust/block
+PATCH  /contacts/:agent_id                                 contacts update           Update contact trust
+DELETE  /contacts/:agent_id                                 contacts remove           Remove contact
+POST  /contacts/:agent_id/revoke                          contacts revoke           Revoke contact
+GET  /contacts/:agent_id/revocations                     contacts revocations      List revocations
+POST  /trust/evaluate                                     trust evaluate            Evaluate trust for agent+machine
+POST  /agents/connect                                     direct connect            Connect to agent
+POST  /machines/connect                                   machines connect          Connect to machine
+POST  /direct/send                                        direct send               Send direct message
+GET  /direct/connections                                 direct connections        List direct connections
+GET  /direct/events                                      direct events             Stream direct messages
+POST  /mls/groups                                         groups create             Create encrypted group
+GET  /mls/groups                                         groups list               List groups
+GET  /mls/groups/:id                                     groups get                Get group details
+POST  /mls/groups/:id/members                             groups add-member         Add member to group
+DELETE  /mls/groups/:id/members/:agent_id                   groups remove-member      Remove member
+POST  /mls/groups/:id/encrypt                             groups encrypt            Encrypt for group
+POST  /mls/groups/:id/decrypt                             groups decrypt            Decrypt from group
+POST  /mls/groups/:id/welcome                             groups welcome            Create welcome for member
+POST  /groups                                             group create              Create named group
+GET  /groups                                             group list                List groups
+GET  /groups/:id                                         group info                Get group info
+GET  /groups/:id/members                                 group members             List named-group members
+POST  /groups/:id/members                                 group add-member          Add named-group member
+DELETE  /groups/:id/members/:agent_id                       group remove-member       Remove named-group member
+POST  /groups/:id/send                                    group send                Publish a signed message to a SignedPublic group
+GET  /groups/:id/messages                                group messages            Retrieve cached public messages (non-members on Public read)
+POST  /groups/:id/invite                                  group invite              Generate invite link
+POST  /groups/join                                        group join                Join group via invite
+PUT  /groups/:id/display-name                            group set-name            Set display name in group
+DELETE  /groups/:id                                         group leave               Leave a group
+GET  /groups/:id/state                                   group state               Inspect the signed state-commit chain for a group
+GET  /groups/:id/state/commits                           group state-commits       Read retained state-commit history (members only, paged)
+POST  /groups/:id/state/seal                              group state-seal          Advance the state-commit chain and republish signed card
+POST  /groups/:id/state/withdraw                          group delete              Delete a group with a terminal withdrawal commit
+PATCH  /groups/:id                                         group update              Update group name/description (admin+)
+PATCH  /groups/:id/policy                                  group policy              Update group policy (admin+)
+PATCH  /groups/:id/members/:agent_id/role                  group set-role            Change a member's role (admin+)
+POST  /groups/:id/ban/:agent_id                           group ban                 Ban a member (admin+)
+DELETE  /groups/:id/ban/:agent_id                           group unban               Unban a member (admin+)
+GET  /groups/:id/requests                                group requests            List join requests (admin+)
+POST  /groups/:id/requests                                group request-access      Submit a join request
+POST  /groups/:id/requests/:request_id/approve            group approve-request     Approve a join request (admin+)
+POST  /groups/:id/requests/:request_id/reject             group reject-request      Reject a join request (admin+)
+DELETE  /groups/:id/requests/:request_id                    group cancel-request      Cancel own pending join request
+GET  /groups/discover                                    group discover            List locally known discoverable groups
+GET  /groups/discover/nearby                             group discover-nearby     Presence-social browse of PublicDirectory groups
+GET  /groups/discover/subscriptions                      group discover-subscriptions  List active shard subscriptions
+POST  /groups/discover/subscribe                          group discover-subscribe  Subscribe to a tag/name/id directory shard
+DELETE  /groups/discover/subscribe/:kind/:shard             group discover-unsubscribe  Unsubscribe from a directory shard
+GET  /groups/cards/:id                                   group card                Fetch a single group card
+POST  /groups/cards/import                                group card-import         Import a group card into local cache
+POST  /groups/:id/secure/encrypt                          group secure-encrypt      Encrypt content with the group's shared secret (member-only)
+POST  /groups/:id/secure/decrypt                          group secure-decrypt      Decrypt content with the group's shared secret (member-only, epoch must match)
+POST  /groups/:id/secure/reseal                           group secure-reseal       Re-seal the current group shared secret to a named recipient (produces a real SecureShareDelivered-format envelope)
+POST  /groups/secure/open-envelope                        group secure-open-envelope  Attempt to open a SecureShareDelivered envelope with this daemon's KEM key (adversarial test)
+GET  /task-lists                                         tasks list                List task lists
+POST  /task-lists                                         tasks create              Create task list
+GET  /task-lists/:id/tasks                               tasks show                Show tasks in list
+POST  /task-lists/:id/tasks                               tasks add                 Add task to list
+PATCH  /task-lists/:id/tasks/:tid                          tasks claim / tasks complete  Claim or complete a task (action: claim|complete)
+GET  /stores                                             store list                List key-value stores
+POST  /stores                                             store create              Create key-value store
+POST  /stores/:id/join                                    store join                Join existing store
+GET  /stores/:id/keys                                    store keys                List keys in store
+PUT  /stores/:id/:key                                    store put                 Put value in store
+GET  /stores/:id/:key                                    store get                 Get value from store
+DELETE  /stores/:id/:key                                    store rm                  Remove key from store
+POST  /files/send                                         send-file                 Send file to agent
+GET  /files/transfers                                    transfers                 List file transfers
+GET  /files/transfers/:id                                transfer-status           Transfer status
+POST  /files/accept/:id                                   accept-file               Accept incoming transfer
+POST  /files/reject/:id                                   reject-file               Reject incoming transfer
+GET  /upgrade                                            upgrade                   Check for updates
+POST  /upgrade/apply                                      upgrade --apply           Apply the latest verified release manifest
+GET  /ws                                                 ws                        General-purpose WebSocket session
+GET  /ws/direct                                          ws direct                 WebSocket session for direct messaging
+GET  /ws/sessions                                        ws sessions               List WebSocket sessions
+GET  /gui                                                gui                       Open the embedded GUI
+
+135 endpoints total


### PR DESCRIPTION
P0 of the #125 / WS1.4 `src/server/mod.rs` decomposition series. Establishes the byte-exact route baseline that every subsequent extraction PR must preserve.

**What:** committed `x0x routes` (text + JSON) snapshots + a README documenting the characterization methodology and the `x0x::server` public-API surface inventory.

**Why:** the plan requires the endpoint table to be byte-identical after every move. The snapshots are the human-readable artifact; the runtime parity chain is already enforced by `route_set_matches_registry` (runs the real router) + `manifest_matches_registry` (pins the committed manifest against the live registry). A mechanical move that drops/renames a route breaks the former even if the snapshot text is unchanged.

No code changes — characterization artifact only. Followed by the extraction PR series: auth.rs → state.rs → ws.rs/sse.rs → routes/ groups.

Refs #125.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds route characterization snapshots for the server decomposition work.

- Adds a README for the snapshot workflow and public API surface.
- Adds a JSON snapshot of the 135 registered routes.
- Adds a text table snapshot of the same route set.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small README cleanup.

- The changed files are documentation and snapshots only.
- The route snapshot contents line up with the described route table shape.
- The README should clarify that the new snapshot files are checked manually unless automation is added.

tests/snapshots/README.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/snapshots/README.md | Adds the route snapshot workflow and API surface notes, with one wording issue around automated coverage. |
| tests/snapshots/server-routes.json | Adds the structured route snapshot for the current 135 endpoints. |
| tests/snapshots/server-routes.txt | Adds the human-readable route table snapshot for the current 135 endpoints. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/snapshots/README.md:17-20
**Snapshot Drift Is Manual**

This section lists the existing registry and router checks under automated guards, but those checks do not read `tests/snapshots/server-routes.txt` or `tests/snapshots/server-routes.json`. If a later extraction changes `x0x routes` output and the snapshots are not regenerated, CI can still pass while the committed byte-exact baseline is stale.

```suggestion
## Automated guards

The snapshots are the human-readable rendering and are currently checked by the
manual re-run-and-diff workflow above. The runtime parity chain is enforced in CI
by existing tests:
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(125/ws1.4-p0): snapshot x0x routes..."](https://github.com/saorsa-labs/x0x/commit/21264444ec753ad1c33c8da0a051d67de7ffd8c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41589723)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->