### PR TITLE
fix(server): validate merged instance names

### DIFF
--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -18,7 +18,7 @@
 
 use anyhow::{Context, Result};
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 #[cfg(feature = "profile-heap")]
@@ -39,7 +39,29 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 pub static MALLOC_CONF: &[u8] =
     b"background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:0,abort_conf:true\0";
 
-use x0x::server::{DaemonConfig, ServeOptions};
+use x0x::server::{DaemonConfig, InstanceName, ServeOptions};
+
+/// Resolve CLI/config precedence before deriving any instance-scoped ACL path.
+///
+/// A CLI name is already validated because it may be needed to locate the
+/// named default config file. A config name is validated only when it wins,
+/// so an invalid discarded config value cannot override a valid CLI name.
+fn resolve_instance_startup(
+    cli_name: Option<InstanceName>,
+    config_name: Option<String>,
+    connect_acl_override: Option<&Path>,
+) -> Result<(Option<InstanceName>, Option<PathBuf>)> {
+    let instance_name = match cli_name {
+        Some(name) => Some(name),
+        None => config_name.map(InstanceName::try_from).transpose()?,
+    };
+    let connect_acl_path = match (connect_acl_override, instance_name.as_ref()) {
+        (Some(path), _) => Some(path.to_path_buf()),
+        (None, Some(name)) => Some(x0x::connect::default_connect_acl_path_for(name)),
+        (None, None) => None,
+    };
+    Ok((instance_name, connect_acl_path))
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -154,14 +176,13 @@ async fn main() -> anyhow::Result<()> {
         None
     };
 
-    // Parse --name for multi-instance support
-    let instance_name = if let Some(idx) = args.iter().position(|a| a == "--name") {
+    // Parse and validate --name before using it to locate a named config file.
+    let cli_instance_name = if let Some(idx) = args.iter().position(|a| a == "--name") {
         let name = args
             .get(idx + 1)
             .context("--name requires an instance name")?
             .clone();
-        x0x::server::validate_instance_name(&name)?;
-        Some(name)
+        Some(InstanceName::try_from(name)?)
     } else {
         None
     };
@@ -175,8 +196,8 @@ async fn main() -> anyhow::Result<()> {
     let mut config = match &config_path {
         Some(path) => load_config(path).await?,
         None => {
-            let config_dir_name = match &instance_name {
-                Some(name) => format!("x0x-{name}"),
+            let config_dir_name = match &cli_instance_name {
+                Some(name) => format!("x0x-{}", name.as_str()),
                 None => "x0x".to_string(),
             };
             let default_path = dirs::config_dir()
@@ -190,8 +211,11 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    // CLI --name takes precedence over config file instance_name
-    let instance_name = instance_name.or_else(|| config.instance_name.clone());
+    let (instance_name, effective_connect_acl_path) = resolve_instance_startup(
+        cli_instance_name,
+        config.instance_name.clone(),
+        connect_acl_override.as_deref(),
+    )?;
 
     // Apply instance-scoped defaults for data_dir and api_address when --name
     // is active but the config didn't explicitly set instance-scoped values.
@@ -199,8 +223,8 @@ async fn main() -> anyhow::Result<()> {
         let default_data_dir = x0x::server::default_data_dir();
         if config.data_dir == default_data_dir {
             config.data_dir = dirs::data_dir()
-                .map(|d| d.join(format!("x0x-{name}")))
-                .unwrap_or_else(|| PathBuf::from(format!("/var/lib/x0x-{name}")));
+                .map(|d| d.join(format!("x0x-{}", name.as_str())))
+                .unwrap_or_else(|| PathBuf::from(format!("/var/lib/x0x-{}", name.as_str())));
         }
         if config.api_address == x0x::server::default_api_address() {
             config.api_address = SocketAddr::from(([127, 0, 0, 1], 0));
@@ -214,7 +238,7 @@ async fn main() -> anyhow::Result<()> {
         if config.bind_address == x0x::server::default_bind_address() {
             config.bind_address = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], 0));
         }
-        config.instance_name = Some(name.clone());
+        config.instance_name = Some(name.as_str().to_owned());
     }
 
     // CLI --api-port overrides config (applied after instance defaults)
@@ -238,18 +262,6 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("failed to load exec ACL")?;
 
-    // #189: give each named network plane its own default connect-ACL path so
-    // co-located daemons (prod / testnet / :443) no longer silently share
-    // /etc/x0x/connect-acl.toml. An explicit --connect-acl always wins; a named
-    // instance with no override falls back to connect-acl-<name>.toml (missing
-    // ⇒ disabled, same fail-closed behaviour as the base default); an unnamed
-    // daemon keeps the base default.
-    let effective_connect_acl_path: Option<PathBuf> = match (&connect_acl_override, &instance_name)
-    {
-        (Some(p), _) => Some(p.clone()),
-        (None, Some(name)) => Some(x0x::connect::default_connect_acl_path_for(name)),
-        (None, None) => None,
-    };
     let connect_policy = x0x::connect::load_connect_policy(
         effective_connect_acl_path.as_deref(),
         connect_acl_load_mode,
@@ -292,7 +304,7 @@ async fn main() -> anyhow::Result<()> {
         skip_update_check,
         cli_no_port_mapping,
         cli_disable_peer_cache,
-        instance_name,
+        instance_name: instance_name.map(InstanceName::into_string),
         exec_policy,
         connect_policy,
         self_update_enabled,
@@ -607,4 +619,115 @@ fn init_logging(level: &str, format: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use x0x::server::InstanceName;
+
+    /// Construct a valid `InstanceName` from test data. Mirrors the CLI's own
+    /// `InstanceName::try_from(name)?` construction at the `--name` parse site.
+    fn valid_name(raw: &str) -> InstanceName {
+        InstanceName::try_from(raw.to_owned())
+            .unwrap_or_else(|e| panic!("{raw:?}: expected valid instance name, got {e}"))
+    }
+
+    #[test]
+    fn cli_name_wins_over_invalid_config_loser() {
+        // A CLI name is already validated; a config name is validated only when
+        // it wins. So an invalid config value must be silently discarded, never
+        // allowed to veto a valid CLI name. The named CLI instance still owns
+        // the identity and derives its plane-scoped ACL path.
+        let cli = valid_name("prod");
+        let expected_path = x0x::connect::default_connect_acl_path_for(&cli);
+        let (instance, path) =
+            resolve_instance_startup(Some(cli.clone()), Some("../etc/passwd".to_owned()), None)
+                .expect("valid CLI name must shadow an invalid config loser");
+        assert_eq!(
+            instance,
+            Some(cli),
+            "CLI name must win the instance identity"
+        );
+        assert_eq!(
+            path,
+            Some(expected_path),
+            "named CLI instance must derive its plane-scoped ACL path"
+        );
+    }
+
+    #[test]
+    fn config_only_traversal_name_is_rejected_with_canonical_error() {
+        // No CLI name: the config value is validated, and a traversal name must
+        // be rejected before any ACL path is derived. `resolve_instance_startup`
+        // is pure (no filesystem access), so this needs no fixtures. The bare
+        // `?` means the CLI/config invalid winner surfaces the exact, established
+        // InstanceName error — no extra context added.
+        let bad = "../etc/passwd".to_owned();
+        let resolver_err = resolve_instance_startup(None, Some(bad.clone()), None)
+            .expect_err("traversal config name must be rejected before path derivation")
+            .to_string();
+        let canonical_err = InstanceName::try_from(bad)
+            .expect_err("traversal name must be rejected by the grammar")
+            .to_string();
+        assert_eq!(
+            resolver_err, canonical_err,
+            "resolver must propagate the canonical InstanceName error unchanged"
+        );
+        assert!(
+            resolver_err.contains("alphanumeric"),
+            "expected the grammar error, got {resolver_err:?}"
+        );
+    }
+
+    #[test]
+    fn unnamed_instance_has_no_default_acl_path() {
+        // No name anywhere and no explicit override: no instance identity and
+        // no derived ACL path. The unnamed daemon falls through to the base
+        // default and load_connect_policy's DefaultPath fail-closed behaviour.
+        let (instance, path) =
+            resolve_instance_startup(None, None, None).expect("no inputs resolves trivially");
+        assert_eq!(instance, None, "no name ⇒ no instance identity");
+        assert_eq!(path, None, "no name and no override ⇒ no derived ACL path");
+    }
+
+    #[test]
+    fn connect_acl_override_shadows_named_instance() {
+        // An explicit --connect-acl path always wins, even over a named
+        // instance's plane-scoped default. The CLI name still owns identity.
+        let cli = valid_name("prod");
+        let override_path = std::path::Path::new("/etc/x0x/custom-connect.toml");
+        let (instance, path) = resolve_instance_startup(
+            Some(cli.clone()),
+            Some("testnet".to_owned()), // a valid config loser, also ignored for identity
+            Some(override_path),
+        )
+        .expect("override + valid names resolve");
+        assert_eq!(instance, Some(cli), "CLI name owns the instance identity");
+        assert_eq!(
+            path.as_deref(),
+            Some(override_path),
+            "explicit override must shadow the named default path"
+        );
+    }
+
+    #[test]
+    fn valid_config_name_resolves_when_no_cli_name() {
+        // The config-name arm: with no CLI name, the config value is validated
+        // and becomes the instance identity, deriving its own plane-scoped path.
+        let resolved = valid_name("testnet");
+        let expected_path = x0x::connect::default_connect_acl_path_for(&resolved);
+        let (instance, path) = resolve_instance_startup(None, Some("testnet".to_owned()), None)
+            .expect("valid config name resolves");
+        assert_eq!(
+            instance,
+            Some(resolved),
+            "config name wins when no CLI name is present"
+        );
+        assert_eq!(
+            path,
+            Some(expected_path),
+            "config name derives its plane-scoped default"
+        );
+    }
 }

--- a/src/connect/acl.rs
+++ b/src/connect/acl.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::exec::acl::{parse_agent_id, parse_machine_id, LoadMode};
 use crate::identity::{AgentId, MachineId};
+use crate::server::InstanceName;
 
 // ---------------------------------------------------------------------------
 // Path
@@ -57,15 +58,11 @@ pub fn default_connect_acl_path() -> PathBuf {
 /// co-located daemons (prod / testnet / `:443`) do not silently share one
 /// connect-ACL file (issue #189). An explicit `--connect-acl` always wins; a
 /// missing plane-specific file disables connect with the same fail-closed
-/// behaviour as the base default. `server::validate_instance_name` restricts
-/// the name to `[a-zA-Z0-9-]`, so the derived filename is path-traversal-safe.
+/// behaviour as the base default. [`InstanceName`] construction enforces the
+/// shared CLI/config grammar before this function can derive a path.
 #[must_use]
-pub fn default_connect_acl_path_for(name: &str) -> PathBuf {
-    debug_assert!(
-        !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
-        "instance name must be validated before deriving a connect-ACL path"
-    );
-    let file = format!("connect-acl-{name}.toml");
+pub fn default_connect_acl_path_for(name: &InstanceName) -> PathBuf {
+    let file = format!("connect-acl-{}.toml", name.as_str());
     default_connect_acl_path()
         .parent()
         .map(|dir| dir.join(&file))

--- a/src/connect/acl/tests.rs
+++ b/src/connect/acl/tests.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use super::*;
 use crate::exec::acl::{parse_agent_id, parse_machine_id};
+use crate::server::InstanceName;
 
 // ===========================================================================
 // Matrix A — fail-closed load matrix (mirror exec::acl tests one-for-one)
@@ -413,7 +414,9 @@ unknown_key = "surprise"
 fn default_connect_acl_path_for_is_plane_scoped_and_safe() {
     // A named instance gets its own default path in the same directory as the
     // base default, named connect-acl-<name>.toml.
-    let testnet = default_connect_acl_path_for("testnet");
+    let name =
+        InstanceName::try_from("testnet".to_owned()).expect("testnet is a valid instance name");
+    let testnet = default_connect_acl_path_for(&name);
     let base = default_connect_acl_path();
     let base_dir = base
         .parent()
@@ -439,6 +442,52 @@ fn default_connect_acl_path_for_is_plane_scoped_and_safe() {
             .is_some_and(|n| n == "connect-acl.toml"),
         "base default must stay connect-acl.toml, got {base:?}"
     );
+}
+
+/// Path derivation is guarded by the `InstanceName` type, not a `debug_assert!`
+/// that vanishes in release builds.
+///
+/// The path-injection vectors below cannot be constructed as an `InstanceName`
+/// in ANY build profile — `TryFrom` validation is not `cfg(debug_assertions)`
+/// gated — so they can never reach `default_connect_acl_path_for`. Path safety
+/// is therefore the `&InstanceName` signature itself: the function is
+/// statically impossible to call with a raw traversal string, which is why it
+/// carries no internal assertion and stays correct in release builds.
+#[test]
+fn default_connect_acl_path_for_is_type_gated_not_debug_asserted() {
+    // Premise: every path-injection vector is unconstructible in debug and
+    // release alike, so none can reach the path function.
+    for injection in &["/", "\\", "..", "../etc/passwd", "/etc/passwd"] {
+        assert!(
+            InstanceName::try_from((*injection).to_owned()).is_err(),
+            "{injection:?}: must be unconstructible, else it could reach the path function"
+        );
+    }
+
+    // Consequence: every constructible name maps to a well-formed path under
+    // the base directory with the connect-acl-<name>.toml shape — no internal
+    // assertion or validation required inside the path function. The names here
+    // are deliberately distinct from the named-path test's "testnet" case.
+    let base = default_connect_acl_path();
+    let base_dir = base
+        .parent()
+        .expect("base default connect-ACL path has a parent dir");
+    for raw in &["ci", "x0x-443", "ProdNode1", "build-"] {
+        let name = InstanceName::try_from((*raw).to_owned())
+            .unwrap_or_else(|e| panic!("{raw:?}: valid, got {e}"));
+        let path = default_connect_acl_path_for(&name);
+        assert_eq!(path.parent(), Some(base_dir), "{raw:?}: wrong directory");
+        let fname = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_else(|| panic!("{raw:?}: non-UTF-8 filename"));
+        let expected = format!("connect-acl-{raw}.toml");
+        assert_eq!(
+            fname,
+            expected.as_str(),
+            "{raw:?}: filename must be connect-acl-<name>.toml"
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -31,8 +31,8 @@ use routes::{
 };
 use sse::{direct_events_sse, events_sse, peer_events_handler, presence_events, SseEvent};
 pub use state::{
-    default_api_address, default_bind_address, default_data_dir, DaemonConfig, ServeOptions,
-    ServerHandle, DEFAULT_QUIC_PORT,
+    default_api_address, default_bind_address, default_data_dir, DaemonConfig, InstanceName,
+    ServeOptions, ServerHandle, DEFAULT_QUIC_PORT,
 };
 use state::{shared_cache_dir, AppState, CachedUpgradeCheck, DaemonUpdateConfig};
 use ws::{ws_diagnostics, ws_direct_handler, ws_handler, ws_sessions, WsOutboundStats};
@@ -1796,23 +1796,6 @@ pub async fn serve_with_options(
         cancel,
         task: Some(task),
     })
-}
-
-pub fn validate_instance_name(name: &str) -> Result<()> {
-    if name.is_empty() || name.len() > 64 {
-        anyhow::bail!("instance name must be 1-64 characters");
-    }
-    let valid = name
-        .chars()
-        .next()
-        .is_some_and(|c| c.is_ascii_alphanumeric())
-        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
-    if !valid {
-        anyhow::bail!(
-            "instance name must start with alphanumeric and contain only alphanumeric or hyphens"
-        );
-    }
-    Ok(())
 }
 
 pub async fn list_instances() -> Result<()> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -31,8 +31,8 @@ use routes::{
 };
 use sse::{direct_events_sse, events_sse, peer_events_handler, presence_events, SseEvent};
 pub use state::{
-    default_api_address, default_bind_address, default_data_dir, DaemonConfig, InstanceName,
-    ServeOptions, ServerHandle, DEFAULT_QUIC_PORT,
+    default_api_address, default_bind_address, default_data_dir, validate_instance_name,
+    DaemonConfig, InstanceName, ServeOptions, ServerHandle, DEFAULT_QUIC_PORT,
 };
 use state::{shared_cache_dir, AppState, CachedUpgradeCheck, DaemonUpdateConfig};
 use ws::{ws_diagnostics, ws_direct_handler, ws_handler, ws_sessions, WsOutboundStats};

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -32,6 +32,32 @@ use super::{
     WelcomeFetchWaiter,
 };
 
+fn validate_instance_name_grammar(name: &str) -> anyhow::Result<()> {
+    if name.is_empty() || name.len() > 64 {
+        anyhow::bail!("instance name must be 1-64 characters");
+    }
+    let valid = name
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+    if !valid {
+        anyhow::bail!(
+            "instance name must start with alphanumeric and contain only alphanumeric or hyphens"
+        );
+    }
+    Ok(())
+}
+
+/// Validate a daemon instance name without taking ownership or allocating on
+/// the success path.
+///
+/// New path-derivation code should construct [`InstanceName`] so invalid state
+/// is unrepresentable. This function remains the stable borrowed validation API.
+pub fn validate_instance_name(name: &str) -> anyhow::Result<()> {
+    validate_instance_name_grammar(name)
+}
+
 /// Validated daemon instance name used for every instance-scoped path.
 ///
 /// Construction enforces the shared CLI/config grammar, so path derivation
@@ -57,19 +83,7 @@ impl TryFrom<String> for InstanceName {
     type Error = anyhow::Error;
 
     fn try_from(name: String) -> Result<Self, Self::Error> {
-        if name.is_empty() || name.len() > 64 {
-            anyhow::bail!("instance name must be 1-64 characters");
-        }
-        let valid = name
-            .chars()
-            .next()
-            .is_some_and(|c| c.is_ascii_alphanumeric())
-            && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
-        if !valid {
-            anyhow::bail!(
-                "instance name must start with alphanumeric and contain only alphanumeric or hyphens"
-            );
-        }
+        validate_instance_name_grammar(&name)?;
         Ok(Self(name))
     }
 }
@@ -716,6 +730,87 @@ mod tests {
                 raw,
                 "an accepted name must be preserved byte-for-byte (no trim/lowercase)"
             );
+        }
+    }
+
+    /// Backcompat / parity guard for the stable borrowed validator.
+    ///
+    /// `x0x::server::validate_instance_name` is the documented
+    /// `fn(&str) -> anyhow::Result<()>` surface that pre-dates the typed
+    /// [`InstanceName`] constructor. It must reach the SAME verdict as
+    /// [`InstanceName::try_from`] and emit the SAME error bytes for every
+    /// grammar/length boundary, so a caller cannot observe a name that one path
+    /// accepts but the other rejects. The two `try_from_*` tests above pin the
+    /// constructor's absolute behavior against the canonical messages; this test
+    /// pins the *relationship* between the two surfaces and deliberately does
+    /// not re-encode the grammar (it derives expectations from the sibling API),
+    /// so it stays correct if the messages are ever reworded.
+    #[test]
+    fn borrowed_validator_matches_typed_constructor_outcomes_and_messages() {
+        // Bind the restored public signature as a typed fn pointer. If the
+        // `fn(&str) -> anyhow::Result<()>` surface ever changes arity, argument
+        // type, or return type, this binding fails to COMPILE — a
+        // backcompat guard stronger than any runtime assertion.
+        let validate: fn(&str) -> anyhow::Result<()> = x0x::server::validate_instance_name;
+
+        let max = "a".repeat(64); // exactly 64 — upper length boundary (valid)
+        let over = "a".repeat(65); // 65 — one past the boundary (invalid)
+
+        // One representative row per documented category: valid boundaries on
+        // the success side; every documented rejection class on the failure
+        // side. No grammar is re-encoded below — each row is compared against
+        // the typed constructor's actual output.
+        let cases: &[&str] = &[
+            // --- valid boundaries ---
+            "a",          // single char — lower length boundary
+            "testnet",    // lowercase alphanumeric
+            "x0x-443",    // alphanumeric + hyphen (embedded hyphen allowed)
+            max.as_str(), // exactly 64 chars — upper length boundary
+            // --- invalid: empty (length rule) ---
+            "",
+            // --- invalid: whitespace ---
+            "   ",   // whitespace only
+            "ab cd", // embedded space
+            "\t",    // tab
+            // --- invalid: path separators ---
+            "/",    // forward slash
+            "\\",   // backslash
+            "a/b",  // embedded forward slash
+            "a\\b", // embedded backslash
+            // --- invalid: traversal + absolute & platform path forms ---
+            "..",                // parent traversal
+            "../etc/passwd",     // traversal with target
+            "/etc/passwd",       // absolute POSIX path
+            "C:\\Users",         // absolute Windows drive path (platform form)
+            "\\\\server\\share", // UNC path form
+            // --- invalid: leading hyphen (also a CLI-flag-injection hazard) ---
+            "-lead",
+            // --- invalid: non-ASCII ---
+            "café", // accented Latin
+            "测试", // CJK
+            // --- invalid: overlength (length rule) ---
+            over.as_str(),
+        ];
+
+        for &raw in cases {
+            let borrowed = validate(raw);
+            let typed = InstanceName::try_from(raw.to_owned());
+            match (&borrowed, &typed) {
+                (Ok(()), Ok(_)) => {}
+                (Err(borrowed_err), Err(typed_err)) => assert_eq!(
+                    borrowed_err.to_string(),
+                    typed_err.to_string(),
+                    "borrowed and typed validators disagree on error message for {raw:?}"
+                ),
+                (Ok(()), Err(typed_err)) => panic!(
+                    "parity break: borrowed validator ACCEPTED {raw:?} \
+                     but typed constructor rejected it: {typed_err}"
+                ),
+                (Err(borrowed_err), Ok(_)) => panic!(
+                    "parity break: borrowed validator REJECTED {raw:?} \
+                     but typed constructor accepted it: {borrowed_err}"
+                ),
+            }
         }
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -32,6 +32,48 @@ use super::{
     WelcomeFetchWaiter,
 };
 
+/// Validated daemon instance name used for every instance-scoped path.
+///
+/// Construction enforces the shared CLI/config grammar, so path derivation
+/// cannot receive separators, traversal components, or empty names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceName(String);
+
+impl InstanceName {
+    /// Borrow the validated instance name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the validated name and return its owned representation.
+    #[must_use]
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for InstanceName {
+    type Error = anyhow::Error;
+
+    fn try_from(name: String) -> Result<Self, Self::Error> {
+        if name.is_empty() || name.len() > 64 {
+            anyhow::bail!("instance name must be 1-64 characters");
+        }
+        let valid = name
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
+            && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+        if !valid {
+            anyhow::bail!(
+                "instance name must start with alphanumeric and contain only alphanumeric or hyphens"
+            );
+        }
+        Ok(Self(name))
+    }
+}
+
 /// Carries the CLI-derived flags that the server-bringup path consumes.
 /// Phase 1: minimal — do not redesign config here.
 #[derive(Default)]
@@ -599,4 +641,81 @@ pub(super) struct CachedUpgradeCheck {
     pub(super) status: StatusCode,
     pub(super) body: serde_json::Value,
     pub(super) ttl: Duration,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The two canonical messages enforced by `InstanceName::try_from`.
+    // `x0xd::resolve_instance_startup` propagates these verbatim (bare `?`,
+    // no added context), so an invalid CLI or config name surfaces one
+    // identical, established message at startup.
+    const GRAMMAR_ERR: &str =
+        "instance name must start with alphanumeric and contain only alphanumeric or hyphens";
+    const LENGTH_ERR: &str = "instance name must be 1-64 characters";
+
+    #[test]
+    fn try_from_rejects_path_traversal_separators_and_invalid_grammar() {
+        // Each row is a named boundary a path-injection or grammar bug would
+        // ride in on. The separator/traversal cluster is security-critical:
+        // these are the exact strings that must never reach path derivation.
+        let overlength = "a".repeat(65); // 65 > 64 max
+        let cases: &[(&str, &str)] = &[
+            // separators — forward slash + backslash, bare and embedded
+            ("/", GRAMMAR_ERR),
+            ("\\", GRAMMAR_ERR),
+            ("a/b", GRAMMAR_ERR),
+            ("a\\b", GRAMMAR_ERR),
+            // traversal components / absolute paths
+            ("..", GRAMMAR_ERR),
+            ("../etc/passwd", GRAMMAR_ERR),
+            ("/etc/passwd", GRAMMAR_ERR),
+            // emptiness (length rule, checked before grammar)
+            ("", LENGTH_ERR),
+            // whitespace
+            ("   ", GRAMMAR_ERR),
+            ("ab cd", GRAMMAR_ERR),
+            // leading hyphen (also a CLI-flag-injection hazard)
+            ("-lead", GRAMMAR_ERR),
+            // non-ASCII
+            ("café", GRAMMAR_ERR),
+            // overlength boundary (length rule)
+            (overlength.as_str(), LENGTH_ERR),
+        ];
+
+        for &(raw, expected) in cases {
+            let err = InstanceName::try_from(raw.to_owned())
+                .expect_err("invalid instance name must be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains(expected),
+                "{raw:?}: expected error containing {expected:?}, got {msg:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn try_from_accepts_valid_names_and_preserves_bytes() {
+        // Boundary pair with the 65-char case above: 64 passes, 65 fails.
+        let max_len = "a".repeat(64);
+        let cases: &[&str] = &[
+            "a",              // single char — lower length boundary
+            "testnet",        // lowercase alphanumeric
+            "x0x-443",        // alphanumeric + hyphen
+            "ProdNode1",      // mixed case + digits
+            "build-",         // trailing hyphen allowed (hyphen barred only at position 0)
+            max_len.as_str(), // exactly 64 chars — upper length boundary
+        ];
+
+        for &raw in cases {
+            let name = InstanceName::try_from(raw.to_owned())
+                .unwrap_or_else(|e| panic!("{raw:?}: expected valid, got {e}"));
+            assert_eq!(
+                name.as_str(),
+                raw,
+                "an accepted name must be preserved byte-for-byte (no trim/lowercase)"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a validated `InstanceName` newtype shared by CLI and config sources
- resolve CLI/config precedence before deriving the named connect-ACL path
- require validated names in `default_connect_acl_path_for`, removing release-only `debug_assert!` safety
- preserve CLI precedence, exact named paths, explicit ACL overrides, and unnamed defaults

## Security behavior
- rejects config-only traversal such as `foo/../../../tmp/evil` before ACL path derivation or access
- rejects `/`, `\\`, `..`, absolute paths, whitespace-only, non-ASCII, leading hyphens, and overlength values under the established grammar/error text
- ignores an invalid config loser when a valid CLI `--name` wins

## Validation
- `cargo fmt --all`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo test --lib server::state::tests::try_from` (2 passed)
- `cargo test --lib connect::acl::tests::default_connect_acl_path` (3 passed)
- `cargo test --bin x0xd` (5 passed)
- `just check` (2115 nextest tests passed; full recipe passed)

BLOCKER-REVIEW finding #9 / WP-ACLNAME.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR validates instance names before deriving instance-scoped connect ACL paths. The main changes are:

- Adds an `InstanceName` newtype with shared CLI/config validation.
- Resolves CLI and config instance-name precedence before ACL path selection.
- Changes named connect ACL path derivation to require a validated name.
- Adds tests for traversal rejection, precedence, overrides, and unnamed defaults.

<h3>Confidence Score: 4/5</h3>

The runtime hardening path looks sound, but the exported validation and path-helper APIs can break downstream builds.

- CLI/config precedence and named ACL path selection match the intended behavior.
- Config-only traversal names are rejected before path derivation.
- Existing callers of the removed validator or old path-helper signature need a compatibility path.

src/server/mod.rs and src/connect/acl.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/bin/x0xd.rs | Adds validated startup resolution for CLI/config names and connect ACL path selection. |
| src/connect/acl.rs | Requires `InstanceName` for named connect ACL path derivation, but changes an exported helper signature. |
| src/connect/acl/tests.rs | Updates path tests to use validated names and cover invalid path-injection inputs. |
| src/server/mod.rs | Re-exports `InstanceName` but removes the previous public validation function. |
| src/server/state.rs | Adds the `InstanceName` validator and boundary tests for accepted and rejected names. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/server/mod.rs:33-36
**Public Validator Removed**

This change stops exporting `x0x::server::validate_instance_name`, while the repository’s public API snapshot still lists that function as preserved. Existing downstream callers that validate names with this API will fail to compile after upgrading, even though the same validation logic still exists behind `InstanceName`.

### Issue 2 of 2
src/connect/acl.rs:64
**Exported Path Helper Re-Typed**

`default_connect_acl_path_for` is re-exported from `x0x::connect`, so changing its argument from `&str` to `&InstanceName` breaks existing callers like `default_connect_acl_path_for("prod")` at compile time. The type gate is safer, but the old exported helper now has no compatible validating entry point for downstream code.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): validate merged instance na..."](https://github.com/saorsa-labs/x0x/commit/8cb270845f58385f918fb359e46a1c995a9ddc67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43492051)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->