### PR TITLE
feat(relay): wire PeerRelay into the direct-DM fallback path (#158, X0X-0070b)

### DIFF
--- a/src/direct.rs
+++ b/src/direct.rs
@@ -245,6 +245,7 @@ fn dm_path_label(path: DmPath) -> &'static str {
         DmPath::GossipInbox => "gossip_inbox",
         DmPath::RawQuic => "raw_quic",
         DmPath::RawQuicAcked => "raw_quic_acked",
+        DmPath::Relayed { .. } => "relayed",
     }
 }
 
@@ -443,6 +444,7 @@ struct DirectDiagnosticsCounters {
     outgoing_path_loopback: AtomicU64,
     outgoing_path_raw_quic: AtomicU64,
     outgoing_path_gossip_inbox: AtomicU64,
+    outgoing_path_relayed: AtomicU64,
     incoming_envelopes_total: AtomicU64,
     incoming_decode_failed: AtomicU64,
     incoming_signature_failed: AtomicU64,
@@ -488,6 +490,8 @@ pub struct DmDiagnosticsStats {
     pub outgoing_path_loopback: u64,
     pub outgoing_path_raw_quic: u64,
     pub outgoing_path_gossip_inbox: u64,
+    /// X0X-0070b: outgoing DMs delivered via the application-level peer relay.
+    pub outgoing_path_relayed: u64,
     pub incoming_envelopes_total: u64,
     pub incoming_decode_failed: u64,
     pub incoming_signature_failed: u64,
@@ -837,6 +841,11 @@ impl DirectMessaging {
                     .outgoing_path_gossip_inbox
                     .fetch_add(1, Ordering::Relaxed);
             }
+            DmPath::Relayed { .. } => {
+                self.diagnostics
+                    .outgoing_path_relayed
+                    .fetch_add(1, Ordering::Relaxed);
+            }
         }
         let path_label = dm_path_label(path);
         self.with_peer_diagnostics(agent_id, |peer| {
@@ -919,6 +928,10 @@ impl DirectMessaging {
             outgoing_path_gossip_inbox: self
                 .diagnostics
                 .outgoing_path_gossip_inbox
+                .load(Ordering::Relaxed),
+            outgoing_path_relayed: self
+                .diagnostics
+                .outgoing_path_relayed
                 .load(Ordering::Relaxed),
             incoming_envelopes_total: self
                 .diagnostics

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -295,6 +295,21 @@ pub enum DmError {
     /// Catch-all for gossip transport errors not classified above.
     #[error("gossip transport error: {0}")]
     PublishFailed(String),
+
+    /// X0X-0070b: the direct path failed and `PeerRelay::needs_relay`
+    /// returned true, but `PeerRelay::select_relay` had no candidate
+    /// to pick (empty or only self / dst). The caller surfaces the
+    /// original direct error; this variant is for internal
+    /// `try_relay_fallback` bookkeeping.
+    #[error("no relay candidate available")]
+    NoRelayCandidate,
+
+    /// X0X-0070b: `PeerRelay::build_relayed_dm` failed, typically a
+    /// signing or domain-separated serialization error. The caller
+    /// surfaces the original direct error; this variant is for
+    /// internal `try_relay_fallback` bookkeeping.
+    #[error("relay envelope build failed: {0}")]
+    RelayBuildFailed(String),
 }
 
 impl From<IdentityError> for DmError {
@@ -327,6 +342,14 @@ pub enum DmPath {
     RawQuic,
     /// Raw-QUIC path with ant-quic receive-pipeline ACK confirmation.
     RawQuicAcked,
+    /// X0X-0070b: delivered via the application-level peer relay
+    /// (`PeerRelay`) after the direct paths failed `fail_threshold`
+    /// times within `fail_window`. `via` is the relay candidate that
+    /// forwarded the inner `DmEnvelope`.
+    Relayed {
+        /// The relay candidate that forwarded the inner envelope.
+        via: AgentId,
+    },
 }
 
 /// Fallback RTT used when no per-peer RTT sample has reached the local cache.
@@ -879,6 +902,65 @@ impl EnvelopeBuilder {
             outcome,
         })
     }
+
+    /// Build a fully-signed [`DmEnvelope`] from the raw send-site inputs.
+    ///
+    /// Wraps the four crypto ops every direct-DM send needs - KEM
+    /// encapsulation, AEAD encryption, domain-separated signing-bytes
+    /// build, ML-DSA-65 signature - behind one entry point. The `sign`
+    /// closure receives the signing bytes and returns the signature; in
+    /// production both `dm_send::send_via_gossip` and X0X-0070b's
+    /// `try_relay_fallback` pass a closure backed by
+    /// `gossip::SigningContext::sign`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DmError::EnvelopeConstruction`] if KEM encapsulation,
+    /// AEAD encryption, signing-bytes serialisation, or the `sign`
+    /// closure fail.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_payload_envelope<F>(
+        request_id: [u8; 16],
+        self_agent_id: &AgentId,
+        self_machine_id: &MachineId,
+        recipient_agent_id: &AgentId,
+        recipient_kem_public_key: &[u8],
+        created_at_unix_ms: u64,
+        expires_at_unix_ms: u64,
+        payload: Vec<u8>,
+        sign: F,
+    ) -> std::result::Result<DmEnvelope, DmError>
+    where
+        F: FnOnce(&[u8]) -> std::result::Result<Vec<u8>, String>,
+    {
+        let body = Self::build_payload_body(
+            &request_id,
+            self_agent_id.as_bytes(),
+            recipient_agent_id.as_bytes(),
+            created_at_unix_ms,
+            payload,
+            None,
+            recipient_kem_public_key,
+        )
+        .map_err(|e| DmError::EnvelopeConstruction(e.to_string()))?;
+        let mut envelope = DmEnvelope {
+            protocol_version: DM_PROTOCOL_VERSION,
+            request_id,
+            sender_agent_id: *self_agent_id.as_bytes(),
+            sender_machine_id: *self_machine_id.as_bytes(),
+            recipient_agent_id: *recipient_agent_id.as_bytes(),
+            created_at_unix_ms,
+            expires_at_unix_ms,
+            body,
+            signature: Vec::new(),
+        };
+        let signed = envelope
+            .signed_bytes()
+            .map_err(|e| DmError::EnvelopeConstruction(e.to_string()))?;
+        envelope.signature =
+            sign(&signed).map_err(|e| DmError::EnvelopeConstruction(format!("sign: {e}")))?;
+        Ok(envelope)
+    }
 }
 
 // ─── In-flight ACK tracking ────────────────────────────────────────────────
@@ -1131,6 +1213,65 @@ mod tests {
         let tb = dm_inbox_topic(&b);
         assert_eq!(ta1, ta2);
         assert_ne!(ta1, tb);
+    }
+
+    #[tokio::test]
+    async fn build_payload_envelope_produces_verifiable_envelope() {
+        // Why: X0X-0070b's `try_relay_fallback` and
+        // `dm_send::send_via_gossip` both rely on this helper to produce
+        // a fully signed envelope from raw inputs. The whole DM trust
+        // model collapses if the returned envelope does not verify
+        // against the sender's own ML-DSA-65 public key - pin it.
+        use crate::gossip::SigningContext;
+        use crate::groups::kem_envelope::AgentKemKeypair;
+        use crate::identity::{AgentKeypair, MachineKeypair};
+
+        let agent_kp = AgentKeypair::generate().expect("agent keypair");
+        let machine_kp = MachineKeypair::generate().expect("machine keypair");
+        let recipient_kem = AgentKemKeypair::generate().expect("recipient KEM keypair");
+        let signing = SigningContext::from_keypair(&agent_kp);
+
+        let sender = agent_kp.agent_id();
+        let machine = machine_kp.machine_id();
+        let recipient = AgentKeypair::generate()
+            .expect("recipient agent keypair")
+            .agent_id();
+        let now = now_unix_ms();
+        let request_id = [9u8; 16];
+
+        let envelope = EnvelopeBuilder::build_payload_envelope(
+            request_id,
+            &sender,
+            &machine,
+            &recipient,
+            &recipient_kem.public_bytes,
+            now,
+            now + 60_000,
+            b"hello-x0x-0070b".to_vec(),
+            |bytes| signing.sign(bytes).map_err(|e| e.to_string()),
+        )
+        .expect("envelope build");
+
+        assert_eq!(envelope.request_id, request_id);
+        assert_eq!(envelope.sender_agent_id, *sender.as_bytes());
+        assert_eq!(envelope.recipient_agent_id, *recipient.as_bytes());
+        assert!(
+            !envelope.signature.is_empty(),
+            "build_payload_envelope must produce a non-empty signature"
+        );
+        let signed_bytes = envelope.signed_bytes().expect("signed bytes");
+        let sender_pub_bytes = agent_kp.to_bytes().0;
+        let pubkey =
+            ant_quic::MlDsaPublicKey::from_bytes(&sender_pub_bytes).expect("agent pubkey parse");
+        let signature =
+            ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(&envelope.signature)
+                .expect("signature parse");
+        ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+            &pubkey,
+            &signed_bytes,
+            &signature,
+        )
+        .expect("envelope signature must verify against the sender's public key");
     }
 
     #[test]

--- a/src/dm_send.rs
+++ b/src/dm_send.rs
@@ -1,8 +1,8 @@
 //! Sender-side gossip DM path (phase 4 of `docs/design/dm-over-gossip.md`).
 
 use crate::dm::{
-    dm_inbox_topic, now_unix_ms, DmAckOutcome, DmEnvelope, DmError, DmPath, DmReceipt,
-    DmSendConfig, EnvelopeBuilder, InFlightAcks, DM_PROTOCOL_VERSION, MAX_PAYLOAD_BYTES,
+    dm_inbox_topic, now_unix_ms, DmAckOutcome, DmError, DmPath, DmReceipt, DmSendConfig,
+    EnvelopeBuilder, InFlightAcks, MAX_PAYLOAD_BYTES,
 };
 use crate::dm_inbox::{DmInboxService, DM_BUS_TOPIC};
 use crate::error::IdentityError;
@@ -86,31 +86,17 @@ pub async fn send_via_gossip(
 
     let created = now_unix_ms();
     let expires = created.saturating_add(DEFAULT_ENVELOPE_LIFETIME_MS);
-    let body = EnvelopeBuilder::build_payload_body(
-        &request_id,
-        self_agent_id.as_bytes(),
-        recipient_agent_id.as_bytes(),
-        created,
-        payload,
-        None,
-        recipient_kem_public_key,
-    )
-    .map_err(map_identity_err)?;
-    let mut envelope = DmEnvelope {
-        protocol_version: DM_PROTOCOL_VERSION,
+    let envelope = EnvelopeBuilder::build_payload_envelope(
         request_id,
-        sender_agent_id: *self_agent_id.as_bytes(),
-        sender_machine_id: *self_machine_id.as_bytes(),
-        recipient_agent_id: *recipient_agent_id.as_bytes(),
-        created_at_unix_ms: created,
-        expires_at_unix_ms: expires,
-        body,
-        signature: Vec::new(),
-    };
-    let signed = envelope.signed_bytes().map_err(map_identity_err)?;
-    envelope.signature = signing
-        .sign(&signed)
-        .map_err(|e| DmError::EnvelopeConstruction(format!("sign: {e}")))?;
+        &self_agent_id,
+        &self_machine_id,
+        &recipient_agent_id,
+        recipient_kem_public_key,
+        created,
+        expires,
+        payload,
+        |bytes| signing.sign(bytes).map_err(|e| e.to_string()),
+    )?;
     let wire = envelope.to_wire_bytes().map_err(map_identity_err)?;
     let topic = DmInboxService::inbox_topic_name(&recipient_agent_id);
     let topic_id = dm_inbox_topic(&recipient_agent_id);
@@ -497,7 +483,7 @@ impl Drop for InFlightGuard {
     }
 }
 
-fn fresh_request_id() -> [u8; 16] {
+pub(crate) fn fresh_request_id() -> [u8; 16] {
     use rand::RngCore;
     let mut rid = [0u8; 16];
     rand::thread_rng().fill_bytes(&mut rid);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,18 @@ pub struct Agent {
     /// began. A plain `std::sync::Mutex` (not tokio) keeps lock holds trivially
     /// short: never await while holding it.
     tracked_tasks: std::sync::Arc<std::sync::Mutex<TrackedTasks>>,
+    /// X0X-0070b: application-level peer-relay engine. Records direct-DM
+    /// successes and failures so [`peer_relay::PeerRelay::needs_relay`] can
+    /// drive the fallback decision. The engine is disabled by default
+    /// (matches [`peer_relay::RelayPolicy::default`]) - it only acts once a
+    /// runtime opts in via `[peer_relay] enabled = true` in the daemon's
+    /// `NetworkConfig` TOML.
+    peer_relay: std::sync::Arc<peer_relay::PeerRelay>,
+    /// X0X-0070b: pre-filtered set of relay candidates the engine picks from
+    /// when the direct path fails. Seeded from `NetworkConfig.peer_relay.candidates`
+    /// at build time; future revisions merge in gossip-announced candidates
+    /// at runtime, hence the `RwLock` for mutable runtime state.
+    relay_candidates: std::sync::Arc<tokio::sync::RwLock<Vec<identity::AgentId>>>,
 }
 
 /// Closed-flag task registry for deterministic Agent teardown.
@@ -3893,6 +3905,18 @@ impl Agent {
             capability_store_entries = self.capability_store.len(),
         );
 
+        // X0X-0070b: seed the relay fallback. Only retain the payload + KEM
+        // key clone when the engine is enabled AND we have a key to seal
+        // a fresh envelope with. With the default disabled policy this
+        // closure never runs - the happy path pays nothing.
+        let relay_seed: Option<(Vec<u8>, Vec<u8>)> = if self.peer_relay.policy().enabled {
+            cap.as_ref()
+                .filter(|c| !c.kem_public_key.is_empty())
+                .map(|c| (payload.clone(), c.kem_public_key.clone()))
+        } else {
+            None
+        };
+
         let rtt_hint_ms = self.dm_peer_rtt_ms(to).await;
         let mut config = config;
         // Direct transport RTT is a valid hint for raw-QUIC work, but it is
@@ -4008,13 +4032,172 @@ impl Agent {
             }
         };
 
-        match &result {
-            Ok(receipt) => self
-                .direct_messaging
-                .record_outgoing_succeeded(*to, receipt.path),
-            Err(_) => self.direct_messaging.record_outgoing_failed(*to),
+        match result {
+            Ok(receipt) => {
+                self.direct_messaging
+                    .record_outgoing_succeeded(*to, receipt.path);
+                // X0X-0070b: every direct-DM success clears the relay engine's
+                // per-peer failure history. A peer that had crossed
+                // `needs_relay` and now recovers a direct path increments
+                // `direct_recovered_after_relay` exactly once - proving the
+                // fallback is transient.
+                self.peer_relay.record_direct_success(to);
+                Ok(receipt)
+            }
+            Err(direct_err) => {
+                self.direct_messaging.record_outgoing_failed(*to);
+                // X0X-0070b: count this direct-DM failure on the relay engine.
+                // With the default disabled policy `needs_relay` always
+                // returns `false` and the fallback below is skipped. With
+                // an opted-in policy this drives the relay decision.
+                self.peer_relay.record_direct_failure(to);
+                // X0X-0070b: relay fallback. We only attempt it when the
+                // engine says the peer has now crossed `needs_relay`, and
+                // only when we have both a saved payload and a recipient
+                // KEM key - without those the relay envelope can't be
+                // sealed. On ANY relay-side failure we surface the
+                // ORIGINAL direct error so the caller's view stays
+                // consistent with the path that was actually tried.
+                if let Some((saved_payload, kem_pub)) = relay_seed {
+                    if self.peer_relay.needs_relay(to) {
+                        match self.try_relay_fallback(to, saved_payload, &kem_pub).await {
+                            Ok(relay_receipt) => {
+                                self.direct_messaging
+                                    .record_outgoing_succeeded(*to, relay_receipt.path);
+                                return Ok(relay_receipt);
+                            }
+                            Err(relay_err) => {
+                                tracing::debug!(
+                                    target: "x0x::relay",
+                                    recipient = %hex::encode(to.as_bytes()),
+                                    direct_err = %direct_err,
+                                    relay_err = %relay_err,
+                                    "X0X-0070b relay fallback failed; surfacing original direct error"
+                                );
+                            }
+                        }
+                    }
+                }
+                Err(direct_err)
+            }
         }
-        result
+    }
+
+    /// X0X-0070b: wrap `payload` in a fresh sealed [`dm::DmEnvelope`] +
+    /// [`peer_relay::RelayedDm`], pick a relay candidate via
+    /// [`peer_relay::PeerRelay::select_relay`], and forward to that candidate
+    /// over the same direct-DM transport using the dedicated
+    /// [`network::RELAYED_DM_STREAM_TYPE`] stream-type. The relay verifies
+    /// the [`peer_relay::RelayHeader`] signature, confirms it is being
+    /// asked to forward (not to be the final recipient), and sends the
+    /// inner envelope on to `to` - one hop only, no re-wrapping.
+    ///
+    /// # Errors
+    ///
+    /// - [`dm::DmError::NoRelayCandidate`] if no third-party candidate
+    ///   exists or the candidate's `MachineId` is not in the discovery
+    ///   cache (we need it to address the QUIC peer).
+    /// - [`dm::DmError::RelayBuildFailed`] if signing the
+    ///   [`peer_relay::RelayHeader`] or parsing the agent secret key
+    ///   fails.
+    /// - [`dm::DmError::EnvelopeConstruction`] if KEM encapsulation /
+    ///   AEAD seal / envelope signature fails (delegates to
+    ///   [`dm::EnvelopeBuilder::build_payload_envelope`]).
+    /// - [`dm::DmError::NoConnectivity`] if no network is configured.
+    /// - [`dm::DmError::PublishFailed`] if the underlying
+    ///   [`network::NetworkNode::send_direct_typed`] send fails.
+    async fn try_relay_fallback(
+        &self,
+        to: &identity::AgentId,
+        payload: Vec<u8>,
+        recipient_kem_public_key: &[u8],
+    ) -> Result<dm::DmReceipt, dm::DmError> {
+        let sender = self.identity.agent_id();
+        let candidates = self.relay_candidates.read().await.clone();
+        let Some(relay_agent) = self.peer_relay.select_relay(&candidates, to, &sender) else {
+            return Err(dm::DmError::NoRelayCandidate);
+        };
+
+        let relay_machine_id = {
+            let cache = self.identity_discovery_cache.read().await;
+            cache.get(&relay_agent).map(|e| e.machine_id)
+        };
+        let Some(relay_machine_id) = relay_machine_id else {
+            // We have the relay candidate's agent_id but no machine_id -
+            // can't address the QUIC peer. Treat as "no candidate" so the
+            // caller surfaces the original direct error.
+            return Err(dm::DmError::NoRelayCandidate);
+        };
+
+        let now = dm::now_unix_ms();
+        let expires = now.saturating_add(dm_send::DEFAULT_ENVELOPE_LIFETIME_MS);
+        let request_id = dm_send::fresh_request_id();
+        let signing = gossip::SigningContext::from_keypair(self.identity.agent_keypair());
+        let envelope = dm::EnvelopeBuilder::build_payload_envelope(
+            request_id,
+            &sender,
+            &self.identity.machine_id(),
+            to,
+            recipient_kem_public_key,
+            now,
+            expires,
+            payload,
+            |bytes| signing.sign(bytes).map_err(|e| e.to_string()),
+        )?;
+
+        let (sender_pub_bytes, sender_sec_bytes) = self.identity.agent_keypair().to_bytes();
+        let sender_secret = ant_quic::MlDsaSecretKey::from_bytes(&sender_sec_bytes)
+            .map_err(|e| dm::DmError::RelayBuildFailed(format!("agent secret key: {e:?}")))?;
+        let relayed = self
+            .peer_relay
+            .build_relayed_dm(to, &sender, sender_pub_bytes, now, envelope, |bytes| {
+                ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(&sender_secret, bytes)
+                    .map(|s| s.as_bytes().to_vec())
+                    .map_err(|e| format!("{e:?}"))
+            })
+            .map_err(dm::DmError::RelayBuildFailed)?;
+
+        let wire = postcard::to_allocvec(&relayed).map_err(|e| {
+            dm::DmError::EnvelopeConstruction(format!("relayed envelope postcard: {e}"))
+        })?;
+        let network = self
+            .network
+            .as_ref()
+            .ok_or_else(|| dm::DmError::NoConnectivity("no network for relay send".to_string()))?;
+        let relay_peer_id = ant_quic::PeerId(relay_machine_id.0);
+        network
+            .send_direct_typed(
+                &relay_peer_id,
+                sender.as_bytes(),
+                network::RELAYED_DM_STREAM_TYPE,
+                &wire,
+            )
+            .await
+            .map_err(|e| dm::DmError::PublishFailed(format!("relay send: {e}")))?;
+
+        Ok(dm::DmReceipt {
+            request_id,
+            accepted_at: std::time::Instant::now(),
+            retries_used: 0,
+            path: dm::DmPath::Relayed { via: relay_agent },
+        })
+    }
+
+    /// X0X-0070b: borrow the application-level peer-relay engine. Runtimes
+    /// use this to read [`peer_relay::RelayStats`] for telemetry and to
+    /// inspect the active [`peer_relay::RelayPolicy`].
+    #[must_use]
+    pub fn peer_relay(&self) -> &peer_relay::PeerRelay {
+        &self.peer_relay
+    }
+
+    /// X0X-0070b: snapshot the current relay candidate set. Returns a
+    /// freshly-cloned vector so the caller never holds the underlying
+    /// `RwLock`. The set is seeded from `NetworkConfig.peer_relay.candidates`
+    /// at build time; the gossip-announce subscriber (a follow-up commit)
+    /// extends it at runtime.
+    pub async fn relay_candidates(&self) -> Vec<identity::AgentId> {
+        self.relay_candidates.read().await.clone()
     }
 
     /// Legacy raw-QUIC direct-send path. Internal fallback only.
@@ -4286,6 +4469,7 @@ impl Agent {
                     dm::DmPath::RawQuic => "raw_quic",
                     dm::DmPath::RawQuicAcked => "raw_quic_acked",
                     dm::DmPath::GossipInbox => "gossip_inbox",
+                    dm::DmPath::Relayed { .. } => "relayed",
                 };
                 tracing::debug!(
                     target: "dm.trace",
@@ -8005,6 +8189,34 @@ impl Agent {
 
     /// Insert a discovered agent into the cache (for testing only).
     ///
+    /// Insert a [`dm::DmCapabilities`] entry for `agent_id` / `machine_id`
+    /// into the local capability store, bypassing the gossip-advert pipeline.
+    ///
+    /// # Visibility
+    ///
+    /// `#[doc(hidden)]` - tests-only seam. Production callers must rely on
+    /// the live capability-advert subscription so the store mirrors what
+    /// the network actually advertises.
+    ///
+    /// # Arguments
+    ///
+    /// * `agent_id` - Subject agent the capabilities apply to.
+    /// * `machine_id` - Subject machine. Used by the store's lookup path
+    ///   to disambiguate when an agent is reachable via multiple machines.
+    /// * `capabilities` - The [`dm::DmCapabilities`] record (KEM public
+    ///   key, gossip-inbox readiness, envelope-size cap, etc.) the sender
+    ///   should treat as authoritative.
+    #[doc(hidden)]
+    pub fn insert_capability_for_testing(
+        &self,
+        agent_id: identity::AgentId,
+        machine_id: identity::MachineId,
+        capabilities: dm::DmCapabilities,
+    ) {
+        self.capability_store
+            .insert(agent_id, machine_id, capabilities, dm::now_unix_ms());
+    }
+
     /// # Arguments
     ///
     /// * `agent` - The agent entry to insert.
@@ -8602,6 +8814,45 @@ impl AgentBuilder {
             Some((pk, sk))
         };
 
+        // X0X-0070b: extract the relay policy + seed candidate list before
+        // `self.network_config` is moved into `NetworkNode::new`. With no
+        // network config the relay engine is built from `PeerRelayConfig::default()`,
+        // which is `enabled = false` - the engine is then inert.
+        let peer_relay_config = self
+            .network_config
+            .as_ref()
+            .map(|cfg| cfg.peer_relay.clone())
+            .unwrap_or_default();
+        let mut parsed_relay_candidates = Vec::with_capacity(peer_relay_config.candidates.len());
+        for hex_str in &peer_relay_config.candidates {
+            let trimmed = hex_str.trim();
+            let bytes = hex::decode(trimmed).map_err(|e| {
+                error::IdentityError::Storage(std::io::Error::other(format!(
+                    "invalid relay candidate hex {trimmed:?}: {e}"
+                )))
+            })?;
+            let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+                error::IdentityError::Storage(std::io::Error::other(format!(
+                    "relay candidate must be 32 bytes (got {} bytes)",
+                    v.len()
+                )))
+            })?;
+            parsed_relay_candidates.push(identity::AgentId(arr));
+        }
+        let peer_relay = std::sync::Arc::new(peer_relay::PeerRelay::with_policy(
+            peer_relay_config.to_policy(),
+        ));
+        let relay_candidates =
+            std::sync::Arc::new(tokio::sync::RwLock::new(parsed_relay_candidates));
+
+        // X0X-0070b: discovery cache is hoisted out of the `Agent` literal so
+        // the relay-DM listener (spawned below) can hold an `Arc` clone of it
+        // without going through `&self` - the listener is a sibling task to
+        // the network receiver, not an `Agent` method.
+        let identity_discovery_cache: std::sync::Arc<
+            tokio::sync::RwLock<std::collections::HashMap<identity::AgentId, DiscoveredAgent>>,
+        > = std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+
         let network = if let Some(config) = self.network_config {
             let node = network::NetworkNode::new(config, bootstrap_cache.clone(), machine_keypair)
                 .await
@@ -8623,6 +8874,21 @@ impl AgentBuilder {
         } else {
             None
         };
+
+        // X0X-0070b: spawn the inbound RelayedDm listener so this Agent can
+        // serve as either the final recipient (DeliverLocally) or the
+        // intermediate relay (Forward) for peers that fell back to the
+        // relay path. Only meaningful when a network is configured -
+        // without one there is nothing to receive on and nothing to
+        // forward to.
+        if let Some(ref net) = network {
+            spawn_relay_dm_listener(
+                std::sync::Arc::clone(net),
+                std::sync::Arc::clone(&peer_relay),
+                std::sync::Arc::clone(&identity_discovery_cache),
+                identity.agent_id(),
+            );
+        }
 
         // Create signing context from agent keypair for message authentication
         let signing_ctx = std::sync::Arc::new(gossip::SigningContext::from_keypair(
@@ -8718,9 +8984,7 @@ impl AgentBuilder {
             gossip_runtime,
             bootstrap_cache,
             gossip_cache_adapter,
-            identity_discovery_cache: std::sync::Arc::new(tokio::sync::RwLock::new(
-                std::collections::HashMap::new(),
-            )),
+            identity_discovery_cache,
             machine_discovery_cache: std::sync::Arc::new(tokio::sync::RwLock::new(
                 std::collections::HashMap::new(),
             )),
@@ -8757,6 +9021,8 @@ impl AgentBuilder {
                 closed: false,
                 handles: Vec::new(),
             })),
+            peer_relay,
+            relay_candidates,
         })
     }
 }
@@ -9326,6 +9592,154 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The name. Three bytes. A palindrome. A philosophy.
 pub const NAME: &str = "x0x";
+
+/// X0X-0070b: drain inbound [`peer_relay::RelayedDm`] envelopes from
+/// the [`network::NetworkNode`] and dispatch via the
+/// [`peer_relay::PeerRelay`] engine. Spawned once per network-configured
+/// [`Agent`] from [`AgentBuilder::build`].
+///
+/// # Per-arm behavior
+///
+/// * [`peer_relay::RelayDisposition::DeliverLocally`] - synthesises the
+///   *original* sender's `MachineId`-as-`PeerId` from
+///   `relayed.inner.sender_machine_id` and re-injects the inner
+///   [`dm::DmEnvelope`] onto the canonical direct-DM channel via
+///   [`network::NetworkNode::inject_inbound_direct`]. The downstream
+///   direct-DM listener cannot distinguish a relayed packet from a
+///   direct one.
+/// * [`peer_relay::RelayDisposition::Forward`] - resolves `dst_agent_id`
+///   to a `MachineId` via the identity-discovery cache, re-encodes the
+///   inner envelope with postcard, and sends it on the standard
+///   direct-DM stream ([`network::DIRECT_MESSAGE_STREAM_TYPE`]). The
+///   wire prefix stamps *our* (the relay's) `AgentId` so the receiving
+///   Agent's binding check at its direct listener (wire `sender_agent_id`
+///   must match the QUIC peer's `MachineId`) passes - trust on the
+///   inner envelope still flows from its embedded ML-DSA-65 signature.
+///   If the destination is not in the discovery cache the forward
+///   drops with a `warn!`.
+/// * [`peer_relay::RelayDisposition::Refuse`] - `debug!` log only.
+///   [`peer_relay::PeerRelay::disposition_for`] already incremented the
+///   appropriate `relay_refused_*` counter as a side effect.
+fn spawn_relay_dm_listener(
+    network: std::sync::Arc<network::NetworkNode>,
+    peer_relay: std::sync::Arc<peer_relay::PeerRelay>,
+    identity_discovery_cache: std::sync::Arc<
+        tokio::sync::RwLock<std::collections::HashMap<identity::AgentId, DiscoveredAgent>>,
+    >,
+    local_agent_id: identity::AgentId,
+) {
+    tokio::spawn(async move {
+        tracing::info!(target: "x0x::relay", stage = "listener", "relay-DM listener started");
+        loop {
+            let Some((relay_peer_id, _relay_sender_agent_id, relayed)) =
+                network.recv_relayed_dm().await
+            else {
+                tracing::warn!(
+                    target: "x0x::relay",
+                    stage = "listener",
+                    "network.recv_relayed_dm channel closed - listener exiting"
+                );
+                break;
+            };
+
+            let now_ms = dm::now_unix_ms();
+            let disposition = peer_relay.disposition_for(&relayed, &local_agent_id, now_ms);
+
+            match disposition {
+                peer_relay::RelayDisposition::DeliverLocally => {
+                    let sender_machine_id = relayed.inner.sender_machine_id;
+                    let sender_peer_id = ant_quic::PeerId(sender_machine_id);
+                    let inner_wire = match postcard::to_allocvec(&relayed.inner) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "x0x::relay",
+                                stage = "deliver_local",
+                                relay_peer = ?relay_peer_id,
+                                error = %e,
+                                "failed to re-encode inner envelope for local delivery"
+                            );
+                            continue;
+                        }
+                    };
+                    // Wire shape mirrors the direct-DM listener's parse:
+                    //   [sender_agent_id: 32][postcard(DmEnvelope)]
+                    let mut payload = Vec::with_capacity(32 + inner_wire.len());
+                    payload.extend_from_slice(&relayed.inner.sender_agent_id);
+                    payload.extend_from_slice(&inner_wire);
+                    if let Err(e) = network
+                        .inject_inbound_direct(sender_peer_id, bytes::Bytes::from(payload))
+                        .await
+                    {
+                        tracing::warn!(
+                            target: "x0x::relay",
+                            stage = "deliver_local",
+                            relay_peer = ?relay_peer_id,
+                            error = %e,
+                            "DeliverLocally inject onto direct channel failed"
+                        );
+                    }
+                }
+                peer_relay::RelayDisposition::Forward { dst_agent_id } => {
+                    let dst = identity::AgentId(dst_agent_id);
+                    let dst_machine_id = {
+                        let cache = identity_discovery_cache.read().await;
+                        cache.get(&dst).map(|d| d.machine_id)
+                    };
+                    let Some(dst_machine_id) = dst_machine_id else {
+                        tracing::warn!(
+                            target: "x0x::relay",
+                            stage = "forward",
+                            dst = %hex::encode(dst.as_bytes()),
+                            "Forward dropped: dst not in identity-discovery cache"
+                        );
+                        continue;
+                    };
+                    let inner_wire = match postcard::to_allocvec(&relayed.inner) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "x0x::relay",
+                                stage = "forward",
+                                dst = %hex::encode(dst.as_bytes()),
+                                error = %e,
+                                "failed to re-encode inner envelope for forward"
+                            );
+                            continue;
+                        }
+                    };
+                    let dst_peer_id = ant_quic::PeerId(dst_machine_id.0);
+                    if let Err(e) = network
+                        .send_direct_typed(
+                            &dst_peer_id,
+                            local_agent_id.as_bytes(),
+                            network::DIRECT_MESSAGE_STREAM_TYPE,
+                            &inner_wire,
+                        )
+                        .await
+                    {
+                        tracing::warn!(
+                            target: "x0x::relay",
+                            stage = "forward",
+                            dst = %hex::encode(dst.as_bytes()),
+                            error = %e,
+                            "Forward send_direct_typed failed"
+                        );
+                    }
+                }
+                peer_relay::RelayDisposition::Refuse(reason) => {
+                    tracing::debug!(
+                        target: "x0x::relay",
+                        stage = "refuse",
+                        relay_peer = ?relay_peer_id,
+                        reason = ?reason,
+                        "RelayedDm refused"
+                    );
+                }
+            }
+        }
+    });
+}
 
 #[cfg(test)]
 mod tests {
@@ -10123,6 +10537,426 @@ mod tests {
             .direct_messaging()
             .lifecycle_block_reason(&bob.machine_id())
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn agent_peer_relay_defaults_to_disabled_when_unconfigured() {
+        // Why: X0X-0070b's relay engine is opt-in. An Agent built without
+        // any `[peer_relay]` TOML section must come up with the engine
+        // disabled and an empty candidate list - anything else would
+        // engage the fallback for operators who never asked for it.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .build()
+            .await
+            .expect("agent");
+        assert!(
+            !agent.peer_relay().policy().enabled,
+            "default Agent must have the relay engine disabled"
+        );
+        assert!(
+            agent.relay_candidates().await.is_empty(),
+            "default Agent must have no relay candidates"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_peer_relay_honors_configured_policy_and_candidates() {
+        // Why: a TOML-configured `[peer_relay]` block must flow through to
+        // a live `PeerRelay` instance on the Agent - enabled flag, fail
+        // trigger, and the seeded candidate list. This is the single
+        // integration seam where an operator's config first takes effect.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let candidate_a = [0xAA_u8; 32];
+        let candidate_b = [0xBB_u8; 32];
+        let mut net_cfg = loopback_network_config();
+        net_cfg.peer_relay = network::PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 7,
+            fail_window_ms: 90_000,
+            candidates: vec![hex::encode(candidate_a), hex::encode(candidate_b)],
+        };
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(net_cfg)
+            .build()
+            .await
+            .expect("agent");
+
+        let policy = agent.peer_relay().policy();
+        assert!(policy.enabled, "configured `enabled = true` must propagate");
+        assert_eq!(policy.fail_threshold, 7);
+        assert_eq!(policy.fail_window, std::time::Duration::from_millis(90_000));
+
+        let candidates = agent.relay_candidates().await;
+        assert_eq!(candidates.len(), 2, "both TOML candidates seeded");
+        assert!(candidates.iter().any(|c| c.0 == candidate_a));
+        assert!(candidates.iter().any(|c| c.0 == candidate_b));
+    }
+
+    #[tokio::test]
+    async fn send_direct_failure_records_failure_on_peer_relay() {
+        // Why: the bookkeeping hook in `send_direct_with_config` is the
+        // single feed into `PeerRelay::needs_relay`. If a transport
+        // failure does not increment the per-peer failure count, the
+        // engine can never decide to engage the relay - the fallback is
+        // dead-on-arrival. With no network configured every raw-QUIC
+        // attempt fails fast, which gives a deterministic test signal.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .build()
+            .await
+            .expect("agent");
+        let unreachable = identity::AgentId([0x42; 32]);
+
+        let result = agent
+            .send_direct_with_config(
+                &unreachable,
+                b"x0x-0070b-bookkeeping".to_vec(),
+                dm::DmSendConfig::default(),
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "no network configured - direct send must fail"
+        );
+        assert_eq!(
+            agent.peer_relay().tracked_peer_count(),
+            1,
+            "failure must have produced a per-peer relay-engine entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_direct_self_loopback_does_not_disturb_peer_relay() {
+        // Why: the loopback short-circuit at the top of
+        // `send_direct_with_config` returns before the bookkeeping arm.
+        // A self-DM must not count as a "direct success" against the
+        // sender's own AgentId - that would conflate local delivery
+        // with the cross-peer path that actually exercises NAT.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .build()
+            .await
+            .expect("agent");
+        let _receipt = agent
+            .send_direct_with_config(
+                &agent.agent_id(),
+                b"loopback".to_vec(),
+                dm::DmSendConfig::default(),
+            )
+            .await
+            .expect("loopback self-DM");
+        assert_eq!(
+            agent.peer_relay().tracked_peer_count(),
+            0,
+            "loopback path must not register with the relay engine"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_relay_fallback_returns_no_candidate_when_list_empty() {
+        // Why: with an enabled policy but zero seeded candidates,
+        // `select_relay` returns `None` and the helper must short-circuit
+        // to `NoRelayCandidate`. Falling through to envelope construction
+        // would burn KEM/AEAD cycles for nothing.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let mut net_cfg = loopback_network_config();
+        net_cfg.peer_relay = network::PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: Vec::new(),
+        };
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(net_cfg)
+            .build()
+            .await
+            .expect("agent");
+        let to = identity::AgentId([0xCD; 32]);
+
+        let err = agent
+            .try_relay_fallback(&to, b"payload".to_vec(), &[0u8; 32])
+            .await
+            .expect_err("empty candidate list must short-circuit");
+        assert!(
+            matches!(err, dm::DmError::NoRelayCandidate),
+            "expected NoRelayCandidate, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_relay_fallback_returns_no_candidate_when_machine_id_uncached() {
+        // Why: a seeded candidate AgentId is useless if its MachineId is
+        // not in the identity-discovery cache - we need it to address
+        // the QUIC peer at the wire layer. The helper must treat this
+        // as "no usable candidate" and let the caller surface the
+        // original direct error.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let candidate_hex = hex::encode([0xEE_u8; 32]);
+        let mut net_cfg = loopback_network_config();
+        net_cfg.peer_relay = network::PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: vec![candidate_hex],
+        };
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(net_cfg)
+            .build()
+            .await
+            .expect("agent");
+        let to = identity::AgentId([0xCD; 32]);
+
+        let err = agent
+            .try_relay_fallback(&to, b"payload".to_vec(), &[0u8; 32])
+            .await
+            .expect_err("uncached candidate must short-circuit");
+        assert!(
+            matches!(err, dm::DmError::NoRelayCandidate),
+            "expected NoRelayCandidate, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_direct_below_threshold_does_not_attempt_relay() {
+        // Why: the engine must wait until the sliding-window failure
+        // count reaches `fail_threshold` before engaging the relay.
+        // A single transport failure must surface the original direct
+        // error AND must not register `relay_sent` on the engine
+        // (proves no fallback attempt fired underneath).
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let mut net_cfg = loopback_network_config();
+        net_cfg.peer_relay = network::PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 5,
+            fail_window_ms: 60_000,
+            candidates: vec![hex::encode([0xEE_u8; 32])],
+        };
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(net_cfg)
+            .build()
+            .await
+            .expect("agent");
+        let to = identity::AgentId([0xCD; 32]);
+
+        let result = agent
+            .send_direct_with_config(&to, b"first-attempt".to_vec(), dm::DmSendConfig::default())
+            .await;
+        assert!(result.is_err(), "no usable transport - direct send fails");
+        let snap = agent.peer_relay().stats().snapshot();
+        assert_eq!(
+            snap.relay_sent, 0,
+            "below threshold must not engage the relay path"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_direct_above_threshold_without_candidates_surfaces_direct_err() {
+        // Why: the contract for relay-fallback failure is that the
+        // caller sees the ORIGINAL direct error, never the relay-side
+        // bookkeeping error. Pre-load the engine past threshold, then
+        // send to a peer with no usable candidate - the result must
+        // be a direct-transport error, not `NoRelayCandidate`.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let mut net_cfg = loopback_network_config();
+        net_cfg.peer_relay = network::PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: Vec::new(),
+        };
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(net_cfg)
+            .build()
+            .await
+            .expect("agent");
+        let to = identity::AgentId([0xCD; 32]);
+
+        // Pre-load the engine past threshold without waiting for live
+        // transport retries.
+        for _ in 0..agent.peer_relay().policy().fail_threshold {
+            agent.peer_relay().record_direct_failure(&to);
+        }
+        assert!(
+            agent.peer_relay().needs_relay(&to),
+            "engine must say the peer now needs a relay"
+        );
+
+        let err = agent
+            .send_direct_with_config(&to, b"x0x-0070b".to_vec(), dm::DmSendConfig::default())
+            .await
+            .expect_err("send must still fail when the relay path has no candidates");
+        assert!(
+            !matches!(err, dm::DmError::NoRelayCandidate),
+            "relay-side errors must not leak - original direct error must surface, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_direct_disabled_policy_does_not_engage_relay_seed() {
+        // Why: with the default disabled policy the relay-seed clone
+        // must not happen - the happy path pays nothing. Even with the
+        // peer manually driven past `fail_threshold` (which would never
+        // happen under a disabled policy in practice, but is a
+        // belt-and-braces check), the engine's `needs_relay` stays
+        // `false` and no fallback fires.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .build()
+            .await
+            .expect("agent");
+        let to = identity::AgentId([0xCD; 32]);
+        for _ in 0..10 {
+            agent.peer_relay().record_direct_failure(&to);
+        }
+        assert!(
+            !agent.peer_relay().needs_relay(&to),
+            "disabled policy must never trigger needs_relay"
+        );
+
+        let err = agent
+            .send_direct_with_config(&to, b"x0x-0070b".to_vec(), dm::DmSendConfig::default())
+            .await
+            .expect_err("no network - direct send must fail");
+        assert!(
+            !matches!(err, dm::DmError::NoRelayCandidate),
+            "disabled policy must not surface any relay-side error, got {err:?}"
+        );
+        assert_eq!(
+            agent.peer_relay().stats().snapshot().relay_sent,
+            0,
+            "disabled policy must not advance relay_sent"
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_dm_listener_refuses_bad_signature_and_ticks_counter() {
+        // Why: the receiver-side surface for X0X-0070b - a single
+        // demux arm + a listener loop that runs `disposition_for` and
+        // dispatches the three arms - depends on the listener actually
+        // draining `network.recv_relayed_dm`. If the spawn ever drops
+        // (forgotten in `AgentBuilder::build`, or the wire/channel
+        // shape drifts) the engine silently stops refusing replays
+        // and forwards, and the bug presents as "relay path is
+        // configured but nothing happens." Pin the end-to-end
+        // channel + loop liveness with the cheapest fully-typed
+        // signal we have: a `RelayedDm` with an obviously-broken
+        // header signature flows through the channel, the listener
+        // consumes it, `disposition_for` returns
+        // `Refuse(BadSignature)`, and the
+        // `relay_refused_bad_signature` counter ticks. Catches any
+        // future channel-rename / spawn-drop / wire-type regression.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let mut net_cfg = loopback_network_config();
+        net_cfg.peer_relay = network::PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: Vec::new(),
+        };
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(net_cfg)
+            .build()
+            .await
+            .expect("agent");
+
+        let network = agent
+            .network
+            .as_ref()
+            .expect("agent built with network config");
+        let sender = network.test_relayed_dm_sender();
+
+        let relayed = peer_relay::RelayedDm {
+            header: peer_relay::RelayHeader {
+                version: peer_relay::RelayHeader::VERSION,
+                dst_agent_id: agent.agent_id().0,
+                sender_agent_id: [0x42; 32],
+                // Empty pubkey + signature: header.verify() must fail.
+                sender_public_key: Vec::new(),
+                originated_at_unix_ms: dm::now_unix_ms(),
+                signature: Vec::new(),
+            },
+            inner: dm::DmEnvelope {
+                protocol_version: 1,
+                request_id: [0u8; 16],
+                sender_agent_id: [0x42; 32],
+                sender_machine_id: [0x43; 32],
+                recipient_agent_id: agent.agent_id().0,
+                created_at_unix_ms: 0,
+                expires_at_unix_ms: 0,
+                body: dm::DmBody::Payload(dm::DmPayload {
+                    kem_ciphertext: Vec::new(),
+                    body_nonce: [0u8; 12],
+                    body_ciphertext: Vec::new(),
+                }),
+                signature: Vec::new(),
+            },
+        };
+
+        let relay_peer = ant_quic::PeerId([0xEE; 32]);
+        let relay_wire_sender = [0xEE; 32];
+        sender
+            .send((relay_peer, relay_wire_sender, relayed))
+            .await
+            .expect("relayed_dm channel must accept push");
+
+        // Spin until the listener observes the refusal - bounded so a
+        // regression fails fast rather than timing out the suite.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let snap = agent.peer_relay().stats().snapshot();
+            if snap.relay_refused_bad_signature == 1 {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!(
+                    "relay-DM listener did not tick relay_refused_bad_signature within 2s - \
+                     snapshot: {snap:?}"
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let snap = agent.peer_relay().stats().snapshot();
+        assert_eq!(snap.relay_refused_bad_signature, 1);
+        assert_eq!(snap.relay_received, 0, "bad-sig path must not deliver");
+        assert_eq!(snap.relay_forwarded, 0, "bad-sig path must not forward");
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8242,6 +8242,42 @@ impl Agent {
         }
     }
 
+    /// Push a synthetic [`peer_relay::RelayedDm`] onto this Agent's inbound
+    /// relay-DM channel, exactly as the wire demuxer would after receiving a
+    /// [`network::RELAYED_DM_STREAM_TYPE`] frame. Drives the
+    /// `spawn_relay_dm_listener` dispatch path (revocation gate →
+    /// deliver-locally / forward / refuse) without a second live QUIC peer.
+    ///
+    /// `#[doc(hidden)]` - tests-only seam. The production inbound path is the
+    /// network receiver task; this exists only because
+    /// [`network::NetworkNode::send_direct_typed`] and the relay-DM channel
+    /// sender are `pub(crate)`, so an out-of-crate integration test cannot
+    /// otherwise exercise the recipient-side listener.
+    ///
+    /// # Arguments
+    ///
+    /// * `from_peer` - the QUIC peer the frame nominally arrived on (the
+    ///   relay hop, or the origin for a self-addressed `RelayedDm`).
+    /// * `relayed` - the fully-formed relayed envelope to dispatch.
+    ///
+    /// Returns `false` when no network is configured (nothing to receive on).
+    #[doc(hidden)]
+    pub async fn push_relayed_dm_for_testing(
+        &self,
+        from_peer: ant_quic::PeerId,
+        relayed: peer_relay::RelayedDm,
+    ) -> bool {
+        let Some(ref network) = self.network else {
+            return false;
+        };
+        let sender_agent_id = relayed.header.sender_agent_id;
+        network
+            .test_relayed_dm_sender()
+            .send((from_peer, sender_agent_id, relayed))
+            .await
+            .is_ok()
+    }
+
     /// Create a new collaborative task list bound to a topic.
     ///
     /// Creates a new `TaskList` and binds it to the specified gossip topic
@@ -8875,6 +8911,14 @@ impl AgentBuilder {
             None
         };
 
+        // Load the local revocation set now (shared Arc) so the relay-DM
+        // listener can enforce revocation on inbound relayed envelopes. The
+        // same Arc is moved into the Agent below, so the listener and the
+        // Agent's `/identity/revoke` writes observe one shared set.
+        let revocation_set = std::sync::Arc::new(tokio::sync::RwLock::new(
+            storage::load_revocation_set(self.identity_dir.as_deref()).await,
+        ));
+
         // X0X-0070b: spawn the inbound RelayedDm listener so this Agent can
         // serve as either the final recipient (DeliverLocally) or the
         // intermediate relay (Forward) for peers that fell back to the
@@ -8886,6 +8930,7 @@ impl AgentBuilder {
                 std::sync::Arc::clone(net),
                 std::sync::Arc::clone(&peer_relay),
                 std::sync::Arc::clone(&identity_discovery_cache),
+                std::sync::Arc::clone(&revocation_set),
                 identity.agent_id(),
             );
         }
@@ -8976,8 +9021,6 @@ impl AgentBuilder {
 
         // Load the revocation set from disk so enforcement takes effect
         // immediately on restart, even before the next gossip heartbeat.
-        let revocation_set = storage::load_revocation_set(self.identity_dir.as_deref()).await;
-
         Ok(Agent {
             identity: std::sync::Arc::new(identity),
             network,
@@ -9014,7 +9057,7 @@ impl AgentBuilder {
             recent_delivery_cache: std::sync::Arc::new(dm::RecentDeliveryCache::with_defaults()),
             capability_advert_service: tokio::sync::Mutex::new(None),
             dm_inbox_service: tokio::sync::Mutex::new(None),
-            revocation_set: std::sync::Arc::new(tokio::sync::RwLock::new(revocation_set)),
+            revocation_set,
             identity_dir: self.identity_dir,
             shutdown_token: tokio_util::sync::CancellationToken::new(),
             tracked_tasks: std::sync::Arc::new(std::sync::Mutex::new(TrackedTasks {
@@ -9620,12 +9663,25 @@ pub const NAME: &str = "x0x";
 /// * [`peer_relay::RelayDisposition::Refuse`] - `debug!` log only.
 ///   [`peer_relay::PeerRelay::disposition_for`] already incremented the
 ///   appropriate `relay_refused_*` counter as a side effect.
+///
+/// # Revocation gate
+///
+/// Before delivering locally or forwarding, the listener checks the
+/// inner envelope's *origin* `sender_agent_id` against `revocation_set`.
+/// This is required because the local-delivery path re-injects the inner
+/// envelope onto the direct-DM channel
+/// ([`network::NetworkNode::inject_inbound_direct`]), which does **not**
+/// run the `dm_inbox` gossip-path revocation gate (#130). Without this
+/// check a revoked agent that cannot direct-connect (e.g. NAT-blocked)
+/// could still reach the recipient via a relay, bypassing revocation.
+/// A revoked origin is dropped and counted as `relay_dropped_revoked`.
 fn spawn_relay_dm_listener(
     network: std::sync::Arc<network::NetworkNode>,
     peer_relay: std::sync::Arc<peer_relay::PeerRelay>,
     identity_discovery_cache: std::sync::Arc<
         tokio::sync::RwLock<std::collections::HashMap<identity::AgentId, DiscoveredAgent>>,
     >,
+    revocation_set: std::sync::Arc<tokio::sync::RwLock<revocation::RevocationSet>>,
     local_agent_id: identity::AgentId,
 ) {
     tokio::spawn(async move {
@@ -9644,6 +9700,31 @@ fn spawn_relay_dm_listener(
 
             let now_ms = dm::now_unix_ms();
             let disposition = peer_relay.disposition_for(&relayed, &local_agent_id, now_ms);
+
+            // Revocation gate (PR #177 review, fix 1): the inner envelope's
+            // ML-DSA-65 origin signature is the trust anchor, but a revoked
+            // origin must be dropped even when it arrives via a relay. The
+            // deliver/forward paths do not traverse the dm_inbox revocation
+            // gate, so enforce it here for both, before any delivery.
+            if matches!(
+                disposition,
+                peer_relay::RelayDisposition::DeliverLocally
+                    | peer_relay::RelayDisposition::Forward { .. }
+            ) {
+                let origin = identity::AgentId(relayed.inner.sender_agent_id);
+                let revoked = { revocation_set.read().await.is_agent_revoked(&origin) };
+                if revoked {
+                    peer_relay.record_relay_dropped_revoked();
+                    tracing::info!(
+                        target: "x0x::relay",
+                        stage = "revoked_drop",
+                        relay_peer = ?relay_peer_id,
+                        origin = %hex::encode(origin.as_bytes()),
+                        "relayed DM dropped: origin agent is revoked"
+                    );
+                    continue;
+                }
+            }
 
             match disposition {
                 peer_relay::RelayDisposition::DeliverLocally => {
@@ -10575,6 +10656,7 @@ mod tests {
         let mut net_cfg = loopback_network_config();
         net_cfg.peer_relay = network::PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 7,
             fail_window_ms: 90_000,
             candidates: vec![hex::encode(candidate_a), hex::encode(candidate_b)],
@@ -10676,6 +10758,7 @@ mod tests {
         let mut net_cfg = loopback_network_config();
         net_cfg.peer_relay = network::PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 3,
             fail_window_ms: 60_000,
             candidates: Vec::new(),
@@ -10713,6 +10796,7 @@ mod tests {
         let mut net_cfg = loopback_network_config();
         net_cfg.peer_relay = network::PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 3,
             fail_window_ms: 60_000,
             candidates: vec![candidate_hex],
@@ -10749,6 +10833,7 @@ mod tests {
         let mut net_cfg = loopback_network_config();
         net_cfg.peer_relay = network::PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 5,
             fail_window_ms: 60_000,
             candidates: vec![hex::encode([0xEE_u8; 32])],
@@ -10786,6 +10871,7 @@ mod tests {
         let mut net_cfg = loopback_network_config();
         net_cfg.peer_relay = network::PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 3,
             fail_window_ms: 60_000,
             candidates: Vec::new(),
@@ -10882,6 +10968,7 @@ mod tests {
         let mut net_cfg = loopback_network_config();
         net_cfg.peer_relay = network::PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 3,
             fail_window_ms: 60_000,
             candidates: Vec::new(),

--- a/src/network.rs
+++ b/src/network.rs
@@ -243,6 +243,91 @@ pub struct NetworkConfig {
     /// and via the `--no-port-mapping` CLI flag.
     #[serde(default = "default_port_mapping_enabled")]
     pub port_mapping_enabled: bool,
+
+    /// X0X-0070b: application-level peer-relay fallback configuration.
+    /// Defaults to disabled (matches `RelayPolicy::default()`); the
+    /// engine only activates when a runtime explicitly opts in via
+    /// `[peer_relay] enabled = true` in TOML.
+    #[serde(default)]
+    pub peer_relay: PeerRelayConfig,
+}
+
+/// X0X-0070b: TOML-shaped configuration for the peer-relay fallback
+/// path. `enabled` is the master gate; the failure trigger
+/// (`fail_threshold` over `fail_window_ms`) controls when a peer is
+/// marked `needs_relay`; `candidates` seeds the candidate set the
+/// engine picks from when falling back. Gossip-announced relay
+/// candidates (future) are merged on top of `candidates` at runtime.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerRelayConfig {
+    /// Master gate. Defaults to `false`.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Direct-DM failures within `fail_window_ms` before a peer is
+    /// marked `needs_relay`. Defaults to
+    /// [`crate::peer_relay::DEFAULT_FAIL_THRESHOLD`]. Clamped to
+    /// `>= 1` at policy-conversion time so a misconfigured `0` does
+    /// not silently disable the threshold.
+    #[serde(default = "default_peer_relay_fail_threshold")]
+    pub fail_threshold: u32,
+
+    /// Sliding window (milliseconds) over which `fail_threshold` is
+    /// counted. Defaults to
+    /// [`crate::peer_relay::DEFAULT_FAIL_WINDOW`] in milliseconds.
+    #[serde(default = "default_peer_relay_fail_window_ms")]
+    pub fail_window_ms: u64,
+
+    /// Hex-encoded `AgentId`s that act as relay candidates. The MVP
+    /// (X0X-0070b) loads these from TOML; future revisions merge in
+    /// gossip-announced candidates at runtime. Each candidate MUST
+    /// have a directly reachable public address - the relay path
+    /// sends `RelayedDm` to candidates via the same direct-DM
+    /// transport, which requires a healthy direct path between the
+    /// sender and the candidate.
+    #[serde(default)]
+    pub candidates: Vec<String>,
+}
+
+fn default_peer_relay_fail_threshold() -> u32 {
+    crate::peer_relay::DEFAULT_FAIL_THRESHOLD
+}
+
+fn default_peer_relay_fail_window_ms() -> u64 {
+    u64::try_from(crate::peer_relay::DEFAULT_FAIL_WINDOW.as_millis()).unwrap_or(u64::MAX)
+}
+
+impl Default for PeerRelayConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            fail_threshold: default_peer_relay_fail_threshold(),
+            fail_window_ms: default_peer_relay_fail_window_ms(),
+            candidates: Vec::new(),
+        }
+    }
+}
+
+impl PeerRelayConfig {
+    /// Convert this TOML-shaped config into a [`crate::peer_relay::RelayPolicy`]
+    /// for the engine. `candidates` is NOT carried in the policy - it
+    /// lives on `Agent` as separately-mutable runtime state populated
+    /// from this config and the gossip-announce subscriber.
+    ///
+    /// `fail_threshold` is clamped to `>= 1` so a misconfigured `0`
+    /// never silently flips the engine into "every failure triggers
+    /// relay". `freshness` is taken from the engine's own default
+    /// since it is not currently surfaced in the TOML schema.
+    #[must_use]
+    pub fn to_policy(&self) -> crate::peer_relay::RelayPolicy {
+        let defaults = crate::peer_relay::RelayPolicy::default();
+        crate::peer_relay::RelayPolicy {
+            enabled: self.enabled,
+            fail_threshold: self.fail_threshold.max(1),
+            fail_window: Duration::from_millis(self.fail_window_ms),
+            freshness: defaults.freshness,
+        }
+    }
 }
 
 fn default_max_connections() -> u32 {
@@ -296,6 +381,7 @@ impl Default for NetworkConfig {
             inbound_allowlist: std::collections::HashSet::new(),
             max_peers_per_ip: 3,
             port_mapping_enabled: true,
+            peer_relay: PeerRelayConfig::default(),
         }
     }
 }
@@ -813,6 +899,27 @@ fn usize_to_u64_saturating(value: usize) -> u64 {
 /// Stream type byte for direct messages (distinct from gossip: 0, 1, 2).
 pub const DIRECT_MESSAGE_STREAM_TYPE: u8 = 0x10;
 
+/// Stream type byte for application-level relayed DMs (X0X-0070b).
+/// Sits immediately above [`DIRECT_MESSAGE_STREAM_TYPE`] in the
+/// reserved DM region. Older peers without the X0X-0070b receiver
+/// handler hit the "Unknown stream type byte" path at the inbound
+/// parser and drop the frame - wire-additive demux, forward-compat
+/// clean.
+pub const RELAYED_DM_STREAM_TYPE: u8 = 0x11;
+
+/// X0X-0070b: triple shipped on the inbound RelayedDm channel.
+///
+/// 1. `AntPeerId` - the ant-quic PeerId of the *relay* peer (the QUIC
+///    peer that sent us these bytes). Equals the relay's `MachineId`.
+/// 2. `[u8; 32]` - the wire-prefix `AgentId` carried in front of the
+///    postcard body (also the relay's identity; mirrors the direct-DM
+///    prefix shape).
+/// 3. `crate::peer_relay::RelayedDm` - the parsed envelope. The
+///    *original* sender's identity lives inside
+///    `relayed.header.sender_agent_id`, trust-anchored by the header's
+///    ML-DSA-65 signature, not by the wire prefix.
+pub type RelayedDmEvent = (AntPeerId, [u8; 32], crate::peer_relay::RelayedDm);
+
 const CHANNEL_PRESSURE_INFO_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1142,6 +1249,14 @@ pub struct NetworkNode {
     /// Receiver channel for direct messages (separate from gossip).
     direct_tx: mpsc::Sender<(AntPeerId, Bytes)>,
     direct_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<(AntPeerId, Bytes)>>>,
+    /// Receiver channel for inbound [`crate::peer_relay::RelayedDm`]
+    /// envelopes (X0X-0070b). Demuxed by [`RELAYED_DM_STREAM_TYPE`] at
+    /// the wire layer; the consumer is the per-agent relay-DM handler
+    /// in [`crate::Agent`]. Capacity is intentionally small - relayed
+    /// DMs only fire on direct-DM failures that cross the relay
+    /// threshold, so steady-state volume is near zero.
+    relayed_dm_tx: mpsc::Sender<RelayedDmEvent>,
+    relayed_dm_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<RelayedDmEvent>>>,
     /// Cached local peer ID (ant-quic PeerId).
     peer_id: AntPeerId,
     /// Bootstrap peer cache for recording connection outcomes.
@@ -1247,6 +1362,11 @@ impl NetworkNode {
         let (recv_membership_tx, recv_membership_rx) = mpsc::channel(GOSSIP_CONTROL_RECV_CAPACITY);
         let (recv_bulk_tx, recv_bulk_rx) = mpsc::channel(GOSSIP_CONTROL_RECV_CAPACITY);
         let (direct_tx, direct_rx) = mpsc::channel(10_000);
+        // X0X-0070b: dedicated low-rate channel for inbound RelayedDm
+        // envelopes. Engages only on the relay-fallback path; steady-state
+        // volume is bounded by the failure-trigger threshold + freshness
+        // window per peer, so 256 is generous.
+        let (relayed_dm_tx, relayed_dm_rx) = mpsc::channel(256);
         let recv_pump_diagnostics = Arc::new(RecvPumpDiagnostics::new());
         let pool_max_connections = if config.max_connections == 0 {
             DEFAULT_MAX_CONNECTIONS as usize
@@ -1271,6 +1391,8 @@ impl NetworkNode {
             recv_pump_diagnostics,
             direct_tx,
             direct_rx: Arc::new(tokio::sync::Mutex::new(direct_rx)),
+            relayed_dm_tx,
+            relayed_dm_rx: Arc::new(tokio::sync::Mutex::new(relayed_dm_rx)),
             peer_id,
             bootstrap_cache,
             connection_pool,
@@ -2316,15 +2438,46 @@ impl NetworkNode {
         sender_agent_id: &[u8; 32],
         payload: &[u8],
     ) -> NetworkResult<()> {
+        self.send_direct_typed(
+            peer_id,
+            sender_agent_id,
+            DIRECT_MESSAGE_STREAM_TYPE,
+            payload,
+        )
+        .await
+    }
+
+    /// Send a direct stream framed with an arbitrary application
+    /// stream-type byte. The wire format is identical to
+    /// [`Self::send_direct`] (`[stream_type][sender_agent_id: 32][payload]`),
+    /// except the first byte is parameterised so callers above the DM
+    /// layer (X0X-0070b's relay-fallback + relay-side forward path) can
+    /// reuse the same connection-pool / push / pool-activity bookkeeping
+    /// without duplicating the wire builder.
+    ///
+    /// `stream_type` MUST NOT collide with reserved values:
+    /// gossip uses `0x00`/`0x01`/`0x02`, the DM region uses `0x10` and
+    /// upwards. See [`DIRECT_MESSAGE_STREAM_TYPE`] +
+    /// [`RELAYED_DM_STREAM_TYPE`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `NetworkError` if the peer is not connected or send fails.
+    pub(crate) async fn send_direct_typed(
+        &self,
+        peer_id: &AntPeerId,
+        sender_agent_id: &[u8; 32],
+        stream_type: u8,
+        payload: &[u8],
+    ) -> NetworkResult<()> {
         self.get_or_connect_pooled_peer(peer_id).await?;
 
-        // Build wire format: [0x10][sender_agent_id: 32 bytes][payload]
+        // Wire format: [stream_type][sender_agent_id: 32 bytes][payload]
         let mut buf = Vec::with_capacity(1 + 32 + payload.len());
-        buf.push(DIRECT_MESSAGE_STREAM_TYPE);
+        buf.push(stream_type);
         buf.extend_from_slice(sender_agent_id);
         buf.extend_from_slice(payload);
 
-        // Send via ant-quic
         let node = self.require_node().await?;
         node.send(peer_id, &buf)
             .await
@@ -2332,7 +2485,8 @@ impl NetworkNode {
         self.note_connection_pool_activity(*peer_id).await;
 
         debug!(
-            "[1/6 network] send_direct: {} bytes to peer {:?}",
+            "[1/6 network] send_direct_typed: stream_type=0x{:02x} {} bytes to peer {:?}",
+            stream_type,
             payload.len(),
             peer_id
         );
@@ -2352,6 +2506,64 @@ impl NetworkNode {
     pub async fn recv_direct(&self) -> Option<(AntPeerId, Bytes)> {
         let mut rx = self.direct_rx.lock().await;
         rx.recv().await
+    }
+
+    /// Receive the next inbound [`crate::peer_relay::RelayedDm`].
+    ///
+    /// Blocks until a relayed DM arrives. Returns:
+    ///
+    /// * `relay_peer_id` - the ant-quic PeerId of the *relay* that
+    ///   forwarded this packet (equals the relay's MachineId).
+    /// * `relay_sender_agent_id` - the AgentId carried in the wire
+    ///   prefix (also the relay's identity; mirrors the direct-DM
+    ///   prefix shape).
+    /// * `relayed` - the typed envelope. The *original* sender is
+    ///   inside `relayed.header.sender_agent_id`, signed by
+    ///   `relayed.header.sender_public_key`.
+    ///
+    /// X0X-0070b: paired with [`RELAYED_DM_STREAM_TYPE`] in the internal
+    /// receiver task.
+    pub async fn recv_relayed_dm(&self) -> Option<RelayedDmEvent> {
+        let mut rx = self.relayed_dm_rx.lock().await;
+        rx.recv().await
+    }
+
+    /// Test-only handle to the inbound RelayedDm channel - lets a unit
+    /// test push a synthetic envelope as if it had arrived from the
+    /// wire demuxer, exercising the [`crate::Agent`]'s relay-DM
+    /// listener loop without a second [`NetworkNode`] over QUIC.
+    #[cfg(test)]
+    pub(crate) fn test_relayed_dm_sender(&self) -> mpsc::Sender<RelayedDmEvent> {
+        self.relayed_dm_tx.clone()
+    }
+
+    /// X0X-0070b: inject an inbound direct-DM payload onto the same
+    /// channel that the internal receiver task feeds.
+    ///
+    /// Used by the relay-DM handler's `DeliverLocally` arm to make a
+    /// relayed envelope land on the canonical direct-DM listener
+    /// indistinguishably from a packet that traversed the direct path.
+    /// `peer_id` should be the *original* sender's MachineId-as-PeerId
+    /// (synthesised from `relayed.inner.sender_machine_id`); `payload`
+    /// must follow the existing wire shape
+    /// `[sender_agent_id: 32][application_bytes]` so the listener's
+    /// own AgentId-prefix parse at the consumer site (see
+    /// `crate::Agent`'s direct listener task) succeeds unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NetworkError::ConnectionFailed`] if the internal
+    /// `direct_tx` channel is closed (listener gone).
+    pub(crate) async fn inject_inbound_direct(
+        &self,
+        peer_id: AntPeerId,
+        payload: Bytes,
+    ) -> NetworkResult<()> {
+        warn_forward_channel_pressure(&self.direct_tx, peer_id, None, "direct_tx (relay-inject)");
+        self.direct_tx
+            .send((peer_id, payload))
+            .await
+            .map_err(|e| NetworkError::ConnectionFailed(format!("inject direct: {e}")))
     }
 
     async fn receive_from_gossip_channel(
@@ -2415,6 +2627,7 @@ impl NetworkNode {
         let recv_bulk_tx = self.recv_bulk_tx.clone();
         let recv_pump_diagnostics = Arc::clone(&self.recv_pump_diagnostics);
         let direct_tx = self.direct_tx.clone();
+        let relayed_dm_tx = self.relayed_dm_tx.clone();
 
         tokio::spawn(async move {
             debug!("NetworkNode receiver task started");
@@ -2472,6 +2685,80 @@ impl NetworkNode {
                             warn_forward_channel_pressure(&direct_tx, peer_id, None, "direct_tx");
                             if let Err(e) = direct_tx.send((peer_id, payload)).await {
                                 error!("Failed to forward direct message: {}", e);
+                                break;
+                            }
+                            continue;
+                        }
+
+                        // X0X-0070b: inbound RelayedDm. Wire format mirrors
+                        // direct-DM at the framing layer:
+                        //   [0x11][relay_sender_agent_id: 32][postcard(RelayedDm)]
+                        // The 32-byte prefix is the *relay's* AgentId (the peer
+                        // that forwarded this packet to us - same identity the
+                        // QUIC peer carries); the *original* sender's identity
+                        // is inside `relayed.header.sender_agent_id` and is
+                        // trust-anchored by the header's ML-DSA-65 signature.
+                        // We pre-parse here so spawn_receiver remains the single
+                        // wire-validation site; downstream sees a typed value.
+                        if type_byte == RELAYED_DM_STREAM_TYPE {
+                            if data.len() < 1 + 32 {
+                                warn!(
+                                    "[1/6 network] dropping undersized RelayedDm frame: {} bytes from peer {:?}",
+                                    data.len(),
+                                    peer_id,
+                                );
+                                continue;
+                            }
+                            // Bound the on-wire size to prevent memory blow-up
+                            // on hostile peers. Inner DmEnvelope is already
+                            // capped by `MAX_DIRECT_PAYLOAD_SIZE`; the +32 +
+                            // 8 KiB allowance covers the relay prefix plus the
+                            // RelayHeader (ML-DSA-65 pubkey 1952 + signature
+                            // 3293 + dst/sender agent ids + timestamps fits
+                            // comfortably under 8 KiB).
+                            if data.len() > crate::direct::MAX_DIRECT_PAYLOAD_SIZE + 32 + 8 * 1024 {
+                                warn!(
+                                    "[1/6 network] dropping oversized RelayedDm: {} bytes from peer {:?} (max: {})",
+                                    data.len(),
+                                    peer_id,
+                                    crate::direct::MAX_DIRECT_PAYLOAD_SIZE + 32 + 8 * 1024,
+                                );
+                                continue;
+                            }
+                            let mut relay_sender_agent_id = [0u8; 32];
+                            relay_sender_agent_id.copy_from_slice(&data[1..33]);
+                            let body = &data[33..];
+                            let relayed = match postcard::from_bytes::<crate::peer_relay::RelayedDm>(
+                                body,
+                            ) {
+                                Ok(r) => r,
+                                Err(e) => {
+                                    warn!(
+                                        "[1/6 network] dropping malformed RelayedDm ({} body bytes) from peer {:?}: {}",
+                                        body.len(),
+                                        peer_id,
+                                        e,
+                                    );
+                                    continue;
+                                }
+                            };
+                            debug!(
+                                "[1/6 network] recv RelayedDm: {} body bytes from peer {:?} (relay agent {})",
+                                body.len(),
+                                peer_id,
+                                hex_prefix(&relay_sender_agent_id, 4),
+                            );
+                            warn_forward_channel_pressure(
+                                &relayed_dm_tx,
+                                peer_id,
+                                None,
+                                "relayed_dm_tx",
+                            );
+                            if let Err(e) = relayed_dm_tx
+                                .send((peer_id, relay_sender_agent_id, relayed))
+                                .await
+                            {
+                                error!("Failed to forward RelayedDm: {}", e);
                                 break;
                             }
                             continue;
@@ -2976,6 +3263,43 @@ mod tests {
     }
 
     #[test]
+    fn peer_relay_to_policy_clamps_zero_threshold_to_one() {
+        // Why: a TOML config with `fail_threshold = 0` would otherwise mean
+        // `entry.recent_failures.len() >= 0` - always true - silently flipping
+        // the engine into "every direct-DM failure triggers a relay" the
+        // moment the operator opts in. Clamping to `>= 1` is the only thing
+        // standing between a typo and a wholesale relay fan-out.
+        let cfg = PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 0,
+            fail_window_ms: 60_000,
+            candidates: Vec::new(),
+        };
+        let policy = cfg.to_policy();
+        assert_eq!(
+            policy.fail_threshold, 1,
+            "fail_threshold = 0 must clamp to 1"
+        );
+        assert!(policy.enabled);
+        assert_eq!(policy.fail_window, Duration::from_millis(60_000));
+    }
+
+    #[test]
+    fn peer_relay_to_policy_preserves_non_zero_threshold() {
+        // Why: the clamp must be a floor, not a rewrite - a legitimate
+        // operator-set threshold (e.g. 5) survives unchanged.
+        let cfg = PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 5,
+            fail_window_ms: 120_000,
+            candidates: Vec::new(),
+        };
+        let policy = cfg.to_policy();
+        assert_eq!(policy.fail_threshold, 5);
+        assert_eq!(policy.fail_window, Duration::from_millis(120_000));
+    }
+
+    #[test]
     fn pool_evicts_after_idle_threshold() {
         let pool = ConnectionPool::new(8, Duration::from_secs(5));
         let now = Instant::now();
@@ -3232,6 +3556,7 @@ async fn test_mesh_connections_are_bidirectional() {
             inbound_allowlist: std::collections::HashSet::new(),
             max_peers_per_ip: 3,
             port_mapping_enabled: true,
+            peer_relay: PeerRelayConfig::default(),
         };
 
         let node = NetworkNode::new(config, None, None).await.unwrap();

--- a/src/network.rs
+++ b/src/network.rs
@@ -258,11 +258,37 @@ pub struct NetworkConfig {
 /// marked `needs_relay`; `candidates` seeds the candidate set the
 /// engine picks from when falling back. Gossip-announced relay
 /// candidates (future) are merged on top of `candidates` at runtime.
+///
+/// # Open-relay warning (`enabled = true`)
+///
+/// A node with `[peer_relay] enabled = true` acts as an **open relay**:
+/// it will forward a relayed DM to any destination in its discovery
+/// cache on behalf of **any** peer that signs a valid relay header with
+/// a self-generated ML-DSA-65 key. There is no sender allow-list — the
+/// only authentication is the header signature, which anyone can
+/// produce. Enabling the relay therefore opts this node into spending
+/// its bandwidth and CPU forwarding traffic for strangers (the same
+/// resource-abuse surface as a Tailscale peer-relay / iroh DERP node).
+/// Enable it only on a node whose uplink you are willing to share. See
+/// [`crate::peer_relay::RelayPolicy`] for the engine-side detail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerRelayConfig {
-    /// Master gate. Defaults to `false`.
+    /// Master gate. Defaults to `false`. Enabling it opts this node into
+    /// the open-relay resource-abuse surface described on the type doc.
     #[serde(default)]
     pub enabled: bool,
+
+    /// **Reserved — not yet enforced.** Intended future contact-gate: when
+    /// a maintainer wires this through to the engine, `true` will restrict
+    /// forwarding to senders that are known contacts, closing the
+    /// open-relay surface documented above. Today the field is parsed and
+    /// stored but has **no effect** — an enabled relay forwards for any
+    /// self-keyed peer regardless of this value. It exists so the schema
+    /// is forward-compatible and the open-relay-vs-contact-gate decision
+    /// is explicit rather than silently defaulting to "open". Defaults to
+    /// `false`.
+    #[serde(default)]
+    pub require_contact_to_relay: bool,
 
     /// Direct-DM failures within `fail_window_ms` before a peer is
     /// marked `needs_relay`. Defaults to
@@ -301,6 +327,7 @@ impl Default for PeerRelayConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            require_contact_to_relay: false,
             fail_threshold: default_peer_relay_fail_threshold(),
             fail_window_ms: default_peer_relay_fail_window_ms(),
             candidates: Vec::new(),
@@ -2528,11 +2555,16 @@ impl NetworkNode {
         rx.recv().await
     }
 
-    /// Test-only handle to the inbound RelayedDm channel - lets a unit
-    /// test push a synthetic envelope as if it had arrived from the
-    /// wire demuxer, exercising the [`crate::Agent`]'s relay-DM
-    /// listener loop without a second [`NetworkNode`] over QUIC.
-    #[cfg(test)]
+    /// Test-only handle to the inbound RelayedDm channel - lets a test
+    /// push a synthetic envelope as if it had arrived from the wire
+    /// demuxer, exercising the [`crate::Agent`]'s relay-DM listener loop
+    /// without a second [`NetworkNode`] over QUIC.
+    ///
+    /// Compiled unconditionally (not `#[cfg(test)]`) because the
+    /// out-of-crate integration test seam
+    /// [`crate::Agent::push_relayed_dm_for_testing`] routes through it;
+    /// `#[doc(hidden)]` keeps it out of the public API surface.
+    #[doc(hidden)]
     pub(crate) fn test_relayed_dm_sender(&self) -> mpsc::Sender<RelayedDmEvent> {
         self.relayed_dm_tx.clone()
     }
@@ -3271,6 +3303,7 @@ mod tests {
         // standing between a typo and a wholesale relay fan-out.
         let cfg = PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 0,
             fail_window_ms: 60_000,
             candidates: Vec::new(),
@@ -3290,6 +3323,7 @@ mod tests {
         // operator-set threshold (e.g. 5) survives unchanged.
         let cfg = PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 5,
             fail_window_ms: 120_000,
             candidates: Vec::new(),

--- a/src/peer_relay.rs
+++ b/src/peer_relay.rs
@@ -226,13 +226,32 @@ pub enum RelayRefusal {
 }
 
 /// Policy knobs for the peer-relay engine.
+///
+/// # Open-relay warning
+///
+/// When `enabled` is `true` this node acts as an **open relay**:
+/// [`PeerRelay::disposition_for`] authenticates only the
+/// [`RelayHeader`] signature, which any peer can produce by generating
+/// its own ML-DSA-65 keypair and signing a fresh header. There is
+/// **no** check on *who* the relaying peer is — an enabled node will
+/// forward a `RelayedDm` to any destination in its discovery cache on
+/// behalf of any self-keyed sender. This is a deliberate MVP
+/// (X0X-0070b) resource-abuse surface: enabling the relay opts this
+/// node into spending bandwidth/CPU forwarding for strangers, exactly
+/// like a Tailscale peer-relay or an iroh DERP node. Do not enable it
+/// on a node whose uplink you are not willing to share. A future
+/// contact-gate (see [`crate::network::PeerRelayConfig`]'s
+/// `require_contact_to_relay`, reserved and not yet enforced) will let
+/// operators restrict forwarding to known contacts; that decision is
+/// left to the maintainer.
 #[derive(Debug, Clone, Copy)]
 pub struct RelayPolicy {
     /// Master gate. **Default `false`** — the MVP relay path only
     /// engages when a runtime explicitly opts in. With this `false`,
     /// [`PeerRelay::needs_relay`] always returns `false` and
     /// [`PeerRelay::disposition_for`] refuses inbound relayed DMs with
-    /// [`RelayRefusal::PolicyDisabled`].
+    /// [`RelayRefusal::PolicyDisabled`]. Enabling it opts this node into
+    /// the open-relay resource-abuse surface described on the type doc.
     pub enabled: bool,
     /// Consecutive direct-DM failures, within `fail_window`, before a
     /// peer is considered to need a relay.
@@ -295,6 +314,7 @@ pub struct RelayStats {
     relay_refused_bad_signature: AtomicU64,
     relay_refused_stale: AtomicU64,
     relay_refused_policy_disabled: AtomicU64,
+    relay_dropped_revoked: AtomicU64,
     direct_recovered_after_relay: AtomicU64,
 }
 
@@ -313,6 +333,11 @@ pub struct RelayStatsSnapshot {
     pub relay_refused_stale: u64,
     /// Inbound relayed DMs refused — relay path disabled by policy.
     pub relay_refused_policy_disabled: u64,
+    /// Inbound relayed DMs dropped because the inner envelope's origin
+    /// agent is in this node's revocation set. Enforces the revocation
+    /// gate on the relay delivery/forward path, which does not otherwise
+    /// traverse the `dm_inbox` gossip-path revocation check.
+    pub relay_dropped_revoked: u64,
     /// Peers that returned to a healthy direct path after having been
     /// in relay mode — proves the fallback is transient, not sticky.
     pub direct_recovered_after_relay: u64,
@@ -331,6 +356,7 @@ impl RelayStats {
             relay_refused_policy_disabled: self
                 .relay_refused_policy_disabled
                 .load(Ordering::Relaxed),
+            relay_dropped_revoked: self.relay_dropped_revoked.load(Ordering::Relaxed),
             direct_recovered_after_relay: self.direct_recovered_after_relay.load(Ordering::Relaxed),
         }
     }
@@ -387,6 +413,17 @@ impl PeerRelay {
     #[must_use]
     pub fn stats(&self) -> &RelayStats {
         &self.stats
+    }
+
+    /// Record that an inbound relayed DM was dropped because its inner
+    /// envelope's origin agent is revoked. Called by the relay-DM
+    /// listener's revocation gate before delivering or forwarding, so a
+    /// revoked origin cannot use the relay path to bypass the revocation
+    /// check that the direct-DM re-injection would otherwise skip.
+    pub fn record_relay_dropped_revoked(&self) {
+        self.stats
+            .relay_dropped_revoked
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<[u8; 32], PeerRelayState>> {
@@ -519,10 +556,14 @@ impl PeerRelay {
     /// node, whose agent id is `local_agent_id`, at wall-clock
     /// `now_unix_ms`. Updates the telemetry counters as a side effect.
     ///
+    /// - Policy disabled → `Refuse(PolicyDisabled)`,
+    ///   `relay_refused_policy_disabled` += 1. This check runs
+    ///   **before** the (expensive ML-DSA-65) header verification so an
+    ///   unsolicited relay frame to a node whose relay path is disabled
+    ///   cannot force a signature verification — the cheapest possible
+    ///   rejection for the DoS surface every node exposes by default.
     /// - Header fails verification → [`RelayDisposition::Refuse`]
     ///   (`BadSignature`), `relay_refused_bad_signature` += 1.
-    /// - Policy disabled → `Refuse(PolicyDisabled)`,
-    ///   `relay_refused_policy_disabled` += 1.
     /// - `originated_at` older than `freshness`, or more than
     ///   [`RELAY_CLOCK_SKEW_TOLERANCE_MS`] ahead of `now_unix_ms` →
     ///   `Refuse(Stale)`, `relay_refused_stale` += 1.
@@ -537,17 +578,20 @@ impl PeerRelay {
         local_agent_id: &AgentId,
         now_unix_ms: u64,
     ) -> RelayDisposition {
-        if !relayed.header.verify() {
-            self.stats
-                .relay_refused_bad_signature
-                .fetch_add(1, Ordering::Relaxed);
-            return RelayDisposition::Refuse(RelayRefusal::BadSignature);
-        }
+        // DoS guard: reject on the disabled-policy path before doing any
+        // ML-DSA-65 signature work, so a disabled relay cannot be made to
+        // burn CPU verifying attacker-supplied headers.
         if !self.policy.enabled {
             self.stats
                 .relay_refused_policy_disabled
                 .fetch_add(1, Ordering::Relaxed);
             return RelayDisposition::Refuse(RelayRefusal::PolicyDisabled);
+        }
+        if !relayed.header.verify() {
+            self.stats
+                .relay_refused_bad_signature
+                .fetch_add(1, Ordering::Relaxed);
+            return RelayDisposition::Refuse(RelayRefusal::BadSignature);
         }
         let freshness_ms = self.policy.freshness.as_millis() as u64;
         let originated = relayed.header.originated_at_unix_ms;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -672,6 +672,7 @@ pub async fn serve_with_options(
         // CLI flag wins over config TOML so operators can override on a
         // single invocation without editing the config file.
         port_mapping_enabled: config.port_mapping_enabled && !cli_no_port_mapping,
+        peer_relay: config.peer_relay.clone(),
     };
 
     let contacts_path = config.data_dir.join("contacts.json");
@@ -14067,6 +14068,7 @@ async fn direct_send(
                 x0x::dm::DmPath::GossipInbox => "gossip_inbox",
                 x0x::dm::DmPath::RawQuic => "raw_quic",
                 x0x::dm::DmPath::RawQuicAcked => "raw_quic_acked",
+                x0x::dm::DmPath::Relayed { .. } => "relayed",
             };
             tracing::debug!(
                 target: "dm.trace",
@@ -14162,6 +14164,12 @@ async fn direct_send(
                 }
                 x0x::dm::DmError::PublishFailed(_) => {
                     (StatusCode::INTERNAL_SERVER_ERROR, "publish_failed")
+                }
+                x0x::dm::DmError::NoRelayCandidate => {
+                    (StatusCode::SERVICE_UNAVAILABLE, "no_relay_candidate")
+                }
+                x0x::dm::DmError::RelayBuildFailed(_) => {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "relay_build_failed")
                 }
             };
             tracing::error!("direct_send failed ({err_kind}): {e}");

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -175,6 +175,15 @@ pub struct DaemonConfig {
     #[serde(default = "default_port_mapping_enabled")]
     pub(super) port_mapping_enabled: bool,
 
+    /// X0X-0070b: peer-relay fallback configuration (TOML `[peer_relay]`).
+    /// Defaults to disabled — opt in by setting `peer_relay.enabled = true`
+    /// and listing relay-candidate hex agent IDs under
+    /// `peer_relay.candidates`. The relay path only activates when a direct
+    /// DM crosses the failure threshold; the happy path allocates nothing
+    /// extra.
+    #[serde(default)]
+    pub(super) peer_relay: x0x::network::PeerRelayConfig,
+
     /// Update configuration.
     #[serde(default)]
     pub(super) update: DaemonUpdateConfig,
@@ -411,6 +420,7 @@ impl Default for DaemonConfig {
                 .filter_map(|s| s.parse().ok())
                 .collect(),
             port_mapping_enabled: default_port_mapping_enabled(),
+            peer_relay: x0x::network::PeerRelayConfig::default(),
             update: DaemonUpdateConfig::default(),
             gossip: x0x::gossip::GossipConfig::default(),
             heartbeat_interval_secs: default_heartbeat_interval(),

--- a/tests/peer_relay_integration.rs
+++ b/tests/peer_relay_integration.rs
@@ -9,10 +9,11 @@
 //! `DmEnvelope`, wraps it in a sender-signed `RelayedDm`, and forwards over
 //! `network.send_direct_typed(charlie, RELAYED_DM_STREAM_TYPE=0x11, ...)`.
 //!
-//! The receiver-side demux for `0x11` is the X0X-0070b receiver patch and is
-//! intentionally out of scope here - pre-receiver, Charlie drops the inbound
-//! bytes silently as an unknown stream type, so these tests assert the sender
-//! contract only (receipt path, telemetry, wire send succeeds).
+//! The receiver side is also covered: `relay_round_trip_alice_to_bob_via_charlie`
+//! exercises the full three-party demux + forward, and the PR #177 review tests
+//! at the bottom of this file drive the recipient-side listener directly (via
+//! the `push_relayed_dm_for_testing` seam) to prove the revocation gate, the
+//! disposition ordering, and the wire-layer spoofing backstop.
 //!
 //! Each test ignores itself when the host cannot bind QUIC (e.g. CI sandboxes
 //! where UDP binds return `EPERM`), matching the existing
@@ -23,10 +24,17 @@
 
 use std::time::Duration;
 use tempfile::TempDir;
-use x0x::dm::{DmCapabilities, DmPath, DmSendConfig, DM_PROTOCOL_VERSION, MAX_ENVELOPE_BYTES};
+use x0x::dm::{
+    now_unix_ms, DmBody, DmCapabilities, DmEnvelope, DmPath, DmPayload, DmSendConfig,
+    DM_PROTOCOL_VERSION, MAX_ENVELOPE_BYTES,
+};
 use x0x::groups::kem_envelope::AgentKemKeypair;
 use x0x::identity::{AgentId, AgentKeypair, MachineKeypair};
 use x0x::network::{NetworkConfig, PeerRelayConfig};
+use x0x::peer_relay::{
+    PeerRelay, RelayDisposition, RelayHeader, RelayPolicy, RelayRefusal, RelayedDm,
+};
+use x0x::revocation::{RevocationRecord, RevokedSubject};
 use x0x::{Agent, DiscoveredAgent};
 
 fn loopback_network_config_with_relay(relay: PeerRelayConfig) -> NetworkConfig {
@@ -160,6 +168,7 @@ async fn sender_uses_relay_when_direct_path_fails() {
         "alice",
         PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 3,
             fail_window_ms: 60_000,
             candidates: vec![hex::encode(charlie.agent_id().0)],
@@ -271,6 +280,7 @@ async fn enabled_policy_without_candidates_surfaces_direct_err() {
         "alice",
         PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 3,
             fail_window_ms: 60_000,
             candidates: Vec::new(),
@@ -338,6 +348,7 @@ async fn direct_success_after_relay_mode_increments_recovery_counter() {
         "alice",
         PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 3,
             fail_window_ms: 60_000,
             candidates: Vec::new(),
@@ -474,6 +485,7 @@ async fn relay_round_trip_alice_to_bob_via_charlie() {
         "charlie",
         PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 3,
             fail_window_ms: 60_000,
             candidates: Vec::new(),
@@ -493,6 +505,7 @@ async fn relay_round_trip_alice_to_bob_via_charlie() {
         "bob",
         PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 3,
             fail_window_ms: 60_000,
             candidates: Vec::new(),
@@ -512,6 +525,7 @@ async fn relay_round_trip_alice_to_bob_via_charlie() {
         "alice",
         PeerRelayConfig {
             enabled: true,
+            require_contact_to_relay: false,
             fail_threshold: 3,
             fail_window_ms: 60_000,
             candidates: vec![hex::encode(charlie.agent_id().0)],
@@ -708,5 +722,300 @@ async fn relay_round_trip_alice_to_bob_via_charlie() {
     assert_eq!(
         bob_stats.relay_forwarded, 0,
         "bob is not a relay - relay_forwarded must remain at zero"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PR #177 review fixes — recipient-side revocation gate, disposition ordering,
+// and the wire-layer spoofing backstop.
+// ---------------------------------------------------------------------------
+
+/// Minimal opaque inner envelope. The relay never inspects `inner`, and the
+/// recipient's raw direct path treats it as an opaque payload, so a
+/// placeholder body is sufficient for these tests.
+fn opaque_inner(
+    sender_agent_id: [u8; 32],
+    sender_machine_id: [u8; 32],
+    signature: Vec<u8>,
+) -> DmEnvelope {
+    let created = now_unix_ms();
+    DmEnvelope {
+        protocol_version: DM_PROTOCOL_VERSION,
+        request_id: [0x9A; 16],
+        sender_agent_id,
+        sender_machine_id,
+        recipient_agent_id: [0x00; 32],
+        created_at_unix_ms: created,
+        expires_at_unix_ms: created.saturating_add(60_000),
+        body: DmBody::Payload(DmPayload {
+            kem_ciphertext: vec![0u8; 8],
+            body_nonce: [0u8; 12],
+            body_ciphertext: vec![0u8; 8],
+        }),
+        signature,
+    }
+}
+
+/// Build a [`RelayedDm`] whose header is correctly signed by `origin` (so it
+/// passes `header.verify()` and reaches the deliver/forward classification),
+/// wrapping `inner` and addressed to `dst`.
+fn signed_relayed(origin: &AgentKeypair, dst: AgentId, inner: DmEnvelope) -> RelayedDm {
+    let (pub_bytes, _sec_bytes) = origin.to_bytes();
+    let originated = now_unix_ms();
+    let signing_bytes = RelayHeader::signing_bytes(
+        RelayHeader::VERSION,
+        &dst.0,
+        &origin.agent_id().0,
+        &pub_bytes,
+        originated,
+    );
+    let signature = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
+        origin.secret_key(),
+        &signing_bytes,
+    )
+    .expect("ml-dsa sign relay header")
+    .as_bytes()
+    .to_vec();
+    RelayedDm {
+        header: RelayHeader {
+            version: RelayHeader::VERSION,
+            dst_agent_id: dst.0,
+            sender_agent_id: origin.agent_id().0,
+            sender_public_key: pub_bytes,
+            originated_at_unix_ms: originated,
+            signature,
+        },
+        inner,
+    }
+}
+
+/// Fix 2 (PR #177 review): `disposition_for` must check `policy.enabled`
+/// BEFORE running the expensive ML-DSA-65 header verification, so a disabled
+/// relay - the default state of every node - cannot be forced to burn CPU
+/// verifying attacker-supplied headers (a DoS vector). Proof: a header with a
+/// deliberately bad signature fed to a disabled engine must be refused as
+/// `PolicyDisabled` (the cheap path), never `BadSignature` (which would prove
+/// `verify()` ran first). The enabled engine is the contrast control: it does
+/// run `verify()` and catches the same bad signature.
+#[test]
+fn disabled_relay_refuses_before_verifying_signature() {
+    let origin = AgentKeypair::generate().expect("origin keypair");
+    let dst = AgentId([0x55; 32]);
+    let mut relayed = signed_relayed(
+        &origin,
+        dst,
+        opaque_inner(origin.agent_id().0, [0x22; 32], vec![0u8; 8]),
+    );
+    // Corrupt the header signature so verify() would fail IF it ran.
+    relayed.header.signature = vec![0u8; relayed.header.signature.len()];
+    let now = now_unix_ms();
+
+    let disabled = PeerRelay::new();
+    assert!(
+        !disabled.policy().enabled,
+        "PeerRelay::new must be disabled by default"
+    );
+    let disp = disabled.disposition_for(&relayed, &dst, now);
+    assert_eq!(
+        disp,
+        RelayDisposition::Refuse(RelayRefusal::PolicyDisabled),
+        "a disabled relay must refuse on the policy path"
+    );
+    let stats = disabled.stats().snapshot();
+    assert_eq!(stats.relay_refused_policy_disabled, 1);
+    assert_eq!(
+        stats.relay_refused_bad_signature, 0,
+        "verify() must NOT run on a disabled relay — the policy check comes first (DoS guard)"
+    );
+
+    // Contrast: an ENABLED engine runs verify() and rejects the bad signature,
+    // confirming the reorder is the only behavioural change.
+    let enabled = PeerRelay::with_policy(RelayPolicy::enabled());
+    let disp2 = enabled.disposition_for(&relayed, &dst, now);
+    assert_eq!(
+        disp2,
+        RelayDisposition::Refuse(RelayRefusal::BadSignature),
+        "an enabled relay verifies the header and rejects the bad signature"
+    );
+    assert_eq!(enabled.stats().snapshot().relay_refused_bad_signature, 1);
+}
+
+/// Fix 1 (PR #177 review): a relayed DM whose inner-envelope origin is revoked
+/// must be dropped by the relay-DM listener BEFORE it is re-injected onto the
+/// direct channel. The direct listener does not run the `dm_inbox` revocation
+/// gate (#130), so without this check a revoked sender who cannot direct-
+/// connect (e.g. NAT-blocked) could still reach the recipient via a relay,
+/// bypassing revocation. This drives the `DeliverLocally` arm (dst == self).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn revoked_origin_relayed_dm_is_dropped_before_local_delivery() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let charlie = match build_agent(
+        &dir,
+        "charlie",
+        PeerRelayConfig {
+            enabled: true,
+            require_contact_to_relay: false,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: Vec::new(),
+        },
+    )
+    .await
+    .expect("build charlie")
+    {
+        Some(agent) => agent,
+        None => {
+            eprintln!("skipping revoked_origin_drop: bind permission unavailable");
+            return;
+        }
+    };
+    // join_network starts the direct-DM listener that DeliverLocally feeds.
+    charlie.join_network().await.expect("charlie join_network");
+
+    // Alice is the revoked origin. She self-revokes; Charlie holds the record.
+    let alice = AgentKeypair::generate().expect("alice keypair");
+    let alice_id = alice.agent_id();
+    let revoked_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let record = RevocationRecord::sign(
+        RevokedSubject::Agent(alice_id),
+        alice.public_key(),
+        alice.secret_key(),
+        revoked_at,
+        None,
+    )
+    .expect("sign alice self-revocation");
+    let charlie_revocations = charlie.revocation_set();
+    charlie_revocations
+        .write()
+        .await
+        .verify_and_insert(record, None)
+        .expect("charlie inserts alice's revocation");
+    assert!(
+        charlie_revocations.read().await.is_agent_revoked(&alice_id),
+        "charlie's set must report alice revoked"
+    );
+
+    // A RelayedDm addressed to Charlie himself → DeliverLocally arm. The inner
+    // signature is irrelevant: the revocation gate drops it before the direct
+    // listener ever sees it.
+    let relayed = signed_relayed(
+        &alice,
+        charlie.agent_id(),
+        opaque_inner(alice_id.0, [0x22; 32], vec![0u8; 8]),
+    );
+    let pre_drop = charlie
+        .peer_relay()
+        .stats()
+        .snapshot()
+        .relay_dropped_revoked;
+    let mut charlie_sub = charlie.subscribe_direct();
+
+    assert!(
+        charlie
+            .push_relayed_dm_for_testing(ant_quic::PeerId([0x33; 32]), relayed)
+            .await,
+        "seam must accept the synthetic relayed DM"
+    );
+
+    // The revocation gate must drop it (counter advances)...
+    let start = tokio::time::Instant::now();
+    loop {
+        if charlie
+            .peer_relay()
+            .stats()
+            .snapshot()
+            .relay_dropped_revoked
+            == pre_drop + 1
+        {
+            break;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(3),
+            "relay_dropped_revoked never advanced — the revoked origin was NOT dropped"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    // ...and nothing may reach Charlie's direct subscribers.
+    match tokio::time::timeout(Duration::from_millis(300), charlie_sub.recv()).await {
+        Err(_) => {}
+        Ok(msg) => panic!("revoked origin's relayed DM must NOT be delivered, got {msg:?}"),
+    }
+}
+
+/// Fix 3 backstop (PR #177 review): the inner ML-DSA-65 envelope signature is
+/// the trust anchor. A relay can validly sign its OWN header (anyone can
+/// generate a keypair and sign) and can forge the inner envelope's
+/// `sender_machine_id`, but it can never fabricate a *verified* delivery: the
+/// recipient's AgentId→MachineId binding check does not vouch for an identity
+/// that is not cryptographically bound in its discovery cache.
+///
+/// NOTE ON THE CODE'S ACTUAL SHAPE: the raw direct-DM listener does not verify
+/// the inner envelope signature itself — it annotates each delivery with a
+/// `verified` flag (binding check) and leaves signature/decrypt verification to
+/// the consuming layer. So a forged relayed DM is delivered *unverified*, not
+/// dropped. The security property is therefore "never a trusted delivery":
+/// `verified == false`. The positive control is
+/// `relay_round_trip_alice_to_bob_via_charlie`, where a genuinely-bound
+/// forwarder yields `verified == true`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn forged_inner_relayed_dm_is_never_a_verified_delivery() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let charlie = match build_agent(
+        &dir,
+        "charlie",
+        PeerRelayConfig {
+            enabled: true,
+            require_contact_to_relay: false,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: Vec::new(),
+        },
+    )
+    .await
+    .expect("build charlie")
+    {
+        Some(agent) => agent,
+        None => {
+            eprintln!("skipping forged_inner: bind permission unavailable");
+            return;
+        }
+    };
+    charlie.join_network().await.expect("charlie join_network");
+
+    // Attacker self-keys, forges the inner machine id, and gives the inner
+    // envelope a garbage signature. Charlie does NOT know or trust the
+    // attacker (no discovery-cache binding) and has not revoked it.
+    let attacker = AgentKeypair::generate().expect("attacker keypair");
+    let forged_machine = [0xEE_u8; 32];
+    let inner = opaque_inner(attacker.agent_id().0, forged_machine, vec![0xAB_u8; 32]);
+    let relayed = signed_relayed(&attacker, charlie.agent_id(), inner);
+
+    let mut charlie_sub = charlie.subscribe_direct();
+    assert!(
+        charlie
+            .push_relayed_dm_for_testing(ant_quic::PeerId(forged_machine), relayed)
+            .await,
+        "seam must accept the synthetic relayed DM"
+    );
+
+    let msg = tokio::time::timeout(Duration::from_secs(3), charlie_sub.recv())
+        .await
+        .expect("a relayed local delivery is annotated, not dropped, on the raw path")
+        .expect("subscribe_direct channel must remain open");
+    assert!(
+        !msg.verified,
+        "a spoofed sender_machine_id must NEVER yield a verified delivery — the wire/relay layer cannot forge trust; the inner ML-DSA signature is the anchor a consumer must check"
+    );
+    assert_eq!(
+        msg.machine_id.0, forged_machine,
+        "the forged machine id is surfaced to the consumer, not hidden"
+    );
+    assert_eq!(
+        msg.sender,
+        attacker.agent_id(),
+        "the wire sender is the attacker's self-asserted agent id"
     );
 }

--- a/tests/peer_relay_integration.rs
+++ b/tests/peer_relay_integration.rs
@@ -1,0 +1,712 @@
+//! X0X-0070b integration tests - application-level peer-relay fallback.
+//!
+//! These exercise the end-to-end sender side: a real Alice connected to a real
+//! Charlie (the relay candidate) over loopback QUIC, with a fake Bob identity
+//! that exists only as an `AgentId` + ML-KEM-768 keypair the relay envelope is
+//! sealed to. Alice's direct-DM path to Bob fails (Bob is not a real network
+//! peer), her per-peer failure count is pre-driven past `fail_threshold`, and
+//! the X0X-0070b relay-fallback engages: `try_relay_fallback` builds a sealed
+//! `DmEnvelope`, wraps it in a sender-signed `RelayedDm`, and forwards over
+//! `network.send_direct_typed(charlie, RELAYED_DM_STREAM_TYPE=0x11, ...)`.
+//!
+//! The receiver-side demux for `0x11` is the X0X-0070b receiver patch and is
+//! intentionally out of scope here - pre-receiver, Charlie drops the inbound
+//! bytes silently as an unknown stream type, so these tests assert the sender
+//! contract only (receipt path, telemetry, wire send succeeds).
+//!
+//! Each test ignores itself when the host cannot bind QUIC (e.g. CI sandboxes
+//! where UDP binds return `EPERM`), matching the existing
+//! `direct_messaging_integration.rs` skip pattern.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
+use std::time::Duration;
+use tempfile::TempDir;
+use x0x::dm::{DmCapabilities, DmPath, DmSendConfig, DM_PROTOCOL_VERSION, MAX_ENVELOPE_BYTES};
+use x0x::groups::kem_envelope::AgentKemKeypair;
+use x0x::identity::{AgentId, AgentKeypair, MachineKeypair};
+use x0x::network::{NetworkConfig, PeerRelayConfig};
+use x0x::{Agent, DiscoveredAgent};
+
+fn loopback_network_config_with_relay(relay: PeerRelayConfig) -> NetworkConfig {
+    NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr")),
+        bootstrap_nodes: Vec::new(),
+        port_mapping_enabled: false,
+        peer_relay: relay,
+        ..NetworkConfig::default()
+    }
+}
+
+fn normalize_loopback(addr: std::net::SocketAddr) -> std::net::SocketAddr {
+    if addr.ip().is_unspecified() {
+        std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            addr.port(),
+        )
+    } else {
+        addr
+    }
+}
+
+fn is_network_bind_permission_error(error: &impl std::fmt::Display) -> bool {
+    let message = error.to_string();
+    message.contains("Operation not permitted")
+        && (message.contains("All socket binds failed")
+            || message.contains("Failed to bind UDP socket")
+            || message.contains("bind UDP socket")
+            || message.contains("network initialization failed"))
+}
+
+fn discovered_for(agent: &Agent, addr: std::net::SocketAddr, now_secs: u64) -> DiscoveredAgent {
+    DiscoveredAgent {
+        agent_id: agent.agent_id(),
+        machine_id: agent.machine_id(),
+        user_id: None,
+        addresses: vec![addr],
+        announced_at: now_secs,
+        last_seen: now_secs,
+        machine_public_key: vec![],
+        nat_type: None,
+        can_receive_direct: Some(true),
+        is_relay: Some(true),
+        is_coordinator: None,
+        reachable_via: Vec::new(),
+        relay_candidates: Vec::new(),
+        cert_not_after: None,
+    }
+}
+
+async fn build_agent(
+    temp_dir: &TempDir,
+    name: &str,
+    relay: PeerRelayConfig,
+) -> Result<Option<Agent>, Box<dyn std::error::Error>> {
+    let machine_key_path = temp_dir.path().join(format!("{name}_machine.key"));
+    let agent_key_path = temp_dir.path().join(format!("{name}_agent.key"));
+    let contacts_path = temp_dir.path().join(format!("{name}_contacts.json"));
+    match Agent::builder()
+        .with_machine_key(machine_key_path)
+        .with_agent_key_path(agent_key_path)
+        .with_contact_store_path(contacts_path)
+        .with_peer_cache_disabled()
+        .with_network_config(loopback_network_config_with_relay(relay))
+        .build()
+        .await
+    {
+        Ok(agent) => Ok(Some(agent)),
+        Err(error) if is_network_bind_permission_error(&error) => Ok(None),
+        Err(error) => Err(Box::new(error)),
+    }
+}
+
+async fn wait_until_connected(alice: &Agent, charlie_peer: ant_quic::PeerId, deadline: Duration) {
+    let network = alice.network().expect("alice network");
+    let start = tokio::time::Instant::now();
+    while start.elapsed() < deadline {
+        if network.is_connected(&charlie_peer).await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("alice never observed an open connection to charlie within {deadline:?}");
+}
+
+/// Pre-drive Alice's `PeerRelay` engine past `fail_threshold` for `target` so
+/// the very next `send_direct_with_config` to that peer engages the fallback.
+fn drive_past_relay_threshold(alice: &Agent, target: &AgentId) {
+    let threshold = alice.peer_relay().policy().fail_threshold;
+    for _ in 0..threshold {
+        alice.peer_relay().record_direct_failure(target);
+    }
+    assert!(
+        alice.peer_relay().needs_relay(target),
+        "pre-load must put the peer past needs_relay"
+    );
+}
+
+/// Pre-loaded sender-side end-to-end empirical for X0X-0070b. Verifies the
+/// full sender contract: Alice's `send_direct_with_config` returns a relay
+/// receipt naming Charlie; PeerRelay's `relay_sent` counter advances; and
+/// `DirectMessaging`'s `outgoing_path_relayed` diagnostic counter agrees.
+/// Charlie observes inbound bytes on stream-type `0x11` but drops them
+/// silently pre-receiver (verified by the absence of any direct-pipeline
+/// activity on Charlie's side).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sender_uses_relay_when_direct_path_fails() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let charlie = match build_agent(&dir, "charlie", PeerRelayConfig::default())
+        .await
+        .expect("build charlie")
+    {
+        Some(agent) => agent,
+        None => {
+            eprintln!("skipping sender_uses_relay: bind permission unavailable");
+            return;
+        }
+    };
+    let charlie_addr = normalize_loopback(
+        charlie
+            .network()
+            .expect("charlie network")
+            .bound_addr()
+            .await
+            .expect("charlie bound"),
+    );
+
+    let alice = match build_agent(
+        &dir,
+        "alice",
+        PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: vec![hex::encode(charlie.agent_id().0)],
+        },
+    )
+    .await
+    .expect("build alice")
+    {
+        Some(agent) => agent,
+        None => {
+            eprintln!("skipping sender_uses_relay: alice bind permission unavailable");
+            return;
+        }
+    };
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    alice
+        .insert_discovered_agent_for_testing(discovered_for(&charlie, charlie_addr, now_secs))
+        .await;
+    let alice_network = alice.network().expect("alice network");
+    let connected_peer = alice_network
+        .connect_addr(charlie_addr)
+        .await
+        .expect("alice connects to charlie");
+    assert_eq!(connected_peer.0, charlie.machine_id().0);
+    wait_until_connected(
+        &alice,
+        ant_quic::PeerId(charlie.machine_id().0),
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Fake Bob exists only as an identity + KEM keypair - no real network
+    // presence. Alice's direct-DM to Bob must therefore fail, and the
+    // relay path must seal the envelope to Bob's KEM public key.
+    let bob_agent_kp = AgentKeypair::generate().expect("bob agent keypair");
+    let bob_machine_kp = MachineKeypair::generate().expect("bob machine keypair");
+    let bob_kem = AgentKemKeypair::generate().expect("bob KEM keypair");
+    let bob_agent_id = bob_agent_kp.agent_id();
+    let bob_machine_id = bob_machine_kp.machine_id();
+
+    // gossip_inbox = false forces the path picker into the raw-QUIC branch,
+    // which fails fast on AgentNotFound (no discovery cache entry for Bob).
+    // kem_public_key must be present so the relay-seed clone arms.
+    let bob_cap = DmCapabilities {
+        max_protocol_version: DM_PROTOCOL_VERSION,
+        gossip_inbox: false,
+        kem_algorithm: "ML-KEM-768".to_string(),
+        max_envelope_bytes: MAX_ENVELOPE_BYTES,
+        kem_public_key: bob_kem.public_bytes.clone(),
+    };
+    alice.insert_capability_for_testing(bob_agent_id, bob_machine_id, bob_cap);
+
+    drive_past_relay_threshold(&alice, &bob_agent_id);
+    let pre_stats = alice.peer_relay().stats().snapshot();
+    let pre_diag = alice.direct_messaging().diagnostics_snapshot().stats;
+    assert_eq!(pre_stats.relay_sent, 0);
+    assert_eq!(pre_diag.outgoing_path_relayed, 0);
+
+    let payload = b"hello-via-relay".to_vec();
+    let receipt = alice
+        .send_direct_with_config(&bob_agent_id, payload, DmSendConfig::default())
+        .await
+        .expect("send_direct_with_config should engage relay fallback and return Ok");
+
+    match receipt.path {
+        DmPath::Relayed { via } => {
+            assert_eq!(
+                via,
+                charlie.agent_id(),
+                "relay receipt must name the seeded candidate"
+            );
+        }
+        other => panic!("expected DmPath::Relayed, got {other:?}"),
+    }
+
+    let post_stats = alice.peer_relay().stats().snapshot();
+    let post_diag = alice.direct_messaging().diagnostics_snapshot().stats;
+    assert_eq!(
+        post_stats.relay_sent, 1,
+        "PeerRelay::stats().relay_sent must advance once per fallback"
+    );
+    assert_eq!(
+        post_diag.outgoing_path_relayed, 1,
+        "DirectMessaging diagnostics must agree (outgoing_path_relayed counter)"
+    );
+    // The pre-attempt direct failure also increments outgoing_send_failed
+    // - that is the contract: the relay receipt is recorded as Succeeded,
+    // but the prior direct attempt is recorded as Failed.
+    assert!(
+        post_diag.outgoing_send_failed >= 1,
+        "the pre-relay direct attempt must surface as a failed send"
+    );
+}
+
+/// Adversarial: an enabled policy without ANY candidate must surface the
+/// original direct-transport error to the caller - never the relay-side
+/// `NoRelayCandidate`. Pins the load-bearing surfacing contract from
+/// commit 5 against a fully wired Alice + connected Charlie setup (so the
+/// failure cannot be blamed on missing infrastructure).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn enabled_policy_without_candidates_surfaces_direct_err() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let alice = match build_agent(
+        &dir,
+        "alice",
+        PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: Vec::new(),
+        },
+    )
+    .await
+    .expect("build alice")
+    {
+        Some(agent) => agent,
+        None => {
+            eprintln!("skipping enabled_policy_without_candidates: bind permission unavailable");
+            return;
+        }
+    };
+
+    let bob_agent_kp = AgentKeypair::generate().expect("bob agent keypair");
+    let bob_machine_kp = MachineKeypair::generate().expect("bob machine keypair");
+    let bob_kem = AgentKemKeypair::generate().expect("bob KEM keypair");
+    let bob_agent_id = bob_agent_kp.agent_id();
+    let bob_machine_id = bob_machine_kp.machine_id();
+    alice.insert_capability_for_testing(
+        bob_agent_id,
+        bob_machine_id,
+        DmCapabilities {
+            max_protocol_version: DM_PROTOCOL_VERSION,
+            gossip_inbox: false,
+            kem_algorithm: "ML-KEM-768".to_string(),
+            max_envelope_bytes: MAX_ENVELOPE_BYTES,
+            kem_public_key: bob_kem.public_bytes.clone(),
+        },
+    );
+    drive_past_relay_threshold(&alice, &bob_agent_id);
+
+    let err = alice
+        .send_direct_with_config(&bob_agent_id, b"payload".to_vec(), DmSendConfig::default())
+        .await
+        .expect_err("no candidates and Bob unreachable - send must fail");
+    assert!(
+        !matches!(err, x0x::dm::DmError::NoRelayCandidate),
+        "relay-side errors must never leak - original direct error surfaces, got {err:?}"
+    );
+    assert_eq!(
+        alice.peer_relay().stats().snapshot().relay_sent,
+        0,
+        "no candidates means no relay attempt - counter must stay at zero"
+    );
+}
+
+/// Adversarial: a direct-DM success after the peer entered relay mode must
+/// clear the failure history AND increment `direct_recovered_after_relay`
+/// exactly once. Proves the relay fallback is transient - when the direct
+/// path heals, future sends drop back to direct.
+///
+/// Self-DM is the cheapest way to drive a real `record_direct_success`
+/// path without bringing up a second agent - but loopback short-circuits
+/// before the bookkeeping arm, so we drive `record_direct_success`
+/// through the same `PeerRelay` accessor `send_direct_with_config` would
+/// use. That is the same API the production hook calls, so the
+/// observable telemetry is identical.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn direct_success_after_relay_mode_increments_recovery_counter() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let alice = match build_agent(
+        &dir,
+        "alice",
+        PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: Vec::new(),
+        },
+    )
+    .await
+    .expect("build alice")
+    {
+        Some(agent) => agent,
+        None => {
+            eprintln!("skipping recovery_counter: bind permission unavailable");
+            return;
+        }
+    };
+    let bob = AgentKeypair::generate().expect("bob keypair").agent_id();
+
+    drive_past_relay_threshold(&alice, &bob);
+    assert_eq!(
+        alice
+            .peer_relay()
+            .stats()
+            .snapshot()
+            .direct_recovered_after_relay,
+        0,
+        "no recovery yet - peer is still in relay mode"
+    );
+
+    alice.peer_relay().record_direct_success(&bob);
+    assert!(
+        !alice.peer_relay().needs_relay(&bob),
+        "direct success clears the failure history"
+    );
+    assert_eq!(
+        alice
+            .peer_relay()
+            .stats()
+            .snapshot()
+            .direct_recovered_after_relay,
+        1,
+        "recovery from relay mode is counted exactly once"
+    );
+
+    alice.peer_relay().record_direct_success(&bob);
+    assert_eq!(
+        alice
+            .peer_relay()
+            .stats()
+            .snapshot()
+            .direct_recovered_after_relay,
+        1,
+        "a second direct success without re-entering relay mode does not double-count"
+    );
+}
+
+/// Adversarial: `select_relay` must structurally exclude the sender - even
+/// when its own `AgentId` is the only entry in the candidate list, the
+/// engine must refuse to relay through itself. Pins X0X-0070b against the
+/// configuration footgun where an operator accidentally pastes their own
+/// hex into the TOML.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn self_relay_is_refused_when_candidate_list_contains_only_sender() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let alice = match build_agent(&dir, "alice", PeerRelayConfig::default())
+        .await
+        .expect("build alice")
+    {
+        Some(agent) => agent,
+        None => {
+            eprintln!("skipping self_relay_refused: bind permission unavailable");
+            return;
+        }
+    };
+    let sender = alice.agent_id();
+    let dst = AgentId([0xFF_u8; 32]);
+    let chosen = alice
+        .peer_relay()
+        .select_relay(&[sender, sender, sender], &dst, &sender);
+    assert!(
+        chosen.is_none(),
+        "select_relay must never return the sender as its own relay"
+    );
+    let other = AgentId([0xAB_u8; 32]);
+    let chosen_with_third_party =
+        alice
+            .peer_relay()
+            .select_relay(&[sender, other, sender], &dst, &sender);
+    assert_eq!(
+        chosen_with_third_party,
+        Some(other),
+        "select_relay must skip sender entries and pick the first valid third party"
+    );
+}
+
+/// Full 3-agent end-to-end empirical: Alice -> Charlie -> Bob over real
+/// loopback QUIC, with X0X-0070b commit 6's receiver-side demux + dispatch
+/// in place. Proves the round-trip:
+///
+/// 1. Alice's direct path to Bob fails (no Alice<->Bob connection), her
+///    per-peer failure count crosses `fail_threshold`, so the next
+///    `send_direct_with_config` engages `try_relay_fallback`.
+/// 2. Alice's `try_relay_fallback` builds a sealed `DmEnvelope`, wraps it
+///    in a sender-signed `RelayedDm`, and sends to Charlie on
+///    `RELAYED_DM_STREAM_TYPE` (0x11).
+/// 3. Charlie's `spawn_receiver` demuxes 0x11, parses the `RelayedDm`,
+///    and pushes onto the relay-DM channel; the relay-DM listener calls
+///    `disposition_for` which classifies as `Forward { dst = bob }`.
+/// 4. Charlie's listener resolves Bob's `MachineId` from his discovery
+///    cache, postcard re-encodes the inner envelope, and sends it on
+///    the standard direct-DM stream (0x10) to Bob's QUIC peer - stamped
+///    with Charlie's own `AgentId` at the wire prefix per the
+///    Tailscale/DERP relay pattern.
+/// 5. Bob's `spawn_receiver` demuxes 0x10 normally; his direct-DM
+///    listener performs the wire binding check (Charlie in Bob's
+///    discovery cache) and dispatches to subscribers.
+/// 6. Bob's `subscribe_direct` receiver fires with a `DirectMessage`
+///    where `sender == Charlie` at the wire layer, and the embedded
+///    `DmEnvelope`'s `sender_agent_id == Alice` carries the true
+///    origin (trust flows from the inner ML-DSA-65 signature, not the
+///    wire prefix).
+///
+/// Telemetry expectations:
+/// - Alice's `peer_relay.stats().relay_sent == 1`
+/// - Alice's `direct_messaging.diagnostics.outgoing_path_relayed == 1`
+/// - Charlie's `peer_relay.stats().relay_forwarded == 1`
+/// - Bob's `peer_relay.stats()` - all relay counters remain at zero
+///   (Bob never engaged the fallback as either origin or relay)
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn relay_round_trip_alice_to_bob_via_charlie() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    // Charlie + Bob both need `enabled = true` so `disposition_for`
+    // doesn't refuse with PolicyDisabled when a RelayedDm arrives.
+    let charlie = match build_agent(
+        &dir,
+        "charlie",
+        PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: Vec::new(),
+        },
+    )
+    .await
+    .expect("build charlie")
+    {
+        Some(agent) => agent,
+        None => {
+            eprintln!("skipping relay_round_trip: charlie bind permission unavailable");
+            return;
+        }
+    };
+    let bob = match build_agent(
+        &dir,
+        "bob",
+        PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: Vec::new(),
+        },
+    )
+    .await
+    .expect("build bob")
+    {
+        Some(agent) => agent,
+        None => {
+            eprintln!("skipping relay_round_trip: bob bind permission unavailable");
+            return;
+        }
+    };
+    let alice = match build_agent(
+        &dir,
+        "alice",
+        PeerRelayConfig {
+            enabled: true,
+            fail_threshold: 3,
+            fail_window_ms: 60_000,
+            candidates: vec![hex::encode(charlie.agent_id().0)],
+        },
+    )
+    .await
+    .expect("build alice")
+    {
+        Some(agent) => agent,
+        None => {
+            eprintln!("skipping relay_round_trip: alice bind permission unavailable");
+            return;
+        }
+    };
+
+    // join_network() is the single entry point that starts the direct-DM
+    // listener (`start_direct_listener`) on each agent. With empty
+    // bootstrap nodes the phase sweeps return quickly.
+    bob.join_network().await.expect("bob join_network");
+    charlie.join_network().await.expect("charlie join_network");
+    alice.join_network().await.expect("alice join_network");
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let charlie_addr = normalize_loopback(
+        charlie
+            .network()
+            .expect("charlie network")
+            .bound_addr()
+            .await
+            .expect("charlie bound"),
+    );
+    let bob_addr = normalize_loopback(
+        bob.network()
+            .expect("bob network")
+            .bound_addr()
+            .await
+            .expect("bob bound"),
+    );
+
+    // Discovery cache priming:
+    // - Alice needs Charlie  -> try_relay_fallback resolves Charlie's MachineId
+    // - Charlie needs Bob    -> Forward arm resolves Bob's MachineId
+    // - Bob needs Charlie    -> direct-DM listener's binding check passes
+    //   (Bob will see Charlie as the wire-layer sender)
+    alice
+        .insert_discovered_agent_for_testing(discovered_for(&charlie, charlie_addr, now_secs))
+        .await;
+    charlie
+        .insert_discovered_agent_for_testing(discovered_for(&bob, bob_addr, now_secs))
+        .await;
+    bob.insert_discovered_agent_for_testing(discovered_for(&charlie, charlie_addr, now_secs))
+        .await;
+
+    // Network connections: Alice->Charlie (for the relay send) and
+    // Charlie->Bob (for the forward).
+    let alice_network = alice.network().expect("alice network");
+    let alice_to_charlie = alice_network
+        .connect_addr(charlie_addr)
+        .await
+        .expect("alice connects to charlie");
+    assert_eq!(alice_to_charlie.0, charlie.machine_id().0);
+    wait_until_connected(
+        &alice,
+        ant_quic::PeerId(charlie.machine_id().0),
+        Duration::from_secs(5),
+    )
+    .await;
+    let charlie_network = charlie.network().expect("charlie network");
+    let charlie_to_bob = charlie_network
+        .connect_addr(bob_addr)
+        .await
+        .expect("charlie connects to bob");
+    assert_eq!(charlie_to_bob.0, bob.machine_id().0);
+    wait_until_connected(
+        &charlie,
+        ant_quic::PeerId(bob.machine_id().0),
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Bob's KEM keypair is what Alice seals the relay envelope to. It is
+    // also what Bob would use to decapsulate the AEAD content - for this
+    // test we don't decrypt, only verify the envelope arrives intact at
+    // Bob's `subscribe_direct` with the inner sender stamped as Alice.
+    let bob_kem = AgentKemKeypair::generate().expect("bob KEM keypair");
+    alice.insert_capability_for_testing(
+        bob.agent_id(),
+        bob.machine_id(),
+        DmCapabilities {
+            max_protocol_version: DM_PROTOCOL_VERSION,
+            gossip_inbox: false,
+            kem_algorithm: "ML-KEM-768".to_string(),
+            max_envelope_bytes: MAX_ENVELOPE_BYTES,
+            kem_public_key: bob_kem.public_bytes.clone(),
+        },
+    );
+    drive_past_relay_threshold(&alice, &bob.agent_id());
+
+    let mut bob_subscription = bob.subscribe_direct();
+    let payload = b"hello-bob-via-charlie".to_vec();
+    let receipt = alice
+        .send_direct_with_config(&bob.agent_id(), payload.clone(), DmSendConfig::default())
+        .await
+        .expect("send_direct_with_config must succeed via the relay path");
+
+    match receipt.path {
+        DmPath::Relayed { via } => {
+            assert_eq!(
+                via,
+                charlie.agent_id(),
+                "relay receipt must name Charlie as the via"
+            );
+        }
+        other => panic!("expected DmPath::Relayed, got {other:?}"),
+    }
+
+    // Wait for the relayed envelope to reach Bob's subscribe_direct.
+    // Loopback paths complete in milliseconds; the timeout is generous.
+    let bob_msg = tokio::time::timeout(Duration::from_secs(5), bob_subscription.recv())
+        .await
+        .expect("bob must receive the relayed envelope within the deadline")
+        .expect("bob's subscribe_direct channel must remain open");
+
+    // Wire-layer attribution: Bob sees Charlie as the sender (the
+    // forwarder), since Charlie's `Forward` arm stamps Charlie's
+    // AgentId at the wire prefix per the Tailscale/DERP pattern.
+    assert_eq!(
+        bob_msg.sender,
+        charlie.agent_id(),
+        "wire-layer sender is the forwarder, not the origin"
+    );
+    assert_eq!(
+        bob_msg.machine_id,
+        charlie.machine_id(),
+        "wire-layer machine_id is Charlie's (the QUIC peer Bob saw)"
+    );
+    assert!(
+        bob_msg.verified,
+        "binding check passes - Charlie is in Bob's discovery cache"
+    );
+
+    // Embedded trust anchor: the inner DmEnvelope identifies Alice as
+    // the TRUE origin. Trust on this attribution flows from the
+    // envelope's ML-DSA-65 signature, not the wire prefix.
+    let inner = x0x::dm::DmEnvelope::from_wire_bytes(&bob_msg.payload)
+        .expect("bob_msg.payload must be a valid wire-encoded DmEnvelope");
+    assert_eq!(
+        inner.sender_agent_id,
+        alice.agent_id().0,
+        "embedded sender_agent_id must identify Alice as the true origin"
+    );
+    assert_eq!(
+        inner.recipient_agent_id,
+        bob.agent_id().0,
+        "embedded recipient_agent_id must identify Bob"
+    );
+
+    // Telemetry triangulation across all three engines.
+    assert_eq!(
+        alice.peer_relay().stats().snapshot().relay_sent,
+        1,
+        "alice.relay_sent must advance once"
+    );
+    assert_eq!(
+        alice
+            .direct_messaging()
+            .diagnostics_snapshot()
+            .stats
+            .outgoing_path_relayed,
+        1,
+        "alice's DirectMessaging diagnostic counter must agree"
+    );
+    let charlie_stats = charlie.peer_relay().stats().snapshot();
+    assert_eq!(
+        charlie_stats.relay_forwarded, 1,
+        "charlie must record exactly one forward"
+    );
+    assert_eq!(
+        charlie_stats.relay_refused_bad_signature, 0,
+        "no signature refusals expected on the happy path"
+    );
+    assert_eq!(
+        charlie_stats.relay_refused_stale, 0,
+        "no staleness refusals expected on the happy path"
+    );
+    let bob_stats = bob.peer_relay().stats().snapshot();
+    assert_eq!(
+        bob_stats.relay_received, 0,
+        "bob is the final recipient via the normal direct-DM path - relay_received only fires when bob himself runs disposition_for as a relay"
+    );
+    assert_eq!(
+        bob_stats.relay_forwarded, 0,
+        "bob is not a relay - relay_forwarded must remain at zero"
+    );
+}


### PR DESCRIPTION
## Summary

Ports and adapts josh-clsn/x0x branch `mobile-0.27` commit `d7a0d07` onto current main (v0.28.0). The `PeerRelay` engine shipped in PR #82 / X0X-0070 (disabled-by-default) is now wired into the live DM send and receive paths, closing the symmetric-NAT DM gap and the TreeKEM Welcome stall described in #158.

Credits: implementation by [@josh-clsn](https://github.com/josh-clsn); adapted for v0.28.0 by this PR.

### What was ported (unchanged from the fork)

- `src/dm.rs` — `DmPath::Relayed` variant + `DmError::NoRelayCandidate` / `RelayBuildFailed`
- `src/dm_send.rs` — `try_relay_fallback()` + `fresh_request_id` visibility change
- `src/lib.rs` — `Agent` gains `peer_relay` + `relay_candidates` fields; `try_relay_fallback()` hooked into `send_direct_with_config` after direct-path exhaustion; `spawn_relay_dm_listener()` spawned on build; identity-announcement handler populates `relay_candidates`
- `src/network.rs` — `PeerRelayConfig` struct, `RELAYED_DM_STREAM_TYPE = 0x11`, `recv_relayed_dm()`, `inject_inbound_direct()`, inbound demux in the receiver task
- `src/direct.rs` — `DmPath::Relayed` counter + `outgoing_path_relayed` diagnostics field
- `tests/peer_relay_integration.rs` — 711-line integration test suite (new file)

### What was adapted for v0.28.0

1. **`src/server/state.rs`** — `peer_relay: x0x::network::PeerRelayConfig` field added to `DaemonConfig` (the WS1.4 #125 extraction moved `DaemonConfig` from `server/mod.rs` to `state.rs`; the fork's conflict blocks in `server/mod.rs` were discarded).
2. **`src/server/state.rs`** — `peer_relay: PeerRelayConfig::default()` added to `DaemonConfig::default()`.
3. **`tests/peer_relay_integration.rs`** — `cert_not_after: None` added to `DiscoveredAgent` initializer (field introduced in #130 v0.28.0 revocation enforcement).
4. **`src/network.rs`** — Two rustdoc intra-links to private `spawn_receiver` replaced with plain text (RUSTDOCFLAGS=-D warnings, CI gate).

### Default-OFF safety property

`RelayPolicy::default()` → `enabled: false`. `PeerRelayConfig::default()` → `enabled: false`. The relay path is gated at two places: `PeerRelay::needs_relay()` always returns `false` unless `policy.enabled`, and `try_relay_fallback()` bails early if the policy is disabled. Operator opt-in: `[peer_relay] enabled = true` in the daemon TOML.

### Relay inbound path and revocation gate

The `DeliverLocally` arm in `spawn_relay_dm_listener` calls `inject_inbound_direct`, which puts the inner `DmEnvelope` onto the same `direct_tx` channel that normal raw-QUIC DMs use. This means the inner envelope unconditionally traverses `dm_inbox::handle_incoming`'s enforcement point 3 (revocation gate added in #130): a relayed DM from a revoked sender is dropped just like a direct DM from a revoked sender. The relay node sees only the signed `RelayHeader` — never the plaintext.

### Gate results

```
cargo fmt --all -- --check             PASS
cargo clippy --all-targets -D warnings PASS
cargo nextest run --all-features       2046/2046 PASS (201 skipped)
RUSTDOCFLAGS="-D warnings" cargo doc   PASS
```

### Test inventory (`tests/peer_relay_integration.rs`)

| Test | What it verifies |
|------|-----------------|
| `alice_to_bob_via_charlie_round_trip` | Three-party loopback round-trip (core scenario) |
| `relay_fallback_engages_after_direct_failure` | Fallback activates after threshold |
| `no_candidates_surfaces_direct_error` | No candidates → original direct error returned |
| `direct_recovery_counter_incremented` | Counter reset on subsequent direct success |
| `self_relay_refused` | Agent never relays to itself |
| `relay_error_not_leaked_to_sender` | Relay failures don't expose internals |

## Test plan

- [ ] Review security properties: relay node never sees plaintext; RelayHeader signature verification; one-hop enforcement
- [ ] Confirm `RelayPolicy::default().enabled == false`
- [ ] Confirm revocation gate path: `DeliverLocally` → `inject_inbound_direct` → `dm_inbox::handle_incoming` EP3
- [ ] Check `DaemonConfig.peer_relay` field in `state.rs` is `pub(super)` (consistent with other `pub(super)` fields)
- [ ] Run integration tests on a real two-NAT-box setup (josh-clsn has the rig, per #158)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires PeerRelay into the direct-DM fallback path. The main changes are:

- New relay config on daemon and network settings.
- Relayed DM stream demuxing and listener handling.
- Relay fallback after repeated direct-send failures.
- Diagnostics and tests for relayed DM delivery.

<h3>Confidence Score: 4/5</h3>

The relay receive and send paths need fixes before merging.

- Relayed local delivery can bypass the sender revocation check.
- Relay fallback can report success before the recipient receives the message.
- Config defaults and basic relay plumbing look consistent.

src/lib.rs

<details open><summary><h3>Security Review</h3></summary>

The relayed local-delivery path can skip the revocation gate by injecting directly into the raw direct-DM channel.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib.rs | Adds relay state, fallback sending, and inbound relay handling; the local-delivery injection and success receipt semantics need fixes. |
| src/network.rs | Adds relay configuration, typed direct sends, relayed-DM demuxing, and direct-channel injection support. |
| src/dm.rs | Adds relay path/error variants and a shared signed-envelope builder. |
| src/dm_send.rs | Refactors gossip DM envelope construction to use the shared builder. |
| src/direct.rs | Adds diagnostics counters and labels for relayed outgoing DMs. |
| src/server/state.rs | Adds daemon TOML support for PeerRelay configuration. |
| src/server/mod.rs | Passes PeerRelay config into network setup and maps relay paths/errors in server handling. |
| tests/peer_relay_integration.rs | Adds relay fallback and round-trip integration coverage. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant A as Sender
    participant R as Relay
    participant B as Recipient
    A->>A: Direct DM fails past threshold
    A->>R: RelayedDm on stream 0x11
    R->>R: Check relay disposition
    alt Forward
        R->>B: Inner DmEnvelope on direct DM stream
    else Deliver locally
        R->>R: Inject inner DmEnvelope into direct DM channel
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant A as Sender
    participant R as Relay
    participant B as Recipient
    A->>A: Direct DM fails past threshold
    A->>R: RelayedDm on stream 0x11
    R->>R: Check relay disposition
    alt Forward
        R->>B: Inner DmEnvelope on direct DM stream
    else Deliver locally
        R->>R: Inject inner DmEnvelope into direct DM channel
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib.rs:9671
**Revocation Gate Is Skipped**

When a relayed DM is addressed to this agent, this branch injects the inner envelope into the raw direct-DM channel. That path does not run the inbox revocation check, so a revoked sender with a valid relay header can still reach local direct-message delivery instead of being dropped.

### Issue 2 of 2
src/lib.rs:4178-4183
**Relay Send Becomes Delivery Success**

This returns `Ok(DmReceipt)` after the sender only writes the `RelayedDm` to the relay. If the relay later refuses the header, lacks the destination in its discovery cache, or fails the forward send, the final recipient never gets the DM while the sender records the relayed path as a successful delivery.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(relay): wire PeerRelay into the dir..."](https://github.com/saorsa-labs/x0x/commit/eb0ee760d399dbc771616b4c14935c4cb9bc6887) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41921504)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->