### PR TITLE
docs(skill): agent-usable SKILL.md for v0.30.0 — ship as v0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.30.1] - 2026-07-11
+
+### Documentation
+
+- **docs(skill): correct auth-exempt paths, add REST examples for forwards/task-lists/stores/groups/exec/files/presence.** `SKILL.md` now documents the full agent-orchestration surface instead of ~16 of 128 routes. Fixed the auth statement — `/health` and `/constitution*` are the only public paths (not `/gui`); `/gui`, `/ws`, `/events` also accept the token via `?token=`; every other route requires the `Authorization: Bearer` header. Added a verified REST-example section covering task-lists, stores, named groups (with the `/groups` vs low-level `/mls/groups` distinction and preset-driven public-vs-encrypted messaging), presence/discovery, files, agent-card/A2A, remote exec (flagged high-risk, trust + ACL gated), contacts CRUD, and the new v0.30.0 tailnet `/forwards`. Every new example was smoke-tested against a live v0.30.1 daemon (single-node plus a two-node run for the peer-dependent flows). `docs/api-reference.md` gains a Remote Exec section and the `/presence/online`+`/presence/foaf` views.
+
 ## [v0.30.0] - 2026-07-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.30.0
+version: 0.30.1
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com
@@ -185,7 +185,9 @@ x0x agent
 x0x subscribe hello-world
 x0x publish hello-world "Hello!"
 
-# REST API (all but /health and /gui require bearer auth)
+# REST API auth: /health and /constitution* are public; /gui, /ws, /events
+# accept the token via ?token=; every other route requires the
+# Authorization: Bearer header shown below.
 DATA_DIR="$HOME/Library/Application Support/x0x"   # macOS
 # DATA_DIR="$HOME/.local/share/x0x"                # Linux
 API=$(cat "$DATA_DIR/api.port")
@@ -295,6 +297,10 @@ x0x agents list               List discovered agents
 x0x presence online           Online agents (network view)
 x0x direct send <id> <msg>    Send a direct message
 x0x send-file <id> <path>     Send a file
+x0x forward add|list|rm       Manage tailnet TCP port-forwards
+x0x group ...                 Named groups (create, invite, join)
+x0x tasks ...                 Task lists   ·   x0x store ...   Replicated KV stores
+x0x exec <id> -- <argv...>    Run a command on a peer (trust + ACL gated)
 x0x constitution              Display the x0x Constitution
 x0x upgrade --check           Check for updates
 ```
@@ -334,6 +340,176 @@ rendezvous_enabled = true             # Global agent findability
 403 Forbidden      {"ok":false,"error":"agent is blocked"}     # Trust check failed
 404 Not Found      {"ok":false,"error":"group not found"}      # Resource missing
 500 Internal Error {"ok":false,"error":"internal error"}       # Server-side failure
+```
+
+## Agent Orchestration (REST)
+
+The endpoints below are the high-value surface for building agents on x0x. All use `$API` and `$TOKEN` from Step 4 and require the `Authorization: Bearer $TOKEN` header. Each example is verified against the v0.30.x daemon. For the complete surface (128 routes), see the [Full API Reference](https://github.com/saorsa-labs/x0x/blob/main/docs/api-reference.md).
+
+### Task Lists (replicated CRDT)
+
+Shared, conflict-free task lists — the backbone for multi-agent work orchestration.
+
+```bash
+# Create a task list
+curl -X POST "http://$API/task-lists" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Sprint Backlog", "topic": "team-sprint-42"}'
+# -> {"ok":true,"id":"team-sprint-42"}
+
+curl -H "Authorization: Bearer $TOKEN" "http://$API/task-lists"                 # list task lists
+
+# Add a task
+curl -X POST "http://$API/task-lists/team-sprint-42/tasks" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Write integration tests", "description": "Cover the KV delta path"}'
+# -> {"ok":true,"task_id":"<64-hex>"}
+
+curl -H "Authorization: Bearer $TOKEN" "http://$API/task-lists/team-sprint-42/tasks"  # list tasks
+
+# Claim or complete a task (action = "claim" | "complete"; tid = the 64-hex task_id)
+curl -X PATCH "http://$API/task-lists/team-sprint-42/tasks/<task_id>" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"action": "claim"}'
+```
+
+### Stores (replicated key–value CRDT)
+
+```bash
+# Create a store
+curl -X POST "http://$API/stores" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "shared-config", "topic": "team-config-store"}'
+# -> {"ok":true,"id":"team-config-store"}
+
+# Put a value — value is BASE64-encoded bytes
+curl -X PUT "http://$API/stores/team-config-store/greeting" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"value": "'$(echo -n "hello" | base64)'", "content_type": "text/plain"}'
+
+curl -H "Authorization: Bearer $TOKEN" "http://$API/stores/team-config-store/keys"     # list keys
+curl -H "Authorization: Bearer $TOKEN" "http://$API/stores/team-config-store/greeting" # get (value is base64)
+curl -X DELETE "http://$API/stores/team-config-store/greeting" -H "Authorization: Bearer $TOKEN"
+
+# Join a store another agent created (replicate it locally)
+curl -X POST "http://$API/stores/team-config-store/join" -H "Authorization: Bearer $TOKEN"
+```
+
+### Named Groups
+
+**`/groups` = policy-driven named groups** (presets, discovery, invites, roster, public messaging, TreeKEM/MLS encryption). **`/mls/groups` = bare MLS primitives** (raw group/key ops, no policy or discovery) — shown earlier under *MLS Group Encryption*. Prefer `/groups` for real applications.
+
+A group's `preset` decides its messaging model: `private_secure` (default, end-to-end encrypted → use `secure/encrypt`) or a public preset (`public_open`, `public_request_secure`, `public_announce` → use public `send`/`messages`).
+
+```bash
+# Encrypted group (default preset private_secure)
+curl -X POST "http://$API/groups" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"name": "my-group"}'
+# -> {"ok":true,"group_id":"<64-hex>", ...}
+
+# Public group for open messaging
+curl -X POST "http://$API/groups" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"name": "townsquare", "preset": "public_open"}'
+
+# Members
+curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/<group_id>/members"
+curl -X POST "http://$API/groups/<group_id>/members" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "<64-hex>"}'   # TreeKEM groups also need "treekem_key_package_b64"
+
+# Public messaging (public presets only)
+curl -X POST "http://$API/groups/<group_id>/send" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"body": "hello group"}'   # optional "kind": "chat" | "announcement"
+curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/<group_id>/messages"
+
+# Encrypted messaging (encrypted presets) — payload is base64
+curl -X POST "http://$API/groups/<group_id>/secure/encrypt" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"payload_b64": "'$(echo -n "secret" | base64)'"}'
+
+# Create an invite link (on a group you admin), then share it out-of-band
+curl -X POST "http://$API/groups/<group_id>/invite" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{}'
+# -> {"ok":true,"invite_link":"x0x://invite/<...>"}
+
+# Join via that invite link (on the other agent)
+curl -X POST "http://$API/groups/join" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"invite": "x0x://invite/<...>"}'
+```
+
+### Presence & Discovery
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" "http://$API/presence/online"       # online agents (network view)
+curl -H "Authorization: Bearer $TOKEN" "http://$API/presence/foaf?ttl=3"   # friends-of-friends walk (ttl hops)
+curl -H "Authorization: Bearer $TOKEN" "http://$API/agents/discovered"     # discovery cache
+curl -H "Authorization: Bearer $TOKEN" "http://$API/agents/reachability/<agent_id>"
+```
+
+### Files
+
+Send a file to another agent (the recipient must be a reachable, known peer). `sha256` is the hex digest of the bytes; supply content inline as base64 (`data_b64`) or reference a local `path`.
+
+```bash
+DATA=$(echo -n "hello" | base64)
+SHA=$(printf "hello" | shasum -a 256 | cut -d' ' -f1)
+curl -X POST "http://$API/files/send" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"agent_id\":\"<64-hex>\",\"filename\":\"note.txt\",\"size\":5,\"sha256\":\"$SHA\",\"data_b64\":\"$DATA\"}"
+# -> {"ok":true,"transfer_id":"..."}
+
+curl -H "Authorization: Bearer $TOKEN" "http://$API/files/transfers"            # incoming/outgoing transfers
+curl -X POST "http://$API/files/accept/<transfer_id>" -H "Authorization: Bearer $TOKEN"   # accept a pending incoming transfer
+```
+
+### Agent Card / A2A
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" "http://$API/agent/card"                 # signed x0x agent card + shareable link
+curl -H "Authorization: Bearer $TOKEN" "http://$API/.well-known/agent-card.json" # Google A2A-format card
+curl -X POST "http://$API/agent/card/import" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"card": "x0x://agent/<...>", "trust_level": "known"}'                    # import a peer's card
+```
+
+### Remote Exec (⚠️ high-risk, trust + ACL gated)
+
+Runs a command on **another** agent's machine. Disabled by default and **fully gated on the responder**: the target runs it only if exec is enabled there, the sender is a verified `Accept`-trust contact, and the `(agent, machine)` + exact argv are allow-listed in its exec ACL. A denied request returns `200` with a `denial_reason` (e.g. `exec_disabled`, `trust_rejected`, `argv_not_allowed`) — the refusal is in the body, not the status. argv is never shell-interpreted. See [docs/exec.md](https://github.com/saorsa-labs/x0x/blob/main/docs/exec.md).
+
+```bash
+curl -X POST "http://$API/exec/run" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "<64-hex>", "argv": ["echo", "hi"]}'   # optional "stdin_b64", "timeout_ms"
+curl -X POST "http://$API/exec/cancel" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"request_id": "<32-hex>"}'
+curl -H "Authorization: Bearer $TOKEN" "http://$API/exec/sessions"
+```
+
+### Contacts
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" "http://$API/contacts"                   # list
+curl -X POST "http://$API/contacts" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "<64-hex>", "trust_level": "known", "label": "peer-a"}'
+curl -X PATCH "http://$API/contacts/<agent_id>" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"trust_level": "trusted"}'
+curl -X DELETE "http://$API/contacts/<agent_id>" -H "Authorization: Bearer $TOKEN"
+```
+
+Trust levels: `blocked` | `unknown` | `known` | `trusted`. (The `/contacts/trust` quick-set under *Trust Management* is a shortcut for the same store.)
+
+### Tailnet Forwards (v0.30.0)
+
+Tunnel a local loopback TCP port to a loopback service on a trusted peer machine (Tailscale-style). Requires connect forwarding enabled (a connect ACL) and the peer to be a trusted contact — otherwise returns `409`. Agent attestation rides relayed forwards automatically; there is nothing extra to call.
+
+```bash
+# Add a forward: local 127.0.0.1:15432 -> peer's 127.0.0.1:22
+curl -X POST "http://$API/forwards" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"local_addr":"127.0.0.1:15432","peer_agent":"<64-hex>","target_host":"127.0.0.1","target_port":22}'
+
+curl -H "Authorization: Bearer $TOKEN" "http://$API/forwards"                   # list
+curl -X DELETE "http://$API/forwards/127.0.0.1:15432" -H "Authorization: Bearer $TOKEN"   # remove
 ```
 
 ## Architecture

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -177,6 +177,9 @@ Notes:
 |---|---|---|---|
 | GET | `/peers` | `x0x peers` | Connected gossip peers |
 | GET | `/presence` | `x0x presence` | Presence view of online agents |
+| GET | `/presence/online` | `x0x presence online` | Online agents (network-view trust filter) |
+| GET | `/presence/foaf` | `x0x presence foaf` | Friends-of-friends discovery walk (`?ttl=<hops>`, default 3; social-view trust filter) |
+| GET | `/presence/status/:id` · `/presence/find/:id` | `x0x presence status/find` | One agent's presence status / lookup |
 | GET | `/network/status` | `x0x network status` | NAT and connectivity diagnostics |
 | GET | `/network/bootstrap-cache` | `x0x network cache` | Bootstrap cache stats |
 
@@ -602,6 +605,37 @@ or
 ```json
 {"reason":"rejected by user"}
 ```
+
+## Remote exec
+
+Run a command on **another** agent's machine. Disabled by default; every request is authorized on the **responder** (target) daemon, not the caller. The target runs `argv` only if remote exec is enabled there, the sender is a verified `Accept`-trust contact, and the `(agent_id, machine_id)` pair + exact argv are allow-listed in its exec ACL (`docs/exec.md`). `argv` is never shell-interpreted. A denied request still returns `200` with a non-null `denial_reason` (e.g. `exec_disabled`, `unverified_sender`, `trust_rejected`, `agent_machine_not_in_acl`, `argv_not_allowed`, `cwd_not_allowed`, `shell_metachar_in_argv`) — the refusal is carried in the body, not the HTTP status.
+
+| Method | Endpoint | CLI | Purpose |
+|---|---|---|---|
+| POST | `/exec/run` | `x0x exec <agent_id> -- <argv...>` | Run a command on a peer |
+| POST | `/exec/cancel` | `x0x exec cancel <request_id>` | Cancel an in-flight request |
+| GET | `/exec/sessions` | `x0x exec sessions` | List pending client + active server sessions |
+
+### Run request body
+
+```json
+{
+  "agent_id": "8a3f...",
+  "argv": ["echo", "hi"],
+  "stdin_b64": "aGVsbG8=",
+  "timeout_ms": 30000
+}
+```
+
+`argv` must be non-empty; `stdin_b64` and `timeout_ms` are optional. Any `cwd` is rejected by the v1 ACL. The response carries `code`, `signal`, `duration_ms`, `stdout_b64`, `stderr_b64`, `truncated`, and `denial_reason` (null on success).
+
+### Cancel request body
+
+```json
+{"request_id":"<32-hex>","agent_id":"8a3f..."}
+```
+
+`agent_id` is optional; when omitted the local pending-session table resolves the target.
 
 ## Upgrade
 


### PR DESCRIPTION
Patch release making `SKILL.md` agent-usable. An audit found it accurate but far too thin (~16 of 128 routes) with one factual auth bug — an agent reading it was blind to the whole orchestration surface and the new tailnet feature.

### Changes
1. **Auth bug fixed.** `/health` and `/constitution*` are the only fully-public paths (not `/gui`); `/gui`, `/ws`, `/events` also accept the token via `?token=`; every other route requires the `Authorization: Bearer` header. *(Empirically confirmed: `/health`+`/constitution`→200 no-token, `/agent`→401 no-token / 200 with token.)*
2. **New v0.30.0 tailnet `/forwards`** documented with a real `ForwardAddRequest` example (`local_addr`, `peer_agent`, `target_host`, `target_port`) + GET/DELETE + CLI. Note that attestation rides relayed forwards automatically.
3. **New "Agent Orchestration (REST)" section** — code-verified examples for task-lists, stores (KV CRDT), named groups (with the `/groups` vs low-level `/mls/groups` distinction and preset-driven public-vs-encrypted messaging), presence/discovery, files, agent-card/A2A, remote exec (flagged high-risk, trust + ACL gated), and contacts CRUD.
4. **`docs/api-reference.md`** gains a Remote Exec section and `/presence/online`+`/presence/foaf`.

### Verification (the important part)
Every new example was **smoke-tested against a live v0.30.1 daemon** — request structs extracted from the handlers (not guessed), then curl'd:
- Single-node: task-lists create/add/claim, stores put/get/keys/delete, groups create/members/secure-encrypt/public-send/messages, contacts CRUD, agent-card import, presence, all GETs — **all 2xx**.
- Two-node run for peer-dependent flows: **files send→transfers→accept (200)**, **group invite→join (201/200)**, **exec/run (200 with `denial_reason:exec_disabled`, expected)**.

No documented example 404s or 400s. Peer-dependent endpoints on a single isolated node return their documented precondition (forwards 409 no-ACL, files/exec need a peer) — the bodies parse correctly; the two-node run confirms 2xx with a real peer.

Bumps version to **0.30.1** (Cargo.toml + SKILL.md frontmatter). CHANGELOG scoped accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the agent-facing documentation for the v0.30.1 release. The main changes are:

- Version metadata bumped in `Cargo.toml` and `SKILL.md`.
- Changelog entry added for v0.30.1.
- `SKILL.md` expanded with auth guidance and REST examples for orchestration endpoints.
- API reference updated for presence views and remote exec.

<h3>Confidence Score: 4/5</h3>

The docs are mostly mergeable after fixing remote exec denial semantics.

- The route and version updates are consistent with the changed documentation.
- Remote exec denials can be misread as successful runs unless the docs call out `ok: true` plus `denial_reason`.
- The issue is contained to the API reference wording.

docs/api-reference.md

<details open><summary><h3>Security Review</h3></summary>

Remote exec is security-sensitive. The new docs should make denial handling explicit because denied requests can still return HTTP 200 with `ok: true`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| SKILL.md | Updates the skill metadata and adds broad REST examples for agent orchestration. |
| docs/api-reference.md | Adds presence endpoints and remote exec docs; the remote exec denial response needs clearer handling guidance. |
| Cargo.toml | Bumps the package version to 0.30.1. |
| CHANGELOG.md | Adds the v0.30.1 documentation release entry. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/api-reference.md:611
**Denied Exec Looks Successful**

Denied exec calls return HTTP 200 with `ok: true`, so clients must treat any non-null `denial_reason` as the refusal signal. This paragraph only says the refusal is in the body and lists some denial values; a client following the usual `ok: false` error pattern can treat `exec_disabled`, ACL denial, or size/time denials as a successful command run.

```suggestion
Run a command on **another** agent's machine. Disabled by default; every request is authorized on the **responder** (target) daemon, not the caller. The target runs `argv` only if remote exec is enabled there, the sender is a verified trusted/pinned contact whose trust decision is `Accept`, and the `(agent_id, machine_id)` pair + exact argv are allow-listed in its exec ACL (`docs/exec.md`). `argv` is never shell-interpreted. A denied request still returns `200` with `ok: true` and a non-null `denial_reason` (for example `exec_disabled`, `unverified_sender`, `trust_rejected`, `agent_machine_not_in_acl`, `argv_not_allowed`, `stdin_too_large`, `timeout_too_large`, `cwd_not_allowed`, `concurrency_limit_reached`, `shell_metachar_in_argv`, `spawn_failed`, or `malformed_frame`) — callers must treat any non-null `denial_reason` as a refusal, not as a successful command run.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(skill): correct auth-exempt paths, ..."](https://github.com/saorsa-labs/x0x/commit/3b1c7a400196c20f4c803f17510d7880e60a5dde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43561819)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->