### PR TITLE
test(139): relax named-group convergence timing budget

### DIFF
--- a/tests/named_group_join_metadata_event.rs
+++ b/tests/named_group_join_metadata_event.rs
@@ -35,7 +35,15 @@ fn authed_client(d: &AgentInstance) -> reqwest::Client {
         .expect("authed client")
 }
 
-async fn wait_until<F, Fut>(timeout: Duration, mut check: F) -> bool
+async fn wait_until<F, Fut>(timeout: Duration, check: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    wait_until_every(timeout, Duration::from_millis(250), check).await
+}
+
+async fn wait_until_every<F, Fut>(timeout: Duration, poll: Duration, mut check: F) -> bool
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = bool>,
@@ -48,7 +56,7 @@ where
         if tokio::time::Instant::now() >= deadline {
             return false;
         }
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        tokio::time::sleep(poll).await;
     }
 }
 
@@ -771,16 +779,30 @@ async fn non_creator_admin_invite_e2e_converges_for_preset(
     let creator = &cluster.alice;
     let admin = &cluster.bob;
     let joiner = &cluster.charlie;
+    // Issue #139: this 3-daemon convergence e2e legitimately takes 130–160s
+    // wall clock on a quiet machine (observed 140s+ for the TreeKEM variant)
+    // and far longer under CPU contention, so derive each wait budget from
+    // the mesh size with a generous per-node multiplier instead of asserting
+    // against a fixed sub-120s window. These are upper bounds only — each
+    // wait returns as soon as convergence is observed, so a healthy mesh
+    // finishes long before the ceiling. (An earlier phase can consume near
+    // its full budget before a later phase fails, so the ceilings do not
+    // imply a hard cap on total wall clock.)
+    let node_count: u32 = 3;
     let join_timeout = if expect_treekem {
-        Duration::from_secs(90)
+        Duration::from_secs(90) * node_count // 270s
     } else {
-        Duration::from_secs(45)
+        Duration::from_secs(30) * node_count // 90s
     };
     let final_timeout = if expect_treekem {
-        Duration::from_secs(120)
+        Duration::from_secs(120) * node_count // 360s
     } else {
-        Duration::from_secs(60)
+        Duration::from_secs(40) * node_count // 120s
     };
+    // Back off the poll cadence for these long convergence waits: each probe
+    // issues several REST round-trips against all three daemons, and a hot
+    // 250ms loop adds load to the very mesh it is waiting on.
+    let poll = Duration::from_secs(1);
 
     let creator_id = creator.agent_id().await;
     let admin_id = admin.agent_id().await;
@@ -805,7 +827,7 @@ async fn non_creator_admin_invite_e2e_converges_for_preset(
         .unwrap_or(&group_id)
         .to_string();
 
-    let creator_sees_admin = wait_until(join_timeout, || async {
+    let creator_sees_admin = wait_until_every(join_timeout, poll, || async {
         list_members(creator, &group_id).await.contains(&admin_id)
     })
     .await;
@@ -813,10 +835,17 @@ async fn non_creator_admin_invite_e2e_converges_for_preset(
         creator_sees_admin,
         "creator never observed admin's initial join"
     );
+    // Pin the creator's state hash once admin is observed as a member, then
+    // wait for the admin to reach that captured baseline. This is a fixed
+    // target rather than a live cross-node comparison: a live equality check
+    // would be a stricter moving-target assertion that #139 does not require,
+    // and the later role-convergence and final-convergence waits already
+    // assert live agreement across all peers after the subsequent
+    // role-change and joiner-join operations.
     let creator_hash_after_admin_join = group_state_field(creator, &group_id, "state_hash")
         .await
         .expect("creator state_hash after admin join");
-    let admin_caught_up = wait_until(join_timeout, || async {
+    let admin_caught_up = wait_until_every(join_timeout, poll, || async {
         group_state_field(admin, &admin_group_id, "state_hash")
             .await
             .as_deref()
@@ -826,7 +855,7 @@ async fn non_creator_admin_invite_e2e_converges_for_preset(
     assert!(admin_caught_up, "admin never caught up after initial join");
 
     let _ = set_member_role(creator, &group_id, &admin_id, "admin").await;
-    let role_converged = wait_until(join_timeout, || async {
+    let role_converged = wait_until_every(join_timeout, poll, || async {
         let creator_details = group_details(creator, &group_id).await;
         let admin_details = group_details(admin, &admin_group_id).await;
         let creator_hash = group_state_field(creator, &group_id, "state_hash").await;
@@ -861,7 +890,7 @@ async fn non_creator_admin_invite_e2e_converges_for_preset(
         .unwrap_or(&group_id)
         .to_string();
 
-    let converged = wait_until(final_timeout, || async {
+    let converged = wait_until_every(final_timeout, poll, || async {
         let creator_details = group_details(creator, &group_id).await;
         let admin_details = group_details(admin, &admin_group_id).await;
         let joiner_details = group_details(joiner, &joiner_group_id).await;


### PR DESCRIPTION
Addresses #139 — the 3-daemon convergence e2e `non_creator_admin_private_secure_invite_e2e_converges_through_real_daemons` asserted against a fixed sub-120s window but legitimately takes 130–160s on a quiet dev machine (observed 140s+ for the TreeKEM variant) and far longer under CPU contention, producing false-alarm failures on loaded dev boxes. It passes on the CI runner.

**Changes (test-only; no production code):**
- Derive each wait budget from node count with a generous per-node multiplier: TreeKEM join `90s*N` (270s) / final `120s*N` (360s); non-TreeKEM join `30s*N` (90s) / final `40s*N` (120s).
- Back off the per-poll cadence to 1s for these long convergence waits (each probe issues several REST round-trips against all three daemons; a hot 250ms loop loads the very mesh it waits on).
- Generalize `wait_until` into `wait_until` + `wait_until_every(timeout, poll, …)` so existing 250ms-poll callers are unchanged.
- **Keep the pin-once state-hash baseline** for the admin-caught-up check (capture creator hash once admin is a member; wait for admin to reach it) — a live cross-node equality check would be a stricter moving-target assertion that #139 does not require, and the later role-convergence and final-convergence waits already assert live agreement across all peers.

Budgets are upper bounds only; each wait returns as soon as convergence is observed.

**Does not weaken convergence semantics and does not remove the test from CI.**

**Verification (target test on a quiet machine):**
- `non_creator_admin_private_secure_invite_e2e_converges_through_real_daemons` (TreeKEM): PASS 85s, PASS 54s — well under the 270s join ceiling.
- `non_creator_admin_invite_e2e_converges_through_real_daemons` (non-TreeKEM sibling): PASS 46s.
- `cargo fmt --all -- --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean.
- For comparison, unmodified `main` (90s join budget) **fails** a 140s run — confirming the budget increase is necessary, not cosmetic.

**Honest residual:** a fully saturated dev box (concurrent full `cargo` builds) can still exceed even these ceilings; the dedicated CI runner is unaffected. This matches #139's own framing ("fails locally under load, passes on runner").

A `reviewer` audit (semantics not weakened, no moving-target assertion, comments accurate) is in-flight; findings attached before merge.

Closes #139.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR relaxes timing in the named-group convergence test. The main changes are:

- Adds a configurable polling helper for long waits.
- Keeps the existing 250ms wait behavior for unchanged callers.
- Raises the 3-node convergence wait budgets.
- Uses a 1s poll interval for the slower daemon convergence checks.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The helper keeps prior polling behavior for existing callers.
- The new long-wait path uses fixed non-zero polling and valid timeout arithmetic.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/named_group_join_metadata_event.rs | Updates the test wait helper and applies longer per-node convergence waits with slower polling for the 3-daemon invite flow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(139): relax named-group convergence..."](https://github.com/saorsa-labs/x0x/commit/0fdfb7dd7f0d2a0bb4231d3894cf6e1d4d57fa7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41704555)</sub>

<!-- /greptile_comment -->