### PR TITLE
chore(deps): bump ant-quic 0.27.30 + saorsa-gossip 0.5.66 (closes #186, #190)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.28"
+ant-quic = "0.27.30"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"
@@ -39,17 +39,17 @@ hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 rand = "0.8"
-saorsa-gossip-coordinator = "0.5.63"
-saorsa-gossip-crdt-sync = "0.5.63"
-saorsa-gossip-groups = "0.5.63"
-saorsa-gossip-identity = "0.5.63"
-saorsa-gossip-membership = "0.5.63"
-saorsa-gossip-presence = "0.5.63"
-saorsa-gossip-pubsub = "0.5.63"
-saorsa-gossip-rendezvous = "0.5.63"
-saorsa-gossip-runtime = "0.5.63"
-saorsa-gossip-transport = "0.5.63"
-saorsa-gossip-types = "0.5.63"
+saorsa-gossip-coordinator = "0.5.66"
+saorsa-gossip-crdt-sync = "0.5.66"
+saorsa-gossip-groups = "0.5.66"
+saorsa-gossip-identity = "0.5.66"
+saorsa-gossip-membership = "0.5.66"
+saorsa-gossip-presence = "0.5.66"
+saorsa-gossip-pubsub = "0.5.66"
+saorsa-gossip-rendezvous = "0.5.66"
+saorsa-gossip-runtime = "0.5.66"
+saorsa-gossip-transport = "0.5.66"
+saorsa-gossip-types = "0.5.66"
 saorsa-pqc = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Threat / why
x0x 0.29.0 pins `ant-quic = "0.27.28"` and `saorsa-gossip-* = "0.5.63"`, which carry two release-blocking defects this bump consumes now that both upstream releases are published:

- **x0x#190 (Windows worker panic `overflow when subtracting duration from instant`)** — fixed upstream: ant-quic `0.27.30` (certificate_negotiation sweep + `paths.rs` `saturating_sub` + regression test; the `nat_traversal`/`mod.rs` sites were already on master via `76aa3cb0`) and saorsa-gossip `0.5.65`+ (`fb17d08` membership `saturating_duration_since`). ant-quic 0.27.30 also bumps crossbeam-epoch past RUSTSEC-2026-0204.
- **x0x#186 (anchor node gossip dispatcher saturates under fanout burst — `dedupe_lock_acquire` 49.6% of handler time)** — fixed upstream in saorsa-gossip `0.5.66` (saorsa-gossip#27: `ShardedTopicMap` 32-shard topics lock + republish stage-attribution fix + PeerScoring/suppressed_peers lock-wait instrumentation). 0.5.66 also migrates the cli/coordinator bins to `self_update 1.0.0-rc.3`, clearing quick-xml RUSTSEC-2026-0194/0195 (bin-only; library crates unaffected).

## Change
- `ant-quic`: `0.27.28` → `0.27.30`
- `saorsa-gossip-*` (11 crates): `0.5.63` → `0.5.66`
- `Cargo.lock` refreshed (only these packages).

## Verification
- `cargo fmt --all -- --check` → clean
- `cargo clippy --all-features --all-targets -- -D warnings` → clean
- `cargo check --workspace --all-targets` → green (47s)

Closes #186. Closes #190.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `ant-quic` by two patch versions and all eleven `saorsa-gossip-*` crates by three patch versions to consume upstream bug-fix releases that address a Windows worker panic and a lock-contention bottleneck in the gossip dispatcher, along with two `cargo-audit`-flagged advisories (RUSTSEC-2026-0204 via crossbeam-epoch in ant-quic, and RUSTSEC-2026-0194/0195 via quick-xml in saorsa-gossip's bin crates).

- **`ant-quic` 0.27.28 → 0.27.30**: picks up `saturating_sub` in `paths.rs` and the certificate-negotiation sweep that fixes the Windows instant-overflow panic (x0x#190).
- **`saorsa-gossip-*` 0.5.63 → 0.5.66** (all 11 crates bumped consistently): picks up `saturating_duration_since` for membership (0.5.65) and the 32-shard `ShardedTopicMap` that resolves the `dedupe_lock_acquire` saturation under fanout burst (0.5.66, x0x#186).
- `Cargo.lock` is intentionally `.gitignore`d in this repo (line 3 of `.gitignore`), so the lock-file refresh described in the PR is local-only and not part of the diff — this is consistent with the project's established convention.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a targeted dependency bump with no logic changes; all updated crates are patch-level increments within their current minor series.

All twelve version lines move by patch increments only, all saorsa-gossip-* crates are bumped consistently to the same version, and the motivating defects (Windows panic, gossip lock saturation) are well-documented with upstream fix references. The Cargo.lock is intentionally .gitignored, so the missing lock-file diff is expected and not a gap. No API-breaking changes are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps ant-quic 0.27.28→0.27.30 and all 11 saorsa-gossip-* crates 0.5.63→0.5.66 to pick up Windows panic fix, gossip lock-contention fix, and two RUSTSEC CVE mitigations; changes are consistent and minimal. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[x0x 0.29.0\nCargo.toml] --> B[ant-quic 0.27.30\n+saturating_sub paths.rs\n+cert negotiation sweep\n+crossbeam-epoch RUSTSEC-2026-0204]
    A --> C[saorsa-gossip-* 0.5.66 x11\n+saturating_duration_since membership\n+ShardedTopicMap 32-shard topics\n+quick-xml RUSTSEC-2026-0194/0195]
    B --> D[Fixes x0x#190\nWindows worker panic\noverflow subtracting duration from instant]
    C --> E[Fixes x0x#186\ngossip dispatcher lock saturation\ndedupe_lock_acquire 49.6% handler time]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[x0x 0.29.0\nCargo.toml] --> B[ant-quic 0.27.30\n+saturating_sub paths.rs\n+cert negotiation sweep\n+crossbeam-epoch RUSTSEC-2026-0204]
    A --> C[saorsa-gossip-* 0.5.66 x11\n+saturating_duration_since membership\n+ShardedTopicMap 32-shard topics\n+quick-xml RUSTSEC-2026-0194/0195]
    B --> D[Fixes x0x#190\nWindows worker panic\noverflow subtracting duration from instant]
    C --> E[Fixes x0x#186\ngossip dispatcher lock saturation\ndedupe_lock_acquire 49.6% handler time]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["## Threat / why"](https://github.com/saorsa-labs/x0x/commit/2c5312a09b1741d87396b66e7b49211ffc8df439) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42984852)</sub>

<!-- /greptile_comment -->