### PR TITLE
fix(revocation): enforce revocation on the raw-QUIC direct DM path (#179)

### DIFF
--- a/src/direct.rs
+++ b/src/direct.rs
@@ -46,7 +46,7 @@
 //! everywhere (EP3 in `dm_inbox`, EP4 in `server/mod`, the relay gate in
 //! `peer_relay`). The raw-QUIC direct listener mirrors that: a DM whose sender
 //! agent or originating machine is revoked is dropped before delivery by
-//! [`inbound_peer_revoked`]. EP5 (`Agent::evict_revoked_subject`) purges caches
+//! `inbound_peer_revoked`. EP5 (`Agent::evict_revoked_subject`) purges caches
 //! and sets trust `Blocked`, but does not close the live QUIC connection — so
 //! without this per-message gate a revoked peer on an established connection
 //! would keep delivering (annotated unverified, but delivered).

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -38,8 +38,18 @@
 //! **Trust annotations.** Each message also carries a `trust_decision` field
 //! from [`TrustEvaluator`](crate::trust::TrustEvaluator), reflecting the
 //! full trust evaluation including contact store trust level and machine
-//! pinning. Messages are never dropped — applications inspect these fields
-//! to decide how to handle each message.
+//! pinning. Messages are never dropped on *trust* grounds — applications
+//! inspect these fields to decide how to handle each message.
+//!
+//! **Revocation is the single exception** (issue #179). A valid revocation is
+//! positive knowledge of a compromised key, and the project fails closed on it
+//! everywhere (EP3 in `dm_inbox`, EP4 in `server/mod`, the relay gate in
+//! `peer_relay`). The raw-QUIC direct listener mirrors that: a DM whose sender
+//! agent or originating machine is revoked is dropped before delivery by
+//! [`inbound_peer_revoked`]. EP5 (`Agent::evict_revoked_subject`) purges caches
+//! and sets trust `Blocked`, but does not close the live QUIC connection — so
+//! without this per-message gate a revoked peer on an established connection
+//! would keep delivering (annotated unverified, but delivered).
 //!
 //! ## Example
 //!
@@ -94,6 +104,29 @@ const DIRECT_DIAGNOSTICS_MIN_RETAIN: usize = 1024;
 /// reconcile against the lifecycle table by calling
 /// [`DirectMessaging::current_generation`] after a lag.
 const LIFECYCLE_REPLACED_BROADCAST_CAPACITY: usize = 256;
+
+/// Direct-path inbound revocation gate (issue #179).
+///
+/// Mirrors EP3 (`dm_inbox::drop_if_sender_revoked`) and the relay gate
+/// (`peer_relay`): a DM arriving over a LIVE direct QUIC connection is
+/// dropped when EITHER the sender agent OR the originating machine is in
+/// the local revocation set. The originating `machine_id` is the
+/// transport-authenticated QUIC peer; `sender` is the agent id parsed from
+/// the envelope prefix.
+///
+/// EP5 (`Agent::evict_revoked_subject`) purges caches and sets trust
+/// `Blocked` but does NOT close the live connection, so without this
+/// per-message check a revoked peer on an established connection keeps
+/// delivering (annotated unverified, but delivered). Revocation is positive
+/// knowledge of compromise — the project fails closed on it everywhere.
+#[must_use]
+pub(crate) fn inbound_peer_revoked(
+    revoked: &crate::revocation::RevocationSet,
+    sender: &AgentId,
+    machine_id: &MachineId,
+) -> bool {
+    revoked.is_agent_revoked(sender) || revoked.is_machine_revoked(machine_id)
+}
 
 #[doc(hidden)]
 pub struct RawQuicAckRaceTestHook {
@@ -1335,6 +1368,67 @@ mod tests {
 
         let other = dm_payload_digest_hex(b"different");
         assert_ne!(other, digest);
+    }
+
+    #[test]
+    fn inbound_peer_revoked_fails_closed_for_agent_or_machine() {
+        // Issue #179: the direct-path gate must drop a DM whose sender agent
+        // OR originating machine is revoked (mirrors EP3 + the relay gate).
+        // Self-revocations verify from the record alone (issuer == subject),
+        // so no certificate is needed.
+        use crate::identity::{AgentKeypair, MachineKeypair};
+        use crate::revocation::{RevocationRecord, RevocationSet, RevokedSubject};
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let revoked_agent = AgentKeypair::generate().unwrap();
+        let revoked_machine = MachineKeypair::generate().unwrap();
+        let clean_agent = AgentId([7u8; 32]);
+        let clean_machine = MachineId([8u8; 32]);
+
+        let mut set = RevocationSet::new();
+        set.verify_and_insert(
+            RevocationRecord::sign(
+                RevokedSubject::Agent(revoked_agent.agent_id()),
+                revoked_agent.public_key(),
+                revoked_agent.secret_key(),
+                now,
+                None,
+            )
+            .unwrap(),
+            None,
+        )
+        .unwrap();
+        set.verify_and_insert(
+            RevocationRecord::sign(
+                RevokedSubject::Machine(revoked_machine.machine_id()),
+                revoked_machine.public_key(),
+                revoked_machine.secret_key(),
+                now,
+                None,
+            )
+            .unwrap(),
+            None,
+        )
+        .unwrap();
+
+        // Revoked agent ⇒ drop regardless of machine.
+        assert!(
+            inbound_peer_revoked(&set, &revoked_agent.agent_id(), &clean_machine),
+            "revoked agent must be dropped on the direct path"
+        );
+        // Revoked machine ⇒ drop regardless of agent.
+        assert!(
+            inbound_peer_revoked(&set, &clean_agent, &revoked_machine.machine_id()),
+            "revoked machine must be dropped on the direct path"
+        );
+        // Neither revoked ⇒ allow.
+        assert!(
+            !inbound_peer_revoked(&set, &clean_agent, &clean_machine),
+            "a clean (agent, machine) pair must not be dropped"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7829,6 +7829,7 @@ impl Agent {
         let dm = std::sync::Arc::clone(&self.direct_messaging);
         let discovery_cache = std::sync::Arc::clone(&self.identity_discovery_cache);
         let contact_store = std::sync::Arc::clone(&self.contact_store);
+        let revocation_set = std::sync::Arc::clone(&self.revocation_set);
         let token = self.shutdown_token.clone();
 
         self.spawn_tracked(async move {
@@ -7926,6 +7927,32 @@ impl Agent {
                     trust_decision = ?trust_decision,
                     "direct message received; dispatching to subscribers"
                 );
+
+                // Enforcement point — direct path revocation gate (issue #179).
+                // Mirrors EP3 (dm_inbox) + the relay gate (peer_relay). EP5
+                // (evict_revoked_subject) purges caches + sets trust=Blocked
+                // but does NOT close the live QUIC connection, so without this
+                // per-message check a revoked peer on an established direct
+                // connection would keep delivering (annotated unverified, but
+                // delivered). Fail closed: drop + count, never reach
+                // mark_connected/handle_incoming. Read lock is held only for
+                // the boolean — no await under it (same contract as EP4).
+                let peer_revoked = {
+                    let revoked = revocation_set.read().await;
+                    direct::inbound_peer_revoked(&revoked, &sender, &machine_id)
+                };
+                if peer_revoked {
+                    dm.record_incoming_dropped_revoked();
+                    tracing::info!(
+                        target: "x0x::direct",
+                        stage = "recv",
+                        sender_prefix = %network::hex_prefix(&sender.0, 4),
+                        machine_prefix = %network::hex_prefix(&machine_id.0, 4),
+                        outcome = "drop_revoked",
+                        "direct message from revoked sender dropped (direct-path revocation gate, mirrors EP3)"
+                    );
+                    continue;
+                }
 
                 // Register and mark the sender as connected for future reverse direct sends.
                 dm.mark_connected(sender, machine_id).await;


### PR DESCRIPTION
Resolves #179 (investigation). The raw-QUIC direct DM listener annotated verified/trust but never checked revocation; EP5 doesn't close a live connection. Adds a per-message revocation gate mirroring dm_inbox EP3 / the relay path, fail-closed. Prerequisite to tailnet T1 (byte-streams ride the same verified/direct path). SECURITY — independent review required.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a revocation enforcement gap on the raw-QUIC direct DM path (issue #179): EP5 (`evict_revoked_subject`) sets trust to `Blocked` but does not terminate a live QUIC connection, so a revoked peer on an already-established connection could keep delivering messages. The fix mirrors the pattern used in EP3 (`dm_inbox`), EP4 (`server/mod`), and the relay gate (`peer_relay`).

- Adds `inbound_peer_revoked` in `src/direct.rs` — a `#[must_use]` function that returns `true` if either the sender's `AgentId` or the transport-authenticated `MachineId` appears in the local `RevocationSet`, with a unit test covering all three cases (revoked agent, revoked machine, clean pair).
- Inserts the per-message gate into the raw-QUIC receive loop in `src/lib.rs`, cloning the `revocation_set` Arc before the task, acquiring a short read-lock per message (no `await` held under the lock), incrementing the new `incoming_dropped_revoked` diagnostic counter, and `continue`-ing before `mark_connected`/`handle_incoming` are ever reached.
- Adds `incoming_dropped_revoked: AtomicU64` to `DirectDiagnosticsCounters` (derived `Default`, initialised to 0) and exposes it in the `DmDiagnosticsStats` snapshot with `#[serde(default)]` for backward-compatible serialisation.

<h3>Confidence Score: 3/5</h3>

The revocation gate correctly prevents delivery and connection registration for revoked peers, but the existing INFO log claiming 'dispatching to subscribers' fires before the gate, producing a false audit trail on every dropped message.

The functional behavior is sound — mark_connected and handle_incoming are never reached for a revoked peer. However, the pre-existing tracing::info! that says 'direct message received; dispatching to subscribers' sits above the newly inserted revocation check, so every revoked-peer drop emits an INFO record claiming dispatch occurred before the drop_revoked record follows. On a path the PR itself flags as requiring independent security review, misleading INFO-level audit logs are a real concern that should be resolved before merging.

src/lib.rs — the ordering of the INFO log relative to the revocation gate needs attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/direct.rs | Adds inbound_peer_revoked gate function (agent OR machine check, #[must_use]), new incoming_dropped_revoked diagnostic counter, and a targeted unit test covering all three cases (revoked agent, revoked machine, clean pair). Logic and test coverage are correct. |
| src/lib.rs | Inserts the per-message revocation gate into the raw-QUIC direct DM receive loop. The gate itself is functionally correct and mark_connected/handle_incoming are never reached for revoked peers, but the existing INFO log 'dispatching to subscribers' fires before the check, creating a false audit trail for every dropped-revoked message. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Q as QUIC Transport
    participant R as DM Receive Loop
    participant V as RevocationSet
    participant D as DirectMessaging
    participant S as Subscribers

    Q->>R: recv_direct payload
    R->>R: parse AgentId + MachineId
    R->>R: verify identity binding
    R->>R: evaluate trust
    R->>V: acquire read lock
    V-->>R: RevocationSet ref
    R->>R: inbound_peer_revoked check
    alt agent OR machine revoked
        R->>D: record_incoming_dropped_revoked
        R->>R: log drop_revoked, continue
    else not revoked
        R->>D: mark_connected
        R->>D: handle_incoming
        D->>S: fan-out DirectMessage
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Q as QUIC Transport
    participant R as DM Receive Loop
    participant V as RevocationSet
    participant D as DirectMessaging
    participant S as Subscribers

    Q->>R: recv_direct payload
    R->>R: parse AgentId + MachineId
    R->>R: verify identity binding
    R->>R: evaluate trust
    R->>V: acquire read lock
    V-->>R: RevocationSet ref
    R->>R: inbound_peer_revoked check
    alt agent OR machine revoked
        R->>D: record_incoming_dropped_revoked
        R->>R: log drop_revoked, continue
    else not revoked
        R->>D: mark_connected
        R->>D: handle_incoming
        D->>S: fan-out DirectMessage
    end
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib.rs`, line 7919-7955 ([link](https://github.com/saorsa-labs/x0x/blob/bf22e1e3b6329b6a909d4f464c28b4b90874b8ac/src/lib.rs#L7919-L7955)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Misleading INFO log fires before the revocation gate**

   The `tracing::info!` at line 7919 logs `"direct message received; dispatching to subscribers"` unconditionally, but the revocation gate only appears twelve lines later (line 7931). Every dropped-revoked message will therefore produce an INFO-level record claiming it was dispatched to subscribers before the `drop_revoked` outcome is logged. On a security-critical path where operators or forensic audits rely on the log stream, this false ordering would lead to the wrong conclusion that a revoked peer's message was actually delivered. Moving the revocation check above the INFO line (or changing the log message to something like `"direct message received; evaluating"` until after the gate) would fix the audit trail.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib.rs
   Line: 7919-7955

   Comment:
   **Misleading INFO log fires before the revocation gate**

   The `tracing::info!` at line 7919 logs `"direct message received; dispatching to subscribers"` unconditionally, but the revocation gate only appears twelve lines later (line 7931). Every dropped-revoked message will therefore produce an INFO-level record claiming it was dispatched to subscribers before the `drop_revoked` outcome is logged. On a security-critical path where operators or forensic audits rely on the log stream, this false ordering would lead to the wrong conclusion that a revoked peer's message was actually delivered. Moving the revocation check above the INFO line (or changing the log message to something like `"direct message received; evaluating"` until after the gate) would fix the audit trail.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/lib.rs:7919-7955
**Misleading INFO log fires before the revocation gate**

The `tracing::info!` at line 7919 logs `"direct message received; dispatching to subscribers"` unconditionally, but the revocation gate only appears twelve lines later (line 7931). Every dropped-revoked message will therefore produce an INFO-level record claiming it was dispatched to subscribers before the `drop_revoked` outcome is logged. On a security-critical path where operators or forensic audits rely on the log stream, this false ordering would lead to the wrong conclusion that a revoked peer's message was actually delivered. Moving the revocation check above the INFO line (or changing the log message to something like `"direct message received; evaluating"` until after the gate) would fix the audit trail.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(identity): enforce per-message revoc..."](https://github.com/saorsa-labs/x0x/commit/bf22e1e3b6329b6a909d4f464c28b4b90874b8ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42162860)</sub>

<!-- /greptile_comment -->