### PR TITLE
fix(153): enforce group membership on group-scoped task lists

### DIFF
--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -14,7 +14,121 @@ use serde::{Deserialize, Serialize};
 use crate as x0x;
 
 use super::super::state::AppState;
-use super::super::{api_error, bad_request, not_found};
+use super::super::{api_error, bad_request, forbidden, not_found};
+
+// ---------------------------------------------------------------------------
+// Group-membership enforcement (#153)
+// ---------------------------------------------------------------------------
+//
+// Task-list REST endpoints are local daemon control-plane endpoints
+// authenticated by the daemon's bearer API token (`src/server/auth.rs`
+// `auth_middleware`). That token authenticates the daemon, NOT a remote
+// requester agent — there is no per-request agent identity in this path.
+//
+// So group isolation is enforced against the daemon's *local* agent: if a
+// task-list id is group-scoped, the daemon's local agent must be an ACTIVE
+// member of that named group, otherwise the handler returns 403. This gives
+// hard cross-daemon isolation (a daemon whose local agent is not in group G
+// cannot read/write G's task lists via its own REST API) and is what the
+// x0x-symphony XSY-0021 two-daemon isolation test proves. Non-group-scoped
+// ids are unchanged.
+//
+// Fail-closed: a malformed scoped id, a missing group, or a
+// non-active/non-member local agent all deny. See `ensure_task_list_access`.
+
+/// Symphony's group-scoped task-list id convention:
+/// `x0x.group.<group_id>.symphony.<list_id>`.
+///
+/// Returns the parsed `<group_id>` when `id` is group-scoped, or `None` for a
+/// plain (non-scoped) task-list id. A string that *looks* scoped but is
+/// malformed (wrong segment count, empty group id, …) is NOT treated as
+/// plain: callers must deny it via [`ensure_task_list_access`].
+pub(in crate::server) fn parse_group_scoped_task_list_id(id: &str) -> Option<GroupScopedId> {
+    // Split on '.' but keep it simple and strict: exactly 5 non-empty segments
+    // `x0x . group . <group_id> . symphony . <list_id>`.
+    let parts: Vec<&str> = id.split('.').collect();
+    if parts.len() != 5 {
+        return None;
+    }
+    if parts[0] != "x0x" || parts[1] != "group" || parts[3] != "symphony" {
+        return None;
+    }
+    let group_id = parts[2];
+    let list_id = parts[4];
+    if group_id.is_empty() || list_id.is_empty() {
+        // Malformed scoped id — signal "looked scoped but invalid" distinctly
+        // from a plain id by returning Some with an empty group id, which the
+        // guard treats as deny. We use a dedicated sentinel for clarity.
+        return Some(GroupScopedId::malformed());
+    }
+    Some(GroupScopedId {
+        group_id: group_id.to_string(),
+        list_id: list_id.to_string(),
+    })
+}
+
+/// A parsed group-scoped task-list id, or a malformed sentinel.
+///
+/// `list_id` is retained for diagnostics/future use but is not consulted by
+/// the membership guard (only `group_id` is needed to check access).
+#[derive(Debug, PartialEq, Eq)]
+pub(in crate::server) struct GroupScopedId {
+    pub(in crate::server) group_id: String,
+    #[allow(dead_code)]
+    pub(in crate::server) list_id: String,
+}
+
+impl GroupScopedId {
+    /// Sentinel for an id that looked scoped (`x0x.group.…`) but was malformed.
+    /// `group_id` is empty so the guard cannot find a matching group ⇒ deny.
+    pub(in crate::server) fn malformed() -> Self {
+        Self {
+            group_id: String::new(),
+            list_id: String::new(),
+        }
+    }
+
+    pub(in crate::server) fn is_malformed(&self) -> bool {
+        self.group_id.is_empty()
+    }
+}
+
+/// Enforcement guard for group-scoped task lists (#153).
+///
+/// - Non-scoped id  ⇒ allow (returns `Ok(())`).
+/// - Group-scoped id ⇒ allow only if the daemon's local agent is an ACTIVE
+///   member of the named group in `state.named_groups`.
+/// - Malformed scoped id, missing group, or non-member ⇒ `Err(403)`.
+///
+/// `Ok(())` means the caller may proceed; the `Err` is an `impl IntoResponse`
+/// 403 ready to return.
+pub(in crate::server) async fn ensure_task_list_access(
+    state: &Arc<AppState>,
+    id: &str,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    let Some(scoped) = parse_group_scoped_task_list_id(id) else {
+        // Plain (non-group-scoped) task-list id — unchanged behavior.
+        return Ok(());
+    };
+    if scoped.is_malformed() {
+        return Err(forbidden("malformed group-scoped task-list id"));
+    }
+    let local_agent_hex = hex::encode(state.agent.agent_id().as_bytes());
+    let groups = state.named_groups.read().await;
+    let Some(info) = groups.get(&scoped.group_id) else {
+        // Unknown group ⇒ fail closed. We do NOT reveal whether the group
+        // exists to a non-member, but the id namespace is public-by-convention
+        // so a plain 403 is the safe, non-leaky response.
+        return Err(forbidden("not a member of task-list group"));
+    };
+    let member = info.members_v2.get(&local_agent_hex);
+    let allowed = member.is_some_and(|m| matches!(m.state, x0x::groups::GroupMemberState::Active));
+    if allowed {
+        Ok(())
+    } else {
+        Err(forbidden("not a member of task-list group"))
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Request / response DTOs
@@ -83,6 +197,10 @@ pub(in crate::server) async fn create_task_list(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateTaskListRequest>,
 ) -> impl IntoResponse {
+    // #153: creating a group-scoped task list requires membership of that group.
+    if let Err(denied) = ensure_task_list_access(&state, &req.topic).await {
+        return denied;
+    }
     match state.agent.create_task_list(&req.name, &req.topic).await {
         Ok(handle) => {
             let id = req.topic.clone();
@@ -101,6 +219,10 @@ pub(in crate::server) async fn list_tasks(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    // #153: group-scoped task lists require local-agent membership.
+    if let Err(denied) = ensure_task_list_access(&state, &id).await {
+        return denied;
+    }
     let lists = state.task_lists.read().await;
     let Some(handle) = lists.get(&id) else {
         return not_found("task list not found");
@@ -134,6 +256,10 @@ pub(in crate::server) async fn add_task(
     Path(id): Path<String>,
     Json(req): Json<AddTaskRequest>,
 ) -> impl IntoResponse {
+    // #153: group-scoped task lists require local-agent membership (write too).
+    if let Err(denied) = ensure_task_list_access(&state, &id).await {
+        return denied;
+    }
     let lists = state.task_lists.read().await;
     let Some(handle) = lists.get(&id) else {
         return not_found("task list not found");
@@ -157,6 +283,10 @@ pub(in crate::server) async fn update_task(
     Path((id, tid)): Path<(String, String)>,
     Json(req): Json<UpdateTaskRequest>,
 ) -> impl IntoResponse {
+    // #153: group-scoped task lists require local-agent membership (write too).
+    if let Err(denied) = ensure_task_list_access(&state, &id).await {
+        return denied;
+    }
     let lists = state.task_lists.read().await;
     let Some(handle) = lists.get(&id) else {
         return not_found("task list not found");
@@ -186,5 +316,78 @@ pub(in crate::server) async fn update_task(
     match result {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_group_scoped_task_list_id: the security crown jewel ──────────
+    //
+    // The parser's contract is the foundation of #153's fail-closed
+    // property. It must partition every input into exactly one of:
+    //   - None              ⇒ plain id, ALLOW (unchanged behavior)
+    //   - Some(valid)       ⇒ group-scoped, defer to membership check
+    //   - Some(malformed)   ⇒ looked scoped but invalid, DENY
+    // A misspelled prefix (`x0x.grop.…`) MUST NOT silently fall through to the
+    // plain-id allow path, and a malformed scoped id MUST NOT be treated as a
+    // valid group lookup.
+
+    #[test]
+    fn parser_recognizes_well_formed_scoped_id() {
+        let parsed = parse_group_scoped_task_list_id("x0x.group.acme-corp.symphony.inbox");
+        let scoped = parsed.expect("well-formed scoped id parses");
+        assert!(!scoped.is_malformed());
+        assert_eq!(scoped.group_id, "acme-corp");
+    }
+
+    #[test]
+    fn parser_treats_plain_id_as_none() {
+        // A non-scoped topic is unchanged behavior — must return None so the
+        // guard allows it without any group lookup.
+        assert_eq!(parse_group_scoped_task_list_id("plain-topic"), None);
+        assert_eq!(parse_group_scoped_task_list_id("inbox"), None);
+        assert_eq!(parse_group_scoped_task_list_id(""), None);
+        // A 4-segment id is NOT the scoped shape (needs exactly 5).
+        assert_eq!(parse_group_scoped_task_list_id("x0x.group.acme"), None);
+        // 6 segments is also not the shape.
+        assert_eq!(
+            parse_group_scoped_task_list_id("x0x.group.acme.symphony.inbox.extra"),
+            None
+        );
+    }
+
+    #[test]
+    fn parser_rejects_wrong_prefix_as_plain() {
+        // A scoped shape with a misspelled prefix is NOT treated as scoped —
+        // it falls through to plain (None). This is safe because such an id
+        // is genuinely not the symphony convention; treating it as scoped
+        // would be over-eager denial of legitimate plain ids.
+        assert_eq!(
+            parse_group_scoped_task_list_id("x0x.grop.acme.symphony.inbox"),
+            None
+        );
+        assert_eq!(
+            parse_group_scoped_task_list_id("foo.group.acme.symphony.inbox"),
+            None
+        );
+        assert_eq!(
+            parse_group_scoped_task_list_id("x0x.group.acme.secure.inbox"),
+            None // wrong 4th segment (not "symphony")
+        );
+    }
+
+    #[test]
+    fn parser_flags_empty_group_or_list_as_malformed() {
+        // A scoped *shape* with an empty group_id or list_id is malformed and
+        // MUST be denied (Some(malformed)), never allowed as plain.
+        let empty_group = parse_group_scoped_task_list_id("x0x.group..symphony.inbox");
+        let scoped = empty_group.expect("scoped shape with empty group is Some");
+        assert!(scoped.is_malformed(), "empty group_id ⇒ malformed ⇒ deny");
+
+        let empty_list = parse_group_scoped_task_list_id("x0x.group.acme.symphony.");
+        let scoped = empty_list.expect("scoped shape with empty list is Some");
+        assert!(scoped.is_malformed(), "empty list_id ⇒ malformed ⇒ deny");
     }
 }

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -181,14 +181,26 @@ pub(in crate::server) struct TaskEntry {
 pub(in crate::server) async fn list_task_lists(
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
-    let lists = state.task_lists.read().await;
-    let entries: Vec<TaskListEntry> = lists
-        .keys()
-        .map(|id| TaskListEntry {
-            id: id.clone(),
-            topic: id.clone(), // topic is used as ID
-        })
-        .collect();
+    // Snapshot the keys, then release the lock before the per-id membership
+    // check (which takes `named_groups.read()`). Holding both read locks at
+    // once is safe for an RwLock, but collecting first keeps the critical
+    // section short and avoids re-entrancy surprises.
+    let ids: Vec<String> = state.task_lists.read().await.keys().cloned().collect();
+    // #153: filter the collection through the same membership guard as the
+    // per-id read/write handlers, so this endpoint does not leak the existence
+    // or exact topics of group-scoped task lists the local agent is not an
+    // active member of. (The per-id handlers already 403 those; this prevents
+    // the collection from enumerating them.) Red-team review of #166 found
+    // this collection endpoint was the sole unguarded path.
+    let mut entries = Vec::with_capacity(ids.len());
+    for id in ids {
+        if ensure_task_list_access(&state, &id).await.is_ok() {
+            entries.push(TaskListEntry {
+                id: id.clone(),
+                topic: id, // topic is used as ID
+            });
+        }
+    }
     Json(serde_json::json!({ "ok": true, "task_lists": entries }))
 }
 


### PR DESCRIPTION
Closes #153.

## Problem

Task-list REST handlers (`/task-lists/:id/tasks` etc.) keyed task lists by arbitrary topic string with **no membership check**. A caller who knew a group-scoped id (`x0x.group.<group_id>.symphony.<list_id>`) could read/write it regardless of group membership. This blocked x0x-symphony XSY-0021 (MLS-encrypted task-list dispatch) from proving **hard** cross-daemon isolation.

## Design (see [issue #153 comment](https://github.com/saorsa-labs/x0x/issues/153#issuecomment-4879262419) for the full rationale)

REST endpoints are **local daemon control-plane** endpoints authenticated by the daemon's bearer API token (`auth_middleware`), which authenticates the *daemon*, not a remote requester agent. So group isolation is enforced against the daemon's **local agent**:

> A group-scoped task-list id is served only if the daemon's local agent (`state.agent.agent_id()`) is an **ACTIVE** member of that named group in `state.named_groups`; otherwise `403`. Non-group-scoped ids are unchanged.

This gives hard cross-daemon isolation (the XSY-0021 two-daemon case: a daemon whose local agent is not in group G cannot read/write G's task lists via its own REST API) **without** inventing a remote-agent REST auth protocol or trusting a client-supplied agent id.

## Implementation (`src/server/routes/tasks.rs`)

- **`parse_group_scoped_task_list_id(id)`**: strict 5-segment parser for `x0x.group.<group_id>.symphony.<list_id>`. Returns `None` for plain ids, `Some(valid)` for scoped, `Some(malformed)` for looked-scoped-but-invalid (empty group/list segment).
- **`ensure_task_list_access(state, id)`**: fail-closed guard. Non-scoped ⇒ allow; malformed scoped ⇒ 403; unknown group ⇒ 403; non-active/non-member local agent ⇒ 403.
- Applied to **read AND write** handlers: `list_tasks`, `add_task`, `update_task`, and `create_task_list` (creating a scoped topic also requires membership).

## Security property (fail-closed in every ambiguous case)

| Input | Result |
|-------|--------|
| Plain id (`inbox`) | allow (unchanged) |
| Well-formed scoped, local agent is ACTIVE member | allow |
| Well-formed scoped, local agent is non-member / Removed / Banned / Pending | **403** |
| Well-formed scoped, group unknown to this daemon | **403** |
| Malformed scoped (`x0x.group..symphony.inbox`, `x0x.group.acme.symphony.`) | **403** |
| Misspelled prefix (`x0x.grop.…`, `foo.group.…`) | treated as plain (None) — safe |

## Verification
- `cargo fmt --all -- --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean
- 4 new parser tests pin the fail-closed contract (well-formed parses; plain + wrong-prefix ⇒ None; empty group/list ⇒ Some(malformed))
- 100 existing tasks/api/proptest tests pass (non-scoped path unchanged)
- `route_set_matches_registry` + `manifest_matches_registry` pass; `tests/snapshots/` untouched (0 lines)

## Acceptance / cross-repo
The end-to-end acceptance proof is the x0x-symphony **XSY-0021 two-daemon isolation test** in the sibling `x0x-symphony` repo (currently `#[ignore]`d). Un-ignoring it is owned by the symphony team and depends on this x0x enforcement landing first.

A `red-team` adversarial security review (fail-closed on every ambiguous case, no bypass, no info-leak) is in-flight; findings attached before merge.

Refs #153.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds group-membership checks for group-scoped task lists. The main changes are:

- A parser for `x0x.group.<group_id>.symphony.<list_id>` task-list ids.
- A guard that requires the local daemon agent to be an active group member.
- Guard calls in create, read, add, and update task-list handlers.
- Parser tests for plain, malformed, and well-formed scoped ids.

<h3>Confidence Score: 4/5</h3>

The group-scoped task-list boundary needs fixes before merging.

- Reserved scoped ids with extra dot segments can skip the new membership guard.
- The list-all endpoint can expose protected scoped task-list ids.
- The local-agent member key format matches the existing lowercase hex format.

src/server/routes/tasks.rs

<details open><summary><h3>Security Review</h3></summary>

The PR strengthens task-list isolation, but two security paths still need fixes:

- Reserved scoped ids with extra dot segments can be treated as plain ids.
- `GET /task-lists` can still disclose group-scoped task-list ids without checking membership.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/routes/tasks.rs | Adds scoped task-list parsing and membership enforcement, with remaining gaps in reserved-id parsing and list-all filtering. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/server/routes/tasks.rs`, line 181-193 ([link](https://github.com/saorsa-labs/x0x/blob/15b695c2bbbd9d385266779cb026e4902b5cd64d/src/server/routes/tasks.rs#L181-L193)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Task List Listing Leaks Scoped Ids**

   `GET /task-lists` still returns every key in `state.task_lists` without applying the new group-membership guard. If this daemon has a stale or replicated handle for `x0x.group.<gid>.symphony.<list_id>` after the local agent is no longer active in `<gid>`, per-list reads and writes return 403 but the listing endpoint still exposes the protected group-scoped id.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/server/routes/tasks.rs
   Line: 181-193

   Comment:
   **Task List Listing Leaks Scoped Ids**

   `GET /task-lists` still returns every key in `state.task_lists` without applying the new group-membership guard. If this daemon has a stale or replicated handle for `x0x.group.<gid>.symphony.<list_id>` after the local agent is no longer active in `<gid>`, per-list reads and writes return 403 but the listing endpoint still exposes the protected group-scoped id.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/server/routes/tasks.rs:50-55
**Scoped Id Falls Through**

When a reserved task-list id has extra dot segments, such as `x0x.group.acme.corp.symphony.inbox`, this branch returns `None` and the guard treats it as a plain id. If a group id or list id can contain a dot, a non-member can use that scoped topic without any membership check.

```suggestion
    if parts.len() != 5 {
        if parts.len() >= 2 && parts[0] == "x0x" && parts[1] == "group" {
            return Some(GroupScopedId::malformed());
        }
        return None;
    }
    if parts[0] != "x0x" || parts[1] != "group" || parts[3] != "symphony" {
        return None;
    }
```

### Issue 2 of 2
src/server/routes/tasks.rs:181-193
**Task List Listing Leaks Scoped Ids**

`GET /task-lists` still returns every key in `state.task_lists` without applying the new group-membership guard. If this daemon has a stale or replicated handle for `x0x.group.<gid>.symphony.<list_id>` after the local agent is no longer active in `<gid>`, per-list reads and writes return 403 but the listing endpoint still exposes the protected group-scoped id.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(153): enforce group membership on gr..."](https://github.com/saorsa-labs/x0x/commit/15b695c2bbbd9d385266779cb026e4902b5cd64d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41712264)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->