### PR TITLE
ci(release): fix green-CI gate (GH_REPO) blocking v0.28.0 publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,10 @@ jobs:
       - name: Require a successful CI run for ${{ github.sha }}
         env:
           GH_TOKEN: ${{ github.token }}
+          # `gh run list` needs the repo; without a checkout `gh` cannot infer
+          # it from git and reports the CI run as "missing", failing the gate
+          # even when CI is green. Pin the repo explicitly.
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           SHA="${{ github.sha }}"


### PR DESCRIPTION
The v0.28.0 release workflow failed at the `require-green-ci` gate: `gh run list` ran without a checkout/repo → "failed to determine base repo: not a git repository" → CI reported "missing" → 20-min timeout → "Refusing to release on unknown CI". Build/sign/publish were all skipped; nothing published.

Main CI on the tagged commit (eeb04ff) is genuinely green — the gate just couldn't see it. Fix: set `GH_REPO: ${{ github.repository }}` on the gate step so `gh` resolves the repo without a git checkout.

After merge, the v0.28.0 release will be re-triggered via workflow_dispatch (or re-tag) against the fixed workflow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes repository resolution in the release CI gate. The main changes are:

- Adds `GH_REPO` to the `gh run list` step.
- Keeps the release gate pointed at the current GitHub repository.
- Documents why the no-checkout job needs explicit repo context.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds explicit GitHub CLI repository context for the release workflow’s green-CI gate. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(release): pin GH\_REPO so the green-CI..."](https://github.com/saorsa-labs/x0x/commit/d8f1d17039815e58f8724bb71055a90fd748c5ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41821474)</sub>

<!-- /greptile_comment -->