### PR TITLE
ci(panic-scanner): recognise file-level #[cfg(test)] submodules (#167)

### DIFF
--- a/scripts/check-panics.sh
+++ b/scripts/check-panics.sh
@@ -51,8 +51,10 @@ scan_pattern() {
 
     # Scan for pattern
     while IFS= read -r match; do
-        # Skip if in tests/ directory or .bak files
-        if echo "$match" | grep -qE "(tests/|\.bak:|\.rs:.*//.*$pattern)"; then
+        # Skip if in tests/ directory, a file named tests.rs (file-level test
+        # submodules declared via `#[cfg(test)] mod tests;` in the parent, e.g.
+        # src/connect/acl/tests.rs), or .bak files.
+        if echo "$match" | grep -qE "(tests/|/tests\.rs:|\.bak:|\.rs:.*//.*$pattern)"; then
             continue
         fi
 


### PR DESCRIPTION
## Summary

- Extends the Panic Scanner's quick-skip regex to also exclude files named `tests.rs` (file-level test submodules declared via `#[cfg(test)] mod tests;` in their parent)
- Unblocks PR #167 whose `src/connect/acl/tests.rs` was falsely flagged as production code containing `.unwrap()` and `panic!()`
- One-line regex change in `scripts/check-panics.sh`; no production behaviour changed

## Root cause

`src/connect/acl.rs:452` declares `#[cfg(test)] mod tests;` which pulls in `src/connect/acl/tests.rs` as a test-only submodule. The scanner's existing quick-skip excluded `tests/` directories but not `tests.rs` files. The `is_in_test_code` awk probe also missed it because the file uses `#![allow(clippy::unwrap_used, clippy::expect_used)]` rather than `#![cfg(test)]` (the outer declaration already gates compilation).

This is the same class of blind spot fixed in PR #109 (commit `ccff898`) for `#![cfg(test)]` — extended here for the companion pattern.

## Verification (run locally)

- `bash scripts/check-panics.sh` **PASSES** on the clean tree after the fix
- Planted `x.unwrap()` in `src/connect/acl.rs` OUTSIDE any test module → scanner **STILL FAILS**, confirming the exclusion is not too broad; plant reverted
- `cargo fmt --all -- --check` PASSES
- `cargo clippy --all-targets --all-features -- -D warnings` PASSES (0 warnings)
- `cargo nextest run --all-features -E 'test(connect)'` PASSES: **102 tests, 102 passed** (all 26 `connect::acl::tests::*` still compile and run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows the panic scanner so file-level Rust test modules are skipped.

- Adds a `/tests.rs:` quick-skip case in `scripts/check-panics.sh`.
- Keeps existing skips for `tests/` directories, `.bak` files, and commented matches.
- Covers `#[cfg(test)] mod tests;` submodules that do not contain an in-file `#![cfg(test)]` marker.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The changed skip matches the intended test-only file-level module case already present in the tree.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-panics.sh | Adds `tests.rs` files to the panic scanner quick-skip regex for test-only submodules. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(panic-scanner): recognise file-level ..."](https://github.com/saorsa-labs/x0x/commit/321e29cda8a6cf3a106f2b7c844377c38d21b5d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41794927)</sub>

<!-- /greptile_comment -->