### PR TITLE
docs(skill): add Symphony + Tailnet to SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -13,6 +13,7 @@ keywords:
   - post-quantum
   - crdt
   - collaboration
+  - task-orchestration
   - nat-traversal
   - direct-messaging
   - identity
@@ -80,6 +81,13 @@ Two communication modes:
 6 bootstrap nodes (NYC, SFO, Helsinki, Nuremberg, Singapore, Tokyo) provide initial discovery and NAT traversal — they never see your data.
 
 For security details (algorithms, RFCs, key pinning), see [docs/security.md](https://github.com/saorsa-labs/x0x/blob/main/docs/security.md).
+
+## Beyond Messaging
+
+x0x is a foundation you build on:
+
+- **Agent work orchestration (Symphony)** — replicated **TaskList CRDTs** (`/task-lists`, `/stores`), MLS group encryption, and a built-in **GUI board view** (state columns, badges, approve/deny actions) make x0x the decentralized backbone for agent work orchestration. The [x0x-symphony](https://github.com/saorsa-labs) runner rides these existing primitives over x0xd's local REST/WebSocket API — no extra services, no new crates. See [docs/symphony-integration.md](https://github.com/saorsa-labs/x0x/blob/main/docs/symphony-integration.md).
+- **Direct machine-to-machine connectivity (Tailnet)** — _in active development, shipping in an upcoming release:_ connect your own computers over any network (home, mobile, hotel) and forward a local TCP port or SOCKS5 to a service on a peer machine, Tailscale-style, over the same post-quantum QUIC transport. Default-deny and loopback-scoped, gated by a per-connection access policy plus the identity key-lifecycle (expiry + revocation). Tracked in [#132](https://github.com/saorsa-labs/x0x/issues/132).
 
 ## Identity: Three Layers
 


### PR DESCRIPTION
Adds a 'Beyond Messaging' section to SKILL.md (the ClawHub-published skill descriptor):
- **Symphony** — advertised as AVAILABLE: x0x ships the backbone (TaskList CRDTs, /task-lists + /stores, the GUI board view with columns/badges/approve-deny from #178, MLS encryption); the x0x-symphony runner rides these over x0xd's API. Added a 'task-orchestration' keyword.
- **Tailnet** — framed as IN ACTIVE DEVELOPMENT / upcoming release, NOT 'available', because the forwarder (#132/#183) is not in v0.28.0 (the version this SKILL.md ships with). Describes port-forward/SOCKS5 over the PQC transport, default-deny + loopback-scoped + gated by the connect ACL + key lifecycle.

Framing note: happy to switch Tailnet to 'available' once #183 ships in a tagged release; advertising it as available now would be inaccurate for the published descriptor.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the published skill descriptor for x0x. The main changes are:

- Adds `task-orchestration` to the skill keywords.
- Adds a “Beyond Messaging” section for Symphony.
- Describes Tailnet as an in-development upcoming capability.

<h3>Confidence Score: 4/5</h3>

The docs change looks mergeable after fixing the Symphony destination link.

- The added Symphony and Tailnet framing matches the inspected repository context.
- The new Symphony link sends readers to the organization root instead of the advertised runner.
- No security concern was found in this documentation-only change.

SKILL.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| SKILL.md | Adds skill metadata and a new Beyond Messaging section; the Symphony runner link should target the concrete project page. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
SKILL.md:89
**Symphony Link Lands On Org**

The new `x0x-symphony` link points to the `saorsa-labs` organization root instead of the runner repository or docs. Readers following the advertised Symphony integration land on a generic org page and may not find the runner described by this section.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(skill): advertise Symphony (availab..."](https://github.com/saorsa-labs/x0x/commit/c09b0dde785fad5c15aa092b72fd7f15a0cff0e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42178335)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->