### PR TITLE
chore(deps): ant-quic 0.27.30 + saorsa-gossip 0.5.66 (fixes #190, closes #186)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.28"
+ant-quic = "0.27.30"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"
@@ -39,17 +39,17 @@ hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 rand = "0.8"
-saorsa-gossip-coordinator = "0.5.63"
-saorsa-gossip-crdt-sync = "0.5.63"
-saorsa-gossip-groups = "0.5.63"
-saorsa-gossip-identity = "0.5.63"
-saorsa-gossip-membership = "0.5.63"
-saorsa-gossip-presence = "0.5.63"
-saorsa-gossip-pubsub = "0.5.63"
-saorsa-gossip-rendezvous = "0.5.63"
-saorsa-gossip-runtime = "0.5.63"
-saorsa-gossip-transport = "0.5.63"
-saorsa-gossip-types = "0.5.63"
+saorsa-gossip-coordinator = "0.5.66"
+saorsa-gossip-crdt-sync = "0.5.66"
+saorsa-gossip-groups = "0.5.66"
+saorsa-gossip-identity = "0.5.66"
+saorsa-gossip-membership = "0.5.66"
+saorsa-gossip-presence = "0.5.66"
+saorsa-gossip-pubsub = "0.5.66"
+saorsa-gossip-rendezvous = "0.5.66"
+saorsa-gossip-runtime = "0.5.66"
+saorsa-gossip-transport = "0.5.66"
+saorsa-gossip-types = "0.5.66"
 saorsa-pqc = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Dependency bump completing two work packages:

- **ant-quic 0.27.30** — complete `Instant - Duration` panic fix for Windows low-uptime starts (**fixes #190**; master fix `76aa3cb0` + ant-quic#207 final sweep + boot-epoch regression test) and the RUSTSEC-2026-0204 crossbeam-epoch bump.
- **saorsa-gossip 0.5.66** — sharded pubsub topics map (32 shards, was a single global write-lock serializing all workers), republish stage-timing attribution fix, PeerScoring/suppressed_peers lock-wait instrumentation (saorsa-gossip#27/#28, adversarially reviewed incl. Codex). **Closes #186** — subject to the fanout-burst re-baseline soak on this branch build: anchor `dedupe_lock_acquire` share must drop ~50% → single digits with `drop_full=0`; also empirically answers the shard-balance question for x0x's tag-shard topics.

Merge gate: burst-soak GO + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps two dependency groups: `ant-quic` from `0.27.28` to `0.27.30` (Windows `Instant - Duration` panic fix and RUSTSEC-2026-0204 crossbeam-epoch advisory) and all eleven `saorsa-gossip-*` crates from `0.5.63` to `0.5.66` (sharded pubsub topics map, republish stage-timing attribution fix, lock-wait instrumentation).

- `ant-quic 0.27.30` addresses a panic on Windows during low-uptime starts and resolves a security advisory in its transitive `crossbeam-epoch` dependency.
- All 11 `saorsa-gossip-*` sub-crates are bumped atomically and consistently to `0.5.66`; no crate is left behind on the old version.
- `Cargo.lock` is `.gitignore`d for this repo, so the exact resolved transitive dependency tree is not captured in-tree — the burst-soak CI run described in the merge gate is the main verification path for the gossip sharding correctness.

<h3>Confidence Score: 5/5</h3>

Safe to merge once the burst-soak CI gate passes — the change is purely a dependency version bump with no in-tree code modifications.

Only Cargo.toml changed. All 11 gossip sub-crates are updated atomically to the same version with no stragglers, and ant-quic moves two patch versions to pick up a panic fix and a security advisory resolution. There are no in-tree logic changes that could introduce regressions.

No files require special attention; the single changed file (Cargo.toml) is consistent and complete.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Version bump: ant-quic 0.27.28→0.27.30 and all 11 saorsa-gossip-* crates 0.5.63→0.5.66; all sub-crates updated consistently, no mismatches. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    x0x["x0x (0.29.0)"]

    subgraph gossip["saorsa-gossip 0.5.63 to 0.5.66"]
        coord["saorsa-gossip-coordinator"]
        crdt["saorsa-gossip-crdt-sync"]
        groups["saorsa-gossip-groups"]
        identity["saorsa-gossip-identity"]
        membership["saorsa-gossip-membership"]
        presence["saorsa-gossip-presence"]
        pubsub["saorsa-gossip-pubsub (sharded topics map, 32 shards)"]
        rendezvous["saorsa-gossip-rendezvous"]
        runtime["saorsa-gossip-runtime"]
        transport["saorsa-gossip-transport"]
        types["saorsa-gossip-types"]
    end

    subgraph quic["ant-quic 0.27.28 to 0.27.30"]
        aq["ant-quic (Instant-Duration panic fix, RUSTSEC-2026-0204 crossbeam-epoch)"]
    end

    x0x --> coord
    x0x --> crdt
    x0x --> groups
    x0x --> identity
    x0x --> membership
    x0x --> presence
    x0x --> pubsub
    x0x --> rendezvous
    x0x --> runtime
    x0x --> transport
    x0x --> types
    x0x --> aq
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    x0x["x0x (0.29.0)"]

    subgraph gossip["saorsa-gossip 0.5.63 to 0.5.66"]
        coord["saorsa-gossip-coordinator"]
        crdt["saorsa-gossip-crdt-sync"]
        groups["saorsa-gossip-groups"]
        identity["saorsa-gossip-identity"]
        membership["saorsa-gossip-membership"]
        presence["saorsa-gossip-presence"]
        pubsub["saorsa-gossip-pubsub (sharded topics map, 32 shards)"]
        rendezvous["saorsa-gossip-rendezvous"]
        runtime["saorsa-gossip-runtime"]
        transport["saorsa-gossip-transport"]
        types["saorsa-gossip-types"]
    end

    subgraph quic["ant-quic 0.27.28 to 0.27.30"]
        aq["ant-quic (Instant-Duration panic fix, RUSTSEC-2026-0204 crossbeam-epoch)"]
    end

    x0x --> coord
    x0x --> crdt
    x0x --> groups
    x0x --> identity
    x0x --> membership
    x0x --> presence
    x0x --> pubsub
    x0x --> rendezvous
    x0x --> runtime
    x0x --> transport
    x0x --> types
    x0x --> aq
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): ant-quic 0.27.30 + saorsa-g..."](https://github.com/saorsa-labs/x0x/commit/bad019e9ad43522bc27142fb5613543a616b220c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42981842)</sub>

<!-- /greptile_comment -->