### PR TITLE
fix(145): announce loop self-skips registering the daemon'\''s own agent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,6 +507,30 @@ where
     }
 }
 
+/// Register a foreign agent's announced machine in the contact store.
+///
+/// Returns `true` if a new machine record was added, `false` otherwise
+/// (the machine was already known, or the announcement is for the daemon's
+/// own agent). The daemon deliberately never creates a contact entry for
+/// itself: a self record would be noise on the `/contacts` surface and would
+/// make contact-set assertions racy (issue #145). The two sibling actions in
+/// the announce loop — epidemic re-broadcast and auto-connect — already
+/// self-skip on `announced != own`; this helper makes the contact upsert the
+/// third self-skipping site.
+async fn register_announced_machine(
+    contact_store: &std::sync::Arc<tokio::sync::RwLock<contacts::ContactStore>>,
+    own_agent_id: identity::AgentId,
+    announced_agent_id: identity::AgentId,
+    announced_machine_id: identity::MachineId,
+) -> bool {
+    if announced_agent_id == own_agent_id {
+        return false;
+    }
+    let mut store = contact_store.write().await;
+    let record = contacts::MachineRecord::new(announced_machine_id, None);
+    store.add_machine(&announced_agent_id, record)
+}
+
 fn local_scoped_bootstrap_addr(addr: std::net::SocketAddr) -> bool {
     if addr.port() == 0 {
         return false;
@@ -5661,11 +5685,21 @@ impl Agent {
                 }
 
                 // Update machine records in the contact store.
-                {
-                    let mut store = contact_store.write().await;
-                    let record = contacts::MachineRecord::new(announcement.machine_id, None);
-                    store.add_machine(&announcement.agent_id, record);
-                }
+                //
+                // The daemon never registers its own agent as a contact: a self
+                // entry would be noise on the `/contacts` projection and pollute
+                // contact-set assertions (issue #145). The rebroadcast and
+                // auto-connect branches below already self-skip on
+                // `announcement.agent_id != own_agent_id`; the machine-record
+                // upsert was the sole outlier. Foreign observation still
+                // registers normally.
+                register_announced_machine(
+                    &contact_store,
+                    own_agent_id,
+                    announcement.agent_id,
+                    announcement.machine_id,
+                )
+                .await;
 
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
@@ -9824,6 +9858,71 @@ mod tests {
         assert!(
             result.is_err(),
             "Old-format announcement should not decode as new struct (protocol upgrade required)"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_announced_machine_skips_self_agent() {
+        // The daemon must never create a contact entry for its own agent: a
+        // self record is noise on `/contacts` and makes contact-set
+        // assertions racy (issue #145). A self-announcement is refused even
+        // though it carries a valid (agent, machine) pair.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = std::sync::Arc::new(tokio::sync::RwLock::new(contacts::ContactStore::new(
+            dir.path().join("contacts.json"),
+        )));
+        let own = identity::AgentId([1u8; 32]);
+        let own_machine = identity::MachineId([2u8; 32]);
+
+        let added = super::register_announced_machine(&store, own, own, own_machine).await;
+
+        assert!(!added, "self-announcement must not register a machine");
+        let store = store.read().await;
+        assert!(
+            store.machines(&own).is_empty(),
+            "self-agent must have no machine record after a self-announcement"
+        );
+        // Stronger invariant: the daemon must have NO contact entry at all
+        // for its own agent, not merely an empty machine list. add_machine
+        // creates the Contact shell on first sight (contacts.rs:423), so this
+        // confirms the self-skip happens before that insertion (#145).
+        assert!(
+            store.list().iter().all(|contact| contact.agent_id != own),
+            "self-agent must not appear in the contact store at all after a \
+             self-announcement"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_announced_machine_registers_foreign_agent() {
+        // Foreign observation must keep registering a machine record so peers
+        // remain observable in the contact surface — the self-skip must not be
+        // over-broad. A second announcement of the same (agent, machine) is
+        // idempotent (returns false, no duplicate record).
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = std::sync::Arc::new(tokio::sync::RwLock::new(contacts::ContactStore::new(
+            dir.path().join("contacts.json"),
+        )));
+        let own = identity::AgentId([1u8; 32]);
+        let peer = identity::AgentId([9u8; 32]);
+        let peer_machine = identity::MachineId([7u8; 32]);
+
+        let added = super::register_announced_machine(&store, own, peer, peer_machine).await;
+        assert!(added, "foreign announcement must register a new machine");
+
+        let added_again = super::register_announced_machine(&store, own, peer, peer_machine).await;
+        assert!(
+            !added_again,
+            "re-announcing the same machine must be idempotent"
+        );
+
+        let store = store.read().await;
+        let machines = store.machines(&peer);
+        assert_eq!(machines.len(), 1, "exactly one machine record");
+        assert_eq!(machines[0].machine_id, peer_machine);
+        assert!(
+            store.machines(&own).is_empty(),
+            "own agent must still have no contact entry"
         );
     }
 

--- a/tests/daemon_api_integration.rs
+++ b/tests/daemon_api_integration.rs
@@ -1303,27 +1303,17 @@ async fn daemon_api_import_card_invalid_trust_level_rejected() -> Result<()> {
         "unexpected error: {error}"
     );
 
-    // The rejected import must leave the trust surface UNTOUCHED. The naive
-    // "card_agent_id must be absent" check is the WRONG invariant here (#142):
-    // `card_agent_id` is THIS daemon's own agent (the card served at
-    // `/agent/card` is self), and the daemon's background announcement-
-    // processing loop (`lib.rs` announcement handler ->
-    // `ContactStore::add_machine`) legitimately registers any OBSERVED agent —
-    // including, on rebroadcast, itself — with `TrustLevel::Unknown` ("seen but
-    // not user-trusted"). That registration races this assertion, so mere
-    // presence does NOT mean the import ran.
-    //
-    // The import is provably side-effect-free on rejection: it returned 400 at
-    // the `trust_level` parse before any `ContactStore::add`. An ACCEPTED import
-    // would instead set the requested trust level (e.g. `known`) AND attach the
-    // card's display-name label. So the correct, provenance-based assertion is:
-    // if the card's agent is present in contacts, it must be the background-
-    // observation record (`trust_level == "unknown"`, untouched by the rejected
-    // import) — never a record the rejected import could have created (which
-    // would carry a non-`unknown` trust level and/or the card's display-name
-    // label). This pins the real invariant — a rejected import elevates no
-    // trust and creates no import-attributable record — without being flapped
-    // by the legitimate background self-registration race.
+    // The rejected import must leave the trust surface UNTOUCHED — the card's
+    // agent must be ABSENT from `/contacts`. This is the strong invariant
+    // issue #142 originally wanted; it was temporarily relaxed to a
+    // provenance-based check in #143 because the daemon's background
+    // announcement-processing loop registered any OBSERVED agent — including
+    // itself on rebroadcast — at `TrustLevel::Unknown`, which raced this
+    // assertion. #145 closed that root cause: the announce loop now
+    // self-skips (see `register_announced_machine` in lib.rs), so the
+    // daemon's own agent (`card_agent_id`, served from `/agent/card`) is
+    // never registered as a contact. The strong absence assertion is
+    // therefore valid again and is the correct invariant to pin.
     let contacts: Value = client.get(d.url("/contacts")).send().await?.json().await?;
     let contact_entries = contacts["contacts"]
         .as_array()
@@ -1332,15 +1322,12 @@ async fn daemon_api_import_card_invalid_trust_level_rejected() -> Result<()> {
         .iter()
         .filter(|contact| contact["agent_id"].as_str() == Some(card_agent_id))
         .collect();
-    for contact in &matching {
-        let trust = contact["trust_level"].as_str().unwrap_or("");
-        ensure!(
-            trust == "unknown",
-            "rejected import must not elevate trust: card agent present with \
-             trust_level {trust:?}, expected `unknown` (background-observation \
-             record untouched by the rejected import) or absence: {contacts:?}"
-        );
-    }
+    ensure!(
+        matching.is_empty(),
+        "rejected import must leave no contact side-effect for the card agent \
+         (announce-loop self-skip via #145 should prevent the daemon's own agent \
+         from being registered): {contacts:?}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Closes #145. Closes #142.

## Problem (#145)

The identity-announcement handler registered every OBSERVED agent into the contact store — including, on rebroadcast, the daemon's **own** agent — creating a `TrustLevel::Unknown` self-contact. That self entry was noise on `/contacts` and made contact-set assertions racy.

**Root cause:** the two sibling actions in the announce loop already self-skip on `announcement.agent_id != own_agent_id`:
- epidemic re-broadcast (`src/lib.rs:~5759`)
- auto-connect (`src/lib.rs:~5795`)

The machine-record upsert was the **sole outlier**. A consumer audit (7 consumers, recorded in [issue #145 comment](https://github.com/saorsa-labs/x0x/issues/145)) confirmed **nothing depends on the daemon's own self-contact record** — the fix is safe.

## Fix
- **`src/lib.rs`**: new `register_announced_machine(store, own, announced_agent, announced_machine) -> bool` helper that refuses to register the local agent (returns `false`) and registers foreign agents via the existing `ContactStore::add_machine` (idempotent on repeat). The announce-loop contact upsert now calls it, making the contact upsert the third self-skipping site.
- **Tests:** `register_announced_machine_skips_self_agent` (self refused → no contact entry) + `register_announced_machine_registers_foreign_agent` (foreign registered, idempotent, own agent untouched).
- **`tests/daemon_api_integration.rs`:** flip `daemon_api_import_card_invalid_trust_level_rejected` back to the **strong absence** assertion #142 originally wanted. #143 had relaxed it to a provenance check precisely *because* the announce loop self-registered; with the self-skip, the daemon's own agent (served at `/agent/card`) is never a contact, so `card_agent_id` absence is the correct invariant again.

## Closes #142
The only writer that could racily create the daemon's OWN agent as a contact was the announce loop; with the self-skip, a rejected card import leaves zero side-effect for the self agent (foreign-agent background registration remains legitimate).

## Verification
- `cargo fmt --all -- --check` clean
- `cargo clippy --all-features --all-targets -- -D warnings` clean
- `register_announced_machine_skips_self_agent` — PASS
- `register_announced_machine_registers_foreign_agent` — PASS (registers foreign, idempotent on repeat)
- `daemon_api_import_card_invalid_trust_level_rejected` — PASS (strong absence assertion now holds; test is `#[ignore]`d in this binary, run with `--run-ignored all`)

> **Note:** the import test is `#[ignore]`d for CI-selection parity with the rest of the `daemon_api_integration` binary; I left it ignored to preserve existing CI behavior. The two new unit tests are the real coverage for the self-skip logic.

A `reviewer` audit (correctness of the self-skip + the audit-consumer assumptions, no over-broad skip, flip justified) is in-flight; findings attached before merge.

Refs #145, #142.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents the daemon from registering its own announced agent as a contact. The main changes are:

- A new helper for announced machine registration.
- The announce loop now self-skips contact-store machine upserts.
- Unit tests cover self-skip and foreign-agent registration.
- The daemon API import test now expects no self-contact side effect.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after confirming the announcement identity binding before the self-skip.

- The import rejection path validates trust level before contact-store writes.
- Foreign announcements still use the existing machine registration path.
- The remaining concern is limited to whether incoming announcement agent ids are authenticated before the new self-skip runs.

src/lib.rs

<details open><summary><h3>Security Review</h3></summary>

The new self-skip depends on `announcement.agent_id` already being authenticated before contact registration. If that binding is not guaranteed before this branch, a spoofed self-agent claim can suppress machine registration.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib.rs | Adds the self-skipping registration helper and routes announce-loop machine upserts through it. |
| tests/daemon_api_integration.rs | Restores the strong absence assertion for rejected invalid-trust card imports. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/lib.rs:526-528
**Unauthenticated Self-Claim Skips Registration**

If an incoming identity announcement reaches this helper before `announcement.agent_id` has been cryptographically bound to the announcing peer, a peer can claim the daemon's own agent id with a different machine id and this branch silently skips the contact-store write. That makes the observed machine disappear from `/contacts` instead of being recorded as a foreign observation.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(145): announce loop self-skips regis..."](https://github.com/saorsa-labs/x0x/commit/afbecb5c82915c190c2a841374808c139c526125) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41705921)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->