### PR TITLE
chore(deps): bump ant-quic to 0.27.28 (byte-stream API for tailnet T1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.27"
+ant-quic = "0.27.28"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
## Summary

- Bumps `ant-quic` from `0.27.27` to `0.27.28` in `Cargo.toml`
- `0.27.28` ships `Node::open_bi` / `accept_bi` — the byte-stream API that unblocks tailnet T1 (#132)
- No stream consumer code added; `src/streams.rs` (consuming `node.open_bi`/`accept_bi`) is the sprint's work, not this PR

## Dependency resolution

`cargo tree -i ant-quic` resolves to a **single** `ant-quic 0.27.28`:

- x0x's `Cargo.toml` `^0.27.28` → 0.27.28
- `saorsa-gossip-* 0.5.64` (pulled in automatically via `^0.5.63`) re-pins to the same 0.27.28

No duplicate ant-quic versions; the gossip transport and x0x's `NetworkNode` share the same `ant_quic` types.

Note: `saorsa-gossip-*` updated from 0.5.63 → 0.5.64 automatically via caret range; this is expected and correct.

## Gate results

| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo nextest run --all-features --workspace` (excl. known-flaky `named_group_join_metadata_event`) | **2043 / 2043 passed**, 201 skipped |
| `RUSTDOCFLAGS=-D warnings cargo doc --all-features --no-deps` | clean |

The `named_group_join_metadata_event` binary is excluded from CI per `.github/workflows/ci.yml` (pre-existing gossip-convergence flake, unrelated to this bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `ant-quic` from `0.27.27` to `0.27.28` in `Cargo.toml`, making the new bidirectional byte-stream API (`Node::open_bi` / `accept_bi`) available to the codebase ahead of the tailnet T1 sprint. No consumer code is introduced in this PR.

- Cargo.lock is intentionally excluded from version control (`.gitignore`), so both the direct `ant-quic` bump and the transitive `saorsa-gossip-*` 0.5.63 → 0.5.64 resolution are authoritative only at build time; the gate run (2043/2043 passing) confirms correctness at the resolved versions.
- No new code paths are added; the change is purely additive at the dependency level.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single-line version bump with no new code paths and a full test suite passing.

The only change is bumping ant-quic from 0.27.27 to 0.27.28. No consumer code is added, no API surface changes, and 2043/2043 tests pass at the resolved versions. The transitive gossip crate bump (0.5.63 → 0.5.64) is the only additional movement, and the PR description confirms both crates converge on the same ant-quic 0.27.28, avoiding version duplication.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Single-line version bump of ant-quic from 0.27.27 to 0.27.28; no structural changes to dependencies or features. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["x0x Cargo.toml\nant-quic = \"0.27.28\""] -->|"caret range ^0.27.28"| B["ant-quic 0.27.28\n(adds Node::open_bi / accept_bi)"]
    A -->|"^0.5.63 (unchanged)"| C["saorsa-gossip-* 0.5.64\n(resolved transitively)"]
    C -->|"re-pins to"| B
    B -->|"single resolved version\n(no duplicates)"| D["Cargo dependency graph\n✅ 2043/2043 tests pass"]
    E["src/streams.rs\n(future sprint work)"] -.->|"will consume"| B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["x0x Cargo.toml\nant-quic = \"0.27.28\""] -->|"caret range ^0.27.28"| B["ant-quic 0.27.28\n(adds Node::open_bi / accept_bi)"]
    A -->|"^0.5.63 (unchanged)"| C["saorsa-gossip-* 0.5.64\n(resolved transitively)"]
    C -->|"re-pins to"| B
    B -->|"single resolved version\n(no duplicates)"| D["Cargo dependency graph\n✅ 2043/2043 tests pass"]
    E["src/streams.rs\n(future sprint work)"] -.->|"will consume"| B
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump ant-quic to 0.27.28 (b..."](https://github.com/saorsa-labs/x0x/commit/452c59cdcf5f2d85a210176043cb55ca2e008830) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42103298)</sub>

<!-- /greptile_comment -->