### PR TITLE
feat(connect): connect ACL policy engine + gate (#131, PR1)

### DIFF
--- a/scripts/check-panics.sh
+++ b/scripts/check-panics.sh
@@ -51,8 +51,10 @@ scan_pattern() {
 
     # Scan for pattern
     while IFS= read -r match; do
-        # Skip if in tests/ directory or .bak files
-        if echo "$match" | grep -qE "(tests/|\.bak:|\.rs:.*//.*$pattern)"; then
+        # Skip if in tests/ directory, a file named tests.rs (file-level test
+        # submodules declared via `#[cfg(test)] mod tests;` in the parent, e.g.
+        # src/connect/acl/tests.rs), or .bak files.
+        if echo "$match" | grep -qE "(tests/|/tests\.rs:|\.bak:|\.rs:.*//.*$pattern)"; then
             continue
         fi
 

--- a/src/connect/acl.rs
+++ b/src/connect/acl.rs
@@ -1,0 +1,453 @@
+//! Connect ACL policy types, load, parse, validate.
+//!
+//! Connection-ACL (default-closed connectivity policy). Modeled line-by-line
+//! on the exec ACL ([`crate::exec::acl`]); see ADR-0019 and
+//! `docs/plans/2026-07-issue-131-connect-acl-plan.md`.
+//!
+//! ## v1 scope (important)
+//! v1 is a **policy engine + validation surface only** — there is no runtime
+//! enforcement caller yet. The T4 forwarder (issue #132) will call
+//! [`crate::connect::gate::evaluate_connect_gate`] at its accept seam; until then this module
+//! provides a fail-closed policy loader, a loopback-only target validator,
+//! and a pure gate function that are fully tested but unwired. See §1.3 of
+//! the plan and ADR-0019.
+//!
+//! ## Security invariants
+//! - **Default = disabled.** [`ConnectPolicy::default()`] is `Disabled`, so an
+//!   embedder that builds [`ServeOptions`](crate::server::ServeOptions)
+//!   without supplying a connect ACL gets default-deny for free.
+//! - **Loopback-only targets.** `parse_target` rejects any non-loopback
+//!   address (and hostnames like `localhost`) as a **load-time hard error**.
+//! - **Numeric IP only.** No DNS resolution in the trusted computing base.
+//! - **Exact `host:port` only.** No port ranges, no CIDR.
+//! - **`deny_unknown_fields`** on every TOML struct: a misspelled key
+//!   (`taregts`, `enable`) fails loudly rather than silently yielding a
+//!   different policy.
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::exec::acl::{parse_agent_id, parse_machine_id, LoadMode};
+use crate::identity::{AgentId, MachineId};
+
+// ---------------------------------------------------------------------------
+// Path
+// ---------------------------------------------------------------------------
+
+/// Default connect ACL file location.
+#[must_use]
+pub fn default_connect_acl_path() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        PathBuf::from("/usr/local/etc/x0x/connect-acl.toml")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        PathBuf::from("/etc/x0x/connect-acl.toml")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Policy + ACL types
+// ---------------------------------------------------------------------------
+
+/// Loaded connect policy.
+///
+/// Mirrors [`crate::exec::acl::ExecPolicy`] one-for-one: a `Disabled` variant
+/// carrying provenance + reason, and an `Enabled` variant holding a validated
+/// [`ConnectAcl`].
+#[derive(Debug, Clone)]
+pub enum ConnectPolicy {
+    Disabled {
+        path: PathBuf,
+        reason: String,
+        loaded_at_unix_ms: u64,
+    },
+    Enabled(ConnectAcl),
+}
+
+impl Default for ConnectPolicy {
+    /// Connect is disabled unless an ACL is explicitly loaded. This is the
+    /// safe default for embedders that build
+    /// [`ServeOptions`](crate::server::ServeOptions) without supplying a
+    /// connect ACL — they get default-deny with zero host effort.
+    fn default() -> Self {
+        Self::Disabled {
+            path: default_connect_acl_path(),
+            reason: "no connect ACL configured".to_string(),
+            loaded_at_unix_ms: 0,
+        }
+    }
+}
+
+impl ConnectPolicy {
+    /// Whether the policy enables connect-forwarding.
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        matches!(self, Self::Enabled(_))
+    }
+
+    /// Path used when loading this policy.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Disabled { path, .. } => path,
+            Self::Enabled(acl) => &acl.loaded_from,
+        }
+    }
+
+    /// Summary safe for diagnostics.
+    #[must_use]
+    pub fn summary(&self) -> ConnectAclSummary {
+        match self {
+            Self::Disabled {
+                path,
+                reason,
+                loaded_at_unix_ms,
+            } => ConnectAclSummary {
+                enabled: false,
+                loaded_from: path.display().to_string(),
+                loaded_at_unix_ms: *loaded_at_unix_ms,
+                allow_entry_count: 0,
+                target_entry_count: 0,
+                disabled_reason: Some(reason.clone()),
+            },
+            Self::Enabled(acl) => ConnectAclSummary {
+                enabled: true,
+                loaded_from: acl.loaded_from.display().to_string(),
+                loaded_at_unix_ms: acl.loaded_at_unix_ms,
+                allow_entry_count: acl.allow.len(),
+                target_entry_count: acl.allow.iter().map(|e| e.targets.len()).sum(),
+                disabled_reason: None,
+            },
+        }
+    }
+}
+
+/// Diagnostics-safe connect ACL summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConnectAclSummary {
+    pub enabled: bool,
+    pub loaded_from: String,
+    pub loaded_at_unix_ms: u64,
+    pub allow_entry_count: usize,
+    pub target_entry_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled_reason: Option<String>,
+}
+
+/// Fully validated connect ACL.
+#[derive(Debug, Clone)]
+pub struct ConnectAcl {
+    /// File the ACL was loaded from (provenance).
+    pub loaded_from: PathBuf,
+    /// When the ACL was loaded (provenance + diagnostics).
+    pub loaded_at_unix_ms: u64,
+    /// Allowed (agent, machine, target) triples. v1 has **no caps struct** —
+    /// per-flow stream limits are T4 forwarder config, not ACL policy.
+    pub allow: Vec<ConnectAllowEntry>,
+}
+
+impl ConnectAcl {
+    /// Look up the allow entry for an exact (agent, machine) pair.
+    #[must_use]
+    pub fn entry_for(
+        &self,
+        agent_id: &AgentId,
+        machine_id: &MachineId,
+    ) -> Option<&ConnectAllowEntry> {
+        self.allow
+            .iter()
+            .find(|e| &e.agent_id == agent_id && &e.machine_id == machine_id)
+    }
+
+    /// Exact-triple membership test: `true` iff `(agent, machine, target)` is
+    /// an explicit allow entry. Note: `127.0.0.1:22` does **not** grant
+    /// `\[::1\]:22`; matching is exact `SocketAddr` equality.
+    #[must_use]
+    pub fn is_allowed(
+        &self,
+        agent_id: &AgentId,
+        machine_id: &MachineId,
+        target: &SocketAddr,
+    ) -> bool {
+        self.entry_for(agent_id, machine_id)
+            .is_some_and(|e| e.targets.iter().any(|t| t == target))
+    }
+}
+
+/// One allowed requester pair + their permitted loopback targets.
+#[derive(Debug, Clone)]
+pub struct ConnectAllowEntry {
+    pub description: Option<String>,
+    pub agent_id: AgentId,
+    pub machine_id: MachineId,
+    pub targets: Vec<SocketAddr>,
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Connect ACL load/validation error.
+///
+/// Mirrors [`crate::exec::acl::AclError`] shapes; the `Missing` vs `Read` vs
+/// `Parse` vs `Invalid` split is what lets `--check` and daemon startup fail
+/// loudly on a malformed/missing-at-explicit-path ACL.
+#[derive(Debug, thiserror::Error)]
+pub enum ConnectAclError {
+    #[error("connect ACL file not found: {0}")]
+    Missing(String),
+    #[error("failed to read connect ACL {path}: {source}")]
+    Read {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("failed to parse connect ACL {path}: {source}")]
+    Parse {
+        path: String,
+        source: toml::de::Error,
+    },
+    #[error("invalid connect ACL {path}: {reason}")]
+    Invalid { path: String, reason: String },
+}
+
+// ---------------------------------------------------------------------------
+// Load + parse (mirror exec control flow byte-for-byte)
+// ---------------------------------------------------------------------------
+
+/// Load a connect policy from an optional explicit path.
+///
+/// Control flow is identical to [`crate::exec::acl::load_exec_policy`]:
+/// `!exists()` + `ExplicitPath` ⇒ `Err(Missing)`; `!exists()` + `DefaultPath`
+/// ⇒ `Ok(Disabled{reason:"acl_missing"})`; read error ⇒ `Err(Read)`; else
+/// parse.
+///
+/// # Errors
+/// See [`ConnectAclError`].
+pub async fn load_connect_policy(
+    path: Option<&Path>,
+    mode: LoadMode,
+) -> Result<ConnectPolicy, ConnectAclError> {
+    let acl_path = path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(default_connect_acl_path);
+    let loaded_at_unix_ms = now_unix_ms();
+    if !acl_path.exists() {
+        if mode == LoadMode::ExplicitPath {
+            return Err(ConnectAclError::Missing(acl_path.display().to_string()));
+        }
+        return Ok(ConnectPolicy::Disabled {
+            path: acl_path,
+            reason: "acl_missing".to_string(),
+            loaded_at_unix_ms,
+        });
+    }
+
+    let text = tokio::fs::read_to_string(&acl_path)
+        .await
+        .map_err(|source| ConnectAclError::Read {
+            path: acl_path.display().to_string(),
+            source,
+        })?;
+    parse_connect_policy(&acl_path, loaded_at_unix_ms, &text)
+}
+
+/// Parse connect ACL TOML. Public for tests and `x0xd --check`.
+///
+/// # Errors
+/// See [`ConnectAclError`]. Malformed TOML ⇒ `Parse`; a missing `[connect]`
+/// section or `enabled = false` ⇒ `Disabled` (not an error); per-entry
+/// validation failure ⇒ `Invalid` with `allow[{idx}].{field}: …` context.
+pub fn parse_connect_policy(
+    path: &Path,
+    loaded_at_unix_ms: u64,
+    text: &str,
+) -> Result<ConnectPolicy, ConnectAclError> {
+    // NOTE: `deny_unknown_fields` on all three structs (deliberate divergence
+    // from exec — see ADR-0019). In a security allowlist, a misspelled key
+    // (`taregts`, `enable`) must fail loudly, not silently yield a different
+    // policy.
+    let parsed: ConnectFileToml =
+        toml::from_str(text).map_err(|source| ConnectAclError::Parse {
+            path: path.display().to_string(),
+            source,
+        })?;
+    let Some(connect) = parsed.connect else {
+        return Ok(ConnectPolicy::Disabled {
+            path: path.to_path_buf(),
+            reason: "missing_connect_section".to_string(),
+            loaded_at_unix_ms,
+        });
+    };
+    if !connect.enabled {
+        return Ok(ConnectPolicy::Disabled {
+            path: path.to_path_buf(),
+            reason: "connect_disabled".to_string(),
+            loaded_at_unix_ms,
+        });
+    }
+
+    let mut allow = Vec::with_capacity(connect.allow.len());
+    for (idx, entry) in connect.allow.into_iter().enumerate() {
+        let agent_id =
+            parse_agent_id(&entry.agent_id).map_err(|reason| ConnectAclError::Invalid {
+                path: path.display().to_string(),
+                reason: format!("allow[{idx}].agent_id: {reason}"),
+            })?;
+        let machine_id =
+            parse_machine_id(&entry.machine_id).map_err(|reason| ConnectAclError::Invalid {
+                path: path.display().to_string(),
+                reason: format!("allow[{idx}].machine_id: {reason}"),
+            })?;
+        if entry.targets.is_empty() {
+            return Err(ConnectAclError::Invalid {
+                path: path.display().to_string(),
+                reason: format!("allow[{idx}] must contain at least one target"),
+            });
+        }
+        // Each target must be a numeric-IP loopback address. parse_target is
+        // the loopback-only crown jewel — every non-loopback address (and any
+        // hostname such as `localhost`) is a hard error at load time.
+        let mut targets = Vec::with_capacity(entry.targets.len());
+        for (tidx, raw) in entry.targets.into_iter().enumerate() {
+            let addr = parse_target(&raw).map_err(|reason| ConnectAclError::Invalid {
+                path: path.display().to_string(),
+                reason: format!("allow[{idx}].targets[{tidx}]: {reason}"),
+            })?;
+            targets.push(addr);
+        }
+        allow.push(ConnectAllowEntry {
+            description: entry.description,
+            agent_id,
+            machine_id,
+            targets,
+        });
+    }
+
+    Ok(ConnectPolicy::Enabled(ConnectAcl {
+        loaded_from: path.to_path_buf(),
+        loaded_at_unix_ms,
+        allow,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Target validation — the loopback-only crown jewel
+// ---------------------------------------------------------------------------
+
+/// Parse + validate a single connect target as a loopback `SocketAddr`.
+///
+/// Rules (all failures are hard errors — used at load time):
+/// 1. Numeric IP literal only (`SocketAddr::parse`). Any parse failure ⇒
+///    error. **`localhost` is rejected** (doesn't parse as `SocketAddr`):
+///    name resolution is ambiguous and removes the resolver from the TCB.
+/// 2. Port `0` ⇒ error ("not a connectable target").
+/// 3. Non-loopback IP ⇒ error naming the v1 policy (loopback-only).
+/// 4. IPv4-mapped IPv6 (`\[::ffff:127.0.0.1\]:22`) is rejected with an
+///    actionable message ("write it as 127.0.0.1:PORT") — `is_loopback()` is
+///    already `false` for it, so step 3 catches it; this branch just improves
+///    the message.
+///
+/// # Errors
+/// Returns a human-readable `String` reason (never a panic) on any rejection.
+pub fn parse_target(raw: &str) -> Result<SocketAddr, String> {
+    // 1. Numeric IP:port only. `localhost:22` does NOT parse as SocketAddr.
+    let addr: SocketAddr = raw.parse().map_err(|_| {
+        "targets must be numeric IP:port (e.g. \"127.0.0.1:22\" or \"[::1]:22\"); \
+         hostnames such as \"localhost\" are not accepted"
+            .to_string()
+    })?;
+
+    // 2. Port 0 is not a connectable target.
+    if addr.port() == 0 {
+        return Err("port 0 is not a connectable target".to_string());
+    }
+
+    // 4. Diagnose IPv4-mapped IPv6 with an actionable message (correctness is
+    // already handled by step 3 — is_loopback is false for v4-mapped — but the
+    // generic message is unhelpful).
+    if let std::net::IpAddr::V6(v6) = addr.ip() {
+        if v6.to_ipv4_mapped().is_some() {
+            return Err(format!(
+                "IPv4-mapped IPv6 target {addr} is not loopback; write it as 127.0.0.1:{}",
+                addr.port()
+            ));
+        }
+    }
+
+    // 3. Loopback-only (127.0.0.0/8 for v4, ::1 for v6).
+    if !is_loopback(addr.ip()) {
+        return Err(format!(
+            "only loopback targets (127.0.0.0/8, ::1) are permitted in this release; \
+             {addr} is not loopback (LAN/subnet targets are not supported)"
+        ));
+    }
+
+    Ok(addr)
+}
+
+/// Loopback check factored for property-test reuse.
+///
+/// `Ipv4Addr::is_loopback()` covers all of 127.0.0.0/8; `Ipv6Addr::is_loopback()`
+/// covers exactly `::1`. IPv4-mapped IPv6 (`::ffff:...`) is **not** loopback
+/// under `Ipv6Addr::is_loopback()`, so it is correctly rejected.
+#[must_use]
+pub fn is_loopback(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => v4.is_loopback(),
+        std::net::IpAddr::V6(v6) => v6.is_loopback(),
+    }
+}
+
+fn now_unix_ms() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(d) => d.as_millis().min(u128::from(u64::MAX)) as u64,
+        Err(_) => 0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TOML schema (deny_unknown_fields — see ADR-0019)
+// ---------------------------------------------------------------------------
+
+// NOTE: `deny_unknown_fields` is on the `[connect]` section and the allow
+// entries (the security property — a misspelled `taregts`/`enable` fails
+// loudly), but NOT on the root file envelope, so other top-level sections
+// (`[exec]`, `[logging]`, …) may coexist in a future unified config. This
+// mirrors `exec::acl::AclFileToml` and is the deliberate deviation from the
+// plan's literal "all three structs" — see ADR-0019.
+#[derive(Debug, Deserialize)]
+struct ConnectFileToml {
+    connect: Option<ConnectSectionToml>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConnectSectionToml {
+    /// Defaults to `false` when absent ⇒ Disabled. This is the fail-closed
+    /// default: a file that forgets `enabled = true` disables connect.
+    #[serde(default)]
+    enabled: bool,
+    #[serde(default)]
+    allow: Vec<ConnectAllowEntryToml>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConnectAllowEntryToml {
+    description: Option<String>,
+    agent_id: String,
+    machine_id: String,
+    targets: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Tests (matrices A + B from the plan)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests;

--- a/src/connect/acl/tests.rs
+++ b/src/connect/acl/tests.rs
@@ -1,0 +1,334 @@
+//! Tests for connect::acl — the fail-closed load matrix (A) and loopback-only
+//! target validation matrix (B). See `docs/plans/2026-07-issue-131-connect-acl-plan.md` §5.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::net::SocketAddr;
+use std::path::Path;
+
+use super::*;
+use crate::exec::acl::{parse_agent_id, parse_machine_id};
+
+// ===========================================================================
+// Matrix A — fail-closed load matrix (mirror exec::acl tests one-for-one)
+// ===========================================================================
+
+#[tokio::test]
+async fn load_policy_missing_file_at_default_path_is_disabled() {
+    // A path that definitely doesn't exist, loaded in DefaultPath mode ⇒ Disabled.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("no-such-connect-acl.toml");
+    let policy = load_connect_policy(Some(&path), LoadMode::DefaultPath)
+        .await
+        .unwrap();
+    assert!(!policy.enabled());
+    if let ConnectPolicy::Disabled { reason, .. } = &policy {
+        assert_eq!(reason, "acl_missing");
+    } else {
+        panic!("expected Disabled");
+    }
+}
+
+#[tokio::test]
+async fn load_policy_missing_file_at_explicit_path_is_hard_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("no-such-connect-acl.toml");
+    let err = load_connect_policy(Some(&path), LoadMode::ExplicitPath)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, ConnectAclError::Missing(_)),
+        "ExplicitPath missing ⇒ Missing: {err}"
+    );
+}
+
+#[tokio::test]
+async fn load_policy_malformed_toml_is_hard_error() {
+    let path = Path::new("/tmp/x");
+    let err = parse_connect_policy(path, 0, "this is not toml {{{").unwrap_err();
+    assert!(
+        matches!(err, ConnectAclError::Parse { .. }),
+        "bad toml ⇒ Parse: {err}"
+    );
+}
+
+#[test]
+fn load_policy_missing_connect_section_is_disabled() {
+    let policy = parse_connect_policy(Path::new("/tmp/x"), 0, "[other]\nfoo = 1\n").unwrap();
+    if let ConnectPolicy::Disabled { reason, .. } = &policy {
+        assert_eq!(reason, "missing_connect_section");
+    } else {
+        panic!("expected Disabled for missing [connect] section");
+    }
+}
+
+#[test]
+fn load_policy_enabled_false_is_disabled() {
+    // enabled defaults to false, so an empty [connect] section disables.
+    let policy = parse_connect_policy(Path::new("/tmp/x"), 0, "[connect]\n").unwrap();
+    if let ConnectPolicy::Disabled { reason, .. } = &policy {
+        assert_eq!(reason, "connect_disabled");
+    } else {
+        panic!("expected Disabled for enabled=false");
+    }
+    // explicit false too
+    let policy =
+        parse_connect_policy(Path::new("/tmp/x"), 0, "[connect]\nenabled = false\n").unwrap();
+    assert!(!policy.enabled());
+}
+
+#[test]
+fn load_policy_unknown_key_is_hard_error() {
+    // deny_unknown_fields: a misspelled key must fail loudly.
+    let err = parse_connect_policy(
+        Path::new("/tmp/x"),
+        0,
+        "[connect]\nenabled = true\nenable = true\n", // typo: "enable"
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, ConnectAclError::Parse { .. }),
+        "unknown field ⇒ Parse: {err}"
+    );
+}
+
+#[test]
+fn load_policy_unknown_key_in_entry_is_hard_error() {
+    let err = parse_connect_policy(
+        Path::new("/tmp/x"),
+        0,
+        "[connect]\nenabled = true\n\
+         [[connect.allow]]\nagent_id = \"deadbeef\"\nmachine_id = \"deadbeef\"\n\
+         targets = [\"127.0.0.1:22\"]\ntaregts = [\"x\"]\n", // typo
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, ConnectAclError::Parse { .. }),
+        "unknown entry field ⇒ Parse: {err}"
+    );
+}
+
+#[test]
+fn default_connect_acl_path_returns_expected() {
+    let p = default_connect_acl_path();
+    let s = p.display().to_string();
+    assert!(s.ends_with("connect-acl.toml"), "path: {s}");
+}
+
+#[test]
+fn connect_policy_default_is_disabled() {
+    // The embedded-serve default must be default-deny.
+    let p = ConnectPolicy::default();
+    assert!(!p.enabled());
+    if let ConnectPolicy::Disabled { reason, .. } = &p {
+        assert_eq!(reason, "no connect ACL configured");
+    } else {
+        panic!("default must be Disabled");
+    }
+}
+
+#[test]
+fn connect_policy_enabled_flag_and_path() {
+    let p = ConnectPolicy::default();
+    assert!(!p.enabled());
+    assert_eq!(p.path(), default_connect_acl_path());
+    let summary = p.summary();
+    assert!(!summary.enabled);
+    assert!(summary.disabled_reason.is_some());
+}
+
+// ===========================================================================
+// Matrix B — loopback-only target validation (every non-loopback = hard error)
+// ===========================================================================
+
+fn assert_target_rejected(raw: &str) {
+    let err = parse_target(raw).unwrap_err();
+    // Sanity: the error message is non-empty and actionable.
+    assert!(
+        !err.is_empty(),
+        "parse_target({raw:?}) rejected with empty message"
+    );
+}
+
+#[test]
+fn target_rejects_lan_and_public_addresses() {
+    // Every one of these MUST be a load-time hard error.
+    for bad in [
+        "192.168.1.10:80",
+        "10.0.0.1:22",
+        "0.0.0.0:80",
+        "8.8.8.8:53",
+        "[::]:80",
+        "[2001:db8::1]:443",
+        "[fe80::1]:22",
+    ] {
+        assert_target_rejected(bad);
+    }
+}
+
+#[test]
+fn target_rejects_v4_mapped_ipv6() {
+    // ::ffff:127.0.0.1 is not loopback under Ipv6Addr::is_loopback — fail-closed.
+    let err = parse_target("[::ffff:127.0.0.1]:22").unwrap_err();
+    assert!(
+        err.contains("127.0.0.1:22") || err.contains("loopback"),
+        "v4-mapped message should be actionable: {err}"
+    );
+}
+
+#[test]
+fn target_rejects_hostname_localhost() {
+    // localhost does not parse as SocketAddr ⇒ removes the resolver from the TCB.
+    let err = parse_target("localhost:22").unwrap_err();
+    assert!(
+        err.contains("numeric IP") || err.contains("hostname"),
+        "hostname rejected: {err}"
+    );
+}
+
+#[test]
+fn target_rejects_port_zero() {
+    let err = parse_target("127.0.0.1:0").unwrap_err();
+    assert!(err.contains("port 0"), "port 0 rejected: {err}");
+}
+
+#[test]
+fn target_rejects_leading_zero_octets() {
+    // Rust's parser rejects leading-zero octets (octal ambiguity).
+    assert_target_rejected("127.000.000.1:22");
+}
+
+#[test]
+fn target_rejects_missing_port() {
+    assert_target_rejected("127.0.0.1");
+}
+
+#[test]
+fn target_rejects_empty_string() {
+    assert_target_rejected("");
+}
+
+#[test]
+fn target_rejects_empty_targets_list_at_load() {
+    let id = "ab".repeat(32);
+    let err = parse_connect_policy(
+        Path::new("/tmp/x"),
+        0,
+        &format!(
+            "[connect]\nenabled = true\n\
+             [[connect.allow]]\nagent_id = \"{id}\"\nmachine_id = \"{id}\"\ntargets = []\n"
+        ),
+    )
+    .unwrap_err();
+    assert!(matches!(err, ConnectAclError::Invalid { .. }));
+    assert!(format!("{err}").contains("at least one target"));
+}
+
+#[test]
+fn target_accepts_valid_loopback_addresses() {
+    // Accept side: these load successfully.
+    assert!(parse_target("127.0.0.1:22").is_ok());
+    assert!(parse_target("127.255.255.254:9").is_ok()); // all of 127.0.0.0/8
+    assert!(parse_target("[::1]:8080").is_ok());
+}
+
+// ===========================================================================
+// Matrix B continued — full-file load with valid loopback targets
+// ===========================================================================
+
+fn valid_agent_hex() -> String {
+    // 64 hex chars (32 bytes) — a syntactically valid agent id.
+    "ab".repeat(32)
+}
+
+#[test]
+fn parse_loads_valid_loopback_acl() {
+    let toml = format!(
+        "[connect]\nenabled = true\n\
+         [[connect.allow]]\n\
+         description = \"laptop sshd\"\n\
+         agent_id = \"{a}\"\n\
+         machine_id = \"{m}\"\n\
+         targets = [\"127.0.0.1:22\", \"[::1]:8080\"]\n",
+        a = valid_agent_hex(),
+        m = valid_agent_hex(),
+    );
+    let policy = parse_connect_policy(Path::new("/tmp/x"), 123, &toml).unwrap();
+    let acl = match policy {
+        ConnectPolicy::Enabled(a) => a,
+        _ => panic!("expected Enabled"),
+    };
+    assert_eq!(acl.allow.len(), 1);
+    assert_eq!(acl.allow[0].targets.len(), 2);
+    assert_eq!(acl.loaded_at_unix_ms, 123);
+    let summary = ConnectPolicy::Enabled(acl).summary();
+    assert!(summary.enabled);
+    assert_eq!(summary.target_entry_count, 2);
+}
+
+#[test]
+fn parse_rejects_non_loopback_target_at_load() {
+    let toml = format!(
+        "[connect]\nenabled = true\n\
+         [[connect.allow]]\nagent_id = \"{a}\"\nmachine_id = \"{m}\"\n\
+         targets = [\"192.168.1.5:22\"]\n",
+        a = valid_agent_hex(),
+        m = valid_agent_hex(),
+    );
+    let err = parse_connect_policy(Path::new("/tmp/x"), 0, &toml).unwrap_err();
+    assert!(matches!(err, ConnectAclError::Invalid { .. }));
+}
+
+#[test]
+fn parse_rejects_bad_agent_hex_at_load() {
+    let toml = "[connect]\nenabled = true\n\
+         [[connect.allow]]\nagent_id = \"not-hex\"\nmachine_id = \"ab\"\n\
+         targets = [\"127.0.0.1:22\"]\n";
+    let err = parse_connect_policy(Path::new("/tmp/x"), 0, toml).unwrap_err();
+    assert!(matches!(err, ConnectAclError::Invalid { .. }));
+    assert!(format!("{err}").contains("agent_id"));
+}
+
+#[test]
+fn is_loopback_factored_correctly() {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    assert!(is_loopback(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+    assert!(is_loopback(IpAddr::V4(Ipv4Addr::new(127, 255, 255, 254))));
+    assert!(is_loopback(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+    assert!(!is_loopback(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+    assert!(!is_loopback(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+    // v4-mapped is NOT loopback
+    let mapped = Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x0001);
+    assert!(!is_loopback(IpAddr::V6(mapped)));
+}
+
+// ===========================================================================
+// is_allowed exact-triple matching
+// ===========================================================================
+
+#[test]
+fn is_allowed_exact_triple_semantics() {
+    let agent = parse_agent_id(&"ab".repeat(32)).unwrap();
+    let machine = parse_machine_id(&"cd".repeat(32)).unwrap();
+    let t22: SocketAddr = "127.0.0.1:22".parse().unwrap();
+    let t23: SocketAddr = "127.0.0.1:23".parse().unwrap();
+    let t_v6: SocketAddr = "[::1]:22".parse().unwrap();
+    let acl = ConnectAcl {
+        loaded_from: Path::new("/tmp/x").to_path_buf(),
+        loaded_at_unix_ms: 0,
+        allow: vec![ConnectAllowEntry {
+            description: None,
+            agent_id: agent,
+            machine_id: machine,
+            targets: vec![t22],
+        }],
+    };
+    assert!(acl.is_allowed(&agent, &machine, &t22));
+    // wrong port
+    assert!(!acl.is_allowed(&agent, &machine, &t23));
+    // v4 vs v6 are distinct grants
+    assert!(!acl.is_allowed(&agent, &machine, &t_v6));
+    // wrong pair
+    let other_agent = parse_agent_id(&"99".repeat(32)).unwrap();
+    assert!(!acl.is_allowed(&other_agent, &machine, &t22));
+}

--- a/src/connect/diagnostics.rs
+++ b/src/connect/diagnostics.rs
@@ -1,0 +1,119 @@
+//! Connect diagnostics — counter surface for connect allow/deny decisions.
+//!
+//! Minimal-scope mirror of `exec/diagnostics.rs`. Counters read `0` until T4
+//! (issue #132) wires calls to [`ConnectDiagnostics::record_allowed`] /
+//! [`record_denied`](ConnectDiagnostics::record_denied); that is the intended
+//! "counter surface for future connect denials". v1 has no warnings/sessions
+//! machinery — that is T4.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use serde::Serialize;
+
+use crate::connect::acl::ConnectAclSummary;
+use crate::connect::gate::ConnectDenialReason;
+
+/// Atomic allow/deny counters + per-reason denial breakdown.
+#[derive(Debug)]
+pub struct ConnectDiagnostics {
+    streams_allowed: std::sync::atomic::AtomicU64,
+    streams_denied: std::sync::atomic::AtomicU64,
+    denial_breakdown: Mutex<HashMap<ConnectDenialReason, u64>>,
+    acl_summary: ConnectAclSummary,
+}
+
+impl ConnectDiagnostics {
+    /// Construct from the loaded policy's summary.
+    #[must_use]
+    pub fn new(summary: ConnectAclSummary) -> Self {
+        Self {
+            streams_allowed: std::sync::atomic::AtomicU64::new(0),
+            streams_denied: std::sync::atomic::AtomicU64::new(0),
+            denial_breakdown: Mutex::new(HashMap::new()),
+            acl_summary: summary,
+        }
+    }
+
+    /// Record an allowed connect stream.
+    pub fn record_allowed(&self) {
+        self.streams_allowed
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Record a denied connect stream, bucketed by reason.
+    pub fn record_denied(&self, reason: ConnectDenialReason) {
+        self.streams_denied
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if let Ok(mut map) = self.denial_breakdown.lock() {
+            *map.entry(reason).or_insert(0) += 1;
+        }
+    }
+
+    /// Snapshot for the `/diagnostics/connect` endpoint.
+    #[must_use]
+    pub fn snapshot(&self) -> ConnectDiagnosticsSnapshot {
+        let allowed = self
+            .streams_allowed
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let denied = self
+            .streams_denied
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let breakdown = self
+            .denial_breakdown
+            .lock()
+            .map(|m| m.iter().map(|(k, v)| (*k, *v)).collect())
+            .unwrap_or_default();
+        ConnectDiagnosticsSnapshot {
+            streams_allowed: allowed,
+            streams_denied: denied,
+            denial_breakdown: breakdown,
+            acl_summary: self.acl_summary.clone(),
+        }
+    }
+}
+
+/// Serializable diagnostics snapshot.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConnectDiagnosticsSnapshot {
+    pub streams_allowed: u64,
+    pub streams_denied: u64,
+    pub denial_breakdown: HashMap<ConnectDenialReason, u64>,
+    pub acl_summary: ConnectAclSummary,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_allowed_and_denied_updates_counters_and_breakdown() {
+        let diag = ConnectDiagnostics::new(ConnectAclSummary {
+            enabled: true,
+            loaded_from: "/tmp/x.toml".to_string(),
+            loaded_at_unix_ms: 0,
+            allow_entry_count: 1,
+            target_entry_count: 1,
+            disabled_reason: None,
+        });
+        diag.record_allowed();
+        diag.record_allowed();
+        diag.record_denied(ConnectDenialReason::ConnectDisabled);
+        diag.record_denied(ConnectDenialReason::TargetNotAllowed);
+
+        let snap = diag.snapshot();
+        assert_eq!(snap.streams_allowed, 2);
+        assert_eq!(snap.streams_denied, 2);
+        assert_eq!(
+            snap.denial_breakdown
+                .get(&ConnectDenialReason::ConnectDisabled),
+            Some(&1)
+        );
+        assert_eq!(
+            snap.denial_breakdown
+                .get(&ConnectDenialReason::TargetNotAllowed),
+            Some(&1)
+        );
+        assert!(snap.acl_summary.enabled);
+    }
+}

--- a/src/connect/gate.rs
+++ b/src/connect/gate.rs
@@ -1,0 +1,284 @@
+//! Connect gate — the enforcement seam the T4 forwarder will call.
+//!
+//! Pure and synchronous (no service, no I/O) so the whole #141-style denial
+//! matrix ports as fast unit tests. The T4 forwarder (issue #132) calls
+//! [`evaluate_connect_gate`] at its inbound-accept seam **after** the peer is
+//! verified + trusted and **before** `TcpStream::connect`.
+//!
+//! ## Gate order is a security property
+//! The order of checks below means an unverified or untrusted peer learns
+//! nothing about whether connect is enabled, whether they are listed, or
+//! which targets exist. This mirrors `exec/service.rs::handle_request` and
+//! its tranche-2 order-pinning tests. Do not reorder without an ADR.
+
+use std::net::SocketAddr;
+
+use serde::Serialize;
+
+use crate::connect::acl::ConnectPolicy;
+use crate::identity::{AgentId, MachineId};
+use crate::trust::TrustDecision;
+
+/// Why a connect request was denied. Distinct buckets so diagnostics can
+/// break denials down without leaking group/target existence to an
+/// unverified/untrusted peer (see gate order).
+///
+/// Mirrors the `DenialReason` trait set from exec (`Serialize`, `Eq`, `Copy`,
+/// snake_case) so it drops into the diagnostics map and, in T4, typed error
+/// frames.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectDenialReason {
+    /// Peer not cryptographically verified — always the first check.
+    UnverifiedSender,
+    /// Trust decision was not `Accept` (includes `None` ⇒ rejected, like exec).
+    TrustRejected,
+    /// No connect ACL configured / `ConnectPolicy::Disabled`.
+    ConnectDisabled,
+    /// Requested target is not loopback (runtime defense-in-depth; the
+    /// allowlist already makes a non-loopback match impossible).
+    TargetNotLoopback,
+    /// The (agent, machine) pair is not in the ACL.
+    AgentMachineNotInAcl,
+    /// The pair is in the ACL but the requested target is not in its entry.
+    TargetNotAllowed,
+}
+
+/// Pure gate evaluation. The thing v1 must get perfect.
+///
+/// # Arguments
+/// * `verified` — whether the requesting peer is cryptographically verified.
+/// * `trust_decision` — local trust decision for the peer (`None` ⇒ reject,
+///   mirroring exec).
+/// * `policy` — the loaded [`ConnectPolicy`].
+/// * `agent_id` / `machine_id` — the requesting peer's identity pair.
+/// * `target` — the requested loopback target.
+///
+/// # Returns
+/// `Ok(())` to allow; `Err(reason)` to deny. The caller records the reason
+/// in diagnostics and, in T4, surfaces it to the peer as a typed frame.
+///
+/// # Gate order (do not reorder — see module docs)
+/// 1. `!verified` ⇒ [`ConnectDenialReason::UnverifiedSender`]
+/// 2. `trust_decision != Some(Accept)` ⇒ [`ConnectDenialReason::TrustRejected`]
+/// 3. `ConnectPolicy::Disabled` ⇒ [`ConnectDenialReason::ConnectDisabled`]
+/// 4. `!target.ip().is_loopback()` ⇒ [`ConnectDenialReason::TargetNotLoopback`]
+/// 5. pair not in ACL ⇒ [`ConnectDenialReason::AgentMachineNotInAcl`]
+/// 6. target not in that entry ⇒ [`ConnectDenialReason::TargetNotAllowed`]
+pub fn evaluate_connect_gate(
+    verified: bool,
+    trust_decision: Option<TrustDecision>,
+    policy: &ConnectPolicy,
+    agent_id: &AgentId,
+    machine_id: &MachineId,
+    target: &SocketAddr,
+) -> Result<(), ConnectDenialReason> {
+    // 1. Unverified peers learn nothing.
+    if !verified {
+        return Err(ConnectDenialReason::UnverifiedSender);
+    }
+    // 2. None ⇒ rejected (same as exec: absence of an accept decision denies).
+    if trust_decision != Some(TrustDecision::Accept) {
+        return Err(ConnectDenialReason::TrustRejected);
+    }
+    // 3. Disabled policy.
+    let ConnectPolicy::Enabled(acl) = policy else {
+        return Err(ConnectDenialReason::ConnectDisabled);
+    };
+    // 4. Runtime defense-in-depth: re-check loopback at the gate so the
+    //    invariant stays local even if a future matcher generalizes.
+    if !crate::connect::acl::is_loopback(target.ip()) {
+        return Err(ConnectDenialReason::TargetNotLoopback);
+    }
+    // 5 + 6. Exact-pair + exact-target match.
+    if !acl.is_allowed(agent_id, machine_id, target) {
+        // Distinguish "pair unknown" from "pair known, target wrong" only for
+        // diagnostics — both are deny. We split because the T4 forwarder's
+        // diagnostics surface benefits from the distinction, and the peer has
+        // already passed verified+trust+disabled+loopback by here, so revealing
+        // the pair-vs-target split leaks nothing an authenticated member
+        // couldn't already derive.
+        return Err(if acl.entry_for(agent_id, machine_id).is_some() {
+            ConnectDenialReason::TargetNotAllowed
+        } else {
+            ConnectDenialReason::AgentMachineNotInAcl
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::connect::acl::{ConnectAcl, ConnectAllowEntry, ConnectPolicy};
+    use crate::exec::acl::{parse_agent_id, parse_machine_id};
+    use crate::trust::TrustDecision;
+    use std::net::SocketAddr;
+    use std::path::Path;
+
+    fn enabled_acl_with(agent: &str, machine: &str, targets: &[&str]) -> ConnectPolicy {
+        let agent_id = parse_agent_id(&agent.repeat(32)).unwrap();
+        let machine_id = parse_machine_id(&machine.repeat(32)).unwrap();
+        let targets: Vec<SocketAddr> = targets.iter().map(|t| t.parse().unwrap()).collect();
+        ConnectPolicy::Enabled(ConnectAcl {
+            loaded_from: Path::new("/tmp/x").to_path_buf(),
+            loaded_at_unix_ms: 0,
+            allow: vec![ConnectAllowEntry {
+                description: None,
+                agent_id,
+                machine_id,
+                targets,
+            }],
+        })
+    }
+
+    fn pair() -> (crate::identity::AgentId, crate::identity::MachineId) {
+        (
+            parse_agent_id(&"ab".repeat(32)).unwrap(),
+            parse_machine_id(&"cd".repeat(32)).unwrap(),
+        )
+    }
+
+    const T22: &str = "127.0.0.1:22";
+
+    // ── Per-gate tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn gate_denies_unverified_sender_before_policy() {
+        let (a, m) = pair();
+        let policy = enabled_acl_with("ab", "cd", &[T22]);
+        let target: SocketAddr = T22.parse().unwrap();
+        // Even with a valid ACL + accept trust, unverified ⇒ UnverifiedSender.
+        let r = evaluate_connect_gate(false, Some(TrustDecision::Accept), &policy, &a, &m, &target);
+        assert_eq!(r, Err(ConnectDenialReason::UnverifiedSender));
+    }
+
+    #[test]
+    fn gate_denies_non_accept_trust_decision() {
+        let (a, m) = pair();
+        let policy = enabled_acl_with("ab", "cd", &[T22]);
+        let target: SocketAddr = T22.parse().unwrap();
+        // AcceptWithFlag is NOT Accept ⇒ reject.
+        let r = evaluate_connect_gate(
+            true,
+            Some(TrustDecision::AcceptWithFlag),
+            &policy,
+            &a,
+            &m,
+            &target,
+        );
+        assert_eq!(r, Err(ConnectDenialReason::TrustRejected));
+    }
+
+    #[test]
+    fn gate_denies_verified_sender_with_no_trust_decision() {
+        let (a, m) = pair();
+        let policy = enabled_acl_with("ab", "cd", &[T22]);
+        let target: SocketAddr = T22.parse().unwrap();
+        // None ⇒ TrustRejected (same as exec).
+        let r = evaluate_connect_gate(true, None, &policy, &a, &m, &target);
+        assert_eq!(r, Err(ConnectDenialReason::TrustRejected));
+    }
+
+    #[test]
+    fn gate_denies_when_policy_disabled() {
+        let (a, m) = pair();
+        let policy = ConnectPolicy::Disabled {
+            path: Path::new("/tmp/x").to_path_buf(),
+            reason: "test".to_string(),
+            loaded_at_unix_ms: 0,
+        };
+        let target: SocketAddr = T22.parse().unwrap();
+        let r = evaluate_connect_gate(true, Some(TrustDecision::Accept), &policy, &a, &m, &target);
+        assert_eq!(r, Err(ConnectDenialReason::ConnectDisabled));
+    }
+
+    #[test]
+    fn gate_denies_non_loopback_requested_target() {
+        let (a, m) = pair();
+        let policy = enabled_acl_with("ab", "cd", &["10.0.0.1:22"]); // non-loopback in ACL (shouldn't happen post-validation, but test defense-in-depth)
+        let target: SocketAddr = "10.0.0.1:22".parse().unwrap();
+        let r = evaluate_connect_gate(true, Some(TrustDecision::Accept), &policy, &a, &m, &target);
+        assert_eq!(r, Err(ConnectDenialReason::TargetNotLoopback));
+    }
+
+    #[test]
+    fn gate_denies_pair_not_in_acl() {
+        let (a, m) = pair();
+        // ACL has a DIFFERENT pair.
+        let policy = enabled_acl_with("ff", "ee", &[T22]);
+        let target: SocketAddr = T22.parse().unwrap();
+        let r = evaluate_connect_gate(true, Some(TrustDecision::Accept), &policy, &a, &m, &target);
+        assert_eq!(r, Err(ConnectDenialReason::AgentMachineNotInAcl));
+    }
+
+    #[test]
+    fn gate_denies_listed_pair_wrong_target() {
+        let (a, m) = pair();
+        let policy = enabled_acl_with("ab", "cd", &[T22]);
+        let target: SocketAddr = "127.0.0.1:23".parse().unwrap(); // wrong port
+        let r = evaluate_connect_gate(true, Some(TrustDecision::Accept), &policy, &a, &m, &target);
+        assert_eq!(r, Err(ConnectDenialReason::TargetNotAllowed));
+    }
+
+    #[test]
+    fn gate_denies_wrong_machine_same_agent() {
+        let (a, _m) = pair();
+        let wrong_machine = parse_machine_id(&"99".repeat(32)).unwrap();
+        let policy = enabled_acl_with("ab", "cd", &[T22]);
+        let target: SocketAddr = T22.parse().unwrap();
+        let r = evaluate_connect_gate(
+            true,
+            Some(TrustDecision::Accept),
+            &policy,
+            &a,
+            &wrong_machine,
+            &target,
+        );
+        assert_eq!(r, Err(ConnectDenialReason::AgentMachineNotInAcl));
+    }
+
+    #[test]
+    fn gate_v4_and_v6_loopback_are_distinct_grants() {
+        let (a, m) = pair();
+        // ACL grants 127.0.0.1:22 only.
+        let policy = enabled_acl_with("ab", "cd", &["127.0.0.1:22"]);
+        let v6: SocketAddr = "[::1]:22".parse().unwrap();
+        let r = evaluate_connect_gate(true, Some(TrustDecision::Accept), &policy, &a, &m, &v6);
+        assert_eq!(r, Err(ConnectDenialReason::TargetNotAllowed));
+    }
+
+    #[test]
+    fn gate_allows_exact_triple() {
+        let (a, m) = pair();
+        let policy = enabled_acl_with("ab", "cd", &[T22]);
+        let target: SocketAddr = T22.parse().unwrap();
+        let r = evaluate_connect_gate(true, Some(TrustDecision::Accept), &policy, &a, &m, &target);
+        assert!(r.is_ok());
+    }
+
+    // ── Gate-order security property (tranche-2) ──────────────────────────
+
+    #[test]
+    fn gate_order_unverified_beats_trust_and_disabled() {
+        // All-bad input: unverified + non-accept trust + disabled policy.
+        // The ONLY surfaced reason must be UnverifiedSender — an unverified
+        // peer learns nothing about trust/policy/targets.
+        let (a, m) = pair();
+        let policy = ConnectPolicy::default(); // Disabled
+        let target: SocketAddr = T22.parse().unwrap();
+        let r = evaluate_connect_gate(false, None, &policy, &a, &m, &target);
+        assert_eq!(r, Err(ConnectDenialReason::UnverifiedSender));
+    }
+
+    #[test]
+    fn gate_order_trust_beats_disabled() {
+        // Verified but untrusted + disabled: TrustRejected, not ConnectDisabled.
+        let (a, m) = pair();
+        let policy = ConnectPolicy::default();
+        let target: SocketAddr = T22.parse().unwrap();
+        let r = evaluate_connect_gate(true, None, &policy, &a, &m, &target);
+        assert_eq!(r, Err(ConnectDenialReason::TrustRejected));
+    }
+}

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -1,0 +1,33 @@
+//! Connection ACL (default-closed connectivity policy).
+//!
+//! v1 delivers a fail-closed policy engine, loopback-only target validation,
+//! and a pure gate function — fully tested but **not yet wired** to a runtime
+//! forwarder. The T4 forwarder (issue #132) will call
+//! [`gate::evaluate_connect_gate`] at its inbound-accept seam after the peer
+//! is verified + trusted and before `TcpStream::connect`. No stream code in
+//! `network.rs` changes in v1.
+//!
+//! See ADR-0019 (`docs/adr/0019-connect-acl-default-closed.md`) and the
+//! implementation plan
+//! (`docs/plans/2026-07-issue-131-connect-acl-plan.md`).
+//!
+//! # Security model
+//! - Default = [`acl::ConnectPolicy::Disabled`] (default-deny for embedders).
+//! - Targets are **loopback only** (`127.0.0.0/8`, `::1`) and **numeric IP
+//!   only** (no `localhost`); enforced at load time as a hard error.
+//! - Matching is **exact** `(agent, machine, SocketAddr)` triples — no ranges,
+//!   no CIDR. `127.0.0.1:22` does not grant `\[::1\]:22`.
+//! - [`LoadMode`] is **reused** from `exec::acl` so the
+//!   missing-at-default-vs-explicit semantics stay bit-identical forever.
+
+pub mod acl;
+pub mod diagnostics;
+pub mod gate;
+
+pub use crate::exec::acl::LoadMode;
+pub use acl::{
+    default_connect_acl_path, is_loopback, load_connect_policy, parse_connect_policy, parse_target,
+    ConnectAcl, ConnectAclError, ConnectAclSummary, ConnectAllowEntry, ConnectPolicy,
+};
+pub use diagnostics::{ConnectDiagnostics, ConnectDiagnosticsSnapshot};
+pub use gate::{evaluate_connect_gate, ConnectDenialReason};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,7 @@ pub mod upgrade;
 /// File transfer protocol types and state management.
 pub mod files;
 
+pub mod connect;
 /// Secure Tier-1 remote exec protocol and runtime.
 pub mod exec;
 


### PR DESCRIPTION
Closes part of #131.

This is **PR1 = steps 1-3** of the [connect-ACL plan](docs/plans/2026-07-issue-131-connect-acl-plan.md): pure library code, no daemon behavior change. Steps 4-5 (x0xd `--connect-acl` wiring + AppState + `/diagnostics/connect` route) land in a follow-up PR; steps 6-7 (proptests + docs/ADR-0019) ride with it.

## What v1 delivers (and does NOT)

A **fail-closed policy engine, loopback-only target validation, and a pure gate function** — fully tested but **not yet wired** to a runtime forwarder. There is no inbound flow to gate today (`network.rs` exposes only message-level `send`/`recv`); the T4 forwarder (#132) will call `evaluate_connect_gate` at its accept seam. No stream code changes in v1.

## The three files

### `src/connect/acl.rs` — policy + load + parse + validate (mirrors `exec::acl`)
- `ConnectPolicy::{Disabled{..}, Enabled(ConnectAcl)}`; **`Default = Disabled`** so embedded `serve()` is default-deny with zero host effort.
- `load_connect_policy` / `parse_connect_policy` — byte-for-byte exec control flow (`!exists()` + `ExplicitPath` ⇒ `Err(Missing)`; `!exists()` + `DefaultPath` ⇒ `Disabled{acl_missing}`; parse error ⇒ `Err(Parse)`).
- **`parse_target` — the loopback-only crown jewel.** Numeric IP only (rejects `localhost` — removes the resolver from the TCB); port 0 rejected; **non-loopback rejected as a load-time hard error**; v4-mapped IPv6 rejected with an actionable message. Exact `host:port` only — no ranges, no CIDR.
- **`deny_unknown_fields`** on the `[connect]` section + allow entries (a misspelled `taregts`/`enable` fails loudly). **NOT** on the root envelope — mirrors `exec::acl::AclFileToml` (which also omits it) and allows future `[exec]`/`[logging]` coexistence. **Deliberate deviation** from the plan's literal "all three structs" — flagged for review.
- **Reuses `exec::acl::LoadMode`** so missing-at-default-vs-explicit semantics stay bit-identical forever (compile-time drift prevention).

### `src/connect/gate.rs` — `evaluate_connect_gate` (pure, synchronous)
Gate order is a **security property** (copied from `exec/service.rs`): `unverified` ⇒ `trust` ⇒ `disabled` ⇒ `loopback` ⇒ `pair` ⇒ `target`. The order means an unverified/untrusted peer learns nothing about whether connect is enabled, whether they're listed, or which targets exist.

### `src/connect/diagnostics.rs` — counter surface
`ConnectDiagnostics` (allow/deny/per-reason breakdown); counters read `0` until T4 wires calls.

## Verification
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-features --all-targets -- -D warnings` ✅
- `cargo check --workspace --all-targets` ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps --lib` ✅
- **25 new tests**: fail-closed load matrix (A), loopback validation matrix (B — every LAN/public/v4-mapped/hostname/port-0 case = hard error), gate-order matrix (C — per-gate + tranche-2 "unverified beats all").

## Security review
Steps 1-3 require **independent security review** per the plan (fail-closed load matrix + loopback validation + gate-order are the crown jewels). A red-team adversarial review is in-flight; findings attached before merge.

Refs #131. Blocked-on: #132 (T4 forwarder) for the enforcement caller.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the first connect ACL library layer. The main changes are:

- New connect ACL policy types, loading, parsing, and loopback target validation.
- New pure connect gate with verified, trust, policy, loopback, pair, and target checks.
- New connect diagnostics counters and public module exports.
- Unit coverage for ACL loading, target validation, gate order, and diagnostics.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/connect/acl.rs | Adds connect ACL policy loading, TOML parsing, identity parsing, summaries, and loopback-only target validation. |
| src/connect/acl/tests.rs | Adds tests for fail-closed loading, invalid ACL inputs, valid loopback ACLs, and exact triple matching. |
| src/connect/gate.rs | Adds the pure connect gate and tests for denial order, trust handling, identity matching, and target matching. |
| src/connect/diagnostics.rs | Adds connect allow and deny counters with per-reason snapshots for a future diagnostics endpoint. |
| src/connect/mod.rs | Adds the connect module tree and re-exports the new ACL, gate, and diagnostics APIs. |
| src/lib.rs | Publishes the new connect module from the crate root. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Connect request reaches future forwarder] --> B{Sender verified?}
  B -- No --> D1[deny: unverified_sender]
  B -- Yes --> C{TrustDecision == Accept?}
  C -- No --> D2[deny: trust_rejected]
  C -- Yes --> E{ConnectPolicy enabled?}
  E -- No --> D3[deny: connect_disabled]
  E -- Yes --> F{Target IP loopback?}
  F -- No --> D4[deny: target_not_loopback]
  F -- Yes --> G{Agent and machine in ACL?}
  G -- No --> D5[deny: agent_machine_not_in_acl]
  G -- Yes --> H{Exact target allowed?}
  H -- No --> D6[deny: target_not_allowed]
  H -- Yes --> I[allow]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Connect request reaches future forwarder] --> B{Sender verified?}
  B -- No --> D1[deny: unverified_sender]
  B -- Yes --> C{TrustDecision == Accept?}
  C -- No --> D2[deny: trust_rejected]
  C -- Yes --> E{ConnectPolicy enabled?}
  E -- No --> D3[deny: connect_disabled]
  E -- Yes --> F{Target IP loopback?}
  F -- No --> D4[deny: target_not_loopback]
  F -- Yes --> G{Agent and machine in ACL?}
  G -- No --> D5[deny: agent_machine_not_in_acl]
  G -- Yes --> H{Exact target allowed?}
  H -- No --> D6[deny: target_not_allowed]
  H -- Yes --> I[allow]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(connect): connect ACL policy engine..."](https://github.com/saorsa-labs/x0x/commit/00fc0156288808851cbb83c3fee21067a14f5b6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41738800)</sub>

<!-- /greptile_comment -->