### PR TITLE
ci: de-flake Test Suite — move timing-brittle tests to integration tier (#14/#175 follow-up)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -110,6 +110,16 @@ jobs:
         run: cargo nextest run --all-features --test kv_first_join_bootstrap --test-threads 1 -- --ignored
       - name: Run local-topic routing tests (issue 89)
         run: cargo nextest run --all-features --test local_topics --test-threads 1 -- --ignored
+      # ── Daemon-backed timing tests de-flaked out of the always-on Test
+      #    Suite (ci.yml). They run here so coverage is preserved without
+      #    gating every PR on convergence/jitter-prone budgets. None of
+      #    these is a required status check.
+      - name: Run peer-lifecycle daemon tests (de-flaked, ignored-only)
+        run: cargo nextest run --all-features --test peer_lifecycle_integration --run-ignored ignored-only
+      - name: Run x0x_0041 reissue timing test (de-flaked, ignored-only)
+        run: cargo nextest run --all-features --test x0x_0041_prefer_newest_test --run-ignored ignored-only
+      - name: Run named-group join-metadata convergence tests (de-flaked, ignored-only)
+        run: cargo nextest run --all-features --test named_group_join_metadata_event --run-ignored ignored-only
 
   # ── Soak test (weekly, ~90min) ────────────────────────────────────────
   soak:

--- a/src/dm_capability.rs
+++ b/src/dm_capability.rs
@@ -131,10 +131,20 @@ impl CapabilityStore {
 
     /// Look up a peer's capability. Returns `None` if unknown or expired.
     pub fn lookup(&self, agent_id: &AgentId) -> Option<DmCapabilities> {
+        self.lookup_at(agent_id, Instant::now())
+    }
+
+    /// Look up a peer's capability as of `now`.
+    ///
+    /// Test seam over [`lookup`](Self::lookup): production callers always go
+    /// through [`lookup`](Self::lookup), which passes `Instant::now()`.
+    /// Exposing the clock lets the TTL-expiry unit test advance time
+    /// deterministically instead of sleeping past a wall-clock boundary —
+    /// the documented CI flake for that assertion (issue: CI de-flake).
+    pub fn lookup_at(&self, agent_id: &AgentId, now: Instant) -> Option<DmCapabilities> {
         let Ok(mut inner) = self.inner.lock() else {
             return None;
         };
-        let now = Instant::now();
         let entry = inner.get(agent_id.as_bytes())?;
         if now.duration_since(entry.seen_at) > self.ttl {
             inner.remove(agent_id.as_bytes());
@@ -254,12 +264,12 @@ mod tests {
 
     #[test]
     fn capability_store_expires_on_ttl() {
-        // TTL is set to 1 s so that CI scheduling jitter (which can be
-        // hundreds of milliseconds on a loaded runner) cannot push the
-        // first lookup past the TTL boundary before the "present" assertion
-        // runs.  The expiry assertion sleeps for 2.5× the TTL, which is
-        // well past the expiry window on any realistic machine.
-        let store = CapabilityStore::with_ttl(Duration::from_secs(1));
+        // Deterministic: insert records `seen_at ≈ now`, then the test
+        // queries `lookup_at` at a synthetic future instant past the TTL.
+        // No wall-clock sleep is involved, so CI scheduling jitter can never
+        // push the "present" lookup past the TTL boundary — the prior flake.
+        let ttl = Duration::from_secs(60);
+        let store = CapabilityStore::with_ttl(ttl);
         let agent_id = AgentId([3u8; 32]);
         let machine_id = MachineId([4u8; 32]);
         store.insert(
@@ -268,12 +278,19 @@ mod tests {
             DmCapabilities::v1_gossip_ready(vec![0u8; 1184]),
             1_000,
         );
-        // Must be present immediately after insert (1 s TTL gives ample room).
-        assert!(store.lookup(&agent_id).is_some());
-        // Sleep well past the TTL so the entry is definitely stale.
-        std::thread::sleep(Duration::from_millis(2_500));
-        // Must be absent after expiry.
-        assert!(store.lookup(&agent_id).is_none());
+        // `seen_at` was captured inside `insert` just before this point, so a
+        // lookup at "now" is well within the TTL.
+        let now = Instant::now();
+        assert!(
+            store.lookup_at(&agent_id, now).is_some(),
+            "entry must be present within the TTL"
+        );
+        // Advance a deterministic span past the TTL and re-query.
+        let after_ttl = now + ttl + Duration::from_millis(1);
+        assert!(
+            store.lookup_at(&agent_id, after_ttl).is_none(),
+            "entry must be evicted once the TTL elapses"
+        );
     }
 
     #[test]

--- a/tests/named_group_join_metadata_event.rs
+++ b/tests/named_group_join_metadata_event.rs
@@ -353,6 +353,7 @@ async fn signed_member_joined_event(
 /// group via invite, alice's `members_v2` reflects bob within the local
 /// mesh budget, and bob's signed public message is accepted by alice within
 /// the same budget.
+#[ignore = "daemon-pair member-joined propagation convergence (gossip wait window) flakes the always-on Test Suite under CI load; runs in the integration tier"]
 #[tokio::test]
 async fn member_joined_event_propagates_to_inviter() {
     let pair = pair().await;
@@ -436,6 +437,7 @@ async fn member_joined_event_propagates_to_inviter() {
 /// Idempotency: a second join attempt with the same invite (or a replayed
 /// MemberJoined event under a duplicate publish) does not double-count
 /// bob in alice's `members_v2`.
+#[ignore = "daemon-pair member-joined idempotency convergence (gossip wait window) flakes the always-on Test Suite under CI load; runs in the integration tier"]
 #[tokio::test]
 async fn member_joined_event_is_idempotent() {
     let pair = pair().await;
@@ -495,6 +497,7 @@ fn group_role_as_u8_is_stable_across_releases() {
 /// fields to the signature. Mutating the signed role after signature
 /// generation must fail before Alice reaches the role-policy rejection path,
 /// while the unmodified payload from the same helper remains acceptable.
+#[ignore = "daemon-pair signature-tamper convergence (gossip wait window) flakes the always-on Test Suite under CI load; runs in the integration tier"]
 #[tokio::test]
 async fn tampered_member_joined_signed_role_is_rejected_before_role_policy() {
     let pair = pair().await;
@@ -627,6 +630,7 @@ async fn tampered_member_joined_signed_role_is_rejected_before_role_policy() {
 /// and a joiner without a minted secret must not be admitted. Forged events
 /// must leave the one-time invite usable for the legitimate Member join that
 /// follows.
+#[ignore = "daemon-pair forgery rejection-counter convergence polls a counter that can exceed the wait window under CI load (#14-class); runs in the integration tier"]
 #[tokio::test]
 async fn forged_member_joined_admin_role_or_secret_is_rejected() {
     let pair = pair().await;
@@ -754,6 +758,7 @@ async fn forged_member_joined_admin_role_or_secret_is_rejected() {
 /// Invite-secret path: alice records a structured one-time invite when she
 /// generates the link, then consumes it when bob's `MemberJoined` request is
 /// accepted and converted into an authority-signed `MemberAdded` commit.
+#[ignore = "daemon-pair invite-secret convergence (gossip wait window) flakes the always-on Test Suite under CI load; runs in the integration tier"]
 #[tokio::test]
 async fn issued_invite_secret_is_recorded_on_inviter() {
     let pair = pair().await;
@@ -972,6 +977,7 @@ async fn non_creator_admin_invite_e2e_converges_for_preset(
 /// invite through the real REST handler, a separate daemon consumes it through
 /// `POST /groups/join`, and the resulting admin-authored `MemberAdded` commit
 /// converges across creator, admin, and joiner.
+#[ignore = "daemon-pair admin-invite convergence (gossip wait window) flakes the always-on Test Suite under CI load; runs in the integration tier"]
 #[tokio::test]
 async fn non_creator_admin_invite_e2e_converges_through_real_daemons() {
     non_creator_admin_invite_e2e_converges_for_preset("public_open", "Admin Invite E2E", false)
@@ -983,6 +989,7 @@ async fn non_creator_admin_invite_e2e_converges_through_real_daemons() {
 /// TreeKEM-backed convergence. Direct expected-inviter sender validation is
 /// covered by the focused `join_result_requires_stored_expected_inviter` unit
 /// regression; this daemon test proves the secure-plane end-to-end join shape.
+#[ignore = "daemon-pair TreeKEM convergence (gossip wait window) flakes the always-on Test Suite under CI load; runs in the integration tier"]
 #[tokio::test]
 async fn non_creator_admin_private_secure_invite_e2e_converges_through_real_daemons() {
     non_creator_admin_invite_e2e_converges_for_preset(

--- a/tests/peer_lifecycle_integration.rs
+++ b/tests/peer_lifecycle_integration.rs
@@ -291,6 +291,7 @@ async fn peer_probe_returns_400_on_invalid_peer_id() {
 // /peers/:peer_id/health — connection health snapshot
 // ---------------------------------------------------------------------------
 
+#[ignore = "daemon-backed + wait_for_peer convergence (15s budget) flakes under CI scheduling load; runs in the integration tier"]
 #[tokio::test]
 async fn peer_health_snapshot_observable_for_live_peer() {
     let _guard = peer_lifecycle_lock();
@@ -506,6 +507,7 @@ async fn direct_send_with_require_ack_round_trips_to_live_peer() {
     );
 }
 
+#[ignore = "daemon-backed direct-send over a live peer; transient connection/convergence under CI load flakes the always-on Test Suite; runs in the integration tier"]
 #[tokio::test]
 async fn direct_send_without_require_ack_omits_ack_block() {
     let _guard = peer_lifecycle_lock();

--- a/tests/x0x_0041_prefer_newest_test.rs
+++ b/tests/x0x_0041_prefer_newest_test.rs
@@ -152,6 +152,7 @@ async fn supersede_propagates_within_500ms_acceptance_budget() {
 /// produce a false failure.  The tighter in-process timing guarantee is
 /// validated by `supersede_propagates_within_500ms_acceptance_budget`, which
 /// exercises the same mechanism without the daemon round-trips.
+#[ignore = "daemon-backed replace/reissue within a 5s budget flakes under CI contention (#148); the deterministic in-process variant covers the SLO. Runs in the integration tier"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn direct_send_reissues_on_replaced_connection_within_500ms(
 ) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Item 0 of the tailnet sprint. Moves 5 timing-brittle tests out of the always-on Test Suite: dm_capability TTL gets a deterministic clock seam (lookup_at, no thread::sleep); the daemon-backed ones (peer_lifecycle ×2, x0x_0041 reissue, named_group_join_metadata_event ×7) are #[ignore]'d and run in integration.yml via --run-ignored ignored-only. Goal: reliably-green Test Suite. Independent review checks: no real coverage dropped (ignored tests still RUN in integration; dm_capability assertion not weakened).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR de-flakes the always-on Test Suite by moving 10 timing-brittle daemon-backed tests out of `ci.yml` and into the integration tier: 5 tests across three files are `#[ignore]`'d and added as explicit steps in `integration.yml`, while the `dm_capability` TTL test is refactored with a deterministic clock seam (`lookup_at`) instead of `thread::sleep`.

- **Clock seam (`src/dm_capability.rs`)**: `lookup_at` is introduced and the TTL test now advances time synthetically; the refactored assertion is correct and eliminates the sleep-based flake. `lookup_at` is declared `pub` rather than `pub(crate)`, which exposes a documented test-seam to external crate consumers.
- **`#[ignore]` annotations**: 10 tests across `named_group_join_metadata_event`, `peer_lifecycle_integration`, and `x0x_0041_prefer_newest_test` are marked ignored with descriptive reason strings and added to the integration job via `--run-ignored ignored-only`; no test logic was changed.
- **Workflow change**: The three new `integration.yml` steps are appended to an existing job that already has 7 heavy steps and a 20-minute ceiling — worth confirming there is sufficient headroom.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are test-tier reorganization with no production logic altered.

The `dm_capability` clock-seam refactor is correct and the TTL assertion is now stronger — deterministic rather than sleep-based. The ten `#[ignore]` annotations preserve coverage by routing the tests to the integration job without changing any test logic. Two minor concerns keep the score from being clean: `lookup_at` is `pub` instead of `pub(crate)`, leaking a documented test-seam into the crate's external API; and the integration job's 20-minute ceiling may be tight after gaining three additional gossip-convergence suites.

`src/dm_capability.rs` for the `pub` vs `pub(crate)` visibility of `lookup_at`; `.github/workflows/integration.yml` to verify the 20-minute job budget still has headroom after the three new steps.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/integration.yml | Adds 3 new steps to the integration job to run the newly-ignored tests under `--run-ignored ignored-only`; the job already has a 20-minute ceiling and carries 7 existing heavy steps before the additions. |
| src/dm_capability.rs | Introduces `lookup_at` as a clock-injection test seam; the TTL test is now deterministic and correct, but `lookup_at` is declared `pub` rather than `pub(crate)`, leaking the seam into the crate's public API. |
| tests/named_group_join_metadata_event.rs | Marks 7 daemon-pair convergence tests `#[ignore]` with descriptive reason strings; no test logic changed. |
| tests/peer_lifecycle_integration.rs | Marks 2 daemon-backed tests `#[ignore]` with descriptive reason strings; no test logic changed. |
| tests/x0x_0041_prefer_newest_test.rs | Marks 1 daemon-backed reissue timing test `#[ignore]` with a descriptive reason; no test logic changed. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR pushed] --> B{ci.yml\nTest Suite\nrequired}
    A --> C{integration.yml\nnon-required}
    B --> D[Unit + fast tests\nincl. dm_capability TTL\ndeterministic clock seam]
    C --> E[daemon_api_integration]
    C --> F[named_group_integration]
    C --> G[ws_integration / kv / local_topics]
    C --> H[NEW: peer_lifecycle_integration\n2 ignored tests]
    C --> I[NEW: x0x_0041_prefer_newest_test\n1 ignored test]
    C --> J[NEW: named_group_join_metadata_event\n7 ignored tests]
    D --> K[Reliably green\nno sleeps / daemon deps]
    H & I & J --> L[Visibility-only\nnot a merge gate]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR pushed] --> B{ci.yml\nTest Suite\nrequired}
    A --> C{integration.yml\nnon-required}
    B --> D[Unit + fast tests\nincl. dm_capability TTL\ndeterministic clock seam]
    C --> E[daemon_api_integration]
    C --> F[named_group_integration]
    C --> G[ws_integration / kv / local_topics]
    C --> H[NEW: peer_lifecycle_integration\n2 ignored tests]
    C --> I[NEW: x0x_0041_prefer_newest_test\n1 ignored test]
    C --> J[NEW: named_group_join_metadata_event\n7 ignored tests]
    D --> K[Reliably green\nno sleeps / daemon deps]
    H & I & J --> L[Visibility-only\nnot a merge gate]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/dm_capability.rs:144
The doc comment explicitly calls `lookup_at` a "test seam" that production callers should never use directly, but it is declared `pub`, making it part of the crate's external API surface. Downstream consumers can call it with arbitrary synthetic timestamps, bypassing the TTL guarantee. The only caller outside the test module is `lookup` itself (within the same crate), so `pub(crate)` is sufficient and matches the stated intent.

```suggestion
    pub(crate) fn lookup_at(&self, agent_id: &AgentId, now: Instant) -> Option<DmCapabilities> {
```

### Issue 2 of 2
.github/workflows/integration.yml:117-122
**Integration job timeout may be tight after these additions**

The `integration` job has `timeout-minutes: 20` and already runs 7 potentially heavy steps (daemon API, named-group, D4, GUI smoke, WebSocket, KV bootstrap, local-topics) before the three newly-added steps. The `named_group_join_metadata_event` suite alone adds 7 gossip-convergence tests, each polling within a wait window that triggered the original flake. If the job was already consuming the majority of its budget, these additions could cause it to hit the 20-minute limit, turning the "visibility-only" steps into timeout failures on every PR run. It's worth either bumping `timeout-minutes` here or confirming current headroom is sufficient.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ci): de-flake recurring timing test..."](https://github.com/saorsa-labs/x0x/commit/6e0d599ae87468934e5e9292d42110ccbcf690d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42162850)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->