### PR TITLE
fix(server): harden TreeKEM recovery cache

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -40,7 +40,7 @@ use ws::{ws_diagnostics, ws_direct_handler, ws_handler, ws_sessions, WsOutboundS
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::path::{Path as FsPath, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
@@ -130,10 +130,12 @@ struct TreeKemMemberKeyPackageCacheState {
     last_error: Option<String>,
 }
 
+#[derive(Clone)]
 struct TreeKemMemberKeyPackageCache {
     path: PathBuf,
-    state: RwLock<TreeKemMemberKeyPackageCacheState>,
-    persistence: Mutex<()>,
+    state: Arc<RwLock<TreeKemMemberKeyPackageCacheState>>,
+    persistence: Arc<Mutex<()>>,
+    retry_scheduled: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
@@ -5965,35 +5967,6 @@ fn member_joined_kp_cache_entry(
     }
 }
 
-fn member_joined_key_package_matches_groups(
-    groups: &HashMap<String, x0x::groups::GroupInfo>,
-    event: &NamedGroupMetadataEvent,
-) -> bool {
-    let NamedGroupMetadataEvent::MemberJoined {
-        group_id,
-        member_agent_id,
-        treekem_key_package_b64: Some(event_key_package),
-        ..
-    } = event
-    else {
-        return false;
-    };
-    let Some(info) = groups.get(group_id).or_else(|| {
-        groups
-            .values()
-            .find(|info| info.stable_group_id() == group_id)
-    }) else {
-        return false;
-    };
-    !info.withdrawn
-        && info.has_active_member(member_agent_id)
-        && info
-            .members_v2
-            .get(member_agent_id)
-            .and_then(|member| member.treekem_key_package_b64.as_ref())
-            == Some(event_key_package)
-}
-
 fn member_joined_key_package_relevant_to_groups(
     groups: &HashMap<String, x0x::groups::GroupInfo>,
     event: &NamedGroupMetadataEvent,
@@ -6007,29 +5980,22 @@ fn member_joined_key_package_relevant_to_groups(
         return false;
     };
     let Some(info) = groups.get(group_id).or_else(|| {
-        groups
-            .values()
-            .find(|info| info.stable_group_id() == group_id || info.mls_group_id == group_id)
+        groups.values().find(|info| {
+            info.stable_group_id() == group_id || info.mls_group_id.as_str() == group_id
+        })
     }) else {
         return false;
     };
-    if info.withdrawn || !verify_member_joined_key_package_event(event) {
+    if info.withdrawn {
         return false;
     }
     if recovery_authority_signature_b64.is_some() {
         verify_authority_attested_member_joined_recovery(info, event)
     } else {
-        true
+        verify_member_joined_key_package_event(event)
     }
 }
 
-async fn member_joined_key_package_matches_roster(
-    state: &AppState,
-    event: &NamedGroupMetadataEvent,
-) -> bool {
-    let groups = state.named_groups.read().await;
-    member_joined_key_package_matches_groups(&groups, event)
-}
 /// Verify that a key-package-bearing `MemberJoined` is self-authenticated by
 /// the claimed member. This is intentionally independent of inviter and roster
 /// state so persisted recovery records can be authenticated during startup.
@@ -6352,6 +6318,10 @@ fn verify_authority_attested_member_joined_recovery(
             .get(member_agent_id)
             .and_then(|member| member.added_by.as_deref())
             == Some(authority_agent_id.as_str());
+    let authority_commit_is_accepted = info
+        .commit_log
+        .iter()
+        .any(|retained| retained.commit == *authority_commit);
     if (!creator_authority && !invited_member_authority)
         || (!member_authenticated && !authority_only_attestation)
         || !package_matches_current_incarnation
@@ -6368,6 +6338,7 @@ fn verify_authority_attested_member_joined_recovery(
         || !(group_id == &info.mls_group_id
             || group_id == info.stable_group_id()
             || stable_group_id.as_deref() == Some(info.stable_group_id()))
+        || !authority_commit_is_accepted
         || !info.has_active_member(member_agent_id)
     {
         return false;
@@ -6400,6 +6371,63 @@ fn verify_authority_attested_member_joined_recovery(
         .is_ok()
 }
 
+fn recovery_cache_group_identity(event: &NamedGroupMetadataEvent) -> &str {
+    match event {
+        NamedGroupMetadataEvent::MemberJoined {
+            group_id,
+            stable_group_id,
+            ..
+        } => stable_group_id.as_deref().unwrap_or(group_id),
+        _ => named_group_metadata_event_group_id(event),
+    }
+}
+
+fn canonical_recovery_cache_group_id(
+    groups: &HashMap<String, x0x::groups::GroupInfo>,
+    event: &NamedGroupMetadataEvent,
+) -> String {
+    let NamedGroupMetadataEvent::MemberJoined {
+        group_id,
+        stable_group_id,
+        ..
+    } = event
+    else {
+        return named_group_metadata_event_group_id(event).to_string();
+    };
+    groups
+        .get(group_id)
+        .or_else(|| {
+            stable_group_id
+                .as_deref()
+                .and_then(|stable| groups.get(stable))
+        })
+        .or_else(|| {
+            groups
+                .values()
+                .filter(|info| {
+                    info.mls_group_id == *group_id
+                        || info.stable_group_id() == group_id
+                        || stable_group_id.as_deref() == Some(info.mls_group_id.as_str())
+                        || stable_group_id.as_deref() == Some(info.stable_group_id())
+                })
+                .min_by_key(|info| info.stable_group_id())
+        })
+        .map_or_else(
+            || recovery_cache_group_identity(event).to_string(),
+            |info| info.stable_group_id().to_string(),
+        )
+}
+
+fn recovery_cache_storage_group_id<'a>(
+    key: &'a str,
+    event: &'a NamedGroupMetadataEvent,
+) -> &'a str {
+    key.split_once(':').map_or_else(
+        || recovery_cache_group_identity(event),
+        |(group_id, _)| group_id,
+    )
+}
+
 fn member_joined_event_timestamp(event: &NamedGroupMetadataEvent) -> u64 {
     match event {
         NamedGroupMetadataEvent::MemberJoined { ts_ms, .. } => *ts_ms,
@@ -6426,6 +6454,38 @@ fn enforce_treekem_member_key_package_cache_bounds(
     state: &mut TreeKemMemberKeyPackageCacheState,
 ) -> usize {
     let mut evicted = 0usize;
+    let mut provisional_by_group = BTreeMap::<String, Vec<(String, u64)>>::new();
+    for (key, entry) in &state.entries {
+        let NamedGroupMetadataEvent::MemberJoined {
+            group_id: _,
+            recovery_authority_signature_b64,
+            ts_ms,
+            ..
+        } = &entry.event
+        else {
+            continue;
+        };
+        if recovery_authority_signature_b64.is_none() {
+            provisional_by_group
+                .entry(recovery_cache_storage_group_id(key, &entry.event).to_string())
+                .or_default()
+                .push((key.clone(), *ts_ms));
+        }
+    }
+    for provisional in provisional_by_group.values_mut() {
+        provisional.sort_by(|(left_key, left_ts), (right_key, right_ts)| {
+            left_ts.cmp(right_ts).then_with(|| left_key.cmp(right_key))
+        });
+        let excess = provisional
+            .len()
+            .saturating_sub(TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP);
+        for (victim, _) in provisional.iter().take(excess) {
+            if let Some(removed) = state.entries.remove(victim) {
+                state.encoded_bytes = state.encoded_bytes.saturating_sub(removed.encoded_bytes);
+                evicted = evicted.saturating_add(1);
+            }
+        }
+    }
     while state.entries.len() > TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_ENTRIES
         || cache_snapshot_encoded_bytes(state) > TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_BYTES
     {
@@ -6447,6 +6507,16 @@ fn enforce_treekem_member_key_package_cache_bounds(
         }
     }
     evicted
+}
+
+fn recovery_event_has_authority_attestation(event: &NamedGroupMetadataEvent) -> bool {
+    matches!(
+        event,
+        NamedGroupMetadataEvent::MemberJoined {
+            recovery_authority_signature_b64: Some(_),
+            ..
+        }
+    )
 }
 
 fn recovery_attestation_revision(event: &NamedGroupMetadataEvent) -> Option<u64> {
@@ -6474,10 +6544,16 @@ fn should_replace_recovery_cache_entry(
         recovery_attestation_revision(candidate),
     ) {
         (None, Some(_)) => true,
+        (Some(_), None) => false,
         (Some(existing_revision), Some(candidate_revision)) => {
             candidate_revision > existing_revision
+                || (candidate_revision == existing_revision
+                    && member_joined_event_timestamp(candidate)
+                        > member_joined_event_timestamp(existing))
         }
-        _ => false,
+        (None, None) => {
+            member_joined_event_timestamp(candidate) > member_joined_event_timestamp(existing)
+        }
     }
 }
 
@@ -6498,7 +6574,7 @@ fn provisional_recovery_cache_victim(
                 return None;
             };
             (recovery_authority_signature_b64.is_none()
-                && named_group_metadata_event_group_id(&entry.event) == group_id)
+                && recovery_cache_storage_group_id(key, &entry.event) == group_id)
                 .then_some((key, *ts_ms))
         })
         .collect::<Vec<_>>();
@@ -6545,20 +6621,36 @@ impl TreeKemMemberKeyPackageCache {
         Ok((
             Self {
                 path,
-                state: RwLock::new(state),
-                persistence: Mutex::new(()),
+                state: Arc::new(RwLock::new(state)),
+                persistence: Arc::new(Mutex::new(())),
+                retry_scheduled: Arc::new(AtomicBool::new(false)),
             },
             evicted,
         ))
     }
 
     async fn get(&self, key: &str) -> Option<NamedGroupMetadataEvent> {
-        self.state
-            .read()
-            .await
+        let state = self.state.read().await;
+        if let Some(entry) = state.entries.get(key) {
+            return Some(entry.event.clone());
+        }
+        state
             .entries
-            .get(key)
-            .map(|entry| entry.event.clone())
+            .values()
+            .filter(|entry| {
+                member_joined_kp_cache_entry(&entry.event)
+                    .is_some_and(|(event_key, _)| event_key == key)
+            })
+            .map(|entry| &entry.event)
+            .max_by(|left, right| {
+                recovery_attestation_revision(left)
+                    .cmp(&recovery_attestation_revision(right))
+                    .then_with(|| {
+                        member_joined_event_timestamp(left)
+                            .cmp(&member_joined_event_timestamp(right))
+                    })
+            })
+            .cloned()
     }
 
     async fn find_for_member(
@@ -6567,12 +6659,36 @@ impl TreeKemMemberKeyPackageCache {
         member_id: &str,
     ) -> Option<NamedGroupMetadataEvent> {
         let state = self.state.read().await;
-        group_ids.iter().find_map(|group_id| {
-            state
-                .entries
-                .get(&join_result_key(group_id, member_id))
-                .map(|entry| entry.event.clone())
-        })
+        state
+            .entries
+            .iter()
+            .filter(|(key, entry)| {
+                let NamedGroupMetadataEvent::MemberJoined {
+                    group_id,
+                    stable_group_id,
+                    member_agent_id,
+                    ..
+                } = &entry.event
+                else {
+                    return false;
+                };
+                member_agent_id.eq_ignore_ascii_case(member_id)
+                    && group_ids.iter().any(|candidate| {
+                        candidate == recovery_cache_storage_group_id(key, &entry.event)
+                            || candidate == group_id
+                            || stable_group_id.as_deref() == Some(candidate.as_str())
+                    })
+            })
+            .map(|(_, entry)| &entry.event)
+            .max_by(|left, right| {
+                recovery_attestation_revision(left)
+                    .cmp(&recovery_attestation_revision(right))
+                    .then_with(|| {
+                        member_joined_event_timestamp(left)
+                            .cmp(&member_joined_event_timestamp(right))
+                    })
+            })
+            .cloned()
     }
 
     async fn events_matching(
@@ -6589,26 +6705,66 @@ impl TreeKemMemberKeyPackageCache {
             .collect()
     }
 
+    #[cfg(test)]
     async fn insert(
         &self,
         key: String,
         event: NamedGroupMetadataEvent,
         overwrite: bool,
     ) -> Result<TreeKemCacheMutation> {
+        self.insert_for_group(key, event, overwrite, None).await
+    }
+
+    async fn insert_for_group(
+        &self,
+        key: String,
+        event: NamedGroupMetadataEvent,
+        overwrite: bool,
+        canonical_group_id: Option<&str>,
+    ) -> Result<TreeKemCacheMutation> {
         let expected_key = member_joined_kp_cache_entry(&event)
             .map(|(expected_key, _)| expected_key)
             .context("TreeKEM recovery cache accepts only key-package MemberJoined events")?;
-        if expected_key != key || !verify_member_joined_key_package_event(&event) {
-            anyhow::bail!("TreeKEM recovery cache rejected invalid key or member signature");
+        let signature_valid = if recovery_event_has_authority_attestation(&event) {
+            verify_recovery_attestation_structure(&event)
+        } else {
+            verify_member_joined_key_package_event(&event)
+        };
+        let signed_stable_key = match &event {
+            NamedGroupMetadataEvent::MemberJoined {
+                stable_group_id: Some(stable_group_id),
+                member_agent_id,
+                ..
+            } => Some(join_result_key(stable_group_id, member_agent_id)),
+            _ => None,
+        };
+        if (expected_key != key && signed_stable_key.as_deref() != Some(key.as_str()))
+            || !signature_valid
+        {
+            anyhow::bail!("TreeKEM recovery cache rejected invalid key or recovery signature");
         }
-        let encoded_bytes = cache_entry_encoded_bytes(&key, &event)
+        let storage_key = if let Some(canonical_group_id) = canonical_group_id {
+            let NamedGroupMetadataEvent::MemberJoined {
+                member_agent_id, ..
+            } = &event
+            else {
+                anyhow::bail!("TreeKEM recovery cache accepts only MemberJoined events");
+            };
+            join_result_key(canonical_group_id, &member_agent_id.to_ascii_lowercase())
+        } else {
+            key
+        };
+        let encoded_bytes = cache_entry_encoded_bytes(&storage_key, &event)
             .context("failed to encode TreeKEM member key-package cache entry")?;
         let evicted = {
             let mut state = self.state.write().await;
-            if let Some(existing) = state.entries.get(&key) {
+            if let Some(existing) = state.entries.get(&storage_key) {
                 if !should_replace_recovery_cache_entry(&existing.event, &event, overwrite) {
                     drop(state);
                     let persistence = self.persist_latest().await;
+                    if matches!(&persistence, TreeKemCachePersistenceStatus::Dirty { .. }) {
+                        self.schedule_persistence_retry();
+                    }
                     return Ok(TreeKemCacheMutation {
                         persistence,
                         evicted: 0,
@@ -6617,10 +6773,10 @@ impl TreeKemMemberKeyPackageCache {
             }
 
             let mut evicted = 0usize;
-            if let Some(previous) = state.entries.remove(&key) {
+            if let Some(previous) = state.entries.remove(&storage_key) {
                 state.encoded_bytes = state.encoded_bytes.saturating_sub(previous.encoded_bytes);
             } else if recovery_attestation_revision(&event).is_none() {
-                let group_id = named_group_metadata_event_group_id(&event);
+                let group_id = recovery_cache_storage_group_id(&storage_key, &event);
                 if let Some(victim) = provisional_recovery_cache_victim(&state, group_id) {
                     if let Some(removed) = state.entries.remove(&victim) {
                         state.encoded_bytes =
@@ -6631,7 +6787,7 @@ impl TreeKemMemberKeyPackageCache {
             }
             state.encoded_bytes = state.encoded_bytes.saturating_add(encoded_bytes);
             state.entries.insert(
-                key,
+                storage_key,
                 TreeKemMemberKeyPackageCacheEntry {
                     event,
                     encoded_bytes,
@@ -6642,6 +6798,9 @@ impl TreeKemMemberKeyPackageCache {
             evicted.saturating_add(enforce_treekem_member_key_package_cache_bounds(&mut state))
         };
         let persistence = self.persist_latest().await;
+        if matches!(&persistence, TreeKemCachePersistenceStatus::Dirty { .. }) {
+            self.schedule_persistence_retry();
+        }
         Ok(TreeKemCacheMutation {
             persistence,
             evicted,
@@ -6653,20 +6812,38 @@ impl TreeKemMemberKeyPackageCache {
         group_ids: &HashSet<String>,
         member_id: &str,
     ) -> TreeKemCacheMutation {
-        self.remove_matching(|event| match event {
+        self.remove_matching(|key, event| match event {
             NamedGroupMetadataEvent::MemberJoined {
                 group_id,
+                stable_group_id,
                 member_agent_id,
                 ..
-            } => group_ids.contains(group_id) && member_agent_id == member_id,
+            } => {
+                member_agent_id.eq_ignore_ascii_case(member_id)
+                    && (group_ids.contains(group_id)
+                        || stable_group_id
+                            .as_ref()
+                            .is_some_and(|stable| group_ids.contains(stable))
+                        || group_ids.contains(recovery_cache_storage_group_id(key, event)))
+            }
             _ => false,
         })
         .await
     }
 
     async fn remove_groups(&self, group_ids: &HashSet<String>) -> TreeKemCacheMutation {
-        self.remove_matching(|event| match event {
-            NamedGroupMetadataEvent::MemberJoined { group_id, .. } => group_ids.contains(group_id),
+        self.remove_matching(|key, event| match event {
+            NamedGroupMetadataEvent::MemberJoined {
+                group_id,
+                stable_group_id,
+                ..
+            } => {
+                group_ids.contains(group_id)
+                    || stable_group_id
+                        .as_ref()
+                        .is_some_and(|stable| group_ids.contains(stable))
+                    || group_ids.contains(recovery_cache_storage_group_id(key, event))
+            }
             _ => false,
         })
         .await
@@ -6674,14 +6851,14 @@ impl TreeKemMemberKeyPackageCache {
 
     async fn remove_matching(
         &self,
-        should_remove: impl Fn(&NamedGroupMetadataEvent) -> bool,
+        should_remove: impl Fn(&str, &NamedGroupMetadataEvent) -> bool,
     ) -> TreeKemCacheMutation {
         let removed = {
             let mut state = self.state.write().await;
             let victims: Vec<String> = state
                 .entries
                 .iter()
-                .filter(|(_, entry)| should_remove(&entry.event))
+                .filter(|(key, entry)| should_remove(key, &entry.event))
                 .map(|(key, _)| key.clone())
                 .collect();
             for key in &victims {
@@ -6696,6 +6873,9 @@ impl TreeKemMemberKeyPackageCache {
             victims.len()
         };
         let persistence = self.persist_latest().await;
+        if matches!(&persistence, TreeKemCachePersistenceStatus::Dirty { .. }) {
+            self.schedule_persistence_retry();
+        }
         TreeKemCacheMutation {
             persistence,
             evicted: removed,
@@ -6760,6 +6940,29 @@ impl TreeKemMemberKeyPackageCache {
         }
     }
 
+    fn schedule_persistence_retry(&self) {
+        if self.retry_scheduled.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let cache = self.clone();
+        tokio::spawn(async move {
+            let mut delay = Duration::from_millis(250);
+            loop {
+                tokio::time::sleep(delay).await;
+                match cache.persist_latest().await {
+                    TreeKemCachePersistenceStatus::Durable { .. } => break,
+                    TreeKemCachePersistenceStatus::Dirty { .. } => {
+                        delay = delay.saturating_mul(2).min(Duration::from_secs(30));
+                    }
+                }
+            }
+            cache.retry_scheduled.store(false, Ordering::Release);
+            if cache.diagnostics().await.dirty {
+                cache.schedule_persistence_retry();
+            }
+        });
+    }
+
     async fn diagnostics(&self) -> TreeKemCacheDiagnostics {
         let state = self.state.read().await;
         TreeKemCacheDiagnostics {
@@ -6800,9 +7003,13 @@ async fn cache_treekem_member_key_package(
     event: NamedGroupMetadataEvent,
     overwrite: bool,
 ) -> TreeKemCachePersistenceStatus {
+    let canonical_group_id = {
+        let groups = state.named_groups.read().await;
+        canonical_recovery_cache_group_id(&groups, &event)
+    };
     match state
         .treekem_member_key_packages
-        .insert(key, event, overwrite)
+        .insert_for_group(key, event, overwrite, Some(&canonical_group_id))
         .await
     {
         Ok(mutation) => {
@@ -7670,23 +7877,7 @@ async fn apply_named_group_metadata_event(
     // as provisional evidence, but it cannot replace an existing entry. The
     // inviter's post-acceptance countersigned event (distributed in MemberAdded)
     // upgrades this cache authoritatively after the roster mutation succeeds.
-    let kp_cache_entry = member_joined_kp_cache_entry(&event);
-    let mut retained_non_inviter_witness = false;
-    let should_exit = apply_named_group_metadata_event_inner_with_witness(
-        state,
-        event,
-        sender,
-        verified,
-        true,
-        Some(&mut retained_non_inviter_witness),
-    )
-    .await;
-    if retained_non_inviter_witness {
-        if let Some((key, cached)) = kp_cache_entry {
-            cache_treekem_member_key_package(state, key, cached, false).await;
-        }
-    }
-    should_exit
+    apply_named_group_metadata_event_inner_serialized(state, event, sender, verified, true).await
 }
 
 async fn apply_named_group_metadata_event_inner(
@@ -7696,24 +7887,16 @@ async fn apply_named_group_metadata_event_inner(
     verified: bool,
     allow_queue: bool,
 ) -> bool {
-    apply_named_group_metadata_event_inner_with_witness(
-        state,
-        event,
-        sender,
-        verified,
-        allow_queue,
-        None,
-    )
-    .await
+    apply_named_group_metadata_event_inner_serialized(state, event, sender, verified, allow_queue)
+        .await
 }
 
-async fn apply_named_group_metadata_event_inner_with_witness(
+async fn apply_named_group_metadata_event_inner_serialized(
     state: &Arc<AppState>,
     event: NamedGroupMetadataEvent,
     sender: AgentId,
     verified: bool,
     allow_queue: bool,
-    non_inviter_recovery_witness: Option<&mut bool>,
 ) -> bool {
     let event_kind = named_group_metadata_event_kind(&event);
     let sender_hex = hex::encode(sender.as_bytes());
@@ -9292,10 +9475,12 @@ async fn apply_named_group_metadata_event_inner_with_witness(
             //    state-commit chain.
             let local_is_inviter = local_agent_hex.eq_ignore_ascii_case(&inviter_agent_id);
             if !local_is_inviter {
-                if treekem_key_package_b64.is_some() {
-                    if let Some(witnessed) = non_inviter_recovery_witness {
-                        *witnessed = true;
-                    }
+                if let Some((key, cached)) = member_joined_kp_cache_entry(&event_for_log) {
+                    // Keep provisional witness insertion inside the same
+                    // membership serialization boundary as terminal pruning.
+                    // Otherwise leave/delete can prune first and this deferred
+                    // insert can resurrect the retired group's package.
+                    cache_treekem_member_key_package(state, key, cached, false).await;
                 }
                 tracing::debug!(
                     group_id = %resolved_group_key,
@@ -12122,6 +12307,7 @@ async fn drop_local_named_group_state(
     stable_group_id: Option<&str>,
     reason: &str,
 ) {
+    let cache_aliases = treekem_cache_group_aliases(state, id).await;
     let stable_group_id = stable_group_id.filter(|stable| *stable != id);
     {
         let mut groups = state.named_groups.write().await;
@@ -12130,6 +12316,7 @@ async fn drop_local_named_group_state(
             groups.remove(stable_group_id);
         }
     }
+    let _ = prune_treekem_cache_groups(state, &cache_aliases, reason).await;
     {
         let mut cache = state.group_card_cache.write().await;
         cache.remove(id);
@@ -12225,9 +12412,11 @@ async fn leave_treekem_group(
         }
     };
 
+    let cache_aliases = treekem_cache_group_aliases(&state, &id).await;
     let mut groups = state.named_groups.write().await;
     groups.remove(&id);
     drop(groups);
+    let _ = prune_treekem_cache_groups(&state, &cache_aliases, "treekem_leave").await;
     state.group_card_cache.write().await.remove(&id);
     state.mls_groups.write().await.remove(&id);
     state.treekem_groups.write().await.remove(&id);
@@ -14682,6 +14871,14 @@ async fn import_group_card(
                     "ignored withdrawn card for live keyed group; signed withdrawal commit required"
                 );
             }
+        } else {
+            let aliases = HashSet::from([group_id.clone()]);
+            let _ = prune_treekem_cache_groups(
+                state.as_ref(),
+                &aliases,
+                "withdrawn_card_import_without_local_group",
+            )
+            .await;
         }
         return (
             StatusCode::OK,
@@ -18228,6 +18425,58 @@ async fn quarantine_corrupt_treekem_cache(path: &FsPath) -> std::io::Result<Path
     Ok(quarantine_path)
 }
 
+fn canonicalize_loaded_treekem_cache_entries(
+    groups: &HashMap<String, x0x::groups::GroupInfo>,
+    entries: BTreeMap<String, NamedGroupMetadataEvent>,
+) -> (BTreeMap<String, NamedGroupMetadataEvent>, bool) {
+    let mut canonical = BTreeMap::<String, NamedGroupMetadataEvent>::new();
+    let mut changed = false;
+    for (persisted_key, event) in entries {
+        let NamedGroupMetadataEvent::MemberJoined {
+            member_agent_id, ..
+        } = &event
+        else {
+            changed = true;
+            continue;
+        };
+        let canonical_key = join_result_key(
+            &canonical_recovery_cache_group_id(groups, &event),
+            &member_agent_id.to_ascii_lowercase(),
+        );
+        changed |= canonical_key != persisted_key;
+        if let Some(existing) = canonical.get(&canonical_key) {
+            changed = true;
+            if !should_replace_recovery_cache_entry(existing, &event, true) {
+                continue;
+            }
+        }
+        canonical.insert(canonical_key, event);
+    }
+    (canonical, changed)
+}
+
+fn persisted_treekem_cache_key_is_valid(
+    groups: &HashMap<String, x0x::groups::GroupInfo>,
+    key: &str,
+    event: &NamedGroupMetadataEvent,
+) -> bool {
+    let Some((expected_key, _)) = member_joined_kp_cache_entry(event) else {
+        return false;
+    };
+    let NamedGroupMetadataEvent::MemberJoined {
+        member_agent_id, ..
+    } = event
+    else {
+        return false;
+    };
+    key == expected_key
+        || key
+            == join_result_key(
+                &canonical_recovery_cache_group_id(groups, event),
+                &member_agent_id.to_ascii_lowercase(),
+            )
+}
+
 async fn load_treekem_member_key_packages(
     path: &FsPath,
     groups: &HashMap<String, x0x::groups::GroupInfo>,
@@ -18238,10 +18487,11 @@ async fn load_treekem_member_key_packages(
                 Ok(mut cache) => {
                     let persisted_count = cache.len();
                     cache.retain(|key, event| {
-                        member_joined_kp_cache_entry(event)
-                            .is_some_and(|(expected_key, _)| expected_key == *key)
+                        persisted_treekem_cache_key_is_valid(groups, key, event)
                             && member_joined_key_package_relevant_to_groups(groups, event)
                     });
+                    let (cache, canonicalized) =
+                        canonicalize_loaded_treekem_cache_entries(groups, cache);
                     let rejected_count = persisted_count.saturating_sub(cache.len());
                     if rejected_count > 0 {
                         tracing::warn!(
@@ -18250,7 +18500,7 @@ async fn load_treekem_member_key_packages(
                             "pruned invalid or irrelevant TreeKEM recovery-cache records at startup"
                         );
                     }
-                    (cache, rejected_count > 0)
+                    (cache, rejected_count > 0 || canonicalized)
                 }
                 Err(error) => {
                     let quarantine_path = quarantine_corrupt_treekem_cache(path)
@@ -18294,13 +18544,14 @@ async fn load_treekem_member_key_packages(
     }
     if cache.diagnostics().await.dirty {
         let persistence = cache.persist_latest().await;
-        if let TreeKemCachePersistenceStatus::Dirty { revision, error } = persistence {
+        if let TreeKemCachePersistenceStatus::Dirty { revision, error } = &persistence {
             tracing::error!(
                 path = %path.display(),
                 revision,
                 error,
                 "startup TreeKEM recovery-cache compaction remains dirty"
             );
+            cache.schedule_persistence_retry();
         }
     }
     let diagnostics = cache.diagnostics().await;
@@ -20159,6 +20410,8 @@ async fn handle_file_complete(
 
 #[cfg(test)]
 mod tests {
+    mod cache_hardening_followup;
+
     use super::*;
     use x0x::upgrade::manifest::{PlatformAsset, SCHEMA_VERSION};
 
@@ -25055,6 +25308,7 @@ mod tests {
             .insert(
                 join_result_key(&group_id, &member_hex),
                 fixture.event.clone(),
+                true,
             )
             .await?;
         assert!(member_treekem_kp(state, &group_id, &member_hex)
@@ -25300,6 +25554,7 @@ mod tests {
             .insert(
                 join_result_key(&group_id, &member_hex),
                 fixture.event.clone(),
+                true,
             )
             .await?;
         assert!(
@@ -25460,7 +25715,10 @@ mod tests {
                 .expect("O logged authority-attested MemberAdded")
         };
         let authority_recovery = fixture
-            .state.treekem_member_key_packages.get(&cache_key).await
+            .state
+            .treekem_member_key_packages
+            .get(&cache_key)
+            .await
             .expect("O cached the authority-attested recovery event");
         {
             let groups = fixture.state.named_groups.read().await;
@@ -25577,7 +25835,10 @@ mod tests {
                 .cloned()
                 .expect("O logged authority-attested MemberAdded")
         };
-        let authority_recovery = o_state.treekem_member_key_packages.get(&join_result_key(&group_id, &member_hex)).await
+        let authority_recovery = o_state
+            .treekem_member_key_packages
+            .get(&join_result_key(&group_id, &member_hex))
+            .await
             .expect("O cached authority-attested recovery");
         assert!(
             apply_named_group_metadata_event(
@@ -26138,33 +26399,57 @@ mod tests {
     #[tokio::test]
     async fn provisional_witness_recovery_cache_is_bounded_per_group() -> Result<()> {
         let fixture = member_joined_treekem_fixture(0xa7, 0xa8).await?;
-        let raw = without_recovery_attestation(fixture.event.clone());
-        for index in 0..=TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP {
-            cache_treekem_member_key_package(
-                &fixture.state,
-                format!("{}:provisional-{index}", fixture.group_id),
-                raw.clone(),
-                false,
-            )
-            .await;
+        let inviter_hex = hex::encode(fixture.state.agent.agent_id().as_bytes());
+        for sequence in 1..=(TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP as u64 + 1) {
+            let (key, event) = signed_provisional_recovery_event_for_test(
+                &fixture.group_id,
+                &fixture.stable_group_id,
+                &inviter_hex,
+                sequence,
+            )?;
+            let status = cache_treekem_member_key_package(&fixture.state, key, event, false).await;
+            assert!(matches!(
+                status,
+                TreeKemCachePersistenceStatus::Durable { .. }
+            ));
         }
-        let cache = fixture.state.treekem_member_key_packages.read().await;
-        let provisional_count = cache
-            .values()
-            .filter(|event| {
+        let provisional = fixture
+            .state
+            .treekem_member_key_packages
+            .events_matching(|event| {
                 matches!(
                     event,
                     NamedGroupMetadataEvent::MemberJoined {
                         recovery_authority_signature_b64: None,
                         ..
-                    } if named_group_metadata_event_group_id(event) == fixture.group_id
+                    } if recovery_cache_group_identity(event) == fixture.stable_group_id
                 )
             })
-            .count();
+            .await;
         assert_eq!(
-            provisional_count,
+            provisional.len(),
             TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP,
-            "valid self-signed witness records cannot grow the per-group provisional cache without bound"
+            "valid independently witnessed records share the bounded cache"
+        );
+        assert!(
+            provisional
+                .iter()
+                .all(verify_member_joined_key_package_event),
+            "every retained provisional record preserves member authentication"
+        );
+        let diagnostics = fixture
+            .state
+            .treekem_member_key_packages
+            .diagnostics()
+            .await;
+        assert!(diagnostics.entries <= diagnostics.max_entries);
+        assert!(diagnostics.encoded_bytes <= diagnostics.max_encoded_bytes);
+        assert_eq!(
+            durable_cache_keys(&fixture.state.treekem_member_key_packages.path)
+                .await?
+                .len(),
+            TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP,
+            "per-group witness compaction is durable"
         );
         Ok(())
     }
@@ -26204,7 +26489,10 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "TreeKEM request approval succeeds");
 
         let recovery = fixture
-            .state.treekem_member_key_packages.get(&join_result_key(&fixture.group_id, &requester_hex)).await
+            .state
+            .treekem_member_key_packages
+            .get(&join_result_key(&fixture.group_id, &requester_hex))
+            .await
             .expect("request approval caches recovery evidence");
         {
             let mut groups = fixture.state.named_groups.write().await;
@@ -26309,7 +26597,10 @@ mod tests {
                 .expect("authority logged JoinRequestApproved")
         };
         let recovery = fixture
-            .state.treekem_member_key_packages.get(&join_result_key(&fixture.group_id, &requester_hex)).await
+            .state
+            .treekem_member_key_packages
+            .get(&join_result_key(&fixture.group_id, &requester_hex))
+            .await
             .expect("authority cached the attested recovery record");
 
         // (1) The approval event carries A's hash.
@@ -26482,7 +26773,10 @@ mod tests {
         );
 
         let recovery = fixture
-            .state.treekem_member_key_packages.get(&join_result_key(&fixture.group_id, &target_hex)).await
+            .state
+            .treekem_member_key_packages
+            .get(&join_result_key(&fixture.group_id, &target_hex))
+            .await
             .expect("direct add caches authority recovery attestation");
         {
             let groups = fixture.state.named_groups.read().await;
@@ -26507,7 +26801,10 @@ mod tests {
         let restarted =
             secure_endpoint_test_state_at(fixture._dir.path(), Arc::clone(&fixture.state.agent))
                 .await?;
-        let restarted_recovery = restarted.treekem_member_key_packages.get(&join_result_key(&fixture.group_id, &target_hex)).await
+        let restarted_recovery = restarted
+            .treekem_member_key_packages
+            .get(&join_result_key(&fixture.group_id, &target_hex))
+            .await
             .expect("authority-only direct-add recovery survives restart");
         let groups = restarted.named_groups.read().await;
         assert!(
@@ -26779,7 +27076,10 @@ mod tests {
         // (1) The creator package was provisioned as a fully authority-attested
         //     recovery record: it carries an authority signature over the
         //     sealed group-state commit (not merely a member self-signature).
-        let cached = state.treekem_member_key_packages.get(&join_result_key(&group_id, &creator_hex)).await
+        let cached = state
+            .treekem_member_key_packages
+            .get(&join_result_key(&group_id, &creator_hex))
+            .await
             .expect("creator recovery record is cached at group creation");
         let cached_package = match &cached {
             NamedGroupMetadataEvent::MemberJoined {
@@ -27029,41 +27329,54 @@ mod tests {
         }
     }
 
-    // ---------------------------------------------------------------------
-    // TreeKEM member key-package cache: loader quarantine, bounds, and
-    // lifecycle regression coverage (WP-TK2 findings 3-6).
-    //
-    // `synthetic_member_joined` builds deliberately NON-verifying
-    // `MemberJoined` events used only to size the cache via `from_entries`,
-    // which enforces count/byte bounds without signature verification. Tests
-    // that exercise the load path or `insert()` use real signed
-    // `member_joined_treekem_fixture` events, since those paths authenticate
-    // the member signature.
-    // ---------------------------------------------------------------------
-
-    /// Compact, deliberately NON-verifying `MemberJoined` for cache *sizing*
-    /// tests. `from_entries` never calls `verify_member_joined_key_package_event`,
-    /// so these events exist purely to control entry count, `ts_ms` ordering,
-    /// and encoded byte size. Must never be passed to `insert()`.
-    fn synthetic_member_joined(
+    fn signed_provisional_recovery_event_for_test(
         group_id: &str,
-        member: &str,
-        ts_ms: u64,
-        key_package_payload_len: usize,
-    ) -> NamedGroupMetadataEvent {
-        NamedGroupMetadataEvent::MemberJoined {
+        stable_group_id: &str,
+        inviter_agent_id: &str,
+        sequence: u64,
+    ) -> Result<(String, NamedGroupMetadataEvent)> {
+        let member_keypair = x0x::identity::AgentKeypair::generate()?;
+        let member_id = member_keypair.agent_id();
+        let member_hex = hex::encode(member_id.as_bytes());
+        let member_public_key_b64 = BASE64.encode(member_keypair.public_key().as_bytes());
+        let prepared = x0x::mls::TreeKemMlsGroup::prepare_member(member_id, &[sequence as u8; 32])?;
+        let key_package = BASE64.encode(prepared.key_package_bytes());
+        let invite_secret = format!("witness-cache-{sequence}");
+        let canonical = canonical_member_joined_bytes(
+            group_id,
+            Some(stable_group_id),
+            &member_hex,
+            &member_public_key_b64,
+            x0x::groups::GroupRole::Member,
+            None,
+            inviter_agent_id,
+            &invite_secret,
+            sequence,
+            Some(&key_package),
+        );
+        let signature = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
+            member_keypair.secret_key(),
+            &canonical,
+        )
+        .map_err(|e| anyhow::anyhow!("sign provisional recovery fixture: {e:?}"))?;
+        let event = NamedGroupMetadataEvent::MemberJoined {
             group_id: group_id.to_string(),
-            stable_group_id: Some(group_id.to_string()),
-            member_agent_id: member.to_string(),
-            member_public_key_b64: BASE64.encode([0xA5u8; 48]),
+            stable_group_id: Some(stable_group_id.to_string()),
+            member_agent_id: member_hex.clone(),
+            member_public_key_b64,
             role: x0x::groups::GroupRole::Member,
             display_name: None,
-            inviter_agent_id: format!("inviter-{group_id}"),
-            invite_secret: format!("invite-{group_id}-{member}"),
-            ts_ms,
-            treekem_key_package_b64: Some(BASE64.encode(vec![0xA5u8; key_package_payload_len])),
-            signature_b64: BASE64.encode([0xA5u8; 64]),
-        }
+            inviter_agent_id: inviter_agent_id.to_string(),
+            invite_secret,
+            ts_ms: sequence,
+            treekem_key_package_b64: Some(key_package),
+            recovery_authority_agent_id: None,
+            recovery_authority_public_key_b64: None,
+            recovery_authority_signature_b64: None,
+            recovery_authority_commit: None,
+            signature_b64: BASE64.encode(signature.as_bytes()),
+        };
+        Ok((join_result_key(group_id, &member_hex), event))
     }
 
     /// Read the durable cache JSON and return its key set. Used to prove the
@@ -27073,696 +27386,5 @@ mod tests {
         let on_disk = tokio::fs::read_to_string(path).await?;
         let parsed: BTreeMap<String, serde_json::Value> = serde_json::from_str(&on_disk)?;
         Ok(parsed.into_keys().collect())
-    }
-
-    /// Locate the `<base>.corrupt-<uuid>` quarantine sibling written when the
-    /// loader quarantines an unparseable cache file.
-    async fn quarantine_sibling(dir: &FsPath, base: &str) -> Option<PathBuf> {
-        let prefix = format!("{base}.corrupt-");
-        let mut rd = tokio::fs::read_dir(dir).await.ok()?;
-        while let Ok(Some(entry)) = rd.next_entry().await {
-            if entry.file_name().to_string_lossy().starts_with(&prefix) {
-                return Some(entry.path());
-            }
-        }
-        None
-    }
-
-    /// WP-TK2: an unparseable or schema-incompatible recovery cache must NOT
-    /// abort startup or overwrite the corrupt bytes. The loader renames the
-    /// file to a quarantine sibling (preserving it verbatim) and starts from
-    /// an empty cache, rewriting the active path as `{}`.
-    #[tokio::test]
-    async fn treekem_recovery_cache_quarantines_corrupt_json_without_overwrite() -> Result<()> {
-        let cases: Vec<(&str, Vec<u8>)> = vec![
-            ("malformed JSON", b"{not valid json".to_vec()),
-            ("truncated JSON", b"{\"g:m\":".to_vec()),
-            ("schema-incompatible value", b"{\"g:m\":123}".to_vec()),
-            ("JSON array (not object)", b"[]".to_vec()),
-        ];
-        let empty_roster: HashMap<String, x0x::groups::GroupInfo> = HashMap::new();
-
-        for (label, corpus) in &cases {
-            let dir = tempfile::tempdir()?;
-            let base = "member-key-packages.json";
-            let path = dir.path().join(base);
-            tokio::fs::write(&path, corpus.as_slice()).await?;
-
-            let cache = load_treekem_member_key_packages(&path, &empty_roster)
-                .await
-                .expect("corrupt cache quarantines and loads empty, not a fatal startup error");
-
-            assert_eq!(
-                cache.diagnostics().await.entries,
-                0,
-                "{label}: in-memory cache empty after quarantine"
-            );
-
-            // Original corrupt bytes are preserved verbatim in a quarantine
-            // sibling (rename, not overwrite).
-            let quarantine = quarantine_sibling(dir.path(), base)
-                .await
-                .unwrap_or_else(|| panic!("{label}: quarantine sibling exists"));
-            let preserved = tokio::fs::read(&quarantine).await?;
-            assert_eq!(
-                preserved, *corpus,
-                "{label}: quarantine preserves the original corrupt bytes verbatim"
-            );
-
-            // The active path is rewritten as an empty cache (no corrupt residue).
-            assert!(
-                durable_cache_keys(&path).await?.is_empty(),
-                "{label}: active path rewritten as an empty cache"
-            );
-        }
-        Ok(())
-    }
-
-    /// WP-TK2: a read error other than `NotFound` (here: the path is a
-    /// directory, so `read_to_string` fails with EISDIR) is fatal — the loader
-    /// surfaces the error and must NOT quarantine or silently start empty.
-    #[tokio::test]
-    async fn treekem_recovery_cache_non_notfound_read_error_is_fatal() -> Result<()> {
-        let dir = tempfile::tempdir()?;
-        let path = dir.path().join("unreadable.json");
-        // A directory exists but cannot be read as a file -> error kind != NotFound.
-        tokio::fs::create_dir(&path).await?;
-
-        let empty_roster: HashMap<String, x0x::groups::GroupInfo> = HashMap::new();
-        let result = load_treekem_member_key_packages(&path, &empty_roster).await;
-        assert!(
-            result.is_err(),
-            "non-NotFound read error must be fatal, not quarantined to empty"
-        );
-
-        // The fatal branch neither quarantines (renames) nor touches the path.
-        let metadata = tokio::fs::metadata(&path)
-            .await
-            .expect("path still present");
-        assert!(
-            metadata.is_dir(),
-            "unreadable directory left in place, not quarantined"
-        );
-        Ok(())
-    }
-
-    /// WP-TK2: at startup the loader retains only self-signed records that
-    /// still match an active roster. A validly-signed record for a group/member
-    /// absent from the roster is PRUNED (memory + durable JSON emptied), while
-    /// the same record IS retained when the roster carries the active member
-    /// with a matching key package — proving the prune is selective, not a wipe.
-    #[tokio::test]
-    async fn treekem_recovery_cache_startup_prunes_roster_irrelevant_signed_records() -> Result<()>
-    {
-        let fixture = member_joined_treekem_fixture(0x91, 0x92).await?;
-        let group_id = fixture.group_id.clone();
-        let member_hex = fixture.member_hex.clone();
-        let key = join_result_key(&group_id, &member_hex);
-        let persisted: BTreeMap<String, NamedGroupMetadataEvent> =
-            [(key.clone(), fixture.event.clone())].into_iter().collect();
-        let json = serde_json::to_string(&persisted)?;
-
-        // Case A: no active roster -> validly-signed record is pruned.
-        {
-            let dir = tempfile::tempdir()?;
-            let path = dir.path().join("kp.json");
-            tokio::fs::write(&path, &json).await?;
-            let empty_roster: HashMap<String, x0x::groups::GroupInfo> = HashMap::new();
-
-            let cache = load_treekem_member_key_packages(&path, &empty_roster).await?;
-            assert_eq!(
-                cache.diagnostics().await.entries,
-                0,
-                "roster-irrelevant record pruned from memory"
-            );
-            assert!(
-                cache.get(&key).await.is_none(),
-                "pruned record absent from memory"
-            );
-            assert!(
-                durable_cache_keys(&path).await?.is_empty(),
-                "durable JSON rewritten empty after startup prune"
-            );
-        }
-
-        // Case B: roster carries the active member with the matching key
-        // package -> the same signed record is retained (selective prune).
-        {
-            let inviter = fixture.state.agent.agent_id();
-            let roster_kp = match &fixture.event {
-                NamedGroupMetadataEvent::MemberJoined {
-                    treekem_key_package_b64: Some(kp),
-                    ..
-                } => kp.clone(),
-                _ => unreachable!("fixture event is MemberJoined with a key package"),
-            };
-            let mut info =
-                treekem_metadata_group_info(inviter, &group_id, &fixture.stable_group_id);
-            let mut member = x0x::groups::GroupMember::new_member(
-                member_hex.clone(),
-                None,
-                Some(hex::encode(inviter.as_bytes())),
-                1,
-            );
-            member.treekem_key_package_b64 = Some(roster_kp);
-            info.members_v2.insert(member_hex.clone(), member);
-            let roster: HashMap<String, x0x::groups::GroupInfo> =
-                [(group_id.clone(), info)].into_iter().collect();
-
-            let dir = tempfile::tempdir()?;
-            let path = dir.path().join("kp.json");
-            tokio::fs::write(&path, &json).await?;
-
-            let cache = load_treekem_member_key_packages(&path, &roster).await?;
-            assert_eq!(
-                cache.diagnostics().await.entries,
-                1,
-                "roster-relevant signed record retained"
-            );
-            assert!(
-                cache.get(&key).await.is_some(),
-                "retained record present in memory"
-            );
-            assert!(
-                durable_cache_keys(&path).await?.contains(&key),
-                "durable JSON retains roster-relevant record (no rewrite when nothing pruned)"
-            );
-        }
-        Ok(())
-    }
-
-    /// WP-TK2: group/member lifecycle removals must evict both the in-memory
-    /// entry and the durable JSON record. `remove_groups` covers the
-    /// group-deletion lifecycle; `remove_member` covers per-member removal.
-    #[tokio::test]
-    async fn treekem_recovery_cache_lifecycle_prune_removes_memory_and_durable() -> Result<()> {
-        let fixture = member_joined_treekem_fixture(0x93, 0x94).await?;
-        let group_id = fixture.group_id.clone();
-        let member_hex = fixture.member_hex.clone();
-        let key = join_result_key(&group_id, &member_hex);
-        let aliases = HashSet::from([group_id.clone()]);
-
-        let dir = tempfile::tempdir()?;
-        let path = dir.path().join("kp.json");
-        let (cache, _) = TreeKemMemberKeyPackageCache::from_entries(path, BTreeMap::new(), false)?;
-
-        // Group lifecycle: remove_groups drops memory + durable JSON.
-        cache
-            .insert(key.clone(), fixture.event.clone(), true)
-            .await?;
-        assert_eq!(cache.diagnostics().await.entries, 1, "seeded one record");
-        let removed_groups = cache.remove_groups(&aliases).await;
-        assert_eq!(
-            removed_groups.evicted, 1,
-            "group lifecycle pruned the record"
-        );
-        assert!(
-            cache.get(&key).await.is_none(),
-            "group prune cleared memory"
-        );
-        assert!(
-            durable_cache_keys(&cache.path).await?.is_empty(),
-            "group prune cleared durable JSON"
-        );
-
-        // Member lifecycle: remove_member drops memory + durable JSON.
-        cache
-            .insert(key.clone(), fixture.event.clone(), true)
-            .await?;
-        assert!(
-            cache.get(&key).await.is_some(),
-            "re-seeded before member prune"
-        );
-        let removed_member = cache.remove_member(&aliases, &member_hex).await;
-        assert_eq!(
-            removed_member.evicted, 1,
-            "member lifecycle pruned the record"
-        );
-        assert!(
-            cache.get(&key).await.is_none(),
-            "member prune cleared memory"
-        );
-        assert!(
-            cache
-                .find_for_member(std::slice::from_ref(&group_id), &member_hex)
-                .await
-                .is_none(),
-            "member prune cleared find_for_member"
-        );
-        assert!(
-            durable_cache_keys(&cache.path).await?.is_empty(),
-            "member prune cleared durable JSON"
-        );
-        Ok(())
-    }
-
-    /// PR #219 review finding #4: the shared retained-tombstone path used by
-    /// GroupDeleted/withdraw/import must prune signed recovery records only
-    /// after the terminal state is committed. Exercise the real GroupDeleted
-    /// apply path rather than calling cache lifecycle helpers directly.
-    #[tokio::test]
-    async fn group_deleted_tombstone_prunes_recovery_cache_memory_and_disk() -> Result<()> {
-        let fixture = member_joined_treekem_fixture(0xb1, 0xb2).await?;
-        let state = &fixture.state;
-        let cache_key = join_result_key(&fixture.group_id, &fixture.member_hex);
-
-        let _ =
-            apply_named_group_metadata_event(state, fixture.event.clone(), fixture.member_id, true)
-                .await;
-        assert!(
-            state
-                .treekem_member_key_packages
-                .get(&cache_key)
-                .await
-                .is_some(),
-            "precondition: real MemberJoined apply seeded the signed recovery record"
-        );
-        assert!(
-            durable_cache_keys(&state.treekem_member_key_packages.path)
-                .await?
-                .contains(&cache_key),
-            "precondition: signed recovery record is durable before terminality"
-        );
-
-        let parent = state
-            .named_groups
-            .read()
-            .await
-            .get(&fixture.group_id)
-            .expect("fixture group retained after MemberJoined")
-            .clone();
-        let mut terminal = parent.clone();
-        terminal.withdrawn = true;
-        let commit = sign_metadata_terminality_commit(&parent, &terminal, state, 1_000);
-        assert!(commit.withdrawn);
-        let event = NamedGroupMetadataEvent::GroupDeleted {
-            group_id: fixture.stable_group_id.clone(),
-            revision: parent.roster_revision.saturating_add(1),
-            actor: hex::encode(state.agent.agent_id().as_bytes()),
-            commit: Some(commit),
-        };
-
-        let applied = apply_named_group_metadata_event_inner(
-            state,
-            event,
-            state.agent.agent_id(),
-            true,
-            true,
-        )
-        .await;
-        assert!(
-            applied,
-            "GroupDeleted committed through the production apply path"
-        );
-        {
-            let groups = state.named_groups.read().await;
-            let tombstone = groups
-                .get(&fixture.group_id)
-                .expect("terminal tombstone retained under storage alias");
-            assert!(
-                tombstone.withdrawn,
-                "terminal state committed before cache pruning"
-            );
-            assert_eq!(tombstone.shared_secret, None);
-        }
-        assert!(
-            state
-                .treekem_member_key_packages
-                .get(&cache_key)
-                .await
-                .is_none(),
-            "GroupDeleted tombstone pruned the in-memory signed recovery record"
-        );
-        assert!(
-            !durable_cache_keys(&state.treekem_member_key_packages.path)
-                .await?
-                .contains(&cache_key),
-            "GroupDeleted tombstone pruned the durable signed recovery record"
-        );
-        Ok(())
-    }
-
-    /// WP-TK2: the entry-count cap is enforced on `from_entries` and overflow
-    /// is shed oldest-`ts_ms`-first until the cache fits.
-    #[tokio::test]
-    async fn treekem_recovery_cache_count_limit_evicts_oldest() -> Result<()> {
-        let cap = TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_ENTRIES;
-        let overflow = 3;
-        let total = cap + overflow;
-
-        let mut entries = BTreeMap::new();
-        for i in 0..total {
-            let g = format!("g{i:04x}");
-            let m = format!("m{i:04x}");
-            entries.insert(
-                format!("{g}:{m}"),
-                synthetic_member_joined(&g, &m, i as u64, 8),
-            );
-        }
-
-        let dir = tempfile::tempdir()?;
-        let path = dir.path().join("kp.json");
-        let (cache, evicted) = TreeKemMemberKeyPackageCache::from_entries(path, entries, true)?;
-        let diag = cache.diagnostics().await;
-
-        assert_eq!(evicted, overflow, "excess entries evicted to reach the cap");
-        assert_eq!(diag.entries, cap, "entry count held at MAX_ENTRIES");
-        assert!(
-            diag.encoded_bytes <= diag.max_encoded_bytes,
-            "byte budget respected after count compaction"
-        );
-        // Eviction is oldest-ts first: the three smallest-ts records (i=0,1,2)
-        // are evicted; i=3 is the first retained and the newest survives.
-        assert!(cache.get("g0000:m0000").await.is_none(), "i=0 evicted");
-        assert!(
-            cache.get("g0002:m0002").await.is_none(),
-            "i=2 evicted (last of overflow trio)"
-        );
-        assert!(
-            cache.get("g0003:m0003").await.is_some(),
-            "i=3 retained (first inside the cap)"
-        );
-        let last_idx = total - 1;
-        assert!(
-            cache
-                .get(&format!("g{last_idx:04x}:m{last_idx:04x}"))
-                .await
-                .is_some(),
-            "newest-ts record retained"
-        );
-        Ok(())
-    }
-
-    /// WP-TK2: the encoded-byte cap is enforced independently of the count
-    /// cap. With a handful of oversized records (count well under MAX_ENTRIES
-    /// but combined bytes over MAX_BYTES), the oldest-ts record is evicted so
-    /// the durable snapshot fits the byte budget.
-    #[tokio::test]
-    async fn treekem_recovery_cache_encoded_byte_limit_evicts_to_fit() -> Result<()> {
-        let payload_len = 2_500_000;
-        let ev_a = synthetic_member_joined("ga", "ma", 100, payload_len);
-        let ev_b = synthetic_member_joined("gb", "mb", 200, payload_len);
-        let ev_c = synthetic_member_joined("gc", "mc", 300, payload_len);
-        let (key_a, key_b, key_c) = (
-            "ga:ma".to_string(),
-            "gb:mb".to_string(),
-            "gc:mc".to_string(),
-        );
-
-        // Assert the byte budget — not the count cap — is the trigger, using
-        // the cache's own encoded-size function (mirrors cache_snapshot_encoded_bytes).
-        let bytes_a = cache_entry_encoded_bytes(&key_a, &ev_a)?;
-        let bytes_b = cache_entry_encoded_bytes(&key_b, &ev_b)?;
-        let bytes_c = cache_entry_encoded_bytes(&key_c, &ev_c)?;
-        let snapshot = |n: usize, sum: usize| {
-            2usize
-                .saturating_add(sum)
-                .saturating_add(n.saturating_sub(1))
-        };
-        let triple = snapshot(3, bytes_a + bytes_b + bytes_c);
-        let surviving_pair = snapshot(2, bytes_b + bytes_c);
-        assert!(
-            triple > TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_BYTES,
-            "precondition: three oversized records exceed the byte budget"
-        );
-        assert!(
-            surviving_pair <= TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_BYTES,
-            "precondition: the two newest records fit the byte budget"
-        );
-
-        let mut entries = BTreeMap::new();
-        entries.insert(key_a.clone(), ev_a);
-        entries.insert(key_b.clone(), ev_b);
-        entries.insert(key_c.clone(), ev_c);
-
-        let dir = tempfile::tempdir()?;
-        let path = dir.path().join("kp.json");
-        let (cache, evicted) = TreeKemMemberKeyPackageCache::from_entries(path, entries, true)?;
-        let diag = cache.diagnostics().await;
-
-        assert_eq!(evicted, 1, "one record evicted to fit the byte budget");
-        assert_eq!(diag.entries, 2, "two records remain");
-        assert!(
-            diag.encoded_bytes <= diag.max_encoded_bytes,
-            "encoded bytes within budget after compaction"
-        );
-        // Oldest-ts (ev_a) is the victim; the two newer records survive.
-        assert!(
-            cache.get(&key_a).await.is_none(),
-            "oldest-ts record evicted"
-        );
-        assert!(cache.get(&key_b).await.is_some(), "newer record retained");
-        assert!(cache.get(&key_c).await.is_some(), "newest record retained");
-        Ok(())
-    }
-
-    /// WP-TK2: eviction is deterministic — victim selection is min `ts_ms`,
-    /// then min key. With one eviction forced (`cap + 1` entries) and three
-    /// entries sharing the smallest `ts_ms`, the lexicographically smallest key
-    /// is the victim while its equal-ts siblings survive.
-    #[tokio::test]
-    async fn treekem_recovery_cache_eviction_tiebreak_is_timestamp_then_key() -> Result<()> {
-        let cap = TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_ENTRIES;
-        let mut entries = BTreeMap::new();
-        // Three equal-ts (ts=10) records with distinct keys.
-        for k in ["tie-a", "tie-b", "tie-c"] {
-            entries.insert(
-                k.to_string(),
-                synthetic_member_joined(k, &format!("mem-{k}"), 10, 8),
-            );
-        }
-        // `cap - 2` newer records (distinct ts) fill the cache to `cap + 1`,
-        // forcing exactly one eviction.
-        for i in 0..(cap - 2) {
-            let g = format!("ng{i:04x}");
-            entries.insert(
-                format!("{g}:m"),
-                synthetic_member_joined(&g, "m", 100 + i as u64, 8),
-            );
-        }
-        assert_eq!(entries.len(), cap + 1, "precondition: one over the cap");
-
-        let dir = tempfile::tempdir()?;
-        let path = dir.path().join("kp.json");
-        let (cache, evicted) = TreeKemMemberKeyPackageCache::from_entries(path, entries, true)?;
-        assert_eq!(evicted, 1, "exactly one record evicted");
-        assert_eq!(cache.diagnostics().await.entries, cap);
-
-        // Tie broken by smallest key: "tie-a" is the victim; "tie-b"/"tie-c"
-        // (equal ts, larger keys) survive.
-        assert!(
-            cache.get("tie-a").await.is_none(),
-            "smallest-key victim evicted on tie"
-        );
-        assert!(
-            cache.get("tie-b").await.is_some(),
-            "larger-key sibling survives the tie"
-        );
-        assert!(
-            cache.get("tie-c").await.is_some(),
-            "largest-key sibling survives the tie"
-        );
-        Ok(())
-    }
-
-    struct TreeKemCacheWriterHookGuard {
-        path: PathBuf,
-    }
-
-    impl Drop for TreeKemCacheWriterHookGuard {
-        fn drop(&mut self) {
-            if let Ok(mut hooks) = TREEKEM_CACHE_WRITER_HOOKS.lock() {
-                hooks.remove(&self.path);
-            }
-        }
-    }
-
-    fn install_treekem_cache_writer_hook(
-        path: &FsPath,
-        release: Option<Arc<tokio::sync::Notify>>,
-        force_error: Option<std::io::Error>,
-    ) -> (Arc<tokio::sync::Notify>, TreeKemCacheWriterHookGuard) {
-        let entered = Arc::new(tokio::sync::Notify::new());
-        let mut hooks = TREEKEM_CACHE_WRITER_HOOKS
-            .lock()
-            .expect("TreeKEM cache writer hook poisoned");
-        hooks.insert(
-            path.to_path_buf(),
-            TreeKemCacheWriterHookControl {
-                entered: Arc::clone(&entered),
-                release,
-                force_error,
-            },
-        );
-        (
-            entered,
-            TreeKemCacheWriterHookGuard {
-                path: path.to_path_buf(),
-            },
-        )
-    }
-
-    async fn signed_cache_fixture_entries() -> Result<(
-        MemberJoinedTreeKemFixture,
-        MemberJoinedTreeKemFixture,
-        String,
-        String,
-    )> {
-        let first = member_joined_treekem_fixture(0xa1, 0xa2).await?;
-        let second = member_joined_treekem_fixture(0xa3, 0xa4).await?;
-        let first_key = join_result_key(&first.group_id, &first.member_hex);
-        let second_key = join_result_key(&second.group_id, &second.member_hex);
-        Ok((first, second, first_key, second_key))
-    }
-
-    /// WP-TK2 #5: the persistence mutex serializes disk writes without holding
-    /// the cache map lock. While the first writer is deterministically parked,
-    /// readers observe both the first mutation and a concurrent newer mutation;
-    /// after release, the coalescing writer persists the newest snapshot.
-    #[tokio::test]
-    async fn treekem_recovery_cache_slow_writer_does_not_block_readers_and_newest_wins(
-    ) -> Result<()> {
-        let (first, second, first_key, second_key) = signed_cache_fixture_entries().await?;
-        let dir = tempfile::tempdir()?;
-        let path = dir.path().join("kp.json");
-        let (cache, _) =
-            TreeKemMemberKeyPackageCache::from_entries(path.clone(), BTreeMap::new(), false)?;
-        let cache = Arc::new(cache);
-        let release = Arc::new(tokio::sync::Notify::new());
-        let (entered, _hook_guard) =
-            install_treekem_cache_writer_hook(&path, Some(Arc::clone(&release)), None);
-
-        let first_cache = Arc::clone(&cache);
-        let first_key_for_write = first_key.clone();
-        let first_event = first.event.clone();
-        let first_write =
-            tokio::spawn(async move { first_cache.insert(first_key_for_write, first_event, true).await });
-        entered.notified().await;
-
-        assert!(
-            cache.get(&first_key).await.is_some(),
-            "reader proceeds while the first disk writer is parked"
-        );
-
-        let second_cache = Arc::clone(&cache);
-        let second_key_for_write = second_key.clone();
-        let second_event = second.event.clone();
-        let second_write = tokio::spawn(async move {
-            second_cache
-                .insert(second_key_for_write, second_event, true)
-                .await
-        });
-        tokio::time::timeout(Duration::from_secs(5), async {
-            while cache.get(&second_key).await.is_none() {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .context("newer in-memory mutation blocked behind slow disk writer")?;
-        assert!(
-            cache.get(&first_key).await.is_some(),
-            "readers remain available after the concurrent mutation"
-        );
-
-        release.notify_one();
-        let first_result = first_write.await??;
-        let second_result = second_write.await??;
-        assert!(matches!(
-            first_result.persistence,
-            TreeKemCachePersistenceStatus::Durable { .. }
-        ));
-        assert!(matches!(
-            second_result.persistence,
-            TreeKemCachePersistenceStatus::Durable { .. }
-        ));
-
-        let durable = durable_cache_keys(&path).await?;
-        assert_eq!(
-            durable,
-            HashSet::from([first_key, second_key]),
-            "serialized/coalesced persistence leaves the newest complete snapshot on disk"
-        );
-        let diagnostics = cache.diagnostics().await;
-        assert!(!diagnostics.dirty);
-        assert_eq!(diagnostics.persisted_revision, diagnostics.revision);
-        Ok(())
-    }
-
-    /// WP-TK2 #6: a failed durable write returns structured `Dirty`, retains
-    /// failure diagnostics, and remains retryable. A later mutation retries the
-    /// entire newest snapshot and clears dirty state only after disk success.
-    #[tokio::test]
-    async fn treekem_recovery_cache_failed_write_stays_dirty_and_retry_persists_newest(
-    ) -> Result<()> {
-        let (first, second, first_key, second_key) = signed_cache_fixture_entries().await?;
-        let dir = tempfile::tempdir()?;
-        let path = dir.path().join("kp.json");
-        let (cache, _) =
-            TreeKemMemberKeyPackageCache::from_entries(path.clone(), BTreeMap::new(), false)?;
-        let (entered, _hook_guard) = install_treekem_cache_writer_hook(
-            &path,
-            None,
-            Some(std::io::Error::new(
-                std::io::ErrorKind::PermissionDenied,
-                "injected TreeKEM cache persistence failure",
-            )),
-        );
-
-        let failed = cache
-            .insert(first_key.clone(), first.event.clone(), true)
-            .await?;
-        entered.notified().await;
-        let TreeKemCachePersistenceStatus::Dirty {
-            revision: failed_revision,
-            error,
-        } = failed.persistence
-        else {
-            anyhow::bail!("injected persistence failure was falsely reported durable");
-        };
-        assert!(error.contains("injected TreeKEM cache persistence failure"));
-        let dirty = cache.diagnostics().await;
-        assert!(dirty.dirty, "failed write remains explicitly dirty");
-        assert_eq!(dirty.revision, failed_revision);
-        assert_eq!(dirty.write_failures, 1);
-        assert!(dirty
-            .last_error
-            .as_deref()
-            .is_some_and(|last| { last.contains("injected TreeKEM cache persistence failure") }));
-        assert!(
-            cache.get(&first_key).await.is_some(),
-            "failed persistence does not discard the retryable in-memory record"
-        );
-        assert!(
-            tokio::fs::try_exists(&path)
-                .await
-                .is_ok_and(|exists| !exists),
-            "failed writer did not create a falsely durable snapshot"
-        );
-
-        let retried = cache
-            .insert(second_key.clone(), second.event.clone(), true)
-            .await?;
-        assert!(matches!(
-            retried.persistence,
-            TreeKemCachePersistenceStatus::Durable { .. }
-        ));
-        let durable = durable_cache_keys(&path).await?;
-        assert_eq!(
-            durable,
-            HashSet::from([first_key, second_key]),
-            "successful retry persists the newest snapshot, including the prior dirty record"
-        );
-        let clean = cache.diagnostics().await;
-        assert!(!clean.dirty, "successful retry clears dirty state");
-        assert_eq!(clean.persisted_revision, clean.revision);
-        assert_eq!(
-            clean.write_failures, 1,
-            "failure history remains observable"
-        );
-        assert_eq!(
-            clean.last_error, None,
-            "active error clears after durability succeeds"
-        );
-        Ok(())
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12097,16 +12097,18 @@ async fn retain_withdrawn_group_tombstone(
     let stable_group_id = info.stable_group_id().to_string();
     info.withdrawn = true;
     clear_group_info_key_material(&mut info);
-    {
+    let aliases = {
         let mut groups = state.named_groups.write().await;
         let mut aliases =
             collect_same_stable_group_aliases(&groups, group_id, Some(&stable_group_id));
         aliases.insert(group_id.to_string());
         aliases.insert(stable_group_id.clone());
-        for alias in aliases {
-            groups.insert(alias, info.clone());
+        for alias in &aliases {
+            groups.insert(alias.clone(), info.clone());
         }
-    }
+        aliases
+    };
+    let _ = prune_treekem_cache_groups(state, &aliases, reason).await;
     wipe_local_group_crypto_material(state, group_id, Some(&stable_group_id), reason).await;
     remove_directory_cache_entries_for_group_info(state, &info).await;
     refresh_group_card_cache_from_info(state, group_id, &info).await;
@@ -27310,6 +27312,92 @@ mod tests {
         assert!(
             durable_cache_keys(&cache.path).await?.is_empty(),
             "member prune cleared durable JSON"
+        );
+        Ok(())
+    }
+
+    /// PR #219 review finding #4: the shared retained-tombstone path used by
+    /// GroupDeleted/withdraw/import must prune signed recovery records only
+    /// after the terminal state is committed. Exercise the real GroupDeleted
+    /// apply path rather than calling cache lifecycle helpers directly.
+    #[tokio::test]
+    async fn group_deleted_tombstone_prunes_recovery_cache_memory_and_disk() -> Result<()> {
+        let fixture = member_joined_treekem_fixture(0xb1, 0xb2).await?;
+        let state = &fixture.state;
+        let cache_key = join_result_key(&fixture.group_id, &fixture.member_hex);
+
+        let _ =
+            apply_named_group_metadata_event(state, fixture.event.clone(), fixture.member_id, true)
+                .await;
+        assert!(
+            state
+                .treekem_member_key_packages
+                .get(&cache_key)
+                .await
+                .is_some(),
+            "precondition: real MemberJoined apply seeded the signed recovery record"
+        );
+        assert!(
+            durable_cache_keys(&state.treekem_member_key_packages.path)
+                .await?
+                .contains(&cache_key),
+            "precondition: signed recovery record is durable before terminality"
+        );
+
+        let parent = state
+            .named_groups
+            .read()
+            .await
+            .get(&fixture.group_id)
+            .expect("fixture group retained after MemberJoined")
+            .clone();
+        let mut terminal = parent.clone();
+        terminal.withdrawn = true;
+        let commit = sign_metadata_terminality_commit(&parent, &terminal, state, 1_000);
+        assert!(commit.withdrawn);
+        let event = NamedGroupMetadataEvent::GroupDeleted {
+            group_id: fixture.stable_group_id.clone(),
+            revision: parent.roster_revision.saturating_add(1),
+            actor: hex::encode(state.agent.agent_id().as_bytes()),
+            commit: Some(commit),
+        };
+
+        let applied = apply_named_group_metadata_event_inner(
+            state,
+            event,
+            state.agent.agent_id(),
+            true,
+            true,
+        )
+        .await;
+        assert!(
+            applied,
+            "GroupDeleted committed through the production apply path"
+        );
+        {
+            let groups = state.named_groups.read().await;
+            let tombstone = groups
+                .get(&fixture.group_id)
+                .expect("terminal tombstone retained under storage alias");
+            assert!(
+                tombstone.withdrawn,
+                "terminal state committed before cache pruning"
+            );
+            assert_eq!(tombstone.shared_secret, None);
+        }
+        assert!(
+            state
+                .treekem_member_key_packages
+                .get(&cache_key)
+                .await
+                .is_none(),
+            "GroupDeleted tombstone pruned the in-memory signed recovery record"
+        );
+        assert!(
+            !durable_cache_keys(&state.treekem_member_key_packages.path)
+                .await?
+                .contains(&cache_key),
+            "GroupDeleted tombstone pruned the durable signed recovery record"
         );
         Ok(())
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -108,6 +108,58 @@ const TREEKEM_EVENT_LOG_PER_GROUP_CAP: usize = 128;
 const TREEKEM_CATCHUP_RESPONSE_EVENT_CAP: usize = 1;
 const TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP: usize = 64;
 const TREEKEM_CATCHUP_THROTTLE: Duration = Duration::from_secs(5);
+
+/// Recovery records are large signed events (~15.7 KiB each). Bound the
+/// compact snapshot to 512 active-member records and 8 MiB encoded JSON.
+/// Both limits are enforced after every mutation and during startup load.
+const TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_ENTRIES: usize = 512;
+const TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_BYTES: usize = 8 * 1024 * 1024;
+
+struct TreeKemMemberKeyPackageCacheEntry {
+    event: NamedGroupMetadataEvent,
+    encoded_bytes: usize,
+}
+
+struct TreeKemMemberKeyPackageCacheState {
+    entries: BTreeMap<String, TreeKemMemberKeyPackageCacheEntry>,
+    encoded_bytes: usize,
+    revision: u64,
+    persisted_revision: u64,
+    dirty: bool,
+    write_failures: u64,
+    last_error: Option<String>,
+}
+
+struct TreeKemMemberKeyPackageCache {
+    path: PathBuf,
+    state: RwLock<TreeKemMemberKeyPackageCacheState>,
+    persistence: Mutex<()>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum TreeKemCachePersistenceStatus {
+    Durable { revision: u64 },
+    Dirty { revision: u64, error: String },
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+struct TreeKemCacheDiagnostics {
+    entries: usize,
+    encoded_bytes: usize,
+    max_entries: usize,
+    max_encoded_bytes: usize,
+    revision: u64,
+    persisted_revision: u64,
+    dirty: bool,
+    write_failures: u64,
+    last_error: Option<String>,
+}
+
+struct TreeKemCacheMutation {
+    persistence: TreeKemCachePersistenceStatus,
+    evicted: usize,
+}
 const DM_INBOX_START_MAX_ATTEMPTS: u32 = 120;
 const DM_INBOX_START_RETRY_DELAY: Duration = Duration::from_millis(250);
 
@@ -129,6 +181,36 @@ static RECOVERED_KP_BEFORE_MEMBERSHIP_LOCK_NOTIFY: StdMutex<
 static NAMED_GROUP_SAVE_AFTER_SNAPSHOT_NOTIFY: StdMutex<
     Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>,
 > = StdMutex::new(None);
+#[cfg(test)]
+struct TreeKemCacheWriterHookControl {
+    // Signalled with a stored permit once the writer has entered the hook, so a
+    // test can deterministically observe that the write is in flight regardless
+    // of await ordering.
+    entered: Arc<tokio::sync::Notify>,
+    // When present, the writer parks here until signalled (slow-disk simulation).
+    release: Option<Arc<tokio::sync::Notify>>,
+    // When present, the write returns this error instead of touching the disk.
+    force_error: Option<std::io::Error>,
+}
+
+// Test-only, path-scoped, one-shot writer seam for the TreeKEM recovery cache.
+// Keyed by the cache's on-disk path so tests over distinct temp directories can
+// never cross-talk. A hook is consumed the first time the writer fires it
+// (`take_*` removes it), and the owning guard removes any still-pending entry
+// on drop, so cleanup is RAII-safe even on panic. Production code only reaches
+// this through the `#[cfg(test)]` block in `write_treekem_cache_json_atomic`.
+#[cfg(test)]
+static TREEKEM_CACHE_WRITER_HOOKS: std::sync::LazyLock<
+    StdMutex<std::collections::HashMap<PathBuf, TreeKemCacheWriterHookControl>>,
+> = std::sync::LazyLock::new(|| StdMutex::new(std::collections::HashMap::new()));
+
+#[cfg(test)]
+fn take_treekem_cache_writer_hook_for_test(path: &FsPath) -> Option<TreeKemCacheWriterHookControl> {
+    TREEKEM_CACHE_WRITER_HOOKS
+        .lock()
+        .expect("TreeKEM cache writer hook poisoned")
+        .remove(path)
+}
 
 // ---------------------------------------------------------------------------
 // Shared application state
@@ -760,9 +842,11 @@ pub async fn serve_with_options(
         .await
         .map_err(|e| anyhow::anyhow!("failed to recover TreeKEM persistence journal: {e}"))?;
     let named_groups = load_named_groups(&named_groups_path).await?;
-    let treekem_member_key_packages_path = treekem_dir.join("member-key-packages.json");
-    let treekem_member_key_packages =
-        load_treekem_member_key_packages(&treekem_member_key_packages_path).await?;
+    let treekem_member_key_packages = load_treekem_member_key_packages(
+        &treekem_dir.join("member-key-packages.json"),
+        &named_groups,
+    )
+    .await?;
 
     // Load or generate API bearer token for local authentication.
     let api_token = auth::load_or_generate_api_token(&config.data_dir).await?;
@@ -893,8 +977,7 @@ pub async fn serve_with_options(
         pending_welcome_acks: RwLock::new(HashMap::new()),
         treekem_pending_events: RwLock::new(HashMap::new()),
         treekem_event_log: RwLock::new(HashMap::new()),
-        treekem_member_key_packages: RwLock::new(treekem_member_key_packages),
-        treekem_member_key_packages_path,
+        treekem_member_key_packages,
         treekem_catchup_throttle: RwLock::new(HashMap::new()),
         group_membership_locks: RwLock::new(HashMap::new()),
         treekem_groups: RwLock::new(treekem_groups),
@@ -5882,6 +5965,71 @@ fn member_joined_kp_cache_entry(
     }
 }
 
+fn member_joined_key_package_matches_groups(
+    groups: &HashMap<String, x0x::groups::GroupInfo>,
+    event: &NamedGroupMetadataEvent,
+) -> bool {
+    let NamedGroupMetadataEvent::MemberJoined {
+        group_id,
+        member_agent_id,
+        treekem_key_package_b64: Some(event_key_package),
+        ..
+    } = event
+    else {
+        return false;
+    };
+    let Some(info) = groups.get(group_id).or_else(|| {
+        groups
+            .values()
+            .find(|info| info.stable_group_id() == group_id)
+    }) else {
+        return false;
+    };
+    !info.withdrawn
+        && info.has_active_member(member_agent_id)
+        && info
+            .members_v2
+            .get(member_agent_id)
+            .and_then(|member| member.treekem_key_package_b64.as_ref())
+            == Some(event_key_package)
+}
+
+fn member_joined_key_package_relevant_to_groups(
+    groups: &HashMap<String, x0x::groups::GroupInfo>,
+    event: &NamedGroupMetadataEvent,
+) -> bool {
+    let NamedGroupMetadataEvent::MemberJoined {
+        group_id,
+        recovery_authority_signature_b64,
+        ..
+    } = event
+    else {
+        return false;
+    };
+    let Some(info) = groups.get(group_id).or_else(|| {
+        groups
+            .values()
+            .find(|info| info.stable_group_id() == group_id || info.mls_group_id == group_id)
+    }) else {
+        return false;
+    };
+    if info.withdrawn || !verify_member_joined_key_package_event(event) {
+        return false;
+    }
+    if recovery_authority_signature_b64.is_some() {
+        verify_authority_attested_member_joined_recovery(info, event)
+    } else {
+        true
+    }
+}
+
+async fn member_joined_key_package_matches_roster(
+    state: &AppState,
+    event: &NamedGroupMetadataEvent,
+) -> bool {
+    let groups = state.named_groups.read().await;
+    member_joined_key_package_matches_groups(&groups, event)
+}
 /// Verify that a key-package-bearing `MemberJoined` is self-authenticated by
 /// the claimed member. This is intentionally independent of inviter and roster
 /// state so persisted recovery records can be authenticated during startup.
@@ -6252,52 +6400,471 @@ fn verify_authority_attested_member_joined_recovery(
         .is_ok()
 }
 
+fn member_joined_event_timestamp(event: &NamedGroupMetadataEvent) -> u64 {
+    match event {
+        NamedGroupMetadataEvent::MemberJoined { ts_ms, .. } => *ts_ms,
+        _ => 0,
+    }
+}
+
+fn cache_entry_encoded_bytes(
+    key: &str,
+    event: &NamedGroupMetadataEvent,
+) -> serde_json::Result<usize> {
+    let key_bytes = serde_json::to_vec(key)?.len();
+    let event_bytes = serde_json::to_vec(event)?.len();
+    Ok(key_bytes.saturating_add(1).saturating_add(event_bytes))
+}
+
+fn cache_snapshot_encoded_bytes(state: &TreeKemMemberKeyPackageCacheState) -> usize {
+    2usize
+        .saturating_add(state.encoded_bytes)
+        .saturating_add(state.entries.len().saturating_sub(1))
+}
+
+fn enforce_treekem_member_key_package_cache_bounds(
+    state: &mut TreeKemMemberKeyPackageCacheState,
+) -> usize {
+    let mut evicted = 0usize;
+    while state.entries.len() > TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_ENTRIES
+        || cache_snapshot_encoded_bytes(state) > TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_BYTES
+    {
+        let victim = state
+            .entries
+            .iter()
+            .min_by(|(left_key, left), (right_key, right)| {
+                member_joined_event_timestamp(&left.event)
+                    .cmp(&member_joined_event_timestamp(&right.event))
+                    .then_with(|| left_key.cmp(right_key))
+            })
+            .map(|(key, _)| key.clone());
+        let Some(victim) = victim else {
+            break;
+        };
+        if let Some(removed) = state.entries.remove(&victim) {
+            state.encoded_bytes = state.encoded_bytes.saturating_sub(removed.encoded_bytes);
+            evicted = evicted.saturating_add(1);
+        }
+    }
+    evicted
+}
+
+fn recovery_attestation_revision(event: &NamedGroupMetadataEvent) -> Option<u64> {
+    let NamedGroupMetadataEvent::MemberJoined {
+        recovery_authority_signature_b64: Some(_),
+        recovery_authority_commit: Some(commit),
+        ..
+    } = event
+    else {
+        return None;
+    };
+    Some(commit.revision)
+}
+
+fn should_replace_recovery_cache_entry(
+    existing: &NamedGroupMetadataEvent,
+    candidate: &NamedGroupMetadataEvent,
+    overwrite: bool,
+) -> bool {
+    if !overwrite {
+        return false;
+    }
+    match (
+        recovery_attestation_revision(existing),
+        recovery_attestation_revision(candidate),
+    ) {
+        (None, Some(_)) => true,
+        (Some(existing_revision), Some(candidate_revision)) => {
+            candidate_revision > existing_revision
+        }
+        _ => false,
+    }
+}
+
+fn provisional_recovery_cache_victim(
+    state: &TreeKemMemberKeyPackageCacheState,
+    group_id: &str,
+) -> Option<String> {
+    let mut provisional = state
+        .entries
+        .iter()
+        .filter_map(|(key, entry)| {
+            let NamedGroupMetadataEvent::MemberJoined {
+                recovery_authority_signature_b64,
+                ts_ms,
+                ..
+            } = &entry.event
+            else {
+                return None;
+            };
+            (recovery_authority_signature_b64.is_none()
+                && named_group_metadata_event_group_id(&entry.event) == group_id)
+                .then_some((key, *ts_ms))
+        })
+        .collect::<Vec<_>>();
+    if provisional.len() < TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP {
+        return None;
+    }
+    provisional.sort_by(|(left_key, left_ts), (right_key, right_ts)| {
+        left_ts.cmp(right_ts).then_with(|| left_key.cmp(right_key))
+    });
+    provisional.first().map(|(key, _)| (*key).clone())
+}
+
+impl TreeKemMemberKeyPackageCache {
+    fn from_entries(
+        path: PathBuf,
+        entries: BTreeMap<String, NamedGroupMetadataEvent>,
+        dirty: bool,
+    ) -> serde_json::Result<(Self, usize)> {
+        let mut state = TreeKemMemberKeyPackageCacheState {
+            entries: BTreeMap::new(),
+            encoded_bytes: 0,
+            revision: u64::from(dirty),
+            persisted_revision: 0,
+            dirty,
+            write_failures: 0,
+            last_error: None,
+        };
+        for (key, event) in entries {
+            let encoded_bytes = cache_entry_encoded_bytes(&key, &event)?;
+            state.encoded_bytes = state.encoded_bytes.saturating_add(encoded_bytes);
+            state.entries.insert(
+                key,
+                TreeKemMemberKeyPackageCacheEntry {
+                    event,
+                    encoded_bytes,
+                },
+            );
+        }
+        let evicted = enforce_treekem_member_key_package_cache_bounds(&mut state);
+        if evicted > 0 && !state.dirty {
+            state.revision = 1;
+            state.dirty = true;
+        }
+        Ok((
+            Self {
+                path,
+                state: RwLock::new(state),
+                persistence: Mutex::new(()),
+            },
+            evicted,
+        ))
+    }
+
+    async fn get(&self, key: &str) -> Option<NamedGroupMetadataEvent> {
+        self.state
+            .read()
+            .await
+            .entries
+            .get(key)
+            .map(|entry| entry.event.clone())
+    }
+
+    async fn find_for_member(
+        &self,
+        group_ids: &[String],
+        member_id: &str,
+    ) -> Option<NamedGroupMetadataEvent> {
+        let state = self.state.read().await;
+        group_ids.iter().find_map(|group_id| {
+            state
+                .entries
+                .get(&join_result_key(group_id, member_id))
+                .map(|entry| entry.event.clone())
+        })
+    }
+
+    async fn events_matching(
+        &self,
+        mut predicate: impl FnMut(&NamedGroupMetadataEvent) -> bool,
+    ) -> Vec<NamedGroupMetadataEvent> {
+        self.state
+            .read()
+            .await
+            .entries
+            .values()
+            .filter(|entry| predicate(&entry.event))
+            .map(|entry| entry.event.clone())
+            .collect()
+    }
+
+    async fn insert(
+        &self,
+        key: String,
+        event: NamedGroupMetadataEvent,
+        overwrite: bool,
+    ) -> Result<TreeKemCacheMutation> {
+        let expected_key = member_joined_kp_cache_entry(&event)
+            .map(|(expected_key, _)| expected_key)
+            .context("TreeKEM recovery cache accepts only key-package MemberJoined events")?;
+        if expected_key != key || !verify_member_joined_key_package_event(&event) {
+            anyhow::bail!("TreeKEM recovery cache rejected invalid key or member signature");
+        }
+        let encoded_bytes = cache_entry_encoded_bytes(&key, &event)
+            .context("failed to encode TreeKEM member key-package cache entry")?;
+        let evicted = {
+            let mut state = self.state.write().await;
+            if let Some(existing) = state.entries.get(&key) {
+                if !should_replace_recovery_cache_entry(&existing.event, &event, overwrite) {
+                    drop(state);
+                    let persistence = self.persist_latest().await;
+                    return Ok(TreeKemCacheMutation {
+                        persistence,
+                        evicted: 0,
+                    });
+                }
+            }
+
+            let mut evicted = 0usize;
+            if let Some(previous) = state.entries.remove(&key) {
+                state.encoded_bytes = state.encoded_bytes.saturating_sub(previous.encoded_bytes);
+            } else if recovery_attestation_revision(&event).is_none() {
+                let group_id = named_group_metadata_event_group_id(&event);
+                if let Some(victim) = provisional_recovery_cache_victim(&state, group_id) {
+                    if let Some(removed) = state.entries.remove(&victim) {
+                        state.encoded_bytes =
+                            state.encoded_bytes.saturating_sub(removed.encoded_bytes);
+                        evicted = evicted.saturating_add(1);
+                    }
+                }
+            }
+            state.encoded_bytes = state.encoded_bytes.saturating_add(encoded_bytes);
+            state.entries.insert(
+                key,
+                TreeKemMemberKeyPackageCacheEntry {
+                    event,
+                    encoded_bytes,
+                },
+            );
+            state.revision = state.revision.saturating_add(1);
+            state.dirty = true;
+            evicted.saturating_add(enforce_treekem_member_key_package_cache_bounds(&mut state))
+        };
+        let persistence = self.persist_latest().await;
+        Ok(TreeKemCacheMutation {
+            persistence,
+            evicted,
+        })
+    }
+
+    async fn remove_member(
+        &self,
+        group_ids: &HashSet<String>,
+        member_id: &str,
+    ) -> TreeKemCacheMutation {
+        self.remove_matching(|event| match event {
+            NamedGroupMetadataEvent::MemberJoined {
+                group_id,
+                member_agent_id,
+                ..
+            } => group_ids.contains(group_id) && member_agent_id == member_id,
+            _ => false,
+        })
+        .await
+    }
+
+    async fn remove_groups(&self, group_ids: &HashSet<String>) -> TreeKemCacheMutation {
+        self.remove_matching(|event| match event {
+            NamedGroupMetadataEvent::MemberJoined { group_id, .. } => group_ids.contains(group_id),
+            _ => false,
+        })
+        .await
+    }
+
+    async fn remove_matching(
+        &self,
+        should_remove: impl Fn(&NamedGroupMetadataEvent) -> bool,
+    ) -> TreeKemCacheMutation {
+        let removed = {
+            let mut state = self.state.write().await;
+            let victims: Vec<String> = state
+                .entries
+                .iter()
+                .filter(|(_, entry)| should_remove(&entry.event))
+                .map(|(key, _)| key.clone())
+                .collect();
+            for key in &victims {
+                if let Some(entry) = state.entries.remove(key) {
+                    state.encoded_bytes = state.encoded_bytes.saturating_sub(entry.encoded_bytes);
+                }
+            }
+            if !victims.is_empty() {
+                state.revision = state.revision.saturating_add(1);
+                state.dirty = true;
+            }
+            victims.len()
+        };
+        let persistence = self.persist_latest().await;
+        TreeKemCacheMutation {
+            persistence,
+            evicted: removed,
+        }
+    }
+
+    async fn persist_latest(&self) -> TreeKemCachePersistenceStatus {
+        let _persistence = self.persistence.lock().await;
+        loop {
+            let (revision, snapshot) = {
+                let state = self.state.read().await;
+                if !state.dirty {
+                    return TreeKemCachePersistenceStatus::Durable {
+                        revision: state.persisted_revision,
+                    };
+                }
+                let snapshot = state
+                    .entries
+                    .iter()
+                    .map(|(key, entry)| (key.clone(), entry.event.clone()))
+                    .collect::<BTreeMap<_, _>>();
+                (state.revision, snapshot)
+            };
+            let json = match serde_json::to_string(&snapshot) {
+                Ok(json) => json,
+                Err(error) => {
+                    return self
+                        .record_persistence_failure(
+                            revision,
+                            format!("serialization failed: {error}"),
+                        )
+                        .await;
+                }
+            };
+            if let Err(error) = write_treekem_cache_json_atomic(&self.path, &json).await {
+                return self
+                    .record_persistence_failure(revision, format!("write failed: {error}"))
+                    .await;
+            }
+            let mut state = self.state.write().await;
+            state.persisted_revision = state.persisted_revision.max(revision);
+            if state.revision == revision {
+                state.dirty = false;
+                state.last_error = None;
+                return TreeKemCachePersistenceStatus::Durable { revision };
+            }
+        }
+    }
+
+    async fn record_persistence_failure(
+        &self,
+        attempted_revision: u64,
+        error: String,
+    ) -> TreeKemCachePersistenceStatus {
+        let mut state = self.state.write().await;
+        state.dirty = true;
+        state.write_failures = state.write_failures.saturating_add(1);
+        state.last_error = Some(error.clone());
+        TreeKemCachePersistenceStatus::Dirty {
+            revision: state.revision.max(attempted_revision),
+            error,
+        }
+    }
+
+    async fn diagnostics(&self) -> TreeKemCacheDiagnostics {
+        let state = self.state.read().await;
+        TreeKemCacheDiagnostics {
+            entries: state.entries.len(),
+            encoded_bytes: cache_snapshot_encoded_bytes(&state),
+            max_entries: TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_ENTRIES,
+            max_encoded_bytes: TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_BYTES,
+            revision: state.revision,
+            persisted_revision: state.persisted_revision,
+            dirty: state.dirty,
+            write_failures: state.write_failures,
+            last_error: state.last_error.clone(),
+        }
+    }
+}
+
+fn log_treekem_cache_mutation(context: &str, mutation: &TreeKemCacheMutation) {
+    if mutation.evicted > 0 {
+        tracing::debug!(
+            context,
+            removed = mutation.evicted,
+            "compacted TreeKEM recovery cache"
+        );
+    }
+    if let TreeKemCachePersistenceStatus::Dirty { revision, error } = &mutation.persistence {
+        tracing::error!(
+            context,
+            revision,
+            error,
+            "TreeKEM recovery cache remains dirty"
+        );
+    }
+}
+
 async fn cache_treekem_member_key_package(
     state: &AppState,
     key: String,
     event: NamedGroupMetadataEvent,
     overwrite: bool,
-) {
-    let mut cache = state.treekem_member_key_packages.write().await;
-    if overwrite {
-        cache.insert(key, event);
-    } else {
-        if !cache.contains_key(&key) {
-            let event_group = named_group_metadata_event_group_id(&event);
-            let provisional_keys = cache
-                .iter()
-                .filter_map(|(cached_key, cached)| {
-                    let NamedGroupMetadataEvent::MemberJoined {
-                        recovery_authority_signature_b64,
-                        ts_ms,
-                        ..
-                    } = cached
-                    else {
-                        return None;
-                    };
-                    (recovery_authority_signature_b64.is_none()
-                        && named_group_metadata_event_group_id(cached) == event_group)
-                        .then_some((cached_key.clone(), *ts_ms))
-                })
-                .collect::<Vec<_>>();
-            if provisional_keys.len() >= TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP {
-                if let Some((oldest, _)) = provisional_keys.into_iter().min_by_key(|(_, ts)| *ts) {
-                    cache.remove(&oldest);
-                }
+) -> TreeKemCachePersistenceStatus {
+    match state
+        .treekem_member_key_packages
+        .insert(key, event, overwrite)
+        .await
+    {
+        Ok(mutation) => {
+            log_treekem_cache_mutation("insert", &mutation);
+            mutation.persistence
+        }
+        Err(error) => {
+            tracing::error!(%error, "failed to mutate TreeKEM recovery cache");
+            TreeKemCachePersistenceStatus::Dirty {
+                revision: state
+                    .treekem_member_key_packages
+                    .diagnostics()
+                    .await
+                    .revision,
+                error: error.to_string(),
             }
         }
-        cache.entry(key).or_insert(event);
     }
-    match serde_json::to_string(&*cache) {
-        Ok(json) => {
-            if let Err(e) =
-                write_named_groups_json_atomic(&state.treekem_member_key_packages_path, &json).await
-            {
-                tracing::error!("Failed to save TreeKEM member key-package cache: {e}");
-            }
-        }
-        Err(e) => tracing::error!("Failed to serialize TreeKEM member key-package cache: {e}"),
-    }
+}
+
+async fn treekem_cache_group_aliases(state: &AppState, group_id: &str) -> HashSet<String> {
+    let groups = state.named_groups.read().await;
+    let stable_group_id = groups
+        .get(group_id)
+        .map(|info| info.stable_group_id())
+        .or_else(|| {
+            groups
+                .values()
+                .find(|info| info.stable_group_id() == group_id || info.mls_group_id == group_id)
+                .map(x0x::groups::GroupInfo::stable_group_id)
+        });
+    let mut aliases = collect_same_stable_group_aliases(&groups, group_id, stable_group_id);
+    aliases.insert(group_id.to_string());
+    aliases
+}
+
+async fn prune_treekem_cache_member(
+    state: &AppState,
+    group_id: &str,
+    member_id: &str,
+    context: &str,
+) -> TreeKemCachePersistenceStatus {
+    let aliases = treekem_cache_group_aliases(state, group_id).await;
+    let mutation = state
+        .treekem_member_key_packages
+        .remove_member(&aliases, member_id)
+        .await;
+    log_treekem_cache_mutation(context, &mutation);
+    mutation.persistence
+}
+
+async fn prune_treekem_cache_groups(
+    state: &AppState,
+    aliases: &HashSet<String>,
+    context: &str,
+) -> TreeKemCachePersistenceStatus {
+    let mutation = state
+        .treekem_member_key_packages
+        .remove_groups(aliases)
+        .await;
+    log_treekem_cache_mutation(context, &mutation);
+    mutation.persistence
 }
 
 /// Install a TreeKEM KeyPackage recovered from a member-signed `MemberJoined`
@@ -6449,10 +7016,7 @@ async fn recover_member_treekem_key_package_locked(
         }
     }
     let key = join_result_key(group_id, member_agent_id);
-    let cached = {
-        let cache = state.treekem_member_key_packages.read().await;
-        cache.get(&key).cloned()
-    };
+    let cached = state.treekem_member_key_packages.get(&key).await;
     let Some(event) = cached else {
         return false;
     };
@@ -6729,14 +7293,11 @@ async fn member_keyed_treekem_catchup_response(
             })
             .cloned()
     }?;
-    let event = {
-        let cache = state.treekem_member_key_packages.read().await;
-        log_keys
-            .iter()
-            .find_map(|group_id| cache.get(&join_result_key(group_id, target_member_id)))
-            .filter(|event| verify_authority_attested_member_joined_recovery(&info, event))
-            .cloned()
-    };
+    let event = state
+        .treekem_member_key_packages
+        .find_for_member(log_keys, target_member_id)
+        .await
+        .filter(|event| verify_authority_attested_member_joined_recovery(&info, event));
     Some(TreeKemCatchupResponse {
         message_type: "treekem_catchup_response".to_string(),
         group_id: request.group_id.clone(),
@@ -7669,6 +8230,7 @@ async fn apply_named_group_metadata_event_inner_with_witness(
             }) else {
                 return false;
             };
+            let cache_aliases = treekem_cache_group_aliases(state, &resolved_group_key).await;
             let removed_self = agent_id == local_agent_hex;
             if removed_self {
                 state.named_groups.write().await.remove(&resolved_group_key);
@@ -7704,6 +8266,8 @@ async fn apply_named_group_metadata_event_inner_with_witness(
                 .await;
                 save_named_groups(state).await;
                 save_mls_groups(state).await;
+                let _ =
+                    prune_treekem_cache_groups(state, &cache_aliases, "member_removed_self").await;
                 return true;
             }
             if let Some((commit_b64, _epoch)) = treekem_payload {
@@ -7741,6 +8305,9 @@ async fn apply_named_group_metadata_event_inner_with_witness(
             save_named_groups(state).await;
             save_mls_groups(state).await;
             remember_treekem_membership_event(state, &event_for_log).await;
+            let _ =
+                prune_treekem_cache_member(state, &resolved_group_key, &agent_id, "member_removed")
+                    .await;
             true
         }
         NamedGroupMetadataEvent::GroupDeleted {
@@ -7939,6 +8506,7 @@ async fn apply_named_group_metadata_event_inner_with_witness(
             ) else {
                 return false;
             };
+            let cache_aliases = treekem_cache_group_aliases(state, &resolved_group_key).await;
             let banned_self = agent_id == local_agent_hex;
             if banned_self {
                 state
@@ -7986,6 +8554,18 @@ async fn apply_named_group_metadata_event_inner_with_witness(
             refresh_group_card_cache_from_info(state, &resolved_group_key, &next).await;
             save_named_groups(state).await;
             remember_treekem_membership_event(state, &event_for_log).await;
+            if banned_self {
+                let _ =
+                    prune_treekem_cache_groups(state, &cache_aliases, "member_banned_self").await;
+            } else {
+                let _ = prune_treekem_cache_member(
+                    state,
+                    &resolved_group_key,
+                    &agent_id,
+                    "member_banned",
+                )
+                .await;
+            }
             true
         }
         NamedGroupMetadataEvent::MemberUnbanned {
@@ -8967,29 +9547,22 @@ async fn apply_named_group_metadata_event_inner_with_witness(
                 )
                 .await;
             }
-            let member_recovery_deliveries = {
-                let cache = state.treekem_member_key_packages.read().await;
-                let mut seen = HashSet::new();
-                cache
-                    .values()
-                    .filter_map(|recovery| {
-                        let NamedGroupMetadataEvent::MemberJoined {
-                            member_agent_id: recovered_member,
-                            ..
-                        } = recovery
-                        else {
-                            return None;
-                        };
-                        if recovered_member == &member_agent_id
-                            || !seen.insert(recovered_member.clone())
-                            || !verify_authority_attested_member_joined_recovery(&next, recovery)
-                        {
-                            return None;
-                        }
-                        Some(recovery.clone())
-                    })
-                    .collect::<Vec<_>>()
-            };
+            let mut seen = HashSet::new();
+            let member_recovery_deliveries = state
+                .treekem_member_key_packages
+                .events_matching(|recovery| {
+                    let NamedGroupMetadataEvent::MemberJoined {
+                        member_agent_id: recovered_member,
+                        ..
+                    } = recovery
+                    else {
+                        return false;
+                    };
+                    recovered_member != &member_agent_id
+                        && seen.insert(recovered_member.clone())
+                        && verify_authority_attested_member_joined_recovery(&next, recovery)
+                })
+                .await;
             let event = NamedGroupMetadataEvent::MemberAdded {
                 group_id: event_group_id.clone(),
                 revision,
@@ -10898,20 +11471,16 @@ async fn add_treekem_named_group_member(
         std::slice::from_ref(&agent_hex),
     );
     spawn_named_group_event_delivery_to_active_members(&state, &next, &member_joined_recovery, &[]);
-    let recovery_deliveries = {
-        let cache = state.treekem_member_key_packages.read().await;
-        cache
-            .values()
-            .filter(|recovery| {
-                matches!(
-                    recovery,
-                    NamedGroupMetadataEvent::MemberJoined { member_agent_id, .. }
-                        if member_agent_id != &agent_hex
-                ) && verify_authority_attested_member_joined_recovery(&next, recovery)
-            })
-            .cloned()
-            .collect::<Vec<_>>()
-    };
+    let recovery_deliveries = state
+        .treekem_member_key_packages
+        .events_matching(|recovery| {
+            matches!(
+                recovery,
+                NamedGroupMetadataEvent::MemberJoined { member_agent_id, .. }
+                    if member_agent_id != &agent_hex
+            ) && verify_authority_attested_member_joined_recovery(&next, recovery)
+        })
+        .await;
     for recovery in recovery_deliveries {
         spawn_named_group_event_delivery(&state, &agent_hex, &recovery);
         spawn_named_group_event_delivery_after(
@@ -11471,6 +12040,7 @@ async fn wipe_local_group_crypto_material(
         expected.retain(|key, _| !join_result_key_matches_any_group_alias(key, &aliases));
     }
 
+    let _ = prune_treekem_cache_groups(state, &aliases, reason).await;
     let mut welcome_ids = Vec::new();
     {
         let mut welcomes = state.pending_welcomes.write().await;
@@ -11823,6 +12393,7 @@ async fn remove_treekem_named_group_member(
     drop(groups);
     save_named_groups(&state).await;
     save_mls_groups(&state).await;
+    let _ = prune_treekem_cache_member(&state, &id, &agent_id_hex, "local_member_removed").await;
 
     let event = NamedGroupMetadataEvent::MemberRemoved {
         group_id: event_group_id,
@@ -12219,6 +12790,8 @@ async fn leave_group(
     publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
     maybe_publish_group_card_after_state_change(&state, &id).await;
 
+    let cache_aliases = treekem_cache_group_aliases(&state, &id).await;
+    let _ = prune_treekem_cache_groups(&state, &cache_aliases, "leave_group").await;
     state.named_groups.write().await.remove(&id);
     let mut cache = state.group_card_cache.write().await;
     prune_expired_group_cards(&mut cache, now_millis_u64());
@@ -13039,6 +13612,7 @@ async fn ban_treekem_group_member(
     groups.insert(id.clone(), next.clone());
     drop(groups);
     save_named_groups(&state).await;
+    let _ = prune_treekem_cache_member(&state, &id, &agent_id_hex, "local_member_banned").await;
 
     let event = NamedGroupMetadataEvent::MemberBanned {
         group_id: event_group_id,
@@ -13663,20 +14237,16 @@ async fn approve_treekem_join_request(
     )
     .await;
     spawn_named_group_event_delivery_to_active_members(&state, &next, &approval_recovery, &[]);
-    let prior_recovery = {
-        let cache = state.treekem_member_key_packages.read().await;
-        cache
-            .values()
-            .filter(|recovery| {
-                matches!(
-                    recovery,
-                    NamedGroupMetadataEvent::MemberJoined { member_agent_id, .. }
-                        if member_agent_id != &requester_hex
-                ) && verify_authority_attested_member_joined_recovery(&next, recovery)
-            })
-            .cloned()
-            .collect::<Vec<_>>()
-    };
+    let prior_recovery = state
+        .treekem_member_key_packages
+        .events_matching(|recovery| {
+            matches!(
+                recovery,
+                NamedGroupMetadataEvent::MemberJoined { member_agent_id, .. }
+                    if member_agent_id != &requester_hex
+            ) && verify_authority_attested_member_joined_recovery(&next, recovery)
+        })
+        .await;
     for recovery in prior_recovery {
         spawn_named_group_event_delivery(&state, &requester_hex, &recovery);
         spawn_named_group_event_delivery_after(
@@ -17033,11 +17603,13 @@ async fn groups_diagnostics(State(state): State<Arc<AppState>>) -> impl IntoResp
     let snap = state
         .groups_diagnostics
         .snapshot(&groups_view, &metadata_keys, &public_keys);
+    let treekem_recovery_cache = state.treekem_member_key_packages.diagnostics().await;
     (
         StatusCode::OK,
         Json(serde_json::json!({
             "ok": true,
             "groups": snap.groups,
+            "treekem_recovery_cache": treekem_recovery_cache,
         })),
     )
 }
@@ -17646,48 +18218,98 @@ async fn restore_treekem_groups(
     restored
 }
 
+async fn quarantine_corrupt_treekem_cache(path: &FsPath) -> std::io::Result<PathBuf> {
+    let mut quarantine_os = path.as_os_str().to_owned();
+    quarantine_os.push(format!(".corrupt-{}", uuid::Uuid::new_v4()));
+    let quarantine_path = PathBuf::from(quarantine_os);
+    tokio::fs::rename(path, &quarantine_path).await?;
+    Ok(quarantine_path)
+}
+
 async fn load_treekem_member_key_packages(
     path: &FsPath,
-) -> Result<HashMap<String, NamedGroupMetadataEvent>> {
-    match tokio::fs::read_to_string(path).await {
+    groups: &HashMap<String, x0x::groups::GroupInfo>,
+) -> Result<TreeKemMemberKeyPackageCache> {
+    let (entries, startup_dirty) = match tokio::fs::read_to_string(path).await {
         Ok(json) => {
-            let mut cache = serde_json::from_str::<HashMap<String, NamedGroupMetadataEvent>>(&json)
-                .with_context(|| {
-                    format!(
-                        "failed to parse TreeKEM member key-package cache {}",
-                        path.display()
-                    )
-                })?;
-            let persisted_count = cache.len();
-            cache.retain(|key, event| {
-                member_joined_kp_cache_entry(event)
-                    .is_some_and(|(expected_key, _)| expected_key == *key)
-                    && (verify_member_joined_key_package_event(event)
-                        || verify_recovery_attestation_structure(event))
-            });
-            let rejected_count = persisted_count.saturating_sub(cache.len());
-            if rejected_count > 0 {
-                tracing::warn!(
-                    path = %path.display(),
-                    rejected_count,
-                    "discarded invalid persisted TreeKEM member key-package recovery records"
-                );
+            match serde_json::from_str::<BTreeMap<String, NamedGroupMetadataEvent>>(&json) {
+                Ok(mut cache) => {
+                    let persisted_count = cache.len();
+                    cache.retain(|key, event| {
+                        member_joined_kp_cache_entry(event)
+                            .is_some_and(|(expected_key, _)| expected_key == *key)
+                            && member_joined_key_package_relevant_to_groups(groups, event)
+                    });
+                    let rejected_count = persisted_count.saturating_sub(cache.len());
+                    if rejected_count > 0 {
+                        tracing::warn!(
+                            path = %path.display(),
+                            rejected_count,
+                            "pruned invalid or irrelevant TreeKEM recovery-cache records at startup"
+                        );
+                    }
+                    (cache, rejected_count > 0)
+                }
+                Err(error) => {
+                    let quarantine_path = quarantine_corrupt_treekem_cache(path)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "failed to quarantine corrupt TreeKEM recovery cache {} after parse error: {error}",
+                                path.display()
+                            )
+                        })?;
+                    tracing::error!(
+                        path = %path.display(),
+                        quarantine_path = %quarantine_path.display(),
+                        cause = %error,
+                        "quarantined corrupt TreeKEM recovery cache; starting empty"
+                    );
+                    (BTreeMap::new(), true)
+                }
             }
-            tracing::info!(
-                path = %path.display(),
-                records = cache.len(),
-                "loaded TreeKEM member key-package recovery cache"
-            );
-            Ok(cache)
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(HashMap::new()),
-        Err(e) => Err(e).with_context(|| {
-            format!(
-                "failed to read TreeKEM member key-package cache {}",
-                path.display()
-            )
-        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => (BTreeMap::new(), false),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to read TreeKEM member key-package cache {}",
+                    path.display()
+                )
+            });
+        }
+    };
+
+    let (cache, evicted) =
+        TreeKemMemberKeyPackageCache::from_entries(path.to_path_buf(), entries, startup_dirty)
+            .context("failed to size TreeKEM member key-package cache")?;
+    if evicted > 0 {
+        tracing::warn!(
+            path = %path.display(),
+            evicted,
+            "bounded TreeKEM recovery cache during startup compaction"
+        );
     }
+    if cache.diagnostics().await.dirty {
+        let persistence = cache.persist_latest().await;
+        if let TreeKemCachePersistenceStatus::Dirty { revision, error } = persistence {
+            tracing::error!(
+                path = %path.display(),
+                revision,
+                error,
+                "startup TreeKEM recovery-cache compaction remains dirty"
+            );
+        }
+    }
+    let diagnostics = cache.diagnostics().await;
+    tracing::info!(
+        path = %path.display(),
+        records = diagnostics.entries,
+        encoded_bytes = diagnostics.encoded_bytes,
+        dirty = diagnostics.dirty,
+        "loaded TreeKEM member key-package recovery cache"
+    );
+    Ok(cache)
 }
 
 async fn load_named_groups(
@@ -17750,6 +18372,24 @@ async fn save_named_groups(state: &AppState) {
         }
         Err(e) => tracing::error!("Failed to serialize named groups: {e}"),
     }
+}
+
+async fn write_treekem_cache_json_atomic(path: &FsPath, json: &str) -> std::io::Result<()> {
+    #[cfg(test)]
+    if let Some(control) = take_treekem_cache_writer_hook_for_test(path) {
+        // The writer has entered the one-shot hook. Signal entry with a stored
+        // permit (notify_one keeps it until awaited, so observation is free of
+        // await-ordering races), then either inject a failure or park until the
+        // test releases a slow-disk simulation.
+        control.entered.notify_one();
+        if let Some(error) = control.force_error {
+            return Err(error);
+        }
+        if let Some(release) = control.release {
+            release.notified().await;
+        }
+    }
+    write_named_groups_json_atomic(path, json).await
 }
 
 async fn write_named_groups_json_atomic(path: &FsPath, json: &str) -> std::io::Result<()> {
@@ -20179,9 +20819,11 @@ mod tests {
         tokio::fs::create_dir_all(&treekem_dir).await?;
         let named_groups_path = data_dir.join("named_groups.json");
         let named_groups = load_named_groups(&named_groups_path).await?;
-        let treekem_member_key_packages_path = treekem_dir.join("member-key-packages.json");
-        let treekem_member_key_packages =
-            load_treekem_member_key_packages(&treekem_member_key_packages_path).await?;
+        let treekem_member_key_packages = load_treekem_member_key_packages(
+            &treekem_dir.join("member-key-packages.json"),
+            &named_groups,
+        )
+        .await?;
         let contacts = Arc::clone(agent.contacts());
         agent.set_contacts(Arc::clone(&contacts));
 
@@ -20226,8 +20868,7 @@ mod tests {
             pending_welcome_waiters: RwLock::new(HashMap::new()),
             pending_welcome_acks: RwLock::new(HashMap::new()),
             treekem_pending_events: RwLock::new(HashMap::new()),
-            treekem_member_key_packages: RwLock::new(treekem_member_key_packages),
-            treekem_member_key_packages_path,
+            treekem_member_key_packages,
             treekem_event_log: RwLock::new(HashMap::new()),
             treekem_catchup_throttle: RwLock::new(HashMap::new()),
             group_membership_locks: RwLock::new(HashMap::new()),
@@ -24349,13 +24990,19 @@ mod tests {
             true,
         )
         .await;
-        assert_eq!(state.treekem_member_key_packages.read().await.len(), 1);
-        tokio::fs::metadata(&state.treekem_member_key_packages_path).await?;
+        assert_eq!(
+            state
+                .treekem_member_key_packages
+                .diagnostics()
+                .await
+                .entries,
+            1
+        );
+        tokio::fs::metadata(&state.treekem_member_key_packages.path).await?;
 
         // Model process loss explicitly, then construct a distinct AppState on
         // the same durable directory. Startup must repopulate the empty runtime
         // cache from the authenticated signed-event file.
-        state.treekem_member_key_packages.write().await.clear();
         let restarted =
             secure_endpoint_test_state_at(fixture._dir.path(), Arc::clone(&state.agent)).await?;
         assert!(!Arc::ptr_eq(state, &restarted));
@@ -24401,10 +25048,13 @@ mod tests {
         // promoted-admin regression. Seed the recovery cache with the member's
         // self-signed MemberJoined (what the inviter / catch-up would supply).
         insert_active_member_without_kp(state, &group_id, &member_hex, &inviter_hex).await;
-        state.treekem_member_key_packages.write().await.insert(
-            join_result_key(&group_id, &member_hex),
-            fixture.event.clone(),
-        );
+        state
+            .treekem_member_key_packages
+            .insert(
+                join_result_key(&group_id, &member_hex),
+                fixture.event.clone(),
+            )
+            .await?;
         assert!(member_treekem_kp(state, &group_id, &member_hex)
             .await
             .is_none());
@@ -24643,10 +25293,13 @@ mod tests {
 
         // Join: roster member (Active, no kp) + cached self-signed event.
         insert_active_member_without_kp(state, &group_id, &member_hex, &inviter_hex).await;
-        state.treekem_member_key_packages.write().await.insert(
-            join_result_key(&group_id, &member_hex),
-            fixture.event.clone(),
-        );
+        state
+            .treekem_member_key_packages
+            .insert(
+                join_result_key(&group_id, &member_hex),
+                fixture.event.clone(),
+            )
+            .await?;
         assert!(
             recover_member_treekem_key_package(state, &group_id, &member_hex).await,
             "first recovery installs"
@@ -24768,13 +25421,13 @@ mod tests {
         assert!(
             w_state
                 .treekem_member_key_packages
-                .read()
+                .get(&cache_key)
                 .await
-                .contains_key(&cache_key),
+                .is_some(),
             "witness caches the signed MemberJoined in-memory"
         );
         assert!(
-            tokio::fs::try_exists(&w_state.treekem_member_key_packages_path).await?,
+            tokio::fs::try_exists(&w_state.treekem_member_key_packages.path).await?,
             "witness persisted the key-package cache to disk"
         );
 
@@ -24805,12 +25458,7 @@ mod tests {
                 .expect("O logged authority-attested MemberAdded")
         };
         let authority_recovery = fixture
-            .state
-            .treekem_member_key_packages
-            .read()
-            .await
-            .get(&cache_key)
-            .cloned()
+            .state.treekem_member_key_packages.get(&cache_key).await
             .expect("O cached the authority-attested recovery event");
         {
             let groups = fixture.state.named_groups.read().await;
@@ -24904,9 +25552,9 @@ mod tests {
         assert!(
             w_state
                 .treekem_member_key_packages
-                .read()
+                .get(&join_result_key(&group_id, &member_hex))
                 .await
-                .contains_key(&join_result_key(&group_id, &member_hex)),
+                .is_some(),
             "independent witness W retained B's recovery record"
         );
 
@@ -24927,12 +25575,7 @@ mod tests {
                 .cloned()
                 .expect("O logged authority-attested MemberAdded")
         };
-        let authority_recovery = o_state
-            .treekem_member_key_packages
-            .read()
-            .await
-            .get(&join_result_key(&group_id, &member_hex))
-            .cloned()
+        let authority_recovery = o_state.treekem_member_key_packages.get(&join_result_key(&group_id, &member_hex)).await
             .expect("O cached authority-attested recovery");
         assert!(
             apply_named_group_metadata_event(
@@ -25465,22 +26108,22 @@ mod tests {
                 .treekem_key_package_b64 = None;
         }
         let cache_key = join_result_key(&group_id, &member_hex);
+        let aliases = HashSet::from([group_id.clone()]);
         state
             .treekem_member_key_packages
-            .write()
-            .await
-            .remove(&cache_key);
+            .remove_member(&aliases, &member_hex)
+            .await;
         assert!(
             !apply_named_group_metadata_event(state, valid_event.clone(), fixture.member_id, true,)
                 .await,
             "self-delivered recovery evidence never exercises roster mutation authority"
         );
         assert!(
-            !state
+            state
                 .treekem_member_key_packages
-                .read()
+                .get(&cache_key)
                 .await
-                .contains_key(&cache_key),
+                .is_none(),
             "a valid old-incarnation attestation cannot poison the current recovery cache"
         );
         assert!(
@@ -25559,12 +26202,7 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "TreeKEM request approval succeeds");
 
         let recovery = fixture
-            .state
-            .treekem_member_key_packages
-            .read()
-            .await
-            .get(&join_result_key(&fixture.group_id, &requester_hex))
-            .cloned()
+            .state.treekem_member_key_packages.get(&join_result_key(&fixture.group_id, &requester_hex)).await
             .expect("request approval caches recovery evidence");
         {
             let mut groups = fixture.state.named_groups.write().await;
@@ -25669,12 +26307,7 @@ mod tests {
                 .expect("authority logged JoinRequestApproved")
         };
         let recovery = fixture
-            .state
-            .treekem_member_key_packages
-            .read()
-            .await
-            .get(&join_result_key(&fixture.group_id, &requester_hex))
-            .cloned()
+            .state.treekem_member_key_packages.get(&join_result_key(&fixture.group_id, &requester_hex)).await
             .expect("authority cached the attested recovery record");
 
         // (1) The approval event carries A's hash.
@@ -25847,12 +26480,7 @@ mod tests {
         );
 
         let recovery = fixture
-            .state
-            .treekem_member_key_packages
-            .read()
-            .await
-            .get(&join_result_key(&fixture.group_id, &target_hex))
-            .cloned()
+            .state.treekem_member_key_packages.get(&join_result_key(&fixture.group_id, &target_hex)).await
             .expect("direct add caches authority recovery attestation");
         {
             let groups = fixture.state.named_groups.read().await;
@@ -25877,12 +26505,7 @@ mod tests {
         let restarted =
             secure_endpoint_test_state_at(fixture._dir.path(), Arc::clone(&fixture.state.agent))
                 .await?;
-        let restarted_recovery = restarted
-            .treekem_member_key_packages
-            .read()
-            .await
-            .get(&join_result_key(&fixture.group_id, &target_hex))
-            .cloned()
+        let restarted_recovery = restarted.treekem_member_key_packages.get(&join_result_key(&fixture.group_id, &target_hex)).await
             .expect("authority-only direct-add recovery survives restart");
         let groups = restarted.named_groups.read().await;
         assert!(
@@ -25990,20 +26613,19 @@ mod tests {
             member_recovery_history.is_empty(),
             "recovery history must not grow the Welcome-bearing MemberAdded payload"
         );
-        let prior_recovery = {
-            let cache = state.treekem_member_key_packages.read().await;
-            cache
-                .values()
-                .find(|event| {
-                    matches!(
-                        event,
-                        NamedGroupMetadataEvent::MemberJoined { member_agent_id, .. }
-                            if member_agent_id == &first_member
-                    )
-                })
-                .cloned()
-                .expect("prior authority-attested recovery record")
-        };
+        let prior_recovery = state
+            .treekem_member_key_packages
+            .events_matching(|event| {
+                matches!(
+                    event,
+                    NamedGroupMetadataEvent::MemberJoined { member_agent_id, .. }
+                        if member_agent_id == &first_member
+                )
+            })
+            .await
+            .into_iter()
+            .next()
+            .expect("prior authority-attested recovery record");
         assert!(
             serde_json::to_vec(&prior_recovery)?.len() < crate::dm::MAX_PAYLOAD_BYTES,
             "each independently delivered recovery record fits one DM payload"
@@ -26155,12 +26777,7 @@ mod tests {
         // (1) The creator package was provisioned as a fully authority-attested
         //     recovery record: it carries an authority signature over the
         //     sealed group-state commit (not merely a member self-signature).
-        let cached = state
-            .treekem_member_key_packages
-            .read()
-            .await
-            .get(&join_result_key(&group_id, &creator_hex))
-            .cloned()
+        let cached = state.treekem_member_key_packages.get(&join_result_key(&group_id, &creator_hex)).await
             .expect("creator recovery record is cached at group creation");
         let cached_package = match &cached {
             NamedGroupMetadataEvent::MemberJoined {
@@ -26281,10 +26898,14 @@ mod tests {
 
         // Seed the recovery cache with the authority-attested record for the
         // ORIGINAL package — the stale evidence that must NOT be replayable.
-        state.treekem_member_key_packages.write().await.insert(
-            join_result_key(&group_id, &member_hex),
-            fixture.event.clone(),
-        );
+        state
+            .treekem_member_key_packages
+            .insert(
+                join_result_key(&group_id, &member_hex),
+                fixture.event.clone(),
+                true,
+            )
+            .await?;
 
         // Replace the member's incarnation hash (a re-key / re-add). The setter
         // MUST wipe the now-stale package bytes because they no longer match.
@@ -26404,5 +27025,656 @@ mod tests {
             active.treekem_key_package_hash = package_hash;
             info.members_v2.insert(member.to_string(), active);
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // TreeKEM member key-package cache: loader quarantine, bounds, and
+    // lifecycle regression coverage (WP-TK2 findings 3-6).
+    //
+    // `synthetic_member_joined` builds deliberately NON-verifying
+    // `MemberJoined` events used only to size the cache via `from_entries`,
+    // which enforces count/byte bounds without signature verification. Tests
+    // that exercise the load path or `insert()` use real signed
+    // `member_joined_treekem_fixture` events, since those paths authenticate
+    // the member signature.
+    // ---------------------------------------------------------------------
+
+    /// Compact, deliberately NON-verifying `MemberJoined` for cache *sizing*
+    /// tests. `from_entries` never calls `verify_member_joined_key_package_event`,
+    /// so these events exist purely to control entry count, `ts_ms` ordering,
+    /// and encoded byte size. Must never be passed to `insert()`.
+    fn synthetic_member_joined(
+        group_id: &str,
+        member: &str,
+        ts_ms: u64,
+        key_package_payload_len: usize,
+    ) -> NamedGroupMetadataEvent {
+        NamedGroupMetadataEvent::MemberJoined {
+            group_id: group_id.to_string(),
+            stable_group_id: Some(group_id.to_string()),
+            member_agent_id: member.to_string(),
+            member_public_key_b64: BASE64.encode([0xA5u8; 48]),
+            role: x0x::groups::GroupRole::Member,
+            display_name: None,
+            inviter_agent_id: format!("inviter-{group_id}"),
+            invite_secret: format!("invite-{group_id}-{member}"),
+            ts_ms,
+            treekem_key_package_b64: Some(BASE64.encode(vec![0xA5u8; key_package_payload_len])),
+            signature_b64: BASE64.encode([0xA5u8; 64]),
+        }
+    }
+
+    /// Read the durable cache JSON and return its key set. Used to prove the
+    /// on-disk state — not just the in-memory cache — after loader/lifecycle
+    /// operations.
+    async fn durable_cache_keys(path: &FsPath) -> Result<HashSet<String>> {
+        let on_disk = tokio::fs::read_to_string(path).await?;
+        let parsed: BTreeMap<String, serde_json::Value> = serde_json::from_str(&on_disk)?;
+        Ok(parsed.into_keys().collect())
+    }
+
+    /// Locate the `<base>.corrupt-<uuid>` quarantine sibling written when the
+    /// loader quarantines an unparseable cache file.
+    async fn quarantine_sibling(dir: &FsPath, base: &str) -> Option<PathBuf> {
+        let prefix = format!("{base}.corrupt-");
+        let mut rd = tokio::fs::read_dir(dir).await.ok()?;
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            if entry.file_name().to_string_lossy().starts_with(&prefix) {
+                return Some(entry.path());
+            }
+        }
+        None
+    }
+
+    /// WP-TK2: an unparseable or schema-incompatible recovery cache must NOT
+    /// abort startup or overwrite the corrupt bytes. The loader renames the
+    /// file to a quarantine sibling (preserving it verbatim) and starts from
+    /// an empty cache, rewriting the active path as `{}`.
+    #[tokio::test]
+    async fn treekem_recovery_cache_quarantines_corrupt_json_without_overwrite() -> Result<()> {
+        let cases: Vec<(&str, Vec<u8>)> = vec![
+            ("malformed JSON", b"{not valid json".to_vec()),
+            ("truncated JSON", b"{\"g:m\":".to_vec()),
+            ("schema-incompatible value", b"{\"g:m\":123}".to_vec()),
+            ("JSON array (not object)", b"[]".to_vec()),
+        ];
+        let empty_roster: HashMap<String, x0x::groups::GroupInfo> = HashMap::new();
+
+        for (label, corpus) in &cases {
+            let dir = tempfile::tempdir()?;
+            let base = "member-key-packages.json";
+            let path = dir.path().join(base);
+            tokio::fs::write(&path, corpus.as_slice()).await?;
+
+            let cache = load_treekem_member_key_packages(&path, &empty_roster)
+                .await
+                .expect("corrupt cache quarantines and loads empty, not a fatal startup error");
+
+            assert_eq!(
+                cache.diagnostics().await.entries,
+                0,
+                "{label}: in-memory cache empty after quarantine"
+            );
+
+            // Original corrupt bytes are preserved verbatim in a quarantine
+            // sibling (rename, not overwrite).
+            let quarantine = quarantine_sibling(dir.path(), base)
+                .await
+                .unwrap_or_else(|| panic!("{label}: quarantine sibling exists"));
+            let preserved = tokio::fs::read(&quarantine).await?;
+            assert_eq!(
+                preserved, *corpus,
+                "{label}: quarantine preserves the original corrupt bytes verbatim"
+            );
+
+            // The active path is rewritten as an empty cache (no corrupt residue).
+            assert!(
+                durable_cache_keys(&path).await?.is_empty(),
+                "{label}: active path rewritten as an empty cache"
+            );
+        }
+        Ok(())
+    }
+
+    /// WP-TK2: a read error other than `NotFound` (here: the path is a
+    /// directory, so `read_to_string` fails with EISDIR) is fatal — the loader
+    /// surfaces the error and must NOT quarantine or silently start empty.
+    #[tokio::test]
+    async fn treekem_recovery_cache_non_notfound_read_error_is_fatal() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("unreadable.json");
+        // A directory exists but cannot be read as a file -> error kind != NotFound.
+        tokio::fs::create_dir(&path).await?;
+
+        let empty_roster: HashMap<String, x0x::groups::GroupInfo> = HashMap::new();
+        let result = load_treekem_member_key_packages(&path, &empty_roster).await;
+        assert!(
+            result.is_err(),
+            "non-NotFound read error must be fatal, not quarantined to empty"
+        );
+
+        // The fatal branch neither quarantines (renames) nor touches the path.
+        let metadata = tokio::fs::metadata(&path)
+            .await
+            .expect("path still present");
+        assert!(
+            metadata.is_dir(),
+            "unreadable directory left in place, not quarantined"
+        );
+        Ok(())
+    }
+
+    /// WP-TK2: at startup the loader retains only self-signed records that
+    /// still match an active roster. A validly-signed record for a group/member
+    /// absent from the roster is PRUNED (memory + durable JSON emptied), while
+    /// the same record IS retained when the roster carries the active member
+    /// with a matching key package — proving the prune is selective, not a wipe.
+    #[tokio::test]
+    async fn treekem_recovery_cache_startup_prunes_roster_irrelevant_signed_records() -> Result<()>
+    {
+        let fixture = member_joined_treekem_fixture(0x91, 0x92).await?;
+        let group_id = fixture.group_id.clone();
+        let member_hex = fixture.member_hex.clone();
+        let key = join_result_key(&group_id, &member_hex);
+        let persisted: BTreeMap<String, NamedGroupMetadataEvent> =
+            [(key.clone(), fixture.event.clone())].into_iter().collect();
+        let json = serde_json::to_string(&persisted)?;
+
+        // Case A: no active roster -> validly-signed record is pruned.
+        {
+            let dir = tempfile::tempdir()?;
+            let path = dir.path().join("kp.json");
+            tokio::fs::write(&path, &json).await?;
+            let empty_roster: HashMap<String, x0x::groups::GroupInfo> = HashMap::new();
+
+            let cache = load_treekem_member_key_packages(&path, &empty_roster).await?;
+            assert_eq!(
+                cache.diagnostics().await.entries,
+                0,
+                "roster-irrelevant record pruned from memory"
+            );
+            assert!(
+                cache.get(&key).await.is_none(),
+                "pruned record absent from memory"
+            );
+            assert!(
+                durable_cache_keys(&path).await?.is_empty(),
+                "durable JSON rewritten empty after startup prune"
+            );
+        }
+
+        // Case B: roster carries the active member with the matching key
+        // package -> the same signed record is retained (selective prune).
+        {
+            let inviter = fixture.state.agent.agent_id();
+            let roster_kp = match &fixture.event {
+                NamedGroupMetadataEvent::MemberJoined {
+                    treekem_key_package_b64: Some(kp),
+                    ..
+                } => kp.clone(),
+                _ => unreachable!("fixture event is MemberJoined with a key package"),
+            };
+            let mut info =
+                treekem_metadata_group_info(inviter, &group_id, &fixture.stable_group_id);
+            let mut member = x0x::groups::GroupMember::new_member(
+                member_hex.clone(),
+                None,
+                Some(hex::encode(inviter.as_bytes())),
+                1,
+            );
+            member.treekem_key_package_b64 = Some(roster_kp);
+            info.members_v2.insert(member_hex.clone(), member);
+            let roster: HashMap<String, x0x::groups::GroupInfo> =
+                [(group_id.clone(), info)].into_iter().collect();
+
+            let dir = tempfile::tempdir()?;
+            let path = dir.path().join("kp.json");
+            tokio::fs::write(&path, &json).await?;
+
+            let cache = load_treekem_member_key_packages(&path, &roster).await?;
+            assert_eq!(
+                cache.diagnostics().await.entries,
+                1,
+                "roster-relevant signed record retained"
+            );
+            assert!(
+                cache.get(&key).await.is_some(),
+                "retained record present in memory"
+            );
+            assert!(
+                durable_cache_keys(&path).await?.contains(&key),
+                "durable JSON retains roster-relevant record (no rewrite when nothing pruned)"
+            );
+        }
+        Ok(())
+    }
+
+    /// WP-TK2: group/member lifecycle removals must evict both the in-memory
+    /// entry and the durable JSON record. `remove_groups` covers the
+    /// group-deletion lifecycle; `remove_member` covers per-member removal.
+    #[tokio::test]
+    async fn treekem_recovery_cache_lifecycle_prune_removes_memory_and_durable() -> Result<()> {
+        let fixture = member_joined_treekem_fixture(0x93, 0x94).await?;
+        let group_id = fixture.group_id.clone();
+        let member_hex = fixture.member_hex.clone();
+        let key = join_result_key(&group_id, &member_hex);
+        let aliases = HashSet::from([group_id.clone()]);
+
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("kp.json");
+        let (cache, _) = TreeKemMemberKeyPackageCache::from_entries(path, BTreeMap::new(), false)?;
+
+        // Group lifecycle: remove_groups drops memory + durable JSON.
+        cache
+            .insert(key.clone(), fixture.event.clone(), true)
+            .await?;
+        assert_eq!(cache.diagnostics().await.entries, 1, "seeded one record");
+        let removed_groups = cache.remove_groups(&aliases).await;
+        assert_eq!(
+            removed_groups.evicted, 1,
+            "group lifecycle pruned the record"
+        );
+        assert!(
+            cache.get(&key).await.is_none(),
+            "group prune cleared memory"
+        );
+        assert!(
+            durable_cache_keys(&cache.path).await?.is_empty(),
+            "group prune cleared durable JSON"
+        );
+
+        // Member lifecycle: remove_member drops memory + durable JSON.
+        cache
+            .insert(key.clone(), fixture.event.clone(), true)
+            .await?;
+        assert!(
+            cache.get(&key).await.is_some(),
+            "re-seeded before member prune"
+        );
+        let removed_member = cache.remove_member(&aliases, &member_hex).await;
+        assert_eq!(
+            removed_member.evicted, 1,
+            "member lifecycle pruned the record"
+        );
+        assert!(
+            cache.get(&key).await.is_none(),
+            "member prune cleared memory"
+        );
+        assert!(
+            cache
+                .find_for_member(std::slice::from_ref(&group_id), &member_hex)
+                .await
+                .is_none(),
+            "member prune cleared find_for_member"
+        );
+        assert!(
+            durable_cache_keys(&cache.path).await?.is_empty(),
+            "member prune cleared durable JSON"
+        );
+        Ok(())
+    }
+
+    /// WP-TK2: the entry-count cap is enforced on `from_entries` and overflow
+    /// is shed oldest-`ts_ms`-first until the cache fits.
+    #[tokio::test]
+    async fn treekem_recovery_cache_count_limit_evicts_oldest() -> Result<()> {
+        let cap = TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_ENTRIES;
+        let overflow = 3;
+        let total = cap + overflow;
+
+        let mut entries = BTreeMap::new();
+        for i in 0..total {
+            let g = format!("g{i:04x}");
+            let m = format!("m{i:04x}");
+            entries.insert(
+                format!("{g}:{m}"),
+                synthetic_member_joined(&g, &m, i as u64, 8),
+            );
+        }
+
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("kp.json");
+        let (cache, evicted) = TreeKemMemberKeyPackageCache::from_entries(path, entries, true)?;
+        let diag = cache.diagnostics().await;
+
+        assert_eq!(evicted, overflow, "excess entries evicted to reach the cap");
+        assert_eq!(diag.entries, cap, "entry count held at MAX_ENTRIES");
+        assert!(
+            diag.encoded_bytes <= diag.max_encoded_bytes,
+            "byte budget respected after count compaction"
+        );
+        // Eviction is oldest-ts first: the three smallest-ts records (i=0,1,2)
+        // are evicted; i=3 is the first retained and the newest survives.
+        assert!(cache.get("g0000:m0000").await.is_none(), "i=0 evicted");
+        assert!(
+            cache.get("g0002:m0002").await.is_none(),
+            "i=2 evicted (last of overflow trio)"
+        );
+        assert!(
+            cache.get("g0003:m0003").await.is_some(),
+            "i=3 retained (first inside the cap)"
+        );
+        let last_idx = total - 1;
+        assert!(
+            cache
+                .get(&format!("g{last_idx:04x}:m{last_idx:04x}"))
+                .await
+                .is_some(),
+            "newest-ts record retained"
+        );
+        Ok(())
+    }
+
+    /// WP-TK2: the encoded-byte cap is enforced independently of the count
+    /// cap. With a handful of oversized records (count well under MAX_ENTRIES
+    /// but combined bytes over MAX_BYTES), the oldest-ts record is evicted so
+    /// the durable snapshot fits the byte budget.
+    #[tokio::test]
+    async fn treekem_recovery_cache_encoded_byte_limit_evicts_to_fit() -> Result<()> {
+        let payload_len = 2_500_000;
+        let ev_a = synthetic_member_joined("ga", "ma", 100, payload_len);
+        let ev_b = synthetic_member_joined("gb", "mb", 200, payload_len);
+        let ev_c = synthetic_member_joined("gc", "mc", 300, payload_len);
+        let (key_a, key_b, key_c) = (
+            "ga:ma".to_string(),
+            "gb:mb".to_string(),
+            "gc:mc".to_string(),
+        );
+
+        // Assert the byte budget — not the count cap — is the trigger, using
+        // the cache's own encoded-size function (mirrors cache_snapshot_encoded_bytes).
+        let bytes_a = cache_entry_encoded_bytes(&key_a, &ev_a)?;
+        let bytes_b = cache_entry_encoded_bytes(&key_b, &ev_b)?;
+        let bytes_c = cache_entry_encoded_bytes(&key_c, &ev_c)?;
+        let snapshot = |n: usize, sum: usize| {
+            2usize
+                .saturating_add(sum)
+                .saturating_add(n.saturating_sub(1))
+        };
+        let triple = snapshot(3, bytes_a + bytes_b + bytes_c);
+        let surviving_pair = snapshot(2, bytes_b + bytes_c);
+        assert!(
+            triple > TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_BYTES,
+            "precondition: three oversized records exceed the byte budget"
+        );
+        assert!(
+            surviving_pair <= TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_BYTES,
+            "precondition: the two newest records fit the byte budget"
+        );
+
+        let mut entries = BTreeMap::new();
+        entries.insert(key_a.clone(), ev_a);
+        entries.insert(key_b.clone(), ev_b);
+        entries.insert(key_c.clone(), ev_c);
+
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("kp.json");
+        let (cache, evicted) = TreeKemMemberKeyPackageCache::from_entries(path, entries, true)?;
+        let diag = cache.diagnostics().await;
+
+        assert_eq!(evicted, 1, "one record evicted to fit the byte budget");
+        assert_eq!(diag.entries, 2, "two records remain");
+        assert!(
+            diag.encoded_bytes <= diag.max_encoded_bytes,
+            "encoded bytes within budget after compaction"
+        );
+        // Oldest-ts (ev_a) is the victim; the two newer records survive.
+        assert!(
+            cache.get(&key_a).await.is_none(),
+            "oldest-ts record evicted"
+        );
+        assert!(cache.get(&key_b).await.is_some(), "newer record retained");
+        assert!(cache.get(&key_c).await.is_some(), "newest record retained");
+        Ok(())
+    }
+
+    /// WP-TK2: eviction is deterministic — victim selection is min `ts_ms`,
+    /// then min key. With one eviction forced (`cap + 1` entries) and three
+    /// entries sharing the smallest `ts_ms`, the lexicographically smallest key
+    /// is the victim while its equal-ts siblings survive.
+    #[tokio::test]
+    async fn treekem_recovery_cache_eviction_tiebreak_is_timestamp_then_key() -> Result<()> {
+        let cap = TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_ENTRIES;
+        let mut entries = BTreeMap::new();
+        // Three equal-ts (ts=10) records with distinct keys.
+        for k in ["tie-a", "tie-b", "tie-c"] {
+            entries.insert(
+                k.to_string(),
+                synthetic_member_joined(k, &format!("mem-{k}"), 10, 8),
+            );
+        }
+        // `cap - 2` newer records (distinct ts) fill the cache to `cap + 1`,
+        // forcing exactly one eviction.
+        for i in 0..(cap - 2) {
+            let g = format!("ng{i:04x}");
+            entries.insert(
+                format!("{g}:m"),
+                synthetic_member_joined(&g, "m", 100 + i as u64, 8),
+            );
+        }
+        assert_eq!(entries.len(), cap + 1, "precondition: one over the cap");
+
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("kp.json");
+        let (cache, evicted) = TreeKemMemberKeyPackageCache::from_entries(path, entries, true)?;
+        assert_eq!(evicted, 1, "exactly one record evicted");
+        assert_eq!(cache.diagnostics().await.entries, cap);
+
+        // Tie broken by smallest key: "tie-a" is the victim; "tie-b"/"tie-c"
+        // (equal ts, larger keys) survive.
+        assert!(
+            cache.get("tie-a").await.is_none(),
+            "smallest-key victim evicted on tie"
+        );
+        assert!(
+            cache.get("tie-b").await.is_some(),
+            "larger-key sibling survives the tie"
+        );
+        assert!(
+            cache.get("tie-c").await.is_some(),
+            "largest-key sibling survives the tie"
+        );
+        Ok(())
+    }
+
+    struct TreeKemCacheWriterHookGuard {
+        path: PathBuf,
+    }
+
+    impl Drop for TreeKemCacheWriterHookGuard {
+        fn drop(&mut self) {
+            if let Ok(mut hooks) = TREEKEM_CACHE_WRITER_HOOKS.lock() {
+                hooks.remove(&self.path);
+            }
+        }
+    }
+
+    fn install_treekem_cache_writer_hook(
+        path: &FsPath,
+        release: Option<Arc<tokio::sync::Notify>>,
+        force_error: Option<std::io::Error>,
+    ) -> (Arc<tokio::sync::Notify>, TreeKemCacheWriterHookGuard) {
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let mut hooks = TREEKEM_CACHE_WRITER_HOOKS
+            .lock()
+            .expect("TreeKEM cache writer hook poisoned");
+        hooks.insert(
+            path.to_path_buf(),
+            TreeKemCacheWriterHookControl {
+                entered: Arc::clone(&entered),
+                release,
+                force_error,
+            },
+        );
+        (
+            entered,
+            TreeKemCacheWriterHookGuard {
+                path: path.to_path_buf(),
+            },
+        )
+    }
+
+    async fn signed_cache_fixture_entries() -> Result<(
+        MemberJoinedTreeKemFixture,
+        MemberJoinedTreeKemFixture,
+        String,
+        String,
+    )> {
+        let first = member_joined_treekem_fixture(0xa1, 0xa2).await?;
+        let second = member_joined_treekem_fixture(0xa3, 0xa4).await?;
+        let first_key = join_result_key(&first.group_id, &first.member_hex);
+        let second_key = join_result_key(&second.group_id, &second.member_hex);
+        Ok((first, second, first_key, second_key))
+    }
+
+    /// WP-TK2 #5: the persistence mutex serializes disk writes without holding
+    /// the cache map lock. While the first writer is deterministically parked,
+    /// readers observe both the first mutation and a concurrent newer mutation;
+    /// after release, the coalescing writer persists the newest snapshot.
+    #[tokio::test]
+    async fn treekem_recovery_cache_slow_writer_does_not_block_readers_and_newest_wins(
+    ) -> Result<()> {
+        let (first, second, first_key, second_key) = signed_cache_fixture_entries().await?;
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("kp.json");
+        let (cache, _) =
+            TreeKemMemberKeyPackageCache::from_entries(path.clone(), BTreeMap::new(), false)?;
+        let cache = Arc::new(cache);
+        let release = Arc::new(tokio::sync::Notify::new());
+        let (entered, _hook_guard) =
+            install_treekem_cache_writer_hook(&path, Some(Arc::clone(&release)), None);
+
+        let first_cache = Arc::clone(&cache);
+        let first_key_for_write = first_key.clone();
+        let first_event = first.event.clone();
+        let first_write =
+            tokio::spawn(async move { first_cache.insert(first_key_for_write, first_event, true).await });
+        entered.notified().await;
+
+        assert!(
+            cache.get(&first_key).await.is_some(),
+            "reader proceeds while the first disk writer is parked"
+        );
+
+        let second_cache = Arc::clone(&cache);
+        let second_key_for_write = second_key.clone();
+        let second_event = second.event.clone();
+        let second_write = tokio::spawn(async move {
+            second_cache
+                .insert(second_key_for_write, second_event, true)
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while cache.get(&second_key).await.is_none() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .context("newer in-memory mutation blocked behind slow disk writer")?;
+        assert!(
+            cache.get(&first_key).await.is_some(),
+            "readers remain available after the concurrent mutation"
+        );
+
+        release.notify_one();
+        let first_result = first_write.await??;
+        let second_result = second_write.await??;
+        assert!(matches!(
+            first_result.persistence,
+            TreeKemCachePersistenceStatus::Durable { .. }
+        ));
+        assert!(matches!(
+            second_result.persistence,
+            TreeKemCachePersistenceStatus::Durable { .. }
+        ));
+
+        let durable = durable_cache_keys(&path).await?;
+        assert_eq!(
+            durable,
+            HashSet::from([first_key, second_key]),
+            "serialized/coalesced persistence leaves the newest complete snapshot on disk"
+        );
+        let diagnostics = cache.diagnostics().await;
+        assert!(!diagnostics.dirty);
+        assert_eq!(diagnostics.persisted_revision, diagnostics.revision);
+        Ok(())
+    }
+
+    /// WP-TK2 #6: a failed durable write returns structured `Dirty`, retains
+    /// failure diagnostics, and remains retryable. A later mutation retries the
+    /// entire newest snapshot and clears dirty state only after disk success.
+    #[tokio::test]
+    async fn treekem_recovery_cache_failed_write_stays_dirty_and_retry_persists_newest(
+    ) -> Result<()> {
+        let (first, second, first_key, second_key) = signed_cache_fixture_entries().await?;
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("kp.json");
+        let (cache, _) =
+            TreeKemMemberKeyPackageCache::from_entries(path.clone(), BTreeMap::new(), false)?;
+        let (entered, _hook_guard) = install_treekem_cache_writer_hook(
+            &path,
+            None,
+            Some(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "injected TreeKEM cache persistence failure",
+            )),
+        );
+
+        let failed = cache
+            .insert(first_key.clone(), first.event.clone(), true)
+            .await?;
+        entered.notified().await;
+        let TreeKemCachePersistenceStatus::Dirty {
+            revision: failed_revision,
+            error,
+        } = failed.persistence
+        else {
+            anyhow::bail!("injected persistence failure was falsely reported durable");
+        };
+        assert!(error.contains("injected TreeKEM cache persistence failure"));
+        let dirty = cache.diagnostics().await;
+        assert!(dirty.dirty, "failed write remains explicitly dirty");
+        assert_eq!(dirty.revision, failed_revision);
+        assert_eq!(dirty.write_failures, 1);
+        assert!(dirty
+            .last_error
+            .as_deref()
+            .is_some_and(|last| { last.contains("injected TreeKEM cache persistence failure") }));
+        assert!(
+            cache.get(&first_key).await.is_some(),
+            "failed persistence does not discard the retryable in-memory record"
+        );
+        assert!(
+            tokio::fs::try_exists(&path)
+                .await
+                .is_ok_and(|exists| !exists),
+            "failed writer did not create a falsely durable snapshot"
+        );
+
+        let retried = cache
+            .insert(second_key.clone(), second.event.clone(), true)
+            .await?;
+        assert!(matches!(
+            retried.persistence,
+            TreeKemCachePersistenceStatus::Durable { .. }
+        ));
+        let durable = durable_cache_keys(&path).await?;
+        assert_eq!(
+            durable,
+            HashSet::from([first_key, second_key]),
+            "successful retry persists the newest snapshot, including the prior dirty record"
+        );
+        let clean = cache.diagnostics().await;
+        assert!(!clean.dirty, "successful retry clears dirty state");
+        assert_eq!(clean.persisted_revision, clean.revision);
+        assert_eq!(
+            clean.write_failures, 1,
+            "failure history remains observable"
+        );
+        assert_eq!(
+            clean.last_error, None,
+            "active error clears after durability succeeds"
+        );
+        Ok(())
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -560,17 +560,12 @@ pub(super) struct AppState {
     /// Bounded per-group log of locally authored/applied TreeKEM membership
     /// events used to satisfy explicit catch-up requests.
     pub(super) treekem_event_log: RwLock<HashMap<String, VecDeque<NamedGroupMetadataEvent>>>,
-    /// Member-keyed cache of verified TreeKEM key-package-bearing
-    /// `MemberJoined` events (`join_result_key(group_id, member_id)` → event).
-    /// Populated by the inviter after authoritative apply and by any receiver
-    /// that validates the joiner's sender binding, signature, AgentId, group,
-    /// and role without applying the inviter-only roster mutation. Promoted
-    /// admins fetch the original signed event through member-keyed catch-up.
-    /// The signature over `canonical_member_joined_bytes` authenticates the
-    /// package, so recovery does not require the inviter or target to cooperate.
-    pub(super) treekem_member_key_packages: RwLock<HashMap<String, NamedGroupMetadataEvent>>,
-    /// Disk location for the signed member key-package recovery cache.
-    pub(super) treekem_member_key_packages_path: PathBuf,
+    /// Bounded member-keyed cache of verified TreeKEM key-package-bearing
+    /// `MemberJoined` recovery records. It retains inviter-authority-attested
+    /// records and independently witnessed provisional records under the same
+    /// global count/byte limits, and owns lifecycle pruning, serialized
+    /// persistence, dirty retry state, and diagnostics.
+    pub(super) treekem_member_key_packages: super::TreeKemMemberKeyPackageCache,
     /// Anti-spam throttle for outbound catch-up requests.
     pub(super) treekem_catchup_throttle: RwLock<HashMap<String, Instant>>,
     /// Per-group serialization for authoritative membership mutations. The

--- a/src/server/tests/cache_hardening_followup.rs
+++ b/src/server/tests/cache_hardening_followup.rs
@@ -1,0 +1,1675 @@
+use super::*;
+
+struct TreeKemCacheWriterHookGuard {
+    path: PathBuf,
+}
+
+impl Drop for TreeKemCacheWriterHookGuard {
+    fn drop(&mut self) {
+        if let Ok(mut hooks) = TREEKEM_CACHE_WRITER_HOOKS.lock() {
+            hooks.remove(&self.path);
+        }
+    }
+}
+
+#[tokio::test]
+async fn recovery_cache_duplicates_upgrade_once_and_keep_newest_authority() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xa9, 0xaa).await?;
+    let raw = without_recovery_attestation(fixture.event.clone());
+    let key = join_result_key(&fixture.group_id, &fixture.member_hex);
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("canonical-recovery.json");
+    let (cache, _) =
+        TreeKemMemberKeyPackageCache::from_entries(path.clone(), BTreeMap::new(), false)?;
+
+    cache.insert(key.clone(), raw.clone(), false).await?;
+    let provisional_revision = cache.diagnostics().await.revision;
+    cache.insert(key.clone(), raw.clone(), false).await?;
+    let after_provisional_retry = cache.diagnostics().await;
+    assert_eq!(after_provisional_retry.entries, 1);
+    assert_eq!(after_provisional_retry.revision, provisional_revision);
+
+    cache
+        .insert(key.clone(), fixture.event.clone(), true)
+        .await?;
+    let authoritative_revision = cache.diagnostics().await.revision;
+    assert_eq!(
+        authoritative_revision,
+        provisional_revision.saturating_add(1)
+    );
+
+    let mut authority_info = fixture
+        .state
+        .named_groups
+        .read()
+        .await
+        .get(&fixture.group_id)
+        .expect("fixture group exists")
+        .clone();
+    authority_info.security_binding =
+        treekem_recovery_security_binding(authority_info.secret_epoch, &raw);
+    let _ = authority_info.seal_commit(
+        fixture.state.agent.identity().agent_keypair(),
+        now_millis_u64(),
+    )?;
+    authority_info.security_binding =
+        treekem_recovery_security_binding(authority_info.secret_epoch, &raw);
+    let newer_commit = authority_info.seal_commit(
+        fixture.state.agent.identity().agent_keypair(),
+        now_millis_u64().saturating_add(1),
+    )?;
+    let newer = attest_member_joined_recovery_event(
+        &raw,
+        fixture.state.agent.identity().agent_keypair(),
+        &newer_commit,
+    )?;
+    cache.insert(key.clone(), newer.clone(), true).await?;
+    let newest_revision = cache.diagnostics().await.revision;
+    assert_eq!(newest_revision, authoritative_revision.saturating_add(1));
+
+    cache
+        .insert(key.clone(), fixture.event.clone(), true)
+        .await?;
+    cache.insert(key.clone(), newer.clone(), true).await?;
+    let after_retries = cache.diagnostics().await;
+    assert_eq!(after_retries.entries, 1);
+    assert_eq!(after_retries.revision, newest_revision);
+    let retained = cache.get(&key).await.expect("canonical recovery retained");
+    assert_eq!(
+        recovery_attestation_revision(&retained),
+        Some(newer_commit.revision),
+        "stale and duplicate deliveries cannot displace the newest authority attestation"
+    );
+    assert_eq!(durable_cache_keys(&path).await?, HashSet::from([key]));
+    assert!(after_retries.entries <= after_retries.max_entries);
+    assert!(after_retries.encoded_bytes <= after_retries.max_encoded_bytes);
+    Ok(())
+}
+
+/// Codex blocker: an authority-attested `MemberJoined` recovery record is
+/// only valid when its authority commit is *exactly retained* in the live
+/// `GroupInfo.commit_log`. A signed, structurally valid commit the accepted
+/// chain never retained must fail full verification; the same commit, once
+/// admitted to `commit_log`, must pass.
+#[tokio::test]
+async fn recovery_attestation_rejects_authority_commit_absent_from_commit_log() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xc1, 0xc2).await?;
+    let inviter = fixture.state.agent.agent_id();
+    let inviter_hex = hex::encode(inviter.as_bytes());
+    let authority_kp = fixture.state.agent.identity().agent_keypair();
+    let group_id = fixture.group_id.clone();
+    let stable_group_id = fixture.stable_group_id.clone();
+    let member_hex = fixture.member_hex.clone();
+    let raw = without_recovery_attestation(fixture.event.clone());
+    let kp_b64 = match &raw {
+        NamedGroupMetadataEvent::MemberJoined {
+            treekem_key_package_b64: Some(kp),
+            ..
+        } => kp.clone(),
+        _ => unreachable!("fixture event carries a TreeKEM key package"),
+    };
+
+    // Live roster where the joining member is active with the matching
+    // package, so every verifier clause except `commit_log` membership holds.
+    let mut info = treekem_metadata_group_info(inviter, &group_id, &stable_group_id);
+    info.roster_revision = info.roster_revision.saturating_add(1);
+    info.add_member(
+        member_hex.clone(),
+        x0x::groups::GroupRole::Member,
+        Some(inviter_hex.clone()),
+        None,
+    );
+    info.set_member_treekem_key_package(&member_hex, kp_b64);
+    info.secret_epoch = fixture.initial_epoch.saturating_add(1);
+    info.security_binding = treekem_recovery_security_binding(info.secret_epoch, &raw);
+    info.recompute_state_hash();
+
+    // Mint a fully signed authority commit on a clone so the live `info`
+    // never retains it in `commit_log`.
+    let mut minter = info.clone();
+    let signed_commit = minter.seal_commit(authority_kp, now_millis_u64())?;
+    let retained = minter
+        .commit_log
+        .last()
+        .cloned()
+        .expect("seal_commit retains the authored commit");
+    assert_eq!(retained.commit, signed_commit);
+    assert!(
+        info.commit_log
+            .iter()
+            .all(|entry| entry.commit != signed_commit),
+        "precondition: live commit_log does not yet retain the signed commit"
+    );
+
+    let absent = attest_member_joined_recovery_event(&raw, authority_kp, &signed_commit)?;
+    assert!(
+        !verify_authority_attested_member_joined_recovery(&info, &absent),
+        "a signed authority commit absent from commit_log must be rejected"
+    );
+
+    // Admit the exact same signed commit into the accepted chain; the only
+    // failing clause clears and the record verifies.
+    info.commit_log.push(retained);
+    let admitted = attest_member_joined_recovery_event(&raw, authority_kp, &signed_commit)?;
+    assert!(
+        verify_authority_attested_member_joined_recovery(&info, &admitted),
+        "the same commit, once retained in commit_log, verifies"
+    );
+    Ok(())
+}
+
+/// Codex blocker: when a live group canonicalizes cache keys to its stable
+/// id, two authority-attested recovery records for the same logical
+/// group/member delivered under different signed MLS aliases collapse to a
+/// single canonical durable entry, and catch-up lookup across aliases
+/// selects the highest accepted authority revision rather than first-alias
+/// arrival order.
+#[tokio::test]
+async fn canonical_alias_records_collapse_and_keep_highest_authority_revision() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xd1, 0xd2).await?;
+    let state = &fixture.state;
+    let stable_group_id = fixture.stable_group_id.clone();
+    let authority_kp = state.agent.identity().agent_keypair();
+    let inviter_hex = hex::encode(state.agent.agent_id().as_bytes());
+    let member_kp = x0x::identity::AgentKeypair::generate()?;
+    let member_hex = hex::encode(member_kp.agent_id().as_bytes());
+    let canonical_key = join_result_key(&stable_group_id, &member_hex);
+
+    // Build a member-signed `MemberJoined` under a given MLS alias and
+    // countersign it with an authority commit of a chosen revision. Each
+    // alias shares the stable id, so both collapse to one canonical key.
+    fn attest_alias_for_member(
+        member_kp: &x0x::identity::AgentKeypair,
+        authority_kp: &x0x::identity::AgentKeypair,
+        alias_group_id: &str,
+        stable_group_id: &str,
+        inviter_hex: &str,
+        epoch: u64,
+    ) -> Result<NamedGroupMetadataEvent> {
+        let member_id = member_kp.agent_id();
+        let member_hex = hex::encode(member_id.as_bytes());
+        let member_pub_b64 = BASE64.encode(member_kp.public_key().as_bytes());
+        let prepared = x0x::mls::TreeKemMlsGroup::prepare_member(member_id, &[epoch as u8; 32])?;
+        let kp_b64 = BASE64.encode(prepared.key_package_bytes());
+        let invite_secret = format!("alias-{alias_group_id}-e{epoch}");
+        let now_ms = 10_000 + epoch;
+        let canonical = canonical_member_joined_bytes(
+            alias_group_id,
+            Some(stable_group_id),
+            &member_hex,
+            &member_pub_b64,
+            x0x::groups::GroupRole::Member,
+            None,
+            inviter_hex,
+            &invite_secret,
+            now_ms,
+            Some(&kp_b64),
+        );
+        let signature = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
+            member_kp.secret_key(),
+            &canonical,
+        )
+        .map_err(|e| anyhow::anyhow!("sign alias member event: {e:?}"))?;
+        let raw = NamedGroupMetadataEvent::MemberJoined {
+            group_id: alias_group_id.to_string(),
+            stable_group_id: Some(stable_group_id.to_string()),
+            member_agent_id: member_hex,
+            member_public_key_b64: member_pub_b64,
+            role: x0x::groups::GroupRole::Member,
+            display_name: None,
+            inviter_agent_id: inviter_hex.to_string(),
+            invite_secret,
+            ts_ms: now_ms,
+            treekem_key_package_b64: Some(kp_b64),
+            recovery_authority_agent_id: None,
+            recovery_authority_public_key_b64: None,
+            recovery_authority_signature_b64: None,
+            recovery_authority_commit: None,
+            signature_b64: BASE64.encode(signature.as_bytes()),
+        };
+        let mut info =
+            treekem_metadata_group_info(authority_kp.agent_id(), alias_group_id, stable_group_id);
+        info.state_revision = epoch;
+        info.secret_epoch = epoch;
+        info.security_binding = treekem_recovery_security_binding(epoch, &raw);
+        info.recompute_state_hash();
+        let commit = info.seal_commit(authority_kp, now_ms)?;
+        attest_member_joined_recovery_event(&raw, authority_kp, &commit)
+    }
+
+    let alias_a = "da".repeat(32);
+    let alias_b = "db".repeat(32);
+    // The higher revision arrives FIRST under alias_b; a lower revision
+    // under alias_a arrives second. Highest-revision-wins must keep it.
+    let higher = attest_alias_for_member(
+        &member_kp,
+        authority_kp,
+        &alias_b,
+        &stable_group_id,
+        &inviter_hex,
+        22,
+    )?;
+    let lower = attest_alias_for_member(
+        &member_kp,
+        authority_kp,
+        &alias_a,
+        &stable_group_id,
+        &inviter_hex,
+        11,
+    )?;
+    let higher_rev = recovery_attestation_revision(&higher).expect("attested");
+    let lower_rev = recovery_attestation_revision(&lower).expect("attested");
+    assert!(higher_rev > lower_rev);
+
+    let first = cache_treekem_member_key_package(
+        state,
+        join_result_key(&alias_b, &member_hex),
+        higher.clone(),
+        true,
+    )
+    .await;
+    assert!(matches!(
+        first,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+    let second = cache_treekem_member_key_package(
+        state,
+        join_result_key(&alias_a, &member_hex),
+        lower.clone(),
+        true,
+    )
+    .await;
+    assert!(matches!(
+        second,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+
+    let diagnostics = state.treekem_member_key_packages.diagnostics().await;
+    assert_eq!(
+        diagnostics.entries, 1,
+        "two alias records collapsed to one canonical entry"
+    );
+    assert_eq!(
+        durable_cache_keys(&state.treekem_member_key_packages.path).await?,
+        HashSet::from([canonical_key.clone()]),
+        "exactly one canonical durable key; no alias keys leaked"
+    );
+
+    let catchup = state
+        .treekem_member_key_packages
+        .find_for_member(&[alias_b, alias_a, stable_group_id.clone()], &member_hex)
+        .await
+        .expect("catch-up lookup resolves the collapsed canonical record");
+    assert_eq!(
+        recovery_attestation_revision(&catchup),
+        Some(higher_rev),
+        "highest authority revision wins, not first-alias arrival order"
+    );
+    Ok(())
+}
+
+/// Codex blocker: the per-group provisional cap cannot be bypassed by
+/// minting alternate signed stable aliases. With live-group
+/// canonicalization, every alias provisional record collapses onto the one
+/// canonical stable group, so the cap is enforced across all of them.
+#[tokio::test]
+async fn canonical_cache_key_prevents_provisional_cap_bypass_via_stable_aliases() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xd3, 0xd4).await?;
+    let state = &fixture.state;
+    let stable_group_id = fixture.stable_group_id.clone();
+    let inviter_hex = hex::encode(state.agent.agent_id().as_bytes());
+    let canonical_prefix = format!("{stable_group_id}:");
+
+    // Each provisional record uses a distinct member under a distinct MLS
+    // alias group id, but all share the same stable id. Without
+    // canonicalization each alias would form its own provisional group.
+    let overflow = 3;
+    let total = TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP + overflow;
+    for sequence in 1..=total {
+        let alias = format!("{sequence:02x}").repeat(32);
+        let (key, event) = signed_provisional_recovery_event_for_test(
+            &alias,
+            &stable_group_id,
+            &inviter_hex,
+            sequence as u64,
+        )?;
+        let status = cache_treekem_member_key_package(state, key, event, false).await;
+        assert!(
+            matches!(status, TreeKemCachePersistenceStatus::Durable { .. }),
+            "alias provisional record admitted"
+        );
+    }
+
+    let provisional = state
+        .treekem_member_key_packages
+        .events_matching(|event| {
+            matches!(
+                event,
+                NamedGroupMetadataEvent::MemberJoined {
+                    recovery_authority_signature_b64: None,
+                    ..
+                }
+            ) && recovery_cache_group_identity(event) == stable_group_id
+        })
+        .await;
+    assert_eq!(
+        provisional.len(),
+        TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP,
+        "alternate stable aliases cannot bypass the per-group provisional cap"
+    );
+
+    let durable = durable_cache_keys(&state.treekem_member_key_packages.path).await?;
+    assert_eq!(
+        durable.len(),
+        TREEKEM_PROVISIONAL_RECOVERY_PER_GROUP_CAP,
+        "canonical compaction is durable"
+    );
+    assert!(
+        durable.iter().all(|key| key.starts_with(&canonical_prefix)),
+        "no non-canonical alias durable keys survive canonicalization"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// TreeKEM member key-package cache: loader quarantine, bounds, and
+// lifecycle regression coverage (WP-TK2 findings 3-6).
+//
+// `synthetic_member_joined` builds deliberately NON-verifying
+// `MemberJoined` events used only to size the cache via `from_entries`,
+// which enforces count/byte bounds without signature verification. Tests
+// that exercise the load path or `insert()` use real signed
+// `member_joined_treekem_fixture` events, since those paths authenticate
+// the member signature.
+// ---------------------------------------------------------------------
+
+/// Compact, deliberately NON-verifying `MemberJoined` for cache *sizing*
+/// tests. `from_entries` never calls `verify_member_joined_key_package_event`,
+/// so these events exist purely to control entry count, `ts_ms` ordering,
+/// and encoded byte size. Must never be passed to `insert()`.
+fn synthetic_member_joined(
+    group_id: &str,
+    member: &str,
+    ts_ms: u64,
+    key_package_payload_len: usize,
+) -> NamedGroupMetadataEvent {
+    NamedGroupMetadataEvent::MemberJoined {
+        group_id: group_id.to_string(),
+        stable_group_id: Some(group_id.to_string()),
+        member_agent_id: member.to_string(),
+        member_public_key_b64: BASE64.encode([0xA5u8; 48]),
+        role: x0x::groups::GroupRole::Member,
+        display_name: None,
+        inviter_agent_id: format!("inviter-{group_id}"),
+        invite_secret: format!("invite-{group_id}-{member}"),
+        ts_ms,
+        treekem_key_package_b64: Some(BASE64.encode(vec![0xA5u8; key_package_payload_len])),
+        recovery_authority_agent_id: None,
+        recovery_authority_public_key_b64: None,
+        recovery_authority_signature_b64: None,
+        recovery_authority_commit: None,
+        signature_b64: BASE64.encode([0xA5u8; 64]),
+    }
+}
+
+/// Locate the `<base>.corrupt-<uuid>` quarantine sibling written when the
+/// loader quarantines an unparseable cache file.
+async fn quarantine_sibling(dir: &FsPath, base: &str) -> Option<PathBuf> {
+    let prefix = format!("{base}.corrupt-");
+    let mut rd = tokio::fs::read_dir(dir).await.ok()?;
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        if entry.file_name().to_string_lossy().starts_with(&prefix) {
+            return Some(entry.path());
+        }
+    }
+    None
+}
+
+/// WP-TK2: an unparseable or schema-incompatible recovery cache must NOT
+/// abort startup or overwrite the corrupt bytes. The loader renames the
+/// file to a quarantine sibling (preserving it verbatim) and starts from
+/// an empty cache, rewriting the active path as `{}`.
+#[tokio::test]
+async fn treekem_recovery_cache_quarantines_corrupt_json_without_overwrite() -> Result<()> {
+    let cases: Vec<(&str, Vec<u8>)> = vec![
+        ("malformed JSON", b"{not valid json".to_vec()),
+        ("truncated JSON", b"{\"g:m\":".to_vec()),
+        ("schema-incompatible value", b"{\"g:m\":123}".to_vec()),
+        ("JSON array (not object)", b"[]".to_vec()),
+    ];
+    let empty_roster: HashMap<String, x0x::groups::GroupInfo> = HashMap::new();
+
+    for (label, corpus) in &cases {
+        let dir = tempfile::tempdir()?;
+        let base = "member-key-packages.json";
+        let path = dir.path().join(base);
+        tokio::fs::write(&path, corpus.as_slice()).await?;
+
+        let cache = load_treekem_member_key_packages(&path, &empty_roster)
+            .await
+            .expect("corrupt cache quarantines and loads empty, not a fatal startup error");
+
+        assert_eq!(
+            cache.diagnostics().await.entries,
+            0,
+            "{label}: in-memory cache empty after quarantine"
+        );
+
+        // Original corrupt bytes are preserved verbatim in a quarantine
+        // sibling (rename, not overwrite).
+        let quarantine = quarantine_sibling(dir.path(), base)
+            .await
+            .unwrap_or_else(|| panic!("{label}: quarantine sibling exists"));
+        let preserved = tokio::fs::read(&quarantine).await?;
+        assert_eq!(
+            preserved, *corpus,
+            "{label}: quarantine preserves the original corrupt bytes verbatim"
+        );
+
+        // The active path is rewritten as an empty cache (no corrupt residue).
+        assert!(
+            durable_cache_keys(&path).await?.is_empty(),
+            "{label}: active path rewritten as an empty cache"
+        );
+    }
+    Ok(())
+}
+
+/// WP-TK2: a read error other than `NotFound` (here: the path is a
+/// directory, so `read_to_string` fails with EISDIR) is fatal — the loader
+/// surfaces the error and must NOT quarantine or silently start empty.
+#[tokio::test]
+async fn treekem_recovery_cache_non_notfound_read_error_is_fatal() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("unreadable.json");
+    // A directory exists but cannot be read as a file -> error kind != NotFound.
+    tokio::fs::create_dir(&path).await?;
+
+    let empty_roster: HashMap<String, x0x::groups::GroupInfo> = HashMap::new();
+    let result = load_treekem_member_key_packages(&path, &empty_roster).await;
+    assert!(
+        result.is_err(),
+        "non-NotFound read error must be fatal, not quarantined to empty"
+    );
+
+    // The fatal branch neither quarantines (renames) nor touches the path.
+    let metadata = tokio::fs::metadata(&path)
+        .await
+        .expect("path still present");
+    assert!(
+        metadata.is_dir(),
+        "unreadable directory left in place, not quarantined"
+    );
+    Ok(())
+}
+
+/// Rebasing TK1 witness recovery with TK2 startup pruning: a valid
+/// provisional witness record is pruned when its group no longer exists,
+/// but retained for a live non-withdrawn group even before the target is in
+/// that witness's roster. Authority-attested records are separately gated
+/// by the committed active-member incarnation.
+#[tokio::test]
+async fn treekem_recovery_cache_startup_prunes_roster_irrelevant_signed_records() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0x91, 0x92).await?;
+    let group_id = fixture.group_id.clone();
+    let member_hex = fixture.member_hex.clone();
+    let key = join_result_key(&group_id, &member_hex);
+    let provisional = without_recovery_attestation(fixture.event.clone());
+    let persisted: BTreeMap<String, NamedGroupMetadataEvent> =
+        [(key.clone(), provisional)].into_iter().collect();
+    let json = serde_json::to_string(&persisted)?;
+
+    // Case A: no live group -> validly signed witness record is pruned.
+    {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("kp.json");
+        tokio::fs::write(&path, &json).await?;
+        let empty_roster: HashMap<String, x0x::groups::GroupInfo> = HashMap::new();
+
+        let cache = load_treekem_member_key_packages(&path, &empty_roster).await?;
+        assert_eq!(
+            cache.diagnostics().await.entries,
+            0,
+            "group-irrelevant witness record pruned from memory"
+        );
+        assert!(
+            cache.get(&key).await.is_none(),
+            "pruned record absent from memory"
+        );
+        assert!(
+            durable_cache_keys(&path).await?.is_empty(),
+            "durable JSON rewritten empty after startup prune"
+        );
+    }
+
+    // Case B: the group remains live, so independently retained witness
+    // evidence survives restart without requiring target admission first.
+    {
+        let inviter = fixture.state.agent.agent_id();
+        let roster_kp = match &fixture.event {
+            NamedGroupMetadataEvent::MemberJoined {
+                treekem_key_package_b64: Some(kp),
+                ..
+            } => kp.clone(),
+            _ => unreachable!("fixture event is MemberJoined with a key package"),
+        };
+        let mut info = treekem_metadata_group_info(inviter, &group_id, &fixture.stable_group_id);
+        let mut member = x0x::groups::GroupMember::new_member(
+            member_hex.clone(),
+            None,
+            Some(hex::encode(inviter.as_bytes())),
+            1,
+        );
+        member.treekem_key_package_b64 = Some(roster_kp);
+        info.members_v2.insert(member_hex.clone(), member);
+        let roster: HashMap<String, x0x::groups::GroupInfo> =
+            [(group_id.clone(), info)].into_iter().collect();
+
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("kp.json");
+        tokio::fs::write(&path, &json).await?;
+
+        let cache = load_treekem_member_key_packages(&path, &roster).await?;
+        assert_eq!(
+            cache.diagnostics().await.entries,
+            1,
+            "live-group witness record retained"
+        );
+        assert!(
+            cache.get(&key).await.is_some(),
+            "retained record present in memory"
+        );
+        let canonical_key = join_result_key(&fixture.stable_group_id, &member_hex);
+        let durable_keys_after_load = durable_cache_keys(&path).await?;
+        assert!(
+            durable_keys_after_load.contains(&canonical_key),
+            "loader rewrites the persisted record under the canonical stable group key"
+        );
+        assert!(
+            !durable_keys_after_load.contains(&key),
+            "legacy MLS-alias durable key dropped after the canonicalizing rewrite"
+        );
+    }
+    Ok(())
+}
+
+/// WP-TK2: group/member lifecycle removals must evict both the in-memory
+/// entry and the durable JSON record. `remove_groups` covers the
+/// group-deletion lifecycle; `remove_member` covers per-member removal.
+#[tokio::test]
+async fn treekem_recovery_cache_lifecycle_prune_removes_memory_and_durable() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0x93, 0x94).await?;
+    let group_id = fixture.group_id.clone();
+    let member_hex = fixture.member_hex.clone();
+    let key = join_result_key(&group_id, &member_hex);
+    let aliases = HashSet::from([group_id.clone()]);
+
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("kp.json");
+    let (cache, _) = TreeKemMemberKeyPackageCache::from_entries(path, BTreeMap::new(), false)?;
+
+    // Group lifecycle: remove_groups drops memory + durable JSON.
+    cache
+        .insert(key.clone(), fixture.event.clone(), true)
+        .await?;
+    assert_eq!(cache.diagnostics().await.entries, 1, "seeded one record");
+    let removed_groups = cache.remove_groups(&aliases).await;
+    assert_eq!(
+        removed_groups.evicted, 1,
+        "group lifecycle pruned the record"
+    );
+    assert!(
+        cache.get(&key).await.is_none(),
+        "group prune cleared memory"
+    );
+    assert!(
+        durable_cache_keys(&cache.path).await?.is_empty(),
+        "group prune cleared durable JSON"
+    );
+
+    // Member lifecycle: remove_member drops memory + durable JSON.
+    cache
+        .insert(key.clone(), fixture.event.clone(), true)
+        .await?;
+    assert!(
+        cache.get(&key).await.is_some(),
+        "re-seeded before member prune"
+    );
+    let removed_member = cache.remove_member(&aliases, &member_hex).await;
+    assert_eq!(
+        removed_member.evicted, 1,
+        "member lifecycle pruned the record"
+    );
+    assert!(
+        cache.get(&key).await.is_none(),
+        "member prune cleared memory"
+    );
+    assert!(
+        cache
+            .find_for_member(std::slice::from_ref(&group_id), &member_hex)
+            .await
+            .is_none(),
+        "member prune cleared find_for_member"
+    );
+    assert!(
+        durable_cache_keys(&cache.path).await?.is_empty(),
+        "member prune cleared durable JSON"
+    );
+    Ok(())
+}
+
+/// PR #219 review finding #4: the shared retained-tombstone path used by
+/// GroupDeleted/withdraw/import must prune signed recovery records only
+/// after terminal state commits. Seed an authenticated cache record, then
+/// exercise the real signed GroupDeleted production apply path.
+#[tokio::test]
+async fn group_deleted_tombstone_prunes_recovery_cache_memory_and_disk() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xb1, 0xb2).await?;
+    let state = &fixture.state;
+    let cache_key = join_result_key(&fixture.group_id, &fixture.member_hex);
+
+    state
+        .treekem_member_key_packages
+        .insert(cache_key.clone(), fixture.event.clone(), true)
+        .await?;
+    assert!(
+        state
+            .treekem_member_key_packages
+            .get(&cache_key)
+            .await
+            .is_some(),
+        "precondition: authority-attested recovery record seeded"
+    );
+    assert!(
+        durable_cache_keys(&state.treekem_member_key_packages.path)
+            .await?
+            .contains(&cache_key),
+        "precondition: signed recovery record is durable before terminality"
+    );
+
+    let parent = state
+        .named_groups
+        .read()
+        .await
+        .get(&fixture.group_id)
+        .expect("fixture group retained after MemberJoined")
+        .clone();
+    let mut terminal = parent.clone();
+    terminal.withdrawn = true;
+    let commit = sign_metadata_terminality_commit(&parent, &terminal, state, 1_000);
+    assert!(commit.withdrawn);
+    let event = NamedGroupMetadataEvent::GroupDeleted {
+        group_id: fixture.stable_group_id.clone(),
+        revision: parent.roster_revision.saturating_add(1),
+        actor: hex::encode(state.agent.agent_id().as_bytes()),
+        commit: Some(commit),
+    };
+
+    let applied =
+        apply_named_group_metadata_event_inner(state, event, state.agent.agent_id(), true, true)
+            .await;
+    assert!(
+        applied,
+        "GroupDeleted committed through the production apply path"
+    );
+    {
+        let groups = state.named_groups.read().await;
+        let tombstone = groups
+            .get(&fixture.group_id)
+            .expect("terminal tombstone retained under storage alias");
+        assert!(
+            tombstone.withdrawn,
+            "terminal state committed before cache pruning"
+        );
+        assert_eq!(tombstone.shared_secret, None);
+    }
+    assert!(
+        state
+            .treekem_member_key_packages
+            .get(&cache_key)
+            .await
+            .is_none(),
+        "GroupDeleted tombstone pruned the in-memory signed recovery record"
+    );
+    assert!(
+        !durable_cache_keys(&state.treekem_member_key_packages.path)
+            .await?
+            .contains(&cache_key),
+        "GroupDeleted tombstone pruned the durable signed recovery record"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn group_deleted_tombstone_prunes_independent_witness_memory_and_disk() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xb5, 0xb6).await?;
+    let (witness, _witness_dir) = secure_endpoint_test_state().await?;
+    add_active_witness_to_treekem_fixture(&fixture, &witness).await?;
+    let raw = without_recovery_attestation(fixture.event.clone());
+    let cache_key = join_result_key(&fixture.group_id, &fixture.member_hex);
+    assert!(
+        !apply_named_group_metadata_event(&witness, raw, fixture.member_id, true).await,
+        "independent witness retains without authoring membership"
+    );
+    assert!(witness
+        .treekem_member_key_packages
+        .get(&cache_key)
+        .await
+        .is_some());
+    let canonical_key = join_result_key(&fixture.stable_group_id, &fixture.member_hex);
+    let durable = durable_cache_keys(&witness.treekem_member_key_packages.path).await?;
+    assert!(
+        durable.contains(&canonical_key),
+        "witness retains the canonical stable durable recovery record"
+    );
+    if canonical_key != cache_key {
+        assert!(
+            !durable.contains(&cache_key),
+            "legacy MLS alias durable key is not retained post-canonicalization"
+        );
+    }
+
+    let parent = witness
+        .named_groups
+        .read()
+        .await
+        .get(&fixture.group_id)
+        .expect("witness group exists")
+        .clone();
+    let mut terminal = parent.clone();
+    terminal.withdrawn = true;
+    let commit = sign_metadata_terminality_commit(&parent, &terminal, &fixture.state, 2_000);
+    let authority = fixture.state.agent.agent_id();
+    let event = NamedGroupMetadataEvent::GroupDeleted {
+        group_id: fixture.stable_group_id.clone(),
+        revision: parent.roster_revision.saturating_add(1),
+        actor: hex::encode(authority.as_bytes()),
+        commit: Some(commit),
+    };
+    assert!(
+        apply_named_group_metadata_event_inner(&witness, event, authority, true, true).await,
+        "signed GroupDeleted commits on the independent witness"
+    );
+    assert!(witness
+        .named_groups
+        .read()
+        .await
+        .get(&fixture.group_id)
+        .is_some_and(|info| info.withdrawn));
+    assert!(
+        witness
+            .treekem_member_key_packages
+            .get(&cache_key)
+            .await
+            .is_none(),
+        "shared tombstone path prunes witness memory"
+    );
+    assert!(
+        !durable_cache_keys(&witness.treekem_member_key_packages.path)
+            .await?
+            .contains(&cache_key),
+        "shared tombstone path prunes witness durability"
+    );
+    Ok(())
+}
+
+/// Codex blocker: TreeKEM active-leave and local-only group-drop must prune
+/// the recovery cache across ALL aliases of the stable group. Because
+/// records are canonicalized to the stable id, pruning by the MLS alias
+/// (the only id the leave/drop handlers hold) still evicts the canonical
+/// memory entry and rewrites the durable JSON.
+#[tokio::test]
+async fn treekem_leave_and_drop_prune_canonical_cache_across_aliases() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xe1, 0xe2).await?;
+    let state = &fixture.state;
+    let group_id = fixture.group_id.clone();
+    let stable_group_id = fixture.stable_group_id.clone();
+    let member_hex = fixture.member_hex.clone();
+    let canonical_key = join_result_key(&stable_group_id, &member_hex);
+
+    let seed = cache_treekem_member_key_package(
+        state,
+        join_result_key(&group_id, &member_hex),
+        fixture.event.clone(),
+        true,
+    )
+    .await;
+    assert!(matches!(
+        seed,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+    assert!(
+        durable_cache_keys(&state.treekem_member_key_packages.path)
+            .await?
+            .contains(&canonical_key),
+        "precondition: record canonicalized to the stable durable key"
+    );
+    assert_eq!(
+        state
+            .treekem_member_key_packages
+            .diagnostics()
+            .await
+            .entries,
+        1,
+        "precondition: one canonical record seeded"
+    );
+
+    // Active leave: the production member-prune helper is invoked with the
+    // MLS alias only; it expands to the full alias set and evicts the
+    // canonical record from memory and durability.
+    let leave = prune_treekem_cache_member(state, &group_id, &member_hex, "active_leave").await;
+    assert!(matches!(
+        leave,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+    assert_eq!(
+        state
+            .treekem_member_key_packages
+            .diagnostics()
+            .await
+            .entries,
+        0,
+        "active leave pruned the canonical memory entry"
+    );
+    assert!(
+        !durable_cache_keys(&state.treekem_member_key_packages.path)
+            .await?
+            .contains(&canonical_key),
+        "active leave pruned the canonical durable record"
+    );
+
+    // Re-seed, then exercise the local-only group drop with the alias set
+    // the production handler computes from the MLS alias.
+    let reseed = cache_treekem_member_key_package(
+        state,
+        join_result_key(&group_id, &member_hex),
+        fixture.event.clone(),
+        true,
+    )
+    .await;
+    assert!(matches!(
+        reseed,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+    let aliases = treekem_cache_group_aliases(state, &group_id).await;
+    assert!(
+        aliases.contains(&stable_group_id),
+        "alias set expands the MLS alias to the canonical stable id"
+    );
+    let drop_status = prune_treekem_cache_groups(state, &aliases, "local_drop").await;
+    assert!(matches!(
+        drop_status,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+    assert_eq!(
+        state
+            .treekem_member_key_packages
+            .diagnostics()
+            .await
+            .entries,
+        0,
+        "local drop pruned the canonical memory entry"
+    );
+    assert!(
+        durable_cache_keys(&state.treekem_member_key_packages.path)
+            .await?
+            .is_empty(),
+        "local drop pruned every canonical durable record"
+    );
+    Ok(())
+}
+
+/// Codex blocker: a withdrawn group-card imported with NO local GroupInfo
+/// must still prune an existing canonical durable recovery record. The
+/// no-local handler knows only the card's stable group id; because the
+/// cache record was canonicalized to that same stable id, the prune reaches
+/// it.
+#[tokio::test]
+async fn withdrawn_card_import_without_local_group_prunes_canonical_record() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xe3, 0xe4).await?;
+    let state = &fixture.state;
+    let group_id = fixture.group_id.clone();
+    let stable_group_id = fixture.stable_group_id.clone();
+    let member_hex = fixture.member_hex.clone();
+    let canonical_key = join_result_key(&stable_group_id, &member_hex);
+
+    let seed = cache_treekem_member_key_package(
+        state,
+        join_result_key(&group_id, &member_hex),
+        fixture.event.clone(),
+        true,
+    )
+    .await;
+    assert!(matches!(
+        seed,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+    assert!(
+        durable_cache_keys(&state.treekem_member_key_packages.path)
+            .await?
+            .contains(&canonical_key),
+        "precondition: canonical durable record seeded"
+    );
+
+    // Drop the live roster entry so the import takes the no-local branch.
+    state.named_groups.write().await.remove(&group_id);
+    assert!(
+        state
+            .named_groups
+            .read()
+            .await
+            .values()
+            .all(|info| info.stable_group_id() != stable_group_id),
+        "precondition: no local group remains for the stable id"
+    );
+
+    let creator = x0x::identity::AgentKeypair::generate()?;
+    let mut card = sample_group_card(&stable_group_id, 2, 5_000);
+    card.withdrawn = true;
+    card.sign(&creator)?;
+
+    let response = import_group_card(State(Arc::clone(state)), Json(card))
+        .await
+        .into_response();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "withdrawn card import accepted on the no-local path"
+    );
+
+    assert!(
+        !durable_cache_keys(&state.treekem_member_key_packages.path)
+            .await?
+            .contains(&canonical_key),
+        "no-local withdrawn-card import pruned the canonical durable record"
+    );
+    assert_eq!(
+        state
+            .treekem_member_key_packages
+            .diagnostics()
+            .await
+            .entries,
+        0,
+        "no-local withdrawn-card import pruned the canonical memory entry"
+    );
+    Ok(())
+}
+
+/// WP-TK2: the entry-count cap is enforced on `from_entries` and overflow
+/// is shed oldest-`ts_ms`-first until the cache fits.
+#[tokio::test]
+async fn treekem_recovery_cache_count_limit_evicts_oldest() -> Result<()> {
+    let cap = TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_ENTRIES;
+    let overflow = 3;
+    let total = cap + overflow;
+
+    let mut entries = BTreeMap::new();
+    for i in 0..total {
+        let g = format!("g{i:04x}");
+        let m = format!("m{i:04x}");
+        entries.insert(
+            format!("{g}:{m}"),
+            synthetic_member_joined(&g, &m, i as u64, 8),
+        );
+    }
+
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("kp.json");
+    let (cache, evicted) = TreeKemMemberKeyPackageCache::from_entries(path, entries, true)?;
+    let diag = cache.diagnostics().await;
+
+    assert_eq!(evicted, overflow, "excess entries evicted to reach the cap");
+    assert_eq!(diag.entries, cap, "entry count held at MAX_ENTRIES");
+    assert!(
+        diag.encoded_bytes <= diag.max_encoded_bytes,
+        "byte budget respected after count compaction"
+    );
+    // Eviction is oldest-ts first: the three smallest-ts records (i=0,1,2)
+    // are evicted; i=3 is the first retained and the newest survives.
+    assert!(cache.get("g0000:m0000").await.is_none(), "i=0 evicted");
+    assert!(
+        cache.get("g0002:m0002").await.is_none(),
+        "i=2 evicted (last of overflow trio)"
+    );
+    assert!(
+        cache.get("g0003:m0003").await.is_some(),
+        "i=3 retained (first inside the cap)"
+    );
+    let last_idx = total - 1;
+    assert!(
+        cache
+            .get(&format!("g{last_idx:04x}:m{last_idx:04x}"))
+            .await
+            .is_some(),
+        "newest-ts record retained"
+    );
+    Ok(())
+}
+
+/// WP-TK2: the encoded-byte cap is enforced independently of the count
+/// cap. With a handful of oversized records (count well under MAX_ENTRIES
+/// but combined bytes over MAX_BYTES), the oldest-ts record is evicted so
+/// the durable snapshot fits the byte budget.
+#[tokio::test]
+async fn treekem_recovery_cache_encoded_byte_limit_evicts_to_fit() -> Result<()> {
+    let payload_len = 2_500_000;
+    let ev_a = synthetic_member_joined("ga", "ma", 100, payload_len);
+    let ev_b = synthetic_member_joined("gb", "mb", 200, payload_len);
+    let ev_c = synthetic_member_joined("gc", "mc", 300, payload_len);
+    let (key_a, key_b, key_c) = (
+        "ga:ma".to_string(),
+        "gb:mb".to_string(),
+        "gc:mc".to_string(),
+    );
+
+    // Assert the byte budget — not the count cap — is the trigger, using
+    // the cache's own encoded-size function (mirrors cache_snapshot_encoded_bytes).
+    let bytes_a = cache_entry_encoded_bytes(&key_a, &ev_a)?;
+    let bytes_b = cache_entry_encoded_bytes(&key_b, &ev_b)?;
+    let bytes_c = cache_entry_encoded_bytes(&key_c, &ev_c)?;
+    let snapshot = |n: usize, sum: usize| {
+        2usize
+            .saturating_add(sum)
+            .saturating_add(n.saturating_sub(1))
+    };
+    let triple = snapshot(3, bytes_a + bytes_b + bytes_c);
+    let surviving_pair = snapshot(2, bytes_b + bytes_c);
+    assert!(
+        triple > TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_BYTES,
+        "precondition: three oversized records exceed the byte budget"
+    );
+    assert!(
+        surviving_pair <= TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_BYTES,
+        "precondition: the two newest records fit the byte budget"
+    );
+
+    let mut entries = BTreeMap::new();
+    entries.insert(key_a.clone(), ev_a);
+    entries.insert(key_b.clone(), ev_b);
+    entries.insert(key_c.clone(), ev_c);
+
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("kp.json");
+    let (cache, evicted) = TreeKemMemberKeyPackageCache::from_entries(path, entries, true)?;
+    let diag = cache.diagnostics().await;
+
+    assert_eq!(evicted, 1, "one record evicted to fit the byte budget");
+    assert_eq!(diag.entries, 2, "two records remain");
+    assert!(
+        diag.encoded_bytes <= diag.max_encoded_bytes,
+        "encoded bytes within budget after compaction"
+    );
+    // Oldest-ts (ev_a) is the victim; the two newer records survive.
+    assert!(
+        cache.get(&key_a).await.is_none(),
+        "oldest-ts record evicted"
+    );
+    assert!(cache.get(&key_b).await.is_some(), "newer record retained");
+    assert!(cache.get(&key_c).await.is_some(), "newest record retained");
+    Ok(())
+}
+
+/// WP-TK2: eviction is deterministic — victim selection is min `ts_ms`,
+/// then min key. With one eviction forced (`cap + 1` entries) and three
+/// entries sharing the smallest `ts_ms`, the lexicographically smallest key
+/// is the victim while its equal-ts siblings survive.
+#[tokio::test]
+async fn treekem_recovery_cache_eviction_tiebreak_is_timestamp_then_key() -> Result<()> {
+    let cap = TREEKEM_MEMBER_KEY_PACKAGE_CACHE_MAX_ENTRIES;
+    let mut entries = BTreeMap::new();
+    // Three equal-ts (ts=10) records with distinct keys.
+    for k in ["tie-a", "tie-b", "tie-c"] {
+        entries.insert(
+            k.to_string(),
+            synthetic_member_joined(k, &format!("mem-{k}"), 10, 8),
+        );
+    }
+    // `cap - 2` newer records (distinct ts) fill the cache to `cap + 1`,
+    // forcing exactly one eviction.
+    for i in 0..(cap - 2) {
+        let g = format!("ng{i:04x}");
+        entries.insert(
+            format!("{g}:m"),
+            synthetic_member_joined(&g, "m", 100 + i as u64, 8),
+        );
+    }
+    assert_eq!(entries.len(), cap + 1, "precondition: one over the cap");
+
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("kp.json");
+    let (cache, evicted) = TreeKemMemberKeyPackageCache::from_entries(path, entries, true)?;
+    assert_eq!(evicted, 1, "exactly one record evicted");
+    assert_eq!(cache.diagnostics().await.entries, cap);
+
+    // Tie broken by smallest key: "tie-a" is the victim; "tie-b"/"tie-c"
+    // (equal ts, larger keys) survive.
+    assert!(
+        cache.get("tie-a").await.is_none(),
+        "smallest-key victim evicted on tie"
+    );
+    assert!(
+        cache.get("tie-b").await.is_some(),
+        "larger-key sibling survives the tie"
+    );
+    assert!(
+        cache.get("tie-c").await.is_some(),
+        "largest-key sibling survives the tie"
+    );
+    Ok(())
+}
+
+fn install_treekem_cache_writer_hook(
+    path: &FsPath,
+    release: Option<Arc<tokio::sync::Notify>>,
+    force_error: Option<std::io::Error>,
+) -> (Arc<tokio::sync::Notify>, TreeKemCacheWriterHookGuard) {
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let mut hooks = TREEKEM_CACHE_WRITER_HOOKS
+        .lock()
+        .expect("TreeKEM cache writer hook poisoned");
+    hooks.insert(
+        path.to_path_buf(),
+        TreeKemCacheWriterHookControl {
+            entered: Arc::clone(&entered),
+            release,
+            force_error,
+        },
+    );
+    (
+        entered,
+        TreeKemCacheWriterHookGuard {
+            path: path.to_path_buf(),
+        },
+    )
+}
+
+async fn signed_cache_fixture_entries() -> Result<(
+    MemberJoinedTreeKemFixture,
+    MemberJoinedTreeKemFixture,
+    String,
+    String,
+)> {
+    let first = member_joined_treekem_fixture(0xa1, 0xa2).await?;
+    let second = member_joined_treekem_fixture(0xa3, 0xa4).await?;
+    let first_key = join_result_key(&first.group_id, &first.member_hex);
+    let second_key = join_result_key(&second.group_id, &second.member_hex);
+    Ok((first, second, first_key, second_key))
+}
+
+/// WP-TK2 #5: the persistence mutex serializes disk writes without holding
+/// the cache map lock. While the first writer is deterministically parked,
+/// readers observe both the first mutation and a concurrent newer mutation;
+/// after release, the coalescing writer persists the newest snapshot.
+#[tokio::test]
+async fn treekem_recovery_cache_slow_writer_does_not_block_readers_and_newest_wins() -> Result<()> {
+    let (first, second, first_key, second_key) = signed_cache_fixture_entries().await?;
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("kp.json");
+    let (cache, _) =
+        TreeKemMemberKeyPackageCache::from_entries(path.clone(), BTreeMap::new(), false)?;
+    let cache = Arc::new(cache);
+    let release = Arc::new(tokio::sync::Notify::new());
+    let (entered, _hook_guard) =
+        install_treekem_cache_writer_hook(&path, Some(Arc::clone(&release)), None);
+
+    let first_cache = Arc::clone(&cache);
+    let first_key_for_write = first_key.clone();
+    let first_event = first.event.clone();
+    let first_write = tokio::spawn(async move {
+        first_cache
+            .insert(first_key_for_write, first_event, true)
+            .await
+    });
+    entered.notified().await;
+
+    assert!(
+        cache.get(&first_key).await.is_some(),
+        "reader proceeds while the first disk writer is parked"
+    );
+
+    let second_cache = Arc::clone(&cache);
+    let second_key_for_write = second_key.clone();
+    let second_event = second.event.clone();
+    let second_write = tokio::spawn(async move {
+        second_cache
+            .insert(second_key_for_write, second_event, true)
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while cache.get(&second_key).await.is_none() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .context("newer in-memory mutation blocked behind slow disk writer")?;
+    assert!(
+        cache.get(&first_key).await.is_some(),
+        "readers remain available after the concurrent mutation"
+    );
+
+    release.notify_one();
+    let first_result = first_write.await??;
+    let second_result = second_write.await??;
+    assert!(matches!(
+        first_result.persistence,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+    assert!(matches!(
+        second_result.persistence,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+
+    let durable = durable_cache_keys(&path).await?;
+    assert_eq!(
+        durable,
+        HashSet::from([first_key, second_key]),
+        "serialized/coalesced persistence leaves the newest complete snapshot on disk"
+    );
+    let diagnostics = cache.diagnostics().await;
+    assert!(!diagnostics.dirty);
+    assert_eq!(diagnostics.persisted_revision, diagnostics.revision);
+    Ok(())
+}
+
+#[tokio::test]
+async fn slow_cache_persistence_does_not_cycle_with_membership_lock() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xbd, 0xbe).await?;
+    let state = Arc::clone(&fixture.state);
+    let key = join_result_key(&fixture.group_id, &fixture.member_hex);
+    let release = Arc::new(tokio::sync::Notify::new());
+    let (entered, _hook_guard) = install_treekem_cache_writer_hook(
+        &state.treekem_member_key_packages.path,
+        Some(Arc::clone(&release)),
+        None,
+    );
+
+    let writer_state = Arc::clone(&state);
+    let writer_event = fixture.event.clone();
+    let writer = tokio::spawn(async move {
+        cache_treekem_member_key_package(&writer_state, key, writer_event, true).await
+    });
+    entered.notified().await;
+
+    let membership_lock = group_membership_lock(&state, &fixture.group_id).await;
+    let membership_guard = tokio::time::timeout(Duration::from_secs(5), membership_lock.lock())
+        .await
+        .context("cache persistence introduced a persistence-to-membership lock cycle")?;
+    assert!(
+        state
+            .treekem_member_key_packages
+            .get(&join_result_key(&fixture.group_id, &fixture.member_hex))
+            .await
+            .is_some(),
+        "cache map remains readable while persistence is parked"
+    );
+
+    release.notify_one();
+    let status = tokio::time::timeout(Duration::from_secs(5), writer)
+        .await
+        .context("membership lock introduced a membership-to-persistence lock cycle")??;
+    assert!(matches!(
+        status,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+    drop(membership_guard);
+    Ok(())
+}
+
+/// WP-TK2 #6: a failed durable write returns structured `Dirty`, retains
+/// failure diagnostics, and remains retryable. A later mutation retries the
+/// entire newest snapshot and clears dirty state only after disk success.
+#[tokio::test]
+async fn treekem_recovery_cache_failed_write_stays_dirty_and_retry_persists_newest() -> Result<()> {
+    let (first, second, first_key, second_key) = signed_cache_fixture_entries().await?;
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("kp.json");
+    let (cache, _) =
+        TreeKemMemberKeyPackageCache::from_entries(path.clone(), BTreeMap::new(), false)?;
+    let (entered, _hook_guard) = install_treekem_cache_writer_hook(
+        &path,
+        None,
+        Some(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "injected TreeKEM cache persistence failure",
+        )),
+    );
+
+    let failed = cache
+        .insert(first_key.clone(), first.event.clone(), true)
+        .await?;
+    entered.notified().await;
+    let TreeKemCachePersistenceStatus::Dirty {
+        revision: failed_revision,
+        error,
+    } = failed.persistence
+    else {
+        anyhow::bail!("injected persistence failure was falsely reported durable");
+    };
+    assert!(error.contains("injected TreeKEM cache persistence failure"));
+    let dirty = cache.diagnostics().await;
+    assert!(dirty.dirty, "failed write remains explicitly dirty");
+    assert_eq!(dirty.revision, failed_revision);
+    assert_eq!(dirty.write_failures, 1);
+    assert!(dirty
+        .last_error
+        .as_deref()
+        .is_some_and(|last| { last.contains("injected TreeKEM cache persistence failure") }));
+    assert!(
+        cache.get(&first_key).await.is_some(),
+        "failed persistence does not discard the retryable in-memory record"
+    );
+    assert!(
+        tokio::fs::try_exists(&path)
+            .await
+            .is_ok_and(|exists| !exists),
+        "failed writer did not create a falsely durable snapshot"
+    );
+
+    let retried = cache
+        .insert(second_key.clone(), second.event.clone(), true)
+        .await?;
+    assert!(matches!(
+        retried.persistence,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+    let durable = durable_cache_keys(&path).await?;
+    assert_eq!(
+        durable,
+        HashSet::from([first_key, second_key]),
+        "successful retry persists the newest snapshot, including the prior dirty record"
+    );
+    let clean = cache.diagnostics().await;
+    assert!(!clean.dirty, "successful retry clears dirty state");
+    assert_eq!(clean.persisted_revision, clean.revision);
+    assert_eq!(
+        clean.write_failures, 1,
+        "failure history remains observable"
+    );
+    assert_eq!(
+        clean.last_error, None,
+        "active error clears after durability succeeds"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn provisional_witness_duplicate_retries_dirty_snapshot_and_survives_restart() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xbb, 0xbc).await?;
+    let raw = without_recovery_attestation(fixture.event.clone());
+    let key = join_result_key(&fixture.group_id, &fixture.member_hex);
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("witness-dirty.json");
+    let (cache, _) =
+        TreeKemMemberKeyPackageCache::from_entries(path.clone(), BTreeMap::new(), false)?;
+    let (entered, _hook_guard) = install_treekem_cache_writer_hook(
+        &path,
+        None,
+        Some(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "injected witness persistence failure",
+        )),
+    );
+
+    let failed = cache.insert(key.clone(), raw.clone(), false).await?;
+    entered.notified().await;
+    assert!(matches!(
+        failed.persistence,
+        TreeKemCachePersistenceStatus::Dirty { .. }
+    ));
+    let dirty_revision = cache.diagnostics().await.revision;
+
+    let retried = cache.insert(key.clone(), raw, false).await?;
+    assert!(matches!(
+        retried.persistence,
+        TreeKemCachePersistenceStatus::Durable { .. }
+    ));
+    let clean = cache.diagnostics().await;
+    assert_eq!(clean.entries, 1);
+    assert_eq!(
+        clean.revision, dirty_revision,
+        "duplicate retry is not a new record"
+    );
+    assert_eq!(clean.persisted_revision, clean.revision);
+
+    let groups = fixture.state.named_groups.read().await.clone();
+    let restarted = load_treekem_member_key_packages(&path, &groups).await?;
+    let restored = restarted.get(&key).await.expect("witness record restored");
+    assert!(verify_member_joined_key_package_event(&restored));
+    assert!(recovery_attestation_revision(&restored).is_none());
+    assert_eq!(restarted.diagnostics().await.entries, 1);
+    Ok(())
+}
+
+/// Codex blocker: a production cache mutation whose first durable write
+/// fails must become durable via the scheduled background retry — with no
+/// second mutation or API call — clearing active diagnostics while
+/// persisting the newest snapshot.
+#[tokio::test]
+async fn dirty_cache_write_becomes_durable_via_autonomous_retry() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xf1, 0xf2).await?;
+    let state = &fixture.state;
+    let group_id = fixture.group_id.clone();
+    let stable_group_id = fixture.stable_group_id.clone();
+    let member_hex = fixture.member_hex.clone();
+    let canonical_key = join_result_key(&stable_group_id, &member_hex);
+    let cache_path = state.treekem_member_key_packages.path.clone();
+
+    // One-shot: the FIRST write fails; the hook is consumed so the
+    // autonomous retry's next write reaches the disk.
+    let (entered, _hook_guard) = install_treekem_cache_writer_hook(
+        &cache_path,
+        None,
+        Some(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "injected autonomous-retry persistence failure",
+        )),
+    );
+
+    // A SINGLE production mutation; no second mutation or API call follows.
+    let failed = cache_treekem_member_key_package(
+        state,
+        join_result_key(&group_id, &member_hex),
+        fixture.event.clone(),
+        true,
+    )
+    .await;
+    entered.notified().await;
+    let TreeKemCachePersistenceStatus::Dirty {
+        revision: failed_revision,
+        error,
+    } = failed
+    else {
+        anyhow::bail!("injected persistence failure was falsely reported durable");
+    };
+    assert!(error.contains("injected autonomous-retry persistence failure"));
+    assert_eq!(
+        failed_revision,
+        state
+            .treekem_member_key_packages
+            .diagnostics()
+            .await
+            .revision
+    );
+    assert!(
+        tokio::fs::try_exists(&cache_path)
+            .await
+            .is_ok_and(|exists| !exists),
+        "failed first write left no durable snapshot"
+    );
+
+    // Wait for the production-spawned retry to settle. No further mutation
+    // drives it.
+    let settled = tokio::time::timeout(std::time::Duration::from_secs(8), async {
+        loop {
+            if !state.treekem_member_key_packages.diagnostics().await.dirty {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    })
+    .await;
+    assert!(
+        settled.is_ok(),
+        "autonomous retry made the dirty cache durable without a second mutation"
+    );
+
+    let clean = state.treekem_member_key_packages.diagnostics().await;
+    assert!(
+        !clean.dirty,
+        "active dirty flag cleared by autonomous retry"
+    );
+    assert_eq!(
+        clean.last_error, None,
+        "active error cleared after durability"
+    );
+    assert_eq!(
+        clean.persisted_revision, clean.revision,
+        "autonomous retry persisted the newest snapshot"
+    );
+    assert_eq!(
+        clean.write_failures, 1,
+        "the single injected failure remains in failure history"
+    );
+    assert_eq!(
+        durable_cache_keys(&cache_path).await?,
+        HashSet::from([canonical_key]),
+        "autonomous retry persisted the canonical newest snapshot"
+    );
+    Ok(())
+}
+
+/// Codex-discovered race: a non-inviter provisional witness insert and
+/// terminal group pruning must share the per-group membership
+/// serialization boundary. When the cache durable writer is parked
+/// mid-insert the membership guard stays held, so a concurrent terminal
+/// GroupDeleted cannot pass the boundary until the insert completes.
+/// After release, pruning wins and leaves both cache memory and durable
+/// JSON empty — no deferred-outer-insertion resurrection. Fails under the
+/// old code that deferred the insert past the guard.
+#[tokio::test]
+async fn non_inviter_witness_insert_blocks_terminal_pruning_at_membership_boundary() -> Result<()> {
+    let fixture = member_joined_treekem_fixture(0xc5, 0xc6).await?;
+    let (witness, _witness_dir) = secure_endpoint_test_state().await?;
+    add_active_witness_to_treekem_fixture(&fixture, &witness).await?;
+
+    let raw = without_recovery_attestation(fixture.event.clone());
+    let cache_key = join_result_key(&fixture.group_id, &fixture.member_hex);
+    let cache_path = witness.treekem_member_key_packages.path.clone();
+    let group_id = fixture.group_id.clone();
+
+    // Park the witness insert's durable writer. The membership guard stays
+    // held while the writer is blocked because the production fix moved
+    // the provisional cache insert inside the guard.
+    let release = Arc::new(tokio::sync::Notify::new());
+    let (entered, _hook_guard) =
+        install_treekem_cache_writer_hook(&cache_path, Some(Arc::clone(&release)), None);
+
+    // Witness side: non-inviter applies MemberJoined through the real
+    // public wrapper. The durable write parks on the hook, so the
+    // membership guard remains held.
+    let apply_state = Arc::clone(&witness);
+    let apply_member = fixture.member_id;
+    let witness_apply = tokio::spawn(async move {
+        apply_named_group_metadata_event(&apply_state, raw, apply_member, true).await
+    });
+    entered.notified().await;
+
+    assert!(
+        witness
+            .treekem_member_key_packages
+            .get(&cache_key)
+            .await
+            .is_some(),
+        "witness provisional insert updated memory before parking on durability"
+    );
+
+    // Build the terminal GroupDeleted event with a signed terminal commit,
+    // following the same construction as the existing tombstone tests.
+    let parent = witness
+        .named_groups
+        .read()
+        .await
+        .get(&group_id)
+        .expect("witness holds the live group")
+        .clone();
+    let mut terminal_info = parent.clone();
+    terminal_info.withdrawn = true;
+    let commit = sign_metadata_terminality_commit(&parent, &terminal_info, &fixture.state, 2_000);
+    let authority = fixture.state.agent.agent_id();
+    let terminal_event = NamedGroupMetadataEvent::GroupDeleted {
+        group_id: fixture.stable_group_id.clone(),
+        revision: parent.roster_revision.saturating_add(1),
+        actor: hex::encode(authority.as_bytes()),
+        commit: Some(commit),
+    };
+
+    // Terminal side: GroupDeleted through the same public wrapper. This
+    // acquires the SAME per-group membership mutex and cannot proceed
+    // while the witness insert is in flight.
+    let terminal_state = Arc::clone(&witness);
+    let terminal_authority = authority;
+    let terminal = tokio::spawn(async move {
+        apply_named_group_metadata_event(&terminal_state, terminal_event, terminal_authority, true)
+            .await
+    });
+
+    // Prove the membership boundary is held: a direct probe of the same
+    // mutex cannot acquire within a bounded window while the witness
+    // insert is parked. This deterministically demonstrates that the
+    // terminal task — which needs the same lock — is also blocked.
+    let probe_lock = group_membership_lock(&witness, &group_id).await;
+    let probe = tokio::time::timeout(Duration::from_millis(200), probe_lock.lock()).await;
+    assert!(
+        probe.is_err(),
+        "membership boundary is held by the in-flight witness insert; \
+         terminal pruning cannot proceed"
+    );
+
+    // Release the parked durable writer. The witness insert completes and
+    // drops the membership guard, allowing the terminal GroupDeleted to
+    // acquire it, commit the terminal tombstone, and prune the cache.
+    release.notify_one();
+
+    let witness_applied = tokio::time::timeout(Duration::from_secs(5), witness_apply)
+        .await
+        .context("witness apply did not complete after releasing the durable writer")??;
+    assert!(
+        !witness_applied,
+        "non-inviter witness retains without authoring membership"
+    );
+
+    let terminal_applied = tokio::time::timeout(Duration::from_secs(5), terminal)
+        .await
+        .context(
+            "terminal GroupDeleted did not complete after the witness insert released the boundary",
+        )??;
+    assert!(
+        terminal_applied,
+        "signed GroupDeleted committed through the production apply path"
+    );
+
+    // Terminal pruning completes last: both in-memory and durable JSON
+    // are empty. No deferred-outer-insertion resurrection occurred.
+    assert_eq!(
+        witness
+            .treekem_member_key_packages
+            .diagnostics()
+            .await
+            .entries,
+        0,
+        "terminal pruning emptied cache memory after the witness insert completed"
+    );
+    assert!(
+        witness
+            .treekem_member_key_packages
+            .get(&cache_key)
+            .await
+            .is_none(),
+        "terminal pruning evicted the provisional witness record from memory"
+    );
+    assert!(
+        durable_cache_keys(&cache_path).await?.is_empty(),
+        "terminal pruning emptied the durable JSON after the witness insert completed"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- quarantine malformed/schema-incompatible TreeKEM recovery-cache files while preserving evidence; keep non-NotFound filesystem failures fatal
- replace the raw map with one bounded cache abstraction owning active-roster startup pruning, lifecycle deletion, deterministic count/byte compaction, persistence serialization, and diagnostics
- release the entry-map lock before serialization/disk I/O; serialize/coalesce writers so the newest snapshot wins
- retain dirty state and structured persistence status on failures, retry newest state on later mutations, and expose status through `/diagnostics/groups`

## Bounds
- maximum entries: 512
- maximum encoded JSON: 8 MiB
- deterministic eviction: oldest signed `ts_ms`, then lexical cache key

## Findings
- BLOCKER-REVIEW #3: corruption quarantine and read-error classification
- BLOCKER-REVIEW #4: bounded lifecycle/compaction and startup pruning
- BLOCKER-REVIEW #5: nonblocking map readers with serialized newest-snapshot persistence
- BLOCKER-REVIEW #6: dirty/retry status and diagnostics

## Verification
- `cargo fmt --all`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo test --all-features treekem_recovery_cache -- --nocapture` (9 passed)
- `cargo test --all-features recovered_member_key_package -- --nocapture` (4 passed)
- `cargo test --all-features member_keyed_catchup_restores_signed_event_after_restart -- --nocapture` (1 passed)
- `just check` (2,121 passed; 217 skipped; docs built)

## Merge note
WP-TK1 concurrently changes `src/server/mod.rs`; merge/rebase that work first or expect a concentrated conflict around `AppState` initialization, TreeKEM metadata-event lifecycle arms, diagnostics, and the in-module test tail. This PR does not merge WP-TK1.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the TreeKEM recovery cache. The main changes are:

- A bounded cache abstraction for member key-package recovery records.
- Startup quarantine and pruning for malformed or stale cache files.
- Serialized persistence with dirty-state diagnostics.
- Lifecycle pruning for removed, banned, deleted, and left groups.

<h3>Confidence Score: 4/5</h3>

The TreeKEM recovery cache can drop valid records when stable group ids and MLS group ids differ.

- Cache insertion can reject a valid signed join record under an alias mismatch.
- Startup pruning can rewrite the durable cache without a valid recovery record.
- The rest of the cache persistence flow is structured and bounded, but these recovery paths need fixes before merging.

src/server/mod.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/mod.rs | Adds the TreeKEM recovery cache implementation, persistence, loader quarantine, lifecycle pruning, diagnostics, and related tests. |
| src/server/state.rs | Replaces the raw recovery-cache map and path fields with the new cache abstraction. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[MemberJoined key package] --> B[Cache insert]
  B --> C{Cache key matches event key?}
  C -->|alias mismatch| D[Reject valid recovery record]
  C -->|match| E[Persist snapshot]
  F[Restart] --> G[Load persisted cache]
  G --> H{Roster match by direct id?}
  H -->|alias mismatch| I[Prune record and rewrite cache]
  H -->|match| J[Keep recovery record]
  D --> K[Recovery or catchup misses key package]
  I --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[MemberJoined key package] --> B[Cache insert]
  B --> C{Cache key matches event key?}
  C -->|alias mismatch| D[Reject valid recovery record]
  C -->|match| E[Persist snapshot]
  F[Restart] --> G[Load persisted cache]
  G --> H{Roster match by direct id?}
  H -->|alias mismatch| I[Prune record and rewrite cache]
  H -->|match| J[Keep recovery record]
  D --> K[Recovery or catchup misses key package]
  I --> K
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/server/mod.rs:6152-6153
**Alias Key Rejects Recovery**

When a join is cached under the stable group id but the signed `MemberJoined` carries the MLS group id, `insert` derives a different `expected_key` and rejects the otherwise valid event. That leaves the recovery cache empty for this member, so promoted-admin recovery or catchup can fail after restart even though the key package was accepted by the roster path.

### Issue 2 of 2
src/server/mod.rs:17202
**Startup Prunes Aliased Entries**

The loader now drops every persisted record that fails `member_joined_key_package_matches_groups`, but that helper does not resolve the full group alias set. If the cached event uses the MLS group id while `named_groups` is keyed by the stable/storage id, startup treats the active member as inactive, rewrites the cache without the record, and permanently removes the recovery key package.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): harden TreeKEM recovery cac..."](https://github.com/saorsa-labs/x0x/commit/6efb297450fa2387525f2e4d127060e3fddda0d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43492295)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->