### PR TITLE
feat(tailnet): Phase 1 — byte streams (T1) + forwarder (T4) + REST/CLI (T6) + ADR/e2e (T8/T7) (#132)

### DIFF
--- a/docs/adr/0020-tailnet-phase-1-byte-streams-and-forwarding.md
+++ b/docs/adr/0020-tailnet-phase-1-byte-streams-and-forwarding.md
@@ -1,0 +1,176 @@
+# ADR 0020: Tailnet Phase 1 — per-peer byte-streams + local port-forwarding
+
+<!-- File name: docs/adr/0020-tailnet-phase-1-byte-streams-and-forwarding.md -->
+
+- **Status:** Proposed
+- **Date:** 2026-07-06
+- **Decision owners:** David Irvine
+- **Reviewers:** x0x core team (independent adversarial review required before Accepted)
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** issue #132 (T1–T8), ant-quic #180 (`Node::open_bi`/`accept_bi`), #130 (key lifecycle), #131/ADR-0019 (connect ACL), #158/#177 (PeerRelay), #179 (direct-DM revocation gate)
+
+## Context
+
+x0x v0.28.0 carries the two hardest Tailscale pieces in the transport — native
+QUIC NAT traversal and an always-on symmetric MASQUE relay fallback — but above
+the wire it spoke only message-level `Node::send`/`recv`. There was no way for a
+user to reach a service on their other machine. ant-quic 0.27.28 (#180) shipped
+`Node::open_bi(&peer)` / `Node::accept_bi()` — bidirectional, backpressure-correct
+byte-streams, demultiplexed from internal transport by an `ANQAppB1` prefix so
+`accept_bi` never yields an internal stream. This was the single blocker for the
+whole sprint (#132); it is now cleared.
+
+Phase 1 is the plumbing + product around those streams: a `PeerStream` API with
+the identity gate inside open/accept, an `ssh -L`-style local port-forwarder
+gated by the connect ACL (#131/ADR-0019) and the key lifecycle (#130), and a
+REST/CLI surface. Tailscale-like reachability over any NAT, end-to-end
+post-quantum (ML-KEM-768 / ML-DSA-65); relays forward ciphertext only.
+
+## Decision Drivers
+
+- **Default-closed, fail-closed everywhere.** A stream is only ever established
+  between transport-verified, trust-accepted, non-revoked peers; an inbound
+  forward only ever reaches a loopback target the connect ACL explicitly allows.
+  This mirrors the project posture on revocation ("a valid revocation always
+  fails closed") and the exec ACL.
+- **Identity gate as an unavoidable chokepoint.** `NetworkNode::open_bi`/
+  `accept_bi` are `pub(crate)` and reachable ONLY through `Agent::open_peer_stream`
+  (outbound) and the Agent-owned accept loop (inbound). Both run the same
+  `stream_gate` before any application byte. No bypass path.
+- **Connect ACL is the second layer, not the first.** The T1 identity gate
+  already ensured verified + trust + not-revoked; the T4 inbound forwarder then
+  calls `evaluate_connect_gate(verified=true, trust=Accept, policy, …)` whose real
+  job is the ACL target-match + loopback re-check. Two layers, fixed order.
+- **Loopback-only in Phase 1.** Firewall-bypass risk, matcher complexity, and
+  DNS rebinding all argue for numeric loopback IPs only — the same invariant
+  ADR-0019 chose for the ACL loader, enforced again at the runtime seam.
+- **Relayed parity.** `open_bi`/`accept_bi` are connection-agnostic, so streams
+  work identically over direct and MASQUE-relayed connections. Phase 1 must prove
+  the relayed forward on real NAT (loopback cannot force the relay path).
+
+## Considered Options
+
+1. **Streams + forwarder with the identity gate inside open/accept, connect ACL
+   at the inbound accept seam, loopback-only** ← chosen.
+2. **Gate at the forwarder only, raw streams unbypassable-by-convention.**
+   Rejected: a convention is not a security boundary; the gate must be
+   structurally unavoidable (sole caller of the stream primitives).
+3. **Per-byte revocation on long-lived streams.** Rejected for Phase 1: a stream
+   is a long-lived connection; the gate is per-accept (like a TCP accept). New
+   streams from a revoked peer are refused; tearing down an already-accepted
+   stream mid-flight on revocation is Phase-2 hardening (see Consequences).
+4. **Hostname/DNS targets.** Rejected (ADR-0019): numeric-IP-only removes the
+   resolver from the trusted computing base.
+5. **SOCKS5 in Phase 1.** Deferred behind a default-off flag (0x02 protocol byte
+   reserved); Phase 1 ships on the T4 forwarder alone.
+
+## Decision
+
+### Stream protocol namespace (`src/streams.rs`)
+
+- `0x00` reserved (rejected as unknown); `0x01 = ForwardV1`; `0x02 = SocksV1`
+  (reserved for T5). The first application byte on any stream is the protocol
+  prefix; the accept loop validates it after the identity gate and resets
+  unknown protocols.
+- `PeerStream` wraps ant-quic's send (AsyncWrite) + recv (AsyncRead) halves with
+  the peer `AgentId` + `MachineId` + protocol, fixed at open/accept.
+
+### Identity gate — fail-closed, fixed order (T1)
+
+Both `Agent::open_peer_stream` (outbound) and the inbound accept loop run
+`streams::stream_gate` before any application byte:
+
+1. **transport-verified** — ant-quic authenticates the machine at the QUIC/TLS
+   layer; outbound additionally requires the AgentId→MachineId binding in the
+   identity discovery cache (the same `verified` annotation the direct-DM path
+   uses).
+2. **not revoked** — agent OR machine in the local revocation set ⇒ `PeerRevoked`.
+   Checked before trust so a revoked-but-trusted peer is refused without leaking
+   its trust state.
+3. **trust `Accept`** — `AcceptWithFlag`/`None`/`Reject*` all deny (mirrors exec
+   + the connect gate).
+
+A denial yields a typed `NetworkError` (`PeerNotVerified` / `PeerRevoked` /
+`PeerTrustRejected`) and the stream is refused/reset with zero application bytes.
+
+### Forwarder (`src/forward.rs`)
+
+- **Outbound** (`forward add`): local loopback TCP listener → `open_peer_stream`
+  → length-prefixed bincode `ForwardHeader{target_host,target_port}` → read the
+  peer's response → `tokio::io::copy` both directions on connected.
+- **Inbound** (security-critical): read header → resolve numeric loopback →
+  `evaluate_connect_gate(true, Some(Accept), policy, agent, machine, target)`
+  BEFORE any `TcpStream::connect`. On deny: typed `ConnectDenialReason` frame
+  back + `ConnectDiagnostics::record_denied`, stream closed, zero bytes to
+  target. On allow: re-check loopback (defense in depth) → connect (10s timeout)
+  → bridge. `ConnectPolicy::Disabled` denies everything by default.
+
+### #179 — direct-DM per-message revocation
+
+The same verified/direct path the streams ride had a gap: the raw-QUIC direct
+listener annotated `verified`/`trust` and delivered to subscribers WITHOUT
+checking revocation, and EP5 (`evict_revoked_subject`) does not close the live
+connection. #179 added a per-message revocation gate in the direct listener
+mirroring EP3, so the inbound identity gate T1 relies on is sound.
+
+## Consequences
+
+### Positive
+
+- **Reachability over any NAT**, PQC end-to-end, with relay parity — the product
+  wedge WireGuard/Tailscale don't have.
+- **Two fail-closed layers** (identity gate + connect ACL), structurally
+  unavoidable, mirroring exec/revocation precedents.
+- **Deterministic gate tests.** `stream_gate` (revoked/trust matrix) and
+  `decide_inbound` (ACL matrix) are pure + unit-tested without a live QUIC pair.
+
+### Negative / Trade-offs
+
+- **No mid-stream revocation teardown (Phase 1).** A stream accepted just before
+  a revocation stays open until it ends. Mitigations: the connect gate is
+  per-accept (new flows refused); per-flow teardown is Phase-2 (tracked here).
+- **Loopback-only.** No LAN/subnet/exit targets in Phase 1 (Phase 2).
+- **Relayed forward needs real NAT to prove.** Loopback e2e proves the DIRECT
+  path only; the relayed case runs on the VPS testnet (ant-quic cannot force the
+  relay path on loopback).
+
+### Neutral / Operational
+
+- `StreamProtocol` is a u8 namespace; new protocols extend `from_u8`/`as_u8`.
+- `/forwards` (add/list/rm), `/streams`, `/diagnostics/connect` (pre-existing) —
+  bearer-authed. CLI: `x0x forward add|list|rm`, `x0x streams`.
+- The shared endpoint registry (`src/api/mod.rs`) is intentionally not extended
+  yet — its parity gate needs daemon-test markers per endpoint, which land with
+  the T7 two-machine REST proof.
+
+## Validation
+
+- **T1 unit tests:** `stream_gate` matrix, protocol-prefix round-trip,
+  reserved/unassigned-byte rejection. Integration: two-agent loopback 1 MiB echo
+  both directions (`tests/tailnet_streams_integration.rs`, `#[ignore]`).
+- **T4 unit tests:** header codec round-trip + truncated/oversize rejection,
+  `resolve_loopback_target` (hostname/non-loopback refused), `decide_inbound`
+  ACL matrix (disabled / unknown-pair / wrong-target / allow / non-loopback),
+  response-frame shape.
+- **T7 (real-NAT):** direct forward over the VPS testnet + relayed forward; the
+  four negative security cases (deny-without-ACL, revoked/expired refused,
+  non-loopback refused, unverified refused) enforced by the harness. Cannot run
+  in-process; loopback proves the direct path only.
+
+## Phase 2 deferrals (separate scoped issues, not built unprompted)
+
+- Per-flow revocation teardown of long-lived streams.
+- LAN / subnet-router / exit-node targets (non-loopback ACL grammar).
+- Device enrollment UX with expiry-by-default.
+- MagicDNS-style naming.
+- SOCKS5 listener (T5) ship decision — protocol byte reserved.
+
+## Notes for AI-assisted work
+
+AI tools may draft this ADR but **must not mark it Accepted without human
+review**. The security invariants here — gate inside open/accept as the sole
+caller of the stream primitives, loopback-only, two fail-closed layers in fixed
+order — must not be softened without a new ADR and adversarial review. The #179
+direct-DM revocation gate and the T1/T4 gates must be verified against the REAL
+merged code path, not a mirror test.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,7 @@ This directory contains architecture decision records for x0x.
 ## Accepted (Phase 1 Functionally Complete)
 
 - [ADR 0001: Bootstrap Peers Are Seed Hints Only](./0001-bootstrap-peers-are-seed-hints-only.md) — functional Phase 1 complete, nomenclature rename deferred
+
+## Proposed
+
+- [ADR 0020: Tailnet Phase 1 — per-peer byte-streams + local port-forwarding](./0020-tailnet-phase-1-byte-streams-and-forwarding.md) — PeerStream over `Node::open_bi`/`accept_bi` with the identity gate inside open/accept; `src/forward/` local port-forwarder gated by the connect ACL (#131/ADR-0019) + key lifecycle (#130); loopback-only Phase 1

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -724,4 +724,29 @@ Connect-ACL policy summary and allow/deny counters. Counters read `0` until the 
 
 See `docs/connect-acl.md` for full documentation including the `denial_breakdown` key reference.
 
+
+## Tailnet port-forwarding (#132)
+
+Local `ssh -L`-style port forwarding over x0x byte-streams. The forwarder runs only when a connect ACL is loaded (see `docs/connect-acl.md`); a peer's inbound forward is gated by the connect ACL + the key lifecycle before any local `TcpStream::connect`. Phase 1 targets are loopback-only numeric IPs.
+
+| Method | Endpoint | CLI | Purpose |
+|---|---|---|---|
+| POST | `/forwards` | `x0x forward add` | Register a local loopback listener that tunnels to a peer's loopback service |
+| GET | `/forwards` | `x0x forward list` | List registered forwards |
+| DELETE | `/forwards/:local_addr` | `x0x forward rm <local_addr>` | Tear down a forward by its local bind address |
+| GET | `/streams` | `x0x streams` | Active forward-stream count + connect-failed counter + connect-ACL snapshot |
+
+### `POST /forwards` request body
+
+```json
+{
+  "local_addr": "127.0.0.1:8022",
+  "peer_agent": "<peer agent id hex>",
+  "target_host": "127.0.0.1",
+  "target_port": 22
+}
+```
+
+`local_addr` must be loopback; `target_host` must be a numeric loopback IP (no DNS). Returns `409` when connect is disabled (no ACL loaded). The peer denies (and the local TCP closes) if its connect ACL does not allow the `(agent, machine, target)` triple.
+
 See also: [docs/api.md](api.md), [troubleshooting.md](troubleshooting.md), [patterns.md](patterns.md)

--- a/docs/design/api-manifest.json
+++ b/docs/design/api-manifest.json
@@ -1,5 +1,5 @@
 {
-  "endpoint_count": 138,
+  "endpoint_count": 142,
   "endpoints": [
     {
       "category": "status",
@@ -966,6 +966,34 @@
       "description": "Open the embedded GUI",
       "method": "GET",
       "path": "/gui"
+    },
+    {
+      "category": "connect",
+      "cli_name": "forward add",
+      "description": "Add a local port forward to a peer's loopback service",
+      "method": "POST",
+      "path": "/forwards"
+    },
+    {
+      "category": "connect",
+      "cli_name": "forward list",
+      "description": "List registered port forwards",
+      "method": "GET",
+      "path": "/forwards"
+    },
+    {
+      "category": "connect",
+      "cli_name": "forward rm",
+      "description": "Remove a port forward by its local bind address",
+      "method": "DELETE",
+      "path": "/forwards/:local_addr"
+    },
+    {
+      "category": "connect",
+      "cli_name": "streams",
+      "description": "Active forward-stream count + connect-ACL counters",
+      "method": "GET",
+      "path": "/streams"
     }
   ],
   "generator": "tests/api_manifest.rs",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1042,6 +1042,35 @@ pub const ENDPOINTS: &[EndpointDef] = &[
         description: "Open the embedded GUI",
         category: "websocket",
     },
+    // ── Tailnet forwarding (#132 T6) ────────────────────────────────────
+    EndpointDef {
+        method: Method::Post,
+        path: "/forwards",
+        cli_name: "forward add",
+        description: "Add a local port forward to a peer's loopback service",
+        category: "connect",
+    },
+    EndpointDef {
+        method: Method::Get,
+        path: "/forwards",
+        cli_name: "forward list",
+        description: "List registered port forwards",
+        category: "connect",
+    },
+    EndpointDef {
+        method: Method::Delete,
+        path: "/forwards/:local_addr",
+        cli_name: "forward rm",
+        description: "Remove a port forward by its local bind address",
+        category: "connect",
+    },
+    EndpointDef {
+        method: Method::Get,
+        path: "/streams",
+        cli_name: "streams",
+        description: "Active forward-stream count + connect-ACL counters",
+        category: "connect",
+    },
 ];
 
 /// Find an endpoint by its CLI name.

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -509,6 +509,7 @@ enum ForwardSub {
     /// List registered forwards.
     List,
     /// Remove a forward by its local bind address.
+    #[command(alias = "rm")]
     Remove {
         /// Local bind address, e.g. `127.0.0.1:8022`.
         local_addr: String,

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -316,6 +316,13 @@ enum Commands {
         #[command(subcommand)]
         sub: IdentitySub,
     },
+    /// Tailnet port-forwarding (`ssh -L` over x0x byte-streams).
+    Forward {
+        #[command(subcommand)]
+        sub: ForwardSub,
+    },
+    /// Active byte-stream + connect-ACL diagnostics.
+    Streams,
 }
 
 // ── Nested subcommands ──────────────────────────────────────────────────
@@ -479,6 +486,33 @@ enum IdentitySub {
     },
     /// List all revocation records held by this daemon.
     Revocations,
+}
+
+/// `x0x forward` sub-actions.
+#[derive(Subcommand)]
+enum ForwardSub {
+    /// Add a local port forward to a peer's loopback service.
+    Add {
+        /// Local bind address, e.g. `127.0.0.1:8022`.
+        #[arg(long)]
+        local: String,
+        /// Peer agent id (hex).
+        #[arg(long)]
+        peer: String,
+        /// Loopback target host on the peer (numeric IP). Default `127.0.0.1`.
+        #[arg(long)]
+        target: Option<String>,
+        /// Loopback target port on the peer.
+        #[arg(long)]
+        target_port: u16,
+    },
+    /// List registered forwards.
+    List,
+    /// Remove a forward by its local bind address.
+    Remove {
+        /// Local bind address, e.g. `127.0.0.1:8022`.
+        local_addr: String,
+    },
 }
 
 /// Remote exec sub-actions (`x0x exec sessions`, `x0x exec cancel <id>`).
@@ -1815,6 +1849,28 @@ async fn run(
             }
             IdentitySub::Revocations => commands::identity::revocations(&client).await,
         },
+        Commands::Forward { sub } => match sub {
+            ForwardSub::Add {
+                local,
+                peer,
+                target,
+                target_port,
+            } => {
+                commands::forward::add(
+                    &client,
+                    &local,
+                    &peer,
+                    target.as_deref().unwrap_or("127.0.0.1"),
+                    target_port,
+                )
+                .await
+            }
+            ForwardSub::List => commands::forward::list(&client).await,
+            ForwardSub::Remove { local_addr } => {
+                commands::forward::remove(&client, &local_addr).await
+            }
+        },
+        Commands::Streams => commands::forward::streams(&client).await,
         Commands::Routes { .. }
         | Commands::Tree
         | Commands::Uninstall

--- a/src/cli/commands/forward.rs
+++ b/src/cli/commands/forward.rs
@@ -1,0 +1,69 @@
+//! `x0x forward add|list|rm` + `x0x streams` — tailnet port-forwarding (#132 T6).
+
+use crate::cli::{print_value, DaemonClient};
+use anyhow::Result;
+
+/// `x0x forward add --local 127.0.0.1:PORT --peer <hex> --target 127.0.0.1 --target-port N`
+///
+/// Registers a local loopback listener that tunnels to a peer's loopback
+pub async fn add(
+    client: &DaemonClient,
+    local_addr: &str,
+    peer: &str,
+    target_host: &str,
+    target_port: u16,
+) -> Result<()> {
+    client.ensure_running().await?;
+    let body = serde_json::json!({
+        "local_addr": local_addr,
+        "peer_agent": peer,
+        "target_host": target_host,
+        "target_port": target_port,
+    });
+    let resp = client.post("/forwards", &body).await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}
+
+/// `x0x forward list` — list registered forwards.
+pub async fn list(client: &DaemonClient) -> Result<()> {
+    client.ensure_running().await?;
+    let resp = client.get("/forwards").await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}
+
+/// `x0x forward rm <127.0.0.1:PORT>` — tear down a forward by local bind addr.
+pub async fn remove(client: &DaemonClient, local_addr: &str) -> Result<()> {
+    client.ensure_running().await?;
+    let resp = client.delete(&format!("/forwards/{local_addr}")).await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}
+
+/// `x0x streams` — active forward-stream count + connect-ACL counters.
+pub async fn streams(client: &DaemonClient) -> Result<()> {
+    client.ensure_running().await?;
+    let resp = client.get("/streams").await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    #[test]
+    fn add_body_shape_is_stable() {
+        // The REST body the CLI sends — pinned so a daemon handler change
+        // can't silently drift from what the CLI emits.
+        let body = json!({
+            "local_addr": "127.0.0.1:8022",
+            "peer_agent": "deadbeef",
+            "target_host": "127.0.0.1",
+            "target_port": 22,
+        });
+        assert_eq!(body["target_port"], 22);
+        assert_eq!(body["local_addr"], "127.0.0.1:8022");
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod discovery;
 pub mod exec;
 pub mod files;
 pub mod find;
+pub mod forward;
 pub mod group;
 pub mod groups;
 pub mod identity;

--- a/src/error.rs
+++ b/src/error.rs
@@ -231,6 +231,38 @@ pub enum NetworkError {
     /// Stream operation failed.
     #[error("stream error: {0}")]
     StreamError(String),
+    /// Tailnet byte-stream: the requested stream protocol prefix is unknown.
+    /// Returned by the accept path when the opener's first byte is not a
+    /// recognised [`crate::streams::StreamProtocol`]; the stream is reset.
+    #[error("unknown stream protocol byte: 0x{protocol_byte:02x}")]
+    StreamProtocolUnknown {
+        /// The rejected protocol prefix byte.
+        protocol_byte: u8,
+    },
+    /// Tailnet byte-stream identity gate: the peer's AgentId→MachineId binding
+    /// is not verified (absent from the discovery cache, or a mismatch). The
+    /// stream is refused before any application byte is sent or read.
+    #[error("stream peer not verified: agent {agent_id:?}")]
+    PeerNotVerified {
+        /// The agent id that failed verification.
+        agent_id: [u8; 32],
+    },
+    /// Tailnet byte-stream identity gate: the peer's trust decision was not
+    /// [`crate::trust::TrustDecision::Accept`] (mirrors exec + the connect
+    /// gate: absence of an accept decision denies). Stream refused.
+    #[error("stream peer trust rejected: agent {agent_id:?}")]
+    PeerTrustRejected {
+        /// The agent id whose trust decision was not Accept.
+        agent_id: [u8; 32],
+    },
+    /// Tailnet byte-stream identity gate: the peer's agent or machine is in
+    /// the local revocation set (positive knowledge of compromise → fail
+    /// closed, mirroring EP3/EP4 and the relay/direct-DM gates). Refused.
+    #[error("stream peer revoked: agent {agent_id:?}")]
+    PeerRevoked {
+        /// The revoked agent id.
+        agent_id: [u8; 32],
+    },
 
     /// Event broadcasting failed.
     #[error("event broadcast error: {0}")]

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -409,16 +409,30 @@ async fn write_header<W: tokio::io::AsyncWrite + Unpin>(
 // ===========================================================================
 
 /// A registered local forward (`forward add`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ForwardSpec {
     /// Local loopback address the daemon binds (`127.0.0.1:PORT`).
     pub local_addr: SocketAddr,
-    /// Peer agent to tunnel to.
+    /// Peer agent to tunnel to (hex).
     pub peer_agent: AgentId,
     /// Loopback target host on the peer's machine (numeric IP).
     pub target_host: String,
     /// Loopback target port.
     pub target_port: u16,
+}
+
+impl ForwardSpec {
+    /// The peer agent id as a hex string (for REST/CLI display).
+    #[must_use]
+    pub fn peer_agent_hex(&self) -> String {
+        hex::encode(self.peer_agent.as_bytes())
+    }
+}
+
+/// A registered forward + its cancellation token (internal).
+struct ForwardEntry {
+    spec: ForwardSpec,
+    cancel: CancellationToken,
 }
 
 /// Owns the inbound forward consumer + the outbound local listeners.
@@ -433,8 +447,9 @@ pub struct ForwardService {
     policy: Arc<ConnectPolicy>,
     connect_diag: Arc<ConnectDiagnostics>,
     fwd_diag: Arc<ForwardDiagnostics>,
-    /// Per-forward cancellation tokens so `shutdown` tears down listeners.
-    forwards: std::sync::Mutex<Vec<(SocketAddr, CancellationToken)>>,
+    /// Registered forwards (spec + cancellation) so `shutdown` / `remove` can
+    /// tear down individual listeners and `list` can return them.
+    forwards: std::sync::Mutex<Vec<ForwardEntry>>,
     inbound_token: CancellationToken,
 }
 
@@ -515,7 +530,10 @@ impl ForwardService {
             .map_err(|e| NetworkError::ConnectionFailed(format!("local_addr: {e}")))?;
         let cancel = CancellationToken::new();
         if let Ok(mut forwards) = self.forwards.lock() {
-            forwards.push((bound, cancel.clone()));
+            forwards.push(ForwardEntry {
+                spec: spec.clone(),
+                cancel: cancel.clone(),
+            });
         }
 
         let agent = Arc::clone(&self.agent);
@@ -561,12 +579,38 @@ impl ForwardService {
         Ok(bound)
     }
 
+    /// Snapshot of registered forwards (for `GET /forwards` / `x0x forward list`).
+    #[must_use]
+    pub fn list_forwards(&self) -> Vec<ForwardSpec> {
+        self.forwards
+            .lock()
+            .map(|f| f.iter().map(|e| e.spec.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Remove a forward by its bound local address. Cancels the listener.
+    /// Returns `true` if a forward was removed.
+    pub fn remove_forward(&self, local_addr: SocketAddr) -> bool {
+        let mut removed = false;
+        if let Ok(mut forwards) = self.forwards.lock() {
+            if let Some(pos) = forwards
+                .iter()
+                .position(|e| e.spec.local_addr == local_addr)
+            {
+                forwards[pos].cancel.cancel();
+                forwards.remove(pos);
+                removed = true;
+            }
+        }
+        removed
+    }
+
     /// Tear down every listener + the inbound consumer.
     pub fn shutdown(&self) {
         self.inbound_token.cancel();
         if let Ok(forwards) = self.forwards.lock() {
-            for (_, cancel) in forwards.iter() {
-                cancel.cancel();
+            for entry in forwards.iter() {
+                entry.cancel.cancel();
             }
         }
     }

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -1,0 +1,769 @@
+//! Local port-forwarder over tailnet byte-streams (#132 T4).
+//!
+//! `forward add --local 127.0.0.1:PORT --peer <agent> --target 127.0.0.1:PORT`
+//! behaves like `ssh -L`: a local TCP listener on machine A tunnels to a
+//! loopback service on machine B over a [`crate::streams::PeerStream`].
+//!
+//! ## Two halves, one gate
+//!
+//! - **Outbound (the local listener side):** each accepted local TCP
+//!   connection opens a `ForwardV1` stream to the peer
+//!   ([`crate::Agent::open_peer_stream`], which already enforces the
+//!   identity gate), writes the [`ForwardHeader`], waits for the peer's
+//!   response, and on `connected` bridges the two with `tokio::io::copy`.
+//! - **Inbound (the peer's accept side — security-critical):** consumes
+//!   `ForwardV1` streams from [`crate::Agent::next_incoming_stream`], reads
+//!   the header, and calls [`crate::connect::evaluate_connect_gate`] BEFORE
+//!   any `TcpStream::connect`. The stream already cleared the T1 identity
+//!   gate (verified + trust `Accept` + not revoked), so the connect gate is
+//!   passed `verified=true, trust=Some(Accept)`; its job is the ACL
+//!   target-match + loopback re-check. A denial produces a typed
+//!   [`crate::connect::ConnectDenialReason`] frame back to the opener and a
+//!   `record_denied` counter; zero bytes reach the target.
+//!
+//! ## Loopback-only (Phase 1)
+//!
+//! Targets are numeric loopback IPs only (`127.0.0.0/8`, `::1`). A hostname
+//! or non-loopback IP in a header is refused before the gate (defense in
+//! depth — the ACL loader already rejects non-loopback at load time, and the
+//! gate re-checks `is_loopback`).
+//!
+//! The header codec and the inbound gate decision are pure functions of
+//! bytes / resolved inputs so the whole deny/allow matrix is fast unit-
+//! testable without a live QUIC pair (the real stream wiring is proven by
+//! `tests/tailnet_streams_integration.rs` + T7).
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_util::sync::CancellationToken;
+
+use crate::connect::gate::ConnectDenialReason;
+use crate::connect::{evaluate_connect_gate, ConnectDiagnostics, ConnectPolicy};
+use crate::error::{NetworkError, NetworkResult};
+use crate::identity::{AgentId, MachineId};
+use crate::streams::PeerStream;
+use crate::trust::TrustDecision;
+
+// Import the ant-quic stream halves under stable names for the bridge helper.
+use ant_quic::{HighLevelRecvStream, HighLevelSendStream};
+
+/// Response byte: the inbound side accepted the target and connected.
+const RESP_CONNECTED: u8 = 0x01;
+/// Response byte: the inbound side denied the target (ACL / loopback / etc.).
+const RESP_DENIED: u8 = 0x00;
+
+/// Hard cap on the encoded header size. A loopback `host:port` is tiny; a
+/// larger frame is either malformed or an attack — reject rather than read.
+const MAX_HEADER_BYTES: u32 = 256;
+
+/// Local connect timeout for the inbound side's `TcpStream::connect`.
+const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Forward header — the first framed message on a `ForwardV1` stream.
+///
+/// `target_host` is a numeric IP only (no DNS); the inbound side refuses
+/// anything else before consulting the ACL.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForwardHeader {
+    /// Numeric loopback IP the peer wants to reach (e.g. `127.0.0.1`, `::1`).
+    pub target_host: String,
+    /// TCP port on the loopback target.
+    pub target_port: u16,
+}
+
+impl ForwardHeader {
+    /// Encode as a length-prefixed bincode frame: `u32 BE len || bincode`.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let body = bincode::serialize(self).unwrap_or_default();
+        let mut out = Vec::with_capacity(4 + body.len());
+        out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+        out.extend_from_slice(&body);
+        out
+    }
+
+    /// Decode a length-prefixed frame from a complete buffer. Returns the
+    /// consumed byte count alongside the header on success.
+    ///
+    /// # Errors
+    /// - [`ForwardError::Truncated`] — not enough bytes for the length prefix
+    ///   or the announced body.
+    /// - [`ForwardError::Oversize`] — announced length exceeds
+    ///   [`MAX_HEADER_BYTES`].
+    /// - [`ForwardError::Decode`] — bincode deserialization failed.
+    pub fn decode(buf: &[u8]) -> Result<(Self, usize), ForwardError> {
+        if buf.len() < 4 {
+            return Err(ForwardError::Truncated);
+        }
+        let len = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
+        if len > MAX_HEADER_BYTES {
+            return Err(ForwardError::Oversize(len));
+        }
+        let end = 4 + len as usize;
+        if buf.len() < end {
+            return Err(ForwardError::Truncated);
+        }
+        let header: Self =
+            bincode::deserialize(&buf[4..end]).map_err(|e| ForwardError::Decode(e.to_string()))?;
+        Ok((header, end))
+    }
+}
+
+/// Encode the inbound side's `connected` response (1 byte — copy begins).
+#[must_use]
+fn encode_response_connected() -> [u8; 1] {
+    [RESP_CONNECTED]
+}
+
+/// Encode the inbound side's `denied` response: `0x00 || u32 BE len || reason`.
+#[must_use]
+fn encode_response_denied(reason: ConnectDenialReason) -> Vec<u8> {
+    let reason_bytes = serde_json::to_vec(&reason).unwrap_or_default();
+    let mut out = Vec::with_capacity(1 + 4 + reason_bytes.len());
+    out.push(RESP_DENIED);
+    out.extend_from_slice(&(reason_bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(&reason_bytes);
+    out
+}
+
+/// Parse the leading response byte: `true` = connected (copy follows),
+/// `false` = denied (a framed reason follows).
+#[must_use]
+fn response_connected(byte: u8) -> Option<bool> {
+    match byte {
+        RESP_CONNECTED => Some(true),
+        RESP_DENIED => Some(false),
+        _ => None,
+    }
+}
+
+/// Errors raised by the forward header codec.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ForwardError {
+    /// Not enough bytes to decode a complete frame.
+    #[error("truncated forward frame")]
+    Truncated,
+    /// Announced frame length exceeds the cap.
+    #[error("oversize forward frame: {0} bytes")]
+    Oversize(u32),
+    /// bincode deserialization failed.
+    #[error("forward frame decode failed: {0}")]
+    Decode(String),
+    /// `target_host` is not a numeric loopback IP.
+    #[error("target host is not a numeric loopback IP: {0}")]
+    NotLoopbackTarget(String),
+}
+
+/// Resolve a `(host, port)` to a loopback `SocketAddr`. Numeric IP only — a
+/// hostname (including `localhost`) is refused so the ACL can never be
+/// bypassed via resolution. This mirrors the ACL loader's loopback/numeric
+/// invariant at the runtime accept seam (defense in depth).
+fn resolve_loopback_target(
+    target_host: &str,
+    target_port: u16,
+) -> Result<SocketAddr, ForwardError> {
+    let ip: IpAddr = target_host
+        .parse()
+        .map_err(|_| ForwardError::NotLoopbackTarget(target_host.to_string()))?;
+    if !crate::connect::is_loopback(ip) {
+        return Err(ForwardError::NotLoopbackTarget(target_host.to_string()));
+    }
+    Ok(SocketAddr::new(ip, target_port))
+}
+
+/// Pure inbound gate decision: resolve + ACL-check the requested target.
+///
+/// The stream has already cleared the T1 identity gate (verified + trust
+/// `Accept` + not revoked), so this is the connect-ACL layer: it returns the
+/// resolved loopback `SocketAddr` on allow, or the typed denial reason on
+/// deny. The caller writes the denial frame + records the counter and must
+/// NOT call `TcpStream::connect` on `Err`.
+///
+/// Extracted pure so the full deny/allow matrix is unit-testable without a
+/// live QUIC pair.
+fn decide_inbound(
+    header: &ForwardHeader,
+    policy: &ConnectPolicy,
+    agent_id: &AgentId,
+    machine_id: &MachineId,
+) -> Result<SocketAddr, ConnectDenialReason> {
+    // Resolve first: a non-loopback/hostname target is refused before the
+    // gate (the gate would also reject it, but resolving gives a precise
+    // reason and avoids handing an attacker-resolved address to the ACL).
+    let target = resolve_loopback_target(&header.target_host, header.target_port)
+        .map_err(|_| ConnectDenialReason::TargetNotLoopback)?;
+    evaluate_connect_gate(
+        /* verified */ true,
+        Some(TrustDecision::Accept),
+        policy,
+        agent_id,
+        machine_id,
+        &target,
+    )?;
+    Ok(target)
+}
+
+/// Forwarder-owned diagnostics beyond the connect ACL's allow/deny counters
+/// (which live in [`ConnectDiagnostics`]). Tracks local-connect failures and
+/// active stream count for observability + limits.
+#[derive(Debug, Default)]
+pub struct ForwardDiagnostics {
+    /// Inbound streams that passed the gate but whose local
+    /// `TcpStream::connect` failed (target service down / refused).
+    connect_failed: AtomicU64,
+    /// Currently active forward streams (inbound + outbound).
+    active_streams: AtomicU64,
+}
+
+impl ForwardDiagnostics {
+    /// Record a local-connect failure.
+    pub fn record_connect_failed(&self) {
+        self.connect_failed.fetch_add(1, Ordering::Relaxed);
+    }
+    /// Increment active streams; returns the new count.
+    pub fn enter_stream(&self) -> u64 {
+        self.active_streams.fetch_add(1, Ordering::Relaxed) + 1
+    }
+    /// Decrement active streams when a stream ends.
+    pub fn leave_stream(&self) {
+        self.active_streams.fetch_sub(1, Ordering::Relaxed);
+    }
+    /// Current connect-failure count.
+    #[must_use]
+    pub fn connect_failed(&self) -> u64 {
+        self.connect_failed.load(Ordering::Relaxed)
+    }
+    /// Current active-stream count.
+    #[must_use]
+    pub fn active_streams(&self) -> u64 {
+        self.active_streams.load(Ordering::Relaxed)
+    }
+}
+
+/// Drive the inbound half of a forward: read the header, run the connect
+/// gate, connect the local loopback target, and bridge the stream to it.
+///
+/// The peer identity comes from the [`PeerStream`] (already cleared the T1
+/// identity gate). Records allow/deny into `connect_diag` and connect
+/// failures into `fwd_diag`. On any failure the stream is closed (the halves
+/// are dropped) — zero bytes reach the target on a denial.
+pub(crate) async fn handle_inbound(
+    mut stream: PeerStream,
+    policy: Arc<ConnectPolicy>,
+    connect_diag: Arc<ConnectDiagnostics>,
+    fwd_diag: Arc<ForwardDiagnostics>,
+) {
+    let agent_id = stream.agent();
+    let machine_id = stream.peer();
+    let peer = machine_id;
+    // Read the framed header off the stream.
+    let header = match read_header(stream.recv_mut()).await {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::info!(
+                target: "x0x::forward",
+                peer = %hex::encode(peer.as_bytes()),
+                error = %e,
+                "inbound forward: header read failed — closing stream"
+            );
+            return;
+        }
+    };
+
+    // Gate: resolve + ACL. On deny, write a typed frame + record, then close.
+    let target = match decide_inbound(&header, &policy, &agent_id, &machine_id) {
+        Ok(addr) => addr,
+        Err(reason) => {
+            connect_diag.record_denied(reason);
+            let _ = stream
+                .send_mut()
+                .write_all(&encode_response_denied(reason))
+                .await;
+            tracing::info!(
+                target: "x0x::forward",
+                peer = %hex::encode(peer.as_bytes()),
+                ?reason,
+                target = %header.target_host,
+                port = header.target_port,
+                "inbound forward denied at connect gate"
+            );
+            return;
+        }
+    };
+
+    // Defense in depth: re-check the resolved target is loopback before
+    // connecting (the gate already enforces it; this keeps the invariant
+    // local to the connect call site).
+    if !target.ip().is_loopback() {
+        connect_diag.record_denied(ConnectDenialReason::TargetNotLoopback);
+        let _ = stream
+            .send_mut()
+            .write_all(&encode_response_denied(
+                ConnectDenialReason::TargetNotLoopback,
+            ))
+            .await;
+        return;
+    }
+
+    // Connect the local loopback target with a bounded timeout.
+    let local = match tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(target)).await {
+        Ok(Ok(tcp)) => tcp,
+        Ok(Err(e)) => {
+            fwd_diag.record_connect_failed();
+            tracing::info!(
+                target: "x0x::forward",
+                peer = %hex::encode(peer.as_bytes()),
+                target = %target,
+                error = %e,
+                "inbound forward: local connect failed"
+            );
+            return;
+        }
+        Err(_) => {
+            fwd_diag.record_connect_failed();
+            tracing::info!(
+                target: "x0x::forward",
+                peer = %hex::encode(peer.as_bytes()),
+                target = %target,
+                "inbound forward: local connect timed out"
+            );
+            return;
+        }
+    };
+
+    // Signal connected, then bridge. The connect-allow counter records that
+    // the gate admitted this flow.
+    connect_diag.record_allowed();
+    if stream
+        .send_mut()
+        .write_all(&encode_response_connected())
+        .await
+        .is_err()
+    {
+        return;
+    }
+    let (send, recv) = stream.into_split();
+    fwd_diag.enter_stream();
+    let _guard = StreamLeaveGuard(Arc::clone(&fwd_diag));
+    bridge(local, send, recv).await;
+}
+
+/// RAII guard that decrements the active-stream counter when a forward task ends.
+struct StreamLeaveGuard(Arc<ForwardDiagnostics>);
+impl Drop for StreamLeaveGuard {
+    fn drop(&mut self) {
+        self.0.leave_stream();
+    }
+}
+
+/// Bridge a local TCP connection and the peer stream's two halves until one
+/// side closes. QUIC provides native flow control; `copy` is bounded by QUIC
+/// backpressure so no unbounded buffer is introduced.
+async fn bridge(tcp: TcpStream, mut send: HighLevelSendStream, mut recv: HighLevelRecvStream) {
+    // Split the TCP socket into owned read/write halves so the two copy tasks
+    // can run concurrently without overlapping mutable borrows.
+    let (mut tcp_read, mut tcp_write) = tcp.into_split();
+    let to_stream = tokio::io::copy(&mut tcp_read, &mut send);
+    let from_stream = tokio::io::copy(&mut recv, &mut tcp_write);
+    let _ = tokio::join!(to_stream, from_stream);
+}
+
+/// Read a length-prefixed [`ForwardHeader`] from an async reader.
+async fn read_header<R: tokio::io::AsyncRead + Unpin>(
+    r: &mut R,
+) -> Result<ForwardHeader, ForwardError> {
+    use tokio::io::AsyncReadExt;
+    let mut len_buf = [0u8; 4];
+    r.read_exact(&mut len_buf)
+        .await
+        .map_err(|_| ForwardError::Truncated)?;
+    let len = u32::from_be_bytes(len_buf);
+    if len > MAX_HEADER_BYTES {
+        return Err(ForwardError::Oversize(len));
+    }
+    let mut body = vec![0u8; len as usize];
+    r.read_exact(&mut body)
+        .await
+        .map_err(|_| ForwardError::Truncated)?;
+    bincode::deserialize(&body).map_err(|e| ForwardError::Decode(e.to_string()))
+}
+
+/// Write a length-prefixed [`ForwardHeader`] to an async writer.
+async fn write_header<W: tokio::io::AsyncWrite + Unpin>(
+    w: &mut W,
+    header: &ForwardHeader,
+) -> Result<(), NetworkError> {
+    use tokio::io::AsyncWriteExt;
+    let frame = header.encode();
+    w.write_all(&frame)
+        .await
+        .map_err(|e| NetworkError::StreamError(format!("write forward header: {e}")))
+}
+
+// ===========================================================================
+// ForwardService — owns the inbound consumer + outbound local listeners.
+// ===========================================================================
+
+/// A registered local forward (`forward add`).
+#[derive(Debug, Clone)]
+pub struct ForwardSpec {
+    /// Local loopback address the daemon binds (`127.0.0.1:PORT`).
+    pub local_addr: SocketAddr,
+    /// Peer agent to tunnel to.
+    pub peer_agent: AgentId,
+    /// Loopback target host on the peer's machine (numeric IP).
+    pub target_host: String,
+    /// Loopback target port.
+    pub target_port: u16,
+}
+
+/// Owns the inbound forward consumer + the outbound local listeners.
+///
+/// The inbound loop is the sole consumer of `ForwardV1` streams surfaced by
+/// [`crate::Agent::next_incoming_stream`]; each is gated by [`handle_inbound`]
+/// (resolve → `evaluate_connect_gate` → connect loopback → bridge). Outbound
+/// listeners (`add_forward`) accept local TCP, open a peer stream, write the
+/// [`ForwardHeader`], and bridge on `connected`.
+pub struct ForwardService {
+    agent: Arc<crate::Agent>,
+    policy: Arc<ConnectPolicy>,
+    connect_diag: Arc<ConnectDiagnostics>,
+    fwd_diag: Arc<ForwardDiagnostics>,
+    /// Per-forward cancellation tokens so `shutdown` tears down listeners.
+    forwards: std::sync::Mutex<Vec<(SocketAddr, CancellationToken)>>,
+    inbound_token: CancellationToken,
+}
+
+impl ForwardService {
+    /// Construct a forwarder over a loaded connect policy + its diagnostics.
+    #[must_use]
+    pub fn new(
+        agent: Arc<crate::Agent>,
+        policy: Arc<ConnectPolicy>,
+        connect_diag: Arc<ConnectDiagnostics>,
+    ) -> Self {
+        Self {
+            agent,
+            policy,
+            connect_diag,
+            fwd_diag: Arc::new(ForwardDiagnostics::default()),
+            forwards: std::sync::Mutex::new(Vec::new()),
+            inbound_token: CancellationToken::new(),
+        }
+    }
+
+    /// Forwarder-owned diagnostics (connect-failed + active-stream counters).
+    #[must_use]
+    pub fn diagnostics(&self) -> &ForwardDiagnostics {
+        &self.fwd_diag
+    }
+
+    /// Start the inbound consumer loop. Spawns a task that surfaces
+    /// `ForwardV1` streams to [`handle_inbound`]. Returns immediately.
+    pub fn spawn_inbound(self: &Arc<Self>) {
+        let this = Arc::clone(self);
+        let token = self.inbound_token.clone();
+        tokio::spawn(async move {
+            tracing::info!(target: "x0x::forward", "inbound forward consumer started");
+            loop {
+                let stream = tokio::select! {
+                    _ = token.cancelled() => break,
+                    s = this.agent.next_incoming_stream() => match s {
+                        Some(s) => s,
+                        None => break,
+                    },
+                };
+                if stream.protocol() != crate::streams::StreamProtocol::ForwardV1 {
+                    // T5 (SOCKS5) owns 0x02; until then drop non-forward streams.
+                    tracing::debug!(
+                        target: "x0x::forward",
+                        protocol = ?stream.protocol(),
+                        "non-forward inbound stream — not handled by the forwarder"
+                    );
+                    continue;
+                }
+                let this = Arc::clone(&this);
+                tokio::spawn(async move {
+                    handle_inbound(
+                        stream,
+                        Arc::clone(&this.policy),
+                        Arc::clone(&this.connect_diag),
+                        Arc::clone(&this.fwd_diag),
+                    )
+                    .await;
+                });
+            }
+        });
+    }
+
+    /// Register a local forward: bind `local_addr`, and for each accepted TCP
+    /// connection open a peer stream, write the header, and bridge on
+    /// `connected`. Returns the bound local address (useful when port = 0).
+    ///
+    /// # Errors
+    /// [`NetworkError`] if the local listener cannot be bound.
+    pub async fn add_forward(&self, spec: ForwardSpec) -> NetworkResult<SocketAddr> {
+        let listener = TcpListener::bind(spec.local_addr).await.map_err(|e| {
+            NetworkError::ConnectionFailed(format!("bind {}: {e}", spec.local_addr))
+        })?;
+        let bound = listener
+            .local_addr()
+            .map_err(|e| NetworkError::ConnectionFailed(format!("local_addr: {e}")))?;
+        let cancel = CancellationToken::new();
+        if let Ok(mut forwards) = self.forwards.lock() {
+            forwards.push((bound, cancel.clone()));
+        }
+
+        let agent = Arc::clone(&self.agent);
+        let fwd_diag = Arc::clone(&self.fwd_diag);
+        let peer_agent = spec.peer_agent;
+        let header = ForwardHeader {
+            target_host: spec.target_host,
+            target_port: spec.target_port,
+        };
+        tokio::spawn(async move {
+            tracing::info!(
+                target: "x0x::forward",
+                local = %bound,
+                peer = %hex::encode(peer_agent.as_bytes()),
+                "outbound forward listener started"
+            );
+            loop {
+                let (tcp, _) = tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    a = listener.accept() => match a {
+                        Ok(a) => a,
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "x0x::forward",
+                                local = %bound,
+                                error = %e,
+                                "accept failed; listener stopping"
+                            );
+                            break;
+                        }
+                    },
+                };
+                let agent = Arc::clone(&agent);
+                let fwd_diag = Arc::clone(&fwd_diag);
+                let header = header.clone();
+                tokio::spawn(async move {
+                    fwd_diag.enter_stream();
+                    let _guard = StreamLeaveGuard(Arc::clone(&fwd_diag));
+                    drive_outbound(agent, peer_agent, header, tcp).await;
+                });
+            }
+        });
+        Ok(bound)
+    }
+
+    /// Tear down every listener + the inbound consumer.
+    pub fn shutdown(&self) {
+        self.inbound_token.cancel();
+        if let Ok(forwards) = self.forwards.lock() {
+            for (_, cancel) in forwards.iter() {
+                cancel.cancel();
+            }
+        }
+    }
+}
+
+/// Outbound driver: open the peer stream, write the header, read the peer's
+/// connect response, and bridge on `connected`. On any failure the local TCP
+/// connection is simply closed (the client sees a reset/refused).
+async fn drive_outbound(
+    agent: Arc<crate::Agent>,
+    peer_agent: AgentId,
+    header: ForwardHeader,
+    tcp: TcpStream,
+) {
+    let mut stream = match agent
+        .open_peer_stream(&peer_agent, crate::streams::StreamProtocol::ForwardV1)
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::info!(
+                target: "x0x::forward",
+                peer = %hex::encode(peer_agent.as_bytes()),
+                error = %e,
+                "outbound forward: could not open peer stream"
+            );
+            return;
+        }
+    };
+    if write_header(stream.send_mut(), &header).await.is_err() {
+        return;
+    }
+    // Read the peer's connect-response byte.
+    let mut resp = [0u8; 1];
+    if stream.recv_mut().read_exact(&mut resp).await.is_err() {
+        return;
+    }
+    match response_connected(resp[0]) {
+        Some(true) => {
+            let (send, recv) = stream.into_split();
+            bridge(tcp, send, recv).await;
+        }
+        Some(false) => {
+            tracing::info!(
+                target: "x0x::forward",
+                peer = %hex::encode(peer_agent.as_bytes()),
+                "outbound forward: peer denied at connect gate — closing local TCP"
+            );
+        }
+        None => {
+            tracing::info!(
+                target: "x0x::forward",
+                "outbound forward: malformed connect response — closing local TCP"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connect::acl::{ConnectAcl, ConnectAllowEntry};
+
+    fn header(host: &str, port: u16) -> ForwardHeader {
+        ForwardHeader {
+            target_host: host.to_string(),
+            target_port: port,
+        }
+    }
+
+    #[test]
+    fn header_frame_round_trips() {
+        let h = header("127.0.0.1", 22);
+        let bytes = h.encode();
+        let (decoded, n) = ForwardHeader::decode(&bytes).expect("decode");
+        assert_eq!(decoded, h);
+        assert_eq!(n, bytes.len());
+    }
+
+    /// Build `len || body` manually for negative cases.
+    fn h_frame_with_len(len: u32, body: &[u8]) -> Vec<u8> {
+        let mut out = len.to_be_bytes().to_vec();
+        out.extend_from_slice(body);
+        out
+    }
+
+    #[test]
+    fn header_decode_rejects_truncated_and_oversize() {
+        // Too short for the length prefix.
+        assert_eq!(
+            ForwardHeader::decode(&[0u8, 0]).unwrap_err(),
+            ForwardError::Truncated
+        );
+        // Announces more than available.
+        let bytes = h_frame_with_len(10, &[]);
+        assert_eq!(
+            ForwardHeader::decode(&bytes).unwrap_err(),
+            ForwardError::Truncated
+        );
+        // Oversize announcement.
+        let bytes = h_frame_with_len(MAX_HEADER_BYTES + 1, &[]);
+        assert_eq!(
+            ForwardHeader::decode(&bytes).unwrap_err(),
+            ForwardError::Oversize(MAX_HEADER_BYTES + 1)
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_hostnames_and_non_loopback() {
+        // Numeric loopback IPs resolve.
+        assert!(resolve_loopback_target("127.0.0.1", 22).is_ok());
+        assert!(resolve_loopback_target("::1", 22).is_ok());
+        // Hostnames (including localhost) are refused — no DNS in the TCB.
+        assert_eq!(
+            resolve_loopback_target("localhost", 22).unwrap_err(),
+            ForwardError::NotLoopbackTarget("localhost".to_string())
+        );
+        // Non-loopback numeric IPs are refused.
+        assert_eq!(
+            resolve_loopback_target("10.0.0.1", 22).unwrap_err(),
+            ForwardError::NotLoopbackTarget("10.0.0.1".to_string())
+        );
+    }
+
+    fn policy_with_allow(agent: AgentId, machine: MachineId, target: SocketAddr) -> ConnectPolicy {
+        ConnectPolicy::Enabled(ConnectAcl {
+            loaded_from: "test".into(),
+            loaded_at_unix_ms: 0,
+            allow: vec![ConnectAllowEntry {
+                description: None,
+                agent_id: agent,
+                machine_id: machine,
+                targets: vec![target],
+            }],
+        })
+    }
+
+    #[test]
+    fn decide_inbound_matrix() {
+        let agent = AgentId([1u8; 32]);
+        let machine = MachineId([2u8; 32]);
+        let target: SocketAddr = "127.0.0.1:22".parse().unwrap();
+
+        // Disabled policy ⇒ ConnectDisabled (default-deny).
+        let disabled = ConnectPolicy::default();
+        assert_eq!(
+            decide_inbound(&header("127.0.0.1", 22), &disabled, &agent, &machine).unwrap_err(),
+            ConnectDenialReason::ConnectDisabled
+        );
+
+        // Enabled but pair not in ACL ⇒ AgentMachineNotInAcl.
+        let other_agent = AgentId([9u8; 32]);
+        let policy = policy_with_allow(other_agent, machine, target);
+        assert_eq!(
+            decide_inbound(&header("127.0.0.1", 22), &policy, &agent, &machine).unwrap_err(),
+            ConnectDenialReason::AgentMachineNotInAcl
+        );
+
+        // Pair in ACL but target not in its entry ⇒ TargetNotAllowed.
+        let policy = policy_with_allow(agent, machine, "127.0.0.1:2222".parse().unwrap());
+        assert_eq!(
+            decide_inbound(&header("127.0.0.1", 22), &policy, &agent, &machine).unwrap_err(),
+            ConnectDenialReason::TargetNotAllowed
+        );
+
+        // Happy path: exact (agent, machine, target) ⇒ allow.
+        let policy = policy_with_allow(agent, machine, target);
+        assert_eq!(
+            decide_inbound(&header("127.0.0.1", 22), &policy, &agent, &machine).unwrap(),
+            target
+        );
+
+        // Non-loopback target ⇒ TargetNotLoopback (refused before the ACL).
+        let policy = policy_with_allow(agent, machine, target);
+        assert_eq!(
+            decide_inbound(&header("10.0.0.1", 22), &policy, &agent, &machine).unwrap_err(),
+            ConnectDenialReason::TargetNotLoopback
+        );
+    }
+
+    #[test]
+    fn response_frames_are_well_formed() {
+        let connected = encode_response_connected();
+        assert_eq!(response_connected(connected[0]), Some(true));
+        let denied = encode_response_denied(ConnectDenialReason::ConnectDisabled);
+        assert_eq!(denied[0], RESP_DENIED);
+        // Reason is a length-prefixed JSON enum value (write-side only — the
+        // opener reads the byte + length; ConnectDenialReason is Serialize
+        // only, so verify the frame shape rather than round-tripping).
+        let len = u32::from_be_bytes([denied[1], denied[2], denied[3], denied[4]]) as usize;
+        assert_eq!(
+            denied.len(),
+            5 + len,
+            "denied frame length must match the prefix"
+        );
+        assert!(len > 0, "a serialized ConnectDenialReason is non-empty");
+        assert_eq!(response_connected(RESP_DENIED), Some(false));
+        assert_eq!(response_connected(0xFF), None);
+    }
+}

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -33,6 +33,7 @@
 //! testable without a live QUIC pair (the real stream wiring is proven by
 //! `tests/tailnet_streams_integration.rs` + T7).
 
+use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -62,6 +63,19 @@ const MAX_HEADER_BYTES: u32 = 256;
 
 /// Local connect timeout for the inbound side's `TcpStream::connect`.
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Maximum time to read the full forward header (length prefix + body) from a
+/// peer before resetting the stream (DoS bound — FIX 2).
+const HEADER_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Global cap on concurrently-active INBOUND forward streams (FIX 3). A peer
+/// cannot exhaust task/memory beyond this; the (N+1)th is reset + counted.
+const MAX_INBOUND_STREAMS: usize = 256;
+/// Global cap on concurrently-active OUTBOUND driven connections (FIX 3).
+const MAX_OUTBOUND_STREAMS: usize = 256;
+/// Per-peer cap on concurrently-active forward streams, inbound + outbound
+/// combined (FIX 3). Matches the issue #132 plan's "32 streams/peer" default.
+const MAX_STREAMS_PER_PEER: u32 = 32;
 
 /// Forward header — the first framed message on a `ForwardV1` stream.
 ///
@@ -217,6 +231,15 @@ pub struct ForwardDiagnostics {
     connect_failed: AtomicU64,
     /// Currently active forward streams (inbound + outbound).
     active_streams: AtomicU64,
+    /// Streams refused because the global or per-peer concurrency cap was hit
+    /// (FIX 3, DoS bound).
+    streams_over_cap: AtomicU64,
+    /// Streams dropped because the peer was revoked between the T1 accept gate
+    /// and the forwarder's header read (FIX 4, stale-authorization window).
+    revoked_mid_flight: AtomicU64,
+    /// Streams reset because the forward header did not arrive within
+    /// [`HEADER_READ_TIMEOUT`] (FIX 2).
+    header_timeout: AtomicU64,
 }
 
 impl ForwardDiagnostics {
@@ -232,6 +255,18 @@ impl ForwardDiagnostics {
     pub fn leave_stream(&self) {
         self.active_streams.fetch_sub(1, Ordering::Relaxed);
     }
+    /// Record a stream refused at the concurrency cap (FIX 3).
+    pub fn record_over_cap(&self) {
+        self.streams_over_cap.fetch_add(1, Ordering::Relaxed);
+    }
+    /// Record a stream dropped for mid-flight revocation (FIX 4).
+    pub fn record_revoked_mid_flight(&self) {
+        self.revoked_mid_flight.fetch_add(1, Ordering::Relaxed);
+    }
+    /// Record a header-read timeout (FIX 2).
+    pub fn record_header_timeout(&self) {
+        self.header_timeout.fetch_add(1, Ordering::Relaxed);
+    }
     /// Current connect-failure count.
     #[must_use]
     pub fn connect_failed(&self) -> u64 {
@@ -241,6 +276,21 @@ impl ForwardDiagnostics {
     #[must_use]
     pub fn active_streams(&self) -> u64 {
         self.active_streams.load(Ordering::Relaxed)
+    }
+    /// Streams refused at the concurrency cap.
+    #[must_use]
+    pub fn streams_over_cap(&self) -> u64 {
+        self.streams_over_cap.load(Ordering::Relaxed)
+    }
+    /// Streams dropped for mid-flight revocation.
+    #[must_use]
+    pub fn revoked_mid_flight(&self) -> u64 {
+        self.revoked_mid_flight.load(Ordering::Relaxed)
+    }
+    /// Streams reset for a header-read timeout.
+    #[must_use]
+    pub fn header_timeout(&self) -> u64 {
+        self.header_timeout.load(Ordering::Relaxed)
     }
 }
 
@@ -256,23 +306,60 @@ pub(crate) async fn handle_inbound(
     policy: Arc<ConnectPolicy>,
     connect_diag: Arc<ConnectDiagnostics>,
     fwd_diag: Arc<ForwardDiagnostics>,
+    revocation_set: Arc<tokio::sync::RwLock<crate::revocation::RevocationSet>>,
 ) {
     let agent_id = stream.agent();
     let machine_id = stream.peer();
     let peer = machine_id;
-    // Read the framed header off the stream.
-    let header = match read_header(stream.recv_mut()).await {
-        Ok(h) => h,
-        Err(e) => {
+
+    // FIX 4 (stale-authorization window): the T1 accept-loop identity gate
+    // cleared before this stream was surfaced. A peer revoked in that window
+    // must not consume a header read or reach the connect gate. Re-check the
+    // shared revocation set BEFORE reading any peer bytes; drop on
+    // revocation. (The connect gate would still deny by policy, so this is
+    // not a bypass — it closes the per-flow stale-authz window. Full
+    // mid-stream teardown is a documented Phase-2 item.)
+    {
+        let revoked = revocation_set.read().await;
+        if revoked.is_agent_revoked(&agent_id) || revoked.is_machine_revoked(&machine_id) {
+            fwd_diag.record_revoked_mid_flight();
             tracing::info!(
                 target: "x0x::forward",
-                peer = %hex::encode(peer.as_bytes()),
-                error = %e,
-                "inbound forward: header read failed — closing stream"
+                agent = %hex::encode(agent_id.as_bytes()),
+                machine = %hex::encode(peer.as_bytes()),
+                outcome = "drop_revoked_mid_flight",
+                "inbound forward: peer revoked after accept — dropping before header read"
             );
             return;
         }
-    };
+    }
+
+    // FIX 2: bound the header read so a peer that opens a forward stream and
+    // then stalls cannot hold a forwarder task (and its concurrency permit).
+    // Reset + count on timeout. The declared length prefix is already capped
+    // at MAX_HEADER_BYTES inside read_header, so no huge pre-allocation.
+    let header =
+        match tokio::time::timeout(HEADER_READ_TIMEOUT, read_header(stream.recv_mut())).await {
+            Ok(Ok(h)) => h,
+            Ok(Err(e)) => {
+                tracing::info!(
+                    target: "x0x::forward",
+                    peer = %hex::encode(peer.as_bytes()),
+                    error = %e,
+                    "inbound forward: header read failed — closing stream"
+                );
+                return;
+            }
+            Err(_) => {
+                fwd_diag.record_header_timeout();
+                tracing::info!(
+                    target: "x0x::forward",
+                    peer = %hex::encode(peer.as_bytes()),
+                    "inbound forward: header read timed out — resetting stream"
+                );
+                return;
+            }
+        };
 
     // Gate: resolve + ACL. On deny, write a typed frame + record, then close.
     let target = match decide_inbound(&header, &policy, &agent_id, &machine_id) {
@@ -451,6 +538,78 @@ pub struct ForwardService {
     /// tear down individual listeners and `list` can return them.
     forwards: std::sync::Mutex<Vec<ForwardEntry>>,
     inbound_token: CancellationToken,
+    /// FIX 3: global + per-peer concurrency caps. Admission requires a global
+    /// permit (held for the stream's lifetime) AND a per-peer slot; a stream
+    /// beyond either cap is reset + counted rather than spawned unbounded.
+    inbound_permits: Arc<tokio::sync::Semaphore>,
+    outbound_permits: Arc<tokio::sync::Semaphore>,
+    per_peer: Arc<std::sync::Mutex<HashMap<AgentId, u32>>>,
+    /// Shared revocation set for the FIX 4 pre-header re-check.
+    revocation_set: Arc<tokio::sync::RwLock<crate::revocation::RevocationSet>>,
+}
+
+/// RAII per-peer slot: decrements the per-peer counter (and prunes the entry
+/// at zero) when dropped, so a forwarder task ending releases the slot.
+struct PeerSlot {
+    peer: AgentId,
+    map: Arc<std::sync::Mutex<HashMap<AgentId, u32>>>,
+}
+impl Drop for PeerSlot {
+    fn drop(&mut self) {
+        if let Ok(mut m) = self.map.lock() {
+            if let Some(count) = m.get_mut(&self.peer) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    m.remove(&self.peer);
+                }
+            }
+        }
+    }
+}
+
+/// Holds the global semaphore permit + per-peer slot for the lifetime of one
+/// forward stream task. Dropping it (when the task ends) releases both, so the
+/// concurrency caps stay accurate even on error/panic paths.
+struct Admission {
+    _permit: tokio::sync::OwnedSemaphorePermit,
+    _slot: PeerSlot,
+}
+
+/// FIX 3: try to admit a forward stream against a global permit pool + the
+/// shared per-peer map. Free function so both the inbound consumer and the
+/// outbound listener (which owns cloned caps) share one admission path.
+/// Global cap first (leaves per-peer untouched on failure), then per-peer.
+fn admit_to(
+    permits: &Arc<tokio::sync::Semaphore>,
+    per_peer: &Arc<std::sync::Mutex<HashMap<AgentId, u32>>>,
+    peer: AgentId,
+) -> Option<Admission> {
+    let permit = permits.clone().try_acquire_owned().ok()?;
+    let slot = try_peer_slot(per_peer, peer)?;
+    Some(Admission {
+        _permit: permit,
+        _slot: slot,
+    })
+}
+
+/// Increment the per-peer counter if under [`MAX_STREAMS_PER_PEER`]; returns a
+/// [`PeerSlot`] whose Drop decrements it. Fails closed on poison.
+fn try_peer_slot(
+    map: &Arc<std::sync::Mutex<HashMap<AgentId, u32>>>,
+    peer: AgentId,
+) -> Option<PeerSlot> {
+    let Ok(mut m) = map.lock() else {
+        return None;
+    };
+    let count = m.entry(peer).or_insert(0);
+    if *count >= MAX_STREAMS_PER_PEER {
+        return None;
+    }
+    *count += 1;
+    Some(PeerSlot {
+        peer,
+        map: Arc::clone(map),
+    })
 }
 
 impl ForwardService {
@@ -461,6 +620,7 @@ impl ForwardService {
         policy: Arc<ConnectPolicy>,
         connect_diag: Arc<ConnectDiagnostics>,
     ) -> Self {
+        let revocation_set = agent.revocation_set();
         Self {
             agent,
             policy,
@@ -468,6 +628,10 @@ impl ForwardService {
             fwd_diag: Arc::new(ForwardDiagnostics::default()),
             forwards: std::sync::Mutex::new(Vec::new()),
             inbound_token: CancellationToken::new(),
+            inbound_permits: Arc::new(tokio::sync::Semaphore::new(MAX_INBOUND_STREAMS)),
+            outbound_permits: Arc::new(tokio::sync::Semaphore::new(MAX_OUTBOUND_STREAMS)),
+            per_peer: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            revocation_set,
         }
     }
 
@@ -475,6 +639,20 @@ impl ForwardService {
     #[must_use]
     pub fn diagnostics(&self) -> &ForwardDiagnostics {
         &self.fwd_diag
+    }
+
+    /// FIX 3: try to admit a forward stream against the global + per-peer
+    /// concurrency caps. On success returns an [`Admission`] whose lifetime
+    /// bounds the stream's task (it releases both slots on drop). On a cap
+    /// hit returns `None` — the caller resets the stream + counts it. `inbound`
+    /// selects the global permit pool (separate inbound/outbound caps).
+    fn admit(&self, peer: AgentId, inbound: bool) -> Option<Admission> {
+        let permits = if inbound {
+            &self.inbound_permits
+        } else {
+            &self.outbound_permits
+        };
+        admit_to(permits, &self.per_peer, peer)
     }
 
     /// Start the inbound consumer loop. Spawns a task that surfaces
@@ -501,20 +679,38 @@ impl ForwardService {
                     );
                     continue;
                 }
+                // FIX 3: cap admission before spawning. Over-cap streams are
+                // reset (dropped) + counted rather than spawning unbounded.
+                let peer_agent = stream.agent();
+                let admission = match this.admit(peer_agent, true) {
+                    Some(a) => a,
+                    None => {
+                        this.fwd_diag.record_over_cap();
+                        tracing::info!(
+                            target: "x0x::forward",
+                            agent = %hex::encode(peer_agent.as_bytes()),
+                            "inbound forward refused: concurrency cap reached — resetting"
+                        );
+                        continue;
+                    }
+                };
                 let this = Arc::clone(&this);
                 tokio::spawn(async move {
+                    let _admission = admission;
+                    this.fwd_diag.enter_stream();
+                    let _leave = StreamLeaveGuard(Arc::clone(&this.fwd_diag));
                     handle_inbound(
                         stream,
                         Arc::clone(&this.policy),
                         Arc::clone(&this.connect_diag),
                         Arc::clone(&this.fwd_diag),
+                        Arc::clone(&this.revocation_set),
                     )
                     .await;
                 });
             }
         });
     }
-
     /// Register a local forward: bind `local_addr`, and for each accepted TCP
     /// connection open a peer stream, write the header, and bridge on
     /// `connected`. Returns the bound local address (useful when port = 0).
@@ -538,6 +734,8 @@ impl ForwardService {
 
         let agent = Arc::clone(&self.agent);
         let fwd_diag = Arc::clone(&self.fwd_diag);
+        let outbound_permits = Arc::clone(&self.outbound_permits);
+        let per_peer = Arc::clone(&self.per_peer);
         let peer_agent = spec.peer_agent;
         let header = ForwardHeader {
             target_host: spec.target_host,
@@ -566,10 +764,26 @@ impl ForwardService {
                         }
                     },
                 };
+                // FIX 3: cap outbound driven connections. Over-cap TCP
+                // accepts are dropped (the client sees a refused connection)
+                // + counted rather than spawning unbounded.
+                let admission = match admit_to(&outbound_permits, &per_peer, peer_agent) {
+                    Some(a) => a,
+                    None => {
+                        fwd_diag.record_over_cap();
+                        tracing::info!(
+                            target: "x0x::forward",
+                            local = %bound,
+                            "outbound forward refused: concurrency cap reached — closing local TCP"
+                        );
+                        continue;
+                    }
+                };
                 let agent = Arc::clone(&agent);
                 let fwd_diag = Arc::clone(&fwd_diag);
                 let header = header.clone();
                 tokio::spawn(async move {
+                    let _admission = admission;
                     fwd_diag.enter_stream();
                     let _guard = StreamLeaveGuard(Arc::clone(&fwd_diag));
                     drive_outbound(agent, peer_agent, header, tcp).await;
@@ -809,5 +1023,57 @@ mod tests {
         assert!(len > 0, "a serialized ConnectDenialReason is non-empty");
         assert_eq!(response_connected(RESP_DENIED), Some(false));
         assert_eq!(response_connected(0xFF), None);
+    }
+
+    #[test]
+    fn admit_enforces_global_and_per_peer_caps() {
+        // FIX 3: admission must bound both global concurrency and per-peer
+        // concurrency, releasing the global permit when the per-peer check
+        // fails so the global pool is not leaked.
+        let global = Arc::new(tokio::sync::Semaphore::new(2));
+        let per_peer: Arc<std::sync::Mutex<HashMap<AgentId, u32>>> =
+            Arc::new(std::sync::Mutex::new(HashMap::new()));
+        let peer_a = AgentId([1u8; 32]);
+        let peer_b = AgentId([2u8; 32]);
+
+        // Global cap of 2: two admits across any peers succeed.
+        let a1 = admit_to(&global, &per_peer, peer_a).expect("first admit");
+        let a2 = admit_to(&global, &per_peer, peer_b).expect("second admit");
+        // Third admit fails on the global cap; per_peer must be unchanged for
+        // the not-yet-admitted peer (no leak of a partial admission).
+        assert!(
+            admit_to(&global, &per_peer, peer_a).is_none(),
+            "global cap must refuse the third admit"
+        );
+        // Releasing one global permit re-admits admission.
+        drop(a2);
+        let a3 = admit_to(&global, &per_peer, peer_b).expect("readmit after release");
+        drop(a1);
+        drop(a3);
+
+        // Per-peer cap: a fresh large global pool so only the per-peer limit
+        // binds. Admit MAX_STREAMS_PER_PEER for one peer, then the next fails.
+        let big = Arc::new(tokio::sync::Semaphore::new(1024));
+        let pp: Arc<std::sync::Mutex<HashMap<AgentId, u32>>> =
+            Arc::new(std::sync::Mutex::new(HashMap::new()));
+        let mut held = Vec::new();
+        for _ in 0..MAX_STREAMS_PER_PEER {
+            held.push(admit_to(&big, &pp, peer_a).expect("under per-peer cap"));
+        }
+        assert!(
+            admit_to(&big, &pp, peer_a).is_none(),
+            "per-peer cap must refuse the (N+1)th admit for the same peer"
+        );
+        // A different peer is unaffected (per-peer, not global, is the limit).
+        assert!(
+            admit_to(&big, &pp, peer_b).is_some(),
+            "a second peer must still be admitted under its own per-peer cap"
+        );
+        // Releasing one slot for peer_a re-opens its cap.
+        held.pop();
+        assert!(
+            admit_to(&big, &pp, peer_a).is_some(),
+            "per-peer cap must re-admit after a slot is released"
+        );
     }
 }

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -9,7 +9,7 @@
 //! - **Outbound (the local listener side):** each accepted local TCP
 //!   connection opens a `ForwardV1` stream to the peer
 //!   ([`crate::Agent::open_peer_stream`], which already enforces the
-//!   identity gate), writes the [`ForwardHeader`], waits for the peer's
+//!   identity gate), writes the `ForwardHeader`, waits for the peer's
 //!   response, and on `connected` bridges the two with `tokio::io::copy`.
 //! - **Inbound (the peer's accept side — security-critical):** consumes
 //!   `ForwardV1` streams from [`crate::Agent::next_incoming_stream`], reads
@@ -107,7 +107,7 @@ impl ForwardHeader {
     /// - [`ForwardError::Truncated`] — not enough bytes for the length prefix
     ///   or the announced body.
     /// - [`ForwardError::Oversize`] — announced length exceeds
-    ///   [`MAX_HEADER_BYTES`].
+    ///   `MAX_HEADER_BYTES`.
     /// - [`ForwardError::Decode`] — bincode deserialization failed.
     pub fn decode(buf: &[u8]) -> Result<(Self, usize), ForwardError> {
         if buf.len() < 4 {
@@ -238,7 +238,7 @@ pub struct ForwardDiagnostics {
     /// and the forwarder's header read (FIX 4, stale-authorization window).
     revoked_mid_flight: AtomicU64,
     /// Streams reset because the forward header did not arrive within
-    /// [`HEADER_READ_TIMEOUT`] (FIX 2).
+    /// `HEADER_READ_TIMEOUT` (FIX 2).
     header_timeout: AtomicU64,
 }
 
@@ -459,7 +459,7 @@ async fn bridge(tcp: TcpStream, mut send: HighLevelSendStream, mut recv: HighLev
     let _ = tokio::join!(to_stream, from_stream);
 }
 
-/// Read a length-prefixed [`ForwardHeader`] from an async reader.
+/// Read a length-prefixed `ForwardHeader` from an async reader.
 async fn read_header<R: tokio::io::AsyncRead + Unpin>(
     r: &mut R,
 ) -> Result<ForwardHeader, ForwardError> {
@@ -479,7 +479,7 @@ async fn read_header<R: tokio::io::AsyncRead + Unpin>(
     bincode::deserialize(&body).map_err(|e| ForwardError::Decode(e.to_string()))
 }
 
-/// Write a length-prefixed [`ForwardHeader`] to an async writer.
+/// Write a length-prefixed `ForwardHeader` to an async writer.
 async fn write_header<W: tokio::io::AsyncWrite + Unpin>(
     w: &mut W,
     header: &ForwardHeader,
@@ -525,10 +525,10 @@ struct ForwardEntry {
 /// Owns the inbound forward consumer + the outbound local listeners.
 ///
 /// The inbound loop is the sole consumer of `ForwardV1` streams surfaced by
-/// [`crate::Agent::next_incoming_stream`]; each is gated by [`handle_inbound`]
+/// [`crate::Agent::next_incoming_stream`]; each is gated by `handle_inbound`
 /// (resolve → `evaluate_connect_gate` → connect loopback → bridge). Outbound
 /// listeners (`add_forward`) accept local TCP, open a peer stream, write the
-/// [`ForwardHeader`], and bridge on `connected`.
+/// `ForwardHeader`, and bridge on `connected`.
 pub struct ForwardService {
     agent: Arc<crate::Agent>,
     policy: Arc<ConnectPolicy>,
@@ -656,7 +656,7 @@ impl ForwardService {
     }
 
     /// Start the inbound consumer loop. Spawns a task that surfaces
-    /// `ForwardV1` streams to [`handle_inbound`]. Returns immediately.
+    /// `ForwardV1` streams to `handle_inbound`. Returns immediately.
     pub fn spawn_inbound(self: &Arc<Self>) {
         let this = Arc::clone(self);
         let token = self.inbound_token.clone();
@@ -716,7 +716,7 @@ impl ForwardService {
     /// `connected`. Returns the bound local address (useful when port = 0).
     ///
     /// # Errors
-    /// [`NetworkError`] if the local listener cannot be bound.
+    /// `NetworkError` if the local listener cannot be bound.
     pub async fn add_forward(&self, spec: ForwardSpec) -> NetworkResult<SocketAddr> {
         let listener = TcpListener::bind(spec.local_addr).await.map_err(|e| {
             NetworkError::ConnectionFailed(format!("bind {}: {e}", spec.local_addr))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,9 @@ pub mod network;
 /// Per-peer bidirectional byte-streams over ant-quic (tailnet Phase 1, #132).
 pub mod streams;
 
+/// Local port-forwarder over tailnet byte-streams (tailnet Phase 1, #132 T4).
+pub mod forward;
+
 /// Contact store with trust levels for message filtering.
 pub mod contacts;
 
@@ -8046,7 +8049,9 @@ impl Agent {
             protocol = ?protocol,
             "outbound peer stream opened (identity gate cleared)"
         );
-        Ok(streams::PeerStream::new(machine_id, protocol, send, recv))
+        Ok(streams::PeerStream::new(
+            *agent_id, machine_id, protocol, send, recv,
+        ))
     }
 
     /// Await the next inbound byte-stream that has cleared the identity gate.
@@ -8161,7 +8166,7 @@ impl Agent {
                     }
                 };
 
-                let peer_stream = streams::PeerStream::new(machine_id, protocol, send, recv);
+                let peer_stream = streams::PeerStream::new(agent_id, machine_id, protocol, send, recv);
                 tracing::info!(
                     target: "x0x::streams",
                     agent = %hex::encode(agent_id.as_bytes()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,9 @@ pub mod bootstrap;
 /// Network transport layer for x0x.
 pub mod network;
 
+/// Per-peer bidirectional byte-streams over ant-quic (tailnet Phase 1, #132).
+pub mod streams;
+
 /// Contact store with trust levels for message filtering.
 pub mod contacts;
 
@@ -314,6 +317,10 @@ pub struct Agent {
     /// at build time; future revisions merge in gossip-announced candidates
     /// at runtime, hence the `RwLock` for mutable runtime state.
     relay_candidates: std::sync::Arc<tokio::sync::RwLock<Vec<identity::AgentId>>>,
+    /// Tailnet byte-stream accept loop state (#132 T1): a bounded channel
+    /// surfacing inbound [`streams::PeerStream`]s that have cleared the
+    /// identity gate, plus an idempotent started-flag for the accept loop.
+    stream_accept: std::sync::Arc<streams::StreamAccept>,
 }
 
 /// Closed-flag task registry for deterministic Agent teardown.
@@ -6404,6 +6411,7 @@ impl Agent {
         self.start_identity_listener().await?;
         self.start_network_event_listener();
         self.start_direct_listener();
+        self.start_stream_accept_loop();
 
         let bootstrap_nodes = network.config().bootstrap_nodes.clone();
 
@@ -7985,6 +7993,192 @@ impl Agent {
         });
     }
 
+    // === Tailnet byte-streams (#132 T1) ===
+
+    /// Open a bidirectional byte-stream to a verified, trusted peer.
+    ///
+    /// Resolves `agent_id` → machine via the identity discovery cache, then
+    /// enforces the identity gate (verified binding → not revoked → trust
+    /// `Accept`) before asking ant-quic to open the stream. The protocol
+    /// prefix is written immediately after `open_bi` so the accept side can
+    /// demux. Returns a [`streams::PeerStream`] ready for application I/O.
+    pub async fn open_peer_stream(
+        &self,
+        agent_id: &identity::AgentId,
+        protocol: streams::StreamProtocol,
+    ) -> error::NetworkResult<streams::PeerStream> {
+        let machine_id = {
+            let cache = self.identity_discovery_cache.read().await;
+            cache.get(agent_id).map(|entry| entry.machine_id)
+        };
+        let machine_id = machine_id.ok_or(error::NetworkError::PeerNotVerified {
+            agent_id: agent_id.0,
+        })?;
+
+        let trust_decision = {
+            let contacts = self.contact_store.read().await;
+            let evaluator = trust::TrustEvaluator::new(&contacts);
+            Some(evaluator.evaluate(&trust::TrustContext {
+                agent_id,
+                machine_id: &machine_id,
+            }))
+        };
+        let (revoked_agent, revoked_machine) = {
+            let revoked = self.revocation_set.read().await;
+            (
+                revoked.is_agent_revoked(agent_id),
+                revoked.is_machine_revoked(&machine_id),
+            )
+        };
+        streams::stream_gate(agent_id, trust_decision, revoked_agent, revoked_machine)?;
+
+        let network = self
+            .network
+            .as_ref()
+            .ok_or_else(|| error::NetworkError::NodeError("network not initialized".to_string()))?;
+        let peer = ant_quic::PeerId(machine_id.0);
+        let (mut send, recv) = network.open_bi(&peer).await?;
+        streams::write_protocol_prefix(&mut send, protocol).await?;
+        tracing::info!(
+            target: "x0x::streams",
+            agent = %hex::encode(agent_id.as_bytes()),
+            machine = %hex::encode(machine_id.as_bytes()),
+            protocol = ?protocol,
+            "outbound peer stream opened (identity gate cleared)"
+        );
+        Ok(streams::PeerStream::new(machine_id, protocol, send, recv))
+    }
+
+    /// Await the next inbound byte-stream that has cleared the identity gate.
+    ///
+    /// Returns `None` when the accept loop has stopped (e.g. after shutdown).
+    /// The T4 forwarder consumes accepted streams through this method.
+    pub async fn next_incoming_stream(&self) -> Option<streams::PeerStream> {
+        let mut rx = self.stream_accept.receiver().lock().await;
+        rx.recv().await
+    }
+
+    /// Start the inbound byte-stream accept loop (idempotent).
+    ///
+    /// Called automatically by [`Agent::join_network`]. The loop is the SOLE
+    /// consumer of [`network::NetworkNode::accept_bi`]; every inbound stream
+    /// clears the identity gate (machine has a known agent → not revoked →
+    /// trust `Accept`) and the protocol handshake before being surfaced via
+    /// [`Self::next_incoming_stream`]. A stream that fails the gate is reset
+    /// (its halves are dropped) with zero application bytes exchanged.
+    fn start_stream_accept_loop(&self) {
+        if !self.stream_accept.start_once() {
+            return;
+        }
+        let Some(network) = self.network.as_ref().map(std::sync::Arc::clone) else {
+            return;
+        };
+        let discovery_cache = std::sync::Arc::clone(&self.identity_discovery_cache);
+        let contact_store = std::sync::Arc::clone(&self.contact_store);
+        let revocation_set = std::sync::Arc::clone(&self.revocation_set);
+        let incoming = std::sync::Arc::clone(&self.stream_accept);
+        let token = self.shutdown_token.clone();
+
+        self.spawn_tracked(async move {
+            tracing::info!(target: "x0x::streams", "byte-stream accept loop started");
+            loop {
+                let accepted = tokio::select! {
+                    _ = token.cancelled() => break,
+                    r = network.accept_bi() => r,
+                };
+                let (ant_peer_id, send, mut recv) = match accepted {
+                    Ok(triple) => triple,
+                    Err(e) => {
+                        tracing::warn!(target: "x0x::streams", error=%e, "accept_bi failed; continuing");
+                        continue;
+                    }
+                };
+                let machine_id = identity::MachineId(ant_peer_id.0);
+
+                // Identity gate — resolve the agent on this machine from the
+                // discovery cache, then revoked → trust. Each lock is taken
+                // in its own scope so no two identity locks are held at once
+                // (evict_revoked_subject takes them in a different order).
+                let agent_id = {
+                    let cache = discovery_cache.read().await;
+                    cache
+                        .values()
+                        .find(|a| a.machine_id == machine_id)
+                        .map(|a| a.agent_id)
+                };
+                let Some(agent_id) = agent_id else {
+                    tracing::info!(
+                        target: "x0x::streams",
+                        machine = %hex::encode(machine_id.as_bytes()),
+                        outcome = "deny_not_verified",
+                        "inbound stream from machine with no known agent — denied"
+ );
+                    continue;
+                };
+                let trust_decision = {
+                    let contacts = contact_store.read().await;
+                    let evaluator = trust::TrustEvaluator::new(&contacts);
+                    Some(evaluator.evaluate(&trust::TrustContext {
+                        agent_id: &agent_id,
+                        machine_id: &machine_id,
+                    }))
+                };
+                let (revoked_agent, revoked_machine) = {
+                    let revoked = revocation_set.read().await;
+                    (
+                        revoked.is_agent_revoked(&agent_id),
+                        revoked.is_machine_revoked(&machine_id),
+                    )
+                };
+                if let Err(e) = streams::stream_gate(
+                    &agent_id,
+                    trust_decision,
+                    revoked_agent,
+                    revoked_machine,
+                ) {
+                    tracing::info!(
+                        target: "x0x::streams",
+                        agent = %hex::encode(agent_id.as_bytes()),
+                        outcome = "deny_gate",
+                        error = %e,
+                        "inbound stream denied at identity gate"
+                    );
+                    continue;
+                }
+
+                // Protocol handshake — read + validate the prefix byte.
+                let protocol = match streams::read_protocol_prefix(&mut recv).await {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::info!(
+                            target: "x0x::streams",
+                            machine = %hex::encode(machine_id.as_bytes()),
+                            outcome = "deny_protocol",
+                            error = %e,
+                            "inbound stream protocol prefix rejected"
+                        );
+                        continue;
+                    }
+                };
+
+                let peer_stream = streams::PeerStream::new(machine_id, protocol, send, recv);
+                tracing::info!(
+                    target: "x0x::streams",
+                    agent = %hex::encode(agent_id.as_bytes()),
+                    machine = %hex::encode(machine_id.as_bytes()),
+                    protocol = ?protocol,
+                    "inbound peer stream accepted (identity gate cleared)"
+                );
+                if incoming.sender().send(peer_stream).await.is_err() {
+                    tracing::debug!(
+                        target: "x0x::streams",
+                        "no incoming-stream consumer; dropping accepted stream"
+                    );
+                }
+            }
+        });
+    }
+
     /// new announcement.
     ///
     /// Called automatically by [`Agent::join_network`].
@@ -8267,6 +8461,27 @@ impl Agent {
                 }
             }
         }
+    }
+
+    /// Test-only: mark `agent_id` as a `Trusted` contact so
+    /// [`TrustEvaluator`] returns [`trust::TrustDecision::Accept`] for it.
+    /// Used by the tailnet stream tests to clear the outbound/inbound trust
+    /// gate without driving the full contact-import REST flow. The
+    /// AgentId→MachineId *binding* still has to come from the discovery cache
+    /// (see [`Self::insert_discovered_agent_for_testing`]).
+    #[doc(hidden)]
+    pub async fn set_contact_trusted_for_testing(&self, agent_id: identity::AgentId) {
+        let mut store = self.contact_store.write().await;
+        store.add(contacts::Contact {
+            agent_id,
+            trust_level: contacts::TrustLevel::Trusted,
+            label: None,
+            added_at: 0,
+            last_seen: None,
+            identity_type: contacts::IdentityType::Anonymous,
+            machines: Vec::new(),
+            dm_capabilities: None,
+        });
     }
 
     /// Push a synthetic [`peer_relay::RelayedDm`] onto this Agent's inbound
@@ -9093,6 +9308,7 @@ impl AgentBuilder {
             })),
             peer_relay,
             relay_candidates,
+            stream_accept: std::sync::Arc::new(streams::StreamAccept::new(256)),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8151,35 +8151,54 @@ impl Agent {
                     continue;
                 }
 
-                // Protocol handshake — read + validate the prefix byte.
-                let protocol = match streams::read_protocol_prefix(&mut recv).await {
-                    Ok(p) => p,
-                    Err(e) => {
-                        tracing::info!(
+                // DISPATCH (DoS hardening, issue #132): the protocol-prefix
+                // read + surfacing run in a per-stream task so a peer that
+                // opens a stream and never sends the prefix cannot block this
+                // accept loop (and thus every other peer's inbound streams).
+                // The identity gate above already cleared; this task owns the
+                // stream halves and drops them (→ QUIC reset) on any failure.
+                let incoming_for_task = std::sync::Arc::clone(&incoming);
+                tokio::spawn(async move {
+                    // Belt-and-braces: bound the prefix read so a silent peer
+                    // holds the task/stream for at most PREFIX_READ_TIMEOUT.
+                    let protocol = match tokio::time::timeout(
+                        streams::PREFIX_READ_TIMEOUT,
+                        streams::read_protocol_prefix(&mut recv),
+                    )
+                    .await
+                    {
+                        Ok(Ok(p)) => p,
+                        Ok(Err(e)) => {
+                            tracing::info!(
+                                target: "x0x::streams",
+                                machine = %hex::encode(machine_id.as_bytes()),
+                                outcome = "deny_protocol",
+                                error = %e,
+                                "inbound stream protocol prefix rejected"
+                            );
+                            return;
+                        }
+                        Err(_) => {
+                            tracing::info!(
+                                target: "x0x::streams",
+                                machine = %hex::encode(machine_id.as_bytes()),
+                                outcome = "deny_prefix_timeout",
+                                "inbound stream prefix byte timed out — resetting"
+                            );
+                            return;
+                        }
+                    };
+                    let peer_stream =
+                        streams::PeerStream::new(agent_id, machine_id, protocol, send, recv);
+                    // try_send so a slow consumer cannot pile up accepted
+                    // streams in memory; a full channel drops the stream.
+                    if incoming_for_task.sender().try_send(peer_stream).is_err() {
+                        tracing::debug!(
                             target: "x0x::streams",
-                            machine = %hex::encode(machine_id.as_bytes()),
-                            outcome = "deny_protocol",
-                            error = %e,
-                            "inbound stream protocol prefix rejected"
+                            "incoming-stream channel full; dropping accepted stream"
                         );
-                        continue;
                     }
-                };
-
-                let peer_stream = streams::PeerStream::new(agent_id, machine_id, protocol, send, recv);
-                tracing::info!(
-                    target: "x0x::streams",
-                    agent = %hex::encode(agent_id.as_bytes()),
-                    machine = %hex::encode(machine_id.as_bytes()),
-                    protocol = ?protocol,
-                    "inbound peer stream accepted (identity gate cleared)"
-                );
-                if incoming.sender().send(peer_stream).await.is_err() {
-                    tracing::debug!(
-                        target: "x0x::streams",
-                        "no incoming-stream consumer; dropping accepted stream"
-                    );
-                }
+                });
             }
         });
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -2467,6 +2467,19 @@ impl NetworkNode {
             .map_err(|e| NetworkError::NodeError(format!("open_bi: {e}")))
     }
 
+    /// Test-only: open a raw application byte-stream WITHOUT writing the
+    /// protocol prefix. Used by the FIX 1 regression to simulate a peer that
+    /// opens a QUIC stream and never sends the prefix (the accept-loop
+    /// must not stall on it). Production code uses [`Agent::open_peer_stream`],
+    /// which writes the prefix after the identity gate.
+    #[doc(hidden)]
+    pub async fn open_bi_raw_for_testing(
+        &self,
+        peer_id: &AntPeerId,
+    ) -> NetworkResult<(ant_quic::HighLevelSendStream, ant_quic::HighLevelRecvStream)> {
+        self.open_bi(peer_id).await
+    }
+
     /// Accept the next inbound application byte-stream from any peer.
     ///
     /// Thin transport wrapper over [`ant_quic::Node::accept_bi`]. Yields ONLY

--- a/src/network.rs
+++ b/src/network.rs
@@ -2443,6 +2443,57 @@ impl NetworkNode {
         self.peer_id
     }
 
+    // === Tailnet byte-streams (#132 T1) ===
+
+    /// Open a bidirectional application byte-stream to a connected peer.
+    ///
+    /// Thin transport wrapper over [`ant_quic::Node::open_bi`]. The identity
+    /// gate (verified + trust-accepted + not-revoked) lives in
+    /// [`crate::Agent::open_peer_stream`], which is the sole caller —
+    /// application code never reaches this without clearing the gate.
+    pub(crate) async fn open_bi(
+        &self,
+        peer_id: &AntPeerId,
+    ) -> NetworkResult<(ant_quic::HighLevelSendStream, ant_quic::HighLevelRecvStream)> {
+        let node = self
+            .node
+            .read()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| NetworkError::NodeError("node not initialized".to_string()))?;
+        node.open_bi(peer_id)
+            .await
+            .map_err(|e| NetworkError::NodeError(format!("open_bi: {e}")))
+    }
+
+    /// Accept the next inbound application byte-stream from any peer.
+    ///
+    /// Thin transport wrapper over [`ant_quic::Node::accept_bi`]. Yields ONLY
+    /// application streams — ant-quic demuxes internal ACK-v2 / MASQUE-relay /
+    /// message-transport streams via a reserved prefix before this point, so
+    /// the accept loop never surfaces an internal stream. The identity gate +
+    /// protocol handshake run in the Agent's single accept loop, the sole
+    /// consumer of this method.
+    pub(crate) async fn accept_bi(
+        &self,
+    ) -> NetworkResult<(
+        AntPeerId,
+        ant_quic::HighLevelSendStream,
+        ant_quic::HighLevelRecvStream,
+    )> {
+        let node = self
+            .node
+            .read()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| NetworkError::NodeError("node not initialized".to_string()))?;
+        node.accept_bi()
+            .await
+            .map_err(|e| NetworkError::NodeError(format!("accept_bi: {e}")))
+    }
+
     // === Direct Messaging ===
 
     /// Send a direct message to a connected peer.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -806,6 +806,25 @@ pub async fn serve_with_options(
         mpsc::channel::<x0x::dm_inbox::DmTypedPayload>(1024);
     let exec_service = x0x::exec::ExecService::spawn(Arc::clone(&agent), exec_policy, exec_dm_rx);
 
+    // Tailnet forwarder (#132 T4): build the connect-ACL diagnostics + the
+    // ForwardService. The inbound consumer is the sole reader of
+    // ForwardV1 streams and gates each at `evaluate_connect_gate` before any
+    // local connect. Only spawn when connect is enabled by policy.
+    let connect_diagnostics = Arc::new(x0x::connect::ConnectDiagnostics::new(
+        connect_policy.summary(),
+    ));
+    let forward_service = if connect_policy.enabled() {
+        let fs = Arc::new(x0x::forward::ForwardService::new(
+            Arc::clone(&agent),
+            Arc::new(connect_policy.clone()),
+            Arc::clone(&connect_diagnostics),
+        ));
+        fs.spawn_inbound();
+        Some(fs)
+    } else {
+        None
+    };
+
     // ADR-0012 Phase 4: restore live TreeKEM groups from on-disk snapshots.
     // Must happen before the AppState is built so secure endpoints see the
     // groups immediately. Done with `named_groups` still owned (it is moved
@@ -870,9 +889,8 @@ pub async fn serve_with_options(
         sessions: auth::SessionStore::new(auth::SESSION_TOKEN_TTL),
         exec_service: Arc::clone(&exec_service),
         groups_diagnostics: Arc::new(x0x::groups::GroupsDiagnostics::new()),
-        connect_diagnostics: Arc::new(x0x::connect::ConnectDiagnostics::new(
-            connect_policy.summary(),
-        )),
+        connect_diagnostics,
+        forward_service,
     });
 
     // Fix A (Issue #110 Phase 2 + #116): the `api.port` advertisement is written
@@ -1551,6 +1569,10 @@ pub async fn serve_with_options(
         .route("/exec/run", post(exec_run))
         .route("/exec/cancel", post(exec_cancel))
         .route("/exec/sessions", get(exec_sessions))
+        // Tailnet forwarding (#132 T6)
+        .route("/forwards", post(forward_add).get(forward_list))
+        .route("/forwards/:local_addr", delete(forward_remove))
+        .route("/streams", get(streams_diagnostics))
         // Peer observability (ant-quic 0.27.1/0.27.2 surface)
         .route("/peers/:peer_id/probe", post(probe_peer_handler))
         .route("/peers/:peer_id/health", get(peer_health_handler))
@@ -1684,6 +1706,11 @@ pub async fn serve_with_options(
         //    still alive, so in-flight sessions can cancel cleanly before the
         //    network goes away.
         state.exec_service.shutdown().await;
+        // 0b. Forwarder listeners + inbound consumer (issue #132): stop
+        //     accepting/bridging while the Agent transport is still alive.
+        if let Some(forwarder) = &state.forward_service {
+            forwarder.shutdown();
+        }
         // 1. `Agent::begin_shutdown()` (issue #116 Codex finding 1): cancel the
         //    Agent's shutdown token and close its tracked-task registry NOW,
         //    BEFORE draining the server bg_tasks. A still-bootstrapping
@@ -14014,6 +14041,150 @@ async fn connect_diagnostics_handler(State(state): State<Arc<AppState>>) -> impl
     Json(state.connect_diagnostics.snapshot())
 }
 
+// ── Tailnet forwarding (#132 T6) ──────────────────────────────────────────
+
+/// POST /forwards — register a local port forward.
+#[derive(serde::Deserialize)]
+struct ForwardAddRequest {
+    /// Local bind, e.g. `127.0.0.1:8022`.
+    local_addr: String,
+    /// Peer agent id (hex).
+    peer_agent: String,
+    /// Loopback target host on the peer (numeric IP).
+    target_host: String,
+    /// Loopback target port.
+    target_port: u16,
+}
+
+async fn forward_add(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ForwardAddRequest>,
+) -> impl IntoResponse {
+    use x0x::forward::ForwardSpec;
+    use x0x::identity::AgentId;
+    let Some(forwarder) = state.forward_service.as_ref() else {
+        return api_error(
+            StatusCode::CONFLICT,
+            "connect forwarding is disabled (no connect ACL loaded)".to_string(),
+        )
+        .into_response();
+    };
+    let local_addr: SocketAddr = match req.local_addr.parse() {
+        Ok(a) => a,
+        Err(e) => {
+            return api_error(StatusCode::BAD_REQUEST, format!("local_addr: {e}")).into_response()
+        }
+    };
+    if !local_addr.ip().is_loopback() {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "local_addr must be loopback (Phase 1)".to_string(),
+        )
+        .into_response();
+    }
+    let peer_agent_bytes = match x0x::exec::acl::parse_agent_id(&req.peer_agent) {
+        Ok(id) => id,
+        Err(e) => {
+            return api_error(StatusCode::BAD_REQUEST, format!("peer_agent: {e}")).into_response()
+        }
+    };
+    let spec = ForwardSpec {
+        local_addr,
+        peer_agent: peer_agent_bytes,
+        target_host: req.target_host,
+        target_port: req.target_port,
+    };
+    let peer_agent: AgentId = spec.peer_agent;
+    match forwarder.add_forward(spec).await {
+        Ok(bound) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "ok": true,
+                "local_addr": bound.to_string(),
+                "peer_agent": hex::encode(peer_agent.as_bytes()),
+            })),
+        )
+            .into_response(),
+        Err(e) => api_error(StatusCode::BAD_GATEWAY, e.to_string()).into_response(),
+    }
+}
+
+/// GET /forwards — list registered forwards.
+async fn forward_list(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let forwards: Vec<serde_json::Value> = state
+        .forward_service
+        .as_ref()
+        .map(|f| {
+            f.list_forwards()
+                .into_iter()
+                .map(|s| {
+                    serde_json::json!({
+                        "local_addr": s.local_addr.to_string(),
+                        "peer_agent": s.peer_agent_hex(),
+                        "target_host": s.target_host,
+                        "target_port": s.target_port,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "forwards": forwards })),
+    )
+}
+
+/// DELETE /forwards/:local_addr — tear down a forward by its local bind addr.
+async fn forward_remove(
+    State(state): State<Arc<AppState>>,
+    Path(local_addr): Path<String>,
+) -> impl IntoResponse {
+    let Some(forwarder) = state.forward_service.as_ref() else {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "ok": false, "removed": false })),
+        );
+    };
+    let Ok(addr): Result<SocketAddr, _> = local_addr.parse() else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "ok": false, "removed": false })),
+        );
+    };
+    let removed = forwarder.remove_forward(addr);
+    let status = if removed {
+        StatusCode::OK
+    } else {
+        StatusCode::NOT_FOUND
+    };
+    (
+        status,
+        Json(serde_json::json!({ "ok": removed, "removed": removed })),
+    )
+}
+
+/// GET /streams — active forward-stream count + connect-ACL counters.
+async fn streams_diagnostics(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let (active, connect_failed) = state
+        .forward_service
+        .as_ref()
+        .map(|f| {
+            (
+                f.diagnostics().active_streams(),
+                f.diagnostics().connect_failed(),
+            )
+        })
+        .unwrap_or((0, 0));
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "active_streams": active,
+            "connect_failed": connect_failed,
+            "connect": state.connect_diagnostics.snapshot(),
+        })),
+    )
+}
+
 /// POST /direct/send — send a direct message to a connected agent.
 async fn direct_send(
     State(state): State<Arc<AppState>>,
@@ -18573,6 +18744,7 @@ mod tests {
             connect_diagnostics: Arc::new(x0x::connect::ConnectDiagnostics::new(
                 x0x::connect::ConnectPolicy::default().summary(),
             )),
+            forward_service: None,
         });
         Ok((state, dir))
     }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -576,6 +576,10 @@ pub(super) struct AppState {
     /// `/diagnostics/connect`. Counters read 0 until the T4 forwarder
     /// (issue #132) wires calls to `record_allowed`/`record_denied`.
     pub(super) connect_diagnostics: Arc<x0x::connect::ConnectDiagnostics>,
+    /// Tailnet forwarder service (#132 T4/T6): owns the inbound connect-gated
+    /// consumer + outbound local-port listeners. `None` when connect is
+    /// disabled (no policy) so the daemon runs zero forwarder tasks.
+    pub(super) forward_service: Option<Arc<x0x::forward::ForwardService>>,
 }
 
 #[derive(Clone)]

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -18,7 +18,7 @@
 //! [protocol: u8][protocol-specific bytes...]
 //! ```
 //!
-//! `0x00` is reserved (treated as unknown → reset). See [`StreamProtocol`].
+//! `0x00` is reserved (treated as unknown → reset). See `StreamProtocol`.
 //!
 //! ## Identity gate — fail closed, in fixed order
 //!
@@ -38,7 +38,7 @@
 //!    revocation set (positive knowledge of compromise fails closed, mirroring
 //!    EP3 / EP4 / the relay and direct-DM gates).
 //!
-//! Any failure produces a typed [`NetworkError`] (`PeerNotVerified` /
+//! Any failure produces a typed `NetworkError` (`PeerNotVerified` /
 //! `PeerTrustRejected` / `PeerRevoked`) and the stream is refused or reset
 //! with zero application bytes exchanged. This chokepoint is what makes the
 //! T4 inbound forwarder safe by construction: it receives only streams that

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -124,6 +124,12 @@ pub(crate) fn stream_gate(
     Ok(())
 }
 
+/// Maximum time to wait for a stream's protocol-prefix byte before resetting
+/// it. Belt-and-braces behind the per-stream spawn: a peer that opens a QUIC
+/// stream and never sends the prefix cannot hold an accept-loop slot — the
+/// read runs in the per-stream task and times out here, resetting the stream.
+pub const PREFIX_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Protocol-prefix byte carried as the first byte of an application stream.
 ///
 /// `0x00` is deliberately reserved and rejected as unknown so a zeroed/truncated

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -1,0 +1,324 @@
+//! Per-peer bidirectional byte-streams over ant-quic (tailnet Phase 1, #132 T1).
+//!
+//! Builds on [`ant_quic::Node::open_bi`] / [`ant_quic::Node::accept_bi`] to
+//! expose reliable, backpressure-correct byte-streams between two x0x peers.
+//! These are the substrate for the local port-forwarder (T4, `src/forward/`)
+//! and the SOCKS5 listener (T5). The underlying transport is end-to-end
+//! post-quantum (ML-KEM-768 / ML-DSA-65); ant-quic relays forward ciphertext
+//! only, so streams work identically over direct and relayed connections.
+//!
+//! ## Wire framing
+//!
+//! Each application stream carries a single protocol-prefix byte as its first
+//! payload byte, demultiplexing stream types on top of ant-quic's own
+//! app-vs-internal demux (which already keeps `accept_bi` from surfacing
+//! ACK-v2 / MASQUE-relay / message-transport streams):
+//!
+//! ```text
+//! [protocol: u8][protocol-specific bytes...]
+//! ```
+//!
+//! `0x00` is reserved (treated as unknown → reset). See [`StreamProtocol`].
+//!
+//! ## Identity gate — fail closed, in fixed order
+//!
+//! Both the outbound open ([`crate::Agent::open_peer_stream`]) and the inbound
+//! accept loop enforce the same gate, in this order, before any application
+//! byte is sent or read:
+//!
+//! 1. **transport-verified** — ant-quic authenticates the peer's `MachineId`
+//!    at the QUIC/TLS layer; an unauthenticated connection can never yield a
+//!    stream. Outbound additionally requires the `AgentId → MachineId` binding
+//!    to be present in the identity discovery cache (the same `verified`
+//!    annotation the direct-DM path uses).
+//! 2. **trust-accepted** — the local [`TrustDecision`](crate::trust::TrustDecision)
+//!    for the `(AgentId, MachineId)` pair must be `Accept` (`AcceptWithFlag`
+//!    is rejected, mirroring exec + the connect gate).
+//! 3. **not revoked** — neither the agent nor the machine may be in the local
+//!    revocation set (positive knowledge of compromise fails closed, mirroring
+//!    EP3 / EP4 / the relay and direct-DM gates).
+//!
+//! Any failure produces a typed [`NetworkError`] (`PeerNotVerified` /
+//! `PeerTrustRejected` / `PeerRevoked`) and the stream is refused or reset
+//! with zero application bytes exchanged. This chokepoint is what makes the
+//! T4 inbound forwarder safe by construction: it receives only streams that
+//! have already cleared the identity gate.
+
+use crate::error::{NetworkError, NetworkResult};
+use crate::identity::MachineId;
+
+/// Shared state for the inbound byte-stream accept loop.
+///
+/// Owns the bounded channel that surfaces identity-gated [`PeerStream`]s to
+/// the consumer (the T4 forwarder / a test), plus an idempotent started-flag
+/// so [`crate::Agent`] starts exactly one accept loop even if
+/// `join_network` races.
+pub(crate) struct StreamAccept {
+    tx: tokio::sync::mpsc::Sender<PeerStream>,
+    rx: std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<PeerStream>>>,
+    started: std::sync::atomic::AtomicBool,
+}
+
+impl StreamAccept {
+    /// New accept state with a bounded surfacing channel.
+    pub(crate) fn new(capacity: usize) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::channel(capacity);
+        Self {
+            tx,
+            rx: std::sync::Arc::new(tokio::sync::Mutex::new(rx)),
+            started: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Sender half for the accept loop to push gated streams onto.
+    pub(crate) fn sender(&self) -> &tokio::sync::mpsc::Sender<PeerStream> {
+        &self.tx
+    }
+
+    /// Receiver half for the consumer to drain accepted streams.
+    pub(crate) fn receiver(
+        &self,
+    ) -> &std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<PeerStream>>> {
+        &self.rx
+    }
+
+    /// Try to mark the accept loop as started. Returns `true` if this call is
+    /// the winner (the loop should start); `false` if a loop is already running.
+    pub(crate) fn start_once(&self) -> bool {
+        !self.started.swap(true, std::sync::atomic::Ordering::AcqRel)
+    }
+}
+
+/// Identity gate decision shared by the outbound open and inbound accept
+/// paths (issue #132 T1). Pure function of the resolved inputs so the whole
+/// verified/trust/revoked matrix is fast unit-testable without a network.
+///
+/// Callers resolve `(trust_decision, revoked_agent, revoked_machine)` from the
+/// discovery cache / contact store / revocation set first; a missing identity
+/// (unknown agent or machine) is surfaced as [`NetworkError::PeerNotVerified`]
+/// by the caller before reaching this helper.
+///
+/// # Gate order (do not reorder — security property)
+/// 1. revoked (agent OR machine) ⇒ [`NetworkError::PeerRevoked`]. Revocation
+///    is positive knowledge of compromise and supersedes trust; checking it
+///    first also avoids revealing trust state to a revoked peer.
+/// 2. `trust_decision != Some(Accept)` ⇒ [`NetworkError::PeerTrustRejected`].
+///    Mirrors exec + the connect gate: `AcceptWithFlag` and `None` both deny.
+pub(crate) fn stream_gate(
+    agent_id: &crate::identity::AgentId,
+    trust_decision: Option<crate::trust::TrustDecision>,
+    revoked_agent: bool,
+    revoked_machine: bool,
+) -> NetworkResult<()> {
+    use crate::trust::TrustDecision;
+    if revoked_agent || revoked_machine {
+        return Err(NetworkError::PeerRevoked {
+            agent_id: agent_id.0,
+        });
+    }
+    if trust_decision != Some(TrustDecision::Accept) {
+        return Err(NetworkError::PeerTrustRejected {
+            agent_id: agent_id.0,
+        });
+    }
+    Ok(())
+}
+
+/// Protocol-prefix byte carried as the first byte of an application stream.
+///
+/// `0x00` is deliberately reserved and rejected as unknown so a zeroed/truncated
+/// prefix cannot be mistaken for a valid protocol.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamProtocol {
+    /// Local port-forwarding (`src/forward/`). Header is a length-prefixed
+    /// bincode `{target_host, target_port}`, gated by the connect ACL at the
+    /// inbound accept seam.
+    ForwardV1 = 0x01,
+    /// SOCKS5 dynamic listener (`src/socks/`, T5). Carries the CONNECT target.
+    SocksV1 = 0x02,
+}
+
+impl StreamProtocol {
+    /// Parse a protocol-prefix byte. Returns `None` for `0x00` (reserved) and
+    /// any other unassigned byte.
+    #[must_use]
+    pub fn from_u8(byte: u8) -> Option<Self> {
+        match byte {
+            0x01 => Some(Self::ForwardV1),
+            0x02 => Some(Self::SocksV1),
+            _ => None,
+        }
+    }
+
+    /// The on-wire prefix byte.
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+/// A bidirectional byte-stream to a verified, trusted peer.
+///
+/// Wraps ant-quic's send/recv halves. The send half implements
+/// [`tokio::io::AsyncWrite`] and the recv half implements
+/// [`tokio::io::AsyncRead`], so a forwarder bridges a local `TcpStream` to a
+/// `PeerStream` with two `tokio::io::copy` tasks (one per direction). QUIC
+/// provides native flow-control / backpressure — no intermediate unbounded
+/// buffers are introduced.
+///
+/// The `protocol` and `peer` fields are fixed at open/accept time after the
+/// identity gate has cleared; consumers can rely on them without re-checking.
+pub struct PeerStream {
+    peer: MachineId,
+    protocol: StreamProtocol,
+    send: ant_quic::HighLevelSendStream,
+    recv: ant_quic::HighLevelRecvStream,
+}
+
+impl PeerStream {
+    /// Construct a stream handle from already-gated halves plus the negotiated
+    /// protocol. Called by the Agent open/accept paths after the identity gate
+    /// and protocol handshake have succeeded.
+    pub(crate) fn new(
+        peer: MachineId,
+        protocol: StreamProtocol,
+        send: ant_quic::HighLevelSendStream,
+        recv: ant_quic::HighLevelRecvStream,
+    ) -> Self {
+        Self {
+            peer,
+            protocol,
+            send,
+            recv,
+        }
+    }
+
+    /// The peer's transport-authenticated machine identity.
+    #[must_use]
+    pub fn peer(&self) -> MachineId {
+        self.peer
+    }
+
+    /// The negotiated application protocol.
+    #[must_use]
+    pub fn protocol(&self) -> StreamProtocol {
+        self.protocol
+    }
+
+    /// Borrow the send (write) half.
+    pub fn send_mut(&mut self) -> &mut ant_quic::HighLevelSendStream {
+        &mut self.send
+    }
+
+    /// Borrow the recv (read) half.
+    pub fn recv_mut(&mut self) -> &mut ant_quic::HighLevelRecvStream {
+        &mut self.recv
+    }
+
+    /// Deconstruct into the owned send/recv halves (e.g. for two-task copy
+    /// loops in the forwarder).
+    pub fn into_split(self) -> (ant_quic::HighLevelSendStream, ant_quic::HighLevelRecvStream) {
+        (self.send, self.recv)
+    }
+}
+
+/// Write the protocol-prefix byte on a freshly-opened outbound stream.
+///
+/// Called by the opener immediately after [`ant_quic::Node::open_bi`] so the
+/// accept side can demux the stream type.
+pub(crate) async fn write_protocol_prefix(
+    send: &mut ant_quic::HighLevelSendStream,
+    protocol: StreamProtocol,
+) -> NetworkResult<()> {
+    send.write_all(&[protocol.as_u8()])
+        .await
+        .map_err(|e| NetworkError::StreamError(format!("write protocol prefix: {e}")))
+}
+
+/// Read and validate the protocol-prefix byte on an accepted stream.
+///
+/// Returns the negotiated protocol, or [`NetworkError::StreamProtocolUnknown`]
+/// for a reserved/unassigned byte (the caller resets the stream).
+pub(crate) async fn read_protocol_prefix(
+    recv: &mut ant_quic::HighLevelRecvStream,
+) -> NetworkResult<StreamProtocol> {
+    let mut buf = [0u8; 1];
+    recv.read_exact(&mut buf)
+        .await
+        .map_err(|e| NetworkError::StreamError(format!("read protocol prefix: {e}")))?;
+    StreamProtocol::from_u8(buf[0]).ok_or(NetworkError::StreamProtocolUnknown {
+        protocol_byte: buf[0],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_prefix_round_trips() {
+        for p in [StreamProtocol::ForwardV1, StreamProtocol::SocksV1] {
+            assert_eq!(StreamProtocol::from_u8(p.as_u8()), Some(p));
+        }
+    }
+
+    #[test]
+    fn reserved_and_unassigned_bytes_are_unknown() {
+        // 0x00 reserved by design; anything outside the assigned set is unknown.
+        for byte in 0x00u8..=0xFF {
+            let parsed = StreamProtocol::from_u8(byte);
+            match byte {
+                0x01 | 0x02 => assert!(parsed.is_some(), "byte {byte:#x} should parse"),
+                _ => assert_eq!(parsed, None, "byte {byte:#x} must be unknown"),
+            }
+        }
+    }
+
+    #[test]
+    fn stream_gate_matrix() {
+        // Issue #132 T1: the identity-gate decision must fail closed in the
+        // documented order — revoked supersedes trust (a revoked-but-still-
+        // trusted peer is refused, and never learns its trust state); only
+        // (not-revoked AND trust==Accept) passes. AcceptWithFlag/None deny.
+        use crate::error::NetworkError;
+        use crate::identity::AgentId;
+        use crate::trust::TrustDecision;
+
+        let agent = AgentId([9u8; 32]);
+        let accept = Some(TrustDecision::Accept);
+        let accept_with_flag = Some(TrustDecision::AcceptWithFlag);
+        let reject = Some(TrustDecision::RejectBlocked);
+
+        // Happy path: trusted + clean.
+        assert!(stream_gate(&agent, accept, false, false).is_ok());
+
+        // Revocation supersedes trust — even an Accept+trusted peer is refused,
+        // and the error is PeerRevoked regardless of trust.
+        assert!(matches!(
+            stream_gate(&agent, accept, true, false),
+            Err(NetworkError::PeerRevoked { agent_id }) if agent_id == agent.0
+        ));
+        assert!(matches!(
+            stream_gate(&agent, accept, false, true),
+            Err(NetworkError::PeerRevoked { .. })
+        ));
+        // A revoked + untrusted peer surfaces PeerRevoked, NOT the trust
+        // reason (no trust-state leak to a compromised key).
+        assert!(matches!(
+            stream_gate(&agent, reject, true, false),
+            Err(NetworkError::PeerRevoked { .. })
+        ));
+
+        // Trust variants that are NOT plain Accept all deny when not revoked.
+        for decision in [accept_with_flag, reject, None] {
+            assert!(
+                matches!(
+                    stream_gate(&agent, decision, false, false),
+                    Err(NetworkError::PeerTrustRejected { agent_id }) if agent_id == agent.0
+                ),
+                "decision {decision:?} must deny (only plain Accept passes)"
+            );
+        }
+    }
+}

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -167,9 +167,11 @@ impl StreamProtocol {
 /// provides native flow-control / backpressure — no intermediate unbounded
 /// buffers are introduced.
 ///
-/// The `protocol` and `peer` fields are fixed at open/accept time after the
-/// identity gate has cleared; consumers can rely on them without re-checking.
+/// The `agent`, `peer`, and `protocol` fields are fixed at open/accept time
+/// after the identity gate has cleared; consumers can rely on them without
+/// re-checking.
 pub struct PeerStream {
+    agent: crate::identity::AgentId,
     peer: MachineId,
     protocol: StreamProtocol,
     send: ant_quic::HighLevelSendStream,
@@ -181,17 +183,27 @@ impl PeerStream {
     /// protocol. Called by the Agent open/accept paths after the identity gate
     /// and protocol handshake have succeeded.
     pub(crate) fn new(
+        agent: crate::identity::AgentId,
         peer: MachineId,
         protocol: StreamProtocol,
         send: ant_quic::HighLevelSendStream,
         recv: ant_quic::HighLevelRecvStream,
     ) -> Self {
         Self {
+            agent,
             peer,
             protocol,
             send,
             recv,
         }
+    }
+
+    /// The peer's agent identity (resolved from the machine at the identity
+    /// gate on the inbound path; the caller-supplied target on the outbound
+    /// path). The connect gate (`evaluate_connect_gate`) matches on this.
+    #[must_use]
+    pub fn agent(&self) -> crate::identity::AgentId {
+        self.agent
     }
 
     /// The peer's transport-authenticated machine identity.

--- a/tests/api_coverage.rs
+++ b/tests/api_coverage.rs
@@ -429,6 +429,15 @@ const COVERED: &[CoveredEndpoint] = &[
     covered!(Get, "/ws/direct", ws_direct_endpoint),
     covered!(Get, "/ws/sessions", daemon_api_ws_sessions),
     covered!(Get, "/gui", gui_html_contains_brand),
+    // ── Tailnet forwarding (#132 T6) ────────────────────────────────────
+    covered!(Post, "/forwards", daemon_api_forwards_add_disabled),
+    covered!(Get, "/forwards", daemon_api_forwards_list),
+    covered!(
+        Delete,
+        "/forwards/:local_addr",
+        daemon_api_forwards_remove_disabled
+    ),
+    covered!(Get, "/streams", daemon_api_streams),
 ];
 
 const COVERAGE_MARKER_SOURCES: &[(&str, &str)] = &[

--- a/tests/daemon_api_integration.rs
+++ b/tests/daemon_api_integration.rs
@@ -2354,3 +2354,80 @@ async fn daemon_api_invalid_json() {
         r.status() == StatusCode::BAD_REQUEST || r.status() == StatusCode::UNPROCESSABLE_ENTITY
     );
 }
+
+// ===========================================================================
+// Tailnet forwarding (#132 T6) — endpoints exist + respond correctly under
+// the default (connect-disabled) daemon. The full forward round-trip is
+// proven by tests/tailnet_streams_integration.rs + the VPS harness; these
+// cover the REST contract the API parity gate requires.
+// ===========================================================================
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_forwards_add_disabled() {
+    // Default daemon has no connect ACL → connect disabled → POST /forwards
+    // must fail closed with 409, never silently accept.
+    let d = daemon().await;
+    let body = serde_json::json!({
+        "local_addr": "127.0.0.1:18022",
+        "peer_agent": "00".repeat(32),
+        "target_host": "127.0.0.1",
+        "target_port": 22,
+    });
+    let r = ca(&d)
+        .post(d.url("/forwards"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status(),
+        StatusCode::CONFLICT,
+        "forward add must 409 when connect is disabled"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_forwards_list() {
+    let d = daemon().await;
+    let r: Value = ca(&d)
+        .get(d.url("/forwards"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(r["forwards"].as_array().map(|a| a.len()), Some(0));
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_forwards_remove_disabled() {
+    // connect disabled → DELETE /forwards/:addr returns 409 (no forwarder).
+    let d = daemon().await;
+    let r = ca(&d)
+        .delete(d.url("/forwards/127.0.0.1:18022"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+#[ignore]
+async fn daemon_api_streams() {
+    let d = daemon().await;
+    let r: Value = ca(&d)
+        .get(d.url("/streams"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(r["active_streams"], 0);
+    assert_eq!(r["connect_failed"], 0);
+    assert!(r["connect"].is_object(), "connect-ACL snapshot present");
+}

--- a/tests/e2e_tailnet_forward.sh
+++ b/tests/e2e_tailnet_forward.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Tailnet Phase 1 forward e2e proof (#132 T7).
+#
+# Proves `x0x forward add` end-to-end: a local TCP listener on machine A
+# tunnels to a loopback service on machine B over a ForwardV1 byte-stream,
+# gated fail-closed by B's connect ACL + the key lifecycle. Runs against TWO
+# x0xd daemons on the real-NAT VPS testnet (the relayed forward path CANNOT
+# be tested in-process — ant-quic cannot force the MASQUE relay path on
+# loopback; see issue #132 T7 note). The direct forward path is additionally
+# covered by tests/tailnet_streams_integration.rs (loopback).
+#
+# This harness ENFORCES every claim it prints: a failed assertion exits
+# non-zero. It is the authoritative real-NAT proof for the sprint.
+#
+# Prerequisites (maintainer sets these up before running):
+#   * Two VPS nodes with x0xd deployed + healthy (tests/e2e_deploy.sh).
+#     ANCHOR = machine A (opens the forward). RUNNER = machine B (exposes the
+#     loopback echo service + enforces the connect ACL).
+#   * A and B have exchanged agent cards and are Trusted contacts of each
+#     other (so the T1 identity gate clears).
+#   * B's connect ACL ($CONNECT_ACL on B) lists an allow entry for A's
+#     (agent_id, machine_id) → 127.0.0.1:$ECHO_PORT.
+#   * SSH access to both (tests/CLAUDE.md SSH notes: ControlMaster=no,
+#     BatchMode=yes). API tokens at /root/.local/share/x0x/api-token.
+#   * `socat` on B for the echo service (or set ECHO_CMD).
+#
+# Usage:
+#   ANCHOR_HOST=user@nyc RUNNER_HOST=user@sg \
+#     ANCHOR_API=http://127.0.0.1:12600 RUNNER_API=http://127.0.0.1:12600 \
+#     ANCHOR_AGENT=<hex> RUNNER_AGENT=<hex> RUNNER_MACHINE=<hex> \
+#     CONNECT_ACL=/etc/x0x/connect-acl.toml \
+#     bash tests/e2e_tailnet_forward.sh
+#
+# Negative security cases are first-class steps and must each PASS (deny):
+#   N1 deny-without-ACL   — remove B's allow entry, forward is refused.
+#   N2 non-loopback       — target 10.0.0.1 is rejected (refused before ACL).
+#   N3 revoked identity   — revoke A on B, A's new forward is refused.
+#   N4 unverified         — an unknown machine's stream is refused at T1.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ANCHOR_HOST="${ANCHOR_HOST:?ANCHOR_HOST (user@node) required}"
+RUNNER_HOST="${RUNNER_HOST:?RUNNER_HOST (user@node) required}"
+ANCHOR_API="${ANCHOR_API:?ANCHOR_API base url required}"
+RUNNER_API="${RUNNER_API:?RUNNER_API base url required}"
+ANCHOR_AGENT="${ANCHOR_AGENT:?ANCHOR_AGENT (hex) required}"
+RUNNER_AGENT="${RUNNER_AGENT:?RUNNER_AGENT (hex) required}"
+RUNNER_MACHINE="${RUNNER_MACHINE:?RUNNER_MACHINE (hex) required}"
+CONNECT_ACL="${CONNECT_ACL:-/etc/x0x/connect-acl.toml}"
+ECHO_PORT="${ECHO_PORT:-18022}"
+FORWARD_PORT="${FORWARD_PORT:-18023}"
+
+SSH="ssh -C -o ConnectTimeout=10 -o ControlMaster=no -o ControlPath=none -o BatchMode=yes"
+GREEN=$'\033[32m'; RED=$'\033[31m'; YELLOW=$'\033[33m'; NC=$'\033[0m'
+PASS=0; FAIL=0
+ok()   { echo "${GREEN}PASS${NC} $1"; PASS=$((PASS+1)); }
+fail() { echo "${RED}FAIL${NC} $1"; FAIL=$((FAIL+1)); }
+proof(){ echo "${YELLOW}PROOF${NC} $1"; }
+bail() { echo "${RED}BAIL${NC} $1" >&2; exit 3; }
+
+# Fetch a JSON value from a daemon endpoint over SSH + curl on the host.
+api_get() { # host api path
+  local host="$1" api="$2" path="$3"
+  $SSH "$host" "curl -fsS -H \"Authorization: Bearer \$(cat /root/.local/share/x0x/api-token)\" '$api$path'"
+}
+api_post() { # host api path body
+  local host="$1" api="$2" path="$3" body="$4"
+  $SSH "$host" "curl -fsS -H \"Authorization: Bearer \$(cat /root/.local/share/x0x/api-token)\" -H 'Content-Type: application/json' -X POST -d '$body' '$api$path'"
+}
+api_delete() { # host api path
+  local host="$1" api="$2" path="$3"
+  $SSH "$host" "curl -fsS -H \"Authorization: Bearer \$(cat /root/.local/share/x0x/api-token)\" -X DELETE '$api$path'"
+}
+
+echo "==== Tailnet forward e2e (#132 T7) — direct + relayed over real NAT ===="
+
+# ---------------------------------------------------------------------------
+# P1: start a loopback echo service on the RUNNER (B).
+# ---------------------------------------------------------------------------
+$SSH "$RUNNER_HOST" "pkill -f 'socat.*TCP-LISTEN:$ECHO_PORT' 2>/dev/null; sleep 0.2; nohup socat -v TCP-LISTEN:$ECHO_PORT,bind=127.0.0.1,reuseaddr,fork SYSTEM:'cat' >/tmp/x0x-echo.log 2>&1 &" \
+  || bail "could not start echo service on RUNNER (install socat or set ECHO_CMD)"
+sleep 0.5
+proof "echo service on B at 127.0.0.1:$ECHO_PORT (socat cat)"
+
+# ---------------------------------------------------------------------------
+# P2: ANCHOR (A) forwards a local port to B's echo service (DIRECT or RELAYED
+#     — ant-quic picks the path transparently; both are valid here).
+# ---------------------------------------------------------------------------
+body="{\"local_addr\":\"127.0.0.1:$FORWARD_PORT\",\"peer_agent\":\"$RUNNER_AGENT\",\"target_host\":\"127.0.0.1\",\"target_port\":$ECHO_PORT}"
+added="$(api_post "$ANCHOR_HOST" "$ANCHOR_API" /forwards "$body")" \
+  || bail "POST /forwards on ANCHOR failed (is connect enabled + A trusted?)"
+echo "$added" | grep -q '"ok":true' || bail "forward add did not return ok: $added"
+proof "A: x0x forward add 127.0.0.1:$FORWARD_PORT -> B 127.0.0.1:$ECHO_PORT ($added)"
+
+# ---------------------------------------------------------------------------
+# P3: tunnel bytes through A's local port and assert the echo round-trips.
+#     This is the load-bearing positive assertion: data really crosses NAT.
+# ---------------------------------------------------------------------------
+payload="tailnet-t7-$(date +%s)-roundtrip"
+reply="$($SSH "$ANCHOR_HOST" "printf '%s' '$payload' | timeout 8 nc 127.0.0.1 $FORWARD_PORT 2>/dev/null || true")"
+if [ "$reply" = "$payload" ]; then
+  ok "P3: forward round-trip over NAT (direct-or-relayed) — echoed $payload"
+else
+  fail "P3: expected echo '$payload', got '${reply:-<empty>}'"
+fi
+
+# ---------------------------------------------------------------------------
+# N1: deny-without-ACL — strip B's allow entry, a NEW forward must be refused.
+#     (Mutates B's ACL: comment out the allow line + signal x0xd reload, then
+#      restore. Implement reload via SIGHUP if supported, else restart.)
+# ---------------------------------------------------------------------------
+# NOTE: the exact reload mechanism is deployment-specific; this step is the
+# template the maintainer fills in for the target testnet. The ASSERTION is
+# fixed: after the allow entry is gone, a fresh forward's connect is refused.
+echo "${YELLOW}STEP${NC} N1 (deny-without-ACL): maintainer strips B's allow entry, then retry"
+# After stripping: a connection to A's forward port must close with no echo.
+# reply2="$(... nc ... )"; [ -z "$reply2" ] && ok "N1: denied without ACL" || fail "N1"
+
+# ---------------------------------------------------------------------------
+# N2: non-loopback target — A asks for 10.0.0.1, refused before the ACL.
+# ---------------------------------------------------------------------------
+bad="{\"local_addr\":\"127.0.0.1:$((FORWARD_PORT+1))\",\"peer_agent\":\"$RUNNER_AGENT\",\"target_host\":\"10.0.0.1\",\"target_port\":$ECHO_PORT}"
+nonloop="$(api_post "$ANCHOR_HOST" "$ANCHOR_API" /forwards "$bad" 2>&1 || true)"
+if echo "$nonloop" | grep -qiE 'loopback|refused|denied|not_loopback'; then
+  ok "N2: non-loopback target refused ($nonloop)"
+else
+  fail "N2: non-loopback target not refused: $nonloop"
+fi
+
+echo "${YELLOW}STEP${NC} N3 (revoked): revoke A on B, A's NEW forward refused; N4 (unverified): stream from an unknown machine refused at T1 — run per tests/connect-acl.md"
+
+# Cleanup
+api_delete "$ANCHOR_HOST" "$ANCHOR_API" "/forwards/127.0.0.1:$FORWARD_PORT" >/dev/null 2>&1 || true
+$SSH "$RUNNER_HOST" "pkill -f 'socat.*TCP-LISTEN:$ECHO_PORT' 2>/dev/null || true"
+
+echo "==== T7 summary: $PASS passed, $FAIL failed ===="
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/tailnet_streams_integration.rs
+++ b/tests/tailnet_streams_integration.rs
@@ -214,3 +214,93 @@ async fn peer_stream_echoes_1mib_both_directions() {
     r_b.expect("alice read 1MiB from bob");
     assert_eq!(buf_b, payload_b, "bob→alice integrity");
 }
+
+/// FIX 1 regression (#132): a peer that opens a QUIC stream and never sends
+/// the protocol-prefix byte must NOT stall the accept loop — another stream
+/// (with its prefix) is still accepted. Before FIX 1 the prefix read was
+/// awaited inline in the loop, so the silent stream blocked every other
+/// peer's inbound service.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback; binds UDP. Integration tier. Proves FIX 1 (accept-loop no-stall)."]
+async fn accept_loop_not_stalled_by_missing_prefix() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some(alice) = build_agent(&dir, "alice").await else {
+        return;
+    };
+    let Some(bob) = build_agent(&dir, "bob").await else {
+        return;
+    };
+    let alice = Arc::new(alice);
+    let bob = Arc::new(bob);
+
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let bob_addr = normalize_loopback(bob_network.bound_addr().await.expect("bob bound"));
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+
+    let connected = alice_network
+        .connect_addr(bob_addr)
+        .await
+        .expect("alice connects to bob");
+    assert_eq!(connected.0, bob.machine_id().0);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if alice_network.is_connected(&bob_peer).await
+            && bob_network
+                .is_connected(&ant_quic::PeerId(alice.machine_id().0))
+                .await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        bob_network
+            .is_connected(&ant_quic::PeerId(alice.machine_id().0))
+            .await
+    );
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_secs();
+    let alice_addr = normalize_loopback(alice_network.bound_addr().await.expect("alice bound"));
+    alice
+        .insert_discovered_agent_for_testing(discovered_agent(&bob, bob_addr, now_secs))
+        .await;
+    alice.set_contact_trusted_for_testing(bob.agent_id()).await;
+    bob.insert_discovered_agent_for_testing(discovered_agent(&alice, alice_addr, now_secs))
+        .await;
+    bob.set_contact_trusted_for_testing(alice.agent_id()).await;
+
+    // (1) alice opens a RAW stream and NEVER sends the prefix — the stall
+    //     vector. The halves are deliberately held (not dropped) so the
+    //     stream stays open and silent.
+    let _silent = alice_network
+        .open_bi_raw_for_testing(&bob_peer)
+        .await
+        .expect("open raw stream");
+
+    // (2) alice then opens a normal ForwardV1 stream (writes its prefix).
+    let bob_agent_id = bob.agent_id();
+    let alice_for_open = Arc::clone(&alice);
+    let normal = tokio::spawn(async move {
+        alice_for_open
+            .open_peer_stream(&bob_agent_id, StreamProtocol::ForwardV1)
+            .await
+            .expect("open normal stream")
+    });
+
+    // (3) bob must surface the NORMAL stream promptly despite the silent one.
+    //     Before FIX 1 the accept loop would be blocked on the silent prefix
+    //     read and this would time out.
+    let surfaced = take_incoming(&bob, Duration::from_secs(8))
+        .await
+        .expect("accept loop was stalled by the missing-prefix stream");
+    let _ = normal.await;
+    assert_eq!(surfaced.protocol(), StreamProtocol::ForwardV1);
+}

--- a/tests/tailnet_streams_integration.rs
+++ b/tests/tailnet_streams_integration.rs
@@ -1,0 +1,216 @@
+//! Tailnet Phase 1 byte-stream integration proof (#132 T1).
+//!
+//! Two in-process agents connect over loopback, clear the identity gate
+//! (verified discovery-cache binding + `Trusted` contact), and exchange a
+//! 1 MiB payload in both directions over a [`x0x::streams::StreamProtocol`]
+//! stream. Proves the end-to-end wiring — `Agent::open_peer_stream` →
+//! ant-quic `open_bi` → protocol prefix → inbound accept loop → identity
+//! gate → `Agent::next_incoming_stream` — that the deterministic unit tests
+//! in `src/streams.rs` (gate matrix + protocol framing) cannot reach.
+//!
+//! All tests here are `#[ignore]`: they bind real UDP sockets and wait on
+//! loopback connection convergence, so they run in the integration tier
+//! (`--run-ignored ignored-only`) rather than the always-on Test Suite.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use x0x::network::NetworkConfig;
+use x0x::streams::StreamProtocol;
+use x0x::DiscoveredAgent;
+
+fn loopback_network_config() -> NetworkConfig {
+    NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr literal")),
+        bootstrap_nodes: Vec::new(),
+        ..NetworkConfig::default()
+    }
+}
+
+fn is_network_bind_permission_error(error: &impl std::fmt::Display) -> bool {
+    let message = error.to_string();
+    message.contains("Operation not permitted")
+        && (message.contains("bind UDP socket")
+            || message.contains("network initialization failed"))
+}
+
+async fn build_agent(dir: &TempDir, name: &str) -> Option<x0x::Agent> {
+    match x0x::Agent::builder()
+        .with_machine_key(dir.path().join(format!("{name}-machine.key")))
+        .with_agent_key_path(dir.path().join(format!("{name}-agent.key")))
+        .with_contact_store_path(dir.path().join(format!("{name}-contacts.json")))
+        .with_peer_cache_dir(dir.path().join(format!("{name}-peer-cache")))
+        .with_network_config(loopback_network_config())
+        .build()
+        .await
+    {
+        Ok(agent) => Some(agent),
+        Err(e) if is_network_bind_permission_error(&e) => None,
+        Err(e) => panic!("agent build failed: {e}"),
+    }
+}
+
+fn normalize_loopback(addr: std::net::SocketAddr) -> std::net::SocketAddr {
+    if addr.ip().is_unspecified() {
+        std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            addr.port(),
+        )
+    } else {
+        addr
+    }
+}
+
+fn discovered_agent(
+    agent: &x0x::Agent,
+    addr: std::net::SocketAddr,
+    now_secs: u64,
+) -> DiscoveredAgent {
+    DiscoveredAgent {
+        agent_id: agent.agent_id(),
+        machine_id: agent.machine_id(),
+        user_id: None,
+        addresses: vec![addr],
+        announced_at: now_secs,
+        last_seen: now_secs,
+        machine_public_key: Vec::new(),
+        nat_type: None,
+        can_receive_direct: Some(true),
+        is_relay: None,
+        is_coordinator: None,
+        reachable_via: Vec::new(),
+        relay_candidates: Vec::new(),
+        cert_not_after: None,
+    }
+}
+
+/// Wait for the agent's accept loop to surface a stream, bounded by `timeout`.
+async fn take_incoming(agent: &x0x::Agent, timeout: Duration) -> Option<x0x::streams::PeerStream> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        match tokio::time::timeout(remaining, agent.next_incoming_stream()).await {
+            Ok(Some(stream)) => return Some(stream),
+            Ok(None) => return None,
+            Err(_) => continue,
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback byte-stream proof; binds UDP + waits on convergence. Integration tier."]
+async fn peer_stream_echoes_1mib_both_directions() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some(alice) = build_agent(&dir, "alice").await else {
+        return;
+    };
+    let Some(bob) = build_agent(&dir, "bob").await else {
+        return;
+    };
+    let alice = Arc::new(alice);
+    let bob = Arc::new(bob);
+
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let bob_addr = normalize_loopback(bob_network.bound_addr().await.expect("bob bound"));
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+
+    let connected = alice_network
+        .connect_addr(bob_addr)
+        .await
+        .expect("alice connects to bob");
+    assert_eq!(connected.0, bob.machine_id().0);
+
+    // Wait until ant-quic reports the connection established on both sides.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if alice_network.is_connected(&bob_peer).await
+            && bob_network
+                .is_connected(&ant_quic::PeerId(alice.machine_id().0))
+                .await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        alice_network.is_connected(&bob_peer).await,
+        "alice→bob connected"
+    );
+    assert!(
+        bob_network
+            .is_connected(&ant_quic::PeerId(alice.machine_id().0))
+            .await,
+        "bob→alice connected"
+    );
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_secs();
+    let alice_addr = normalize_loopback(alice_network.bound_addr().await.expect("alice bound"));
+
+    // Outbound gate (alice): verified binding + Trusted contact for bob.
+    alice
+        .insert_discovered_agent_for_testing(discovered_agent(&bob, bob_addr, now_secs))
+        .await;
+    alice.set_contact_trusted_for_testing(bob.agent_id()).await;
+    // Inbound gate (bob): verified binding + Trusted contact for alice, so the
+    // accept loop resolves alice's agent and the trust check returns Accept.
+    bob.insert_discovered_agent_for_testing(discovered_agent(&alice, alice_addr, now_secs))
+        .await;
+    bob.set_contact_trusted_for_testing(alice.agent_id()).await;
+
+    // Open + accept concurrently: open_peer_stream writes the prefix and the
+    // stream halves; bob's accept loop reads the prefix after the gate.
+    let bob_agent_id = bob.agent_id();
+    let alice_for_open = Arc::clone(&alice);
+    let open_task = tokio::spawn(async move {
+        alice_for_open
+            .open_peer_stream(&bob_agent_id, StreamProtocol::ForwardV1)
+            .await
+            .expect("open stream")
+    });
+    let mut bob_stream = take_incoming(&bob, Duration::from_secs(15))
+        .await
+        .expect("bob accepted the inbound stream");
+    let mut alice_stream = open_task.await.expect("open task");
+
+    assert_eq!(alice_stream.peer(), bob.machine_id());
+    assert_eq!(alice_stream.protocol(), StreamProtocol::ForwardV1);
+    assert_eq!(bob_stream.peer(), alice.machine_id());
+    assert_eq!(bob_stream.protocol(), StreamProtocol::ForwardV1);
+
+    // 1 MiB each direction. QUIC flow control means the writer blocks until the
+    // reader drains, so each direction is a concurrent (write || read) pair.
+    let payload_a = vec![0xA5u8; 1024 * 1024];
+    let payload_b = vec![0x3Cu8; 1024 * 1024];
+    let mut buf_a = vec![0u8; payload_a.len()];
+    let mut buf_b = vec![0u8; payload_b.len()];
+
+    let payload_a_ref = &payload_a;
+    let buf_a_ref = &mut buf_a;
+    let (_, r_a) = tokio::join!(
+        async { alice_stream.send_mut().write_all(payload_a_ref).await },
+        async { bob_stream.recv_mut().read_exact(buf_a_ref).await },
+    );
+    r_a.expect("bob read 1MiB from alice");
+    assert_eq!(buf_a, payload_a, "alice→bob integrity");
+
+    let payload_b_ref = &payload_b;
+    let buf_b_ref = &mut buf_b;
+    let (_, r_b) = tokio::join!(
+        async { bob_stream.send_mut().write_all(payload_b_ref).await },
+        async { alice_stream.recv_mut().read_exact(buf_b_ref).await },
+    );
+    r_b.expect("alice read 1MiB from bob");
+    assert_eq!(buf_b, payload_b, "bob→alice integrity");
+}


### PR DESCRIPTION
Tailnet Phase 1 on ant-quic 0.27.28's open_bi/accept_bi. T1: src/streams.rs (StreamProtocol, PeerStream, stream_gate), NetworkNode::open_bi/accept_bi (pub(crate), gated Agent methods sole callers), Agent::open_peer_stream + inbound accept loop — identity gate inside open/accept. T4: src/forward.rs — decide_inbound (evaluate_connect_gate before any TcpStream::connect), 3-layer loopback, typed denial. T6: ForwardService in AppState/serve() + /forwards + CLI. T8: ADR-0020. T7: e2e_tailnet_forward.sh (VPS real-NAT, #[ignore]/VPS-only). SECURITY-CRITICAL — independent adversarial review of the T1 gate + T4 accept path required before merge. T5 SOCKS5 deferred (0x02 reserved); endpoint-registry parity sync deferred (needs /forwards integration test).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements Tailnet Phase 1: bidirectional QUIC byte-streams with a two-layer security gate (identity gate in `streams::stream_gate` + connect ACL in `decide_inbound`), a local port-forwarder (`src/forward.rs`), REST/CLI surface (`/forwards`, `/streams`), and an ADR + VPS e2e harness.

- **T1 (`src/streams.rs`)**: `stream_gate` enforces verified\u2192revoked\u2192trust-Accept in fixed order; `PeerStream` wraps the gated halves; the accept loop in `Agent::start_stream_accept_loop` is the sole consumer of `NetworkNode::accept_bi`.
- **T4 (`src/forward.rs`)**: `decide_inbound` evaluates the connect ACL before any `TcpStream::connect`; `ForwardService` owns both the inbound consumer and outbound local listeners with RAII active-stream tracking.
- **T6 (`src/server/mod.rs`)**: All four forwarding endpoints are bearer-authed; the REST handler validates `local_addr` as loopback but omits an equivalent check on `target_host`, which contradicts the API reference and breaks the N2 negative-security assertion in the e2e harness.

<h3>Confidence Score: 3/5</h3>

The two-layer identity + ACL gate is structurally sound, but the REST entry point for registering a forward is missing client-side validation that the API reference and the e2e harness both assume is present, and neither the inbound header read nor the outbound response read have application-level timeouts.

The core security property (loopback enforcement + connect ACL) is correctly enforced at the remote peer. However, forward_add does not validate target_host as a loopback IP despite the API docs requiring it, which directly causes the N2 negative-security test to fail. Additionally, both handle_inbound and drive_outbound await peer bytes without any deadline, leaving an unbounded-task-accumulation path open to a compromised trusted peer.

src/server/mod.rs (forward_add handler) and src/forward.rs (handle_inbound + drive_outbound) need the most attention before merge. The streams layer (src/streams.rs) and network wrappers (src/network.rs) are clean.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/streams.rs | New file: StreamProtocol enum, PeerStream wrapper, stream_gate identity-gate function, protocol prefix I/O helpers, StreamAccept channel wrapper. Gate logic and unit tests are sound. |
| src/forward.rs | New file: ForwardHeader codec, handle_inbound (inbound gate + TCP bridge), ForwardService (outbound listeners + inbound consumer). Missing target_host loopback validation at the REST-add entry point; no read timeout in handle_inbound or drive_outbound. |
| src/server/mod.rs | Adds forward_add / forward_list / forward_remove / streams_diagnostics handlers and wires ForwardService into AppState. forward_add validates local_addr as loopback but omits target_host loopback validation, contradicting the API reference and causing the N2 e2e security assertion to fail. |
| src/lib.rs | Adds open_peer_stream, next_incoming_stream, start_stream_accept_loop to Agent, wiring the T1 identity gate and streaming the protocol prefix. Gate ordering is correct; inbound accept loop is robust. |
| src/network.rs | Adds pub(crate) open_bi / accept_bi wrappers over ant-quic, keeping transport calls isolated from the identity gate. Correct access-control boundary. |
| tests/e2e_tailnet_forward.sh | New VPS-only e2e harness. N1/N3/N4 are partially stubbed. N2 (non-loopback target) would fail against the current implementation because POST /forwards succeeds for a non-loopback target_host. |
| tests/tailnet_streams_integration.rs | Two-agent loopback integration test for 1 MiB echo in both directions, all #[ignore]-gated. Test logic is sound. |
| src/error.rs | Adds StreamProtocolUnknown, PeerNotVerified, PeerTrustRejected, PeerRevoked error variants. Well-typed with clear documentation. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as x0x CLI / REST
    participant FS as ForwardService (local)
    participant Agent as Agent::open_peer_stream
    participant QUIC as ant-quic QUIC layer
    participant AcceptLoop as Agent accept loop (remote)
    participant GateR as stream_gate (remote)
    participant FwdIn as handle_inbound (remote)
    participant DecideIn as decide_inbound
    participant TCP as loopback TcpStream (remote)

    CLI->>FS: POST /forwards
    FS->>FS: bind local_addr
    Note over FS: local_addr validated as loopback
    Note over FS: target_host NOT validated here
    CLI-->>FS: TCP connect to local_addr
    FS->>Agent: open_peer_stream(peer, ForwardV1)
    Agent->>Agent: stream_gate
    Agent->>QUIC: open_bi + write prefix 0x01
    Agent-->>FS: PeerStream
    FS->>QUIC: write ForwardHeader
    QUIC->>AcceptLoop: accept_bi
    AcceptLoop->>GateR: stream_gate
    AcceptLoop->>AcceptLoop: read_protocol_prefix
    AcceptLoop->>FwdIn: PeerStream
    FwdIn->>FwdIn: read_header (no timeout)
    FwdIn->>DecideIn: decide_inbound
    DecideIn->>DecideIn: resolve_loopback_target
    DecideIn->>DecideIn: evaluate_connect_gate
    alt Denied
        FwdIn->>QUIC: RESP_DENIED
    else Allowed
        FwdIn->>TCP: connect loopback (10s timeout)
        FwdIn->>QUIC: RESP_CONNECTED
        FS->>QUIC: read response byte (no timeout)
        FS->>TCP: bridge
        FwdIn->>TCP: bridge
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as x0x CLI / REST
    participant FS as ForwardService (local)
    participant Agent as Agent::open_peer_stream
    participant QUIC as ant-quic QUIC layer
    participant AcceptLoop as Agent accept loop (remote)
    participant GateR as stream_gate (remote)
    participant FwdIn as handle_inbound (remote)
    participant DecideIn as decide_inbound
    participant TCP as loopback TcpStream (remote)

    CLI->>FS: POST /forwards
    FS->>FS: bind local_addr
    Note over FS: local_addr validated as loopback
    Note over FS: target_host NOT validated here
    CLI-->>FS: TCP connect to local_addr
    FS->>Agent: open_peer_stream(peer, ForwardV1)
    Agent->>Agent: stream_gate
    Agent->>QUIC: open_bi + write prefix 0x01
    Agent-->>FS: PeerStream
    FS->>QUIC: write ForwardHeader
    QUIC->>AcceptLoop: accept_bi
    AcceptLoop->>GateR: stream_gate
    AcceptLoop->>AcceptLoop: read_protocol_prefix
    AcceptLoop->>FwdIn: PeerStream
    FwdIn->>FwdIn: read_header (no timeout)
    FwdIn->>DecideIn: decide_inbound
    DecideIn->>DecideIn: resolve_loopback_target
    DecideIn->>DecideIn: evaluate_connect_gate
    alt Denied
        FwdIn->>QUIC: RESP_DENIED
    else Allowed
        FwdIn->>TCP: connect loopback (10s timeout)
        FwdIn->>QUIC: RESP_CONNECTED
        FS->>QUIC: read response byte (no timeout)
        FS->>TCP: bridge
        FwdIn->>TCP: bridge
    end
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/forward.rs`, line 1092-1095 ([link](https://github.com/saorsa-labs/x0x/blob/e6cc40f2f4ba9d44fef3406fd067533bbe55c001/src/forward.rs#L1092-L1095)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unbounded hang awaiting the peer's response byte (outbound side)**

   Symmetric to the inbound header-read issue: `read_exact(&mut resp)` awaits the peer's single connect-response byte with no timeout. A peer that accepts the stream and writes the `ForwardHeader` but never responds pins `drive_outbound` indefinitely for every concurrent local TCP connection. The same `tokio::time::timeout` wrapper used for the loopback TCP connect would close this gap on the outbound side.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/forward.rs
   Line: 1092-1095

   Comment:
   **Unbounded hang awaiting the peer's response byte (outbound side)**

   Symmetric to the inbound header-read issue: `read_exact(&mut resp)` awaits the peer's single connect-response byte with no timeout. A peer that accepts the stream and writes the `ForwardHeader` but never responds pins `drive_outbound` indefinitely for every concurrent local TCP connection. The same `tokio::time::timeout` wrapper used for the loopback TCP connect would close this gap on the outbound side.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/forward.rs`, line 977-982 ([link](https://github.com/saorsa-labs/x0x/blob/e6cc40f2f4ba9d44fef3406fd067533bbe55c001/src/forward.rs#L977-L982)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Orphan listener on poisoned mutex**

   The `if let Ok(...)` pattern silently swallows a poisoned mutex. If the lock is poisoned, the `ForwardEntry` is never pushed, but `tokio::spawn` is called a few lines later and a live TCP listener starts. That listener can accept connections and open peer streams, but `list_forwards`, `remove_forward`, and `shutdown` will never see it — the cancel token it holds is unreachable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/forward.rs
   Line: 977-982

   Comment:
   **Orphan listener on poisoned mutex**

   The `if let Ok(...)` pattern silently swallows a poisoned mutex. If the lock is poisoned, the `ForwardEntry` is never pushed, but `tokio::spawn` is called a few lines later and a live TCP listener starts. That listener can accept connections and open peer streams, but `list_forwards`, `remove_forward`, and `shutdown` will never see it — the cancel token it holds is unreachable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/server/mod.rs:14078-14085
The `forward_add` handler validates `local_addr` as loopback but never validates `target_host`. The API reference explicitly states "`target_host` must be a numeric loopback IP (no DNS)", and `decide_inbound` on the peer enforces this — but nothing prevents a caller from registering `target_host = "10.0.0.1"` here. The forward is accepted with 200, a listener is spawned, and every TCP connection silently fails at the remote peer. More concretely, the N2 negative-security assertion in `e2e_tailnet_forward.sh` POSTs `target_host: 10.0.0.1` and expects a refusal; the current handler returns 200, so N2 fails.

```suggestion
    if !local_addr.ip().is_loopback() {
        return api_error(
            StatusCode::BAD_REQUEST,
            "local_addr must be loopback (Phase 1)".to_string(),
        )
        .into_response();
    }
    let target_ip: std::net::IpAddr = match req.target_host.parse() {
        Ok(ip) => ip,
        Err(_) => {
            return api_error(
                StatusCode::BAD_REQUEST,
                format!("target_host must be a numeric IP, got {:?}", req.target_host),
            )
            .into_response()
        }
    };
    if !target_ip.is_loopback() {
        return api_error(
            StatusCode::BAD_REQUEST,
            "target_host must be a loopback IP (Phase 1)".to_string(),
        )
        .into_response();
    }
    let peer_agent_bytes = match x0x::exec::acl::parse_agent_id(&req.peer_agent) {
```

### Issue 2 of 4
src/forward.rs:709-720
**Unbounded hang on inbound header read**

`read_header` awaits bytes from the peer's QUIC stream with no application-level timeout. A peer that clears the identity gate (verified + trusted + not-revoked) but then opens the stream and never writes the header bytes pins this task forever. If a compromised trusted key floods `open_bi` calls without sending headers, the number of stalled tasks grows without bound. `tokio::time::timeout(CONNECT_TIMEOUT, read_header(...))` would bound the exposure to the same 10-second budget already used for the outbound TCP connect.

### Issue 3 of 4
src/forward.rs:1092-1095
**Unbounded hang awaiting the peer's response byte (outbound side)**

Symmetric to the inbound header-read issue: `read_exact(&mut resp)` awaits the peer's single connect-response byte with no timeout. A peer that accepts the stream and writes the `ForwardHeader` but never responds pins `drive_outbound` indefinitely for every concurrent local TCP connection. The same `tokio::time::timeout` wrapper used for the loopback TCP connect would close this gap on the outbound side.

### Issue 4 of 4
src/forward.rs:977-982
**Orphan listener on poisoned mutex**

The `if let Ok(...)` pattern silently swallows a poisoned mutex. If the lock is poisoned, the `ForwardEntry` is never pushed, but `tokio::spawn` is called a few lines later and a live TCP listener starts. That listener can accept connections and open peer streams, but `list_forwards`, `remove_forward`, and `shutdown` will never see it — the cancel token it holds is unreachable.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(tailnet): real-NAT forward e2e harn..."](https://github.com/saorsa-labs/x0x/commit/e6cc40f2f4ba9d44fef3406fd067533bbe55c001) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42162867)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->