### PR TITLE
fix(connect): per-plane default connect-ACL path for named instances (#189)

### DIFF
--- a/docs/connect-acl.md
+++ b/docs/connect-acl.md
@@ -15,7 +15,7 @@ Default path:
 - Linux: `/etc/x0x/connect-acl.toml`
 - macOS: `/usr/local/etc/x0x/connect-acl.toml`
 
-> **Co-located daemons share the default path.** If more than one `x0xd` runs on a host (for example a prod instance plus a `--name testnet` instance), they all resolve the same default `/etc/x0x/connect-acl.toml` unless each is given its own `--connect-acl`. Creating the file to configure one plane silently arms every other plane on its next restart / self-upgrade — a latent way for a test/dev policy to activate on prod. Give each plane an explicit `--connect-acl` path. See issue #189.
+> **Named instances get their own default ACL path.** A daemon started with `--name <plane>` (for example `--name testnet`) resolves its default connect ACL from `connect-acl-<plane>.toml` (e.g. `/etc/x0x/connect-acl-testnet.toml`), not the shared `/etc/x0x/connect-acl.toml`, so co-located prod / testnet / `:443` daemons no longer silently arm each other from one policy file (#189). An unnamed daemon still uses the shared default — give it an explicit `--connect-acl` if you run more than one unnamed instance. `x0xd` logs the resolved connect-ACL path at startup.
 
 Override for tests or non-default installs:
 

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -238,10 +238,33 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("failed to load exec ACL")?;
 
-    let connect_policy =
-        x0x::connect::load_connect_policy(connect_acl_override.as_deref(), connect_acl_load_mode)
-            .await
-            .context("failed to load connect ACL")?;
+    // #189: give each named network plane its own default connect-ACL path so
+    // co-located daemons (prod / testnet / :443) no longer silently share
+    // /etc/x0x/connect-acl.toml. An explicit --connect-acl always wins; a named
+    // instance with no override falls back to connect-acl-<name>.toml (missing
+    // ⇒ disabled, same fail-closed behaviour as the base default); an unnamed
+    // daemon keeps the base default.
+    let effective_connect_acl_path: Option<PathBuf> = match (&connect_acl_override, &instance_name)
+    {
+        (Some(p), _) => Some(p.clone()),
+        (None, Some(name)) => Some(x0x::connect::default_connect_acl_path_for(name)),
+        (None, None) => None,
+    };
+    let connect_policy = x0x::connect::load_connect_policy(
+        effective_connect_acl_path.as_deref(),
+        connect_acl_load_mode,
+    )
+    .await
+    .context("failed to load connect ACL")?;
+    tracing::info!(
+        target: "x0x::startup",
+        path = %effective_connect_acl_path
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| x0x::connect::default_connect_acl_path().display().to_string()),
+        explicit = connect_acl_override.is_some(),
+        "Resolved connect-ACL policy path"
+    );
 
     if doctor_mode {
         return run_doctor(&config).await;

--- a/src/connect/acl.rs
+++ b/src/connect/acl.rs
@@ -50,6 +50,28 @@ pub fn default_connect_acl_path() -> PathBuf {
     }
 }
 
+/// Default connect-ACL file location for a named instance.
+///
+/// Named instances get a plane-specific default — the same directory as
+/// [`default_connect_acl_path`] but named `connect-acl-<name>.toml` — so
+/// co-located daemons (prod / testnet / `:443`) do not silently share one
+/// connect-ACL file (issue #189). An explicit `--connect-acl` always wins; a
+/// missing plane-specific file disables connect with the same fail-closed
+/// behaviour as the base default. `server::validate_instance_name` restricts
+/// the name to `[a-zA-Z0-9-]`, so the derived filename is path-traversal-safe.
+#[must_use]
+pub fn default_connect_acl_path_for(name: &str) -> PathBuf {
+    debug_assert!(
+        !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
+        "instance name must be validated before deriving a connect-ACL path"
+    );
+    let file = format!("connect-acl-{name}.toml");
+    default_connect_acl_path()
+        .parent()
+        .map(|dir| dir.join(&file))
+        .unwrap_or_else(|| PathBuf::from(file))
+}
+
 // ---------------------------------------------------------------------------
 // Policy + ACL types
 // ---------------------------------------------------------------------------

--- a/src/connect/acl/tests.rs
+++ b/src/connect/acl/tests.rs
@@ -404,3 +404,57 @@ unknown_key = "surprise"
         "unknown field in allow entry must be an error"
     );
 }
+
+// ===========================================================================
+// Plane-specific default path (#189)
+// ===========================================================================
+
+#[test]
+fn default_connect_acl_path_for_is_plane_scoped_and_safe() {
+    // A named instance gets its own default path in the same directory as the
+    // base default, named connect-acl-<name>.toml.
+    let testnet = default_connect_acl_path_for("testnet");
+    let base = default_connect_acl_path();
+    let base_dir = base
+        .parent()
+        .expect("base default connect-ACL path has a parent dir");
+    assert_eq!(
+        testnet.parent(),
+        Some(base_dir),
+        "named-instance default lives in the same dir as the base default"
+    );
+    assert!(
+        testnet
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n == "connect-acl-testnet.toml"),
+        "named-instance default must be connect-acl-<name>.toml, got {testnet:?}"
+    );
+
+    // The base default is unchanged for unnamed daemons.
+    assert_ne!(base, testnet, "named and base defaults must differ");
+    assert!(
+        base.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n == "connect-acl.toml"),
+        "base default must stay connect-acl.toml, got {base:?}"
+    );
+}
+
+#[tokio::test]
+async fn load_policy_missing_plane_specific_default_is_disabled() {
+    // #189: a named instance's plane-specific default, when missing, must be
+    // Disabled (NOT a hard error) — matching the base default's fail-closed
+    // behaviour so an unconfigured plane stays disabled.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("connect-acl-testnet.toml");
+    let policy = load_connect_policy(Some(&path), LoadMode::DefaultPath)
+        .await
+        .unwrap();
+    assert!(!policy.enabled());
+    if let ConnectPolicy::Disabled { reason, .. } = &policy {
+        assert_eq!(reason, "acl_missing");
+    } else {
+        panic!("expected Disabled for a missing plane-specific default");
+    }
+}

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -24,8 +24,9 @@ pub mod gate;
 
 pub use crate::exec::acl::LoadMode;
 pub use acl::{
-    default_connect_acl_path, is_loopback, load_connect_policy, parse_connect_policy, parse_target,
-    ConnectAcl, ConnectAclError, ConnectAclSummary, ConnectAllowEntry, ConnectPolicy,
+    default_connect_acl_path, default_connect_acl_path_for, is_loopback, load_connect_policy,
+    parse_connect_policy, parse_target, ConnectAcl, ConnectAclError, ConnectAclSummary,
+    ConnectAllowEntry, ConnectPolicy,
 };
 pub use diagnostics::{ConnectDiagnostics, ConnectDiagnosticsSnapshot};
 pub use gate::{evaluate_connect_gate, ConnectDenialReason};


### PR DESCRIPTION
## Summary

Fixes the co-located-daemon connect-ACL footgun (#189): prod, testnet, and `:443` daemons all resolved the **same** default path (`/etc/x0x/connect-acl.toml`) unless each was given `--connect-acl`, so configuring one plane silently armed the others. The connect ACL is a security policy (default-deny per-flow), so sharing one file across planes is a real footgun.

### Fix
A named instance (`--name <plane>`) with no `--connect-acl` now resolves its default from `connect-acl-<plane>.toml` (same directory as the base default). Precedence:
1. `--connect-acl <PATH>` → explicit (missing = hard error, unchanged).
2. `--name <plane>`, no override → `connect-acl-<plane>.toml` (missing = disabled, fail-closed).
3. Neither → base `connect-acl.toml` (unchanged — backward compatible).

`x0xd` now logs the resolved connect-ACL path at startup so the sharing is visible.

### Security
- Path-traversal-safe: `server::validate_instance_name` restricts `--name` to `[a-zA-Z0-9-]` (1-64 chars), so `connect-acl-<name>.toml` can't escape the directory. A `debug_assert!` guards internal callers.
- Fail-closed: a missing plane-specific file ⇒ `Disabled { acl_missing }`, same as the base default — an unconfigured plane stays disabled, never inherits another's policy.

### Functional proof (`x0xd --check`)
- `--name testnet` → `loaded_from: /usr/local/etc/x0x/connect-acl-testnet.toml`, disabled (missing).
- no `--name` → `loaded_from: /usr/local/etc/x0x/connect-acl.toml`, disabled (missing).

## Verification
- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo check --workspace --all-targets`, `cargo doc --all-features --no-deps` (`-D warnings`) — all clean.
- `cargo nextest run --all-features --workspace` — **2055 passed / 217 skipped** (+2 new path tests).
- Local Phase-D 2-instance testnet smoke (`tests/e2e_dogfood_local.sh`, boots named `alice`/`bob` instances) — **19/19 pass**.
- Review: independent model review PASS on correctness / security / backward-compat (verdict SHIP); functional `--check` proof; direct source verification.

Closes #189.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gives named daemon instances their own default connect-ACL file. The main changes are:

- A named instance resolves `connect-acl-<name>.toml` in the base ACL directory.
- Explicit `--connect-acl` paths keep their existing precedence and error behavior.
- Startup logging now shows the resolved connect-ACL path.
- Docs and tests cover the new plane-scoped default behavior.

<h3>Confidence Score: 4/5</h3>

The config-sourced instance name path needs a fix before merging.

- CLI-provided names are validated before use.
- Config-provided names can still reach the new ACL filename derivation.
- The changed load-mode behavior otherwise matches the intended missing-file semantics.

src/bin/x0xd.rs

<details open><summary><h3>Security Review</h3></summary>

A config-sourced instance name can reach the new connect-ACL path derivation without the validation used by the CLI `--name` path. That can select an unexpected security policy file.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/bin/x0xd.rs | Adds connect-ACL path selection and logging; the config-sourced instance name path can bypass validation before deriving the ACL filename. |
| src/connect/acl.rs | Adds the named-instance ACL path helper; it is correct for validated names but enforces that precondition only in debug builds. |
| src/connect/mod.rs | Re-exports the new helper through the connect module. |
| src/connect/acl/tests.rs | Adds tests for plane-scoped ACL filenames and missing named defaults disabling connect. |
| docs/connect-acl.md | Documents the new named-instance default path and the unchanged unnamed default. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/bin/x0xd.rs:250
**Config Name Bypasses Validation**

When the effective instance name comes from the daemon config, this path derivation can receive a value that did not pass the `--name` validation used by the safety comment. In release builds the helper only has a `debug_assert!`, so a configured name containing separators or other invalid characters can derive an unexpected connect-ACL path and load or disable the wrong policy file.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(connect): per-plane default connect-..."](https://github.com/saorsa-labs/x0x/commit/b80ffb4ca8cd66f5d2eb87316a01defd2574f291) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42522172)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->