### PR TITLE
fix(revocation): gossip DM EP3 machine-id revocation parity (#184)

### DIFF
--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -283,14 +283,15 @@ impl InboxPipeline {
         // Enforcement point 3 — revocation gate.
         // Check after the envelope-signature is verified so we know the
         // sender_agent_id is authentic.  Never hold the lock across `.await`.
-        // NOTE: this gate checks agent-id revocation only, not machine-id
-        // revocation (unlike EP1/EP2 which check both). Intentional for now —
-        // the DM envelope's authenticated identity is the sender agent-id;
-        // machine-id revocation for the DM path is tracked as a follow-up.
+        // Checks BOTH agent-id and machine-id revocation, matching EP1/EP2 and
+        // the raw-QUIC direct path (`direct::inbound_peer_revoked`) — a DM whose
+        // originating machine is revoked is dropped even when the agent-id is
+        // clean (issue #184).
         {
             let revoked = self.revocation_set.read().await;
             let sender_agent_id = AgentId(envelope.sender_agent_id);
-            if drop_if_sender_revoked(&self.dm, &revoked, &sender_agent_id) {
+            let sender_machine_id = MachineId(envelope.sender_machine_id);
+            if drop_if_sender_revoked(&self.dm, &revoked, &sender_agent_id, &sender_machine_id) {
                 tracing::info!(
                     target: "dm.trace",
                     stage = "inbound_revoked_sender_dropped",
@@ -537,12 +538,23 @@ impl InboxPipeline {
 /// drop the DM). Returns `false` for a non-revoked sender without touching the
 /// counter.
 ///
-/// Extracted as a pure function of `(DirectMessaging, RevocationSet, AgentId)`
-/// so the revocation gate can be unit-tested without a live inbox pipeline,
-/// and so a future refactor of `handle_incoming` cannot silently drop the
-/// counter side-effect.
-fn drop_if_sender_revoked(dm: &DirectMessaging, revoked: &RevocationSet, sender: &AgentId) -> bool {
-    if revoked.is_agent_revoked(sender) {
+/// Pure revocation-gate predicate for the gossip DM path (EP3).
+///
+/// Drops (and counts) a DM whose sender agent OR originating machine is in
+/// the local revocation set — matching the raw-QUIC direct path
+/// (`direct::inbound_peer_revoked`) and EP1/EP2, so both DM paths are
+/// fail-closed on a machine revocation even when the agent-id is clean
+/// (issue #184). Extracted as a pure function of
+/// `(DirectMessaging, RevocationSet, AgentId, MachineId)` so the gate can be
+/// unit-tested without a live inbox pipeline, and so a future refactor of
+/// `handle_incoming` cannot silently drop the counter side-effect.
+fn drop_if_sender_revoked(
+    dm: &DirectMessaging,
+    revoked: &RevocationSet,
+    sender: &AgentId,
+    machine: &MachineId,
+) -> bool {
+    if revoked.is_agent_revoked(sender) || revoked.is_machine_revoked(machine) {
         dm.record_incoming_dropped_revoked();
         true
     } else {
@@ -577,7 +589,7 @@ pub fn verify_envelope_signature(envelope: &DmEnvelope, public_key_bytes: &[u8])
 mod tests {
     use super::*;
     use crate::dm::MAX_ENVELOPE_BYTES;
-    use crate::identity::AgentKeypair;
+    use crate::identity::{AgentKeypair, MachineKeypair};
 
     fn test_keypair() -> AgentKeypair {
         AgentKeypair::generate().expect("keygen")
@@ -736,6 +748,8 @@ mod tests {
     #[test]
     fn revoked_sender_dm_is_dropped_and_counted() {
         let dm = DirectMessaging::new();
+        // A machine that is NOT revoked — isolates the drop to the agent revocation.
+        let clean_machine = MachineId([0xAB; 32]);
 
         // A foreign sender self-revokes its own agent-id (valid authority).
         let sender_kp = test_keypair();
@@ -756,7 +770,7 @@ mod tests {
         // A revoked sender's DM is dropped and increments the counter.
         let before = dm.diagnostics_snapshot().stats.incoming_dropped_revoked;
         assert!(
-            drop_if_sender_revoked(&dm, &set, &sender),
+            drop_if_sender_revoked(&dm, &set, &sender, &clean_machine),
             "a DM from a revoked sender must be dropped"
         );
         let after = dm.diagnostics_snapshot().stats.incoming_dropped_revoked;
@@ -770,13 +784,55 @@ mod tests {
         // proving the gate is precise, not a blanket drop.
         let other = test_keypair().agent_id();
         assert!(
-            !drop_if_sender_revoked(&dm, &set, &other),
+            !drop_if_sender_revoked(&dm, &set, &other, &clean_machine),
             "a DM from a non-revoked sender must pass the gate"
         );
         assert_eq!(
             dm.diagnostics_snapshot().stats.incoming_dropped_revoked,
             after,
             "a passing DM must not touch incoming_dropped_revoked"
+        );
+    }
+
+    /// A DM whose originating MACHINE is revoked (but whose agent-id is clean)
+    /// MUST be dropped and counted — issue #184, bringing EP3 to machine-id
+    /// parity with the raw-QUIC direct path (`direct::inbound_peer_revoked`)
+    /// and EP1/EP2. The revocation is applied via the real `verify_and_insert`
+    /// receive path with a valid machine self-revocation, so this fails if the
+    /// machine-revocation half of the EP3 gate regresses.
+    #[test]
+    fn machine_revoked_sender_dm_is_dropped_and_counted() {
+        let dm = DirectMessaging::new();
+
+        // A foreign machine self-revokes its own machine-id (valid authority).
+        let machine_kp = MachineKeypair::generate().expect("machine keygen");
+        let revoked_machine = machine_kp.machine_id();
+        let now = now_unix_ms() / 1000;
+        let record = crate::revocation::RevocationRecord::sign(
+            crate::revocation::RevokedSubject::Machine(revoked_machine),
+            machine_kp.public_key(),
+            machine_kp.secret_key(),
+            now,
+            Some("compromised hardware".to_string()),
+        )
+        .expect("sign machine self-revocation");
+        let mut set = RevocationSet::new();
+        set.verify_and_insert(record, None)
+            .expect("machine self-revocation verifies and inserts");
+
+        // A clean (non-revoked) agent on the revoked machine is still dropped —
+        // the machine revocation is decisive, not the agent revocation.
+        let clean_agent = test_keypair().agent_id();
+        let before = dm.diagnostics_snapshot().stats.incoming_dropped_revoked;
+        assert!(
+            drop_if_sender_revoked(&dm, &set, &clean_agent, &revoked_machine),
+            "a DM from a machine-revoked (agent-clean) sender must be dropped (#184)"
+        );
+        let after = dm.diagnostics_snapshot().stats.incoming_dropped_revoked;
+        assert_eq!(
+            after,
+            before + 1,
+            "dropping a machine-revoked DM must increment incoming_dropped_revoked"
         );
     }
 


### PR DESCRIPTION
## Summary

Brings the gossip DM revocation gate (EP3) to machine-id parity with the raw-QUIC direct path, closing the asymmetry flagged by the #177 / #182 security reviews. Closes #184.

### The gap
EP3 (`src/dm_inbox.rs::handle_incoming`) checked **agent-id revocation only**, while the direct path (`direct::inbound_peer_revoked`) and EP1/EP2 check **both agent AND machine**. A peer whose **machine** was revoked (agent-id clean) could still deliver DMs over gossip, while the direct path dropped them.

### The fix
- Extend `drop_if_sender_revoked` to take the sender's `MachineId` and drop when EITHER the agent OR the originating machine is revoked — mirroring `direct.rs:128` exactly (`is_agent_revoked || is_machine_revoked`).
- Update the EP3 call site to pass `envelope.sender_machine_id`.
- Replace the stale "intentional for now — machine-id revocation tracked as a follow-up" NOTE.

### Security note
`envelope.sender_machine_id` is covered by the `DmEnvelope` ML-DSA-65 signature (`src/dm.rs::signed_bytes` includes it), and EP3 already enforces `sender_agent_id == pubsub sender` — so the machine_id the new gate reads is authenticated and tamper-proof. The gate remains fail-closed and counter-instrumented (`incoming_dropped_revoked`).

### Tests
- New `machine_revoked_sender_dm_is_dropped_and_counted`: a DM from a machine-revoked (agent-clean) sender is dropped + counted, via the real `verify_and_insert` receive path with a valid machine self-revocation.
- Updated `revoked_sender_dm_is_dropped_and_counted` to pass a clean machine so the agent-revoked drop stays attributable to the agent; still asserts a clean (agent, machine) pair passes.

## Verification
- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo check --workspace --all-targets`, `cargo doc --all-features --no-deps` (`-D warnings`) — all clean.
- `cargo nextest run --all-features --workspace` — **2053 passed / 217 skipped** (the +1 vs main is the new test).
- Local Phase-D 2-instance testnet smoke (`tests/e2e_dogfood_local.sh`) — **19/19 pass**, DM round-trip through EP3 intact.
- Review: signature-bound-field check (tamper-proof), independent model review PASS on correctness / security / test-quality (verdict SHIP). (The `task` review subagents still hit the session-level 404 bug, so I used direct verification + the independent pass.)

Closes #184. Related: #130, #179, #182. (EP4 group-metadata + relay-gate machine-revocation parity is tracked under #191 item 6 — out of scope here.)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR brings the gossip DM revocation gate closer to the direct path. The main changes are:

- Passes `sender_machine_id` into the EP3 revocation check.
- Drops gossip DMs when either the sender agent or sender machine is revoked.
- Adds unit coverage for machine-revoked senders and updates the existing agent-revocation test.

<h3>Confidence Score: 4/5</h3>

The gossip DM revocation path can still accept messages from a revoked machine.

- The new predicate drops trusted machine ids correctly.
- The changed call site gets the machine id from the signed envelope.
- Gossip binds the sender agent, but not the sender machine, so a clean-agent sender can report a clean machine id.

src/dm_inbox.rs

<details open><summary><h3>Security Review</h3></summary>

The new gossip DM machine-revocation check still uses an envelope-sourced machine id. A sender with a clean agent key can sign a DM with a clean machine id and bypass the intended machine-revocation drop.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dm_inbox.rs | Updates EP3 DM revocation logic and tests, but the changed call site checks a self-reported envelope machine id instead of a transport-bound machine identity. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/dm_inbox.rs:293-294
**Self-Reported Machine Revocation**

When a gossip DM comes from a clean agent on a revoked machine, this check looks up the envelope's signed `sender_machine_id` rather than a transport-bound machine identity. A sender that still controls the clean agent key can sign the envelope with any non-revoked machine id, so the new gate passes the DM even though the direct path would drop the same revoked machine.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(revocation): bring gossip DM EP3 to ..."](https://github.com/saorsa-labs/x0x/commit/6a58d0b9eb061ee2fc475114cce59f91df23d517) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42504133)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->