### PR TITLE
feat(identity): key expiry, renewal, and gossiped revocation (#130)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,14 @@ pub enum IdentityError {
     /// or the certificate data has been tampered with.
     #[error("certificate verification failed: {0}")]
     CertificateVerification(String),
+
+    /// Revocation record signature or authority check failed.
+    ///
+    /// The record's signature is invalid, or the issuer is neither the subject
+    /// (self-revocation) nor the user who certified the subject agent
+    /// (issuer-revocation). Third-party revocation is never accepted.
+    #[error("revocation rejected: {0}")]
+    Revocation(String),
 }
 
 /// Standard Result type for x0x identity operations.

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -463,6 +463,20 @@ pub struct AgentCertificate {
     ///
     /// `None` (the default for legacy certificates) means the certificate
     /// never expires. When present it is covered by the signature.
+    ///
+    /// NOTE on `#[serde(default)]`: bincode is a positional (non-self-describing)
+    /// format and IGNORES `serde(default)` — it cannot recover a trailing field
+    /// that is absent from the byte stream. This attribute therefore only aids
+    /// self-describing formats (JSON/TOML). On-disk cert files stay
+    /// backward-compatible via the explicit magic-marker versioning in
+    /// [`to_storage_bytes`](Self::to_storage_bytes) /
+    /// [`from_storage_bytes`](Self::from_storage_bytes), NOT via this attribute.
+    /// For certificates embedded in gossip announcements the extra positional
+    /// bytes ARE a wire-format change: this is the known, coordinated
+    /// fleet-upgrade break documented in the plan (D3) — the "no breaking
+    /// change" guarantee covers on-disk key/cert files only, not the
+    /// announcement wire format in a mixed-version fleet carrying user-certified
+    /// agents.
     #[serde(default)]
     not_after: Option<u64>,
 }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -407,14 +407,48 @@ impl UserKeypair {
     }
 }
 
+/// Clock-skew tolerance, in seconds, applied to every credential expiry
+/// check across the codebase (certificates today; future expiring records).
+///
+/// A credential is only treated as expired once `now` is more than this many
+/// seconds past its `not_after`, so honestly-issued credentials are not
+/// rejected because two machines' clocks disagree by a few minutes.
+pub const EXPIRY_CLOCK_SKEW_SECS: u64 = 300;
+
+/// Return whether an optional `not_after` expiry has elapsed at `now_unix`,
+/// applying [`EXPIRY_CLOCK_SKEW_SECS`] tolerance.
+///
+/// **Absence of expiry means valid forever**: `None` is never expired. This
+/// is the default-safe rule that keeps pre-expiry credentials (old key files
+/// and certificates with no `not_after`) valid without any migration. Fail
+/// **open** only for a genuinely-missing expiry — never for a present one.
+#[must_use]
+pub fn is_expired(not_after: Option<u64>, now_unix: u64) -> bool {
+    match not_after {
+        None => false,
+        Some(not_after) => now_unix > not_after.saturating_add(EXPIRY_CLOCK_SKEW_SECS),
+    }
+}
+
 /// Certificate binding an agent to a user identity.
 ///
 /// An `AgentCertificate` is a cryptographic attestation that a specific agent
 /// belongs to a specific user. It is created by signing the agent's public key
 /// with the user's secret key.
 ///
-/// The signed message format is:
-/// `b"x0x-agent-cert-v1" || user_pubkey || agent_pubkey || timestamp`
+/// # Signed message format and versioning
+///
+/// When the certificate has **no expiry** (`not_after == None`) the signed
+/// message is byte-identical to every certificate x0x has ever issued:
+/// `b"x0x-agent-cert-v1" || user_pubkey || agent_pubkey || issued_at`.
+/// Such a certificate verifies unchanged — **absence of expiry means valid
+/// forever**.
+///
+/// When an expiry **is** present the signed message uses a distinct domain
+/// prefix and appends the expiry, so `not_after` is signature-covered:
+/// `b"x0x-agent-cert-v2" || user_pubkey || agent_pubkey || issued_at ||
+/// not_after`. Stripping or altering the expiry therefore fails verification
+/// rather than silently extending validity.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentCertificate {
     /// The user's ML-DSA-65 public key bytes.
@@ -425,11 +459,39 @@ pub struct AgentCertificate {
     signature: Vec<u8>,
     /// Unix timestamp when the certificate was issued.
     issued_at: u64,
+    /// Optional Unix timestamp after which the certificate is expired.
+    ///
+    /// `None` (the default for legacy certificates) means the certificate
+    /// never expires. When present it is covered by the signature.
+    #[serde(default)]
+    not_after: Option<u64>,
+}
+
+/// On-disk shape of a pre-#130 (`v1`) certificate: the four original fields
+/// with no `not_after`. Used only to decode legacy `agent.cert` files, which
+/// were written as a bare `bincode(AgentCertificate)` before the expiry field
+/// existed. Mapped into an [`AgentCertificate`] with `not_after: None`.
+#[derive(Serialize, Deserialize)]
+struct AgentCertificateV1Disk {
+    user_public_key: Vec<u8>,
+    agent_public_key: Vec<u8>,
+    signature: Vec<u8>,
+    issued_at: u64,
 }
 
 impl AgentCertificate {
-    /// Certificate message prefix for domain separation.
+    /// Certificate message prefix for domain separation (no-expiry / v1).
     const CERT_PREFIX: &'static [u8] = b"x0x-agent-cert-v1";
+
+    /// Certificate message prefix for domain separation (with-expiry / v2).
+    const CERT_V2_PREFIX: &'static [u8] = b"x0x-agent-cert-v2";
+
+    /// Magic marker prefixing an expiry-carrying (`v2`) certificate on disk.
+    ///
+    /// A legacy `agent.cert` begins with the bincode length prefix of the
+    /// ML-DSA-65 user public key (`0xA0 0x07 …`), so it can never collide
+    /// with this marker; its absence unambiguously means "legacy, no expiry".
+    const CERT_DISK_V2_MAGIC: &'static [u8; 4] = b"X0C2";
 
     /// Issue a new certificate binding an agent to a user.
     ///
@@ -438,6 +500,25 @@ impl AgentCertificate {
     pub fn issue(
         user_kp: &UserKeypair,
         agent_kp: &AgentKeypair,
+    ) -> Result<Self, crate::error::IdentityError> {
+        Self::issue_with_expiry(user_kp, agent_kp, None)
+    }
+
+    /// Issue a new certificate binding an agent to a user, with an optional
+    /// expiry.
+    ///
+    /// `not_after == None` produces a non-expiring certificate whose signed
+    /// message is byte-identical to [`issue`](Self::issue) (v1). `Some`
+    /// produces a v2 certificate whose expiry is covered by the signature.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::IdentityError::CertificateVerification`] if the
+    /// system clock is before the Unix epoch or signing fails.
+    pub fn issue_with_expiry(
+        user_kp: &UserKeypair,
+        agent_kp: &AgentKeypair,
+        not_after: Option<u64>,
     ) -> Result<Self, crate::error::IdentityError> {
         let issued_at = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -452,7 +533,7 @@ impl AgentCertificate {
         let user_pub_bytes = user_kp.public_key().as_bytes().to_vec();
         let agent_pub_bytes = agent_kp.public_key().as_bytes().to_vec();
 
-        let message = Self::build_message(&user_pub_bytes, &agent_pub_bytes, issued_at);
+        let message = Self::build_message(&user_pub_bytes, &agent_pub_bytes, issued_at, not_after);
 
         let signature = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
             user_kp.secret_key(),
@@ -467,6 +548,7 @@ impl AgentCertificate {
             agent_public_key: agent_pub_bytes,
             signature: signature.as_bytes().to_vec(),
             issued_at,
+            not_after,
         })
     }
 
@@ -494,6 +576,7 @@ impl AgentCertificate {
             &self.user_public_key,
             &self.agent_public_key,
             self.issued_at,
+            self.not_after,
         );
 
         ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
@@ -535,16 +618,113 @@ impl AgentCertificate {
         self.issued_at
     }
 
+    /// Get the optional expiry timestamp (`None` ⇒ never expires).
+    #[must_use]
+    pub fn not_after(&self) -> Option<u64> {
+        self.not_after
+    }
+
+    /// Return whether this certificate is expired at `now_unix`, applying
+    /// [`EXPIRY_CLOCK_SKEW_SECS`] tolerance. A certificate with no expiry is
+    /// never expired.
+    #[must_use]
+    pub fn is_expired(&self, now_unix: u64) -> bool {
+        is_expired(self.not_after, now_unix)
+    }
+
+    /// Encode this certificate for on-disk storage.
+    ///
+    /// A non-expiring certificate is written as the legacy `v1` bincode shape
+    /// (byte-identical to pre-#130 `agent.cert` files) so downgrades keep
+    /// working; an expiring certificate is written as the `X0C2` magic marker
+    /// followed by the full bincode encoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::IdentityError::Serialization`] on encode failure.
+    pub fn to_storage_bytes(&self) -> Result<Vec<u8>, crate::error::IdentityError> {
+        match self.not_after {
+            None => {
+                let v1 = AgentCertificateV1Disk {
+                    user_public_key: self.user_public_key.clone(),
+                    agent_public_key: self.agent_public_key.clone(),
+                    signature: self.signature.clone(),
+                    issued_at: self.issued_at,
+                };
+                bincode::serialize(&v1)
+                    .map_err(|e| crate::error::IdentityError::Serialization(e.to_string()))
+            }
+            Some(_) => {
+                let body = bincode::serialize(self)
+                    .map_err(|e| crate::error::IdentityError::Serialization(e.to_string()))?;
+                let mut out = Vec::with_capacity(Self::CERT_DISK_V2_MAGIC.len() + body.len());
+                out.extend_from_slice(Self::CERT_DISK_V2_MAGIC);
+                out.extend_from_slice(&body);
+                Ok(out)
+            }
+        }
+    }
+
+    /// Decode a certificate from on-disk storage bytes.
+    ///
+    /// Detects the v2 magic marker; without it the bytes are a legacy v1
+    /// `agent.cert` and decode with `not_after: None` (valid forever).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::IdentityError::Serialization`] on decode failure.
+    pub fn from_storage_bytes(bytes: &[u8]) -> Result<Self, crate::error::IdentityError> {
+        if bytes.len() >= Self::CERT_DISK_V2_MAGIC.len()
+            && &bytes[..Self::CERT_DISK_V2_MAGIC.len()] == Self::CERT_DISK_V2_MAGIC
+        {
+            bincode::deserialize(&bytes[Self::CERT_DISK_V2_MAGIC.len()..])
+                .map_err(|e| crate::error::IdentityError::Serialization(e.to_string()))
+        } else {
+            let v1: AgentCertificateV1Disk = bincode::deserialize(bytes)
+                .map_err(|e| crate::error::IdentityError::Serialization(e.to_string()))?;
+            Ok(Self {
+                user_public_key: v1.user_public_key,
+                agent_public_key: v1.agent_public_key,
+                signature: v1.signature,
+                issued_at: v1.issued_at,
+                not_after: None,
+            })
+        }
+    }
+
     /// Build the message that gets signed/verified.
-    fn build_message(user_pubkey: &[u8], agent_pubkey: &[u8], timestamp: u64) -> Vec<u8> {
-        let mut message = Vec::with_capacity(
-            Self::CERT_PREFIX.len() + user_pubkey.len() + agent_pubkey.len() + 8,
-        );
-        message.extend_from_slice(Self::CERT_PREFIX);
-        message.extend_from_slice(user_pubkey);
-        message.extend_from_slice(agent_pubkey);
-        message.extend_from_slice(&timestamp.to_le_bytes());
-        message
+    ///
+    /// Version-selecting: `not_after == None` reproduces the exact v1 bytes;
+    /// `Some` uses the v2 prefix and appends the expiry so it is signed over.
+    fn build_message(
+        user_pubkey: &[u8],
+        agent_pubkey: &[u8],
+        timestamp: u64,
+        not_after: Option<u64>,
+    ) -> Vec<u8> {
+        match not_after {
+            None => {
+                let mut message = Vec::with_capacity(
+                    Self::CERT_PREFIX.len() + user_pubkey.len() + agent_pubkey.len() + 8,
+                );
+                message.extend_from_slice(Self::CERT_PREFIX);
+                message.extend_from_slice(user_pubkey);
+                message.extend_from_slice(agent_pubkey);
+                message.extend_from_slice(&timestamp.to_le_bytes());
+                message
+            }
+            Some(not_after) => {
+                let mut message = Vec::with_capacity(
+                    Self::CERT_V2_PREFIX.len() + user_pubkey.len() + agent_pubkey.len() + 16,
+                );
+                message.extend_from_slice(Self::CERT_V2_PREFIX);
+                message.extend_from_slice(user_pubkey);
+                message.extend_from_slice(agent_pubkey);
+                message.extend_from_slice(&timestamp.to_le_bytes());
+                message.extend_from_slice(&not_after.to_le_bytes());
+                message
+            }
+        }
     }
 }
 
@@ -1007,6 +1187,150 @@ mod tests {
         // Timestamp is recent
         assert!(cert.issued_at() > 0);
     }
+
+    // ── Certificate expiry (issue #130) ──
+
+    fn now_unix() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[test]
+    fn cert_v1_without_not_after_still_verifies() {
+        // The no-break guarantee: a certificate with no expiry must sign and
+        // verify over the exact v1 message bytes, forever. If this regresses,
+        // every existing certificate on the network stops verifying.
+        let user_kp = UserKeypair::generate().unwrap();
+        let agent_kp = AgentKeypair::generate().unwrap();
+        let cert = AgentCertificate::issue(&user_kp, &agent_kp).unwrap();
+        assert_eq!(cert.not_after(), None, "issue() must produce a v1 cert");
+        cert.verify().expect("a no-expiry cert must verify");
+        // The signed message must use the v1 prefix (byte-for-byte legacy).
+        let msg = AgentCertificate::build_message(
+            user_kp.public_key().as_bytes(),
+            agent_kp.public_key().as_bytes(),
+            cert.issued_at(),
+            None,
+        );
+        assert_eq!(
+            &msg[..AgentCertificate::CERT_PREFIX.len()],
+            AgentCertificate::CERT_PREFIX,
+            "a no-expiry cert must sign over the v1 domain prefix"
+        );
+        assert!(
+            !cert.is_expired(now_unix()),
+            "no-expiry cert is never expired"
+        );
+    }
+
+    #[test]
+    fn cert_with_not_after_signs_and_verifies() {
+        // A v2 (expiring) cert must round-trip: sign over the v2 message and
+        // verify, with the expiry preserved.
+        let user_kp = UserKeypair::generate().unwrap();
+        let agent_kp = AgentKeypair::generate().unwrap();
+        let expiry = now_unix() + 3600;
+        let cert = AgentCertificate::issue_with_expiry(&user_kp, &agent_kp, Some(expiry)).unwrap();
+        assert_eq!(cert.not_after(), Some(expiry));
+        cert.verify()
+            .expect("a within-validity v2 cert must verify");
+    }
+
+    #[test]
+    fn cert_not_after_tamper_fails_verification() {
+        // not_after is signature-covered: stripping it (v2 -> None) or moving
+        // it must break verification, so an attacker cannot extend validity or
+        // downgrade an expiring cert into a non-expiring one.
+        let user_kp = UserKeypair::generate().unwrap();
+        let agent_kp = AgentKeypair::generate().unwrap();
+        let expiry = now_unix() + 3600;
+        let mut cert =
+            AgentCertificate::issue_with_expiry(&user_kp, &agent_kp, Some(expiry)).unwrap();
+
+        // Strip the expiry: signature was over the v2 message, so verifying
+        // as v1 must fail.
+        cert.not_after = None;
+        assert!(
+            cert.verify().is_err(),
+            "stripping the expiry must fail verification, not read as never-expiring"
+        );
+
+        // Extend the expiry: a different not_after changes the signed bytes.
+        cert.not_after = Some(expiry + 1_000_000);
+        assert!(
+            cert.verify().is_err(),
+            "altering the expiry must fail verification"
+        );
+    }
+
+    #[test]
+    fn expiry_allows_within_skew() {
+        // A cert whose not_after is 120s in the past is still honored because
+        // it is within the 300s clock-skew tolerance — honestly-issued certs
+        // must not be rejected over minor clock disagreement.
+        let now = 1_000_000_000u64;
+        let not_after = now - 120;
+        assert!(
+            !is_expired(Some(not_after), now),
+            "an expiry 120s past must be tolerated (within {EXPIRY_CLOCK_SKEW_SECS}s skew)"
+        );
+    }
+
+    #[test]
+    fn expiry_rejects_beyond_skew() {
+        // A cert 600s past its not_after is beyond tolerance and must be
+        // treated as expired.
+        let now = 1_000_000_000u64;
+        let not_after = now - 600;
+        assert!(
+            is_expired(Some(not_after), now),
+            "an expiry 600s past must be rejected (beyond {EXPIRY_CLOCK_SKEW_SECS}s skew)"
+        );
+        // And None is never expired regardless of now.
+        assert!(!is_expired(None, now), "absence of expiry is never expired");
+    }
+
+    #[test]
+    fn cert_v1_disk_bytes_load_unchanged() {
+        // A pre-#130 agent.cert (bare v1 bincode, no expiry) must decode via
+        // the new versioned loader with not_after=None, and a no-expiry cert
+        // must serialize back to those exact legacy bytes (downgrade-safe).
+        let user_kp = UserKeypair::generate().unwrap();
+        let agent_kp = AgentKeypair::generate().unwrap();
+        let cert = AgentCertificate::issue(&user_kp, &agent_kp).unwrap();
+        let legacy = bincode::serialize(&AgentCertificateV1Disk {
+            user_public_key: cert.user_public_key.clone(),
+            agent_public_key: cert.agent_public_key.clone(),
+            signature: cert.signature.clone(),
+            issued_at: cert.issued_at,
+        })
+        .unwrap();
+        assert_eq!(
+            cert.to_storage_bytes().unwrap(),
+            legacy,
+            "a no-expiry cert must write the exact legacy disk bytes"
+        );
+        let loaded = AgentCertificate::from_storage_bytes(&legacy).unwrap();
+        assert_eq!(loaded, cert, "legacy disk bytes must decode unchanged");
+        loaded.verify().expect("legacy-loaded cert must verify");
+    }
+
+    #[test]
+    fn cert_v2_disk_bytes_roundtrip() {
+        // An expiring cert must round-trip through the v2 disk format.
+        let user_kp = UserKeypair::generate().unwrap();
+        let agent_kp = AgentKeypair::generate().unwrap();
+        let expiry = now_unix() + 86_400;
+        let cert = AgentCertificate::issue_with_expiry(&user_kp, &agent_kp, Some(expiry)).unwrap();
+        let bytes = cert.to_storage_bytes().unwrap();
+        let loaded = AgentCertificate::from_storage_bytes(&bytes).unwrap();
+        assert_eq!(loaded, cert, "v2 disk bytes must round-trip exactly");
+        assert_eq!(loaded.not_after(), Some(expiry));
+        loaded.verify().expect("v2-loaded cert must verify");
+    }
+
     #[test]
     fn test_agent_certificate_wrong_key_fails() {
         let user_kp = UserKeypair::generate().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,13 @@ pub mod identity;
 /// persistent storage of MachineKeypair and AgentKeypair.
 pub mod storage;
 
+/// Signed identity revocation records and the grow-only revocation set.
+///
+/// See [`revocation::RevocationRecord`] for the authority rules (self- and
+/// issuer-revocation only) and [`revocation::RevocationSet`] for the local,
+/// gossip-fed set consulted at every trust gate.
+pub mod revocation;
+
 /// Bootstrap node discovery and connection.
 ///
 /// This module handles initial connection to bootstrap nodes with

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -210,6 +210,20 @@ impl RevocationRecord {
         ))
     }
 
+    /// Whether this is a self-revocation — the issuer key hashes to the subject
+    /// id.
+    ///
+    /// A self-revocation re-verifies from the record alone (no certificate
+    /// needed); an issuer-revocation requires the subject agent's certificate.
+    /// A malformed issuer key yields `false` (it will fail verification anyway).
+    #[must_use]
+    pub fn is_self_revocation(&self) -> bool {
+        match MlDsaPublicKey::from_bytes(&self.issuer_public_key) {
+            Ok(pk) => &derive_peer_id_from_public_key(&pk).0 == self.subject.id_bytes(),
+            Err(_) => false,
+        }
+    }
+
     /// BLAKE3 hash of the canonical (signed) message, used for de-duplication.
     ///
     /// Two records for the same `(subject, issuer, revoked_at, reason)` hash
@@ -226,16 +240,37 @@ impl RevocationRecord {
     }
 }
 
+/// A revocation record plus the subject certificate (if any) that authorizes
+/// it, as stored on disk.
+///
+/// `subject_cert` is `Some` only for **issuer-revocations**, where the record
+/// is authorized by the user key that signed the subject agent's certificate:
+/// that certificate is required to re-verify authority on load. Self-revocations
+/// carry `None` (they re-verify from the record alone). Persisting the cert is
+/// what lets [`RevocationSet::from_bytes`] re-check authority — so a
+/// tampered/forged `revocations.bin` cannot inject an unverified revocation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedRevocation {
+    record: RevocationRecord,
+    subject_cert: Option<AgentCertificate>,
+}
+
 /// In-memory grow-only set of verified revocations.
 ///
 /// Maintains `HashSet`s of revoked agent/machine ids for O(1) gate checks plus
 /// a hash-keyed map of the full records for rebroadcast. Records are only ever
 /// added; there is no removal (no un-revocation).
+///
+/// Every record in the set has passed [`RevocationRecord::verify_authority`] —
+/// both on first receipt and again when reloaded from disk. Insertion therefore
+/// only happens through [`verify_and_insert`](Self::verify_and_insert); the
+/// crate-internal raw insert performs no crypto and must only ever be handed a
+/// record that was just verified.
 #[derive(Debug, Default, Clone)]
 pub struct RevocationSet {
     revoked_agents: HashSet<AgentId>,
     revoked_machines: HashSet<MachineId>,
-    records_by_hash: HashMap<[u8; 32], RevocationRecord>,
+    records_by_hash: HashMap<[u8; 32], PersistedRevocation>,
 }
 
 impl RevocationSet {
@@ -275,18 +310,48 @@ impl RevocationSet {
         self.records_by_hash.contains_key(hash)
     }
 
-    /// Insert an already-verified record. Returns `true` if it was new.
+    /// Verify a record's authority, then insert it. Returns `true` if it was
+    /// newly added, `false` if already present (idempotent).
     ///
-    /// Callers MUST verify authority via
-    /// [`RevocationRecord::verify_authority`] before inserting; this method
-    /// performs no cryptographic checks so that loading a locally-persisted,
-    /// previously-verified set stays cheap.
-    pub fn insert_verified(&mut self, record: RevocationRecord) -> bool {
-        let hash = record.record_hash();
+    /// This is the ONLY way a record enters the set. `subject_cert` supplies
+    /// the subject agent's certificate for issuer-revocations (pass `None` for
+    /// self-revocations, or when no certificate is known — issuer-revocations
+    /// then fail closed). The validating certificate is retained so the record
+    /// re-verifies on a later [`from_bytes`](Self::from_bytes).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Revocation`] if the record's signature is
+    /// invalid or the issuer lacks authority over the subject.
+    pub fn verify_and_insert(
+        &mut self,
+        record: RevocationRecord,
+        subject_cert: Option<&AgentCertificate>,
+    ) -> Result<bool, IdentityError> {
+        record.verify_authority(subject_cert)?;
+        // Retain the certificate only when it was actually needed to prove
+        // authority (issuer-revocation). Self-revocations re-verify without it.
+        let retained_cert = if record.is_self_revocation() {
+            None
+        } else {
+            subject_cert.cloned()
+        };
+        Ok(self.insert_verified(PersistedRevocation {
+            record,
+            subject_cert: retained_cert,
+        }))
+    }
+
+    /// Raw insert of an already-verified record. Performs NO cryptographic
+    /// checks — it is module-private and reachable ONLY through
+    /// [`verify_and_insert`](Self::verify_and_insert), which is the sole path a
+    /// record can enter the set. Returns `true` if new.
+    fn insert_verified(&mut self, persisted: PersistedRevocation) -> bool {
+        let hash = persisted.record.record_hash();
         if self.records_by_hash.contains_key(&hash) {
             return false;
         }
-        match &record.subject {
+        match &persisted.record.subject {
             RevokedSubject::Agent(id) => {
                 self.revoked_agents.insert(*id);
             }
@@ -294,24 +359,28 @@ impl RevocationSet {
                 self.revoked_machines.insert(*id);
             }
         }
-        self.records_by_hash.insert(hash, record);
+        self.records_by_hash.insert(hash, persisted);
         true
     }
 
     /// All held records (order unspecified), for rebroadcast/anti-entropy.
     #[must_use]
     pub fn all_records(&self) -> Vec<RevocationRecord> {
-        self.records_by_hash.values().cloned().collect()
+        self.records_by_hash
+            .values()
+            .map(|p| p.record.clone())
+            .collect()
     }
 
     /// Encode the set for on-disk persistence: `X0XR` magic + bincode of the
-    /// record list.
+    /// record list (each record carrying the certificate that authorizes it,
+    /// where applicable).
     ///
     /// # Errors
     ///
     /// Returns [`IdentityError::Serialization`] on encode failure.
     pub fn to_bytes(&self) -> Result<Vec<u8>, IdentityError> {
-        let records: Vec<&RevocationRecord> = self.records_by_hash.values().collect();
+        let records: Vec<&PersistedRevocation> = self.records_by_hash.values().collect();
         let body = bincode::serialize(&records)
             .map_err(|e| IdentityError::Serialization(e.to_string()))?;
         let mut out = Vec::with_capacity(REVOCATIONS_FILE_MAGIC.len() + body.len());
@@ -320,16 +389,22 @@ impl RevocationSet {
         Ok(out)
     }
 
-    /// Decode a set previously written by [`to_bytes`](Self::to_bytes).
+    /// Decode a set previously written by [`to_bytes`](Self::to_bytes),
+    /// **re-verifying every record's authority on load**.
     ///
-    /// Records are inserted without re-verifying signatures — they were
-    /// verified before this daemon persisted them. An empty or magic-less
-    /// input yields an empty set (forward-compatible with a missing file).
+    /// The on-disk file is untrusted input: a record that fails re-verification
+    /// (forged signature, or an issuer-revocation whose persisted certificate
+    /// no longer authorizes it) is silently dropped rather than trusted, so a
+    /// tampered `revocations.bin` cannot inject an unverified revocation.
+    /// Legitimately-verified records — including issuer-revocations, whose
+    /// authorizing certificate is persisted alongside them — are preserved.
+    ///
+    /// An empty input yields an empty set (a missing file is not an error).
     ///
     /// # Errors
     ///
-    /// Returns [`IdentityError::Serialization`] if the body is present but
-    /// malformed.
+    /// Returns [`IdentityError::Serialization`] if the magic is missing or the
+    /// body is malformed.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, IdentityError> {
         if bytes.is_empty() {
             return Ok(Self::new());
@@ -341,12 +416,15 @@ impl RevocationSet {
                 "revocation file missing X0XR magic".to_string(),
             ));
         }
-        let records: Vec<RevocationRecord> =
+        let persisted: Vec<PersistedRevocation> =
             bincode::deserialize(&bytes[REVOCATIONS_FILE_MAGIC.len()..])
                 .map_err(|e| IdentityError::Serialization(e.to_string()))?;
         let mut set = Self::new();
-        for record in records {
-            set.insert_verified(record);
+        for entry in persisted {
+            // Re-verify authority against the persisted certificate. A record
+            // that no longer verifies is dropped (not present in the set) —
+            // this is the load-path enforcement of the authority model.
+            let _ = set.verify_and_insert(entry.record, entry.subject_cert.as_ref());
         }
         Ok(set)
     }
@@ -499,9 +577,12 @@ mod tests {
         )
         .unwrap();
         let mut set = RevocationSet::new();
-        assert!(set.insert_verified(record.clone()), "first insert is new");
         assert!(
-            !set.insert_verified(record.clone()),
+            set.verify_and_insert(record.clone(), None).unwrap(),
+            "first insert is new"
+        );
+        assert!(
+            !set.verify_and_insert(record.clone(), None).unwrap(),
             "re-inserting the same record must be idempotent"
         );
         assert_eq!(set.len(), 1);
@@ -512,11 +593,16 @@ mod tests {
     #[test]
     fn revocation_set_persists_and_reloads() {
         // The on-disk round-trip preserves the gate state — a daemon restart
-        // must not forget revocations it learned.
+        // must not forget revocations it learned. Includes an issuer-revocation
+        // (cert persisted alongside) so the reload re-verifies it via that cert.
         let agent = AgentKeypair::generate().unwrap();
         let machine = MachineKeypair::generate().unwrap();
+        let user = UserKeypair::generate().unwrap();
+        let issued_agent = AgentKeypair::generate().unwrap();
+        let cert = AgentCertificate::issue(&user, &issued_agent).unwrap();
         let mut set = RevocationSet::new();
-        set.insert_verified(
+        // self-revocation (agent)
+        set.verify_and_insert(
             RevocationRecord::sign(
                 RevokedSubject::Agent(agent.agent_id()),
                 agent.public_key(),
@@ -525,8 +611,11 @@ mod tests {
                 None,
             )
             .unwrap(),
-        );
-        set.insert_verified(
+            None,
+        )
+        .unwrap();
+        // self-revocation (machine)
+        set.verify_and_insert(
             RevocationRecord::sign(
                 RevokedSubject::Machine(machine.machine_id()),
                 machine.public_key(),
@@ -535,12 +624,134 @@ mod tests {
                 None,
             )
             .unwrap(),
-        );
+            None,
+        )
+        .unwrap();
+        // issuer-revocation (user revokes a certified agent)
+        set.verify_and_insert(
+            RevocationRecord::sign(
+                RevokedSubject::Agent(issued_agent.agent_id()),
+                user.public_key(),
+                user.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+            Some(&cert),
+        )
+        .unwrap();
         let bytes = set.to_bytes().unwrap();
         let reloaded = RevocationSet::from_bytes(&bytes).unwrap();
-        assert_eq!(reloaded.len(), 2);
+        assert_eq!(reloaded.len(), 3, "all three records must survive reload");
         assert!(reloaded.is_agent_revoked(&agent.agent_id()));
         assert!(reloaded.is_machine_revoked(&machine.machine_id()));
+        assert!(
+            reloaded.is_agent_revoked(&issued_agent.agent_id()),
+            "issuer-revocation must re-verify on load via its persisted cert"
+        );
+    }
+
+    #[test]
+    fn revocation_set_from_bytes_rejects_forged_and_unrelated_records() {
+        // SECURITY: revocations.bin is untrusted input. A record whose signature
+        // is forged (tampered after signing) and an issuer-revocation whose
+        // persisted cert does not authorize it must both be DROPPED on load,
+        // while a legitimately-signed self-revocation and a properly-certified
+        // issuer-revocation must survive. This pins load-path authority
+        // enforcement — without it a tampered file would inject revocations.
+        let good_agent = AgentKeypair::generate().unwrap();
+        let user = UserKeypair::generate().unwrap();
+        let issued_agent = AgentKeypair::generate().unwrap();
+        let good_cert = AgentCertificate::issue(&user, &issued_agent).unwrap();
+
+        // Legit self-revocation.
+        let good_self = PersistedRevocation {
+            record: RevocationRecord::sign(
+                RevokedSubject::Agent(good_agent.agent_id()),
+                good_agent.public_key(),
+                good_agent.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+            subject_cert: None,
+        };
+
+        // Legit issuer-revocation, cert persisted alongside.
+        let good_issuer = PersistedRevocation {
+            record: RevocationRecord::sign(
+                RevokedSubject::Agent(issued_agent.agent_id()),
+                user.public_key(),
+                user.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+            subject_cert: Some(good_cert.clone()),
+        };
+
+        // Forged: a validly-signed self-revocation tampered after signing.
+        let forged_agent = AgentKeypair::generate().unwrap();
+        let mut forged_record = RevocationRecord::sign(
+            RevokedSubject::Agent(forged_agent.agent_id()),
+            forged_agent.public_key(),
+            forged_agent.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        forged_record.revoked_at = forged_record.revoked_at.wrapping_add(1);
+        let forged = PersistedRevocation {
+            record: forged_record,
+            subject_cert: None,
+        };
+
+        // Unrelated issuer: a third party's key with a cert that does not bind
+        // them to the subject.
+        let attacker = UserKeypair::generate().unwrap();
+        let victim_agent = AgentKeypair::generate().unwrap();
+        let unrelated = PersistedRevocation {
+            record: RevocationRecord::sign(
+                RevokedSubject::Agent(victim_agent.agent_id()),
+                attacker.public_key(),
+                attacker.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+            // Attach a real cert, but it certifies issued_agent (not the
+            // victim) and is signed by `user` (not the attacker).
+            subject_cert: Some(good_cert),
+        };
+
+        // Craft the on-disk bytes directly (bypassing verify_and_insert) to
+        // simulate a tampered file.
+        let entries = vec![good_self, good_issuer, forged, unrelated];
+        let mut bytes = REVOCATIONS_FILE_MAGIC.to_vec();
+        bytes.extend_from_slice(&bincode::serialize(&entries).unwrap());
+
+        let loaded = RevocationSet::from_bytes(&bytes).unwrap();
+        assert_eq!(
+            loaded.len(),
+            2,
+            "only the two authoritative records may survive load"
+        );
+        assert!(
+            loaded.is_agent_revoked(&good_agent.agent_id()),
+            "legit self-revocation must survive"
+        );
+        assert!(
+            loaded.is_agent_revoked(&issued_agent.agent_id()),
+            "legit issuer-revocation (with cert) must survive"
+        );
+        assert!(
+            !loaded.is_agent_revoked(&forged_agent.agent_id()),
+            "forged record must be rejected on load"
+        );
+        assert!(
+            !loaded.is_agent_revoked(&victim_agent.agent_id()),
+            "unrelated-issuer record must be rejected on load"
+        );
     }
 
     #[test]

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -1,0 +1,550 @@
+//! Key/identity revocation records and the local grow-only revocation set
+//! (issue #130).
+//!
+//! A [`RevocationRecord`](crate::revocation::RevocationRecord) is a signed, self-authenticating statement that a
+//! specific agent or machine identity is revoked. Records are gossiped across
+//! the network and enforced at every trust gate (see the enforcement points in
+//! `lib.rs`, `dm_inbox.rs`, and `server/mod.rs`). Presence of a *valid*
+//! revocation always fails **closed**.
+//!
+//! # Who may revoke — exactly two rules
+//!
+//! Both are verifiable from the record alone plus (for issuer-revocation) a
+//! certificate already known for the subject; neither needs any trust state:
+//!
+//! 1. **Self-revocation** — the issuer key *is* the subject: the SHA-256 of
+//!    `issuer_public_key` equals the revoked `AgentId`/`MachineId`. Always
+//!    valid; an attacker "revoking" a stolen key only helps the victim.
+//! 2. **Issuer-revocation** — for an `Agent` subject, the issuer key is the
+//!    user key that signed that agent's [`AgentCertificate`](crate::identity::AgentCertificate). The user who
+//!    vouched for an agent may un-vouch it.
+//!
+//! There is **no third-party revocation** and **no un-revocation**: the set is
+//! grow-only (a G-Set), which removes the entire replay/rollback class —
+//! replaying a revocation is idempotent and there is no "restore" message to
+//! replay. Records are de-duplicated by the BLAKE3 hash of their canonical
+//! bytes.
+
+use std::collections::{HashMap, HashSet};
+
+use ant_quic::crypto::raw_public_keys::pqc::{
+    sign_with_ml_dsa, verify_with_ml_dsa, MlDsaPublicKey, MlDsaSecretKey, MlDsaSignature,
+};
+use ant_quic::derive_peer_id_from_public_key;
+use serde::{Deserialize, Serialize};
+
+use crate::error::IdentityError;
+use crate::identity::{AgentCertificate, AgentId, MachineId};
+
+/// Domain-separation prefix for the bytes a revocation signs over.
+const REVOCATION_MSG_PREFIX: &[u8] = b"x0x-revocation-v1";
+
+/// Magic marker prefixing the on-disk revocation set file.
+const REVOCATIONS_FILE_MAGIC: &[u8; 4] = b"X0XR";
+
+/// The identity a revocation record targets.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RevokedSubject {
+    /// A portable agent identity.
+    Agent(AgentId),
+    /// A hardware-pinned machine identity.
+    Machine(MachineId),
+}
+
+impl RevokedSubject {
+    /// Domain tag byte distinguishing the subject kind in signed bytes.
+    fn tag(&self) -> u8 {
+        match self {
+            RevokedSubject::Agent(_) => 0x01,
+            RevokedSubject::Machine(_) => 0x02,
+        }
+    }
+
+    /// The raw 32-byte identifier of the subject.
+    fn id_bytes(&self) -> &[u8; 32] {
+        match self {
+            RevokedSubject::Agent(id) => id.as_bytes(),
+            RevokedSubject::Machine(id) => id.as_bytes(),
+        }
+    }
+}
+
+/// A signed, self-authenticating revocation of an agent or machine identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevocationRecord {
+    /// The identity being revoked.
+    pub subject: RevokedSubject,
+    /// The revoker's ML-DSA-65 public key bytes.
+    pub issuer_public_key: Vec<u8>,
+    /// Unix timestamp when the revocation was issued (informational only).
+    pub revoked_at: u64,
+    /// Optional human-readable reason.
+    pub reason: Option<String>,
+    /// ML-DSA-65 signature over the canonical message.
+    pub signature: Vec<u8>,
+}
+
+impl RevocationRecord {
+    /// Canonical bytes signed by a revocation:
+    /// `prefix || subject_tag || subject_id || issuer_pubkey || revoked_at ||
+    /// reason_len || reason`.
+    ///
+    /// `reason` is length-prefixed so two records that differ only by where a
+    /// field boundary falls cannot collide.
+    fn canonical_message(
+        subject: &RevokedSubject,
+        issuer_public_key: &[u8],
+        revoked_at: u64,
+        reason: &Option<String>,
+    ) -> Vec<u8> {
+        let reason_bytes = reason.as_ref().map(|s| s.as_bytes()).unwrap_or(&[]);
+        let mut msg = Vec::with_capacity(
+            REVOCATION_MSG_PREFIX.len()
+                + 1
+                + 32
+                + issuer_public_key.len()
+                + 8
+                + 8
+                + reason_bytes.len(),
+        );
+        msg.extend_from_slice(REVOCATION_MSG_PREFIX);
+        msg.push(subject.tag());
+        msg.extend_from_slice(subject.id_bytes());
+        msg.extend_from_slice(issuer_public_key);
+        msg.extend_from_slice(&revoked_at.to_le_bytes());
+        msg.extend_from_slice(&(reason_bytes.len() as u64).to_le_bytes());
+        msg.extend_from_slice(reason_bytes);
+        msg
+    }
+
+    /// Sign a new revocation record.
+    ///
+    /// The caller supplies the issuer's public key bytes and secret key. For a
+    /// **self-revocation**, pass the keypair whose id equals `subject`; for an
+    /// **issuer-revocation**, pass the user keypair that signed the subject
+    /// agent's certificate. Authority is (re-)checked in
+    /// [`verify_authority`](Self::verify_authority) on receipt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::CertificateVerification`] if signing fails.
+    pub fn sign(
+        subject: RevokedSubject,
+        issuer_public_key: &MlDsaPublicKey,
+        issuer_secret_key: &MlDsaSecretKey,
+        revoked_at: u64,
+        reason: Option<String>,
+    ) -> Result<Self, IdentityError> {
+        let issuer_pub_bytes = issuer_public_key.as_bytes().to_vec();
+        let message = Self::canonical_message(&subject, &issuer_pub_bytes, revoked_at, &reason);
+        let signature = sign_with_ml_dsa(issuer_secret_key, &message).map_err(|e| {
+            IdentityError::CertificateVerification(format!("revocation signing failed: {e:?}"))
+        })?;
+        Ok(Self {
+            subject,
+            issuer_public_key: issuer_pub_bytes,
+            revoked_at,
+            reason,
+            signature: signature.as_bytes().to_vec(),
+        })
+    }
+
+    /// Verify the signature and the authority of this record.
+    ///
+    /// `subject_cert` is a certificate known for the subject agent (from the
+    /// discovery cache or the same gossip batch), used only to check
+    /// issuer-revocation authority; pass `None` if none is known. The
+    /// signature is always checked first, so a forged record is rejected even
+    /// when a certificate is supplied.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Revocation`] if the signature is invalid or the
+    /// issuer is neither the subject (self) nor the certifying user (issuer).
+    pub fn verify_authority(
+        &self,
+        subject_cert: Option<&AgentCertificate>,
+    ) -> Result<(), IdentityError> {
+        // 1. Signature check — the record must be authentic before its claimed
+        //    authority means anything.
+        let issuer_pubkey = MlDsaPublicKey::from_bytes(&self.issuer_public_key)
+            .map_err(|_| IdentityError::Revocation("invalid issuer public key".to_string()))?;
+        let signature = MlDsaSignature::from_bytes(&self.signature)
+            .map_err(|e| IdentityError::Revocation(format!("invalid signature format: {e:?}")))?;
+        let message = Self::canonical_message(
+            &self.subject,
+            &self.issuer_public_key,
+            self.revoked_at,
+            &self.reason,
+        );
+        verify_with_ml_dsa(&issuer_pubkey, &message, &signature)
+            .map_err(|e| IdentityError::Revocation(format!("bad signature: {e:?}")))?;
+
+        // 2. Self-revocation: the issuer key hashes to the subject id.
+        let issuer_id = derive_peer_id_from_public_key(&issuer_pubkey).0;
+        if &issuer_id == self.subject.id_bytes() {
+            return Ok(());
+        }
+
+        // 3. Issuer-revocation (Agent subjects only): the issuer key is the
+        //    user key that signed the subject agent's certificate.
+        if let RevokedSubject::Agent(subject_agent) = &self.subject {
+            if let Some(cert) = subject_cert {
+                let cert_binds_subject = cert
+                    .agent_id()
+                    .map(|a| a == *subject_agent)
+                    .unwrap_or(false);
+                let cert_is_valid = cert.verify().is_ok();
+                let issuer_is_certifier = cert
+                    .user_id()
+                    .map(|u| u.as_bytes() == &issuer_id)
+                    .unwrap_or(false);
+                if cert_binds_subject && cert_is_valid && issuer_is_certifier {
+                    return Ok(());
+                }
+            }
+        }
+
+        Err(IdentityError::Revocation(
+            "issuer is neither the subject nor the certifying user".to_string(),
+        ))
+    }
+
+    /// BLAKE3 hash of the canonical (signed) message, used for de-duplication.
+    ///
+    /// Two records for the same `(subject, issuer, revoked_at, reason)` hash
+    /// identically, so merging is idempotent.
+    #[must_use]
+    pub fn record_hash(&self) -> [u8; 32] {
+        let message = Self::canonical_message(
+            &self.subject,
+            &self.issuer_public_key,
+            self.revoked_at,
+            &self.reason,
+        );
+        *blake3::hash(&message).as_bytes()
+    }
+}
+
+/// In-memory grow-only set of verified revocations.
+///
+/// Maintains `HashSet`s of revoked agent/machine ids for O(1) gate checks plus
+/// a hash-keyed map of the full records for rebroadcast. Records are only ever
+/// added; there is no removal (no un-revocation).
+#[derive(Debug, Default, Clone)]
+pub struct RevocationSet {
+    revoked_agents: HashSet<AgentId>,
+    revoked_machines: HashSet<MachineId>,
+    records_by_hash: HashMap<[u8; 32], RevocationRecord>,
+}
+
+impl RevocationSet {
+    /// Create an empty set.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether an agent id is revoked.
+    #[must_use]
+    pub fn is_agent_revoked(&self, id: &AgentId) -> bool {
+        self.revoked_agents.contains(id)
+    }
+
+    /// Whether a machine id is revoked.
+    #[must_use]
+    pub fn is_machine_revoked(&self, id: &MachineId) -> bool {
+        self.revoked_machines.contains(id)
+    }
+
+    /// Number of distinct records held.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.records_by_hash.len()
+    }
+
+    /// Whether the set holds no records.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.records_by_hash.is_empty()
+    }
+
+    /// Whether a record (by canonical hash) is already known.
+    #[must_use]
+    pub fn contains_hash(&self, hash: &[u8; 32]) -> bool {
+        self.records_by_hash.contains_key(hash)
+    }
+
+    /// Insert an already-verified record. Returns `true` if it was new.
+    ///
+    /// Callers MUST verify authority via
+    /// [`RevocationRecord::verify_authority`] before inserting; this method
+    /// performs no cryptographic checks so that loading a locally-persisted,
+    /// previously-verified set stays cheap.
+    pub fn insert_verified(&mut self, record: RevocationRecord) -> bool {
+        let hash = record.record_hash();
+        if self.records_by_hash.contains_key(&hash) {
+            return false;
+        }
+        match &record.subject {
+            RevokedSubject::Agent(id) => {
+                self.revoked_agents.insert(*id);
+            }
+            RevokedSubject::Machine(id) => {
+                self.revoked_machines.insert(*id);
+            }
+        }
+        self.records_by_hash.insert(hash, record);
+        true
+    }
+
+    /// All held records (order unspecified), for rebroadcast/anti-entropy.
+    #[must_use]
+    pub fn all_records(&self) -> Vec<RevocationRecord> {
+        self.records_by_hash.values().cloned().collect()
+    }
+
+    /// Encode the set for on-disk persistence: `X0XR` magic + bincode of the
+    /// record list.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Serialization`] on encode failure.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, IdentityError> {
+        let records: Vec<&RevocationRecord> = self.records_by_hash.values().collect();
+        let body = bincode::serialize(&records)
+            .map_err(|e| IdentityError::Serialization(e.to_string()))?;
+        let mut out = Vec::with_capacity(REVOCATIONS_FILE_MAGIC.len() + body.len());
+        out.extend_from_slice(REVOCATIONS_FILE_MAGIC);
+        out.extend_from_slice(&body);
+        Ok(out)
+    }
+
+    /// Decode a set previously written by [`to_bytes`](Self::to_bytes).
+    ///
+    /// Records are inserted without re-verifying signatures — they were
+    /// verified before this daemon persisted them. An empty or magic-less
+    /// input yields an empty set (forward-compatible with a missing file).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Serialization`] if the body is present but
+    /// malformed.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, IdentityError> {
+        if bytes.is_empty() {
+            return Ok(Self::new());
+        }
+        if bytes.len() < REVOCATIONS_FILE_MAGIC.len()
+            || &bytes[..REVOCATIONS_FILE_MAGIC.len()] != REVOCATIONS_FILE_MAGIC
+        {
+            return Err(IdentityError::Serialization(
+                "revocation file missing X0XR magic".to_string(),
+            ));
+        }
+        let records: Vec<RevocationRecord> =
+            bincode::deserialize(&bytes[REVOCATIONS_FILE_MAGIC.len()..])
+                .map_err(|e| IdentityError::Serialization(e.to_string()))?;
+        let mut set = Self::new();
+        for record in records {
+            set.insert_verified(record);
+        }
+        Ok(set)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use crate::identity::{AgentKeypair, MachineKeypair, UserKeypair};
+
+    fn now() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[test]
+    fn revocation_self_signed_verifies() {
+        // An agent revoking its own id is always authoritative: the issuer key
+        // hashes to the subject. This is the "revoke a stolen key" path and
+        // must never require external state.
+        let agent = AgentKeypair::generate().unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            agent.public_key(),
+            agent.secret_key(),
+            now(),
+            Some("compromised".to_string()),
+        )
+        .unwrap();
+        record
+            .verify_authority(None)
+            .expect("self-revocation must verify with no certificate");
+    }
+
+    #[test]
+    fn revocation_machine_self_signed_verifies() {
+        let machine = MachineKeypair::generate().unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Machine(machine.machine_id()),
+            machine.public_key(),
+            machine.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        record
+            .verify_authority(None)
+            .expect("machine self-revocation must verify");
+    }
+
+    #[test]
+    fn revocation_user_signed_for_certified_agent_verifies() {
+        // The user who certified an agent may revoke it. Authority is proven by
+        // the agent's certificate binding agent->user and the issuer being that
+        // user key.
+        let user = UserKeypair::generate().unwrap();
+        let agent = AgentKeypair::generate().unwrap();
+        let cert = AgentCertificate::issue(&user, &agent).unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            user.public_key(),
+            user.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        record
+            .verify_authority(Some(&cert))
+            .expect("issuer (certifying user) revocation must verify");
+    }
+
+    #[test]
+    fn revocation_user_without_cert_rejected() {
+        // Without the certificate proving the agent->user binding, a user key
+        // has no authority over the agent — fail closed.
+        let user = UserKeypair::generate().unwrap();
+        let agent = AgentKeypair::generate().unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            user.public_key(),
+            user.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        assert!(
+            record.verify_authority(None).is_err(),
+            "issuer-revocation without the binding certificate must be rejected"
+        );
+    }
+
+    #[test]
+    fn revocation_unrelated_key_rejected() {
+        // A third party (neither the subject nor its certifier) cannot revoke,
+        // even with a validly-signed record. This is the core no-third-party
+        // property.
+        let user = UserKeypair::generate().unwrap();
+        let agent = AgentKeypair::generate().unwrap();
+        let cert = AgentCertificate::issue(&user, &agent).unwrap();
+        let attacker = UserKeypair::generate().unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            attacker.public_key(),
+            attacker.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        assert!(
+            record.verify_authority(Some(&cert)).is_err(),
+            "an unrelated key must not be able to revoke, even with the cert"
+        );
+    }
+
+    #[test]
+    fn revocation_forged_signature_rejected() {
+        // Tampering the record after signing must fail the signature check
+        // before authority is ever considered.
+        let agent = AgentKeypair::generate().unwrap();
+        let mut record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            agent.public_key(),
+            agent.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        record.revoked_at = record.revoked_at.wrapping_add(1);
+        assert!(
+            record.verify_authority(None).is_err(),
+            "a tampered record must fail the signature check"
+        );
+    }
+
+    #[test]
+    fn revocation_set_merge_grow_only_idempotent() {
+        // Merging the same record twice is a no-op; the set only grows. This is
+        // what makes gossip replay harmless.
+        let agent = AgentKeypair::generate().unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            agent.public_key(),
+            agent.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        let mut set = RevocationSet::new();
+        assert!(set.insert_verified(record.clone()), "first insert is new");
+        assert!(
+            !set.insert_verified(record.clone()),
+            "re-inserting the same record must be idempotent"
+        );
+        assert_eq!(set.len(), 1);
+        assert!(set.is_agent_revoked(&agent.agent_id()));
+        assert!(!set.is_machine_revoked(&MachineKeypair::generate().unwrap().machine_id()));
+    }
+
+    #[test]
+    fn revocation_set_persists_and_reloads() {
+        // The on-disk round-trip preserves the gate state — a daemon restart
+        // must not forget revocations it learned.
+        let agent = AgentKeypair::generate().unwrap();
+        let machine = MachineKeypair::generate().unwrap();
+        let mut set = RevocationSet::new();
+        set.insert_verified(
+            RevocationRecord::sign(
+                RevokedSubject::Agent(agent.agent_id()),
+                agent.public_key(),
+                agent.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+        );
+        set.insert_verified(
+            RevocationRecord::sign(
+                RevokedSubject::Machine(machine.machine_id()),
+                machine.public_key(),
+                machine.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+        );
+        let bytes = set.to_bytes().unwrap();
+        let reloaded = RevocationSet::from_bytes(&bytes).unwrap();
+        assert_eq!(reloaded.len(), 2);
+        assert!(reloaded.is_agent_revoked(&agent.agent_id()));
+        assert!(reloaded.is_machine_revoked(&machine.machine_id()));
+    }
+
+    #[test]
+    fn revocation_set_from_empty_is_empty() {
+        assert!(RevocationSet::from_bytes(&[]).unwrap().is_empty());
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,15 +13,96 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::fs;
 
-/// Serialized keypair representation for storage.
+/// Serialized keypair representation for storage (legacy v1 format).
 ///
-/// Uses raw bytes for efficiency rather than base64 encoding.
+/// Uses raw bytes for efficiency rather than base64 encoding. This is the
+/// on-disk shape produced by every x0x release to date: a bare
+/// `bincode(public_key, secret_key)` with no version marker. New code keeps
+/// writing exactly these bytes whenever no expiry is recorded, so existing
+/// `~/.x0x/*.key` files stay byte-for-byte compatible.
 #[derive(Serialize, Deserialize)]
 struct SerializedKeypair {
     /// Raw public key bytes
     public_key: Vec<u8>,
-    /// Raw secret key bytes  
+    /// Raw secret key bytes
     secret_key: Vec<u8>,
+}
+
+/// Serialized keypair representation carrying a local expiry (v2 format).
+///
+/// Only written when a `not_after` is recorded. The on-disk encoding is
+/// [`KEYFILE_V2_MAGIC`] followed by `bincode(public_key, secret_key,
+/// not_after)`. The magic marker lets the loader distinguish this from the
+/// legacy format without ambiguity.
+#[derive(Serialize, Deserialize)]
+struct SerializedKeypairV2 {
+    /// Raw public key bytes
+    public_key: Vec<u8>,
+    /// Raw secret key bytes
+    secret_key: Vec<u8>,
+    /// Unix timestamp after which this key material is considered expired.
+    ///
+    /// This is a **local record only** — key-file expiry is never enforced
+    /// over the network (only [`crate::identity::AgentCertificate`] expiry is).
+    not_after: u64,
+}
+
+/// Magic marker prefixing a v2 (expiry-carrying) key file.
+///
+/// A legacy v1 file begins with the bincode length prefix of the ML-DSA-65
+/// public key (`0xA0 0x07 …`), so it can never collide with this marker; a
+/// missing marker therefore unambiguously means "legacy, no expiry".
+const KEYFILE_V2_MAGIC: &[u8; 4] = b"X0K2";
+
+/// Encode raw key material with an optional local expiry.
+///
+/// `None` produces the legacy v1 bytes verbatim (no marker, no extra bytes)
+/// so existing deployments' files are unchanged. `Some` produces the v2
+/// format ([`KEYFILE_V2_MAGIC`] + bincode with the trailing `not_after`).
+fn encode_keypair_bytes(
+    public_key: Vec<u8>,
+    secret_key: Vec<u8>,
+    not_after: Option<u64>,
+) -> Result<Vec<u8>> {
+    match not_after {
+        None => {
+            let data = SerializedKeypair {
+                public_key,
+                secret_key,
+            };
+            bincode::serialize(&data).map_err(|e| IdentityError::Serialization(e.to_string()))
+        }
+        Some(not_after) => {
+            let data = SerializedKeypairV2 {
+                public_key,
+                secret_key,
+                not_after,
+            };
+            let body = bincode::serialize(&data)
+                .map_err(|e| IdentityError::Serialization(e.to_string()))?;
+            let mut out = Vec::with_capacity(KEYFILE_V2_MAGIC.len() + body.len());
+            out.extend_from_slice(KEYFILE_V2_MAGIC);
+            out.extend_from_slice(&body);
+            Ok(out)
+        }
+    }
+}
+
+/// Decode key-file bytes into raw key material plus an optional local expiry.
+///
+/// Detects the v2 magic marker; when absent the bytes are the legacy v1
+/// format and `not_after` is `None` (absence of expiry ⇒ never expires).
+fn decode_keypair_bytes(bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>, Option<u64>)> {
+    if bytes.len() >= KEYFILE_V2_MAGIC.len() && &bytes[..KEYFILE_V2_MAGIC.len()] == KEYFILE_V2_MAGIC
+    {
+        let data: SerializedKeypairV2 = bincode::deserialize(&bytes[KEYFILE_V2_MAGIC.len()..])
+            .map_err(|e| IdentityError::Serialization(e.to_string()))?;
+        Ok((data.public_key, data.secret_key, Some(data.not_after)))
+    } else {
+        let data: SerializedKeypair =
+            bincode::deserialize(bytes).map_err(|e| IdentityError::Serialization(e.to_string()))?;
+        Ok((data.public_key, data.secret_key, None))
+    }
 }
 
 /// Serialize a MachineKeypair to bytes for storage.
@@ -34,11 +115,11 @@ struct SerializedKeypair {
 ///
 /// A vector containing the serialized keypair data
 pub fn serialize_machine_keypair(kp: &MachineKeypair) -> Result<Vec<u8>> {
-    let data = SerializedKeypair {
-        public_key: kp.public_key().as_bytes().to_vec(),
-        secret_key: kp.secret_key().as_bytes().to_vec(),
-    };
-    bincode::serialize(&data).map_err(|e| IdentityError::Serialization(e.to_string()))
+    encode_keypair_bytes(
+        kp.public_key().as_bytes().to_vec(),
+        kp.secret_key().as_bytes().to_vec(),
+        None,
+    )
 }
 
 /// Deserialize a MachineKeypair from bytes.
@@ -51,9 +132,46 @@ pub fn serialize_machine_keypair(kp: &MachineKeypair) -> Result<Vec<u8>> {
 ///
 /// A deserialized MachineKeypair
 pub fn deserialize_machine_keypair(bytes: &[u8]) -> Result<MachineKeypair> {
-    let data: SerializedKeypair =
-        bincode::deserialize(bytes).map_err(|e| IdentityError::Serialization(e.to_string()))?;
-    MachineKeypair::from_bytes(&data.public_key, &data.secret_key)
+    let (public_key, secret_key, _not_after) = decode_keypair_bytes(bytes)?;
+    MachineKeypair::from_bytes(&public_key, &secret_key)
+}
+
+/// Deserialize a MachineKeypair along with its optional local expiry.
+///
+/// Returns `(keypair, not_after)` where `not_after` is `None` for legacy
+/// (v1) key files — absence of expiry means the key never expires.
+///
+/// # Errors
+///
+/// Returns [`IdentityError::Serialization`] if the bytes are not a valid
+/// key file, or a key-material error if the embedded bytes are malformed.
+pub fn deserialize_machine_keypair_with_expiry(
+    bytes: &[u8],
+) -> Result<(MachineKeypair, Option<u64>)> {
+    let (public_key, secret_key, not_after) = decode_keypair_bytes(bytes)?;
+    Ok((
+        MachineKeypair::from_bytes(&public_key, &secret_key)?,
+        not_after,
+    ))
+}
+
+/// Serialize a MachineKeypair recording an optional local expiry.
+///
+/// `None` writes the legacy v1 format byte-for-byte; `Some` writes the v2
+/// format carrying `not_after`.
+///
+/// # Errors
+///
+/// Returns [`IdentityError::Serialization`] if encoding fails.
+pub fn serialize_machine_keypair_with_expiry(
+    kp: &MachineKeypair,
+    not_after: Option<u64>,
+) -> Result<Vec<u8>> {
+    encode_keypair_bytes(
+        kp.public_key().as_bytes().to_vec(),
+        kp.secret_key().as_bytes().to_vec(),
+        not_after,
+    )
 }
 
 /// Serialize an AgentKeypair to bytes for storage.
@@ -66,11 +184,30 @@ pub fn deserialize_machine_keypair(bytes: &[u8]) -> Result<MachineKeypair> {
 ///
 /// A vector containing the serialized keypair data
 pub fn serialize_agent_keypair(kp: &AgentKeypair) -> Result<Vec<u8>> {
-    let data = SerializedKeypair {
-        public_key: kp.public_key().as_bytes().to_vec(),
-        secret_key: kp.secret_key().as_bytes().to_vec(),
-    };
-    bincode::serialize(&data).map_err(|e| IdentityError::Serialization(e.to_string()))
+    encode_keypair_bytes(
+        kp.public_key().as_bytes().to_vec(),
+        kp.secret_key().as_bytes().to_vec(),
+        None,
+    )
+}
+
+/// Serialize an AgentKeypair recording an optional local expiry.
+///
+/// `None` writes the legacy v1 format byte-for-byte; `Some` writes the v2
+/// format carrying `not_after`.
+///
+/// # Errors
+///
+/// Returns [`IdentityError::Serialization`] if encoding fails.
+pub fn serialize_agent_keypair_with_expiry(
+    kp: &AgentKeypair,
+    not_after: Option<u64>,
+) -> Result<Vec<u8>> {
+    encode_keypair_bytes(
+        kp.public_key().as_bytes().to_vec(),
+        kp.secret_key().as_bytes().to_vec(),
+        not_after,
+    )
 }
 
 /// Deserialize an AgentKeypair from bytes.
@@ -83,9 +220,25 @@ pub fn serialize_agent_keypair(kp: &AgentKeypair) -> Result<Vec<u8>> {
 ///
 /// A deserialized AgentKeypair
 pub fn deserialize_agent_keypair(bytes: &[u8]) -> Result<AgentKeypair> {
-    let data: SerializedKeypair =
-        bincode::deserialize(bytes).map_err(|e| IdentityError::Serialization(e.to_string()))?;
-    AgentKeypair::from_bytes(&data.public_key, &data.secret_key)
+    let (public_key, secret_key, _not_after) = decode_keypair_bytes(bytes)?;
+    AgentKeypair::from_bytes(&public_key, &secret_key)
+}
+
+/// Deserialize an AgentKeypair along with its optional local expiry.
+///
+/// Returns `(keypair, not_after)` where `not_after` is `None` for legacy
+/// (v1) key files — absence of expiry means the key never expires.
+///
+/// # Errors
+///
+/// Returns [`IdentityError::Serialization`] if the bytes are not a valid
+/// key file, or a key-material error if the embedded bytes are malformed.
+pub fn deserialize_agent_keypair_with_expiry(bytes: &[u8]) -> Result<(AgentKeypair, Option<u64>)> {
+    let (public_key, secret_key, not_after) = decode_keypair_bytes(bytes)?;
+    Ok((
+        AgentKeypair::from_bytes(&public_key, &secret_key)?,
+        not_after,
+    ))
 }
 
 /// x0x configuration directory path.
@@ -381,11 +534,11 @@ pub async fn load_agent_keypair_from<P: AsRef<Path>>(path: P) -> Result<AgentKey
 ///
 /// A vector containing the serialized keypair data
 pub fn serialize_user_keypair(kp: &UserKeypair) -> Result<Vec<u8>> {
-    let data = SerializedKeypair {
-        public_key: kp.public_key().as_bytes().to_vec(),
-        secret_key: kp.secret_key().as_bytes().to_vec(),
-    };
-    bincode::serialize(&data).map_err(|e| IdentityError::Serialization(e.to_string()))
+    encode_keypair_bytes(
+        kp.public_key().as_bytes().to_vec(),
+        kp.secret_key().as_bytes().to_vec(),
+        None,
+    )
 }
 
 /// Deserialize a UserKeypair from bytes.
@@ -398,9 +551,8 @@ pub fn serialize_user_keypair(kp: &UserKeypair) -> Result<Vec<u8>> {
 ///
 /// A deserialized UserKeypair
 pub fn deserialize_user_keypair(bytes: &[u8]) -> Result<UserKeypair> {
-    let data: SerializedKeypair =
-        bincode::deserialize(bytes).map_err(|e| IdentityError::Serialization(e.to_string()))?;
-    UserKeypair::from_bytes(&data.public_key, &data.secret_key)
+    let (public_key, secret_key, _not_after) = decode_keypair_bytes(bytes)?;
+    UserKeypair::from_bytes(&public_key, &secret_key)
 }
 
 /// Save a UserKeypair to the default storage location (`~/.x0x/user.key`).
@@ -838,6 +990,87 @@ mod tests {
             kp.user_id(),
             loaded.user_id(),
             "user_id must survive a save/load round-trip"
+        );
+    }
+
+    // ── Key-file expiry format versioning (issue #130) ──
+
+    #[test]
+    fn keyfile_without_expiry_writes_legacy_format() {
+        // The no-break guarantee: when no expiry is recorded, the bytes must
+        // be identical to the legacy `bincode(public_key, secret_key)` shape
+        // an older x0x would write and read. A regression here silently
+        // rewrites every user's key file into a format old daemons reject.
+        let kp = MachineKeypair::generate().unwrap();
+        let modern = serialize_machine_keypair(&kp).unwrap();
+        let legacy = bincode::serialize(&SerializedKeypair {
+            public_key: kp.public_key().as_bytes().to_vec(),
+            secret_key: kp.secret_key().as_bytes().to_vec(),
+        })
+        .unwrap();
+        assert_eq!(
+            modern, legacy,
+            "a no-expiry key file must be byte-for-byte the legacy format"
+        );
+        // And must NOT carry the v2 marker.
+        assert_ne!(
+            &modern[..KEYFILE_V2_MAGIC.len()],
+            KEYFILE_V2_MAGIC,
+            "legacy bytes must not begin with the v2 magic marker"
+        );
+    }
+
+    #[test]
+    fn legacy_keyfile_bytes_load_via_new_loader() {
+        // Bytes written by a pre-#130 x0x (bare bincode, no marker) must load
+        // through the new versioned loader unchanged, reporting no expiry.
+        let kp = AgentKeypair::generate().unwrap();
+        let legacy = bincode::serialize(&SerializedKeypair {
+            public_key: kp.public_key().as_bytes().to_vec(),
+            secret_key: kp.secret_key().as_bytes().to_vec(),
+        })
+        .unwrap();
+        let (loaded, not_after) = deserialize_agent_keypair_with_expiry(&legacy).unwrap();
+        assert_eq!(
+            loaded.public_key().as_bytes(),
+            kp.public_key().as_bytes(),
+            "legacy key bytes must decode to the same public key"
+        );
+        assert_eq!(
+            not_after, None,
+            "absence of an expiry field must decode as None (never expires)"
+        );
+    }
+
+    #[test]
+    fn v2_keyfile_roundtrip_preserves_not_after() {
+        // The v2 format must round-trip the recorded expiry exactly, and the
+        // v1 loader must still recover the key material from a v2 file.
+        let kp = MachineKeypair::generate().unwrap();
+        let expiry = 1_900_000_000u64;
+        let bytes = serialize_machine_keypair_with_expiry(&kp, Some(expiry)).unwrap();
+        assert_eq!(
+            &bytes[..KEYFILE_V2_MAGIC.len()],
+            KEYFILE_V2_MAGIC,
+            "a v2 key file must begin with the magic marker"
+        );
+        let (loaded, not_after) = deserialize_machine_keypair_with_expiry(&bytes).unwrap();
+        assert_eq!(
+            not_after,
+            Some(expiry),
+            "the recorded expiry must survive a v2 round-trip"
+        );
+        assert_eq!(
+            loaded.public_key().as_bytes(),
+            kp.public_key().as_bytes(),
+            "v2 key material must survive a round-trip"
+        );
+        // The plain (non-expiry) loader must also cope with a v2 file.
+        let plain = deserialize_machine_keypair(&bytes).unwrap();
+        assert_eq!(
+            plain.public_key().as_bytes(),
+            kp.public_key().as_bytes(),
+            "the plain loader must recover key material from a v2 file"
         );
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -605,8 +605,7 @@ pub async fn load_user_keypair_from<P: AsRef<Path>>(path: P) -> Result<UserKeypa
 pub async fn save_agent_certificate(cert: &AgentCertificate) -> Result<()> {
     let dir = x0x_dir().await?;
     let path = dir.join(AGENT_CERT_FILE);
-    let bytes =
-        bincode::serialize(cert).map_err(|e| IdentityError::Serialization(e.to_string()))?;
+    let bytes = cert.to_storage_bytes()?;
     write_private_file(&path, bytes).await
 }
 
@@ -614,7 +613,7 @@ pub async fn save_agent_certificate(cert: &AgentCertificate) -> Result<()> {
 pub async fn load_agent_certificate() -> Result<AgentCertificate> {
     let path = x0x_dir().await?.join(AGENT_CERT_FILE);
     let bytes = fs::read(&path).await.map_err(IdentityError::from)?;
-    bincode::deserialize(&bytes).map_err(|e| IdentityError::Serialization(e.to_string()))
+    AgentCertificate::from_storage_bytes(&bytes)
 }
 
 /// Check if an agent certificate exists in the default storage location.
@@ -632,15 +631,14 @@ pub async fn save_agent_certificate_to<P: AsRef<Path> + Clone>(
     cert: &AgentCertificate,
     path: P,
 ) -> Result<()> {
-    let bytes =
-        bincode::serialize(cert).map_err(|e| IdentityError::Serialization(e.to_string()))?;
+    let bytes = cert.to_storage_bytes()?;
     write_private_file(path.as_ref(), bytes).await
 }
 
 /// Load an AgentCertificate from the specified file path.
 pub async fn load_agent_certificate_from<P: AsRef<Path>>(path: P) -> Result<AgentCertificate> {
     let bytes = tokio::fs::read(path).await.map_err(IdentityError::from)?;
-    bincode::deserialize(&bytes).map_err(|e| IdentityError::Serialization(e.to_string()))
+    AgentCertificate::from_storage_bytes(&bytes)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implements the cryptographic core of issue #130 (key lifecycle: expiry, renewal, revocation), following `docs/plans/2026-07-issue-130-key-lifecycle-plan.md`. ADR is 0018 (0019 reserved for the connect ACL).

This PR lands **steps 1–3** of the plan's 9-step breakdown — the security-critical, independently-reviewable foundation (versioned key/cert containers, signature-covered certificate expiry, and the signed revocation module). The network-wiring steps (4–9) are scoped as follow-up below.

## What landed (one commit per step)

### Step 1 — `refactor(storage)`: versioned key-file format
- Magic-marked (`X0K2`) v2 key-file format carrying an optional local `not_after`. When no expiry is recorded, the bytes are **byte-for-byte the legacy format**, so existing `~/.x0x/*.key` files stay compatible. A legacy file begins with the ML-DSA-65 public-key length prefix (`0xA0 0x07 …`) so it can never collide with the marker; absence of the marker unambiguously means "legacy, never expires".
- Key-file expiry is a **local record only** — never enforced over the network (only cert expiry is).

### Step 2 — `feat(identity)`: signature-covered certificate expiry
- `AgentCertificate` gains `not_after: Option<u64>`. **Absence of expiry ⇒ valid forever**: with `None`, the signed message and on-disk bytes are byte-identical to every cert x0x has issued (v1 domain prefix `x0x-agent-cert-v1`), so old certs verify unchanged.
- With `Some`, the signature is taken over a distinct v2 domain prefix (`x0x-agent-cert-v2`) with the expiry appended — so **stripping or altering the expiry fails verification** rather than silently extending validity.
- Cert files use the same magic-marker versioning (`X0C2`): a no-expiry cert writes the legacy 4-field bincode (downgrade-safe); legacy `agent.cert` files decode via a private v1 disk shape → `not_after: None`.
- One shared expiry helper: `EXPIRY_CLOCK_SKEW_SECS = 300` and `is_expired(not_after, now)` — **fail open only for a genuinely-missing expiry**, never for a present one.

### Step 3 — `feat(identity)`: signed revocation records + grow-only set
- New `src/revocation.rs`. `RevocationRecord` is signed and self-authenticating. Authority is **exactly two rules**, both verifiable without any trust state:
  1. **self-revocation** — the issuer key hashes to the subject id (revoking a stolen key only helps the victim);
  2. **issuer-revocation** — for an `Agent` subject, the issuer is the user key that signed the agent's certificate (proven by that cert).
- **No third-party revocation. No un-revocation.** `RevocationSet` is a grow-only G-Set (O(1) agent/machine gate checks + hash-keyed record map for rebroadcast), de-duplicated by BLAKE3 of the canonical signed bytes → gossip replay is idempotent, no rollback class. Persists as an `X0XR`-magic bincode file.
- Adds `IdentityError::Revocation`.

## Security properties & the tests that pin them
- **Absence of expiry = valid forever** → `cert_v1_without_not_after_still_verifies`, `cert_v1_disk_bytes_load_unchanged`, `legacy_keyfile_bytes_load_via_new_loader`, `keyfile_without_expiry_writes_legacy_format`, `is_expired(None, ..) == false`.
- **Expiry is signature-covered** → `cert_not_after_tamper_fails_verification` (stripping and extending both fail).
- **Clock skew (300s)** → `expiry_allows_within_skew` (−120s honored), `expiry_rejects_beyond_skew` (−600s expired).
- **Revocation authority (self + issuer only, fail-closed)** → `revocation_self_signed_verifies`, `revocation_machine_self_signed_verifies`, `revocation_user_signed_for_certified_agent_verifies`, `revocation_user_without_cert_rejected`, `revocation_unrelated_key_rejected`, `revocation_forged_signature_rejected`.
- **Grow-only / partition-tolerance building blocks** → `revocation_set_merge_grow_only_idempotent`, `revocation_set_persists_and_reloads`.

## Gate results (rebased on latest `main`)
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅ zero warnings
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` ✅
- `cargo nextest run --all-features --workspace` → **2008 passed, 194 skipped, 1 flake**. The lone failure is the pre-existing timing flake `named_group_join_metadata_event::forged_member_joined_admin_role_or_secret_is_rejected` (a convergence **timeout**, not an assertion; passes in isolation; unrelated to this PR — a recent commit relaxed its timing budget). This PR touches no group-join code.
- New tests added by this PR: **21** (3 storage, 8 cert/expiry, 10 revocation) — all green.

## Deferred to follow-up (plan steps 4–9)
The revocation module is pure (no network wiring yet). Remaining, per plan D4/D5/D7:
- **Step 4 — gossip propagation**: `REVOCATION_TOPIC`, `revocation_set` field on `Agent`, subscribe/apply task at startup, publish-on-issue, heartbeat anti-entropy rebroadcast, disk load.
- **Step 5 — enforcement wiring [SEC]** (the 5 D5 points): announcement ingest (drop revoked/expired; add `cert_not_after` to `DiscoveredAgent`), `is_agent_machine_verified`, DM-inbox drop + counter, group-metadata gate **revocation-beats-`bypass_verified`** ordering (must not regress #99 MemberRemoved/GroupDeleted), and active cache-eviction/contact-block on receipt.
- **Step 6** — `POST /identity/renew` + mutable cert slot + re-announce.
- **Step 7** — `POST /identity/revoke`, `GET /identity/revocations` REST/CLI + `api/mod.rs` registry.
- **Step 8** — three two-daemon e2e tests (`daemon_api_integration.rs` conventions, `#[ignore]`-tiered).
- **Step 9** — ADR-0018 + `docs/api-reference.md` + CHANGELOG.

The public APIs needed by steps 4–7 already exist in this PR (`RevocationRecord::sign/verify_authority`, `RevocationSet`, `issue_with_expiry`, `is_expired`, versioned storage helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Security review follow-up (commit `fix(identity): re-verify revocation authority on load …`)

Addressed the HIGH + two MEDIUM findings from independent review:

- **[HIGH] `from_bytes` now re-verifies authority on load.** `revocations.bin` is treated as untrusted input. Each record is persisted **together with the subject certificate that authorizes it** (present only for issuer-revocations; self-revocations re-verify from the record alone). On load, every record is re-run through `verify_authority` against that persisted cert; any that fails — a forged signature, or an issuer-revocation whose cert doesn't authorize it — is **dropped**, so a tampered file cannot inject a revocation. Pinned by `revocation_set_from_bytes_rejects_forged_and_unrelated_records`.
- **[MEDIUM] Verify-then-insert is the only entry path.** `pub fn verify_and_insert(record, subject_cert)` verifies authority then inserts atomically; the raw insert is now module-private (stronger than `pub(crate)`) and reachable only through it. `from_bytes` and the future step-4 gossip handler both route through it — removing the "forgot to verify" footgun.
- **[MEDIUM] bincode / `serde(default)` documented** on `AgentCertificate.not_after`.

### Compatibility guarantee — precise scope
The **no-breaking-change guarantee applies to ON-DISK key/cert files only** (magic-marker versioning: `X0K2`/`X0C2`/`X0XR`). It does **not** cover the announcement **wire format**: a certificate embedded in a gossip announcement gains trailing positional bincode bytes when `not_after` is present, so a mixed-version fleet carrying **user-certified** agents is a known, coordinated-fleet-upgrade break (plan D3). Announcements without a user cert (`agent_certificate: None`, a single `0x00`) are unaffected.

### Intentional behavior to document in ADR-0018
An **expired user certificate can still authorize an issuer-revocation**: `cert.verify()` checks the binding signature, not expiry, and `verify_authority` deliberately does not expiry-check the authorizing cert. This is intentional — it permits **emergency revocation of an agent after its certificate has expired**. To be recorded in ADR-0018 (step 9).
