### PR TITLE
test(ws): stalled-reader slow-consumer harness + let Close(1013) reach the wire (#149)

### DIFF
--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -405,7 +405,7 @@ async fn handle_ws_connection(
     // then exits even if the close frame cannot flush (the reader is stalled).
     let writer_session_id = session_id.clone();
     let writer_slow_close = slow_close.clone();
-    let writer = tokio::spawn(async move {
+    let mut writer = tokio::spawn(async move {
         run_ws_writer(&mut outbound_rx, &mut ws_tx, &writer_slow_close).await;
         tracing::debug!(session_id = %writer_session_id, "WebSocket writer stopped");
     });
@@ -514,11 +514,21 @@ async fn handle_ws_connection(
         cleanup_ws_topic_if_empty(&state, topic, &session_id).await;
     }
 
-    writer.abort();
+    // Retire the feeders and drop the last outbound sender so the writer can
+    // observe channel closure and exit on its own.
     keepalive.abort();
     if let Some(h) = direct_handle {
         h.abort();
     }
+    drop(outbound_tx);
+    // Give the writer a bounded grace period instead of aborting it outright:
+    // on a slow-consumer close it is inside its 2s Close(1013) flush budget,
+    // and an immediate abort tears the socket down before the documented
+    // close frame can ever reach the (possibly now-draining) client — the
+    // #149 stalled-reader harness observed a raw connection reset instead of
+    // the 1013. Any other writer exits promptly once the senders are gone.
+    let _ = tokio::time::timeout(Duration::from_secs(3), &mut writer).await;
+    writer.abort();
 
     tracing::info!(session_id = %session_id, "WebSocket session closed");
 }

--- a/tests/ws_integration.rs
+++ b/tests/ws_integration.rs
@@ -570,3 +570,200 @@ async fn ws_message_ordering() {
 
     ws.close(None).await.expect("close");
 }
+
+// ---------------------------------------------------------------------------
+// WS1.1 stalled-reader harness (#149, follow-up to #147 / #122)
+// ---------------------------------------------------------------------------
+
+/// Read the WS outbound counters from `GET /diagnostics/ws`.
+async fn ws_outbound_counters(client: &reqwest::Client, d: &DaemonFixture) -> (u64, u64) {
+    let v: Value = client
+        .get(d.url("/diagnostics/ws"))
+        .send()
+        .await
+        .expect("GET /diagnostics/ws")
+        .json()
+        .await
+        .expect("parse /diagnostics/ws");
+    (
+        v["ws_outbound_dropped"]
+            .as_u64()
+            .expect("ws_outbound_dropped field"),
+        v["ws_slow_consumer_closes"]
+            .as_u64()
+            .expect("ws_slow_consumer_closes field"),
+    )
+}
+
+/// A local WS client that stops draining its socket must not grow daemon
+/// memory without bound.
+///
+/// WHY: the per-session outbound queue is the daemon's only memory bound
+/// against a misbehaving local client — one that completes the handshake,
+/// subscribes, then never reads another frame while topic traffic keeps
+/// flowing. PR #147 bounded the queue (`WS_OUTBOUND_CAPACITY=1024`) with two
+/// feeder policies (topic frames drop-with-counter; DM/keepalive frames close
+/// the session with WS 1013) and pinned both with unit tests against fakes.
+/// This test is the deferred end-to-end leg (#149): it proves the policy
+/// actually fires against a REAL stalled socket.
+///
+/// The documented obstacle (issue #149): no external frame flood can fill the
+/// bounded queue on its own — the `gossip → broadcast(256) → outbound(1024) →
+/// writer → TCP` pipeline absorbs any burst unless the writer itself is stuck
+/// flushing to a stalled socket. So the harness uses a cooperating stalled
+/// reader: `tokio-tungstenite` only reads from the TCP socket when the stream
+/// is polled, so after subscribing the client simply never polls `ws.next()`.
+/// The kernel recv buffer fills, the TCP window closes, the daemon's writer
+/// blocks in `ws_tx.send()`, and the queue fills behind it.
+///
+/// End-to-end assertions:
+/// 1. `ws_outbound_dropped` climbs (topic frames dropped on the Full queue);
+/// 2. the 30s keepalive pinger — the reliable detector — closes the session,
+///    incrementing `ws_slow_consumer_closes` exactly once, within a bounded
+///    wall-clock window;
+/// 3. once the client resumes draining, it receives the WS Close frame
+///    carrying 1013 "Try Again Later" — the documented, client-visible
+///    contract (this caught a real bug: session cleanup used to abort the
+///    writer mid-flush, so the 1013 never reached the wire and clients only
+///    ever saw a raw connection reset);
+/// 4. the session is removed from `/ws/sessions` (resources reclaimed).
+///
+/// ~60-90s wall clock (dominated by the 30s keepalive cadence), hence the
+/// `--ignored` integration tier.
+#[tokio::test]
+#[ignore]
+async fn ws_stalled_reader_fills_queue_and_closes_1013() {
+    let d = daemon().await;
+    let client = client_with_auth(&d);
+    let topic = format!("stall-test-{}", rand::random::<u32>());
+
+    let mut ws = ws_connect(&d, "/ws").await;
+    let connected = ws_recv_text(&mut ws, 5).await.expect("connected frame");
+    let frame: Value = serde_json::from_str(&connected).expect("parse connected");
+    let session_id = frame["session_id"]
+        .as_str()
+        .expect("session_id in connected frame")
+        .to_string();
+    ws_subscribe_topic(&mut ws, &topic).await;
+
+    let (base_dropped, base_closes) = ws_outbound_counters(&client, &d).await;
+
+    // ── STALL: from here on the client never polls `ws`, so nothing is read
+    // from the socket. Large payloads (~22KB per frame after base64+JSON)
+    // saturate the kernel buffers quickly so the writer blocks after a few
+    // frames instead of a few thousand.
+    let payload = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        [b'x'; 16 * 1024],
+    );
+
+    // Publish until the per-session queue observes Full (drops counted).
+    // Kernel buffers absorb a few frames and the mpsc holds 1024, so >1100
+    // frames are needed; REST publishes run in concurrent waves because a
+    // single serial publish round-trip is far too slow to beat the deadline.
+    let fill_deadline = tokio::time::Instant::now() + Duration::from_secs(180);
+    let mut dropped = base_dropped;
+    let mut published: u32 = 0;
+    while dropped <= base_dropped {
+        assert!(
+            tokio::time::Instant::now() < fill_deadline,
+            "outbound queue never filled: published {published} frames, \
+             ws_outbound_dropped still {dropped} (baseline {base_dropped})"
+        );
+        let wave: Vec<_> = (0..64)
+            .map(|_| {
+                client
+                    .post(d.url("/publish"))
+                    .json(&json!({"topic": &topic, "payload": &payload}))
+                    .send()
+            })
+            .collect();
+        for resp in futures::future::join_all(wave).await {
+            let resp = resp.expect("publish");
+            assert_eq!(resp.status(), 200, "publish #{published} failed");
+            published += 1;
+        }
+        (dropped, _) = ws_outbound_counters(&client, &d).await;
+    }
+    assert!(
+        dropped > base_dropped,
+        "ws_outbound_dropped must climb once the queue is full"
+    );
+
+    // ── The keepalive pinger (30s cadence) is the detector: its feed_critical
+    // hits the Full queue and closes the session. Bounded window: one full
+    // interval plus slack.
+    let close_deadline = tokio::time::Instant::now() + Duration::from_secs(45);
+    let mut closes = base_closes;
+    while closes <= base_closes {
+        assert!(
+            tokio::time::Instant::now() < close_deadline,
+            "slow-consumer close did not fire within 45s of queue saturation \
+             (ws_slow_consumer_closes still {closes}, baseline {base_closes})"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        (_, closes) = ws_outbound_counters(&client, &d).await;
+    }
+    assert_eq!(
+        closes,
+        base_closes + 1,
+        "slow-consumer close must be counted exactly once per session"
+    );
+
+    // ── Resume draining: the kernel-buffered backlog flushes first, then the
+    // writer's Close(1013) (it holds a 2s flush budget and cleanup grants a
+    // bounded grace period before aborting it, so the close frame reaches the
+    // wire once the client drains — the client-visible contract).
+    let drain_deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    let mut close_code: Option<u16> = None;
+    while tokio::time::Instant::now() < drain_deadline {
+        match tokio::time::timeout(Duration::from_secs(5), ws.next()).await {
+            Ok(Some(Ok(Message::Close(close_frame)))) => {
+                close_code = close_frame.as_ref().map(|f| u16::from(f.code));
+                break;
+            }
+            Ok(Some(Ok(_))) => continue, // buffered backlog frames
+            Ok(Some(Err(e))) => panic!(
+                "stalled session must end with a Close(1013) frame, \
+                 not an abrupt socket error: {e}"
+            ),
+            Ok(None) => panic!("stalled session must end with a Close(1013) frame, not EOF"),
+            Err(_) => break, // stream open and quiet — deadline loop decides
+        }
+    }
+    assert_eq!(
+        close_code,
+        Some(1013),
+        "slow-consumer close must reach the client as WS 1013 Try Again Later"
+    );
+    eprintln!(
+        "stalled reader: published={published} dropped={} close_code={close_code:?}",
+        dropped - base_dropped
+    );
+
+    // ── The session must be gone from /ws/sessions (resources reclaimed).
+    let sessions_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let v: Value = client
+            .get(d.url("/ws/sessions"))
+            .send()
+            .await
+            .expect("GET /ws/sessions")
+            .json()
+            .await
+            .expect("parse /ws/sessions");
+        let still_present = v["sessions"]
+            .as_array()
+            .expect("sessions array")
+            .iter()
+            .any(|s| s["session_id"].as_str() == Some(session_id.as_str()));
+        if !still_present {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < sessions_deadline,
+            "stalled session {session_id} still registered after slow-consumer close"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}


### PR DESCRIPTION
# Summary

Closes #149 — the deferred stalled-reader integration harness for the WS1.1 per-WebSocket outbound-queue slow-consumer close (follow-up to PR #147 / #122). One new `#[ignore]`d daemon-backed test in `tests/ws_integration.rs` (already in the CI `--ignored` integration tier — no workflow change needed), plus a small production fix the harness immediately caught.

## How the documented obstacle was solved

Issue #149 documented why the literal test wasn't viable in PR #147: no external frame flood can fill the bounded per-session queue — the `gossip → broadcast(256) → outbound(1024) → writer → TCP` pipeline absorbs any burst unless the writer itself is stuck flushing to a stalled socket.

The harness therefore uses a **cooperating stalled reader**: `tokio-tungstenite` only reads from the TCP socket when the stream is polled, so after subscribing the client simply never polls `ws.next()`. The kernel recv buffer fills, the TCP window closes, the daemon's writer blocks in `ws_tx.send()`, and the per-session mpsc fills behind it. Two accelerators make it CI-viable:

- **Large frames** (16 KiB payloads → ~22 KB per WS frame) so kernel buffers saturate after a handful of frames instead of thousands;
- **Concurrent REST `/publish` waves** (64 in flight) — a serial publish loop is ~5 msg/s and cannot out-run the 1024-slot capacity within any reasonable deadline (this is exactly what defeated the PR #147 attempt: 555 frames in 120 s, zero drops).

The 30 s keepalive cadence keeps the test at ~30–95 s wall clock, so it sits in the `--ignored` integration tier like the rest of `ws_integration.rs`.

## What the test proves end-to-end (`ws_stalled_reader_fills_queue_and_closes_1013`)

A misbehaving local WS client must not grow daemon memory without bound:

1. `ws_outbound_dropped` climbs — topic frames are dropped, not buffered, once the queue observes Full;
2. the keepalive pinger closes the session within a bounded window (≤45 s of saturation), incrementing `ws_slow_consumer_closes` **exactly once**;
3. once the client resumes draining it receives the WS **Close(1013 "Try Again Later")** frame — the client-visible contract;
4. the session disappears from `/ws/sessions` (resources reclaimed).

## Production fix the harness caught (src/server/mod.rs, +14/−2)

First green run terminated with `Connection reset without closing handshake` — the 1013 close frame **never reached the wire**: session cleanup called `writer.abort()` immediately after the reader loop broke, killing the writer inside its 2 s Close(1013) flush budget (the socket buffers are saturated at that moment by construction, so the flush always loses that race).

Fix: cleanup now retires the feeders, drops the last outbound sender (so the writer observes channel closure and exits on its own in the normal path), and grants the writer a bounded 3 s grace period before aborting. With the fix the client deterministically receives Close(1013); the test pins it strictly.

## Negative sanity check (run ad hoc, not committed)

Same flow pointed at a **healthy draining client** (reader task continuously polling): 1,664 published frames — well over the 1024 capacity — produced `ws_outbound_dropped = 0` and the harness assertions failed as designed. The harness detects regressions in both directions.

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo nextest run --all-features --test ws_integration --run-ignored ignored-only` — **all 10 WS integration tests green including the new harness** (the CI tier that exercises the changed code; integration.yml already runs this file, no workflow change needed)
- `cargo nextest run --all-features --workspace` (non-ignored): 1948/1954 passed. The 6 failures are the documented **local-only timing flakes** (#139 class: `named_group_join_metadata_event` — verified failing identically on clean `origin/main` in this environment; #148 class: `peer_lifecycle_integration` direct-send timing — passes on clean main and intermittently everywhere here, and the file opens no WebSocket, so there is no causal path from this diff)

Refs #147, #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds coverage for stalled WebSocket readers and changes cleanup so slow-consumer closes can flush.

- Adds an ignored stalled-reader integration test for queue saturation and Close(1013).
- Adds a helper for reading WebSocket outbound diagnostics counters.
- Changes WebSocket cleanup to stop feeders, drop the outbound sender, and wait briefly for the writer before aborting.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small cleanup-latency check.

- No blocking issues found in the changed code.
- The only flagged path is a bounded wait during ordinary WebSocket shutdown when sender clones are still alive.

src/server/mod.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/mod.rs | WebSocket session cleanup now gives the writer a bounded chance to finish before aborting. |
| tests/ws_integration.rs | Adds an ignored daemon-backed integration test for stalled-reader slow-consumer behavior. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as Stalled WS client
    participant Queue as Outbound queue
    participant Feeders as Feeders
    participant Writer as Writer task
    participant Cleanup as Cleanup path

    Client->>Feeders: Subscribe then stop reading
    Feeders->>Queue: Topic frames fill queue
    Feeders->>Feeders: Critical feed sees Full
    Feeders->>Writer: Cancel slow-close token
    Writer->>Client: Try Close(1013)
    Cleanup->>Feeders: Abort feeders
    Cleanup->>Queue: Drop local sender
    Cleanup->>Writer: Wait up to 3s, then abort
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as Stalled WS client
    participant Queue as Outbound queue
    participant Feeders as Feeders
    participant Writer as Writer task
    participant Cleanup as Cleanup path

    Client->>Feeders: Subscribe then stop reading
    Feeders->>Queue: Topic frames fill queue
    Feeders->>Feeders: Critical feed sees Full
    Feeders->>Writer: Cancel slow-close token
    Writer->>Client: Try Close(1013)
    Cleanup->>Feeders: Abort feeders
    Cleanup->>Queue: Drop local sender
    Cleanup->>Writer: Wait up to 3s, then abort
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/server/mod.rs:18508
**Cleanup Can Wait On Live Senders**

When a normal WebSocket shutdown has topic or direct feeder tasks that have been aborted but have not yet dropped their `outbound_tx` clones, `outbound_rx.recv()` can remain open after the local sender is dropped. This makes cleanup sit in the full 3 second timeout before aborting the writer, leaving the socket write half alive longer than necessary on ordinary session closes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ws): stalled-reader slow-consumer h..."](https://github.com/saorsa-labs/x0x/commit/e9f510750aac70b93d7ca1748b7ed2ef1b21a2e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41614694)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->