### PR TITLE
refactor(125/WS1.4): extract routes/tasks.rs (task-list handlers)

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,12 +21,12 @@ mod ws;
 #[cfg(test)]
 use routes::CardQuery;
 use routes::{
-    add_contact, add_machine, agent_info, agent_sign, agent_user_id_handler, agent_verify,
-    announce_identity, delete_contact, delete_machine, discovered_machine, discovered_machines,
-    get_a2a_agent_card, get_agent_card, import_agent_card, introduction, list_contacts,
-    list_machines, list_revocations, machines_by_user_handler, pin_machine,
-    populate_invite_base_state_from_group_info, quick_trust, revoke_contact, unpin_machine,
-    update_contact,
+    add_contact, add_machine, add_task, agent_info, agent_sign, agent_user_id_handler,
+    agent_verify, announce_identity, create_task_list, delete_contact, delete_machine,
+    discovered_machine, discovered_machines, get_a2a_agent_card, get_agent_card, import_agent_card,
+    introduction, list_contacts, list_machines, list_revocations, list_task_lists, list_tasks,
+    machines_by_user_handler, pin_machine, populate_invite_base_state_from_group_info, quick_trust,
+    revoke_contact, unpin_machine, update_contact, update_task,
 };
 use sse::{direct_events_sse, events_sse, peer_events_handler, presence_events, SseEvent};
 pub use state::{
@@ -298,27 +298,6 @@ struct SubscribeRequest {
     topic: String,
 }
 
-/// POST /task-lists request body.
-#[derive(Debug, Deserialize)]
-struct CreateTaskListRequest {
-    name: String,
-    topic: String,
-}
-
-/// POST /task-lists/:id/tasks request body.
-#[derive(Debug, Deserialize)]
-struct AddTaskRequest {
-    title: String,
-    #[serde(default)]
-    description: Option<String>,
-}
-
-/// PATCH /task-lists/:id/tasks/:tid request body.
-#[derive(Debug, Deserialize)]
-struct UpdateTaskRequest {
-    action: String, // "claim" or "complete"
-}
-
 /// Generic JSON response wrapper.
 #[derive(Debug, Serialize)]
 struct ApiResponse<T: Serialize> {
@@ -510,24 +489,6 @@ struct DiscoveredMachineEntry {
 #[derive(Debug, Serialize)]
 struct PeerEntry {
     id: String,
-}
-
-/// Task list entry.
-#[derive(Debug, Serialize)]
-struct TaskListEntry {
-    id: String,
-    topic: String,
-}
-
-/// Task snapshot for API response.
-#[derive(Debug, Serialize)]
-struct TaskEntry {
-    id: String,
-    title: String,
-    description: String,
-    state: String,
-    assignee: Option<String>,
-    priority: u8,
 }
 
 // ---------------------------------------------------------------------------
@@ -13399,135 +13360,6 @@ async fn secure_open_envelope_adversarial(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Task list handlers
-// ---------------------------------------------------------------------------
-
-/// GET /task-lists
-async fn list_task_lists(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let lists = state.task_lists.read().await;
-    let entries: Vec<TaskListEntry> = lists
-        .keys()
-        .map(|id| TaskListEntry {
-            id: id.clone(),
-            topic: id.clone(), // topic is used as ID
-        })
-        .collect();
-    Json(serde_json::json!({ "ok": true, "task_lists": entries }))
-}
-
-/// POST /task-lists
-async fn create_task_list(
-    State(state): State<Arc<AppState>>,
-    Json(req): Json<CreateTaskListRequest>,
-) -> impl IntoResponse {
-    match state.agent.create_task_list(&req.name, &req.topic).await {
-        Ok(handle) => {
-            let id = req.topic.clone();
-            state.task_lists.write().await.insert(id.clone(), handle);
-            (
-                StatusCode::CREATED,
-                Json(serde_json::json!({ "ok": true, "id": id })),
-            )
-        }
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
-    }
-}
-
-/// GET /task-lists/:id/tasks
-async fn list_tasks(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-) -> impl IntoResponse {
-    let lists = state.task_lists.read().await;
-    let Some(handle) = lists.get(&id) else {
-        return not_found("task list not found");
-    };
-
-    match handle.list_tasks().await {
-        Ok(tasks) => {
-            let entries: Vec<TaskEntry> = tasks
-                .into_iter()
-                .map(|t| TaskEntry {
-                    id: format!("{}", t.id),
-                    title: t.title,
-                    description: t.description,
-                    state: format!("{}", t.state),
-                    assignee: t.assignee.map(|a| format!("{a}")),
-                    priority: t.priority,
-                })
-                .collect();
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({ "ok": true, "tasks": entries })),
-            )
-        }
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
-    }
-}
-
-/// POST /task-lists/:id/tasks
-async fn add_task(
-    State(state): State<Arc<AppState>>,
-    Path(id): Path<String>,
-    Json(req): Json<AddTaskRequest>,
-) -> impl IntoResponse {
-    let lists = state.task_lists.read().await;
-    let Some(handle) = lists.get(&id) else {
-        return not_found("task list not found");
-    };
-
-    match handle
-        .add_task(req.title, req.description.unwrap_or_default())
-        .await
-    {
-        Ok(task_id) => (
-            StatusCode::CREATED,
-            Json(serde_json::json!({ "ok": true, "task_id": format!("{task_id}") })),
-        ),
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
-    }
-}
-
-/// PATCH /task-lists/:id/tasks/:tid
-async fn update_task(
-    State(state): State<Arc<AppState>>,
-    Path((id, tid)): Path<(String, String)>,
-    Json(req): Json<UpdateTaskRequest>,
-) -> impl IntoResponse {
-    let lists = state.task_lists.read().await;
-    let Some(handle) = lists.get(&id) else {
-        return not_found("task list not found");
-    };
-
-    // Parse task ID from hex
-    let task_id_bytes: [u8; 32] = match hex::decode(&tid) {
-        Ok(bytes) if bytes.len() == 32 => {
-            let mut arr = [0u8; 32];
-            arr.copy_from_slice(&bytes);
-            arr
-        }
-        _ => {
-            return bad_request("invalid task ID (expected 64 hex chars)");
-        }
-    };
-    let task_id = x0x::crdt::TaskId::from_bytes(task_id_bytes);
-
-    let result = match req.action.as_str() {
-        "claim" => handle.claim_task(task_id).await,
-        "complete" => handle.complete_task(task_id).await,
-        _ => {
-            return bad_request("action must be 'claim' or 'complete'");
-        }
-    };
-
-    match result {
-        Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
-    }
-}
-
-// ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
 // Embedded GUI
 // ---------------------------------------------------------------------------

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -8,6 +8,7 @@
 mod contacts;
 mod identity;
 mod machines;
+mod tasks;
 
 pub(super) use contacts::{
     add_contact, delete_contact, list_contacts, list_revocations, quick_trust, revoke_contact,
@@ -24,3 +25,4 @@ pub(super) use machines::{
     add_machine, delete_machine, discovered_machine, discovered_machines, list_machines,
     machines_by_user_handler, pin_machine, unpin_machine,
 };
+pub(super) use tasks::{add_task, create_task_list, list_task_lists, list_tasks, update_task};

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -1,0 +1,190 @@
+//! Task-list REST handlers (`category: "tasks"` in `src/api/mod.rs`).
+//!
+//! Extracted verbatim from `src/server/mod.rs` as part of the #125 / WS1.4
+//! server decomposition. The router registrations stay in the parent module.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate as x0x;
+
+use super::super::state::AppState;
+use super::super::{api_error, bad_request, not_found};
+
+// ---------------------------------------------------------------------------
+// Request / response DTOs
+// ---------------------------------------------------------------------------
+
+/// POST /task-lists request body.
+#[derive(Debug, Deserialize)]
+pub(in crate::server) struct CreateTaskListRequest {
+    pub(in crate::server) name: String,
+    pub(in crate::server) topic: String,
+}
+
+/// POST /task-lists/:id/tasks request body.
+#[derive(Debug, Deserialize)]
+pub(in crate::server) struct AddTaskRequest {
+    pub(in crate::server) title: String,
+    #[serde(default)]
+    pub(in crate::server) description: Option<String>,
+}
+
+/// PATCH /task-lists/:id/tasks/:tid request body.
+#[derive(Debug, Deserialize)]
+pub(in crate::server) struct UpdateTaskRequest {
+    pub(in crate::server) action: String, // "claim" or "complete"
+}
+
+/// Task list entry.
+#[derive(Debug, Serialize)]
+pub(in crate::server) struct TaskListEntry {
+    pub(in crate::server) id: String,
+    pub(in crate::server) topic: String,
+}
+
+/// Task snapshot for API response.
+#[derive(Debug, Serialize)]
+pub(in crate::server) struct TaskEntry {
+    pub(in crate::server) id: String,
+    pub(in crate::server) title: String,
+    pub(in crate::server) description: String,
+    pub(in crate::server) state: String,
+    pub(in crate::server) assignee: Option<String>,
+    pub(in crate::server) priority: u8,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// GET /task-lists
+pub(in crate::server) async fn list_task_lists(
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    let lists = state.task_lists.read().await;
+    let entries: Vec<TaskListEntry> = lists
+        .keys()
+        .map(|id| TaskListEntry {
+            id: id.clone(),
+            topic: id.clone(), // topic is used as ID
+        })
+        .collect();
+    Json(serde_json::json!({ "ok": true, "task_lists": entries }))
+}
+
+/// POST /task-lists
+pub(in crate::server) async fn create_task_list(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateTaskListRequest>,
+) -> impl IntoResponse {
+    match state.agent.create_task_list(&req.name, &req.topic).await {
+        Ok(handle) => {
+            let id = req.topic.clone();
+            state.task_lists.write().await.insert(id.clone(), handle);
+            (
+                StatusCode::CREATED,
+                Json(serde_json::json!({ "ok": true, "id": id })),
+            )
+        }
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
+    }
+}
+
+/// GET /task-lists/:id/tasks
+pub(in crate::server) async fn list_tasks(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let lists = state.task_lists.read().await;
+    let Some(handle) = lists.get(&id) else {
+        return not_found("task list not found");
+    };
+
+    match handle.list_tasks().await {
+        Ok(tasks) => {
+            let entries: Vec<TaskEntry> = tasks
+                .into_iter()
+                .map(|t| TaskEntry {
+                    id: format!("{}", t.id),
+                    title: t.title,
+                    description: t.description,
+                    state: format!("{}", t.state),
+                    assignee: t.assignee.map(|a| format!("{a}")),
+                    priority: t.priority,
+                })
+                .collect();
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({ "ok": true, "tasks": entries })),
+            )
+        }
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
+    }
+}
+
+/// POST /task-lists/:id/tasks
+pub(in crate::server) async fn add_task(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<AddTaskRequest>,
+) -> impl IntoResponse {
+    let lists = state.task_lists.read().await;
+    let Some(handle) = lists.get(&id) else {
+        return not_found("task list not found");
+    };
+
+    match handle
+        .add_task(req.title, req.description.unwrap_or_default())
+        .await
+    {
+        Ok(task_id) => (
+            StatusCode::CREATED,
+            Json(serde_json::json!({ "ok": true, "task_id": format!("{task_id}") })),
+        ),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
+    }
+}
+
+/// PATCH /task-lists/:id/tasks/:tid
+pub(in crate::server) async fn update_task(
+    State(state): State<Arc<AppState>>,
+    Path((id, tid)): Path<(String, String)>,
+    Json(req): Json<UpdateTaskRequest>,
+) -> impl IntoResponse {
+    let lists = state.task_lists.read().await;
+    let Some(handle) = lists.get(&id) else {
+        return not_found("task list not found");
+    };
+
+    // Parse task ID from hex
+    let task_id_bytes: [u8; 32] = match hex::decode(&tid) {
+        Ok(bytes) if bytes.len() == 32 => {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&bytes);
+            arr
+        }
+        _ => {
+            return bad_request("invalid task ID (expected 64 hex chars)");
+        }
+    };
+    let task_id = x0x::crdt::TaskId::from_bytes(task_id_bytes);
+
+    let result = match req.action.as_str() {
+        "claim" => handle.claim_task(task_id).await,
+        "complete" => handle.complete_task(task_id).await,
+        _ => {
+            return bad_request("action must be 'claim' or 'complete'");
+        }
+    };
+
+    match result {
+        Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
+    }
+}


### PR DESCRIPTION
Second wave of the #125 server decomposition: mechanical extraction of the `tasks` route category (`category: "tasks"` in `src/api/mod.rs`) out of `src/server/mod.rs` into `src/server/routes/tasks.rs`.

**Moved verbatim (pure relocation):**
- 5 handlers: `list_task_lists`, `create_task_list`, `list_tasks`, `add_task`, `update_task`
- 5 DTOs: `CreateTaskListRequest`, `AddTaskRequest`, `UpdateTaskRequest`, `TaskListEntry`, `TaskEntry`

Handlers widened to `pub(in crate::server)` — the floor forced by the `pub(super)` re-export in `routes/mod.rs` (see PR #161 / E0364: a `pub(super) use` re-export requires the item to be visible at `crate::server`). Route registrations stay in `src/server/mod.rs` via the existing `use routes::{...}` import block (extended with the 5 new handler names).

**Why this is safe:** the `route_set_matches_registry` + `manifest_matches_registry` guards and the `tests/snapshots/server-routes.*` snapshot enforce byte-identical routing.

**This is the prerequisite for #153** (group-membership enforcement on these task-list handlers, which currently return 403 for no one). #153 lands in a separate PR — this one is a pure move with no behavior changes.

**Verification:**
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `route_set_matches_registry` + `manifest_matches_registry` — PASS
- `tests/snapshots/` diff vs main — empty (0 lines)
- 94 tasks/api/proptest tests — all PASS (`test(/task/) | test(/api_coverage/) | test(/api_manifest/)`)

A `reviewer` pure-move audit is in-flight; findings attached before merge.

Refs #125.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the task-list route handlers into a dedicated route module. The main changes are:

- Extracted task-list DTOs and handlers into `src/server/routes/tasks.rs`.
- Added the new `tasks` route module and re-exported its handlers.
- Updated `src/server/mod.rs` to import the moved handler names.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The moved handlers keep the same route names, JSON shapes, status codes, and error paths.
- The new module uses the same visibility and import pattern as the existing route modules.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/mod.rs | Removes the inline task-list DTOs and handlers, then imports the moved handler names through the existing route module. |
| src/server/routes/mod.rs | Adds the `tasks` module and re-exports the task-list handlers for the parent server module. |
| src/server/routes/tasks.rs | Adds the relocated task-list DTOs and handlers with matching request handling and response behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(125/WS1.4): extract routes/task..."](https://github.com/saorsa-labs/x0x/commit/efb1a9d5570f3bb8b78a3a5db539871bb3a9affb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41709967)</sub>

<!-- /greptile_comment -->