### PR TITLE
fix(security): key-lifecycle enforcement gaps — runtime expiry gate, gossip issuer revocation, pubsub RevocationSet (#191)

### DIFF
--- a/src/connectivity.rs
+++ b/src/connectivity.rs
@@ -421,6 +421,7 @@ mod tests {
             reachable_via: Vec::new(),
             relay_candidates: Vec::new(),
             cert_not_after: None,
+            agent_certificate: None,
         }
     }
 

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -483,6 +483,7 @@ struct DirectDiagnosticsCounters {
     incoming_signature_failed: AtomicU64,
     incoming_trust_rejected: AtomicU64,
     incoming_dropped_revoked: AtomicU64,
+    incoming_dropped_expired: AtomicU64,
     incoming_typed_route_dropped: AtomicU64,
     incoming_delivered_to_subscribe: AtomicU64,
     subscriber_channel_lagged: AtomicU64,
@@ -533,6 +534,11 @@ pub struct DmDiagnosticsStats {
     /// Non-zero means a revoked peer is still attempting to communicate.
     #[serde(default)]
     pub incoming_dropped_revoked: u64,
+    /// DMs dropped because the sender's cached agent certificate has expired
+    /// past `not_after` (issue #191 runtime expiry gate). Non-zero means an
+    /// expired peer is still attempting to communicate on a live connection.
+    #[serde(default)]
+    pub incoming_dropped_expired: u64,
     /// Redundant typed-route gossip-DM fallback hand-offs dropped on a full
     /// route channel (non-zero ⇒ a route consumer is lagging). Safe drops —
     /// the primary per-group/store pubsub path still delivers.
@@ -917,6 +923,13 @@ impl DirectMessaging {
             .incoming_dropped_revoked
             .fetch_add(1, Ordering::Relaxed);
     }
+    /// Record a DM dropped because the sender's cached cert has expired
+    /// (issue #191 runtime expiry gate).
+    pub(crate) fn record_incoming_dropped_expired(&self) {
+        self.diagnostics
+            .incoming_dropped_expired
+            .fetch_add(1, Ordering::Relaxed);
+    }
 
     /// Record a DM trust-policy rejection.
     pub(crate) fn record_incoming_trust_rejected(&self, agent_id: AgentId) {
@@ -985,6 +998,10 @@ impl DirectMessaging {
             incoming_dropped_revoked: self
                 .diagnostics
                 .incoming_dropped_revoked
+                .load(Ordering::Relaxed),
+            incoming_dropped_expired: self
+                .diagnostics
+                .incoming_dropped_expired
                 .load(Ordering::Relaxed),
             incoming_typed_route_dropped: self
                 .diagnostics

--- a/src/gossip/pubsub.rs
+++ b/src/gossip/pubsub.rs
@@ -254,6 +254,12 @@ pub struct PubSubManager {
     /// Contact store for trust-based message filtering.
     /// Set via `set_contacts()` after construction.
     contacts: std::sync::OnceLock<Arc<tokio::sync::RwLock<ContactStore>>>,
+    /// Authoritative gossiped revocation set (issue #130 / #191). Runtime-
+    /// injected via `set_revocation_set()` after construction (mirrors
+    /// `contacts`). Delivery consults this BEFORE the operator-local
+    /// ContactStore so a gossiped issuer/agent revocation closes the path
+    /// even before the eviction loop sets `trust = Blocked`.
+    revocation_set: std::sync::OnceLock<Arc<tokio::sync::RwLock<crate::revocation::RevocationSet>>>,
     /// Drop-detection counters exposed at `GET /diagnostics/gossip`.
     stats: Arc<PubSubStats>,
     /// Subscriber channels for `local:` topics (issue #89). These topics
@@ -342,6 +348,7 @@ impl PubSubManager {
             topic_ref_counts: Arc::new(RwLock::new(HashMap::new())),
             signing,
             contacts: std::sync::OnceLock::new(),
+            revocation_set: std::sync::OnceLock::new(),
             stats: Arc::new(PubSubStats::default()),
             local_topics: Arc::new(RwLock::new(HashMap::new())),
         })
@@ -373,6 +380,19 @@ impl PubSubManager {
     /// Calling more than once is a no-op (first caller wins).
     pub fn set_contacts(&self, store: Arc<tokio::sync::RwLock<ContactStore>>) {
         let _ = self.contacts.set(store);
+    }
+    /// Attach the authoritative gossiped revocation set (issue #191).
+    ///
+    /// When set, payloads delivered via the subscribe path whose sender is in
+    /// the revocation set are dropped before reaching subscribers — closing
+    /// the window between a gossiped revocation arriving and the eviction
+    /// loop setting `trust = Blocked`. Call once after construction; a second
+    /// call is a no-op (first caller wins), matching `set_contacts`.
+    pub fn set_revocation_set(
+        &self,
+        set: Arc<tokio::sync::RwLock<crate::revocation::RevocationSet>>,
+    ) {
+        let _ = self.revocation_set.set(set);
     }
 
     /// Subscribe to a topic.
@@ -422,6 +442,7 @@ impl PubSubManager {
         tokio::task::yield_now().await;
         let (tx, rx) = mpsc::channel(10_000);
         let contacts = self.contacts.get().cloned();
+        let revocation_set = self.revocation_set.get().cloned();
 
         {
             let mut counts = self.topic_ref_counts.write().await;
@@ -438,7 +459,12 @@ impl PubSubManager {
                     payload_len = encoded_payload.len(),
                     "[4/6 pubsub] received from PlumTree, decoding"
                 );
-                let Some(message) = decode_for_delivery(encoded_payload, contacts.as_ref()).await
+                let Some(message) = decode_for_delivery(
+                    encoded_payload,
+                    contacts.as_ref(),
+                    revocation_set.as_ref(),
+                )
+                .await
                 else {
                     stats.incoming_decode_failed.fetch_add(1, Ordering::Relaxed);
                     tracing::warn!(
@@ -709,9 +735,15 @@ impl PubSubManager {
 }
 
 /// Decode and filter a delivered payload before exposing it to x0x subscribers.
+///
+/// Revocation is checked against the authoritative gossiped `RevocationSet`
+/// (issue #191) before the operator-local `ContactStore`, so a gossiped
+/// issuer/agent revocation closes delivery even before the eviction loop sets
+/// `trust = Blocked`.
 async fn decode_for_delivery(
     encoded_payload: Bytes,
-    contacts: Option<&Arc<tokio::sync::RwLock<ContactStore>>>,
+    contacts: Option<&Arc<RwLock<ContactStore>>>,
+    revocation_set: Option<&Arc<RwLock<crate::revocation::RevocationSet>>>,
 ) -> Option<PubSubMessage> {
     let mut message = match decode_auto(encoded_payload) {
         Ok(msg) => msg,
@@ -728,6 +760,19 @@ async fn decode_for_delivery(
             message.sender
         );
         return None;
+    }
+    // Authoritative gossiped revocation set (issue #191). Checked before the
+    // ContactStore below, which is operator-local only — without this a
+    // gossiped revocation reaches delivery only once the eviction loop has
+    // set trust = Blocked (a race reopens it).
+    if let (Some(rev_set), Some(sender)) = (revocation_set, message.sender) {
+        if rev_set.read().await.is_agent_revoked(&sender) {
+            tracing::debug!(
+                "Dropping delivered payload from revoked sender {} (RevocationSet)",
+                sender
+            );
+            return None;
+        }
     }
 
     if let (Some(store), Some(sender)) = (contacts, message.sender) {
@@ -1371,6 +1416,82 @@ mod tests {
         assert_eq!(msg.payload, payload);
         assert_eq!(msg.sender, Some(ctx.agent_id));
         assert!(msg.verified);
+    }
+
+    /// Issue #191 gap 3: pubsub delivery must consult the authoritative
+    /// gossiped `RevocationSet`, not just the operator-local ContactStore.
+    /// Pre-fix `decode_for_delivery` never checked `RevocationSet`, so a
+    /// gossiped revocation reached delivery only once the eviction loop had
+    /// set `trust = Blocked` — a race (revocation received, eviction not yet
+    /// run) or a later `set_trust` off Blocked reopened delivery from the
+    /// revoked sender. Here a verified v2 payload from a RevocationSet-
+    /// revoked sender is dropped; a non-revoked sender is delivered.
+    #[tokio::test]
+    async fn decode_for_delivery_drops_revoked_sender_via_revocation_set() {
+        // Build a RevocationSet holding a self-revoked agent (the sender).
+        let kp = AgentKeypair::generate().expect("keygen");
+        let ctx = SigningContext::from_keypair(&kp);
+        let revoked_agent = ctx.agent_id;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let record = crate::revocation::RevocationRecord::sign(
+            crate::revocation::RevokedSubject::Agent(revoked_agent),
+            kp.public_key(),
+            kp.secret_key(),
+            now,
+            None,
+        )
+        .expect("sign revocation");
+        let mut set = crate::revocation::RevocationSet::new();
+        set.verify_and_insert(record, None)
+            .expect("self-revocation verifies without a cert");
+        let rev_set = std::sync::Arc::new(tokio::sync::RwLock::new(set));
+
+        let topic = "chat";
+        let payload = Bytes::from("hello");
+        // A verified v2 payload signed by the (now-revoked) sender.
+        let signing_payload =
+            build_signing_payload(ctx.agent_id.as_bytes(), topic.as_bytes(), &payload);
+        let signature = ctx.sign(&signing_payload).expect("sign message");
+        let encoded = encode_v2(
+            &ctx.agent_id,
+            &ctx.public_key_bytes,
+            &signature,
+            topic,
+            &payload,
+        )
+        .expect("encode");
+
+        // contacts = None isolates the RevocationSet check. The payload's
+        // signature verifies, but the sender is revoked → dropped.
+        assert!(
+            decode_for_delivery(encoded.clone(), None, Some(&rev_set))
+                .await
+                .is_none(),
+            "payload from a RevocationSet-revoked sender must be dropped"
+        );
+
+        // A non-revoked sender (different agent) is delivered.
+        let other = AgentKeypair::generate().expect("keygen2");
+        let other_ctx = SigningContext::from_keypair(&other);
+        let sp2 = build_signing_payload(other_ctx.agent_id.as_bytes(), topic.as_bytes(), &payload);
+        let sig2 = other_ctx.sign(&sp2).expect("sign2");
+        let encoded2 = encode_v2(
+            &other_ctx.agent_id,
+            &other_ctx.public_key_bytes,
+            &sig2,
+            topic,
+            &payload,
+        )
+        .expect("encode2");
+        assert!(
+            decode_for_delivery(encoded2, None, Some(&rev_set))
+                .await
+                .is_some(),
+            "payload from a non-revoked sender must be delivered"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1307,6 +1307,14 @@ pub struct DiscoveredAgent {
     /// identity announcement, if any.  `None` means the cert carries no
     /// expiry — the agent is considered valid indefinitely.
     pub cert_not_after: Option<u64>,
+    /// The agent certificate embedded in the identity announcement, if any.
+    ///
+    /// Retained so a gossiped **issuer-revocation** (a user un-vouching this
+    /// agent) can be authority-verified on receipt: `verify_authority` for an
+    /// issuer-revocation requires the subject cert (issue #191). `None` for
+    /// pre-#130 peers that announce no cert, and for machine/rendezvous-only
+    /// cache entries.
+    pub agent_certificate: Option<identity::AgentCertificate>,
 }
 
 /// Cached machine endpoint data derived from signed machine announcements.
@@ -1340,6 +1348,29 @@ pub struct DiscoveredMachine {
     /// Human identities currently linked to this machine by consented agent
     /// announcements.
     pub user_ids: Vec<identity::UserId>,
+}
+
+/// Build a `subject AgentId → AgentCertificate` lookup from the discovery
+/// cache, used to authority-verify gossiped **issuer-revocations** (a user
+/// un-vouching a certified agent) on receipt (issue #191).
+///
+/// `verify_authority` for an issuer-revocation requires the subject agent's
+/// certificate; self-revocations and machine-revocations need none. Only
+/// entries that actually carry a cert contribute; entries without one
+/// (pre-#130 peers, machine/rendezvous-only entries) are absent, so an
+/// issuer-revocation for such a subject is rejected fail-closed by the
+/// caller — the cert must have been announced first (EP1).
+fn collect_subject_certs(
+    cache: &std::collections::HashMap<identity::AgentId, DiscoveredAgent>,
+) -> std::collections::HashMap<identity::AgentId, identity::AgentCertificate> {
+    cache
+        .values()
+        .filter_map(|a| {
+            a.agent_certificate
+                .as_ref()
+                .map(|c| (a.agent_id, c.clone()))
+        })
+        .collect()
 }
 
 impl DiscoveredMachine {
@@ -2080,6 +2111,7 @@ impl HeartbeatContext {
             reachable_via: announcement.reachable_via.clone(),
             relay_candidates: announcement.relay_candidates.clone(),
             cert_not_after: None,
+            agent_certificate: None,
         };
         upsert_discovered_machine_from_agent(&self.machine_cache, &discovered_agent).await;
         upsert_discovered_agent(&self.cache, discovered_agent).await;
@@ -4997,7 +5029,13 @@ impl Agent {
     /// Without a contact store, all messages pass through (open relay mode).
     pub fn set_contacts(&self, store: std::sync::Arc<tokio::sync::RwLock<contacts::ContactStore>>) {
         if let Some(runtime) = &self.gossip_runtime {
-            runtime.pubsub().set_contacts(store);
+            let pubsub = runtime.pubsub();
+            pubsub.set_contacts(store);
+            // Thread the authoritative gossiped RevocationSet into pub/sub
+            // delivery so a gossiped revocation closes the subscribe path
+            // (issue #191 gap 3). Wired here so every runtime that sets
+            // contacts also sets revocation — they share the same lifecycle.
+            pubsub.set_revocation_set(self.revocation_set());
         }
     }
 
@@ -5249,6 +5287,7 @@ impl Agent {
             reachable_via: announcement.reachable_via.clone(),
             relay_candidates: announcement.relay_candidates.clone(),
             cert_not_after: None,
+            agent_certificate: None,
         };
         upsert_discovered_machine_from_agent(&self.machine_discovery_cache, &discovered_agent)
             .await;
@@ -5940,13 +5979,30 @@ impl Agent {
                                 }
                             };
                         let mut newly_inserted = Vec::new();
+                        // Resolve subject certificates from the discovery cache
+                        // so gossiped issuer-revocations (a user un-vouching a
+                        // certified agent) can be authority-verified on receipt
+                        // (issue #191). `verify_authority` for an issuer-
+                        // revocation requires the subject cert; self/machine
+                        // revocations need none. A cert not in the local cache
+                        // means the issuer-revocation is rejected fail-closed
+                        // — the cert must have been announced first (EP1).
+                        // Built before taking the revocation-set write lock so
+                        // no two identity locks are held at once.
+                        let subject_certs = collect_subject_certs(&*cache.read().await);
                         {
                             let mut set = revocation_set.write().await;
                             for record in records {
                                 if set.contains_hash(&record.record_hash()) {
                                     continue; // already known — skip re-verification
                                 }
-                                match set.verify_and_insert(record.clone(), None) {
+                                let subject_cert = match &record.subject {
+                                    revocation::RevokedSubject::Agent(agent_id) => {
+                                        subject_certs.get(agent_id)
+                                    }
+                                    _ => None,
+                                };
+                                match set.verify_and_insert(record.clone(), subject_cert) {
                                     Ok(true) => newly_inserted.push(record),
                                     Ok(false) => {} // dup
                                     Err(e) => {
@@ -5958,21 +6014,34 @@ impl Agent {
                             }
                         }
                         if !newly_inserted.is_empty() {
-                            // Persist asynchronously — best-effort; if it fails the
-                            // revocation is still enforced in memory for this run.
-                            let set_snap = revocation_set.read().await.all_records();
+                            // Persist asynchronously — best-effort; if it fails
+                            // the revocation is still enforced in memory for this
+                            // run. Snapshot the live set's encoded bytes under a
+                            // brief read lock (issuer-revocations carry their
+                            // authorizing cert in PersistedRevocation, which the
+                            // encoder preserves); the disk write runs off-lock.
+                            // The previous rebuild re-inserted records with
+                            // `None` cert, silently dropping every issuer-
+                            // revocation on save (issue #191).
+                            let persisted_bytes = revocation_set.read().await.to_bytes();
                             let id_dir = identity_dir_for_listener.clone();
                             tokio::spawn(async move {
-                                let tmp = revocation::RevocationSet::new();
-                                let _ = storage::save_revocation_set(&tmp, id_dir.as_deref()).await;
-                                // Rebuild correctly from snapshot.
-                                drop(tmp);
-                                let mut rebuilding = revocation::RevocationSet::new();
-                                for r in set_snap {
-                                    let _ = rebuilding.verify_and_insert(r, None);
-                                }
-                                if let Err(e) = storage::save_revocation_set(&rebuilding, id_dir.as_deref()).await {
-                                    tracing::warn!("failed to persist revocation set: {e}");
+                                match persisted_bytes {
+                                    Ok(bytes) => {
+                                        if let Err(e) = storage::save_revocation_set_bytes(
+                                            bytes,
+                                            id_dir.as_deref(),
+                                        )
+                                        .await
+                                        {
+                                            tracing::warn!(
+                                                "failed to persist revocation set: {e}"
+                                            );
+                                        }
+                                    }
+                                    Err(e) => tracing::warn!(
+                                        "failed to encode revocation set for persistence: {e}"
+                                    ),
                                 }
                             });
                             // Evict revoked subjects from discovery caches.
@@ -6162,6 +6231,7 @@ impl Agent {
                     reachable_via: announcement.reachable_via.clone(),
                     relay_candidates: announcement.relay_candidates.clone(),
                     cert_not_after,
+                    agent_certificate: announcement.agent_certificate.clone(),
                 };
                 upsert_discovered_machine_from_agent(&machine_cache, &discovered_agent).await;
                 upsert_discovered_agent(&cache, discovered_agent).await;
@@ -7474,6 +7544,7 @@ impl Agent {
                                     .agent_certificate
                                     .as_ref()
                                     .and_then(|c| c.not_after()),
+                                agent_certificate: ann.agent_certificate.clone(),
                             };
                             upsert_discovered_machine_from_agent(&machine_cache, &discovered_agent)
                                 .await;
@@ -7509,6 +7580,7 @@ impl Agent {
                     reachable_via: Vec::new(),
                     relay_candidates: Vec::new(),
                     cert_not_after: None,
+                    agent_certificate: None,
                 },
             )
             .await;
@@ -7916,12 +7988,12 @@ impl Agent {
                 );
 
                 // Verify AgentId→MachineId binding against identity discovery cache.
-                let verified = {
+                let (verified, cert_not_after) = {
                     let cache = discovery_cache.read().await;
                     cache
                         .get(&sender)
-                        .map(|entry| entry.machine_id == machine_id)
-                        .unwrap_or(false)
+                        .map(|entry| (entry.machine_id == machine_id, entry.cert_not_after))
+                        .unwrap_or((false, None))
                 };
 
                 // Evaluate trust for the (AgentId, MachineId) pair.
@@ -7983,6 +8055,25 @@ impl Agent {
                     );
                     continue;
                 }
+                // Enforcement — runtime cert-expiry gate (issue #191). EP1
+                // drops expired announcements at ingest, but a previously
+                // cached entry is never re-checked on the live path; without
+                // this an expired peer stays trusted until TTL eviction. Fail
+                // closed: drop + count, mirroring the revoked EP above.
+                // Absent expiry (None) is fail-open — is_expired returns false
+                // for pre-#130 peers that carry no not_after.
+                if identity::is_expired(cert_not_after, Agent::unix_timestamp_secs()) {
+                    dm.record_incoming_dropped_expired();
+                    tracing::info!(
+                        target: "x0x::direct",
+                        stage = "recv",
+                        sender_prefix = %network::hex_prefix(&sender.0, 4),
+                        machine_prefix = %network::hex_prefix(&machine_id.0, 4),
+                        outcome = "drop_expired",
+                        "direct message from sender with expired cert dropped (runtime expiry gate, issue #191)"
+                    );
+                    continue;
+                }
 
                 // Register and mark the sender as connected for future reverse direct sends.
                 dm.mark_connected(sender, machine_id).await;
@@ -8029,13 +8120,20 @@ impl Agent {
         agent_id: &identity::AgentId,
         protocol: streams::StreamProtocol,
     ) -> error::NetworkResult<streams::PeerStream> {
-        let machine_id = {
+        let (machine_id, cert_not_after) = {
             let cache = self.identity_discovery_cache.read().await;
-            cache.get(agent_id).map(|entry| entry.machine_id)
+            cache
+                .get(agent_id)
+                .map(|entry| (entry.machine_id, entry.cert_not_after))
+                .ok_or(error::NetworkError::PeerNotVerified {
+                    agent_id: agent_id.0,
+                })?
         };
-        let machine_id = machine_id.ok_or(error::NetworkError::PeerNotVerified {
-            agent_id: agent_id.0,
-        })?;
+        // Runtime cert-expiry gate (issue #191): EP1 drops expired
+        // announcements at ingest but never re-checks a cached entry on the
+        // live path. Absent expiry (None) is fail-open — is_expired returns
+        // false, preserving compatibility with pre-#130 peers.
+        let expired = identity::is_expired(cert_not_after, Self::unix_timestamp_secs());
 
         let trust_decision = {
             let contacts = self.contact_store.read().await;
@@ -8052,7 +8150,13 @@ impl Agent {
                 revoked.is_machine_revoked(&machine_id),
             )
         };
-        streams::stream_gate(agent_id, trust_decision, revoked_agent, revoked_machine)?;
+        streams::stream_gate(
+            agent_id,
+            trust_decision,
+            revoked_agent,
+            revoked_machine,
+            expired,
+        )?;
 
         let network = self
             .network
@@ -8131,16 +8235,16 @@ impl Agent {
                 // stream (fail-closed, #192). Each lock is taken in its own
                 // scope so no two identity locks are held at once
                 // (evict_revoked_subject takes them in a different order).
-                let agents: Vec<identity::AgentId> = {
+                let agents: Vec<(identity::AgentId, Option<u64>)> = {
                     let cache = discovery_cache.read().await;
-                    let mut found: Vec<identity::AgentId> = cache
+                    let mut found: Vec<(identity::AgentId, Option<u64>)> = cache
                         .values()
                         .filter(|a| a.machine_id == machine_id)
-                        .map(|a| a.agent_id)
+                        .map(|a| (a.agent_id, a.cert_not_after))
                         .collect();
                     // Deterministic order so logging / per-peer concurrency
                     // keying are stable across HashMap iteration orders.
-                    found.sort_by_key(|a| a.0);
+                    found.sort_by_key(|(a, _)| a.0);
                     found
                 };
                 if agents.is_empty() {
@@ -8152,8 +8256,12 @@ impl Agent {
                     );
                     continue;
                 }
+                let now_secs = Agent::unix_timestamp_secs();
                 let mut gate_denied: Option<(identity::AgentId, error::NetworkError)> = None;
-                for agent_id in &agents {
+                for (agent_id, cert_not_after) in &agents {
+                    // Runtime cert-expiry gate (issue #191): a cached entry
+                    // whose cert has expired must be refused on the live path.
+                    let expired = identity::is_expired(*cert_not_after, now_secs);
                     let trust_decision = {
                         let contacts = contact_store.read().await;
                         let evaluator = trust::TrustEvaluator::new(&contacts);
@@ -8174,6 +8282,7 @@ impl Agent {
                         trust_decision,
                         revoked_agent,
                         revoked_machine,
+                        expired,
                     ) {
                         gate_denied = Some((*agent_id, e));
                         break;
@@ -8191,6 +8300,11 @@ impl Agent {
                     );
                     continue;
                 }
+
+                // Gate cleared for every agent — drop the expiry metadata and
+                // keep the ordered agent list for the stream handle.
+                let agents: Vec<identity::AgentId> =
+                    agents.into_iter().map(|(a, _)| a).collect();
 
                 // DISPATCH (DoS hardening, issue #132): the protocol-prefix
                 // read + surfacing run in a per-stream task so a peer that
@@ -11548,6 +11662,93 @@ mod tests {
         );
     }
 
+    /// Issue #191 gap 2: a gossiped **issuer-revocation** (a user un-vouching
+    /// a certified agent) MUST propagate over gossip. The gossip wire carries
+    /// bare `RevocationRecord`s (no certs), so the receiver resolves the
+    /// subject cert from its discovery cache — via `collect_subject_certs`,
+    /// the exact lookup the gossip-receive loop now performs — and passes it
+    /// to `verify_and_insert`. Pre-fix the loop passed `None`, and
+    /// `verify_authority` rejects an issuer-revocation without a cert, so only
+    /// self-revocations ever propagated network-wide.
+    #[test]
+    fn issuer_revocation_propagates_over_gossip_via_cache_cert_lookup() {
+        let user = identity::UserKeypair::generate().unwrap();
+        let issued_agent = identity::AgentKeypair::generate().unwrap();
+        let agent_id = issued_agent.agent_id();
+        // The user vouches for the agent — this cert is what authorizes a
+        // later issuer-revocation (verify_authority checks the issuer key is
+        // the certifying user).
+        let cert = identity::AgentCertificate::issue(&user, &issued_agent).unwrap();
+
+        // Seed the discovery cache exactly as EP1 does on a real announcement:
+        // the cert is retained so a gossiped issuer-revocation can be verified.
+        let mut cache = std::collections::HashMap::new();
+        cache.insert(
+            agent_id,
+            DiscoveredAgent {
+                agent_id,
+                machine_id: identity::MachineId([0u8; 32]),
+                user_id: None,
+                addresses: Vec::new(),
+                announced_at: 0,
+                last_seen: 0,
+                machine_public_key: Vec::new(),
+                nat_type: None,
+                can_receive_direct: None,
+                is_relay: None,
+                is_coordinator: None,
+                reachable_via: Vec::new(),
+                relay_candidates: Vec::new(),
+                cert_not_after: cert.not_after(),
+                agent_certificate: Some(cert.clone()),
+            },
+        );
+
+        // The gossip-receive path resolves subject certs from the cache.
+        let subject_certs = collect_subject_certs(&cache);
+        let looked_up = subject_certs
+            .get(&agent_id)
+            .expect("the cache lookup must find the subject cert");
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // The user revokes the agent it vouched for (issuer-revocation).
+        let record = revocation::RevocationRecord::sign(
+            revocation::RevokedSubject::Agent(agent_id),
+            user.public_key(),
+            user.secret_key(),
+            now,
+            Some("issuer revokes compromised agent".to_string()),
+        )
+        .unwrap();
+
+        // With the cache-resolved cert, the issuer-revocation verifies +
+        // inserts (the post-fix gossip behavior).
+        let mut set = revocation::RevocationSet::new();
+        assert!(
+            set.verify_and_insert(record.clone(), Some(looked_up))
+                .unwrap(),
+            "issuer-revocation must verify and insert with the cache-resolved cert"
+        );
+        assert!(
+            set.is_agent_revoked(&agent_id),
+            "the agent must now be revoked network-wide"
+        );
+
+        // Pre-fix proof: without the cert (the old `None` gossip path), an
+        // issuer-revocation is REJECTED by verify_authority — which is exactly
+        // why issuer-revocations were inert over gossip before this fix.
+        assert!(
+            revocation::RevocationSet::new()
+                .verify_and_insert(record, None)
+                .is_err(),
+            "an issuer-revocation must be rejected without the subject cert \
+             (the pre-fix gossip behavior this closes)"
+        );
+    }
+
     /// An announcement without NAT fields (as produced by old nodes) should still
     /// deserialise correctly via bincode — new fields are `Option` so `None` (0x00)
     /// is a valid encoding.
@@ -12122,6 +12323,7 @@ fn discovered_agent_fixture(
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     }
 }
 

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -163,6 +163,7 @@ pub fn presence_record_to_discovered_agent(
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     })
 }
 
@@ -745,6 +746,7 @@ mod tests {
             reachable_via: Vec::new(),
             relay_candidates: Vec::new(),
             cert_not_after: None,
+            agent_certificate: None,
         }
     }
 

--- a/src/server/routes/identity.rs
+++ b/src/server/routes/identity.rs
@@ -649,6 +649,7 @@ pub(in crate::server) async fn import_agent_card(
                 reachable_via: Vec::new(),
                 relay_candidates: Vec::new(),
                 cert_not_after: None,
+                agent_certificate: None,
             })
             .await;
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -700,6 +700,23 @@ pub async fn save_revocation_set(set: &RevocationSet, identity_dir: Option<&Path
     write_private_file(&path, bytes).await
 }
 
+/// Persist pre-encoded revocation-set bytes to disk (issue #191).
+///
+/// Companion to [`save_revocation_set`] for the gossip-receive path, which
+/// snapshots the live set's [`to_bytes`](RevocationSet::to_bytes) output under
+/// a brief read lock and writes it off-lock. This preserves issuer-
+/// revocations' authorizing certificates (carried in `PersistedRevocation`)
+/// — the previous rebuild re-inserted records with `None` cert and silently
+/// dropped every issuer-revocation on save.
+pub async fn save_revocation_set_bytes(bytes: Vec<u8>, identity_dir: Option<&Path>) -> Result<()> {
+    let Some(path) = revocation_path(identity_dir) else {
+        return Err(IdentityError::Storage(std::io::Error::other(
+            "no home directory and no identity_dir — cannot persist revocations",
+        )));
+    };
+    write_private_file(&path, bytes).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -98,28 +98,41 @@ impl StreamAccept {
 
 /// Identity gate decision shared by the outbound open and inbound accept
 /// paths (issue #132 T1). Pure function of the resolved inputs so the whole
-/// verified/trust/revoked matrix is fast unit-testable without a network.
+/// verified/trust/revoked/expired matrix is fast unit-testable without a
+/// network.
 ///
-/// Callers resolve `(trust_decision, revoked_agent, revoked_machine)` from the
-/// discovery cache / contact store / revocation set first; a missing identity
-/// (unknown agent or machine) is surfaced as [`NetworkError::PeerNotVerified`]
+/// Callers resolve `(trust_decision, revoked_agent, revoked_machine, expired)`
+/// from the discovery cache / contact store / revocation set first; a missing
+/// identity (unknown agent or machine) is surfaced as [`NetworkError::PeerNotVerified`]
 /// by the caller before reaching this helper.
 ///
 /// # Gate order (do not reorder — security property)
 /// 1. revoked (agent OR machine) ⇒ [`NetworkError::PeerRevoked`]. Revocation
 ///    is positive knowledge of compromise and supersedes trust; checking it
 ///    first also avoids revealing trust state to a revoked peer.
-/// 2. `trust_decision != Some(Accept)` ⇒ [`NetworkError::PeerTrustRejected`].
+/// 2. `expired` (cached `cert_not_after` past expiry + skew) ⇒
+///    [`NetworkError::PeerNotVerified`]. EP1 drops expired announcements at
+///    ingest, but a previously-cached entry is never re-checked on the live
+///    path; without this an expired peer stays trusted until TTL eviction
+///    (issue #191). Absent expiry (`cert_not_after == None`, pre-#130 peers)
+///    is fail-open — callers pass `expired == false`.
+/// 3. `trust_decision != Some(Accept)` ⇒ [`NetworkError::PeerTrustRejected`].
 ///    Mirrors exec + the connect gate: `AcceptWithFlag` and `None` both deny.
 pub(crate) fn stream_gate(
     agent_id: &crate::identity::AgentId,
     trust_decision: Option<crate::trust::TrustDecision>,
     revoked_agent: bool,
     revoked_machine: bool,
+    expired: bool,
 ) -> NetworkResult<()> {
     use crate::trust::TrustDecision;
     if revoked_agent || revoked_machine {
         return Err(NetworkError::PeerRevoked {
+            agent_id: agent_id.0,
+        });
+    }
+    if expired {
+        return Err(NetworkError::PeerNotVerified {
             agent_id: agent_id.0,
         });
     }
@@ -338,22 +351,22 @@ mod tests {
         let reject = Some(TrustDecision::RejectBlocked);
 
         // Happy path: trusted + clean.
-        assert!(stream_gate(&agent, accept, false, false).is_ok());
+        assert!(stream_gate(&agent, accept, false, false, false).is_ok());
 
         // Revocation supersedes trust — even an Accept+trusted peer is refused,
         // and the error is PeerRevoked regardless of trust.
         assert!(matches!(
-            stream_gate(&agent, accept, true, false),
+            stream_gate(&agent, accept, true, false, false),
             Err(NetworkError::PeerRevoked { agent_id }) if agent_id == agent.0
         ));
         assert!(matches!(
-            stream_gate(&agent, accept, false, true),
+            stream_gate(&agent, accept, false, true, false),
             Err(NetworkError::PeerRevoked { .. })
         ));
         // A revoked + untrusted peer surfaces PeerRevoked, NOT the trust
         // reason (no trust-state leak to a compromised key).
         assert!(matches!(
-            stream_gate(&agent, reject, true, false),
+            stream_gate(&agent, reject, true, false, false),
             Err(NetworkError::PeerRevoked { .. })
         ));
 
@@ -361,11 +374,44 @@ mod tests {
         for decision in [accept_with_flag, reject, None] {
             assert!(
                 matches!(
-                    stream_gate(&agent, decision, false, false),
+                    stream_gate(&agent, decision, false, false, false),
                     Err(NetworkError::PeerTrustRejected { agent_id }) if agent_id == agent.0
                 ),
                 "decision {decision:?} must deny (only plain Accept passes)"
             );
         }
+    }
+    // Issue #191 gap 1: a cached peer whose agent certificate has expired
+    // past `not_after` MUST be refused at the runtime stream gate, even when
+    // it is trusted (Accept) and not revoked. Pre-fix `stream_gate` took no
+    // expiry input and returned `Ok` for this case — an expired peer stayed
+    // trusted until TTL eviction. Absent expiry (None → caller passes
+    // `expired == false`) stays fail-open for pre-#130 peers.
+    #[test]
+    fn stream_gate_rejects_expired_cert() {
+        use crate::error::NetworkError;
+        use crate::identity::AgentId;
+        use crate::trust::TrustDecision;
+
+        let agent = AgentId([9u8; 32]);
+        let accept = Some(TrustDecision::Accept);
+
+        // Expired + trusted + clean ⇒ denied as PeerNotVerified (the binding
+        // is no longer trustworthy once its cert has expired).
+        assert!(matches!(
+            stream_gate(&agent, accept, false, false, true),
+            Err(NetworkError::PeerNotVerified { agent_id }) if agent_id == agent.0
+        ));
+
+        // Not expired (present-and-valid, or absent) ⇒ the gate passes for a
+        // trusted, clean peer — fail-open on absent expiry is preserved.
+        assert!(stream_gate(&agent, accept, false, false, false).is_ok());
+
+        // Revocation still supersedes expiry: a revoked-and-expired peer is
+        // reported as PeerRevoked (no trust-state leak, consistent order).
+        assert!(matches!(
+            stream_gate(&agent, accept, true, false, true),
+            Err(NetworkError::PeerRevoked { agent_id }) if agent_id == agent.0
+        ));
     }
 }

--- a/tests/announcement_test.rs
+++ b/tests/announcement_test.rs
@@ -409,6 +409,7 @@ async fn discovery_cache_insert_and_retrieve() {
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     };
 
     agent
@@ -457,6 +458,7 @@ async fn reachability_info_from_discovery_cache() {
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     };
 
     agent.insert_discovered_agent_for_testing(fake).await;

--- a/tests/connectivity_test.rs
+++ b/tests/connectivity_test.rs
@@ -54,6 +54,7 @@ fn fake_discovered(
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     }
 }
 

--- a/tests/direct_messaging_integration.rs
+++ b/tests/direct_messaging_integration.rs
@@ -56,6 +56,7 @@ fn discovered_agent(agent: &Agent, addr: std::net::SocketAddr, now_secs: u64) ->
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     }
 }
 

--- a/tests/identity_announcement_integration.rs
+++ b/tests/identity_announcement_integration.rs
@@ -413,6 +413,7 @@ fn fake_agent_with_timestamps(announced_at: u64, last_seen: u64) -> DiscoveredAg
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     }
 }
 

--- a/tests/peer_relay_integration.rs
+++ b/tests/peer_relay_integration.rs
@@ -83,6 +83,7 @@ fn discovered_for(agent: &Agent, addr: std::net::SocketAddr, now_secs: u64) -> D
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     }
 }
 

--- a/tests/presence_wiring_test.rs
+++ b/tests/presence_wiring_test.rs
@@ -166,6 +166,7 @@ async fn test_online_agents_uses_presence_beacon_liveness() -> Result<(), Box<dy
             reachable_via: Vec::new(),
             relay_candidates: Vec::new(),
             cert_not_after: None,
+            agent_certificate: None,
         })
         .await;
 

--- a/tests/proptest_presence.rs
+++ b/tests/proptest_presence.rs
@@ -74,6 +74,7 @@ proptest! {
                 reachable_via: Vec::new(),
                 relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
             },
         );
 

--- a/tests/tailnet_streams_integration.rs
+++ b/tests/tailnet_streams_integration.rs
@@ -83,6 +83,7 @@ fn discovered_agent(
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     }
 }
 

--- a/tests/x0x_0041_prefer_newest_test.rs
+++ b/tests/x0x_0041_prefer_newest_test.rs
@@ -85,6 +85,7 @@ fn discovered_agent(agent: &Agent, addr: std::net::SocketAddr, now_secs: u64) ->
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     }
 }
 

--- a/tests/x0x_0041_synthetic_kill_restart.rs
+++ b/tests/x0x_0041_synthetic_kill_restart.rs
@@ -254,6 +254,7 @@ async fn synthetic_kill_restart_lands_on_new_connection_within_500ms() {
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     };
     alice.insert_discovered_agent_for_testing(bob_card).await;
     alice
@@ -278,6 +279,7 @@ async fn synthetic_kill_restart_lands_on_new_connection_within_500ms() {
         reachable_via: Vec::new(),
         relay_candidates: Vec::new(),
         cert_not_after: None,
+        agent_certificate: None,
     };
     bob.insert_discovered_agent_for_testing(alice_card).await;
 


### PR DESCRIPTION
Closes #191.

From the 2026-07-07 security review of the v0.28/v0.29 key-lifecycle surface (#130). Three MEDIUM enforcement gaps — revocation is correctly fail-closed on every live path, but the lifecycle had these holes. All three are fixed here in one coherent, fail-closed pass: **on any uncertainty (missing cert, unverifiable revocation state, expired cert) the path denies, never allows.** Surgical — only the lifecycle/revocation enforcement paths and their tests are touched.

## Gap 1 — runtime expiry gate was dead code
**Fix.** `is_expired()` was enforced only at announcement ingest (EP1); no live acceptance path re-evaluated `cert_not_after`, so an expired peer stayed trusted until TTL eviction (and EP1 dropping expired re-announcements *preserved* the stale cache entry). Wired the expiry half into the live gates:
- `streams::stream_gate` gains an `expired` input (checked after revoked, before trust → `PeerNotVerified`), consumed by both `open_peer_stream` and the inbound stream accept loop.
- The direct-DM listener adds a fail-closed expiry deny (new `incoming_dropped_expired` diagnostic), mirroring the #179 revoked EP.
- Absent expiry (`None`) stays fail-open for pre-#130 peers.

**Proving test.** `stream_gate_rejects_expired_cert` — an expired cert is denied at the runtime gate even when trusted and not revoked; revoked still supersedes expired.

## Gap 2 — issuer revocations were inert over gossip
**Fix.** The gossip revocation-batch loop called `verify_and_insert(record, None)` unconditionally; `verify_authority` rejects an issuer-revocation (a user un-vouching a certified agent) without the subject cert, so only self-revocations propagated network-wide.
- `DiscoveredAgent` now retains `agent_certificate` (populated at the EP1 announcement handler). `collect_subject_certs` resolves the subject cert from the discovery cache and the gossip loop passes it to `verify_and_insert` (built before the revocation-set write lock — no nested identity locks).
- The gossip persistence path is rewritten to snapshot the live set's `to_bytes()` (which carries `PersistedRevocation` certs) off-lock. The old rebuild re-inserted records with `None` cert and silently dropped **every** issuer-revocation on save — a latent bug that only manifested once issuer-revocations could actually insert. New `storage::save_revocation_set_bytes`.

**Proving test.** `issuer_revocation_propagates_over_gossip_via_cache_cert_lookup` — with the cache-resolved cert the issuer-revocation verifies+inserts (agent revoked network-wide); without the cert (`None`, the pre-fix gossip path) it is rejected.

## Gap 3 — pubsub bypassed the RevocationSet
**Fix.** `decode_for_delivery` checked `ContactStore::is_revoked` (operator-local) + `trust == Blocked`, never `RevocationSet::is_agent_revoked` (the #130 gossiped set). A gossiped revocation reached delivery only once the eviction loop set `trust = Blocked` — a race, or a later `set_trust` off Blocked, reopened delivery from a revoked sender.
- `PubSubManager` gains a `revocation_set` handle (`set_revocation_set`, wired via `Agent::set_contacts` alongside contacts); `decode_for_delivery` consults the authoritative `RevocationSet` **before** the operator-local `ContactStore`.

**Proving test.** `decode_for_delivery_drops_revoked_sender_via_revocation_set` — a verified v2 payload from a `RevocationSet`-revoked sender is dropped (contacts = `None` isolates the check); a non-revoked sender is delivered.

## Validation
`just check` fully green:
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings` (no warnings)
- `cargo nextest run --all-features --workspace` — **2082 passed, 0 failed** (217 skipped)
- `cargo doc --all-features --no-deps` builds

No `unwrap`/`expect`/`panic` in production code. `RUSTFLAGS="-D warnings"` standard.

## Out of scope
The issue's finding #6 (EP4 group-metadata + relay-DM agent-only revocation, "extends #184") is intentionally **not** included — it is a separate machine-revocation-parity concern outside this PR's three-gap scope.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens key-lifecycle enforcement across live networking paths. The main changes are:

- Runtime stream and direct-message gates now check cached certificate expiry.
- Gossip issuer revocations now resolve subject certificates from discovery cache.
- Revocation persistence now saves the encoded live set snapshot.
- Pubsub delivery now consults the authoritative gossiped revocation set.
- Tests and diagnostics were added for the new enforcement paths.

<h3>Confidence Score: 4/5</h3>

The key-lifecycle changes need fixes around certificate cache freshness before merging.

- Renewed certificates can still be denied because live gates read stale cached expiry.
- Issuer revocations can be dropped when revocation gossip arrives before the subject certificate is cached.
- The rest of the revocation and pubsub wiring is mostly contained and follows the intended fail-closed direction.

src/lib.rs

<details open><summary><h3>Security Review</h3></summary>

The PR strengthens revocation and expiry enforcement, but two security-sensitive lifecycle gaps remain: renewed cert expiry can stay stale in the cache, and an issuer revocation can be dropped if it races ahead of the subject certificate announcement.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib.rs | Adds the main certificate-retention, revocation-gossip, persistence, and runtime expiry wiring; the changed paths can still use stale or missing cert cache state. |
| src/streams.rs | Adds the expired input to the stream gate and preserves revoked-before-expired ordering. |
| src/gossip/pubsub.rs | Adds RevocationSet injection and delivery-time sender revocation filtering. |
| src/storage.rs | Adds a helper for writing pre-encoded revocation-set bytes. |
| src/direct.rs | Adds diagnostics for direct messages dropped due to expired cached certificates. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib.rs:8151
**Stale Certificate Expiry**

When a peer renews its agent certificate, the cache merge path does not refresh `cert_not_after` or `agent_certificate` on the existing `DiscoveredAgent`. This new runtime gate then keeps checking the old expiry, so a valid renewed peer can be denied for streams and direct messages after the first cached certificate expires.

### Issue 2 of 2
src/lib.rs:5992
**Revocation Beats Certificate Cache**

This snapshots subject certificates once before processing the gossip batch, and an issuer revocation with no cached cert is rejected and not retried. If the revocation gossip arrives just before the subject's cert-bearing announcement is inserted, the valid revocation is dropped permanently on this node, leaving the revoked agent accepted until the revocation is gossiped again.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): key-lifecycle enforcement..."](https://github.com/saorsa-labs/x0x/commit/584e781e959fc802f4d41a406ca97fea001d58ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42692485)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->