### PR TITLE
fix(security): LOW-severity defense-in-depth batch (#195)

### DIFF
--- a/docs/exec.md
+++ b/docs/exec.md
@@ -24,6 +24,8 @@ Remote execution is processed only when all of the following are true:
 5. the argv vector matches an allowed command;
 6. stdin, timeout, concurrency, and output caps pass.
 
+**Caller-authentication trust anchor.** Exec authorization rests on the `(agent_id, machine_id)` pair being *cryptographically* authenticated, not merely claimed: both fields are mandatory in every ACL entry, and the `machine_id` is the QUIC peer identity established by the post-quantum (ML-DSA-65) transport handshake — an attacker cannot present a forged `machine_id` without the peer's machine keypair. So an exec request is honored only from hardware the operator explicitly pinned in the ACL. This invariant must survive refactors (issue #195).
+
 ## ACL location
 
 Default path:

--- a/src/exec/service.rs
+++ b/src/exec/service.rs
@@ -718,6 +718,35 @@ impl ExecService {
         timeout_ms: u32,
         cwd: Option<String>,
     ) {
+        // #195 item 4: cheap pre-spawn verified/trust peek. Deny unverified or
+        // non-Accept senders WITHOUT spawning a handler task, so a peer flooding
+        // ExecFrame::Request can't force unbounded short-lived task spawns (each
+        // of these denies anyway, before any child process is considered).
+        // `handle_request` re-checks the same gates defensively.
+        if !inbound.verified {
+            self.diagnostics.record_request_received();
+            self.deny(
+                inbound.sender,
+                inbound.machine_id,
+                request_id,
+                &argv,
+                DenialReason::UnverifiedSender,
+            )
+            .await;
+            return;
+        }
+        if inbound.trust_decision != Some(TrustDecision::Accept) {
+            self.diagnostics.record_request_received();
+            self.deny(
+                inbound.sender,
+                inbound.machine_id,
+                request_id,
+                &argv,
+                DenialReason::TrustRejected,
+            )
+            .await;
+            return;
+        }
         // Hold the lock across spawn + insert so `shutdown()` draining the map
         // observes a consistent set: either this handle is present (and will be
         // awaited/aborted) or the token was already cancelled and we decline.
@@ -2466,6 +2495,53 @@ mod tests {
             .await;
 
         assert_single_denial(&service, DenialReason::TrustRejected).await;
+    }
+
+    // ── #195 item 4: pre-spawn verified/trust peek (no task spawned) ─────────
+
+    #[tokio::test]
+    async fn spawn_request_handler_denies_unverified_without_spawning() {
+        // #195 item 4: an unverified sender is denied at the pre-spawn peek, so
+        // NO handler task is created (request_task_handles stays empty) — a peer
+        // flooding ExecFrame::Request can't force unbounded task spawns.
+        let service = test_service().await;
+        Arc::clone(&service)
+            .spawn_request_handler(
+                inbound_payload(false, Some(TrustDecision::Accept)),
+                ExecRequestId([78; 16]),
+                vec!["echo".to_string(), "ok".to_string()],
+                None,
+                60_000,
+                None,
+            )
+            .await;
+        assert_single_denial(&service, DenialReason::UnverifiedSender).await;
+        assert!(
+            service.request_task_handles.lock().await.is_empty(),
+            "unverified request must not spawn a handler task"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_request_handler_denies_non_accept_trust_without_spawning() {
+        // #195 item 4: a trust-rejected sender is likewise denied pre-spawn —
+        // no handler task, no child-process path reached.
+        let service = test_service().await;
+        Arc::clone(&service)
+            .spawn_request_handler(
+                inbound_payload(true, Some(TrustDecision::AcceptWithFlag)),
+                ExecRequestId([79; 16]),
+                vec!["echo".to_string(), "ok".to_string()],
+                None,
+                60_000,
+                None,
+            )
+            .await;
+        assert_single_denial(&service, DenialReason::TrustRejected).await;
+        assert!(
+            service.request_task_handles.lock().await.is_empty(),
+            "trust-rejected request must not spawn a handler task"
+        );
     }
 
     #[tokio::test]

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -434,8 +434,6 @@ pub(crate) async fn handle_inbound(
         return;
     }
     let (send, recv) = stream.into_split();
-    fwd_diag.enter_stream();
-    let _guard = StreamLeaveGuard(Arc::clone(&fwd_diag));
     bridge(local, send, recv).await;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2546,6 +2546,25 @@ impl Agent {
             }
         };
 
+        // #195 item 5: consult the revocation set inline so a known-revoked-but-
+        // not-yet-evicted agent can't be the target of an outbound connect —
+        // closes the race between a revocation arriving and the eviction loop
+        // purging the discovery cache. Pairs with #191 item 5.
+        {
+            let revoked = self.revocation_set.read().await;
+            if revoked.is_agent_revoked(agent_id) || revoked.is_machine_revoked(&agent.machine_id) {
+                tracing::info!(
+                    target: "x0x::connect",
+                    stage = "connect_to_agent",
+                    %agent_prefix,
+                    outcome = "revoked",
+                    dur_ms = call_start.elapsed().as_millis() as u64,
+                    "connect target is revoked — refusing before any dial"
+                );
+                return Ok(connectivity::ConnectOutcome::NotFound);
+            }
+        }
+
         let info = connectivity::ReachabilityInfo::from_discovered(&agent);
         let v4_addrs = info.addresses.iter().filter(|a| a.is_ipv4()).count();
         let v6_addrs = info.addresses.len() - v4_addrs;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -761,6 +761,20 @@ pub async fn serve_with_options(
         .context("failed to bind API address")?;
     let actual_api_addr = listener.local_addr()?;
 
+    // #195: warn loudly when the control plane is bound off-loopback — the
+    // API is bearer-token-only with no auth rate-limiting, so a non-loopback
+    // bind exposes it off-host. --api-port only changes the port and stays
+    // loopback-safe; only a TOML `api_address = "0.0.0.0:…"` reaches here.
+    if !actual_api_addr.ip().is_loopback() {
+        tracing::warn!(
+            target: "x0x::startup",
+            api_address = %actual_api_addr,
+            "API listener bound on a NON-LOOPBACK address — the control plane is reachable \
+             off-host, protected only by the bearer token (no auth rate-limiting). Bind \
+             127.0.0.1 (the default) unless you intentionally want remote control-plane access."
+        );
+    }
+
     let (broadcast_tx, _) = broadcast::channel::<SseEvent>(256);
     // Load or generate the per-daemon ML-KEM-768 keypair. Persisted under
     // `<data_dir>/agent_kem.key` with mode 0600. This keypair is the root of

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -591,7 +591,19 @@ async fn handle_ws_command(
                 session.subscribed_topics.clone()
             };
             let mut requested_topics = HashSet::new();
+            const MAX_WS_TOPICS_PER_SESSION: usize = 64;
             for topic in &topics {
+                // #195: per-session topic cap — an authenticated client could
+                // otherwise spawn an unbounded number of per-topic forwarder
+                // tasks (one gossip sub + broadcast + forward task each).
+                if already_subscribed.len() + requested_topics.len() >= MAX_WS_TOPICS_PER_SESSION {
+                    tracing::warn!(
+                        target: "x0x::ws",
+                        cap = MAX_WS_TOPICS_PER_SESSION,
+                        "WS Subscribe per-session topic cap reached — ignoring further topics"
+                    );
+                    break;
+                }
                 if !requested_topics.insert(topic.clone()) || already_subscribed.contains(topic) {
                     continue;
                 }


### PR DESCRIPTION
## Summary

Closes #195 — the LOW-severity defense-in-depth batch from the 2026-07-07 production review. Six cheap hardening items; none remotely exploitable today (all auth-gated, loopback-bound, or opt-in).

| # | Item | File | Fix |
|---|------|------|-----|
| 1 | api_address off-loopback | `server/mod.rs` | Loud startup WARN when the API binds non-loopback (bearer-token-only, no auth rate-limit). `--api-port` stays loopback-safe. |
| 2 | WS Subscribe topic cap | `server/ws.rs` | Per-session cap of 64 subscribed topics — stops an authenticated client spawning unbounded per-topic forwarder tasks. |
| 3 | active_streams double-count | `forward.rs` | Drop the inner `enter_stream()`/guard in `handle_inbound`; the spawn wrapper already counts once. Fixes `/streams` over-report of +1 per bridged inbound. Caps (semaphore) unaffected. |
| 4 | Pre-auth exec task spawn | `exec/service.rs` | Pre-spawn verified/trust peek denies unverified/non-Accept senders **without spawning a task** — stops unbounded task spawns under a Request flood. `handle_request` re-checks defensively. |
| 5 | connect_to_agent eviction race | `lib.rs` | Inline `RevocationSet` check so a revoked-but-not-yet-evicted agent can't be an outbound-connect target (pairs with #191). Fail-closed → `NotFound`. |
| 6 | Exec trust-anchor docs | `docs/exec.md` | Document that exec auth rests on `(agent_id, machine_id)` being cryptographically authenticated (machine_id = QUIC/ML-DSA-65 peer identity). |

## Verification
- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo check --workspace --all-targets`, `cargo doc --all-features --no-deps` (`-D warnings`) — all clean.
- `cargo nextest run --all-features --workspace` — **2057 passed / 217 skipped** (+2 new exec pre-spawn tests).
- Local Phase-D 2-instance testnet smoke — **19/19 pass**.
- Review: independent model review — all 6 items PASS, SECURITY clean, item-4 tests prove no-spawn-on-deny (verdict SHIP); direct source verification (item-3 caller analysis, item-5 ConnectOutcome fail-closed).

Closes #195.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a small security hardening batch across the daemon.

- Warns when the API listener binds off loopback.
- Caps WebSocket subscriptions per session.
- Removes duplicate inbound stream accounting.
- Denies rejected exec requests before spawning handler tasks.
- Checks revocations before outbound agent connects.
- Documents the exec caller trust anchor.

<h3>Confidence Score: 4/5</h3>

The WebSocket subscription cap needs a protocol fix before merging.

- Over-cap subscribe requests can be partially applied while clients receive a full success acknowledgement.
- The exec, revocation, stream accounting, and startup warning changes match the inspected caller behavior.

src/server/ws.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/exec/service.rs | Adds pre-spawn denial for unverified or non-accepted exec requests while preserving denial accounting. |
| src/forward.rs | Removes duplicate active-stream accounting from inbound forwarding. |
| src/lib.rs | Adds an inline revocation check before dialing a discovered agent. |
| src/server/mod.rs | Adds a startup warning for non-loopback API binds. |
| src/server/ws.rs | Adds a WebSocket topic cap, but over-cap requests can still be acknowledged as fully subscribed. |
| docs/exec.md | Documents the cryptographic trust anchor for exec ACL entries. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/server/ws.rs:596-606
**Over-Cap Topics Are Acknowledged**

When a client subscribes to more than 64 distinct new topics, this branch stops creating subscriptions but the handler still acknowledges the original topic list. The client can receive `Subscribed` for topics that have no forwarder task, so messages for those topics are silently missed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): LOW-severity defense-in-d..."](https://github.com/saorsa-labs/x0x/commit/63a27f7783042ef94a8433fa8d747d62b7d48b9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42632157)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->