### PR TITLE
docs(plans): 2026-07 release handoff + #130/#131 implementation plans

### DIFF
--- a/docs/plans/2026-07-issue-130-key-lifecycle-plan.md
+++ b/docs/plans/2026-07-issue-130-key-lifecycle-plan.md
@@ -1,0 +1,173 @@
+# Implementation Plan — Issue #130: Key lifecycle (expiry, renewal, revocation)
+(Produced by plan-130 read-only planning agent, 2026-07-03. Hand verbatim to the implementation agent.)
+
+## 0. Context and investigated facts
+
+All paths relative to /Users/davidirvine/Desktop/Devel/projects/x0x.
+
+**The "verified" gates (four consumers, one annotation source per transport path):**
+
+1. **PubSub signature verification** — src/gossip/pubsub.rs:1044-1064: incoming v2 pubsub messages carry the sender's ML-DSA-65 public key; `verify_signature` checks it and sets `PubSubMessage.verified` (struct at src/gossip/pubsub.rs:162-178, also carries `trust_level`). Self-authenticating (AgentId = SHA-256 of pubkey) — needs no identity cache.
+2. **Gossip-DM inbox** — src/dm_inbox.rs `InboxPipeline::handle_incoming` (~line 195): requires `msg.verified`, decodes the `DmEnvelope`, verifies envelope signature, checks `envelope.sender_agent_id == pubsub_sender`, then builds `DmTypedPayload { verified: true, trust_decision, .. }` (src/dm_inbox.rs:429). This payload is what exec gates on.
+3. **Exec service** — src/exec/service.rs:767-778: denies `!inbound.verified` (DenialReason::UnverifiedSender) then `trust_decision != Some(TrustDecision::Accept)`. Gate order pinned by tests at service.rs:2438-2699.
+4. **Group metadata apply gate** — src/server/mod.rs:7678-7688: `bypass_verified = matches!(...)` for MemberRemoved{commit: Some} / GroupDeleted (self-authenticating signed commits, delivery-critical for the removed peer); `if !verified && !bypass_verified { reject }`.
+
+Cache backing the annotations: `Agent::is_agent_machine_verified` (src/lib.rs:6677) reads `identity_discovery_cache` (`DiscoveredAgent` entries); populated from `IdentityAnnouncement`s (IDENTITY_ANNOUNCE_TOPIC = "x0x.identity.announce.v2", src/lib.rs:345) which optionally embed an `AgentCertificate`.
+
+**Identity types** (src/identity.rs): MachineKeypair, AgentKeypair (:228), UserKeypair (:307), AgentCertificate (:419) with fields user_public_key, agent_public_key, signature, issued_at; signed message `b"x0x-agent-cert-v1" || user_pubkey || agent_pubkey || issued_at` (CERT_PREFIX :431, build_message ~:538, verify() :477). **No revocation or expiry concept exists anywhere today.**
+
+**Storage** (src/storage.rs): `SerializedKeypair { public_key: Vec<u8>, secret_key: Vec<u8> }` (:19-26) via plain bincode; files ~/.x0x/machine.key, agent.key, user.key, agent.cert (AGENT_CERT_FILE :104, cert save/load :452-491, path-scoped variants e.g. save_agent_certificate_to :479). **bincode 1.x cannot skip a missing trailing Option field — old files fail to decode as a grown struct** (behavior documented by existing test identity_announcement_backward_compat_no_nat_fields, src/lib.rs:9782-9830).
+
+**Announcement wire**: IdentityAnnouncement/UserAnnouncement/MachineAnnouncement are bincode with reject_trailing_bytes() (src/lib.rs:1505-1537). UserAnnouncement (src/lib.rs:1021) is a user-signed list of AgentCertificates. Precedent: the NAT-fields change was a documented non-transparent protocol evolution ("nodes must upgrade together"; fleet self-updates).
+
+**Propagation patterns**: well-known topic consts (src/lib.rs:345-359, src/upgrade/manifest.rs:11 RELEASE_TOPIC), periodic identity heartbeat re-announce (interval const near src/lib.rs:656), groups OR-Set anti-entropy (src/groups/).
+
+**Surfaces**: routes still live in src/server/mod.rs (identity block :1582-1610) — the routes/ extraction is in flight; place handlers wherever identity routes live at implementation time. Registry: src/api/mod.rs EndpointDef entries (category "identity"). CLI: src/bin/x0x.rs Commands enum (:57) + src/cli/commands/identity.rs. Daemon config: src/server/state.rs DaemonConfig (:138, identity_dir at :229). ADRs: docs/adr/, **next number is 0018**.
+
+---
+
+## 1. Design decisions
+
+### D1 — What v1 renews, expires, revokes
+
+| Layer | Expiry | Renewal | Revocation |
+|---|---|---|---|
+| AgentCertificate | `not_after: Option<u64>` — the only network-enforced expiry | `x0x identity renew` re-issues cert (user key), no downtime | implied by agent/user revocation |
+| Agent key | not_after on the key file (local record only) | out of scope v1 (new AgentId = new identity) — ADR "future work" | RevokedSubject::Agent(AgentId) |
+| Machine key | not_after on the key file (local record only) | out of scope v1 (new MachineId = new QUIC PeerId ⇒ inherently a reconnect) — ADR | RevokedSubject::Machine(MachineId) |
+
+Rationale: machine key is the QUIC transport identity — rotating it IS downtime by definition; agent key is the addressable identity — rotating it orphans contacts/groups. The AgentCertificate is the only credential re-issuable transparently (peers already handle cert updates via re-announcement). This satisfies "renewal round-trips without downtime" honestly.
+
+### D2 — Key-file format versioning (the no-breaking-change requirement)
+
+New container: `magic b"X0XK" (4 bytes) || version u8 (=2) || bincode(SerializedKeypairV2 { public_key, secret_key, not_after: Option<u64> })`. Cert file gets magic b"X0XC" similarly.
+
+- **Read**: file starts with magic → parse V2; otherwise → legacy bincode(SerializedKeypair). Unambiguous: a legacy file's first 8 bytes are the LE u64 length of the ML-DSA-65 public key (1952 = A0 07 00 00 00 00 00 00); it can never begin with 'X' (0x58).
+- **Write**: **legacy format when not_after is None; V2 only when Some.** Preserves DOWNGRADE compatibility too (an older x0xd after rollback still reads keys of users who never set expiry) — important given the self-update/rollback system.
+- Rejected alternatives: enum-wrapping (u32 variant tag could collide with legacy length prefixes, forces rewriting every existing file); trailing-Option reliance (bincode 1.x hard-fails, per src/lib.rs:9782 test).
+
+### D3 — AgentCertificate expiry without breaking old certs
+
+Add trailing `not_after: Option<u64>` to AgentCertificate + new constructor `issue_with_expiry(user_kp, agent_kp, not_after)`. **Signature compatibility rule**: when not_after is None, the signed message is byte-identical to v1 (x0x-agent-cert-v1 prefix, no extra bytes); when Some, use prefix b"x0x-agent-cert-v2" and append not_after LE bytes. verify() (src/identity.rs:477) reconstructs based on presence. Consequences:
+
+- Old certs loaded from legacy files (decoded via a private AgentCertificateV1Disk shape, mapped with not_after: None) verify unchanged. **Absence of expiry = valid, forever** (default-safe).
+- not_after is signature-covered when present — a stripped/tampered expiry fails verification (pin with a test).
+- **Wire impact**: announcements embedding a cert change encoding (bincode is positional). Mitigating facts: (a) announcements WITHOUT a user identity carry agent_certificate: None (a single 0x00 byte) — those stay byte-compatible across versions; (b) the codebase's blessed stance for cert-carrying announcements is coordinated fleet upgrade (src/lib.rs:9816-9830; fleet self-updates). Document in ADR. Alternative (bump topics to .v3, dual-publish) is heavier and not required — flag in ADR as escape hatch.
+
+### D4 — Revocation record
+
+New module src/revocation.rs:
+
+```rust
+pub enum RevokedSubject { Agent(AgentId), Machine(MachineId) }
+pub struct RevocationRecord {
+    pub subject: RevokedSubject,
+    pub issuer_public_key: Vec<u8>,   // ML-DSA-65
+    pub revoked_at: u64,              // informational
+    pub reason: Option<String>,
+    pub signature: Vec<u8>,           // over b"x0x-revocation-v1" || subject tag+id || issuer_pubkey || revoked_at || reason
+}
+```
+
+**Who may revoke — exactly two rules, both verifiable without trust state:**
+1. **Self-revocation**: issuer key IS the subject (hash of issuer_public_key == the AgentId, or == the MachineId). Always valid — an attacker "revoking" a stolen key only helps the victim.
+2. **Issuer revocation**: for Agent subjects, issuer key hashes to the UserId appearing in a known AgentCertificate for that agent (check discovery cache / cert carried in the same gossip batch). The user who vouched can un-vouch.
+
+No third-party revocation in v1. **No un-revocation in v1** — the set is grow-only (G-Set), which eliminates the entire replay/rollback class: replaying a revocation is idempotent and there is no "restore" message to replay. Dedupe by BLAKE3 hash of canonical record bytes. State the no-un-revoke rule explicitly in the ADR.
+
+**Storage**: in-memory RevocationSet (HashSet<AgentId> + HashSet<MachineId> for O(1) gate checks + HashMap<[u8;32], RevocationRecord> for rebroadcast) as Arc<RwLock<RevocationSet>> on Agent. Persisted to <identity_dir>/revocations.bin (magic b"X0XR" + bincode Vec<RevocationRecord>) via the existing write_private_file pattern; loaded at agent build. Use identity_dir scoping (multi-instance daemons already scope identity there per the #97 agent.cert fix; DaemonConfig.identity_dir src/server/state.rs:229). Not KvStore — the gate must be consultable synchronously at agent-layer with zero daemon dependency.
+
+**Propagation**: new const `REVOCATION_TOPIC: &str = "x0x.revocation.v1"` next to the announce topics (src/lib.rs:345-359). Payload = bincode Vec<RevocationRecord> (reject_trailing_bytes + size limit like deserialize_machine_announcement, src/lib.rs:1503).
+- On issue: persist, apply locally, publish immediately.
+- On receipt: verify each unknown record against rules 1/2, merge, persist, enforce (D5).
+- **Anti-entropy**: piggyback on the identity heartbeat cadence (interval const near src/lib.rs:656) — every heartbeat, publish the full local revocation set; also once after join_network. Records are rare and ~5.3 KB each (pubkey 1952 B + sig 3309 B); full-set periodic broadcast is fine for v1 and is what makes it partition-tolerant (a daemon offline during the revocation learns from any peer's next rebroadcast). Known records are hash-deduped before re-verification. ADR flags digest-exchange (OR-Set style like groups tag shards) as the scale-up path — not needed now.
+
+### D5 — Enforcement points (fail closed on revocation; absence of expiry = valid)
+
+Do NOT thread state into src/gossip/pubsub.rs — enforce at consumers, which all have Agent/AppState access:
+
+1. **Announcement ingest** (identity announce handler in src/lib.rs populating identity_discovery_cache): drop announcements from revoked agents/machines; drop (or cache without user attestation) announcements whose embedded cert is expired (now > not_after + skew) or fails verify. Starves the verified annotation for revoked peers at the source.
+2. **is_agent_machine_verified** (src/lib.rs:6677): read-time checks — return false if agent or bound machine is revoked, or if the cached cert is expired. Store `cert_not_after: Option<u64>` on DiscoveredAgent at ingest so this is a field compare (REST responses are serde_json — additive field safe).
+3. **DM inbox** (src/dm_inbox.rs handle_incoming, right after the envelope-signature check ~line 268): drop when envelope.sender_agent_id is revoked (add a `dropped_revoked` counter beside record_incoming_signature_failed). Kills DMs AND exec (exec rides typed DM payloads) in one place; src/exec/service.rs:767-778 needs no change and inherits the denial.
+4. **Group metadata gate** (src/server/mod.rs:7678-7688): insert the revocation check BEFORE the bypass_verified branch — a revoked sender fails closed even for self-authenticating events. This does NOT regress #99/MemberRemoved semantics: bypass_verified exists because ABSENCE of a cache entry is racy; revocation is POSITIVE knowledge and is exactly what must not be bypassed. Pin with a test that a merely-unverified (not revoked) sender's MemberRemoved{commit: Some} still applies.
+5. **Active drop on receipt**: when a revocation is applied — (a) evict subject from identity_discovery_cache, machine cache, bootstrap cache; (b) close any live connection to the revoked MachineId — implementer: check NetworkNode/ant_quic::Node for a disconnect/close API (src/network.rs); if none exposed, message-layer denial + cache eviction (no re-dial) is v1 behavior and the ADR notes the QUIC connection lingers until idle timeout; (c) mark the contact Blocked-equivalent — TrustEvaluator::evaluate (src/trust.rs:106) already rejects Blocked first, which is how "cached-peer trust honors it on receipt" is satisfied.
+
+### D6 — Expiry check + clock skew
+
+One helper, one constant, used everywhere:
+
+```rust
+// src/identity.rs
+pub const EXPIRY_CLOCK_SKEW_SECS: u64 = 300;
+pub fn is_expired(not_after: Option<u64>, now_unix: u64) -> bool {
+    match not_after { None => false, Some(t) => now_unix > t.saturating_add(EXPIRY_CLOCK_SKEW_SECS) }
+}
+```
+
+None ⇒ never expired (default-safe; existing deployments unaffected). Optional hardening: reject certs with issued_at > now + EXPIRY_CLOCK_SKEW_SECS (future-dated).
+
+### D7 — Renewal without downtime
+
+POST /identity/renew (body { "ttl_secs": Option<u64> } or { "not_after": Option<u64> }; both null ⇒ non-expiring cert):
+1. Load user keypair (storage::load_user_keypair); 409 if no user identity (cert renewal requires the issuing user key — opt-in identity, never auto-generated).
+2. AgentCertificate::issue_with_expiry(&user_kp, &agent_kp, not_after).
+3. Persist via path-scoped save_agent_certificate_to (src/storage.rs:479) using the daemon's scoped cert path.
+4. Swap in memory: today the cert sits immutably in Identity/Agent (src/identity.rs:563) — refactor the agent-held cert slot to Arc<RwLock<Option<AgentCertificate>>> (or add Agent::replace_agent_certificate), auditing readers (announcement build src/lib.rs:5869-5943, UserAnnouncement::sign path :5229, /agent handler).
+5. Trigger immediate identity re-announce (+ user announce) so peers refresh the cached cert.
+
+Machine key, agent key, QUIC connections, gossip sessions: untouched ⇒ zero interruption.
+
+---
+
+## 2. REST / CLI surface
+
+src/api/mod.rs registry additions (category "identity", alongside the /agent/* block at :84-136):
+
+| Method | Path | cli_name | Description |
+|---|---|---|---|
+| POST | /identity/renew | identity renew | Re-issue AgentCertificate (user key), optional expiry |
+| POST | /identity/revoke | identity revoke | Sign + publish + persist a revocation (self or issued-agent) |
+| GET | /identity/revocations | identity revocations | List known revocation records |
+
+Routes: register in the identity block of src/server/mod.rs (:1582-1610) OR the extracted identity routes file if the routes/ extraction has landed — check before implementing. Handlers follow the agent_verify pattern. CLI: new `Identity { sub: IdentitySub }` variant in Commands (src/bin/x0x.rs:57), handlers in src/cli/commands/identity.rs (thin DaemonClient wrappers — see `announce` there for the shape). /identity/revoke body: { "subject": "agent"|"machine", "id": "<hex64>", "reason": "..." }; self-revocation when the id is the daemon's own.
+
+---
+
+## 3. Test plan
+
+| Test | Tier | Pins |
+|---|---|---|
+| cert_v1_without_not_after_still_verifies | unit src/identity.rs | old certs (no field) verify forever — the no-break guarantee |
+| cert_with_not_after_signs_and_verifies | unit | v2 message construction round-trip |
+| cert_not_after_tamper_fails_verification | unit | expiry is signature-covered; stripping ≠ extending validity |
+| legacy_keyfile_bytes_load_via_new_loader (serialize with a literal old-shape struct) | unit src/storage.rs | old ~/.x0x/*.key files keep working — acceptance criterion |
+| keyfile_without_expiry_writes_legacy_format | unit | downgrade compatibility is intentional, not accidental |
+| v2_keyfile_roundtrip_preserves_not_after | unit | new format works |
+| expiry_allows_within_skew / expiry_rejects_beyond_skew (now−120 s OK; now−600 s refused) | unit | the 5-min tolerance is load-bearing |
+| revocation_self_signed_verifies / revocation_user_signed_for_certified_agent_verifies / revocation_unrelated_key_rejected | unit src/revocation.rs | the two authority rules and nothing more |
+| revocation_set_merge_grow_only_idempotent + revocation_set_persists_and_reloads | unit | partition-tolerance building blocks |
+| expired_cert_announcement_not_trusted | integration (announcement ingest) | expired credential refused at the gate feeding `verified` |
+| dm_from_revoked_sender_dropped | integration (dm_inbox pipeline, injected set) | acceptance: DM from revoked peer denied |
+| exec_request_from_revoked_peer_denied | integration (mirror src/exec/service.rs:2438+ style) | acceptance: exec from revoked peer denied |
+| member_removed_bypass_survives_revocation_checks | integration (server gate) | revocation must not break the #99 self-authenticating paths |
+| revocation_propagates_two_daemons_drops_peer | e2e (tests/daemon_api_integration.rs pattern) | B self-revokes → A refuses B's DM after propagation; A's cache evicted |
+| revocation_learned_after_restart (daemon offline during publish, learns via heartbeat rebroadcast) | e2e | partition tolerance / eventual propagation |
+| renew_no_interruption (continuous DM ping during renew; zero failures; peer sees new issued_at) | e2e | acceptance: renewal round-trips without downtime |
+
+---
+
+## 4. Stepwise task breakdown (one reviewable commit each; [SEC] = security-critical, needs independent review)
+
+1. **Versioned key/cert file container** — src/storage.rs: magic+version container, legacy fallback read, write-legacy-when-no-expiry. Tests: legacy-bytes load, format-choice, v2 round-trip. Accept: all existing storage tests green; new tests pin both directions. [SEC]
+2. **AgentCertificate.not_after + v2 signed message** — src/identity.rs: field, issue_with_expiry, conditional build_message, verify() update, is_expired + EXPIRY_CLOCK_SKEW_SECS. Accept: v1 certs verify; tamper test red-before/green-after. [SEC]
+3. **Revocation module** — new src/revocation.rs: record, sign/verify, authority rules, RevocationSet, persistence. Pure, no wiring. Accept: unit tests green; no .unwrap() in production paths. [SEC]
+4. **Gossip propagation** — REVOCATION_TOPIC const, subscribe task in Agent startup, publish-on-issue, heartbeat piggyback rebroadcast, startup load, size-limited decode. Accept: two-agent in-process test shows merge.
+5. **Enforcement wiring** — the five points in D5: announcement ingest, is_agent_machine_verified + DiscoveredAgent.cert_not_after, dm_inbox drop + counter, server gate ordering vs bypass_verified, cache eviction/contact-block/disconnect-on-receipt. Accept: integration tests green; exec tests at service.rs:2438+ untouched and green. [SEC — the heart of the issue; gate must be fail-closed on revocation, fail-open on absent expiry]
+6. **Renew flow** — mutable cert slot on Agent, POST /identity/renew handler, re-announce trigger. Accept: renew round-trips in a single-daemon test; readers audited (src/lib.rs:5869, :5229).
+7. **Revoke + list REST/CLI + registry** — endpoints, EndpointDef entries, Commands::Identity subtree. Accept: tests/api_coverage.rs / api_manifest.rs pass (registry and router in sync).
+8. **Two-daemon e2e** — the three e2e tests above in tests/, following daemon_api_integration.rs conventions (X0X_TEST_BINARY override, --name/--api-port/--no-hard-coded-bootstrap).
+9. **ADR-0018 + docs** — docs/adr/0018-key-lifecycle-expiry-renewal-revocation.md (expiry semantics incl. absence=valid, v1/v2 cert message rule, revocation authority rules, grow-only/no-un-revoke, propagation + heartbeat anti-entropy, 300 s skew, wire-compat stance for cert-carrying announcements, QUIC-connection-linger limitation, deferred: key rotation, un-revocation, digest anti-entropy). Update docs/api-reference.md, CHANGELOG; mirror to Obsidian vault per repo convention.
+
+**Sequencing**: 1→2→3 (2 and 3 independent after 1); 4-5 depend on 3; 6-7 depend on 2; 8 last. Every step keeps `just check` green (fmt, clippy -D warnings, nextest --all-features --workspace).
+
+**Known risks**: (a) the cert-slot refactor in step 6 touches the announcement build path — the ML-DSA announce-signature area has prior transport-level bug history (ant-quic zero-gap reassembly), so any new sig failures there are likely transport, not this change; (b) identity_discovery_cache writes race the verified annotation (the original reason for bypass_verified) — keep revocation checks read-only against the RwLock and never hold it across .await in the DM inbox loop (that loop also publishes ACKs and must not stall — see the non-blocking comment at src/dm_inbox.rs:429+); (c) step 5's gate-order test must prove revocation beats bypass_verified while plain-unverified does not regress.

--- a/docs/plans/2026-07-issue-131-connect-acl-plan.md
+++ b/docs/plans/2026-07-issue-131-connect-acl-plan.md
@@ -1,0 +1,202 @@
+# Implementation plan — Issue #131: Connection ACL (default-closed connectivity policy)
+(Produced by plan-131 read-only planning agent, 2026-07-03. Hand verbatim to the implementation agent.)
+(ORCHESTRATOR NOTE: ADR number collision with plan-130 — use ADR-0019 for this one, docs/adr/0019-connect-acl-default-closed.md; key lifecycle takes 0018.)
+
+## 0. Scoping decision (read first)
+
+**What v1 can genuinely enforce today: nothing at runtime — and that is by design.** The per-peer byte-stream API is Tailnet Phase 1 (#132/T1) and does not exist yet: `src/network.rs` exposes only message-level `Node::send`/`recv` (framing `[0x10][agent_id:32][payload]`, `network.rs:2313-2360`); ant-quic's `open_bi()/accept_bi()` are public but unused by x0x. There is **no existing inbound flow to gate**: direct-message streams, exec frames, gossip, and file transfer are message surfaces with their own gates — do **not** touch them. The release plan doc (`docs/plans/2026-07-production-hardening-and-tailnet.md:183-192`, section T3) confirms this: T3 (this issue) is a hard prereq gate that "blocks T4 enablement"; enforcement is wired in T4's forward-accept path.
+
+**The v1 deliverable is therefore:** a fail-closed policy engine (`ConnectPolicy`), the config-file surface (`connect-acl.toml`), `--connect-acl` flag + `x0xd --check` validation, a `/diagnostics/connect` counter surface, and — critically — a **pure gate-evaluation function** that encodes the full deny-gate ordering, fully tested against the exec ACL's default-deny matrix. The T4 forwarder's accept path calls that one function; nothing else changes when enforcement lands. The enforcement hook is stubbed at that seam (a callable function with no caller yet), not as dead code in `network.rs`.
+
+Everything below is modeled line-by-line on the exec ACL: `src/exec/acl.rs` (937 lines), `src/exec/service.rs` gate order (`service.rs:756-800`), `src/exec/diagnostics.rs`, and the #124/#141 tranche-2 test matrix (`service.rs:~2643-2700`, `tests/exec_acl_unit.rs`).
+
+---
+
+## 1. New module: `src/connect/`
+
+Register `pub mod connect;` in `src/lib.rs` (insert near `pub mod exec;` at `lib.rs:157`; rustdoc required — CI uses `RUSTDOCFLAGS="-D warnings"`). Note: `src/cli/commands/connect.rs` already exists (four-word `x0x connect` command) — no code collision (different namespace), but don't rename it and don't put the new CLI handler there (see §4).
+
+### 1.1 `src/connect/acl.rs` — policy types, load, parse, validate
+
+Mirror `src/exec/acl.rs` structurally, item for item:
+
+| Exec item (src/exec/acl.rs) | Connect mirror |
+|---|---|
+| `default_exec_acl_path()` (acl.rs:10-19) | `default_connect_acl_path()` → `/usr/local/etc/x0x/connect-acl.toml` (macOS), `/etc/x0x/connect-acl.toml` (elsewhere) |
+| `LoadMode` (acl.rs:23-28) | **reused, not duplicated** — see below |
+| `ExecPolicy::{Disabled{path,reason,loaded_at_unix_ms}, Enabled(ExecAcl)}` (acl.rs:32-39) | `ConnectPolicy::{Disabled{…}, Enabled(ConnectAcl)}` |
+| `Default for ExecPolicy` = Disabled (acl.rs:41-52) | `Default for ConnectPolicy` = `Disabled{reason: "no connect ACL configured"}` — makes embedded `serve()` (issue #110) default-deny with zero host effort |
+| `enabled()/path()/summary()` (acl.rs:57-94) | same; `ConnectAclSummary { enabled, loaded_from, loaded_at_unix_ms, allow_entry_count, target_entry_count, disabled_reason }` |
+| `ExecAcl` (acl.rs:112-119) | `ConnectAcl { loaded_from: PathBuf, loaded_at_unix_ms: u64, allow: Vec<ConnectAllowEntry> }` — **no caps struct in v1** (per-peer stream limits are T4 forwarder config, not ACL policy — Rule 2) |
+| `AllowEntry` (acl.rs:155-161) | `ConnectAllowEntry { description: Option<String>, agent_id: AgentId, machine_id: MachineId, targets: Vec<SocketAddr> }` |
+| `AclError` (acl.rs:188-207) | `ConnectAclError::{Missing, Read, Parse, Invalid}` (thiserror, same shapes) |
+| `load_exec_policy()` (acl.rs:289-313) | `load_connect_policy(path: Option<&Path>, mode: LoadMode) -> Result<ConnectPolicy, ConnectAclError>` — **byte-for-byte same control flow**: `!exists()` + `ExplicitPath` → `Err(Missing)`; `!exists()` + `DefaultPath` → `Ok(Disabled{reason:"acl_missing"})`; read error → `Err(Read)`; then parse |
+| `parse_exec_policy()` (acl.rs:315-402) | `parse_connect_policy(path, loaded_at_unix_ms, text)` — pub for tests and `--check`; TOML parse error → `Err(Parse)`; missing `[connect]` section → `Disabled{"missing_connect_section"}`; `enabled = false` (serde default false) → `Disabled{"connect_disabled"}`; per-entry validation failure → `Err(Invalid)` with `allow[{idx}].targets[{tidx}]: …` context |
+| `has_agent_machine()` (acl.rs:490-497) | `ConnectAcl::entry_for(agent_id, machine_id) -> Option<&ConnectAllowEntry>` (exact pair equality) + `is_allowed(agent_id, machine_id, target: &SocketAddr) -> bool` (exact triple) |
+| `parse_agent_id/parse_machine_id/parse_32_byte_hex` (acl.rs:560-580) | **reuse the exec ones** — already `pub` in `exec::acl`; import, don't copy |
+
+**LoadMode decision: reuse `crate::exec::acl::LoadMode`, re-exported as `x0x::connect::LoadMode`.** The missing-at-default-vs-explicit semantics MUST stay bit-identical between the two ACLs forever; one type enforces that at compile time and prevents drift. Cost: generalize its two doc comments (acl.rs:24, acl.rs:26 say "disables exec safely" / "configuration error") to ACL-generic wording — a 2-line doc edit, justified Rule-3 deviation to note in the PR. Do **not** hoist to a new shared module — churn for one enum.
+
+**TOML file format** (documented in §5):
+
+```toml
+# /etc/x0x/connect-acl.toml
+[connect]
+enabled = true   # defaults to false when absent
+
+[[connect.allow]]
+description = "laptop → this box sshd"
+agent_id = "<64 hex chars>"
+machine_id = "<64 hex chars>"
+targets = ["127.0.0.1:22", "127.0.0.1:5900", "[::1]:8080"]
+```
+
+Serde structs: `ConnectFileToml { connect: Option<ConnectSectionToml> }`, `ConnectSectionToml { enabled (default false), allow (default empty) }`, `ConnectAllowEntryToml { description, agent_id: String, machine_id: String, targets: Vec<String> }` — with **one deliberate divergence from exec: `#[serde(deny_unknown_fields)]` on all three structs.** Rationale: in a security allowlist, a misspelled key (`taregts = [...]`, `enable = true`) must fail loudly, not silently yield a different policy. Strictly more fail-closed; the brief's rule is "default-deny in every ambiguous case", and an unrecognized key is ambiguity. Flag in the PR that exec ACL should get the same treatment as a follow-up issue (not in this PR — Rule 3).
+
+### 1.2 Target validation — the loopback-only crown jewel
+
+Validation function `parse_target(raw: &str) -> Result<SocketAddr, String>` (pub, unit- and property-tested in isolation):
+
+1. `raw.parse::<SocketAddr>()` — **numeric IP literals only**. Any parse failure → error. This eliminates the hostname problem class:
+   - **`localhost` is rejected** (doesn't parse as `SocketAddr`). Justification for docs + error message: name resolution is ambiguous (`localhost` may resolve to `::1`, `127.0.0.1`, or — via `/etc/hosts` tampering — a non-loopback address; classic rebinding trick). Numeric-only removes the resolver from the TCB. Error must be actionable: `targets must be numeric IP:port (e.g. "127.0.0.1:22" or "[::1]:22"); hostnames such as "localhost" are not accepted`.
+   - Rust's parser already rejects leading-zero octets (`127.000.000.1` — octal ambiguity); cover with a test anyway.
+2. `addr.port() == 0` → error ("port 0 is not a connectable target").
+3. `!addr.ip().is_loopback()` → error naming the address and the v1 policy ("only loopback targets (127.0.0.0/8, ::1) are permitted in this release; LAN/subnet targets are not supported"). `Ipv4Addr::is_loopback()` covers all of 127.0.0.0/8; `Ipv6Addr::is_loopback()` covers exactly `::1`.
+4. IPv4-**mapped** IPv6 (`[::ffff:127.0.0.1]:22`): `Ipv6Addr::is_loopback()` is `false` for it, so step 3 already rejects it — fail-closed falls out for free — but add an explicit pinning test, plus a targeted error branch (`ip.to_ipv4_mapped().is_some()`) whose message says "write it as 127.0.0.1:PORT" (diagnosability, not correctness).
+
+**Target grammar decision: exact `host:port` literals only — no port ranges, no port lists, no CIDR.** The plan doc's T3 sketch mentions `"localhost-port-range:8000-8100"`; the release brief overrides to minimal, and that's right: (a) matches exec's exact-argv philosophy; (b) ranges introduce matcher/overlap/fencepost ambiguity in the security-critical path for zero v1 need; (c) a dozen ports is a dozen TOML lines; (d) extension is backward-compatible later (new optional entry key), while removing shipped range syntax would be breaking. State this in the ADR.
+
+Additional entry validation in `parse_connect_policy`: empty `targets` → `Invalid` ("allow[{idx}] must contain at least one target" — mirrors exec's empty-commands rejection at acl.rs:369-374). Duplicate targets within an entry: permitted (harmless; exec doesn't dedup either).
+
+Store validated targets as `Vec<SocketAddr>`; matching is exact `SocketAddr` equality — `127.0.0.1:22` does not grant `[::1]:22`; pin with a test and document.
+
+### 1.3 `src/connect/gate.rs` — the enforcement seam
+
+The function the T4 forwarder will call; the thing v1 must get perfect. Pure and synchronous — no service, no I/O — so the whole #141 matrix ports as fast unit tests:
+
+```rust
+pub enum ConnectDenialReason {
+    UnverifiedSender, TrustRejected, ConnectDisabled,
+    AgentMachineNotInAcl, TargetNotLoopback, TargetNotAllowed,
+}
+
+pub fn evaluate_connect_gate(
+    verified: bool,
+    trust_decision: Option<TrustDecision>,
+    policy: &ConnectPolicy,
+    agent_id: &AgentId,
+    machine_id: &MachineId,
+    target: &SocketAddr,
+) -> Result<(), ConnectDenialReason>
+```
+
+Gate order — a security property in itself, copied from `exec/service.rs::handle_request` (service.rs:756-800) and its tranche-2 order-pinning tests:
+
+1. `!verified` → `UnverifiedSender`
+2. `trust_decision != Some(TrustDecision::Accept)` → `TrustRejected` (**`None` falls through to TrustRejected** — same as exec)
+3. `ConnectPolicy::Disabled` → `ConnectDisabled`
+4. `!target.ip().is_loopback()` → `TargetNotLoopback` — **runtime defense-in-depth**: in T4 the requested target arrives off the wire from the peer; exact-equality matching against a loopback-only allowlist already makes a non-loopback match impossible, but this explicit check keeps the invariant local to the gate, survives any future matcher generalization, and gives a distinct diagnostics bucket
+5. pair `(agent_id, machine_id)` not in ACL → `AgentMachineNotInAcl`
+6. target not in that entry's `targets` → `TargetNotAllowed`
+
+Write the same block comment exec has (service.rs tranche-2 header): the order means an unverified/untrusted peer learns nothing about whether connect is enabled, whether they're listed, or which targets exist. Mirror exec `DenialReason` traits (`Serialize`, `Hash`, `Eq`, `Copy`, snake_case) so it drops into the diagnostics map and, in T4, typed error frames.
+
+### 1.4 `src/connect/diagnostics.rs` — counter surface
+
+Mirror `src/exec/diagnostics.rs:15-28` at minimal scope: `ConnectDiagnostics { streams_allowed: AtomicU64, streams_denied: AtomicU64, denial_breakdown: Mutex<HashMap<ConnectDenialReason, u64>>, acl_summary: ConnectAclSummary }` with `new(summary)`, `record_allowed()`, `record_denied(reason)` (mirrors diagnostics.rs:60-66), and a `Serialize` snapshot type. No warnings/sessions machinery — that's T4. Counters read 0 until T4 wires calls; that is the intended "counter surface for future connect denials".
+
+### 1.5 `src/connect/mod.rs`
+
+Module rustdoc (state loopback-only v1 and the T4 relationship) + re-exports mirroring `src/exec/mod.rs`: `default_connect_acl_path, load_connect_policy, parse_connect_policy, parse_target, ConnectAcl, ConnectPolicy, ConnectAclSummary, ConnectDenialReason, evaluate_connect_gate, ConnectDiagnostics, ConnectDiagnosticsSnapshot, LoadMode` (re-export of `exec::acl::LoadMode`).
+
+---
+
+## 2. x0xd wiring (`src/bin/x0xd.rs`)
+
+Mirror the exec ACL sites exactly:
+
+- Help text: add `--connect-acl <PATH>  Override default connect ACL path` next to `--exec-acl` (x0xd.rs:75).
+- Flag parse: copy the `--exec-acl` block (x0xd.rs:95-109) → `connect_acl_override: Option<PathBuf>` + `connect_acl_load_mode` (`ExplicitPath` iff flag present, else `DefaultPath`).
+- Load: immediately after the exec load (x0xd.rs:221-224): `let connect_policy = x0x::connect::load_connect_policy(connect_acl_override.as_deref(), connect_acl_load_mode).await.context("failed to load connect ACL")?;` Placement **before** the `check_only`/`doctor` branches (like exec) means: malformed file, missing-at-explicit-path, or any non-loopback target **prevents daemon startup and fails `--check`** — exactly the issue's requirement (reject at load/--check time, never silently at runtime).
+- `--check` block (x0xd.rs:229-234): add `println!("Connect ACL summary: {:#?}", connect_policy.summary());`.
+- `ServeOptions` construction (x0xd.rs:246-253): pass `connect_policy`.
+
+**Config-section clarification** (brief said "mirror a `[connect]` config section"): the exec precedent is that the `[exec]` section lives **in the ACL file**, not in the daemon config TOML — the daemon config knows nothing about exec. Mirror exactly: `[connect]` is the section header inside `connect-acl.toml`; no `DaemonConfig` changes. State this in docs so nobody adds a redundant config knob.
+
+## 3. Server state + diagnostics endpoint
+
+- `ServeOptions` (`src/server/state.rs:38-60`): add `pub connect_policy: x0x::connect::ConnectPolicy` with rustdoc noting the `Default` (= Disabled) keeps embedded `serve()` default-deny. `ServeOptions` is `#[derive(Default)]` — `ConnectPolicy`'s Default impl satisfies it.
+- `AppState` (same file, `pub(super)`): add `pub(super) connect_policy: Arc<ConnectPolicy>` and `pub(super) connect_diagnostics: Arc<ConnectDiagnostics>`; construct near the `ExecService::spawn` site (`src/server/mod.rs:1011`, AppState fill at :1075): `Arc::new(ConnectDiagnostics::new(options.connect_policy.summary()))`. No service to spawn, no shutdown-ordering impact (pure data — do not touch the #116 teardown sequence at mod.rs:1081-1100).
+- Route: `.route("/diagnostics/connect", get(connect_diagnostics_handler))` beside `/diagnostics/exec` (`src/server/mod.rs:1747`); handler mirrors `exec_diagnostics` (mod.rs:15582) — returns the snapshot JSON.
+- Registry (`src/api/mod.rs`, entry shape at :239-244): add `EndpointDef { method: Get, path: "/diagnostics/connect", cli_name: "diagnostics connect", description: "Connection-ACL policy summary and stream allow/deny counters", category: "connect" }`. The registry's coverage tests (`tests/api_coverage.rs` / `api_manifest.rs`) will demand route + CLI both exist — that's the point.
+
+**Coordination warning:** the routes/ extraction from `server/mod.rs` (WS1.4, task #3) is in progress on another branch. Keep the `server/mod.rs` diff minimal (one route line, one handler fn, two AppState fields + init) and rebase late; if diagnostics routes have moved to `src/server/routes/` by implementation time, follow wherever `/diagnostics/exec` lives then.
+
+## 4. CLI
+
+`x0x diagnostics connect` — mirror `src/cli/commands/exec.rs:102-106` (`client.get("/diagnostics/exec")` + `print_value`). Do **not** put it in `src/cli/commands/connect.rs` (that's the four-word `x0x connect` command); place the function wherever the `diagnostics` subcommand dispatcher in `src/cli/mod.rs` routes `diagnostics exec`, following that pattern.
+
+## 5. Tests (the security deliverable — mirror the #141 matrices exactly)
+
+**A. Fail-closed load matrix** — unit tests in `src/connect/acl.rs` mirroring `exec/acl.rs:744-841` names one-for-one:
+- `load_policy_missing_file_at_default_path_is_disabled`
+- `load_policy_missing_file_at_explicit_path_is_hard_error`
+- `load_policy_malformed_toml_is_hard_error`
+- `load_policy_missing_connect_section_is_disabled`
+- `load_policy_enabled_false_is_disabled`
+- `default_connect_acl_path_returns_expected`, `connect_policy_path_*`, `connect_policy_enabled_flag`, `connect_policy_default_is_disabled` (pins the embedded-serve default)
+- new: `load_policy_unknown_key_is_hard_error` (pins `deny_unknown_fields`)
+
+**B. Loopback-only validation matrix** — every one a **load-time hard error** (`Invalid`), each its own test: `192.168.1.10:80`, `10.0.0.1:22`, `0.0.0.0:80`, `8.8.8.8:53`, `[::]:80`, `[2001:db8::1]:443`, `[fe80::1]:22`, `[::ffff:127.0.0.1]:22` (v4-mapped), `localhost:22` (hostname), `127.0.0.1:0` (port 0), `127.000.000.1:22` (leading zeros), `127.0.0.1` (no port), empty `targets = []`, empty-string target. Accept side: `127.0.0.1:22`, `127.255.255.254:9`, `[::1]:8080` load successfully.
+
+**C. Gate-order matrix** — unit tests on `evaluate_connect_gate` mirroring exec's per-gate + tranche-2 tests (service.rs:2438-2700):
+- `gate_denies_unverified_sender_before_policy`
+- `gate_denies_non_accept_trust_decision`
+- `gate_denies_verified_sender_with_no_trust_decision` (None → TrustRejected)
+- `gate_order_unverified_beats_trust_and_disabled` (all-bad input surfaces `UnverifiedSender` only — pins evaluation order; copy exec's comment on why order is a security property)
+- `gate_order_trust_beats_disabled`, `gate_denies_when_policy_disabled`, `gate_denies_pair_not_in_acl`, `gate_denies_listed_pair_wrong_target` (same pair, port 23 vs allowed 22 → `TargetNotAllowed`), `gate_denies_wrong_machine_same_agent` + vice versa (exact-pair semantics), `gate_denies_non_loopback_requested_target` (re-check fires even with Enabled policy → `TargetNotLoopback`), `gate_v4_and_v6_loopback_are_distinct_grants`, `gate_allows_exact_triple`.
+
+**D. Integration file** `tests/connect_acl_unit.rs` mirroring `tests/exec_acl_unit.rs` (crate-public-API level: `parse_connect_policy` from TOML strings; `invalid_hex_fails_closed`, `disabled_policy_when_connect_section_missing_or_false`, `missing_default_acl_disables_but_explicit_missing_errors` with tempdir).
+
+**E. Property tests** `tests/connect_acl_proptest.rs` (proptest at `Cargo.toml:103`; pattern precedent `tests/direct_msg_proptest.rs`):
+1. `parse_target` never panics on arbitrary `String`.
+2. Soundness (crown jewel): for arbitrary `(u32 → Ipv4Addr, u16 port)`, `parse_target` accepts **iff** first octet == 127 **and** port != 0; same for arbitrary `Ipv6Addr` (accepts iff `ip == ::1 && port != 0` — automatically proves v4-mapped rejection).
+3. Round-trip: any accepted target re-formats (`to_string`) and re-parses to an equal `SocketAddr`.
+4. Matcher soundness: for a random allowlist and random query triples, `is_allowed(a,m,t) == true` ⟹ the exact triple is present (no false accepts, ever).
+
+**F. `--check` end-to-end (small but real):** spawn `x0xd --check --connect-acl <tmp>` (precedent: `X0XD_TEST_BINARY` in daemon integration tests) asserting exit 0 + summary line for a valid file and non-zero for malformed / non-loopback / missing-explicit. If binary-spawn plumbing is disproportionate, cover the same behavior at `load_connect_policy` level (matrices A/B already do) and assert only the valid-file `--check` path in one shell smoke — either way, don't skip silently (Rule 12).
+
+## 6. Docs + ADR
+
+- **`docs/connect-acl.md`** modeled on `docs/exec.md` (what it is / security model / ACL location + LoadMode semantics equivalent to exec.md:27-40 / minimal ACL example / v1 loopback-only rationale incl. the `localhost` and exact-target decisions / relationship to #132 forwarder / diagnostics endpoint). Add to the On-Demand Reference list in `x0x/CLAUDE.md`.
+- **`docs/api-reference.md`**: `/diagnostics/connect` entry.
+- **ADR `docs/adr/0019-connect-acl-default-closed.md`** (status **Proposed**): decisions = per-flow default-closed ACL mirrored on exec; sibling file `connect-acl.toml`; shared `LoadMode` fail-closed semantics; loopback-only v1 with non-loopback as load-time validation error (LAN/subnet-router = out of scope, future revision); exact `SocketAddr` targets only (extension is additive); numeric-IP-only (no hostname resolution in the TCB); gate order as security property; `deny_unknown_fields` divergence; restart-loaded only (hot-reload explicitly deferred — the issue lists it as an "option"; exec is restart-loaded and v1 mirrors it). The tailnet epic ADR (#132/T8) should reference this ADR rather than restate it.
+- Obsidian vault mirror per repo convention after docs land.
+
+## 7. Stepwise task breakdown
+
+| # | Step | Acceptance criteria | Security review? |
+|---|------|---------------------|------------------|
+| 1 | `src/connect/acl.rs`: types, LoadMode reuse (+2-line doc generalization in exec/acl.rs), `load_connect_policy`, `parse_connect_policy`, `parse_target` | Matrices **A + B** green; clippy `-D warnings`; no unwrap/expect in prod paths; rustdoc complete | **YES — independent review required** (fail-closed load matrix + loopback validation are the crown jewels; every ambiguous case must land on deny/error) |
+| 2 | `src/connect/gate.rs`: `ConnectDenialReason` + `evaluate_connect_gate` | Matrix **C** green, incl. all-bad-input order test | **YES** (gate order = information-leak property) |
+| 3 | `src/connect/diagnostics.rs` + `mod.rs` re-exports + `lib.rs` registration | record/snapshot round-trip test; denial_breakdown keyed correctly | no |
+| 4 | x0xd wiring: flag, help, load-before-check, `--check` summary, `ServeOptions.connect_policy` (+ `server/state.rs` field) | Matrix **F**; manual: `x0xd --check` shows both ACL summaries; malformed file blocks startup, not just --check | **YES** (verify startup-blocking) |
+| 5 | AppState fields + `/diagnostics/connect` route/handler + registry entry + CLI `diagnostics connect` | `x0x routes` lists it; api-coverage/manifest tests green; CLI round-trip against live daemon returns snapshot with `enabled:false` by default | no |
+| 6 | Property tests (matrix **E**) | all 4 properties pass at default case count; no `#[ignore]` | **YES** (review the properties themselves — a weak property is false assurance) |
+| 7 | Docs + ADR 0019 + CLAUDE.md pointer + vault sync | doc TOML examples fed through `parse_connect_policy` in a test; ADR follows TEMPLATE.md | ADR maintainer sign-off |
+
+Steps 1-3 = one PR-sized unit (pure library code, no daemon behavior change); 4-5 a second; 6-7 ride with either. Full gate before each merge: `just check` (fmt, clippy `-D warnings`, nextest all-features, doc build).
+
+## 8. Explicit non-goals (state in the PR)
+
+- No enforcement caller: `evaluate_connect_gate` gets its first caller in T4 (#132 forwarder inbound-accept, after verified+trust, before `TcpStream::connect`). No stream code in `network.rs`.
+- No gating of existing DM/exec/gossip/file surfaces — they are not connection-forwarding.
+- No hot-reload (restart-loaded, like exec). No port ranges/CIDR/LAN targets. No caps in the ACL file. No `DaemonConfig` section.
+- Typed deny **frames** to the peer are T4 (no wire protocol yet); v1's deny output is the `ConnectDenialReason` value + diagnostics counter.
+
+## 9. Risks / open flags
+
+1. **`server/mod.rs` contention** with the in-flight WS1.4 routes extraction (task #3) — keep step 5's diff minimal and rebase last.
+2. **`deny_unknown_fields` divergence from exec** — deliberate and safer, but a pattern fork (Rule 7): approve explicitly or strike; if approved, file the exec follow-up issue.
+3. **Plan-doc drift**: `docs/plans/2026-07-production-hardening-and-tailnet.md:186` sketches port-range syntax; this plan overrides to exact-only per the release brief — update the plan doc's T3 bullet when this lands so the two documents don't conflict.
+4. The 2-line `LoadMode` doc generalization touches `src/exec/acl.rs` — trivially safe, but a touch outside the new module; noted per Rule 3.

--- a/docs/plans/2026-07-release-handoff.md
+++ b/docs/plans/2026-07-release-handoff.md
@@ -1,0 +1,83 @@
+# Handoff: x0x production release (post-v0.27 hardening + security foundations)
+
+**Date:** 2026-07-03. **Author:** release-orchestration session (Claude), handing off to the dev team.
+**Goal:** a tagged, soak-verified production release with two security foundations in place — key expiry/revocation (#130) and a default-deny connection ACL (#131) — so the machine-to-machine connectivity sprint (tailnet, #132) starts on solid ground. #132 itself is explicitly OUT of this release.
+
+**Definition of done**
+1. `src/server/mod.rs` decomposition (#125) complete: `mod.rs` < ~2,000 lines, `x0x routes` snapshot byte-identical at every step.
+2. Sweep issues closed: #139, #142, #145, #153 (and #149/#127 — already done).
+3. #130 and #131 merged, each after an INDEPENDENT security review confirming the properties in the real code path (not just tests): default-deny, fail-closed, no-breaking-change for old keys.
+4. Release tagged via the normal release train (which is CI-gated since #138); fleet soak with the existing harnesses shows no regression vs the v0.27.x baseline; focused review of the whole diff since v0.27; readiness summary written.
+
+---
+
+## 1. Already merged to main (verified; main CI green at `3fba957`)
+
+| Change | Commit/PR | Verification done |
+|---|---|---|
+| auth.rs extraction + token hygiene (#127/WS1.6: constant-time compare, session-token-only `?token=`) | #151, #155 | code-read in src/server/auth.rs; #127 closed with evidence |
+| state.rs extraction | #156 | diff read (pure move), snapshot guard, CI |
+| ws.rs + sse.rs extraction (mod.rs 25,217 → 23,883) | `efe775a` — **landed as an accidental direct push, not a PR** (see §5 process notes); post-hoc verified | independent line-level diff audit (pure move; snapshots byte-identical); main CI green; deviation documented on #125 |
+| WS stalled-reader harness (#149) + real fix: Close(1013) now reaches the wire (cleanup granted the writer a 3s close-flush grace instead of immediate abort) | #157 | diff read; strict `assert_eq!(close_code, Some(1013))` e2e; negative sanity check against a healthy client |
+
+## 2. In-flight work — exact recovery state
+
+### 2a. Routes extraction, first group — worktree ALIVE, work UNCOMMITTED
+- Worktree: `.claude/worktrees/agent-a0663e5c3e7f564e3` on branch `eng-a/125-ws1.4-routes-1` (based on `efe775a`; rebase onto current main is trivial — #157 only touched ws.rs).
+- Staged there: new `src/server/routes/{mod,contacts,identity,machines}.rs` + matching `mod.rs` shrink. It was mid-validation (full nextest) when stopped.
+- To finish: run the full gate (`cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run --all-features --workspace`), confirm `tests/snapshots/server-routes.*` untouched and the enforcing tests (`route_set_matches_registry`, `manifest_matches_registry`) pass, commit `refactor(125/WS1.4): extract routes/ (contacts, identity, machines) (#125)`, push **with explicit refspec** (see §5), PR, merge on green.
+- Then repeat for the remaining registry categories (enumerate: `grep 'category:' src/api/mod.rs | sort -u`) at 2–3 categories per PR — largest families (groups/named-groups, tasks, kv, exec, upgrade, diagnostics, presence…) until `mod.rs` < ~2,000 lines. Constraints per PR: mechanical move only; colocated `#[cfg(test)]` moves with handlers; `pub(super)` visibility; snapshots never regenerated.
+
+### 2b. #139 timing-brittle e2e — worktree ALIVE, work UNCOMMITTED
+- Worktree: `.claude/worktrees/agent-a75dd846e9c1c0157` on branch `test/139-convergence-timeout-budget` (based on `6b7ac7b`; rebase needed).
+- Uncommitted change in `tests/named_group_join_metadata_event.rs` (inspect `git -C <worktree> diff` — the timeout/budget change lives in that file's shared convergence helpers).
+- Intent (from issue #139, do not weaken semantics): derive the convergence wait budget from node count with a generous multiplier (target: a legitimate 130–160s 3-daemon convergence passes; keep per-poll cadence relaxed). Do NOT remove the test from CI.
+- Verify: run the target test twice on a quiet machine (`--run-ignored=all` if ignored), full gate, PR.
+
+### 2c. #145/#142 announce-loop self-contact — WORK LOST, FULL SPEC PRESERVED
+- The implementing worktree was cleaned before push (local branch `fix/145-announce-self-contact` exists but points at plain main — delete it or reset it). The complete consumer audit (7 consumers, all does-not-depend) **and the exact fix + test spec are preserved as a comment on issue #145** (2026-07-03). Reimplementation is ~30 min from that spec. It was once validated at 1947/1956 nextest with only pre-existing unrelated failures.
+- Closing #145 with that fix also closes #142 (rationale in the issue comment).
+
+### 2d. #130 / #131 implementations — NOT STARTED (stopped at spawn), PLANS COMPLETE
+See §4.
+
+## 3. Remaining Phase-1 items (do before #130/#131 merge)
+
+- **#153 — task-list REST handlers must enforce group membership** (security-relevant, feeds symphony XSY-0021 isolation): handlers at the task-lists routes (currently `src/server/mod.rs` ~2275, will move into `routes/tasks.rs`) must (1) recognize group-scoped IDs `x0x.group.<group_id>.symphony.<list_id>`, (2) consult named-group/MLS membership for the requesting agent, (3) return 403 for non-members on read AND write. Schedule after the tasks routes are extracted to avoid churn. Un-`#[ignore]` the XSY-0021 two-daemon isolation test as the acceptance proof. Treat as security-relevant: independent review that non-membership ⇒ deny in the real handler path.
+- **Pre-existing local flakes** observed repeatedly during this session (fail on loaded machines, pass on quiet/CI): `named_group_join_metadata_event` family, `peer_lifecycle_integration::direct_send_without_require_ack_omits_ack_block`. #139's fix addresses the first family. Don't paper over new failures by attributing to these without reproducing them on unmodified main first.
+
+## 4. Phase 2 — the two security foundations
+
+Complete, code-grounded implementation plans (file/line-referenced, stepwise with per-step acceptance criteria and [SEC] flags) are in this directory:
+- **`2026-07-issue-130-key-lifecycle-plan.md`** → ADR-0018. Key points: expiry only network-enforced on AgentCertificate (`not_after`, signature-covered, v1-byte-identical message when absent so old certs verify forever); magic-prefixed v2 key-file container with legacy-format writes when no expiry (downgrade-safe); grow-only revocation set (self-revocation + issuer-revocation only; no un-revoke ⇒ no replay class); gossip topic `x0x.revocation.v1` + heartbeat rebroadcast for partition tolerance; five enforcement points with revocation beating `bypass_verified` while plain-unverified does NOT regress the #99 MemberRemoved paths; `POST /identity/renew` with zero downtime (cert re-issue + re-announce; machine/agent keys untouched); 300s clock skew via one shared helper.
+- **`2026-07-issue-131-connect-acl-plan.md`** → ADR-0019. Key points: v1 = fail-closed policy engine + `connect-acl.toml` + `--connect-acl` flag + `--check`/startup validation + `/diagnostics/connect` + pure `evaluate_connect_gate()` — the tailnet forwarder (T4) becomes its first caller; the plan explains why there is genuinely no runtime flow to gate yet. LoadMode REUSED from exec (compile-time semantic lock: missing-at-default=disabled, missing-at-explicit=hard error, malformed=hard error); `deny_unknown_fields` (APPROVED divergence from exec — file the exec retrofit follow-up issue); loopback-only numeric-IP targets (localhost/hostnames rejected, v4-mapped rejected, port 0 rejected — all load-time errors); gate order = information-leak property (unverified > trust > disabled > pair > target); full #141-mirror test matrices + property tests (accept iff loopback ∧ port≠0).
+
+**Merge protocol for both (non-negotiable):** green CI is necessary but not sufficient. An independent reviewer (not the implementer) must read the enforcing code and confirm on the real code path: every ambiguous ACL case denies; expiry absence is valid but presence is enforced; revocation is fail-closed everywhere including the group-metadata gate; old key files/certs load and verify unchanged. Verify subagent/team claims against the actual diff — this session caught one agent-reported "done" that was not (and past sessions caught outright fabrication).
+
+## 5. Process notes / incidents from this session (read before starting)
+
+1. **Push discipline.** One agent's `git push -u origin <branch>` silently fast-forwarded **origin/main** because the worktree had `push.default=upstream` with upstream = origin/main. Rule: `git config push.default simple` in every fresh worktree, and push with an explicit refspec (`git push origin HEAD:refs/heads/<branch>`). The incident commit was fully verified post-hoc (see #125 comment); main was deliberately not rewound.
+2. **Disk.** Four parallel cargo builds + 78 GB of stale incremental debris filled the disk to 0 bytes and wedged every process. Keep ≤2–3 concurrent full builds; prune `target/` debris periodically (sibling projects' targets were ~220 GB before cleanup).
+3. **Worktree work loss.** A completed agent worktree was auto-cleaned with uncommitted changes (the #145 fix). Rule: commit early on the branch and push before long validation runs.
+4. **Unrelated open PRs** #152/#159 (symphony GUI, other workstream) and #88 (design doc): not part of this release; don't let the release tag wait on them.
+
+## 6. Phase 3 — certification
+
+1. **Pre-tag:** all of §2–§4 merged; `just check` green locally; main CI + Integration & Soak workflow green; CHANGELOG updated; version bump per the release skill (`gsd-commit-and-release` flow — note version_sync in SKILL.md and that the release train is CI-gated, #138/#128).
+2. **Tag + release:** minor bump (new features: identity lifecycle, connect ACL) → v0.28.0. crates.io publish + GH release per the existing release workflow; fleet self-upgrades (watch it).
+3. **Soak:** use the existing harnesses — `tests/launch_readiness.py` SLO gates (GO/NO-GO windows), `tests/e2e_deploy.sh` fleet deploy, 6h minimum soak on the isolated test plane (ports 13600/6483 — NEVER the prod plane), comparing against the v0.27.x baseline metrics (peer counts 12–15, drop_full=0 windows, per-peer timeout ceilings per `docs/plans/2026-07-production-hardening-and-tailnet.md` §review protocol). New for this release: confirm revocation propagation and renew-no-downtime on two fleet nodes, and `x0xd --check` with a valid + invalid connect ACL on one node.
+4. **Focused review:** full diff `git log v0.27.0..HEAD` — one reviewer per area (server decomposition = snapshot/manifest guarantees; identity/revocation = security properties; connect = matrices; ws = 1013 semantics), then a readiness summary: what changed, what was verified, explicit confirmation that #130 + #131 properties hold, known residual risks (pre-existing flakes, the QUIC-connection-linger limitation noted in ADR-0018).
+
+## 7. Suggested sequencing (dependency-safe)
+
+```
+[A] routes-1 PR (recover worktree)          [B] #139 PR (recover worktree)   [C] #145/#142 reimplement (30 min)
+        ↓ merge                                       ↓ merge                          ↓ merge
+[A2..A4] remaining routes PRs (serial) ──────────────────────────────────────────────────
+        ↓ (tasks routes landed)
+[D] #153 membership enforcement (independent review)
+                                        [E] #130 per plan (parallel with A2+, rebase late)   [F] #131 per plan (parallel, rebase late)
+        ↓ all merged, independent security reviews done
+[G] tag v0.28.0 → fleet soak → focused review → readiness report
+```
+A/B/C/E/F can start immediately in parallel (≤3 concurrent builds); D waits for the tasks-routes extraction; G waits for everything.


### PR DESCRIPTION
Release handoff from the post-v0.27 hardening orchestration session (definition of done, verified merged state, in-flight recovery state, remaining Phase-1 items, Phase-2 merge protocol, Phase-3 certification, sequencing, process warnings) plus code-grounded stepwise implementation plans for #130 (ADR-0018 key lifecycle) and #131 (ADR-0019 connect ACL). Docs-only; no code change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds planning docs for the July release handoff. The main changes are:

- A key lifecycle plan for expiry, renewal, and revocation.
- A connect ACL plan for default-closed loopback-only forwarding policy.
- A release handoff with remaining work, recovery notes, and release sequencing.

<h3>Confidence Score: 4/5</h3>

The docs are mostly mergeable, but the release handoff has broken recovery instructions.

- The implementation plans are detailed and do not change runtime behavior.
- The handoff points to local worktrees and branches that are not available in this checkout.
- The missing recovery state can send maintainers down the wrong release path.

docs/plans/2026-07-release-handoff.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/plans/2026-07-issue-130-key-lifecycle-plan.md | Adds a forward-looking implementation plan for certificate expiry, renewal, revocation, storage compatibility, propagation, and enforcement. |
| docs/plans/2026-07-issue-131-connect-acl-plan.md | Adds a forward-looking implementation plan for a connect ACL module, daemon wiring, diagnostics, CLI support, tests, and docs. |
| docs/plans/2026-07-release-handoff.md | Adds release handoff and recovery instructions, including some recovery paths that do not match the available repository state. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs/plans/2026-07-release-handoff.md:25-33
**Phantom Recovery Worktrees**

The handoff says these worktrees are alive and contain uncommitted recovery work, but the referenced worktree paths, branches, and staged route files are not present in this checkout. A maintainer following this state will try to recover work that cannot be recovered from the repo, delaying the release sequence or forcing a restart from an inaccurate checkpoint.

### Issue 2 of 2
docs/plans/2026-07-release-handoff.md:38
**Missing Recovery Branch**

This line says `fix/145-announce-self-contact` exists locally and only needs deletion or reset, but that branch is not present in this checkout. Anyone following the handoff will hit a dead recovery step and then depend on an external issue comment for the only remaining implementation spec.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(plans): add 2026-07 release handoff..."](https://github.com/saorsa-labs/x0x/commit/2507551826e0fa85f78fc7437a20e4140287e0bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41699343)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->