### PR TITLE
docs: fix post-v0.29.0 drift (#194)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -78,7 +78,7 @@ Two communication modes:
 | **Gossip pub/sub** | Broadcast to many agents | Eventually consistent, epidemic |
 | **Direct messaging** | Private between two agents | Immediate, reliable, ordered |
 
-6 bootstrap nodes (NYC, SFO, Helsinki, Nuremberg, Singapore, Tokyo) provide initial discovery and NAT traversal — they never see your data.
+6 bootstrap nodes (NYC, SFO, Helsinki, Nuremberg, Singapore, Sydney) provide initial discovery and NAT traversal — they never see your data.
 
 For security details (algorithms, RFCs, key pinning), see [docs/security.md](https://github.com/saorsa-labs/x0x/blob/main/docs/security.md).
 
@@ -320,7 +320,7 @@ rendezvous_enabled = true             # Global agent findability
 <data_dir>/api-token         # Bearer token for CLI/apps/scripts
 <data_dir>/contacts.json     # Trust/contact store
 <data_dir>/mls_groups.bin    # MLS group state
-<data_dir>/peer_cache/       # Bootstrap peer cache
+<data_dir>/peers/peers.cache   # Bootstrap peer cache
 ```
 
 **Default identity_dir:** `~/.x0x/` | named instances: `~/.x0x-<name>/`

--- a/docs/AGENT_CARD.md
+++ b/docs/AGENT_CARD.md
@@ -99,8 +99,8 @@ x0x provides 6 global bootstrap nodes:
 | SFO, US | `quic://147.182.234.192:5483` | QUIC |
 | Helsinki, FI | `quic://65.21.157.229:5483` | QUIC |
 | Nuremberg, DE | `quic://116.203.101.172:5483` | QUIC |
-| Singapore, SG | `quic://149.28.156.231:5483` | QUIC |
-| Tokyo, JP | `quic://45.77.176.184:5483` | QUIC |
+| Singapore, SG | `quic://152.42.210.67:5483` | QUIC |
+| Sydney, AU | `quic://170.64.176.102:5483` | QUIC |
 
 Agents can connect to any bootstrap node to join the network. Once connected, they discover peers via gossip.
 

--- a/docs/architecture/running-autonomi-on-x0x.md
+++ b/docs/architecture/running-autonomi-on-x0x.md
@@ -22,7 +22,7 @@ There is no transport barrier. We verified that `saorsa-transport` and `ant-quic
 
 | Capability | Status | Detail |
 |-----------|--------|--------|
-| Global bootstrap network | **Live** | 6 nodes: NYC, SFO, Helsinki, Nuremberg, Singapore, Tokyo |
+| Global bootstrap network | **Live** | 6 nodes: NYC, SFO, Helsinki, Nuremberg, Singapore, Sydney |
 | Post-quantum transport | **Live** | ML-KEM-768 key exchange, ML-DSA-65 signatures (ant-quic) |
 | NAT traversal | **Live** | Native QUIC extension frames, no STUN/ICE/TURN |
 | MASQUE relay | **Live** | CONNECT-UDP Bind fallback for symmetric NAT |

--- a/docs/connect-acl.md
+++ b/docs/connect-acl.md
@@ -1,8 +1,8 @@
 # x0x connect ACL — default-closed connectivity policy
 
-The connect ACL controls which remote agents may request an outbound TCP connection through the local `x0xd` daemon. It is the policy engine for the Tailnet T4 forwarder (issue #132); the forwarder wires up runtime enforcement but the policy engine, validation surface, and diagnostics endpoint are delivered ahead of it in v1.
+The connect ACL controls which remote agents may request an outbound TCP connection through the local `x0xd` daemon. It is the policy engine for the Tailnet forwarder — the forwarder shipped in v0.29.0 (#183), so an enabled ACL authorizes live TCP forwards at runtime (inbound loopback targets only).
 
-**v1 scope:** policy engine, startup validation, diagnostics. There is no runtime forwarder yet. All connection-forwarding requests are denied at the gate until T4 ships.
+**Scope:** policy engine, startup validation, diagnostics, and runtime enforcement. An enabled ACL authorizes per-flow TCP forwards; a disabled or absent ACL denies every forward request at the gate.
 
 ## Default behaviour
 
@@ -14,6 +14,8 @@ Default path:
 
 - Linux: `/etc/x0x/connect-acl.toml`
 - macOS: `/usr/local/etc/x0x/connect-acl.toml`
+
+> **Co-located daemons share the default path.** If more than one `x0xd` runs on a host (for example a prod instance plus a `--name testnet` instance), they all resolve the same default `/etc/x0x/connect-acl.toml` unless each is given its own `--connect-acl`. Creating the file to configure one plane silently arms every other plane on its next restart / self-upgrade — a latent way for a test/dev policy to activate on prod. Give each plane an explicit `--connect-acl` path. See issue #189.
 
 Override for tests or non-default installs:
 
@@ -92,7 +94,7 @@ Returns the [`ConnectDiagnosticsSnapshot`](../src/connect/diagnostics.rs):
 }
 ```
 
-When connect is enabled, `acl_summary.enabled` is `true`, the entry counts are populated, and `disabled_reason` is absent. Counters read `0` until the T4 forwarder (issue #132) is wired.
+When connect is enabled, `acl_summary.enabled` is `true`, the entry counts are populated, and `disabled_reason` is absent. The `streams_allowed` / `streams_denied` counters increment on each authorized or denied forward.
 
 The `denial_breakdown` map is keyed by `ConnectDenialReason` in `snake_case`:
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -181,7 +181,7 @@ saorsa-pqc ◄── saorsa-mls
 
 **Surfaces**: Rust crate (`use x0x::Agent`), CLI (`x0x`), daemon with REST/WS API (`x0xd`), embedded GUI. Non-Rust applications integrate by talking to `x0xd` over HTTP; there are no first-party Node.js or Python FFI bindings.
 
-**6 global bootstrap nodes**: NYC, SFO, Helsinki, Nuremberg, Singapore, Tokyo.
+**6 global bootstrap nodes**: NYC, SFO, Helsinki, Nuremberg, Singapore, Sydney.
 
 ### communitas — The Example Application
 
@@ -237,7 +237,7 @@ saorsa-pqc ◄── saorsa-mls
 | saorsa-3 | 147.182.234.192 | SFO, US | DigitalOcean |
 | saorsa-6 | 65.21.157.229 | Helsinki, FI | Hetzner |
 | saorsa-7 | 116.203.101.172 | Nuremberg, DE | Hetzner |
-| saorsa-8 | 149.28.156.231 | Singapore, SG | Vultr |
-| saorsa-9 | 45.77.176.184 | Tokyo, JP | Vultr |
+| saorsa-8 | 152.42.210.67 | Singapore, SG | DigitalOcean |
+| saorsa-9 | 170.64.176.102 | Sydney, AU | DigitalOcean |
 
 These nodes are critical infrastructure — every x0x user worldwide connects to them on first join.

--- a/src/cli/commands/network.rs
+++ b/src/cli/commands/network.rs
@@ -138,7 +138,9 @@ pub async fn diagnostics_ws(client: &DaemonClient) -> Result<()> {
 ///
 /// Connect-ACL policy summary (enabled flag, loaded-from path, allow-entry
 /// count) and cumulative stream allow/deny counters with per-reason breakdown.
-/// Counters read 0 until the T4 forwarder (issue #132) is wired.
+/// Counters increment on each authorized/denied forward when connect is
+/// enabled (the forwarder, shipped in #183, calls the diagnostics); they
+/// read 0 when connect is disabled (the default).
 pub async fn diagnostics_connect(client: &DaemonClient) -> Result<()> {
     client.run_get("/diagnostics/connect").await
 }

--- a/src/connect/acl.rs
+++ b/src/connect/acl.rs
@@ -4,13 +4,13 @@
 //! on the exec ACL ([`crate::exec::acl`]); see ADR-0019 and
 //! `docs/plans/2026-07-issue-131-connect-acl-plan.md`.
 //!
-//! ## v1 scope (important)
-//! v1 is a **policy engine + validation surface only** — there is no runtime
-//! enforcement caller yet. The T4 forwarder (issue #132) will call
-//! [`crate::connect::gate::evaluate_connect_gate`] at its accept seam; until then this module
-//! provides a fail-closed policy loader, a loopback-only target validator,
-//! and a pure gate function that are fully tested but unwired. See §1.3 of
-//! the plan and ADR-0019.
+//! ## Scope
+//!
+//! Fail-closed policy loader, loopback-only target validator, and a pure
+//! gate function ([`crate::connect::gate::evaluate_connect_gate`]). The
+//! forwarder shipped in v0.29.0 (#183) and calls the gate at its inbound
+//! accept seam — after the peer is verified + trusted and before
+//! `TcpStream::connect`. See ADR-0019.
 //!
 //! ## Security invariants
 //! - **Default = disabled.** [`ConnectPolicy::default()`] is `Disabled`, so an

--- a/src/connect/diagnostics.rs
+++ b/src/connect/diagnostics.rs
@@ -1,10 +1,12 @@
 //! Connect diagnostics — counter surface for connect allow/deny decisions.
 //!
-//! Minimal-scope mirror of `exec/diagnostics.rs`. Counters read `0` until T4
-//! (issue #132) wires calls to [`ConnectDiagnostics::record_allowed`] /
-//! [`record_denied`](ConnectDiagnostics::record_denied); that is the intended
-//! "counter surface for future connect denials". v1 has no warnings/sessions
-//! machinery — that is T4.
+//! Minimal-scope mirror of `exec/diagnostics.rs`. The forwarder (shipped in
+//! #183) calls [`ConnectDiagnostics::record_allowed`] /
+//! [`record_denied`](ConnectDiagnostics::record_denied) on each authorized or
+//! denied forward when connect is enabled, so the counters reflect live
+//! traffic; they read `0` when connect is disabled (the default). Intentionally
+//! no warnings/sessions machinery (connect diagnostics is counters + summary
+//! only).
 
 use std::collections::HashMap;
 use std::sync::Mutex;

--- a/src/connect/gate.rs
+++ b/src/connect/gate.rs
@@ -1,4 +1,4 @@
-//! Connect gate — the enforcement seam the T4 forwarder will call.
+//! Connect gate — the enforcement seam the forwarder calls.
 //!
 //! Pure and synchronous (no service, no I/O) so the whole #141-style denial
 //! matrix ports as fast unit tests. The T4 forwarder (issue #132) calls

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -1,11 +1,9 @@
 //! Connection ACL (default-closed connectivity policy).
 //!
-//! v1 delivers a fail-closed policy engine, loopback-only target validation,
-//! and a pure gate function — fully tested but **not yet wired** to a runtime
-//! forwarder. The T4 forwarder (issue #132) will call
+//! Fail-closed policy engine, loopback-only target validation, and a pure
+//! gate function. The forwarder (shipped in v0.29.0, #183) calls
 //! [`gate::evaluate_connect_gate`] at its inbound-accept seam after the peer
-//! is verified + trusted and before `TcpStream::connect`. No stream code in
-//! `network.rs` changes in v1.
+//! is verified + trusted and before `TcpStream::connect`.
 //!
 //! See ADR-0019 (`docs/adr/0019-connect-acl-default-closed.md`) and the
 //! implementation plan

--- a/src/peer_relay.rs
+++ b/src/peer_relay.rs
@@ -37,17 +37,16 @@
 //!   `dst` / `originated_at` is rejected.
 //! - One hop only — structurally enforced by the type system.
 //!
-//! ## MVP scope
+//! ## Status
 //!
-//! This ships the **primitives + telemetry**: the `RelayedDm` /
-//! `RelayHeader` wire types, signed-bytes construction + verification,
-//! the `PeerRelay` engine (per-peer failure tracking, `needs_relay`
-//! decision, relay-candidate selection), and the `RelayStats`
-//! counters. The `RelayPolicy` is **disabled by default** — the relay
-//! path only engages when a runtime explicitly enables it. Wiring the
-//! engine into `Agent::send_direct_with_config`'s fallback path and
-//! `NetworkNode`'s inbound handler is X0X-0070b (same MVP-split
-//! pattern as X0X-0073 → X0X-0073b).
+//! The primitives, telemetry, **and** runtime wiring all ship here: the
+//! `RelayedDm` / `RelayHeader` wire types, signed-bytes construction +
+//! verification, the `PeerRelay` engine (per-peer failure tracking,
+//! `needs_relay` decision, relay-candidate selection), the `RelayStats`
+//! counters, and the fallback path in `Agent::send_direct_with_config`
+//! plus the inbound receiver in `NetworkNode` (X0X-0070b, shipped). The
+//! `RelayPolicy` is **disabled by default** — the relay path only engages
+//! when a runtime explicitly enables it.
 //!
 //! Reference: Tailscale Peer Relays beta
 //! <https://tailscale.com/blog/peer-relays-beta>; iroh DERP

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14035,8 +14035,9 @@ async fn exec_diagnostics(State(state): State<Arc<AppState>>) -> impl IntoRespon
 ///
 /// Returns the [`x0x::connect::ConnectDiagnosticsSnapshot`]: enabled flag,
 /// loaded-from path, allow-entry count, cumulative allow/deny counters, and
-/// per-reason denial breakdown. Counters read 0 until the T4 forwarder
-/// (issue #132) is wired; the ACL summary is always populated.
+/// per-reason denial breakdown. Counters reflect live forwards when connect
+/// is enabled (forwarder shipped in #183) and read 0 when it is disabled; the
+/// ACL summary is always populated.
 async fn connect_diagnostics_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     Json(state.connect_diagnostics.snapshot())
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -573,8 +573,9 @@ pub(super) struct AppState {
     /// Per-group ingest diagnostics surfaced via `/diagnostics/groups`.
     pub(super) groups_diagnostics: Arc<x0x::groups::GroupsDiagnostics>,
     /// Connect-ACL allow/deny counters + policy summary for
-    /// `/diagnostics/connect`. Counters read 0 until the T4 forwarder
-    /// (issue #132) wires calls to `record_allowed`/`record_denied`.
+    /// `/diagnostics/connect`. Counters reflect live forwards when connect is
+    /// enabled (the forwarder calls `record_allowed`/`record_denied`) and read
+    /// 0 when it is disabled (the default).
     pub(super) connect_diagnostics: Arc<x0x::connect::ConnectDiagnostics>,
     /// Tailnet forwarder service (#132 T4/T6): owns the inbound connect-gated
     /// consumer + outbound local-port listeners. `None` when connect is


### PR DESCRIPTION
## Summary

Fixes the post-v0.29.0 documentation drift identified in #194. Two drift classes, fixed everywhere the same error appeared (ADRs and the #131 plan left untouched as immutable history).

### 1. Connect forwarder is live (shipped #183 / v0.29.0) — docs said "not yet wired"
The forwarder calls `evaluate_connect_gate` before `TcpStream::connect` (`src/forward.rs:213`) and `ConnectDiagnostics::record_allowed/record_denied` on each forward (`src/forward.rs:368,389,427`); `server/mod.rs` spawns `ForwardService` when connect is enabled. Corrected:
- `docs/connect-acl.md` — no longer claims "no runtime forwarder yet" / "denied until T4 ships"; now states an enabled ACL forwards live traffic.
- `src/connect/{acl,mod,gate,diagnostics}.rs`, `src/cli/commands/network.rs`, `src/server/{mod,state}.rs`, `src/peer_relay.rs` — module/field docs no longer say "not yet wired" / "Counters read 0 until T4 wired".
- `docs/connect-acl.md` — added a co-located-daemon shared-default-path warning (the #189 footgun) so creating one `connect-acl.toml` can't silently arm every plane on the host.

### 2. Bootstrap peer list + data dir drift
Source of truth: `DEFAULT_BOOTSTRAP_PEERS` (`src/network.rs:122-127`) and `peers/peers.cache` (`src/server/mod.rs:656,668`).
- `SKILL.md`, `docs/ecosystem.md`, `docs/AGENT_CARD.md`, `docs/architecture/running-autonomi-on-x0x.md` — the 6th bootstrap peer is **Sydney** (`170.64.176.102`), not Tokyo; Singapore is `152.42.210.67`.
- `SKILL.md` — peer cache dir is `<data_dir>/peers/peers.cache`, not `peer_cache/`.

## Verification
- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo check --workspace --all-targets`, `cargo doc --all-features --no-deps` (RUSTDOCFLAGS="-D warnings") — all clean.
- `cargo nextest run --all-features --workspace` — **2052 passed, 217 skipped** (skipped = `#[ignore]` timing-sensitive).
- Local Phase-D 2-instance testnet smoke (`tests/e2e_dogfood_local.sh`) — **19/19 pass**.
- Review: claims verified directly against source; independent model review PASS on accuracy / security-framing / completeness (verdict SHIP). (Note: the 3 `task` review subagents failed with a session-level 404 wiring bug, so I substituted direct source-verification + an independent pass.)

Doc-only change (module-doc comments + markdown) — zero executable code touched.

Closes #194.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates documentation that drifted after v0.29.0. The main changes are:

- Connect ACL docs now describe the shipped runtime forwarder.
- Connect diagnostics docs now describe live allow/deny counters.
- Bootstrap peer docs now use Singapore and Sydney endpoints.
- Peer cache docs now point at the current `peers/peers.cache` path.
- Peer relay module docs now describe shipped runtime wiring.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small relay documentation cleanup.

- The changed files are documentation and Rust doc comments.
- The connect ACL, diagnostics, bootstrap peer, and cache-path updates match the inspected runtime paths.
- The peer relay status wording should clarify that disabled policy refuses relay handling after inbound frame parsing.

src/peer_relay.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/connect-acl.md | Updates the connect ACL guide to describe shipped forwarding, live counters, disabled defaults, and the shared default ACL path. |
| SKILL.md | Updates bootstrap node geography and the documented peer cache path. |
| docs/AGENT_CARD.md | Updates the documented Singapore and Sydney bootstrap endpoints. |
| docs/ecosystem.md | Updates bootstrap node location, IP, and provider metadata. |
| src/connect/acl.rs | Updates connect ACL module docs to describe the shipped forwarder enforcement seam. |
| src/connect/diagnostics.rs | Updates connect diagnostics docs to describe live counter behavior. |
| src/connect/mod.rs | Updates top-level connect module docs to remove stale future-forwarder wording. |
| src/peer_relay.rs | Updates peer relay module docs to describe shipped runtime wiring, with one wording issue around disabled inbound parsing. |
| src/cli/commands/network.rs | Updates CLI diagnostics docs to describe live connect counters and disabled defaults. |
| src/server/mod.rs | Updates server diagnostics handler docs to describe live connect counter behavior. |
| src/server/state.rs | Updates AppState docs for connect diagnostics lifecycle and disabled defaults. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/peer_relay.rs:47-49
**Disabled Relay Still Parses Frames**

When relay policy is disabled, the runtime still demuxes and deserializes `RELAYED_DM_STREAM_TYPE` frames before the relay listener refuses them. This wording says the relay path only engages when enabled, which can mislead operators into thinking disabled relay has no inbound parse/allocation surface.

```suggestion
//! plus the inbound receiver in `NetworkNode` (X0X-0070b, shipped). The
//! `RelayPolicy` is **disabled by default** — send/forward/deliver decisions
//! only engage when a runtime explicitly enables it; inbound relay frames may
//! still be parsed before being refused by policy.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix post-v0.29.0 drift (#194)"](https://github.com/saorsa-labs/x0x/commit/b15c65421e8332797dceeec67529c46fe8a407e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42491943)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->