### PR TITLE
feat(gui): symphony board view + approval column, rebased onto v0.28.0 (#152, #159)

### DIFF
--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -166,6 +166,9 @@ tr:hover td{background:rgba(255,255,255,.01)}
 .chat-input input{flex:1}
 
 /* Kanban */
+.kanban-toolbar{justify-content:space-between;flex-wrap:wrap}
+.board-filter{display:inline-flex;align-items:center;gap:6px;color:var(--tx2);font-size:12px;white-space:nowrap}
+.board-filter input{flex:0;margin:0;accent-color:var(--cy)}
 .kanban{display:flex;gap:var(--sp3);overflow-x:auto;padding-bottom:var(--sp2)}
 .kanban-col{flex:1;min-width:220px;background:var(--bg2);border:1px solid var(--bd);border-radius:var(--r-md)}
 .kanban-hd{padding:var(--sp3);font:600 11px var(--sans);text-transform:uppercase;color:var(--tx3);border-bottom:1px solid var(--bd);letter-spacing:.5px;display:flex;justify-content:space-between}
@@ -175,6 +178,14 @@ tr:hover td{background:rgba(255,255,255,.01)}
 .kanban-card:hover{border-color:var(--cy);transform:translateY(-1px);box-shadow:0 4px 12px rgba(0,0,0,.2)}
 .kanban-card .title{font-size:12px;font-weight:500}
 .kanban-card .meta{font-size:10px;color:var(--tx3);margin-top:var(--sp1)}
+.sym-badges{display:flex;flex-wrap:wrap;gap:4px;margin-top:var(--sp2)}
+.sym-badge{display:inline-flex;align-items:center;gap:3px;padding:1px 6px;font:600 9px var(--sans);text-transform:uppercase;letter-spacing:.35px;border:1px solid;border-radius:var(--r-full);white-space:nowrap}
+.sym-badge.info{color:var(--cy);border-color:var(--cy);background:var(--cy-dim)}
+.sym-badge.ok{color:var(--gn);border-color:var(--gn);background:var(--gn-dim)}
+.sym-badge.warn{color:var(--am);border-color:var(--am);background:var(--am-dim)}
+.sym-badge.bad{color:var(--rd);border-color:var(--rd);background:var(--rd-dim)}
+.sym-badge.muted{color:var(--tx3);border-color:var(--bd);background:rgba(74,77,102,.12)}
+.sym-badge.pri{color:var(--lv);border-color:var(--lv);background:var(--lv-dim)}
 
 /* Sub-tabs */
 .sub-tabs{display:flex;gap:0;border-bottom:1px solid var(--bd);margin-bottom:var(--sp4);overflow-x:auto}
@@ -1789,6 +1800,7 @@ function renderIdentityChainLegacy(){
    JS SECTION 7: SPACE VIEW
    ═══════════════════════════════════════════════════════════════════ */
 let spaceChatTopic='',spaceBoardId='',spaceKvId='',currentChannelTopic='';
+let boardSymphonyOnly=LS.get('board_symphony_only',false),boardPollSeq=0;
 // Confidentiality of the currently-mounted space, fetched from
 // `GET /groups/:id`. Used by sendSpaceChat() to route SignedPublic
 // groups through `POST /groups/:id/send` (which produces an
@@ -2156,10 +2168,11 @@ function scrollToMsg(msgId){
 
 // --- Space: Board ---
 function renderSpaceBoard(el,sid){
-  el.innerHTML=`<div class="row mb"><input id="board-in" placeholder="New task…" style="flex:1"><button class="pri" onclick="addBoardTask()">Add</button></div>
+  el.innerHTML=`<div class="row mb kanban-toolbar"><input id="board-in" placeholder="New task…" style="flex:1"><button class="pri" onclick="addBoardTask()">Add</button><label class="board-filter"><input type="checkbox" id="board-symphony-only" onchange="toggleBoardSymphonyFilter(this.checked)" ${boardSymphonyOnly?'checked':''}> Symphony</label></div>
   <div class="kanban">
     <div class="kanban-col"><div class="kanban-hd">To Do <span class="count" id="kb-todo-n">0</span></div><div class="kanban-body" id="kb-todo"></div></div>
     <div class="kanban-col"><div class="kanban-hd">In Progress <span class="count" id="kb-wip-n">0</span></div><div class="kanban-body" id="kb-wip"></div></div>
+    <div class="kanban-col"><div class="kanban-hd">Review <span class="count" id="kb-review-n">0</span></div><div class="kanban-body" id="kb-review"></div></div>
     <div class="kanban-col"><div class="kanban-hd">Done <span class="count" id="kb-done-n">0</span></div><div class="kanban-body" id="kb-done"></div></div>
   </div>`;
   initBoard(sid);
@@ -2181,23 +2194,204 @@ async function addBoardTask(){
   inp.value='';pollBoard();
 }
 
+function toggleBoardSymphonyFilter(on){
+  boardSymphonyOnly=!!on;LS.set('board_symphony_only',boardSymphonyOnly);pollBoard();
+}
+
+function boardMaybeJson(v){
+  if(!v)return null;
+  if(typeof v==='object')return v;
+  if(typeof v!=='string')return null;
+  const s=v.trim();
+  if(!s||s[0]!=='{')return null;
+  try{return JSON.parse(s)}catch(e){return null}
+}
+
+function boardTaskSymphonyMeta(t){
+  const meta={has:false};
+  const absorb=o=>{
+    o=boardMaybeJson(o);if(!o||typeof o!=='object')return;
+    const s=o.symphony||o.issue||o.metadata;
+    if(s&&s!==o)absorb(s);
+    if(o.state!==undefined){meta.state=o.state;meta.has=true}
+    if(o.priority!==undefined){meta.priority=o.priority;meta.has=true}
+    if(o.labels!==undefined){meta.labels=o.labels;meta.has=true}
+    if(o.shard){meta.shard=o.shard;meta.has=true}
+    if(o.shard_role!==undefined){meta.shardRole=o.shard_role;meta.has=true}
+    if(o.shardRole!==undefined){meta.shardRole=o.shardRole;meta.has=true}
+    if(o.claim_ttl_ms!==undefined){meta.claimTtlMs=o.claim_ttl_ms;meta.has=true}
+    if(o.claim){meta.claim=o.claim;meta.has=true}
+    if(o.handoff){meta.handoff=o.handoff;meta.has=true}
+    if(o.validation_status!==undefined){meta.validationStatus=o.validation_status;meta.has=true}
+    if(o.validationStatus!==undefined){meta.validationStatus=o.validationStatus;meta.has=true}
+  };
+  absorb(t.symphony);absorb(t.issue);absorb(t.metadata);absorb(t.description);
+  return meta;
+}
+
+function boardDecodeKvJson(r){
+  if(!r||!r.ok||!r.value)return null;
+  try{return JSON.parse(u8decode(r.value))}catch(e){}
+  try{return JSON.parse(r.value)}catch(e){}
+  return null;
+}
+
+async function boardFetchSymphonySidecars(listId,tasks){
+  const out={};tasks.forEach(t=>{out[t.id]={}});
+  const storeId='symphony-'+listId;
+  const keys=await api('/stores/'+encodeURIComponent(storeId)+'/keys');
+  if(!(keys&&keys.ok&&Array.isArray(keys.keys)))return out;
+  const have=new Set(keys.keys.map(k=>typeof k==='string'?k:k.key).filter(Boolean));
+  const jobs=[];
+  tasks.forEach(t=>{
+    const tid=t.id||'';
+    const claimKey='claim-'+tid,handoffKey='handoff-'+tid;
+    if(have.has(claimKey))jobs.push(api('/stores/'+encodeURIComponent(storeId)+'/'+encodeURIComponent(claimKey)).then(r=>{out[tid].claimBlob=boardDecodeKvJson(r)}));
+    if(have.has(handoffKey))jobs.push(api('/stores/'+encodeURIComponent(storeId)+'/'+encodeURIComponent(handoffKey)).then(r=>{out[tid].handoffBlob=boardDecodeKvJson(r)}));
+  });
+  await Promise.all(jobs);
+  return out;
+}
+
+function boardMergeSymphonyMeta(t,sidecars){
+  const meta=boardTaskSymphonyMeta(t),sc=sidecars[t.id]||{};
+  if(sc.claimBlob){meta.claimBlob=sc.claimBlob;meta.claim=sc.claimBlob.claim||meta.claim;meta.claimStatus=sc.claimBlob.status;meta.has=true}
+  if(sc.handoffBlob){meta.handoffBlob=sc.handoffBlob;meta.handoff=sc.handoffBlob.handoff||meta.handoff;meta.has=true}
+  if(meta.has&&meta.priority===undefined&&t.priority!==undefined)meta.priority=t.priority;
+  return meta;
+}
+
+function boardNormalizeState(s){
+  if(s&&typeof s==='object')s=s.state||s.status||s.name||s.value||'';
+  s=String(s||'').trim().toLowerCase().replace(/[\s-]+/g,'_');
+  if(s==='to_do'||s==='empty')return'todo';
+  if(s==='wip'||s==='claimed'||s.startsWith('claimed_')||s.startsWith('claimed:'))return'in_progress';
+  if(s==='complete'||s==='completed')return'done';
+  if(s==='ready_for_review')return'review';
+  return s;
+}
+
+function boardSymphonyState(meta){
+  if(!meta||!meta.has)return null;
+  if(meta.state!==undefined)return boardNormalizeState(meta.state);
+  if(meta.handoff)return'review';
+  const st=String(meta.claimStatus||'').toLowerCase();
+  if(st==='active')return'in_progress';
+  if(st==='completed')return'review';
+  if(st==='released')return'todo';
+  if(st==='blocked')return'todo';
+  if(meta.claim)return'in_progress';
+  return null;
+}
+
+function boardCheckboxState(t){
+  const s=boardNormalizeState(t.state);
+  if(s==='done')return'done';
+  if(s==='in_progress')return'in_progress';
+  return'todo';
+}
+
+function boardColumnForTask(t,meta){
+  const s=boardSymphonyState(meta);
+  if(s==='todo'||s==='in_progress'||s==='review'||s==='done')return s;
+  return boardCheckboxState(t);
+}
+
+function boardRoleLabel(v){
+  if(!v)return'';
+  if(typeof v==='object'){
+    if(v.backup!==undefined)return'backup'+(v.backup!==null?' '+v.backup:'');
+    v=v.role||v.shard_role||v.shardRole||Object.keys(v)[0]||'';
+  }
+  v=String(v).toLowerCase().replace(/[\s-]+/g,'_');
+  if(v.startsWith('backup'))return'backup';
+  if(v.startsWith('manual'))return'manual';
+  if(v==='primary')return'primary';
+  return v;
+}
+
+function boardShardRole(meta){
+  const c=meta.claim||{};
+  return boardRoleLabel(meta.shardRole||c.shard_role||c.shardRole||(meta.shard&&meta.shard.role));
+}
+
+function boardAge(ms){
+  if(ms<60000)return'now';
+  const m=Math.floor(ms/60000);if(m<60)return m+'m';
+  const h=Math.floor(m/60);if(h<48)return h+'h';
+  return Math.floor(h/24)+'d';
+}
+
+function boardHeartbeatFreshness(meta){
+  const c=meta.claim||{},hb=c.heartbeat_at||c.heartbeatAt||c.at||meta.heartbeat_at;
+  const at=Date.parse(hb||'');
+  if(!Number.isFinite(at))return{state:'unknown',label:'unknown'};
+  const age=Math.max(0,Date.now()-at),ttl=Number(meta.claimTtlMs||(meta.shard&&meta.shard.claim_ttl_ms))||10*60*1000;
+  if(age<=ttl/2)return{state:'fresh',label:'fresh '+boardAge(age)};
+  if(age<=ttl)return{state:'stale',label:'stale '+boardAge(age)};
+  return{state:'expired',label:'expired '+boardAge(age)};
+}
+
+function boardValidationStatus(meta){
+  const h=meta.handoff||{};
+  const direct=meta.validationStatus||meta.validation_status||h.validation_status||h.validationStatus;
+  if(direct)return boardNormalizeState(direct)==='passed'?'passed':boardNormalizeState(direct)==='failed'?'failed':'unknown';
+  const vals=Array.isArray(h.validation)?h.validation:[];
+  if(vals.some(v=>boardNormalizeState(v.status)==='failed'))return'failed';
+  if(vals.length&&vals.every(v=>boardNormalizeState(v.status)==='passed'))return'passed';
+  return meta.has?'unknown':'';
+}
+
+function boardBadge(cls,text){return'<span class="sym-badge '+cls+'">'+esc(text)+'</span>'}
+
+function boardSymphonyBadges(meta){
+  if(!meta||!meta.has)return'';
+  const b=[],role=boardShardRole(meta),status=String(meta.claimStatus||'').toLowerCase();
+  if(role)b.push(boardBadge('info','role '+role));
+  if(meta.claim||status){
+    const hb=boardHeartbeatFreshness(meta),agent=(meta.claim&&(meta.claim.by||meta.claim.agent||meta.claim.agent_id))||'';
+    let cls=hb.state==='fresh'?'ok':hb.state==='stale'?'warn':hb.state==='expired'?'bad':'muted';
+    let text='claimed'+(agent?' '+short(agent,8):'')+' '+hb.label;
+    if(status&&status!=='active'){cls=status==='blocked'?'bad':'muted';text='claim '+status}
+    b.push(boardBadge(cls,text));
+  }
+  const val=boardValidationStatus(meta);
+  if(val)b.push(boardBadge(val==='passed'?'ok':val==='failed'?'bad':'muted','validation '+val));
+  if(meta.priority!==undefined&&meta.priority!==null&&meta.priority!=='')b.push(boardBadge('pri','P'+meta.priority));
+  return b.length?'<div class="sym-badges">'+b.join('')+'</div>':'';
+}
+
 async function pollBoard(){
   if(!spaceBoardId)return;
+  const seq=++boardPollSeq;
   const r=await api('/task-lists/'+spaceBoardId+'/tasks');if(!r||!r.tasks)return;
-  const todo=r.tasks.filter(t=>t.state==='Empty'||t.state==='empty');
-  const wip=r.tasks.filter(t=>t.state&&(t.state.startsWith('Claimed')||t.state.startsWith('claimed')));
-  const done=r.tasks.filter(t=>t.state&&(t.state.startsWith('Done')||t.state.startsWith('done')));
-  const render=(arr,canAct,action)=>arr.map(t=>`<div class="kanban-card" ${canAct?'onclick="boardAction(\''+escJs(t.id)+'\',\''+escJs(action)+'\')"':''}>
-    <div class="title">${esc(t.title)}</div>
-    <div class="meta">${canAct?'click to '+action:''} ${t.claimed_by?trustHtml(getContactTrust(t.claimed_by)):''}</div>
-  </div>`).join('')||'<div style="color:var(--tx3);font-size:11px;padding:8px">Empty</div>';
+  const sidecars=await boardFetchSymphonySidecars(spaceBoardId,r.tasks);
+  if(seq!==boardPollSeq)return;
+  const cols={todo:[],in_progress:[],review:[],done:[]};
+  r.tasks.forEach(t=>{
+    const meta=boardMergeSymphonyMeta(t,sidecars);
+    if(boardSymphonyOnly&&!meta.has)return;
+    const col=boardColumnForTask(t,meta);
+    (cols[col]||cols.todo).push({task:t,meta});
+  });
+  const render=(arr,col)=>arr.map(({task:t,meta})=>{
+    const action=col==='todo'?'claim':col==='in_progress'?'complete':'';
+    const who=t.assignee||t.claimed_by||'';
+    return `<div class="kanban-card" ${action?'onclick="boardAction(\''+escJs(t.id)+'\',\''+escJs(action)+'\')"':''}>
+      <div class="title">${esc(t.title)}</div>
+      <div class="meta">${action?'click to '+action:''} ${who?trustHtml(getContactTrust(who)):''}</div>
+      ${boardSymphonyBadges(meta)}
+    </div>`;
+  }).join('')||'<div style="color:var(--tx3);font-size:11px;padding:8px">Empty</div>';
   const e=id=>document.getElementById(id);
-  if(e('kb-todo'))e('kb-todo').innerHTML=render(todo,true,'claim');
-  if(e('kb-wip'))e('kb-wip').innerHTML=render(wip,true,'complete');
-  if(e('kb-done'))e('kb-done').innerHTML=render(done,false,'');
-  if(e('kb-todo-n'))e('kb-todo-n').textContent=todo.length;
-  if(e('kb-wip-n'))e('kb-wip-n').textContent=wip.length;
-  if(e('kb-done-n'))e('kb-done-n').textContent=done.length;
+  if(e('kb-todo'))e('kb-todo').innerHTML=render(cols.todo,'todo');
+  if(e('kb-wip'))e('kb-wip').innerHTML=render(cols.in_progress,'in_progress');
+  if(e('kb-review'))e('kb-review').innerHTML=render(cols.review,'review');
+  if(e('kb-done'))e('kb-done').innerHTML=render(cols.done,'done');
+  if(e('kb-todo-n'))e('kb-todo-n').textContent=cols.todo.length;
+  if(e('kb-wip-n'))e('kb-wip-n').textContent=cols.in_progress.length;
+  if(e('kb-review-n'))e('kb-review-n').textContent=cols.review.length;
+  if(e('kb-done-n'))e('kb-done-n').textContent=cols.done.length;
 }
 
 async function boardAction(tid,action){

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -178,6 +178,9 @@ tr:hover td{background:rgba(255,255,255,.01)}
 .kanban-card:hover{border-color:var(--cy);transform:translateY(-1px);box-shadow:0 4px 12px rgba(0,0,0,.2)}
 .kanban-card .title{font-size:12px;font-weight:500}
 .kanban-card .meta{font-size:10px;color:var(--tx3);margin-top:var(--sp1)}
+.kanban-card.pending-approval{border-color:var(--am)}
+.kanban-card-actions{display:flex;gap:var(--sp2);margin-top:var(--sp2)}
+.kanban-card-actions button{flex:1;padding:5px 8px;font-size:11px}
 .sym-badges{display:flex;flex-wrap:wrap;gap:4px;margin-top:var(--sp2)}
 .sym-badge{display:inline-flex;align-items:center;gap:3px;padding:1px 6px;font:600 9px var(--sans);text-transform:uppercase;letter-spacing:.35px;border:1px solid;border-radius:var(--r-full);white-space:nowrap}
 .sym-badge.info{color:var(--cy);border-color:var(--cy);background:var(--cy-dim)}
@@ -705,6 +708,35 @@ async function api(path,opt){
     }
     return data;
   }catch(e){return null}
+}
+
+const DEFAULT_SYMPHONY_DAEMON_URL='http://127.0.0.1:8642';
+function symphonyDaemonUrl(){
+  const v=String(LS.get('symphonyDaemonUrl',DEFAULT_SYMPHONY_DAEMON_URL)||DEFAULT_SYMPHONY_DAEMON_URL).trim();
+  return (v||DEFAULT_SYMPHONY_DAEMON_URL).replace(/\/+$/,'');
+}
+function symphonyDaemonToken(){return String(LS.get('symphonyDaemonToken','')||'').trim()}
+
+async function symApi(path,opt){
+  const base=symphonyDaemonUrl();
+  try{
+    const hdrs={'Content-Type':'application/json',...(opt||{}).headers};
+    const token=symphonyDaemonToken();
+    if(token)hdrs['Authorization']='Bearer '+token;
+    const r=await fetch(base+path,{...opt,headers:hdrs});
+    const data=await r.json().catch(()=>({ok:r.ok,error:r.statusText||'request failed'}));
+    if(data&&typeof data==='object'){
+      data._http_ok=r.ok;
+      data._http_status=r.status;
+      if(!r.ok&&!data.error)data.error=r.statusText||('HTTP '+r.status);
+    }
+    if(r.status===401||r.status===403)toast('symphony daemon token rejected','error');
+    else if(!r.ok)toast('symphony daemon request failed: '+apiError(data),'error');
+    return data;
+  }catch(e){
+    toast('symphony daemon unreachable at '+base,'error');
+    return null;
+  }
 }
 
 async function refreshAgentIdentity(){
@@ -2171,6 +2203,7 @@ function renderSpaceBoard(el,sid){
   el.innerHTML=`<div class="row mb kanban-toolbar"><input id="board-in" placeholder="New task…" style="flex:1"><button class="pri" onclick="addBoardTask()">Add</button><label class="board-filter"><input type="checkbox" id="board-symphony-only" onchange="toggleBoardSymphonyFilter(this.checked)" ${boardSymphonyOnly?'checked':''}> Symphony</label></div>
   <div class="kanban">
     <div class="kanban-col"><div class="kanban-hd">To Do <span class="count" id="kb-todo-n">0</span></div><div class="kanban-body" id="kb-todo"></div></div>
+    <div class="kanban-col"><div class="kanban-hd">Pending Approval <span class="count" id="kb-approval-n">0</span></div><div class="kanban-body" id="kb-approval"></div></div>
     <div class="kanban-col"><div class="kanban-hd">In Progress <span class="count" id="kb-wip-n">0</span></div><div class="kanban-body" id="kb-wip"></div></div>
     <div class="kanban-col"><div class="kanban-hd">Review <span class="count" id="kb-review-n">0</span></div><div class="kanban-body" id="kb-review"></div></div>
     <div class="kanban-col"><div class="kanban-hd">Done <span class="count" id="kb-done-n">0</span></div><div class="kanban-body" id="kb-done"></div></div>
@@ -2255,11 +2288,20 @@ async function boardFetchSymphonySidecars(listId,tasks){
 
 function boardMergeSymphonyMeta(t,sidecars){
   const meta=boardTaskSymphonyMeta(t),sc=sidecars[t.id]||{};
-  if(sc.claimBlob){meta.claimBlob=sc.claimBlob;meta.claim=sc.claimBlob.claim||meta.claim;meta.claimStatus=sc.claimBlob.status;meta.has=true}
+  if(sc.claimBlob){
+    meta.claimBlob=sc.claimBlob;meta.claim=sc.claimBlob.claim||meta.claim;meta.claimStatus=sc.claimBlob.status;meta.has=true;
+    const rr=sc.claimBlob.release_reason||sc.claimBlob.releaseReason||{};
+    if(rr.code!==undefined){meta.releaseReasonCode=boardNormalizeReasonCode(rr.code);meta.releaseReasonMessage=rr.message||''}
+    if(rr.content_hash!==undefined)meta.contentHash=rr.content_hash;
+    if(rr.signer_agent_id!==undefined)meta.signerAgentId=rr.signer_agent_id;
+  }
   if(sc.handoffBlob){meta.handoffBlob=sc.handoffBlob;meta.handoff=sc.handoffBlob.handoff||meta.handoff;meta.has=true}
   if(meta.has&&meta.priority===undefined&&t.priority!==undefined)meta.priority=t.priority;
   return meta;
 }
+
+function boardNormalizeReasonCode(v){return String(v||'').trim().toLowerCase().replace(/[\s-]+/g,'_')}
+function boardIsPendingApprovalReason(v){return['awaiting_approval','approval_verifier_unconfigured','verify_transport_error'].includes(boardNormalizeReasonCode(v))}
 
 function boardNormalizeState(s){
   if(s&&typeof s==='object')s=s.state||s.status||s.name||s.value||'';
@@ -2273,6 +2315,7 @@ function boardNormalizeState(s){
 
 function boardSymphonyState(meta){
   if(!meta||!meta.has)return null;
+  if(boardIsPendingApprovalReason(meta.releaseReasonCode))return'pending_approval';
   if(meta.state!==undefined)return boardNormalizeState(meta.state);
   if(meta.handoff)return'review';
   const st=String(meta.claimStatus||'').toLowerCase();
@@ -2293,7 +2336,7 @@ function boardCheckboxState(t){
 
 function boardColumnForTask(t,meta){
   const s=boardSymphonyState(meta);
-  if(s==='todo'||s==='in_progress'||s==='review'||s==='done')return s;
+  if(s==='todo'||s==='pending_approval'||s==='in_progress'||s==='review'||s==='done')return s;
   return boardCheckboxState(t);
 }
 
@@ -2348,6 +2391,7 @@ function boardSymphonyBadges(meta){
   if(!meta||!meta.has)return'';
   const b=[],role=boardShardRole(meta),status=String(meta.claimStatus||'').toLowerCase();
   if(role)b.push(boardBadge('info','role '+role));
+  if(meta.releaseReasonCode)b.push(boardBadge(boardIsPendingApprovalReason(meta.releaseReasonCode)?'warn':'muted','reason '+meta.releaseReasonCode));
   if(meta.claim||status){
     const hb=boardHeartbeatFreshness(meta),agent=(meta.claim&&(meta.claim.by||meta.claim.agent||meta.claim.agent_id))||'';
     let cls=hb.state==='fresh'?'ok':hb.state==='stale'?'warn':hb.state==='expired'?'bad':'muted';
@@ -2367,7 +2411,7 @@ async function pollBoard(){
   const r=await api('/task-lists/'+spaceBoardId+'/tasks');if(!r||!r.tasks)return;
   const sidecars=await boardFetchSymphonySidecars(spaceBoardId,r.tasks);
   if(seq!==boardPollSeq)return;
-  const cols={todo:[],in_progress:[],review:[],done:[]};
+  const cols={todo:[],pending_approval:[],in_progress:[],review:[],done:[]};
   r.tasks.forEach(t=>{
     const meta=boardMergeSymphonyMeta(t,sidecars);
     if(boardSymphonyOnly&&!meta.has)return;
@@ -2375,23 +2419,56 @@ async function pollBoard(){
     (cols[col]||cols.todo).push({task:t,meta});
   });
   const render=(arr,col)=>arr.map(({task:t,meta})=>{
-    const action=col==='todo'?'claim':col==='in_progress'?'complete':'';
+    const isApproval=col==='pending_approval';
+    const action=isApproval?'':col==='todo'?'claim':col==='in_progress'?'complete':'';
     const who=t.assignee||t.claimed_by||'';
-    return `<div class="kanban-card" ${action?'onclick="boardAction(\''+escJs(t.id)+'\',\''+escJs(action)+'\')"':''}>
+    const guard={};
+    if(meta.contentHash)guard.contentHash=meta.contentHash;
+    if(meta.signerAgentId)guard.signerAgentId=meta.signerAgentId;
+    const guardJson=escJs(JSON.stringify(guard));
+    const approvalActions=isApproval?`<div class="kanban-card-actions">
+        <button class="pri" onclick="event.stopPropagation();boardApprovalAction('${escJs(t.id)}','approve',JSON.parse('${guardJson}'))">Approve</button>
+        <button class="danger" onclick="event.stopPropagation();boardApprovalAction('${escJs(t.id)}','deny',JSON.parse('${guardJson}'))">Deny</button>
+      </div>`:'';
+    return `<div class="kanban-card${isApproval?' pending-approval':''}" ${action?'onclick="boardAction(\''+escJs(t.id)+'\',\''+escJs(action)+'\')"':''}>
       <div class="title">${esc(t.title)}</div>
-      <div class="meta">${action?'click to '+action:''} ${who?trustHtml(getContactTrust(who)):''}</div>
+      <div class="meta">${isApproval?'awaiting operator approval':action?'click to '+action:''} ${who?trustHtml(getContactTrust(who)):''}</div>
       ${boardSymphonyBadges(meta)}
+      ${approvalActions}
     </div>`;
   }).join('')||'<div style="color:var(--tx3);font-size:11px;padding:8px">Empty</div>';
   const e=id=>document.getElementById(id);
   if(e('kb-todo'))e('kb-todo').innerHTML=render(cols.todo,'todo');
+  if(e('kb-approval'))e('kb-approval').innerHTML=render(cols.pending_approval,'pending_approval');
   if(e('kb-wip'))e('kb-wip').innerHTML=render(cols.in_progress,'in_progress');
   if(e('kb-review'))e('kb-review').innerHTML=render(cols.review,'review');
   if(e('kb-done'))e('kb-done').innerHTML=render(cols.done,'done');
   if(e('kb-todo-n'))e('kb-todo-n').textContent=cols.todo.length;
+  if(e('kb-approval-n'))e('kb-approval-n').textContent=cols.pending_approval.length;
   if(e('kb-wip-n'))e('kb-wip-n').textContent=cols.in_progress.length;
   if(e('kb-review-n'))e('kb-review-n').textContent=cols.review.length;
   if(e('kb-done-n'))e('kb-done-n').textContent=cols.done.length;
+}
+
+async function boardLookupPendingApproval(tid){
+  const r=await symApi('/symphony/approvals/pending');
+  if(!r||r._http_ok===false)return false;
+  const rows=Array.isArray(r)?r:(Array.isArray(r.approvals)?r.approvals:[]);
+  return rows.find(x=>String(x.issue_id||x.id||'')===String(tid))||null;
+}
+
+async function boardApprovalAction(tid,verdict,meta){
+  if(!confirm(verdict+' task '+tid+'?'))return;
+  const pending=await boardLookupPendingApproval(tid);
+  if(pending===false)return;
+  const guard=pending||meta||{};
+  const body={verdict};
+  const contentHash=guard.content_hash||guard.contentHash;
+  const signerAgentId=guard.signer_agent_id||guard.signerAgentId;
+  if(contentHash)body.expected_content_hash=contentHash;
+  if(signerAgentId)body.expected_signer_agent_id=signerAgentId;
+  const r=await symApi('/symphony/approvals/'+encodeURIComponent(tid),{method:'POST',body:JSON.stringify(body)});
+  if(r&&r._http_ok!==false){toast((verdict==='approve'?'approved':'denied')+' '+tid,'success');pollBoard()}
 }
 
 async function boardAction(tid,action){
@@ -3944,6 +4021,15 @@ function renderSettings(){
     <div style="font-size:11px;color:var(--tx3);margin-top:4px">Shown in chat messages and your identity card.</div>
   </div>
   <div class="card mb2">
+    <h3 style="margin-top:0">Symphony Daemon</h3>
+    <div class="row" style="gap:var(--sp2);flex-wrap:wrap">
+      <input id="set-symphony-url" value="${esc(symphonyDaemonUrl())}" placeholder="http://127.0.0.1:8642" style="flex:2;min-width:220px">
+      <input id="set-symphony-token" type="password" value="${esc(symphonyDaemonToken())}" placeholder="Bearer token" autocomplete="off" style="flex:1;min-width:180px">
+      <button class="pri" onclick="saveSymphonyDaemonSettings()">Save</button>
+    </div>
+    <div style="font-size:11px;color:var(--tx3);margin-top:4px">Approve/deny uses the separate x0x-symphonyd REST API, not x0xd. Default URL: http://127.0.0.1:8642.</div>
+  </div>
+  <div class="card mb2">
     <h3 style="margin-top:0">Your Identity</h3>
     <p style="font-size:12px;color:var(--tx2);margin-bottom:var(--sp3)">Your identity is permanent — derived from your cryptographic keys. Share your link so others can find and contact you.</p>
     <div class="id-card-ids" style="margin-bottom:var(--sp3)">
@@ -3990,6 +4076,15 @@ function saveName(){
   LS.set('display_name',name);
   renderSidebar();
   toast('Name saved','success');
+}
+
+function saveSymphonyDaemonSettings(){
+  const urlEl=document.getElementById('set-symphony-url'),tokEl=document.getElementById('set-symphony-token');
+  const url=(urlEl&&urlEl.value.trim())||DEFAULT_SYMPHONY_DAEMON_URL;
+  const token=(tokEl&&tokEl.value.trim())||'';
+  LS.set('symphonyDaemonUrl',url);
+  LS.set('symphonyDaemonToken',token);
+  toast('Symphony daemon settings saved','success');
 }
 
 let myCardLink=savedCard||'';


### PR DESCRIPTION
## Summary

Supersedes #152 (`symphony-board-view`) and #159 (`symphony-approval-column`), rebased cleanly onto v0.28.0 / current `main`.

- **Board view** (from #152): Kanban board with badge display, state columns (To Do / In Progress / Review / Done), symphony-only filter (persisted to localStorage), and task metadata extraction helpers.
- **Approval column** (from #159 / XSY-0054): Adds a fifth `Pending Approval` Kanban column, `pending-approval` card styling, approve/deny action buttons, and `boardIsPendingApprovalReason()` normalization of symphony release-reason codes.

## Why they were conflicting

#152 was stacked on a WS1.1 commit (`7c702f3`, feat(ws): bound the per-WS outbound queue) that modified `src/server/mod.rs`. After these PRs were opened, `main` shipped v0.28.0 which included WS1.4 (#125), extracting the WS handling from `server/mod.rs` into `server/ws.rs`. All WS1.1 logic (`WS_OUTBOUND_CAPACITY`, `feed_droppable`, `feed_critical`, `run_ws_writer`, `/diagnostics/ws`) is already present in `main` via that extraction.

## What changed vs the original PRs

The WS1.1 server commit is already in `main` — only the two pure-GUI commits were cherry-picked:

| Commit | Files |
|--------|-------|
| `feat(gui): symphony board view` | `src/gui/x0x-gui.html` only (+208 / -14) |
| `symphony GUI: add approval column (XSY-0054)` | `src/gui/x0x-gui.html` only (+101 / -6) |

No `src/server/`, `src/api/`, or test files changed — no conflict risk.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run --all-features -E 'test(api_coverage) or test(api_manifest) or test(route_set)'` — pass (registry ↔ routes ↔ manifest in sync)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` — clean, no warnings
- [ ] CI full suite (triggered on push)

Please close #152 and #159 after this merges (or before — they're superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Symphony-focused board view to the GUI. The main changes are:

- Kanban columns for Symphony states and pending approval.
- Symphony metadata parsing from task fields and sidecar store entries.
- Approve and deny buttons that call a separate Symphony daemon.
- Settings for the Symphony daemon URL and token.
- A persisted Symphony-only board filter.

<h3>Confidence Score: 4/5</h3>

The approval path needs fixes before merging.

- Missing pending-approval rows can still use stale card metadata for approve or deny requests.
- Browser calls to the separate daemon depend on CORS support for the GUI origin.
- The rest of the board rendering changes are isolated to the GUI.

src/gui/x0x-gui.html

<details open><summary><h3>Security Review</h3></summary>

The approval flow sends operator decisions to a separate daemon and stores its bearer token in browser localStorage. The main security concern is that stale or missing pending-approval lookup data can still fall back to old card metadata and send an approval decision.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/gui/x0x-gui.html | Adds the Symphony board UI, approval column, metadata extraction, daemon settings, and approve/deny request flow. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Browser as GUI board
  participant X0XD as x0xd API
  participant Store as Symphony sidecar store
  participant Daemon as Symphony daemon
  Browser->>X0XD: "GET /task-lists/{id}/tasks"
  Browser->>Store: "GET symphony-{listId}/claim-{taskId}"
  Browser->>Browser: Classify card into Pending Approval
  Browser->>Daemon: GET /symphony/approvals/pending
  Browser->>Daemon: "POST /symphony/approvals/{taskId}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Browser as GUI board
  participant X0XD as x0xd API
  participant Store as Symphony sidecar store
  participant Daemon as Symphony daemon
  Browser->>X0XD: "GET /task-lists/{id}/tasks"
  Browser->>Store: "GET symphony-{listId}/claim-{taskId}"
  Browser->>Browser: Classify card into Pending Approval
  Browser->>Daemon: GET /symphony/approvals/pending
  Browser->>Daemon: "POST /symphony/approvals/{taskId}"
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/gui/x0x-gui.html:2463-2464
**Stale Approval Guard Fallback**

When the daemon no longer lists this task as pending, `pending` is `null` and this falls back to the card's render-time `meta`. A stale sidecar can still send an approve or deny POST with old or empty guard fields, so an operator can act on a task that is no longer the pending approval shown by the board.

```suggestion
  if(!pending){toast('approval is no longer pending; refreshing board','error');pollBoard();return}
  const guard=pending;
```

### Issue 2 of 2
src/gui/x0x-gui.html:720-726
**Cross-Origin Approval Requests**

The board is served from `location.origin`, but approval lookups and actions fetch `http://127.0.0.1:8642` by default with JSON and optional authorization headers. In a browser this needs the separate daemon to allow the x0xd GUI origin in CORS preflight; without that, the new approve and deny buttons cannot reach a running daemon.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["symphony GUI: add approval column (XSY-0..."](https://github.com/saorsa-labs/x0x/commit/6b54fbe288f1f272a155cbd8e152a2a383a9eb06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41942724)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->