### PR TITLE
chore(release): v0.29.0 — tailnet Phase 1 (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.29.0] - 2026-07-07
+
+### Added
+
+- **Tailnet Phase 1: per-peer byte streams + connect-gated port forwarding ([#132](https://github.com/saorsa-labs/x0x/issues/132), [#183](https://github.com/saorsa-labs/x0x/pull/183), [ADR-0020](docs/adr/0020-tailnet-phase-1-byte-streams-and-forwarding.md)).** A per-peer byte-stream API over ant-quic's `open_bi`/`accept_bi`, plus a local TCP port-forwarder (`/forwards`, `x0x forward add|list|rm`) that tunnels a loopback port to a loopback service on a trusted peer — Tailscale-style machine-to-machine connectivity over the same post-quantum QUIC transport. This wires the previously-dormant connect ACL ([#131](https://github.com/saorsa-labs/x0x/issues/131), shipped in v0.28.0) as its first runtime caller: every inbound forward is gated fail-closed through the full chain (sender verified → not revoked → trust `Accept` → connect enabled → target loopback → `(agent, machine)` pair in the ACL → target in the entry). Denials reach zero bytes to the target. SOCKS5 forwarding is deferred to a later phase.
+
+### Security
+
+- **DoS hardening on the byte-stream accept + forward paths ([#183](https://github.com/saorsa-labs/x0x/pull/183)).** The inbound accept loop dispatches each stream to a per-stream task (no head-of-line blocking) with a bounded protocol-prefix read; the forwarder bounds its header read with a timeout and a fixed maximum header size; inbound and outbound concurrency are capped globally and per-peer (RAII admission slots released on drop); and `handle_inbound` re-checks the revocation set before reading any peer bytes, closing the accept-to-header stale-authorization window. The fail-closed properties were confirmed by two independent adversarial reviews and a full-ring VPS soak (real-WAN forward round-trip plus `target_not_allowed` and `target_not_loopback` deny proofs observed firing at the gate).
+
 ## [v0.28.0] - 2026-07-04
 
 ### Upgrade notes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.28.0
+version: 0.29.0
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com
@@ -87,7 +87,7 @@ For security details (algorithms, RFCs, key pinning), see [docs/security.md](htt
 x0x is a foundation you build on:
 
 - **Agent work orchestration (Symphony)** — replicated **TaskList CRDTs** (`/task-lists`, `/stores`), MLS group encryption, and a built-in **GUI board view** (state columns, badges, approve/deny actions) make x0x the decentralized backbone for agent work orchestration. The [x0x-symphony](https://github.com/saorsa-labs) runner rides these existing primitives over x0xd's local REST/WebSocket API — no extra services, no new crates. See [docs/symphony-integration.md](https://github.com/saorsa-labs/x0x/blob/main/docs/symphony-integration.md).
-- **Direct machine-to-machine connectivity (Tailnet)** — _in active development, shipping in an upcoming release:_ connect your own computers over any network (home, mobile, hotel) and forward a local TCP port or SOCKS5 to a service on a peer machine, Tailscale-style, over the same post-quantum QUIC transport. Default-deny and loopback-scoped, gated by a per-connection access policy plus the identity key-lifecycle (expiry + revocation). Tracked in [#132](https://github.com/saorsa-labs/x0x/issues/132).
+- **Direct machine-to-machine connectivity (Tailnet)** — _available (Phase 1):_ connect your own computers over any network (home, mobile, hotel) and forward a local TCP port to a loopback service on a peer machine, Tailscale-style, over the same post-quantum QUIC transport. Default-deny and loopback-scoped, gated by a per-connection access policy plus the identity key-lifecycle (expiry + revocation). SOCKS5 forwarding is planned for a later phase. Manage forwards via `/forwards` (`x0x forward add|list|rm`). Tracked in [#132](https://github.com/saorsa-labs/x0x/issues/132).
 
 ## Identity: Three Layers
 


### PR DESCRIPTION
Release v0.29.0. Ships tailnet Phase 1 (#183, merged): per-peer byte streams + connect-gated TCP port forwarding, DoS-hardened, dual-reviewed, full-ring VPS soak passed.

- Cargo.toml + SKILL.md → 0.29.0 (version_sync OK)
- SKILL.md Tailnet capability flipped forthcoming → available (Phase 1; SOCKS5 deferred)
- CHANGELOG v0.29.0 entry (Added: tailnet forwarding; Security: byte-stream DoS hardening)
- release-dryrun OK

On merge, tag v0.29.0 → release.yml publishes (crates.io + GH + ClawHub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the v0.29.0 release metadata. The main changes are:

- Cargo package version bumped to 0.29.0.
- SKILL.md version bumped to 0.29.0.
- Tailnet Phase 1 documented as available.
- CHANGELOG.md updated with v0.29.0 release notes.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Package version was updated from 0.28.0 to 0.29.0. |
| SKILL.md | Skill metadata version was updated and the Tailnet section now describes Phase 1 availability. |
| CHANGELOG.md | Adds the v0.29.0 release entry with Tailnet feature and security notes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.29.0 — tailnet Phase ..."](https://github.com/saorsa-labs/x0x/commit/c1ae9c288437b5f886874583cab83dc030ce9f40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42228196)</sub>

<!-- /greptile_comment -->