### PR TITLE
fix(groups): strip TreeKEM key packages from invite links + member-keyed kp catch-up (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Strip TreeKEM KeyPackages from invite links + on-demand key-package catch-up ([#205](https://github.com/saorsa-labs/x0x/issues/205), fixes [#188](https://github.com/saorsa-labs/x0x/issues/188)).** `private_secure` invite links embedded the full roster including each member's ~15.7 KiB TreeKEM KeyPackage + ~1.2 KiB ML-KEM public key. The join cmd-DM crossed the 49 152-byte gossip cap at the 3rd roster member, so every later joiner's invite was rejected at the sender with `envelope_construction` and the joiner never joined (issue #188 root cause). Key packages commit nothing to invite validation — `roster_root` covers only `(id, role, state)` triples and the link is unsigned — so they are now stripped at mint in `populate_invite_base_state_from_group_info`, dropping the failing 3-member cmd-DM from ~63 KiB to ~6.5 KiB (the cap is not crossed until ~140 members). A mint-time budget (`INVITE_LINK_MAX_BYTES` = 40 KiB, enforced by `SignedInvite::encode_link`) fails loudly at `/groups/:id/invite` instead of as a later cross-node 400. The `signable_bytes` domain tag bumps `v2`→`v3`. Backward compatible both directions: the fields are `#[serde(default)]`, so old kp-bearing links still parse and old daemons reading stripped links see `None`.
+
+  Closes a regression the stripping introduces: a joiner later promoted to Admin cannot remove/ban a member whose key package it never learned (the `MemberJoined` apply is inviter-only and the authority-signed `MemberAdded` carries no package). On the `FAILED_DEPENDENCY` path, `remove`/`ban` now recover the target's package from a member-keyed cache of self-signed `MemberJoined` events, authenticated by re-verifying the joiner's ML-DSA-65 signature; on a local miss they fire a member-keyed TreeKEM catch-up request (extending `handle_treekem_catchup_request` with a `target_member_id`, reusing the existing verified-DM / active-member / 5 s-throttle gates) and return a retryable `member_key_package_pending`. The TreeKEM-join dogfood assertion is required again (all runners must join).
+
 ## [v0.29.0] - 2026-07-07
 
 ### Added

--- a/src/groups/invite.rs
+++ b/src/groups/invite.rs
@@ -18,6 +18,17 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Default invite expiry: 7 days in seconds.
 pub const DEFAULT_EXPIRY_SECS: u64 = 7 * 24 * 60 * 60;
 
+/// Safe upper bound on an encoded invite link.
+///
+/// The gossip-inbox DM path caps user payloads at
+/// [`crate::dm::MAX_PAYLOAD_BYTES`] (49 152). Invite links travel as the bulk
+/// of the `group_join` cmd-DM, so a link near that cap guarantees the DM is
+/// rejected at the sender with `envelope_construction` (issue #188). 40 KiB
+/// leaves room for the cmd-DM envelope wrapper while flagging roster growth at
+/// the mint site instead of as a mysterious cross-node 400. See issues #188 /
+/// #205.
+pub const INVITE_LINK_MAX_BYTES: usize = 40 * 1024;
+
 /// A signed invite token for joining a group.
 ///
 /// Tokens are serialized to base64url for sharing via email, chat, QR codes, etc.
@@ -85,6 +96,31 @@ pub struct SignedInvite {
     /// (hex-encoded). Currently not validated by the join flow.
     pub signature: String,
 }
+/// Error returned when an encoded invite link exceeds the safe DM budget.
+///
+/// Carries the measured and limit sizes so callers can surface a structured
+/// error at the mint site (issue #205) instead of letting the link 400 later
+/// at `/direct/send` with an opaque `envelope_construction`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InviteLinkTooLarge {
+    /// Measured encoded link length in bytes.
+    pub actual: usize,
+    /// Budget enforced by [`INVITE_LINK_MAX_BYTES`].
+    pub limit: usize,
+}
+
+impl std::fmt::Display for InviteLinkTooLarge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "encoded invite link ({} B) exceeds safe DM budget ({} B); \
+             strip key packages or slim the roster before minting",
+            self.actual, self.limit
+        )
+    }
+}
+
+impl std::error::Error for InviteLinkTooLarge {}
 
 impl SignedInvite {
     /// Create a new invite (without signature — call `sign()` separately).
@@ -141,7 +177,7 @@ impl SignedInvite {
     #[must_use]
     pub fn signable_bytes(&self) -> Vec<u8> {
         let mut data = Vec::new();
-        data.extend_from_slice(b"x0x.invite.v2|");
+        data.extend_from_slice(b"x0x.invite.v3|");
         data.extend_from_slice(self.group_id.as_bytes());
         data.extend_from_slice(self.stable_group_id.as_deref().unwrap_or("").as_bytes());
         data.extend_from_slice(&self.group_created_at.unwrap_or_default().to_le_bytes());
@@ -277,6 +313,26 @@ impl SignedInvite {
         use base64::Engine;
         let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes());
         format!("x0x://invite/{b64}")
+    }
+
+    /// Encode this invite as a shareable link, rejecting oversized payloads.
+    ///
+    /// Wraps [`Self::to_link`] with the [`INVITE_LINK_MAX_BYTES`] budget check
+    /// so a roster that would blow the gossip-DM cap fails loudly at the mint
+    /// site (issue #205) rather than 400-ing later at `/direct/send`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InviteLinkTooLarge`] when the encoded link exceeds the budget.
+    pub fn encode_link(&self) -> Result<String, InviteLinkTooLarge> {
+        let link = self.to_link();
+        if link.len() > INVITE_LINK_MAX_BYTES {
+            return Err(InviteLinkTooLarge {
+                actual: link.len(),
+                limit: INVITE_LINK_MAX_BYTES,
+            });
+        }
+        Ok(link)
     }
 
     /// Parse an invite from a link string.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -878,6 +878,7 @@ pub async fn serve_with_options(
         pending_welcome_acks: RwLock::new(HashMap::new()),
         treekem_pending_events: RwLock::new(HashMap::new()),
         treekem_event_log: RwLock::new(HashMap::new()),
+        treekem_member_key_packages: RwLock::new(HashMap::new()),
         treekem_catchup_throttle: RwLock::new(HashMap::new()),
         group_membership_locks: RwLock::new(HashMap::new()),
         treekem_groups: RwLock::new(treekem_groups),
@@ -3798,6 +3799,13 @@ struct TreeKemCatchupRequest {
     from_treekem_epoch: u64,
     current_state_hash: String,
     missing_prev_state_hash: Option<String>,
+    /// Issue #205: when set, this is a member-keyed key-package fetch — the
+    /// responder returns the cached, self-signed `MemberJoined` for this member
+    /// (carrying its TreeKEM KeyPackage) instead of the revision-gap frontier.
+    /// Backward compatible: old daemons ignore the field and serve the normal
+    /// frontier; `#[serde(default)]` lets new daemons parse old requests.
+    #[serde(default)]
+    target_member_id: Option<String>,
     limit: usize,
 }
 
@@ -5823,6 +5831,240 @@ async fn remember_treekem_membership_event(state: &AppState, event: &NamedGroupM
     }
 }
 
+/// Extract the member-keyed cache entry (`join_result_key`, event) from a
+/// key-package-bearing `MemberJoined`. Returns `None` for non-`MemberJoined`
+/// events or those without an embedded key package. Used by
+/// [`apply_named_group_metadata_event`] to populate
+/// [`AppState::treekem_member_key_packages`] on the inviter side (issue #205).
+fn member_joined_kp_cache_entry(
+    event: &NamedGroupMetadataEvent,
+) -> Option<(String, NamedGroupMetadataEvent)> {
+    if let NamedGroupMetadataEvent::MemberJoined {
+        group_id,
+        member_agent_id,
+        treekem_key_package_b64: Some(_),
+        ..
+    } = event
+    {
+        Some((join_result_key(group_id, member_agent_id), event.clone()))
+    } else {
+        None
+    }
+}
+
+/// Install a TreeKEM KeyPackage recovered from a cached, self-signed
+/// `MemberJoined` event. The normal `MemberJoined` apply is inviter-only, so a
+/// promoted admin that never witnessed the join learns the target's key package
+/// here. The package is authenticated by re-verifying the joiner's ML-DSA-65
+/// signature over `canonical_member_joined_bytes` (independent of the inviter
+/// gate); the roster/state-commit chain is untouched. Returns `true` only when
+/// a previously-absent package was installed (issue #205).
+async fn apply_recovered_member_key_package(
+    state: &Arc<AppState>,
+    event: &NamedGroupMetadataEvent,
+) -> bool {
+    use base64::Engine as _;
+    let NamedGroupMetadataEvent::MemberJoined {
+        group_id,
+        stable_group_id,
+        member_agent_id,
+        member_public_key_b64,
+        role,
+        display_name,
+        inviter_agent_id,
+        invite_secret,
+        ts_ms,
+        treekem_key_package_b64,
+        signature_b64,
+    } = event
+    else {
+        return false;
+    };
+    let Some(kp_b64) = treekem_key_package_b64.clone() else {
+        return false;
+    };
+    let pubkey_bytes = match BASE64.decode(member_public_key_b64) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    let pubkey = match ant_quic::MlDsaPublicKey::from_bytes(&pubkey_bytes) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let sig_bytes = match BASE64.decode(signature_b64) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    let sig = match ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(&sig_bytes) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let canonical = canonical_member_joined_bytes(
+        group_id,
+        stable_group_id.as_deref(),
+        member_agent_id,
+        member_public_key_b64,
+        *role,
+        display_name.as_deref(),
+        inviter_agent_id,
+        invite_secret,
+        *ts_ms,
+        treekem_key_package_b64.as_deref(),
+    );
+    if ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(&pubkey, &canonical, &sig)
+        .is_err()
+    {
+        tracing::warn!(
+            group_id = %LogHexId::group(group_id),
+            member = %LogHexId::agent(member_agent_id),
+            "recovered MemberJoined key package: signature did not verify — refusing to install"
+        );
+        return false;
+    }
+    // Derived AgentId must match the claimed member.
+    let derived = hex::encode(ant_quic::derive_peer_id_from_public_key(&pubkey).0);
+    if !derived.eq_ignore_ascii_case(member_agent_id) {
+        return false;
+    }
+    // Resolve the local group by storage key (mls_group_id) or stable alias.
+    let storage_key = {
+        let groups = state.named_groups.read().await;
+        groups
+            .get_key_value(group_id)
+            .map(|(k, _)| k.clone())
+            .or_else(|| {
+                groups
+                    .iter()
+                    .find(|(_, info)| info.stable_group_id() == group_id)
+                    .map(|(k, _)| k.clone())
+            })
+    };
+    let Some(storage_key) = storage_key else {
+        return false;
+    };
+    let installed = {
+        let mut groups = state.named_groups.write().await;
+        let Some(info) = groups.get_mut(&storage_key) else {
+            return false;
+        };
+        if !info.has_member(member_agent_id) {
+            return false;
+        }
+        // Never clobber a package we already hold.
+        if info
+            .members_v2
+            .get(member_agent_id)
+            .and_then(|m| m.treekem_key_package_b64.clone())
+            .is_some()
+        {
+            return false;
+        }
+        info.set_member_treekem_key_package(member_agent_id, kp_b64.clone());
+        true
+    };
+    if installed {
+        save_named_groups(state).await;
+        let mut cache = state.treekem_member_key_packages.write().await;
+        cache.insert(join_result_key(group_id, member_agent_id), event.clone());
+    }
+    installed
+}
+
+/// On-demand TreeKEM KeyPackage recovery for a promoted admin missing a
+/// member's package (issue #205). If the roster already carries it, this is a
+/// no-op success; otherwise it looks up this node's cached, self-signed
+/// `MemberJoined` for the member and installs its (signature-verified) package.
+/// Returns `true` when the roster now carries the package.
+async fn recover_member_treekem_key_package(
+    state: &Arc<AppState>,
+    group_id: &str,
+    member_agent_id: &str,
+) -> bool {
+    {
+        let groups = state.named_groups.read().await;
+        if let Some(info) = groups.get(group_id) {
+            if info
+                .members_v2
+                .get(member_agent_id)
+                .and_then(|m| m.treekem_key_package_b64.clone())
+                .is_some()
+            {
+                return true;
+            }
+        }
+    }
+    let key = join_result_key(group_id, member_agent_id);
+    let cached = {
+        let cache = state.treekem_member_key_packages.read().await;
+        cache.get(&key).cloned()
+    };
+    let Some(event) = cached else {
+        return false;
+    };
+    apply_recovered_member_key_package(state, &event).await
+}
+
+/// Resolve a target member's TreeKEM KeyPackage (base64) for a verified
+/// removal/ban, recovering it on demand (issue #205) when the local roster
+/// lacks it. Caller must have already enforced admin authority. On a local
+/// recovery miss it fires an async member-keyed catch-up so a client retry
+/// succeeds after delivery, and returns `FAILED_DEPENDENCY` with `retry: true`.
+async fn resolve_member_treekem_kp_for_removal(
+    state: &Arc<AppState>,
+    group_id: &str,
+    agent_id_hex: &str,
+) -> Result<String, (StatusCode, Json<serde_json::Value>)> {
+    let existing = {
+        let groups = state.named_groups.read().await;
+        groups
+            .get(group_id)
+            .or_else(|| {
+                groups
+                    .values()
+                    .find(|info| info.stable_group_id() == group_id)
+            })
+            .and_then(|info| info.members_v2.get(agent_id_hex))
+            .and_then(|m| m.treekem_key_package_b64.clone())
+    };
+    if let Some(kp_b64) = existing {
+        return Ok(kp_b64);
+    }
+    if recover_member_treekem_key_package(state, group_id, agent_id_hex).await {
+        let recovered = {
+            let groups = state.named_groups.read().await;
+            groups
+                .get(group_id)
+                .or_else(|| {
+                    groups
+                        .values()
+                        .find(|info| info.stable_group_id() == group_id)
+                })
+                .and_then(|info| info.members_v2.get(agent_id_hex))
+                .and_then(|m| m.treekem_key_package_b64.clone())
+        };
+        if let Some(kp_b64) = recovered {
+            return Ok(kp_b64);
+        }
+    }
+    // Local recovery miss — request the package from peers that witnessed the
+    // join (fire-and-forget) and tell the client to retry once it lands.
+    let bg_state = Arc::clone(state);
+    let bg_group = group_id.to_string();
+    let bg_member = agent_id_hex.to_string();
+    tokio::spawn(async move {
+        request_member_key_package_catchup(&bg_state, &bg_group, &bg_member).await;
+    });
+    Err((
+        StatusCode::FAILED_DEPENDENCY,
+        Json(serde_json::json!({
+            "ok": false,
+            "error": "member_key_package_pending",
+            "detail": "member is missing TreeKEM KeyPackage; on-demand catch-up requested — retry shortly",
+            "retry": true,
+        })),
+    ))
+}
+
 async fn queue_treekem_membership_event(
     state: &Arc<AppState>,
     group_id: &str,
@@ -5927,6 +6169,7 @@ async fn request_treekem_catchup_for_gap(
             from_treekem_epoch: from_epoch,
             current_state_hash: current_state_hash.clone(),
             missing_prev_state_hash: frontier.commit.prev_state_hash.clone(),
+            target_member_id: None,
             limit: TREEKEM_CATCHUP_RESPONSE_EVENT_CAP,
         };
         let payload = match serde_json::to_vec(&request) {
@@ -6056,6 +6299,42 @@ async fn handle_treekem_catchup_request(
         tracing::warn!(group_id = %LogHexId::group(&request.group_id), requester = %sender_hex, "rejecting unauthorized TreeKEM catch-up request");
         return;
     }
+    // Issue #205: member-keyed TreeKEM KeyPackage fetch. The requester is a
+    // promoted admin missing a member's key package; serve this node's cached,
+    // self-signed `MemberJoined` for the target (this node witnessed the join).
+    // The same gates apply (verified DM, sender == requester, active member or
+    // target-of-cached-add). The requester authenticates the package via the
+    // embedded ML-DSA-65 signature in `apply_recovered_member_key_package`.
+    if let Some(target_member_id) = request.target_member_id.clone() {
+        let event = {
+            let cache = state.treekem_member_key_packages.read().await;
+            log_keys
+                .iter()
+                .find_map(|g| cache.get(&join_result_key(g, &target_member_id)))
+                .cloned()
+        };
+        let response = TreeKemCatchupResponse {
+            message_type: "treekem_catchup_response".to_string(),
+            group_id: request.group_id.clone(),
+            events: event.into_iter().collect(),
+            truncated: false,
+        };
+        let payload = match serde_json::to_vec(&response) {
+            Ok(payload) => payload,
+            Err(e) => {
+                tracing::warn!(group_id = %LogHexId::group(&request.group_id), "failed to serialize member-keyed TreeKEM catch-up response: {e}");
+                return;
+            }
+        };
+        if let Err(e) = state
+            .agent
+            .send_direct_with_config(sender, payload, direct_message_send_config())
+            .await
+        {
+            tracing::warn!(group_id = %LogHexId::group(&request.group_id), requester = %sender_hex, "failed to send member-keyed TreeKEM catch-up response: {e}");
+        }
+        return;
+    }
     let mut events = {
         let logs = state.treekem_event_log.read().await;
         let mut events = Vec::new();
@@ -6112,7 +6391,15 @@ async fn handle_treekem_catchup_response(
     let mut events = response.events;
     events.sort_by_key(treekem_membership_event_sort_key);
     for event in events {
+        // Issue #205: a kp-bearing `MemberJoined` delivered by a member-keyed
+        // catch-up won't apply on a non-inviter (the normal apply is
+        // inviter-only). Clone it before the move so we can signature-verify +
+        // install the target's key package for a promoted admin that lacks it.
+        let recovery_event = member_joined_kp_cache_entry(&event).map(|(_, ev)| ev);
         apply_named_group_metadata_event(state, event, *sender, true).await;
+        if let Some(ev) = recovery_event {
+            apply_recovered_member_key_package(state, &ev).await;
+        }
     }
     replay_pending_treekem_events(state, &response.group_id).await;
     if was_truncated {
@@ -6151,6 +6438,7 @@ async fn request_treekem_catchup_page(state: &Arc<AppState>, group_id: &str, pee
         from_treekem_epoch: from_epoch,
         current_state_hash,
         missing_prev_state_hash: None,
+        target_member_id: None,
         limit: TREEKEM_CATCHUP_RESPONSE_EVENT_CAP,
     };
     let payload = match serde_json::to_vec(&request) {
@@ -6166,6 +6454,100 @@ async fn request_treekem_catchup_page(state: &Arc<AppState>, group_id: &str, pee
         .await
     {
         tracing::debug!(group_id = %group_id, peer = %hex::encode(peer.as_bytes()), "paged TreeKEM catch-up request failed: {e}");
+    }
+}
+
+/// Issue #205: ask peers that witnessed a member's join for that member's
+/// cached, self-signed `MemberJoined` (carrying the TreeKEM KeyPackage) so a
+/// promoted admin missing the package can recover it. Candidates are the
+/// member's recorded inviter (`added_by`) and the group's other active
+/// members; the request is throttled per `{group}:member:{member}:{peer}` with
+/// the same 5 s window as the revision-gap catch-up.
+async fn request_member_key_package_catchup(
+    state: &Arc<AppState>,
+    group_id: &str,
+    member_agent_id: &str,
+) {
+    let local_agent_hex = hex::encode(state.agent.agent_id().as_bytes());
+    let (from_revision, from_epoch, current_state_hash, candidates) = {
+        let groups = state.named_groups.read().await;
+        let Some(info) = groups.get(group_id).or_else(|| {
+            groups
+                .values()
+                .find(|info| info.stable_group_id() == group_id)
+        }) else {
+            return;
+        };
+        if info.withdrawn {
+            return;
+        }
+        // Prefer the inviter (it authored the join), then fall back to every
+        // other active member — any node that applied the MemberJoined has the
+        // cached package.
+        let mut candidate_hexes: Vec<String> = info
+            .members_v2
+            .get(member_agent_id)
+            .and_then(|m| m.added_by.clone())
+            .into_iter()
+            .collect();
+        for (aid, m) in &info.members_v2 {
+            if !aid.eq_ignore_ascii_case(&local_agent_hex)
+                && !candidate_hexes.iter().any(|c| c.eq_ignore_ascii_case(aid))
+                && m.state == x0x::groups::GroupMemberState::Active
+            {
+                candidate_hexes.push(aid.clone());
+            }
+        }
+        (
+            info.state_revision,
+            info.secret_epoch,
+            info.state_hash.clone(),
+            candidate_hexes,
+        )
+    };
+    for candidate_hex in candidates {
+        if candidate_hex.eq_ignore_ascii_case(&local_agent_hex) {
+            continue;
+        }
+        let Ok(peer) = parse_agent_id_hex(&candidate_hex) else {
+            continue;
+        };
+        let throttle_key = format!("{group_id}:member:{member_agent_id}:{candidate_hex}");
+        {
+            let mut throttle = state.treekem_catchup_throttle.write().await;
+            if throttle
+                .get(&throttle_key)
+                .is_some_and(|last| last.elapsed() < TREEKEM_CATCHUP_THROTTLE)
+            {
+                continue;
+            }
+            throttle.insert(throttle_key, Instant::now());
+        }
+        let request = TreeKemCatchupRequest {
+            message_type: "treekem_catchup_request".to_string(),
+            group_id: group_id.to_string(),
+            requester_agent_id: local_agent_hex.clone(),
+            from_revision,
+            from_treekem_epoch: from_epoch,
+            current_state_hash: current_state_hash.clone(),
+            missing_prev_state_hash: None,
+            target_member_id: Some(member_agent_id.to_string()),
+            limit: TREEKEM_CATCHUP_RESPONSE_EVENT_CAP,
+        };
+        let payload = match serde_json::to_vec(&request) {
+            Ok(payload) => payload,
+            Err(e) => {
+                tracing::warn!(group_id = %LogHexId::group(&group_id), member = %LogHexId::agent(&member_agent_id), "failed to serialize member-keyed TreeKEM catch-up request: {e}");
+                continue;
+            }
+        };
+        if let Err(e) = state
+            .agent
+            .send_direct_with_config(&peer, payload, direct_message_send_config())
+            .await
+        {
+            tracing::debug!(group_id = %group_id, member = %LogHexId::agent(&member_agent_id), peer = %candidate_hex, "member-keyed TreeKEM catch-up request failed: {e}");
+        }
     }
 }
 
@@ -6208,7 +6590,21 @@ async fn apply_named_group_metadata_event(
     sender: AgentId,
     verified: bool,
 ) -> bool {
-    apply_named_group_metadata_event_inner(state, event, sender, verified, true).await
+    // Issue #205: a node that authoritatively applies a joiner's self-signed
+    // `MemberJoined` (the inviter) caches the key-package-bearing event so a
+    // later promoted admin — which never sees the join, since `MemberJoined`
+    // apply is inviter-only — can recover the target's TreeKEM KeyPackage via
+    // the member-keyed catch-up protocol. Clone before the move into `inner`.
+    let kp_cache_entry = member_joined_kp_cache_entry(&event);
+    let applied =
+        apply_named_group_metadata_event_inner(state, event, sender, verified, true).await;
+    if applied {
+        if let Some((key, cached)) = kp_cache_entry {
+            let mut cache = state.treekem_member_key_packages.write().await;
+            cache.insert(key, cached);
+        }
+    }
+    applied
 }
 
 async fn apply_named_group_metadata_event_inner(
@@ -8905,7 +9301,31 @@ async fn create_group_invite(
             x0x::groups::GroupRole::Member,
         );
 
-        let link = invite.to_link();
+        // Issue #205: enforce the DM-safe budget at mint so a roster that
+        // would blow the gossip-DM cap fails loudly here, not as an opaque
+        // `envelope_construction` 400 at /direct/send later (issue #188).
+        let link = match invite.encode_link() {
+            Ok(link) => link,
+            Err(e) => {
+                tracing::error!(
+                    group_id = %LogHexId::group(&id),
+                    actual = e.actual,
+                    limit = e.limit,
+                    "refusing to mint oversized invite link: {e}"
+                );
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "ok": false,
+                        "error": "invite_too_large",
+                        "detail": e.to_string(),
+                        "actual_bytes": e.actual,
+                        "limit_bytes": e.limit,
+                    })),
+                )
+                    .into_response();
+            }
+        };
         let mls_group_id = info.mls_group_id.clone();
         let group_name = info.name.clone();
         let expires_at = invite.expires_at;
@@ -10368,7 +10788,7 @@ async fn remove_treekem_named_group_member(
         }
     };
 
-    let (mut next, metadata_topic, event_group_id, target_kp_bytes) = {
+    let (mut next, metadata_topic, event_group_id) = {
         let groups = state.named_groups.read().await;
         let Some(info) = groups.get(&id) else {
             return (
@@ -10392,37 +10812,33 @@ async fn remove_treekem_named_group_member(
         if let Some(resp) = last_admin_precheck(info, |g| g.remove_member(&agent_id_hex, None)) {
             return resp;
         }
-        let Some(kp_b64) = info
-            .members_v2
-            .get(&agent_id_hex)
-            .and_then(|m| m.treekem_key_package_b64.clone())
-        else {
-            return (
-                StatusCode::FAILED_DEPENDENCY,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "member is missing TreeKEM KeyPackage"
-                })),
-            );
-        };
-        let target_kp_bytes = match base64::engine::general_purpose::STANDARD.decode(kp_b64) {
-            Ok(bytes) => bytes,
-            Err(_) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "member TreeKEM KeyPackage is not valid base64"
-                    })),
-                );
-            }
-        };
         (
             info.clone(),
             info.metadata_topic.clone(),
             info.stable_group_id().to_string(),
-            target_kp_bytes,
         )
+    };
+    // Issue #205: resolve the target's TreeKEM KeyPackage, recovering it on
+    // demand (local cache, then async member-keyed catch-up) when the roster
+    // lacks it. Mirror it onto the cloned snapshot so a later write-back never
+    // clobbers a recovered package.
+    let target_kp_b64 =
+        match resolve_member_treekem_kp_for_removal(&state, &id, &agent_id_hex).await {
+            Ok(kp_b64) => kp_b64,
+            Err(resp) => return resp,
+        };
+    next.set_member_treekem_key_package(&agent_id_hex, target_kp_b64.clone());
+    let target_kp_bytes = match base64::engine::general_purpose::STANDARD.decode(&target_kp_b64) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "ok": false,
+                    "error": "member TreeKEM KeyPackage is not valid base64"
+                })),
+            );
+        }
     };
 
     let group = {
@@ -11596,7 +12012,7 @@ async fn ban_treekem_group_member(
             );
         }
     };
-    let (mut next, metadata_topic, event_group_id, target_kp_bytes) = {
+    let (mut next, metadata_topic, event_group_id) = {
         let groups = state.named_groups.read().await;
         let Some(info) = groups.get(&id) else {
             return (
@@ -11614,37 +12030,32 @@ async fn ban_treekem_group_member(
         if let Some(resp) = last_admin_precheck(info, |g| g.ban_member(&agent_id_hex, None)) {
             return resp;
         }
-        let Some(kp_b64) = info
-            .members_v2
-            .get(&agent_id_hex)
-            .and_then(|m| m.treekem_key_package_b64.clone())
-        else {
-            return (
-                StatusCode::FAILED_DEPENDENCY,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": "member is missing TreeKEM KeyPackage"
-                })),
-            );
-        };
-        let target_kp_bytes = match base64::engine::general_purpose::STANDARD.decode(kp_b64) {
-            Ok(bytes) => bytes,
-            Err(_) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "ok": false,
-                        "error": "member TreeKEM KeyPackage is not valid base64"
-                    })),
-                );
-            }
-        };
         (
             info.clone(),
             info.metadata_topic.clone(),
             info.stable_group_id().to_string(),
-            target_kp_bytes,
         )
+    };
+    // Issue #205: resolve the target's TreeKEM KeyPackage with on-demand
+    // recovery, mirroring it onto the cloned snapshot so the banned member's
+    // package survives the write-back.
+    let target_kp_b64 =
+        match resolve_member_treekem_kp_for_removal(&state, &id, &agent_id_hex).await {
+            Ok(kp_b64) => kp_b64,
+            Err(resp) => return resp,
+        };
+    next.set_member_treekem_key_package(&agent_id_hex, target_kp_b64.clone());
+    let target_kp_bytes = match base64::engine::general_purpose::STANDARD.decode(&target_kp_b64) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "ok": false,
+                    "error": "member TreeKEM KeyPackage is not valid base64"
+                })),
+            );
+        }
     };
     let group = {
         let map = state.treekem_groups.read().await;
@@ -18730,6 +19141,7 @@ mod tests {
             pending_welcome_waiters: RwLock::new(HashMap::new()),
             pending_welcome_acks: RwLock::new(HashMap::new()),
             treekem_pending_events: RwLock::new(HashMap::new()),
+            treekem_member_key_packages: RwLock::new(HashMap::new()),
             treekem_event_log: RwLock::new(HashMap::new()),
             treekem_catchup_throttle: RwLock::new(HashMap::new()),
             group_membership_locks: RwLock::new(HashMap::new()),
@@ -22267,6 +22679,7 @@ mod tests {
             from_treekem_epoch: 1,
             current_state_hash: "state-1".to_string(),
             missing_prev_state_hash: Some("state-2".to_string()),
+            target_member_id: None,
             limit: 8,
         };
         let encoded = serde_json::to_value(&request).expect("catch-up request serializes");
@@ -22511,5 +22924,367 @@ mod tests {
         assert_eq!(decoded.store_id, "store-1");
         assert_eq!(decoded.peer_id, peer_id);
         assert_eq!(decoded.delta.version, delta.version);
+    }
+    /// Issue #205: minting a `private_secure` invite must strip per-member
+    /// TreeKEM KeyPackages + ML-KEM keys (each ~15.7 KiB / ~1.2 KiB) so the
+    /// join cmd-DM stays under the 49 152-byte gossip cap. Covers the
+    /// growth-curve regression (1/3/10 members), the mint-time budget
+    /// assertion, backward compat both directions, and that stripping does not
+    /// change `roster_root` (the only thing a joiner validates).
+    #[test]
+    fn invite_link_strips_key_packages_and_stays_under_dm_budget() {
+        use x0x::groups::invite::{SignedInvite, INVITE_LINK_MAX_BYTES};
+        use x0x::groups::state_commit::compute_roster_root;
+        use x0x::groups::{GroupInfo, GroupMember, GroupPolicyPreset};
+
+        let authority = x0x::identity::AgentKeypair::generate().expect("authority keypair");
+        let agent_id = authority.agent_id();
+        let owner_hex = hex::encode(agent_id.as_bytes());
+        let group_id = "7e".repeat(16);
+        // Measured testnet sizes (issue #188): ~15 688 B TreeKEM KeyPackage,
+        // ~1 184 B ML-KEM-768 public key.
+        let kp_blob = BASE64.encode(vec![0xaau8; 15_688]);
+        let kem_blob = BASE64.encode(vec![0xbbu8; 1_184]);
+
+        let build_info = |n_joiners: usize| -> GroupInfo {
+            let mut info = GroupInfo::with_policy(
+                "growth".to_string(),
+                "growth-curve".to_string(),
+                agent_id,
+                group_id.clone(),
+                GroupPolicyPreset::PrivateSecure.to_policy(),
+            );
+            info.secure_plane = x0x::mls::SecureGroupPlane::TreeKem;
+            info.members_v2.insert(
+                owner_hex.clone(),
+                GroupMember::new_admin(owner_hex.clone(), None, 1),
+            );
+            for i in 0..n_joiners {
+                let m_hex = format!("{:064x}", i + 1);
+                let mut m = GroupMember::new_member(
+                    m_hex.clone(),
+                    Some(format!("m{i}")),
+                    Some(owner_hex.clone()),
+                    1,
+                );
+                m.treekem_key_package_b64 = Some(kp_blob.clone());
+                m.kem_public_key_b64 = Some(kem_blob.clone());
+                info.members_v2.insert(m_hex, m);
+            }
+            info.recompute_state_hash();
+            info
+        };
+
+        for &n_joiners in &[1usize, 3, 10] {
+            let info = build_info(n_joiners);
+            let full_root = compute_roster_root(&info.members_v2);
+            let mut invite =
+                SignedInvite::new(group_id.clone(), "growth".to_string(), &agent_id, 3600);
+            populate_invite_base_state_from_group_info(&mut invite, &info);
+
+            let roster = invite
+                .base_members_v2
+                .as_ref()
+                .expect("base roster embedded");
+            for m in roster.values() {
+                assert!(m.treekem_key_package_b64.is_none(), "kp stripped at mint");
+                assert!(m.kem_public_key_b64.is_none(), "kem key stripped at mint");
+            }
+            // Stripping must not change the committed roster root.
+            assert_eq!(
+                compute_roster_root(roster),
+                full_root,
+                "roster_root unchanged by strip"
+            );
+
+            let link = invite
+                .encode_link()
+                .expect("stripped invite is under the DM budget")
+                .len();
+            assert!(
+                link <= INVITE_LINK_MAX_BYTES,
+                "{n_joiners}-joiner stripped invite too large: {link} B"
+            );
+            assert!(
+                link <= x0x::dm::MAX_PAYLOAD_BYTES,
+                "{n_joiners}-joiner stripped invite exceeds DM payload cap: {link} B"
+            );
+        }
+
+        // Pre-fix regression proof (issue #188 root cause): a 3-joiner invite
+        // that EMBEDS key packages crosses both the budget and the DM cap.
+        let info3 = build_info(3);
+        let mut fat_invite =
+            SignedInvite::new(group_id.clone(), "growth".to_string(), &agent_id, 3600);
+        fat_invite.base_members_v2 = Some(info3.members_v2.clone());
+        let fat_len = fat_invite.to_link().len();
+        assert!(
+            fat_len > INVITE_LINK_MAX_BYTES,
+            "pre-fix 3-joiner invite should exceed budget: {fat_len} B"
+        );
+        assert!(
+            fat_len > x0x::dm::MAX_PAYLOAD_BYTES,
+            "pre-fix 3-joiner invite should exceed DM cap: {fat_len} B"
+        );
+        assert!(
+            fat_invite.encode_link().is_err(),
+            "budget assertion rejects fat invite"
+        );
+
+        // Backward compat both directions: fields are `#[serde(default)]`, so an
+        // old (kp-bearing) link still parses and a new (stripped) link degrades
+        // gracefully on an old daemon (kp reads as None).
+        let mut slim_invite =
+            SignedInvite::new(group_id.clone(), "growth".to_string(), &agent_id, 3600);
+        populate_invite_base_state_from_group_info(&mut slim_invite, &info3);
+        let slim_link = slim_invite.encode_link().expect("slim under budget");
+        let parsed_slim = SignedInvite::from_link(&slim_link).expect("slim link round-trips");
+        assert!(parsed_slim
+            .base_members_v2
+            .as_ref()
+            .expect("roster")
+            .values()
+            .all(|m| m.treekem_key_package_b64.is_none()));
+        let parsed_fat =
+            SignedInvite::from_link(&fat_invite.to_link()).expect("fat link round-trips");
+        assert!(parsed_fat
+            .base_members_v2
+            .as_ref()
+            .expect("roster")
+            .values()
+            .any(|m| m.treekem_key_package_b64.is_some()));
+        assert_eq!(
+            compute_roster_root(parsed_slim.base_members_v2.as_ref().expect("roster")),
+            compute_roster_root(parsed_fat.base_members_v2.as_ref().expect("roster")),
+            "roster_root identical across formats"
+        );
+    }
+
+    /// `member_joined_kp_cache_entry` extracts only key-package-bearing
+    /// `MemberJoined` events, keyed by `join_result_key`. This is the helper
+    /// the inviter-side apply wrapper uses to populate the recovery cache.
+    #[test]
+    fn member_joined_kp_cache_entry_extracts_package_bearing_events() {
+        let group_id = "71".repeat(32);
+        let member = "8a".repeat(32);
+        let with_kp = NamedGroupMetadataEvent::MemberJoined {
+            group_id: group_id.clone(),
+            stable_group_id: Some(group_id.clone()),
+            member_agent_id: member.clone(),
+            member_public_key_b64: "k".to_string(),
+            role: x0x::groups::GroupRole::Member,
+            display_name: None,
+            inviter_agent_id: "ff".repeat(32),
+            invite_secret: "s".to_string(),
+            ts_ms: 1,
+            treekem_key_package_b64: Some("kp".to_string()),
+            signature_b64: "sig".to_string(),
+        };
+        let (key, _) = member_joined_kp_cache_entry(&with_kp).expect("kp-bearing event extracted");
+        assert_eq!(key, join_result_key(&group_id, &member));
+
+        let mut no_kp = with_kp.clone();
+        if let NamedGroupMetadataEvent::MemberJoined {
+            treekem_key_package_b64,
+            ..
+        } = &mut no_kp
+        {
+            *treekem_key_package_b64 = None;
+        }
+        assert!(
+            member_joined_kp_cache_entry(&no_kp).is_none(),
+            "no package → no cache entry"
+        );
+        assert!(
+            member_joined_kp_cache_entry(&NamedGroupMetadataEvent::GroupDeleted {
+                group_id: group_id.clone(),
+                revision: 1,
+                actor: member.clone(),
+                commit: None,
+            })
+            .is_none(),
+            "non-MemberJoined event ignored"
+        );
+    }
+
+    /// Issue #205: a promoted admin missing a member's TreeKEM KeyPackage
+    /// recovers it from this node's cached, self-signed `MemberJoined` and the
+    /// removal-path resolver returns it. The cache mirrors what a node holds
+    /// after applying the join (inviter) or receiving a member-keyed catch-up.
+    #[tokio::test]
+    async fn recovered_member_key_package_installs_from_cache() -> Result<()> {
+        let fixture = member_joined_treekem_fixture(0x71, 0x72).await?;
+        let state = &fixture.state;
+        let group_id = fixture.group_id.clone();
+        let member_hex = fixture.member_hex.clone();
+        let inviter_hex = hex::encode(state.agent.agent_id().as_bytes());
+
+        // Roster carries the member (Active) WITHOUT a key package — the
+        // promoted-admin regression. Seed the recovery cache with the member's
+        // self-signed MemberJoined (what the inviter / catch-up would supply).
+        insert_active_member_without_kp(state, &group_id, &member_hex, &inviter_hex).await;
+        state.treekem_member_key_packages.write().await.insert(
+            join_result_key(&group_id, &member_hex),
+            fixture.event.clone(),
+        );
+        assert!(member_treekem_kp(state, &group_id, &member_hex)
+            .await
+            .is_none());
+
+        // On-demand recovery signature-verifies the cached event + installs.
+        let recovered = recover_member_treekem_key_package(state, &group_id, &member_hex).await;
+        assert!(recovered, "kp recovered from cache");
+        assert!(member_treekem_kp(state, &group_id, &member_hex)
+            .await
+            .is_some());
+
+        // The removal-path resolver returns it (fast path: roster now carries it).
+        let resolved = resolve_member_treekem_kp_for_removal(state, &group_id, &member_hex).await;
+        assert!(resolved.is_ok(), "resolver returns kp after recovery");
+        Ok(())
+    }
+
+    /// Issue #205: the recovered key-package install is fail-closed — a forged
+    /// signature, an unknown member, or an already-present package is refused,
+    /// and a member with no cached event surfaces a retryable pending error.
+    #[tokio::test]
+    async fn recovered_member_key_package_refuses_forgery_and_gates() -> Result<()> {
+        let fixture = member_joined_treekem_fixture(0x73, 0x74).await?;
+        let state = &fixture.state;
+        let group_id = fixture.group_id.clone();
+        let member_hex = fixture.member_hex.clone();
+        let inviter_hex = hex::encode(state.agent.agent_id().as_bytes());
+        let valid_event = fixture.event.clone();
+
+        // Roster carries the member (Active) WITHOUT a key package.
+        insert_active_member_without_kp(state, &group_id, &member_hex, &inviter_hex).await;
+
+        // Forged signature → refused, roster unchanged.
+        let forged = match valid_event.clone() {
+            NamedGroupMetadataEvent::MemberJoined {
+                group_id,
+                stable_group_id,
+                member_agent_id,
+                member_public_key_b64,
+                role,
+                display_name,
+                inviter_agent_id,
+                invite_secret,
+                ts_ms,
+                treekem_key_package_b64,
+                ..
+            } => NamedGroupMetadataEvent::MemberJoined {
+                group_id,
+                stable_group_id,
+                member_agent_id,
+                member_public_key_b64,
+                role,
+                display_name,
+                inviter_agent_id,
+                invite_secret,
+                ts_ms,
+                treekem_key_package_b64,
+                signature_b64: BASE64.encode(vec![0xcdu8; 64]),
+            },
+            _ => unreachable!("fixture is MemberJoined"),
+        };
+        assert!(
+            !apply_recovered_member_key_package(state, &forged).await,
+            "forged signature refused"
+        );
+        assert!(
+            member_treekem_kp(state, &group_id, &member_hex)
+                .await
+                .is_none(),
+            "forged event did not install a package"
+        );
+
+        // Valid cached event → installs.
+        assert!(
+            apply_recovered_member_key_package(state, &valid_event).await,
+            "valid signature installs"
+        );
+        // Already-present package → no-op refusal (no clobber).
+        assert!(
+            !apply_recovered_member_key_package(state, &valid_event).await,
+            "already-present package not re-installed"
+        );
+
+        // Unknown member (not in roster) → refused even with an otherwise-valid
+        // signature for a different agent_id.
+        let stranger = format!("{:064x}", 0x9999u64);
+        let stranger_event = match valid_event.clone() {
+            NamedGroupMetadataEvent::MemberJoined {
+                group_id,
+                stable_group_id,
+                member_public_key_b64,
+                role,
+                display_name,
+                inviter_agent_id,
+                invite_secret,
+                ts_ms,
+                treekem_key_package_b64,
+                signature_b64,
+                ..
+            } => NamedGroupMetadataEvent::MemberJoined {
+                group_id,
+                stable_group_id,
+                member_agent_id: stranger.clone(),
+                member_public_key_b64,
+                role,
+                display_name,
+                inviter_agent_id,
+                invite_secret,
+                ts_ms,
+                treekem_key_package_b64,
+                signature_b64,
+            },
+            _ => unreachable!("fixture is MemberJoined"),
+        };
+        assert!(
+            !apply_recovered_member_key_package(state, &stranger_event).await,
+            "unknown member refused"
+        );
+
+        // No cached event for a member → resolver returns a retryable pending error.
+        let resolved = resolve_member_treekem_kp_for_removal(state, &group_id, &stranger).await;
+        assert!(resolved.is_err(), "missing kp with no cache is pending");
+        let (status, body) = resolved.expect_err("pending error");
+        assert_eq!(status, StatusCode::FAILED_DEPENDENCY);
+        assert_eq!(body["error"], "member_key_package_pending");
+        assert_eq!(body["retry"], true);
+        Ok(())
+    }
+
+    async fn member_treekem_kp(
+        state: &Arc<AppState>,
+        group_id: &str,
+        member: &str,
+    ) -> Option<String> {
+        let groups = state.named_groups.read().await;
+        groups
+            .get(group_id)
+            .and_then(|info| info.members_v2.get(member))
+            .and_then(|m| m.treekem_key_package_b64.clone())
+    }
+
+    async fn insert_active_member_without_kp(
+        state: &Arc<AppState>,
+        group_id: &str,
+        member: &str,
+        added_by: &str,
+    ) {
+        let mut groups = state.named_groups.write().await;
+        if let Some(info) = groups.get_mut(group_id) {
+            info.members_v2.insert(
+                member.to_string(),
+                x0x::groups::GroupMember::new_member(
+                    member.to_string(),
+                    None,
+                    Some(added_by.to_string()),
+                    1,
+                ),
+            );
+        }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9307,14 +9307,14 @@ async fn create_group_invite(
         let link = match invite.encode_link() {
             Ok(link) => link,
             Err(e) => {
-                tracing::error!(
+                tracing::warn!(
                     group_id = %LogHexId::group(&id),
                     actual = e.actual,
                     limit = e.limit,
                     "refusing to mint oversized invite link: {e}"
                 );
                 return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
+                    StatusCode::PAYLOAD_TOO_LARGE,
                     Json(serde_json::json!({
                         "ok": false,
                         "error": "invite_too_large",
@@ -23254,6 +23254,180 @@ mod tests {
         assert_eq!(body["error"], "member_key_package_pending");
         assert_eq!(body["retry"], true);
         Ok(())
+    }
+
+    /// Issue #205 review nit: a `MemberJoined` validly signed for member X in
+    /// group A must be REFUSED for group B. `canonical_member_joined_bytes`
+    /// binds `group_id` (and `stable_group_id`) into the signed payload, so a
+    /// replay against a different group fails signature verification even when
+    /// the target member exists there. This pins the cross-group forgery guard.
+    #[tokio::test]
+    async fn recovered_member_key_package_refuses_cross_group_forgery() -> Result<()> {
+        let fixture = member_joined_treekem_fixture(0x75, 0x76).await?;
+        let state = &fixture.state;
+        let inviter_hex = hex::encode(state.agent.agent_id().as_bytes());
+        let member_hex = fixture.member_hex.clone();
+
+        // Install a SECOND, independent TreeKEM group B in the same state and
+        // make the fixture's member a roster member of B (no key package).
+        let group_b = "77".repeat(32);
+        let stable_b = "78".repeat(32);
+        let info_b = treekem_metadata_group_info(state.agent.agent_id(), &group_b, &stable_b);
+        state
+            .named_groups
+            .write()
+            .await
+            .insert(group_b.clone(), info_b);
+        insert_active_member_without_kp(state, &group_b, &member_hex, &inviter_hex).await;
+
+        // Take the member's validly-signed event for group A and tamper only the
+        // group id fields to claim group B. The signature stays valid-for-A.
+        let cross_group_event = match fixture.event.clone() {
+            NamedGroupMetadataEvent::MemberJoined {
+                member_agent_id,
+                member_public_key_b64,
+                role,
+                display_name,
+                inviter_agent_id,
+                invite_secret,
+                ts_ms,
+                treekem_key_package_b64,
+                signature_b64,
+                ..
+            } => NamedGroupMetadataEvent::MemberJoined {
+                group_id: group_b.clone(),
+                stable_group_id: Some(stable_b.clone()),
+                member_agent_id,
+                member_public_key_b64,
+                role,
+                display_name,
+                inviter_agent_id,
+                invite_secret,
+                ts_ms,
+                treekem_key_package_b64,
+                signature_b64,
+            },
+            _ => unreachable!("fixture is MemberJoined"),
+        };
+        assert!(
+            !apply_recovered_member_key_package(state, &cross_group_event).await,
+            "cross-group forgery refused — group_id is bound into the signed canonical bytes"
+        );
+        assert!(
+            member_treekem_kp(state, &group_b, &member_hex)
+                .await
+                .is_none(),
+            "group B roster untouched by group A's signed event"
+        );
+        Ok(())
+    }
+
+    /// Issue #205 review nit: remove → re-add lifecycle. A cached, self-signed
+    /// `MemberJoined` must NOT silently re-key a Removed member, and after a
+    /// re-add it may only re-install the SAME package the member would produce
+    /// afresh. Safety rests on a load-bearing invariant: `agent_treekem_seed`
+    /// derives the TreeKEM seed deterministically from the agent's static
+    /// keypair secret + group id, and `prepare_member` is deterministic in that
+    /// seed — so for an unchanged AgentId the cached package is byte-identical
+    /// to a fresh `prepare_member` output and matches the re-added ratchet leaf.
+    /// A re-keyed member has a different AgentId (it is derived from the
+    /// ML-DSA public key) and therefore a different cache key, so a stale
+    /// package can never cross-contaminate a re-keyed member. If
+    /// `prepare_member` ever becomes non-deterministic, a staleness guard must
+    /// be added here.
+    #[tokio::test]
+    async fn recovered_member_key_package_remove_then_readd_reinstalls_same_package() -> Result<()>
+    {
+        let fixture = member_joined_treekem_fixture(0x79, 0x7a).await?;
+        let state = &fixture.state;
+        let group_id = fixture.group_id.clone();
+        let member_hex = fixture.member_hex.clone();
+        let inviter_hex = hex::encode(state.agent.agent_id().as_bytes());
+        let original_kp = match &fixture.event {
+            NamedGroupMetadataEvent::MemberJoined {
+                treekem_key_package_b64: Some(kp),
+                ..
+            } => kp.clone(),
+            _ => unreachable!("fixture carries a key package"),
+        };
+
+        // Join: roster member (Active, no kp) + cached self-signed event.
+        insert_active_member_without_kp(state, &group_id, &member_hex, &inviter_hex).await;
+        state.treekem_member_key_packages.write().await.insert(
+            join_result_key(&group_id, &member_hex),
+            fixture.event.clone(),
+        );
+        assert!(
+            recover_member_treekem_key_package(state, &group_id, &member_hex).await,
+            "first recovery installs"
+        );
+        assert_eq!(
+            member_treekem_kp(state, &group_id, &member_hex)
+                .await
+                .as_deref(),
+            Some(original_kp.as_str()),
+            "installed package matches the signed event"
+        );
+
+        // Remove: the member is no longer Active. The stale cache must NOT
+        // silently re-key a removed member.
+        set_member_state(
+            state,
+            &group_id,
+            &member_hex,
+            x0x::groups::GroupMemberState::Removed,
+        )
+        .await;
+        assert!(
+            !recover_member_treekem_key_package(state, &group_id, &member_hex).await,
+            "removed member is not re-keyable from the stale cache"
+        );
+        assert!(
+            member_treekem_kp(state, &group_id, &member_hex)
+                .await
+                .is_none(),
+            "removed member keeps no package"
+        );
+
+        // Re-add: fresh Active entry, no package, cache unchanged. Recovery may
+        // re-install — and because the seed is deterministic for the same
+        // AgentId, the re-installed package is byte-identical to the original
+        // (i.e. what a fresh join would publish), so it matches the new leaf.
+        set_member_state(
+            state,
+            &group_id,
+            &member_hex,
+            x0x::groups::GroupMemberState::Active,
+        )
+        .await;
+        assert!(
+            recover_member_treekem_key_package(state, &group_id, &member_hex).await,
+            "re-added member recovers the cached package"
+        );
+        assert_eq!(
+            member_treekem_kp(state, &group_id, &member_hex)
+                .await
+                .as_deref(),
+            Some(original_kp.as_str()),
+            "re-installed package is the deterministic (same-key) package, not a stale leaf"
+        );
+        Ok(())
+    }
+
+    async fn set_member_state(
+        state: &Arc<AppState>,
+        group_id: &str,
+        member: &str,
+        new_state: x0x::groups::GroupMemberState,
+    ) {
+        let mut groups = state.named_groups.write().await;
+        if let Some(info) = groups.get_mut(group_id) {
+            if let Some(m) = info.members_v2.get_mut(member) {
+                m.state = new_state;
+                m.treekem_key_package_b64 = None;
+                m.updated_at = 2;
+            }
+        }
     }
 
     async fn member_treekem_kp(

--- a/src/server/routes/identity.rs
+++ b/src/server/routes/identity.rs
@@ -366,7 +366,25 @@ pub(in crate::server) fn populate_invite_base_state_from_group_info(
     invite.genesis_creation_nonce = info.genesis.as_ref().map(|g| g.creation_nonce.clone());
     invite.base_state_revision = Some(info.state_revision);
     invite.base_state_hash = Some(info.state_hash.clone());
-    invite.base_members_v2 = Some(info.members_v2.clone());
+    // Issue #205: strip per-member crypto material that contributes nothing to
+    // invite validation. `roster_root` commits only to `(id, role, state)`
+    // triples (state_commit.rs), the link is unsigned, and admission is the
+    // `invite_secret` handshake + authority-signed `MemberAdded`. Each member's
+    // ~15.7 KiB TreeKEM KeyPackage + ~1.2 KiB ML-KEM pubkey would otherwise be
+    // copy-pasted into the join cmd-DM, crossing the 49 152-byte gossip cap at
+    // the 3rd roster member (issue #188). Joiners learn both keys out-of-band
+    // (MemberAdded / Welcome / GET /agent), so the slim roster is sufficient.
+    let slim_roster = info
+        .members_v2
+        .iter()
+        .map(|(agent_id, member)| {
+            let mut slim = member.clone();
+            slim.treekem_key_package_b64 = None;
+            slim.kem_public_key_b64 = None;
+            (agent_id.clone(), slim)
+        })
+        .collect();
+    invite.base_members_v2 = Some(slim_roster);
     invite.base_prev_state_hash = info.prev_state_hash.clone();
     invite.secure_plane = Some(info.secure_plane);
     invite.base_secret_epoch = Some(info.secret_epoch);
@@ -433,9 +451,24 @@ pub(in crate::server) async fn get_agent_card(
                 x0x::groups::invite::DEFAULT_EXPIRY_SECS,
             );
             populate_invite_base_state_from_group_info(&mut invite, info);
+            // Enforce the DM-safe budget at mint; an oversized link would 400
+            // later when the card consumer DMs the join. Skip rather than poison
+            // the whole agent card (issue #205).
+            let invite_link = match invite.encode_link() {
+                Ok(link) => link,
+                Err(e) => {
+                    tracing::warn!(
+                        group_id = %info.mls_group_id,
+                        actual = e.actual,
+                        limit = e.limit,
+                        "skipping oversized group invite in agent card: {e}"
+                    );
+                    continue;
+                }
+            };
             card.groups.push(x0x::groups::card::CardGroup {
                 name: info.name.clone(),
-                invite_link: invite.to_link(),
+                invite_link,
             });
         }
     }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -501,6 +501,14 @@ pub(super) struct AppState {
     /// Bounded per-group log of locally authored/applied TreeKEM membership
     /// events used to satisfy explicit catch-up requests.
     pub(super) treekem_event_log: RwLock<HashMap<String, VecDeque<NamedGroupMetadataEvent>>>,
+    /// Member-keyed cache of verified TreeKEM key-package-bearing
+    /// `MemberJoined` events (`join_result_key(group_id, member_id)` → event).
+    /// Populated when a node applies a joiner's self-signed `MemberJoined`
+    /// (inviter side) and served to promoted admins that never saw the join via
+    /// the member-keyed catch-up protocol (issue #205). The ML-DSA-65 signature
+    /// over `canonical_member_joined_bytes` authenticates the embedded key
+    /// package, so a recovering admin installs it without the inviter-only gate.
+    pub(super) treekem_member_key_packages: RwLock<HashMap<String, NamedGroupMetadataEvent>>,
     /// Anti-spam throttle for outbound catch-up requests.
     pub(super) treekem_catchup_throttle: RwLock<HashMap<String, Instant>>,
     /// Per-group serialization for authoritative membership mutations. The

--- a/tests/e2e_vps_groups.py
+++ b/tests/e2e_vps_groups.py
@@ -920,6 +920,18 @@ class FleetHarness:
                     f"outcome={resp.get('outcome')}",
                 )
 
+        # Issue #205: the TreeKEM-join dogfood assertion is required again.
+        # Invites no longer embed per-member TreeKEM KeyPackages, so every
+        # joiner's cmd-DM fits the 49 152-byte gossip cap and all runners join
+        # (previously only the first two could, then the roster crossed the cap
+        # at the 3rd member — issue #188). allow_skips still tolerates an
+        # unreachable subset for partial-fleet runs.
+        if not self.allow_skips:
+            self.assert_pass(
+                "all runners joined the TreeKEM group (issue #205)",
+                len(joined) == len(members),
+                f"joined={joined} expected={members}",
+            )
         self.assert_pass(
             "TreeKEM group has >=2 joiners (needed to exercise applied path)",
             len(joined) >= 2,


### PR DESCRIPTION
## Summary

Implements all 6 work items of #205, fixing the #188 join-400 root cause: `private_secure` invite links embedded each member's ~15.7 KiB TreeKEM KeyPackage + ~1.2 KiB ML-KEM key, so the join cmd-DM crossed the 49 152-byte gossip cap at the **3rd roster member** and every later joiner's invite was rejected at the sender with `envelope_construction`.

### Why stripping is safe (the two load-bearing facts)
1. `roster_root` = BLAKE3 over sorted `(id, role, state)` triples (`state_commit.rs:89`) — `treekem_key_package_b64` **and** `kem_public_key_b64` are excluded from the commitment. Everything a joiner validates (root recomputation, later membership commits) needs only the slim triples.
2. The invite link is **unsigned** (vestigial `signature` field, `invite.rs:1-8`). Admission = the `invite_secret` handshake + the authority-signed `MemberAdded`; the embedded key packages provide **zero** validation value. Joiners learn both keys out-of-band (`MemberAdded` / `Welcome` / `GET /agent`).

`GroupMember.treekem_key_package_b64` and `kem_public_key_b64` are already `Option<String>` + `#[serde(default)]`, so this is wire-compatible both directions.

## Changes

**1. Strip at mint** — `populate_invite_base_state_from_group_info` clones the roster with both crypto fields set to `None`. Both mint sites (`POST /groups/:id/invite`, `GET /agent/card?include_groups`).

**2. Mint-time budget** — `SignedInvite::encode_link()` wraps `to_link()` with `INVITE_LINK_MAX_BYTES` (40 KiB); `/groups/:id/invite` returns a structured `invite_too_large` (500) at the source instead of a later opaque cross-node 400. Card mint skips an oversized group rather than poisoning the card.

**3. On-demand kp catch-up (closes the stripping regression)** — a joiner promoted to Admin could no longer remove/ban a member whose kp it never learned (`MemberJoined` apply is inviter-only; `MemberAdded` carries no kp). On the `FAILED_DEPENDENCY` path, `remove`/`ban` now:
- recover the target's kp from a member-keyed cache of self-signed `MemberJoined` events (`treekem_member_key_packages`), authenticated by re-verifying the joiner's ML-DSA-65 signature (`apply_recovered_member_key_package`);
- on a local miss, fire a **member-keyed** TreeKEM catch-up request (`TreeKemCatchupRequest.target_member_id`, extending `handle_treekem_catchup_request`) — reusing the existing gates (signed-DM verified, active-member or target-of-cached-add, 5 s throttle) — and return a retryable `member_key_package_pending`.

**4. `signable_bytes`** domain tag bumped `x0x.invite.v2` → `x0x.invite.v3`.

**5. Tests** (see below).

**6. Dogfood** — the TreeKEM-join assertion in `run_treekem_state_commit_audit` is required again (all runners must join), gated behind `allow_skips` for partial-fleet runs.

## Size numbers (growth-curve test, `kp_blob`=15 688 B)

| members | pre-fix link (B) | stripped link (B) | ≤ 49 152? |
|---|---|---|---|
| 1 | 19 472 | 3 804 | ✓ |
| 3 | 66 791 | 6 516 | ✓ (pre-fix ✗) |
| 10 | 184 279 | 8 838 | ✓ |

Cap not crossed until ~140 members.

## Threat / regression analysis
- **Admission security unchanged**: `invite_secret` handshake + authority-signed `MemberAdded` + `state_hash`/`roster_root` validation all untouched.
- **Recovered kp is authenticated**: `apply_recovered_member_key_package` independently re-verifies the joiner's ML-DSA-65 signature over `canonical_member_joined_bytes` and the derived `AgentId`; forged signatures, unknown members, and already-present packages are refused (fail-closed). It never invents roster entries or clobbers an existing kp.
- **Backward compatible**: old kp-bearing links still parse; old daemons reading stripped links see `None` (graceful). `target_member_id` is `#[serde(default)]` so old daemons ignore it and serve the normal frontier.

## Proving tests (`cargo nextest run -p x0x`)
- `invite_link_strips_key_packages_and_stays_under_dm_budget` — 1/3/10-member links stay under budget + DM cap; pre-fix 3-member fat invite proven to exceed both + rejected by `encode_link`; roster_root identical across formats; round-trips both directions.
- `member_joined_kp_cache_entry_extracts_package_bearing_events` — cache helper extracts only kp-bearing `MemberJoined`.
- `recovered_member_key_package_installs_from_cache` — promoted-admin recovery re-installs a verified kp; resolver returns it.
- `recovered_member_key_package_refuses_forgery_and_gates` — forged signature / unknown member / already-present refused; empty-cache resolver returns retryable `member_key_package_pending`.

## Validation
`just check` fully green: `fmt-check`, `clippy --all-targets --all-features -- -D warnings`, `cargo check --workspace --all-targets`, `nextest --all-features --workspace` (2094 passed, 217 skipped), `cargo doc --all-features`.

The 6-node testnet dogfood (acceptance) is operational — the harness flip lands in this PR; the cross-region run itself runs out-of-band.

Closes #205
Refs #188

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces invite size and adds key-package recovery for TreeKEM member actions. The main changes are:

- Strips TreeKEM and ML-KEM public material from invite base rosters.
- Adds a 40 KiB invite-link budget at invite mint sites.
- Adds member-keyed TreeKEM KeyPackage catch-up for remove and ban flows.
- Updates tests and the VPS dogfood assertion for full TreeKEM joins.

<h3>Confidence Score: 4/5</h3>

The member-keyed recovery path needs a fix before merging.

- Invite stripping and size checks match the roster-root contract.
- The new recovery fanout can accept a package from the member being removed or banned.
- Local recovery can miss a cached package when stable and storage group ids differ.

src/server/mod.rs

<details open><summary><h3>Security Review</h3></summary>

The new member-keyed catch-up path can ask the removal target for its own recovered package. A target can respond first with a self-signed but leaf-mismatching package, which can block its own removal or ban.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/groups/invite.rs | Adds the invite-link byte budget, oversized-link error, and invite signing domain bump. |
| src/server/routes/identity.rs | Builds slim invite rosters and uses the budgeted encoder for agent-card group links. |
| src/server/state.rs | Adds the in-memory cache for key-package-bearing MemberJoined events. |
| src/server/mod.rs | Adds member-keyed catch-up and remove/ban recovery, with issues in recovery source selection and cache alias lookup. |
| tests/e2e_vps_groups.py | Restores the full TreeKEM join assertion when skipped runners are not allowed. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Admin as Promoted admin
  participant Target as Target member
  participant Inviter as Cached inviter
  participant Cache as Admin cache
  Admin->>Target: catch-up request(target_member_id)
  Admin->>Inviter: catch-up request(target_member_id)
  Target-->>Admin: self-signed MemberJoined with different package
  Admin->>Cache: install first verified package
  Inviter-->>Admin: original cached MemberJoined
  Admin->>Cache: skip because package already exists
  Admin->>Admin: remove/ban uses mismatched package and cannot find the target leaf
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Admin as Promoted admin
  participant Target as Target member
  participant Inviter as Cached inviter
  participant Cache as Admin cache
  Admin->>Target: catch-up request(target_member_id)
  Admin->>Inviter: catch-up request(target_member_id)
  Target-->>Admin: self-signed MemberJoined with different package
  Admin->>Cache: install first verified package
  Inviter-->>Admin: original cached MemberJoined
  Admin->>Cache: skip because package already exists
  Admin->>Admin: remove/ban uses mismatched package and cannot find the target leaf
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/server/mod.rs:6487-6500
**Target Can Poison Recovery**

When an admin is missing the target's package, this fanout asks every other active member for the cached `MemberJoined`, which includes the member being removed or banned. The target can answer first with a valid self-signed event carrying a different TreeKEM KeyPackage; the admin installs it and refuses later honest packages as already present, so the TreeKEM remove/ban uses bytes that do not match the target leaf and the operation can stay blocked.

```suggestion
        let mut candidate_hexes: Vec<String> = info
            .members_v2
            .get(member_agent_id)
            .and_then(|m| m.added_by.clone())
            .into_iter()
            .filter(|aid| !aid.eq_ignore_ascii_case(member_agent_id))
            .collect();
        for (aid, m) in &info.members_v2 {
            if !aid.eq_ignore_ascii_case(&local_agent_hex)
                && !aid.eq_ignore_ascii_case(member_agent_id)
                && !candidate_hexes.iter().any(|c| c.eq_ignore_ascii_case(aid))
                && m.state == x0x::groups::GroupMemberState::Active
            {
                candidate_hexes.push(aid.clone());
            }
        }
```

### Issue 2 of 2
src/server/mod.rs:5991-5999
**Alias Key Misses Cache**

The recovery cache is written with the `group_id` stored inside the cached `MemberJoined`, but this lookup only tries the caller's `group_id`. If a remove or ban route is invoked with the stable group id while the cached event was keyed by the storage id, local recovery misses an entry that is already present and returns `member_key_package_pending` instead of completing the operation.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(groups): strip TreeKEM key packages ..."](https://github.com/saorsa-labs/x0x/commit/4fe25bca22580418f057fb17c31672c929f5cd15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42740365)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->