### PR TITLE
fix: close all v0.30.1 convergence-test gaps (KV ownership, restart persistence, structured claims, soak harness)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ NETWORK_TEST_REPORT.txt
 .pi/messenger/
 native-build.log
 wpa-build.log
+
+# Convergence soak harness output (daemon logs, per-run reports)
+tests/convergence/out/

--- a/README.md
+++ b/README.md
@@ -536,9 +536,14 @@ x0x routes
 For live data — chat messages, direct messages, events — use WebSocket. Multiple apps share one daemon through independent WebSocket sessions. `127.0.0.1:12700` is the default API address, but using `api.port` is more correct for named instances and custom configs.
 
 ```bash
-# Using $API and $TOKEN from the REST API section above
-wscat -c "ws://$API/ws?token=$TOKEN"         # General-purpose session
-wscat -c "ws://$API/ws/direct?token=$TOKEN"  # Auto-subscribe to direct messages
+# Using $API and $TOKEN from the REST API section above.
+# The durable token is never accepted in a URL — mint a short-lived
+# session token (10 min TTL) and pass THAT as ?token=:
+SESSION=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "http://$API/auth/session" | jq -r .session_token)
+
+wscat -c "ws://$API/ws?token=$SESSION"         # General-purpose session
+wscat -c "ws://$API/ws/direct?token=$SESSION"  # Auto-subscribe to direct messages
 ```
 
 **Subscribe to topics:**
@@ -587,18 +592,28 @@ A complete chat app in a single HTML file — serve it from `http://127.0.0.1` o
     const TOKEN = 'YOUR_TOKEN_HERE'; // inject from <data_dir>/api-token
     const TOPIC = 'my-chat-room';
     const API = 'http://127.0.0.1:12700';
-    const WS_URL = `ws://127.0.0.1:12700/ws?token=${TOKEN}`;
 
-    // Connect WebSocket
-    const ws = new WebSocket(WS_URL);
-    ws.onopen = () => ws.send(JSON.stringify({type:'subscribe', topics:[TOPIC]}));
-    ws.onmessage = (e) => {
-      const msg = JSON.parse(e.data);
-      if (msg.type === 'message') {
-        const div = document.getElementById('messages');
-        div.innerHTML += `<p><b>${msg.origin?.slice(0,8)}:</b> ${atob(msg.payload)}</p>`;
-      }
-    };
+    // WebSockets can't set an Authorization header, so exchange the durable
+    // token for a short-lived session token and pass that as ?token=
+    // (the durable token is rejected in query strings).
+    let ws;
+    (async () => {
+      const { session_token } = await fetch(`${API}/auth/session`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      }).then((r) => r.json());
+
+      // Connect WebSocket
+      ws = new WebSocket(`ws://127.0.0.1:12700/ws?token=${session_token}`);
+      ws.onopen = () => ws.send(JSON.stringify({type:'subscribe', topics:[TOPIC]}));
+      ws.onmessage = (e) => {
+        const msg = JSON.parse(e.data);
+        if (msg.type === 'message') {
+          const div = document.getElementById('messages');
+          div.innerHTML += `<p><b>${msg.origin?.slice(0,8)}:</b> ${atob(msg.payload)}</p>`;
+        }
+      };
+    })();
 
     // Send via REST
     function send() {

--- a/SKILL.md
+++ b/SKILL.md
@@ -185,9 +185,11 @@ x0x agent
 x0x subscribe hello-world
 x0x publish hello-world "Hello!"
 
-# REST API auth: /health and /constitution* are public; /gui, /ws, /events
-# accept the token via ?token=; every other route requires the
-# Authorization: Bearer header shown below.
+# REST API auth: /health and /constitution* are public; every other route
+# requires the Authorization: Bearer header shown below. Browser endpoints
+# (/gui, /ws, /ws/direct, /events, /direct/events) also accept
+# ?token=<session_token> — but ONLY a short-lived session token minted via
+# POST /auth/session (the durable api-token is never accepted in a URL).
 DATA_DIR="$HOME/Library/Application Support/x0x"   # macOS
 # DATA_DIR="$HOME/.local/share/x0x"                # Linux
 API=$(cat "$DATA_DIR/api.port")
@@ -246,11 +248,17 @@ curl -X POST "http://$API/mls/groups/GROUP_ID/encrypt" \
 For real-time bidirectional communication, use WebSocket instead of REST+SSE:
 
 ```bash
+# Mint a short-lived session token first — the durable api-token is
+# rejected in query strings (Bearer header only). Sessions expire after
+# 10 minutes ({"session_token": "...", "expires_in": 600}).
+SESSION=$(curl -s -X POST "http://$API/auth/session" \
+  -H "Authorization: Bearer $TOKEN" | jq -r .session_token)
+
 # Connect (general purpose)
-wscat -c "ws://$API/ws?token=$TOKEN"
+wscat -c "ws://$API/ws?token=$SESSION"
 
 # Connect with auto-subscribe to direct messages
-wscat -c "ws://$API/ws/direct?token=$TOKEN"
+wscat -c "ws://$API/ws/direct?token=$SESSION"
 
 # Check active sessions
 curl -H "Authorization: Bearer $TOKEN" "http://$API/ws/sessions"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -579,6 +579,16 @@ or
 }
 ```
 
+### Store write authorization
+
+Stores default to the `Signed` policy: only the creating agent (the owner)
+may write. `PUT` and `DELETE` on `/stores/:id/:key` return **403** with
+`{"ok":false,"error":"not authorized: store policy is signed; owner is <hex>"}`
+when this daemon's agent is not authorized — including on a joined replica
+that has not yet learned the store's authoritative owner from the
+owner-signed announcement (`"not authorized: store owner unknown: ..."`).
+Reads are always allowed.
+
 ## File transfers
 
 | Method | Endpoint | CLI | Purpose |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -558,6 +558,50 @@ or
 {"action":"complete"}
 ```
 
+### Task versions, structured claim fields, and optimistic concurrency
+
+Every task-list response carries the list's `version` — a counter bumped on
+each local or merged mutation. Mutation responses (create list, add task,
+claim, complete) return:
+
+```json
+{"ok":true,"version":7,"committed":"local"}
+```
+
+`"committed":"local"` is explicit about the consistency model: success means
+the mutation was committed to the **local** CRDT replica and a delta was
+published to peers — it does NOT mean any peer has observed it yet.
+Replication is eventual (gossip anti-entropy).
+
+Each task in `GET /task-lists/:id/tasks` includes structured ownership fields
+alongside the legacy `state` string (unchanged for backward compatibility):
+
+- `claimed_by` / `claimed_at` — hex AgentId and Unix-ms timestamp of the
+  deterministic claim winner (the OR-Set resolution both replicas converge
+  to). Non-null once claimed; `claimed_by` survives completion.
+- `completed_by` / `completed_at` — same, for the winning completion; null
+  unless done.
+- `assignee` — hex AgentId from the task's LWW assignee register, now
+  populated by claim/complete (was previously always null).
+
+The update-task request accepts an optional `expected_version` for
+compare-and-set semantics (honored for both `claim` and `complete`):
+
+```json
+{"action":"claim","expected_version":7}
+```
+
+If `expected_version` does not match the list's current version, nothing is
+mutated and the daemon returns **409 Conflict**:
+
+```json
+{"ok":false,"error":"version conflict","current_version":9}
+```
+
+Without `expected_version`, behavior is unchanged: concurrent claims from two
+agents both return 200, and the CRDT merge deterministically resolves a
+single winner (`claimed_by`) after convergence.
+
 ## Key-value stores
 
 | Method | Endpoint | CLI | Purpose |

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -22,7 +22,7 @@ For named instances (`x0xd --name alice`), the directory is `x0x-alice/` instead
 
 ## Authentication
 
-All API endpoints (except `/health` and `/gui`) require a bearer token:
+All API endpoints (except `/health` and `/constitution*`) require a bearer token:
 
 ```
 Authorization: Bearer <token>
@@ -30,10 +30,13 @@ Authorization: Bearer <token>
 
 The token is generated once on first daemon startup and persists across restarts. It's stored at `<data_dir>/api-token` with 0600 permissions (owner read/write only).
 
-WebSocket connections pass the token as a query parameter since browsers cannot set custom headers on WebSocket upgrades:
+WebSocket connections pass a token as a query parameter since browsers cannot set custom headers on WebSocket upgrades — but the durable API token is **never** accepted in a URL. Exchange it for a short-lived session token (10 min TTL) via `POST /auth/session` and pass that instead:
 
 ```
-ws://127.0.0.1:12700/ws?token=<token>
+POST /auth/session            (Authorization: Bearer <durable token>)
+  → {"session_token": "...", "expires_in": 600}
+
+ws://127.0.0.1:12700/ws?token=<session_token>
 ```
 
 ## Quick Start Examples
@@ -109,8 +112,13 @@ const headers = { Authorization: `Bearer ${apiToken}` };
 const agent = await fetch(`${base}/agent`, { headers }).then((r) => r.json());
 console.log(`Agent ID: ${agent.agent_id}`);
 
-// WebSocket with token
-const ws = new WebSocket(`ws://${apiAddr}/ws?token=${apiToken}`);
+// WebSocket: mint a short-lived session token — the durable token
+// is rejected in query strings.
+const { session_token } = await fetch(`${base}/auth/session`, {
+  method: "POST",
+  headers,
+}).then((r) => r.json());
+const ws = new WebSocket(`ws://${apiAddr}/ws?token=${session_token}`);
 ws.onmessage = (e) => console.log(JSON.parse(e.data));
 ws.onopen = () => {
   ws.send(JSON.stringify({ type: "subscribe", topics: ["my-app/events"] }));

--- a/docs/primers/apps.md
+++ b/docs/primers/apps.md
@@ -60,10 +60,15 @@ Avoid hardcoding `127.0.0.1:12700`. Use `api.port` and `api-token` from the data
 </html>
 ```
 
-For real-time features:
+For real-time features, exchange the durable token for a short-lived session token first — `?token=` only accepts session tokens minted via `POST /auth/session`, never the durable api-token:
 
 ```javascript
-const ws = new WebSocket(`ws://127.0.0.1:12700/ws?token=${TOKEN}`);
+const { session_token } = await fetch(`${apiBase}/auth/session`, {
+  method: "POST",
+  headers: { Authorization: `Bearer ${token}` }
+}).then((r) => r.json());
+
+const ws = new WebSocket(`ws://127.0.0.1:12700/ws?token=${session_token}`);
 
 ws.onopen = () => {
   ws.send(JSON.stringify({

--- a/docs/primers/messaging.md
+++ b/docs/primers/messaging.md
@@ -141,11 +141,11 @@ Important: direct events do not currently include `verified` or `trust_level`. T
 
 ## WebSocket for apps
 
-For browser or app UIs, use the WebSocket endpoints with the token in the query string:
+For browser or app UIs, use the WebSocket endpoints with a token in the query string. Only a short-lived session token is accepted there — mint one with `POST /auth/session` (durable Bearer token required; returns `{"session_token": "...", "expires_in": 600}`). The durable api-token is never valid in a URL:
 
 ```text
-ws://127.0.0.1:12700/ws?token=<TOKEN>
-ws://127.0.0.1:12700/ws/direct?token=<TOKEN>
+ws://127.0.0.1:12700/ws?token=<SESSION_TOKEN>
+ws://127.0.0.1:12700/ws/direct?token=<SESSION_TOKEN>
 ```
 
 Client messages:

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -19,7 +19,7 @@ The apps connect to `http://localhost:12700` by default. To target another daemo
 x0x-chat.html?api=http://127.0.0.1:51555&token=<api-token>
 ```
 
-The apps remember those values in `localStorage` as `x0x.apiBase` and `x0x.apiToken`. WebSocket apps derive their `ws://.../ws?token=...` endpoint from the configured API base.
+The apps remember those values in `localStorage` as `x0x.apiBase` and `x0x.apiToken`. WebSocket apps exchange the durable token for a short-lived session token (`POST /auth/session`) on every connection attempt, then connect to `ws://.../ws?token=<session_token>` — the durable token never appears in a URL.
 
 When using an authenticated daemon from a browser, serve these files from a loopback HTTP origin so the daemon CORS policy can allow the request:
 

--- a/examples/apps/x0x-chat.html
+++ b/examples/apps/x0x-chat.html
@@ -137,7 +137,19 @@ const API_URL = (CONFIG.get("api") || localStorage.getItem("x0x.apiBase") || "ht
 const API_TOKEN = CONFIG.get("token") || localStorage.getItem("x0x.apiToken") || "";
 if (CONFIG.get("api")) localStorage.setItem("x0x.apiBase", API_URL);
 if (CONFIG.get("token")) localStorage.setItem("x0x.apiToken", API_TOKEN);
-const WS_URL = API_URL.replace(/^http/, "ws") + "/ws" + (API_TOKEN ? "?token=" + encodeURIComponent(API_TOKEN) : "");
+const WS_BASE = API_URL.replace(/^http/, "ws") + "/ws";
+// The durable token must never appear in a URL; exchange it for a short-lived
+// session token (POST /auth/session) each time the WebSocket is opened.
+async function wsUrl() {
+  if (!API_TOKEN) return WS_BASE;
+  const res = await fetch(API_URL + "/auth/session", {
+    method: "POST",
+    headers: { "Authorization": "Bearer " + API_TOKEN },
+  });
+  if (!res.ok) throw new Error("session mint failed: " + res.status);
+  const body = await res.json();
+  return WS_BASE + "?token=" + encodeURIComponent(body.session_token);
+}
 
 const DEFAULT_ROOM = "x0x-chat/general";
 const RECONNECT_MS = 3000;
@@ -209,9 +221,11 @@ function subscribe(topic) {
   subscribedTopics.add(topic);
 }
 
-function connect() {
+async function connect() {
   setStatus(false, "Connecting…");
-  try { ws = new WebSocket(WS_URL); } catch { scheduleReconnect(); return; }
+  let url;
+  try { url = await wsUrl(); } catch { scheduleReconnect(); return; }
+  try { ws = new WebSocket(url); } catch { scheduleReconnect(); return; }
 
   ws.onmessage = function (ev) {
     let msg; try { msg = JSON.parse(ev.data); } catch { return; }

--- a/examples/apps/x0x-swarm.html
+++ b/examples/apps/x0x-swarm.html
@@ -96,7 +96,19 @@ const API_URL = (CONFIG.get("api") || localStorage.getItem("x0x.apiBase") || "ht
 const API_TOKEN = CONFIG.get("token") || localStorage.getItem("x0x.apiToken") || "";
 if (CONFIG.get("api")) localStorage.setItem("x0x.apiBase", API_URL);
 if (CONFIG.get("token")) localStorage.setItem("x0x.apiToken", API_TOKEN);
-const WS_URL = API_URL.replace(/^http/, "ws") + "/ws" + (API_TOKEN ? "?token=" + encodeURIComponent(API_TOKEN) : "");
+const WS_BASE = API_URL.replace(/^http/, "ws") + "/ws";
+// The durable token must never appear in a URL; exchange it for a short-lived
+// session token (POST /auth/session) each time the WebSocket is opened.
+async function wsUrl() {
+  if (!API_TOKEN) return WS_BASE;
+  const res = await fetch(API_URL + "/auth/session", {
+    method: "POST",
+    headers: { "Authorization": "Bearer " + API_TOKEN },
+  });
+  if (!res.ok) throw new Error("session mint failed: " + res.status);
+  const body = await res.json();
+  return WS_BASE + "?token=" + encodeURIComponent(body.session_token);
+}
 
 let ws = null, connected = false, myAgentId = null, sessionId = null, taskListId = null;
 let myTasks = [], feedEvents = [], agents = new Map(), taskMap = new Map();
@@ -168,9 +180,11 @@ async function ensureTaskList() {
   } catch (e) { console.warn("Could not create task list", e); }
 }
 
-function connectWs() {
+async function connectWs() {
   if (ws) try { ws.close(); } catch (e) { /* ignore */ }
-  ws = new WebSocket(WS_URL);
+  let url;
+  try { url = await wsUrl(); } catch (e) { setStatus(false, "Auth failed"); return; }
+  ws = new WebSocket(url);
   ws.onopen = () => {
     setStatus(false, "Subscribing");
   };

--- a/justfile
+++ b/justfile
@@ -108,3 +108,17 @@ bump-version VERSION:
 
 release-dryrun:
     bash scripts/release-dryrun.sh
+
+# ── Convergence soak (tests/convergence) ──────────────────────────────────
+
+# Full soak: repeat the 3-node convergence scenario (cold-join, live
+# propagation, restart recovery, concurrent claims, signed-store non-owner
+# write) with per-phase gossip-diagnostics deltas. Requires a release x0xd
+# (cargo build --release --bin x0xd) or X0XD_TEST_BINARY.
+# Usage: just convergence-soak [RUNS]
+convergence-soak RUNS="10":
+    python3 tests/convergence/convergence_soak.py --runs {{RUNS}}
+
+# Single-run smoke of the convergence harness (same phases, one pass).
+convergence-soak-quick:
+    python3 tests/convergence/convergence_soak.py --runs 1

--- a/src/crdt/task_item.rs
+++ b/src/crdt/task_item.rs
@@ -165,6 +165,12 @@ impl TaskItem {
     /// Adds a Claimed state to the OR-Set. If multiple agents claim concurrently,
     /// all claims are recorded, and the earliest timestamp wins as the "current" state.
     ///
+    /// Also sets the `assignee` LWW register to the claiming agent, so the
+    /// task's assignee is observable without parsing the checkbox state.
+    /// Under truly concurrent claims the LWW register may resolve to either
+    /// claimer; the authoritative winner is [`TaskItem::claim_record`], which
+    /// derives deterministically from the OR-Set.
+    ///
     /// # Arguments
     ///
     /// * `agent_id` - The agent claiming this task
@@ -216,6 +222,11 @@ impl TaskItem {
             .add(claimed_state, tag)
             .map_err(|e| CrdtError::Merge(format!("Failed to add claimed state: {}", e)))?;
 
+        // Mirror the claim into the assignee LWW register so the assignee is
+        // directly observable (same timestamp source as update_assignee: the
+        // register's own vector clock keyed by peer_id).
+        self.assignee.set(Some(agent_id), peer_id);
+
         Ok(())
     }
 
@@ -223,6 +234,10 @@ impl TaskItem {
     ///
     /// Adds a Done state to the OR-Set. If multiple agents complete concurrently,
     /// the earliest completion wins.
+    ///
+    /// Also sets the `assignee` LWW register to the completing agent
+    /// (mirroring [`TaskItem::claim`]). The authoritative completer is
+    /// [`TaskItem::completion_record`], derived from the OR-Set.
     ///
     /// # Arguments
     ///
@@ -287,6 +302,9 @@ impl TaskItem {
         self.checkbox
             .add(done_state, tag)
             .map_err(|e| CrdtError::Merge(format!("Failed to add done state: {}", e)))?;
+
+        // Mirror the completion into the assignee LWW register (see claim).
+        self.assignee.set(Some(agent_id), peer_id);
 
         Ok(())
     }
@@ -399,6 +417,59 @@ impl TaskItem {
 
         // Otherwise empty
         CheckboxState::Empty
+    }
+
+    /// The winning claim record, if this task has ever been claimed.
+    ///
+    /// Resolves the OR-Set's `Claimed` entries to a single deterministic
+    /// winner (earliest timestamp, `CheckboxState` ordering as tiebreaker) —
+    /// the same resolution [`TaskItem::current_state`] uses. Unlike
+    /// `current_state`, the claim record remains available after the task
+    /// transitions to Done.
+    ///
+    /// # Returns
+    ///
+    /// `Some((agent_id, timestamp_ms))` for the winning claim, or `None` if
+    /// the task was never claimed.
+    #[must_use]
+    pub fn claim_record(&self) -> Option<(AgentId, u64)> {
+        self.checkbox
+            .elements()
+            .into_iter()
+            .filter(|s| s.is_claimed())
+            .min()
+            .and_then(|s| match s {
+                CheckboxState::Claimed {
+                    agent_id,
+                    timestamp,
+                } => Some((*agent_id, *timestamp)),
+                _ => None,
+            })
+    }
+
+    /// The winning completion record, if this task has been completed.
+    ///
+    /// Resolves the OR-Set's `Done` entries to a single deterministic winner
+    /// (earliest timestamp, `CheckboxState` ordering as tiebreaker).
+    ///
+    /// # Returns
+    ///
+    /// `Some((agent_id, timestamp_ms))` for the winning completion, or `None`
+    /// if the task is not done.
+    #[must_use]
+    pub fn completion_record(&self) -> Option<(AgentId, u64)> {
+        self.checkbox
+            .elements()
+            .into_iter()
+            .filter(|s| s.is_done())
+            .min()
+            .and_then(|s| match s {
+                CheckboxState::Done {
+                    agent_id,
+                    timestamp,
+                } => Some((*agent_id, *timestamp)),
+                _ => None,
+            })
     }
 
     /// Merge another TaskItem into this one.
@@ -768,6 +839,87 @@ mod tests {
             CrdtError::Merge(_) => {}
             _ => panic!("Expected Merge error"),
         }
+    }
+
+    // ── Structured claim/completion semantics (task-claim API fix) ─────────
+    //
+    // WHY: the REST API used to return bare {"ok":true} on claim and the
+    // assignee register stayed None forever — ownership was only recoverable
+    // by parsing the Display string "claimed:<hex>". These tests pin the
+    // contract that claim/complete populate the assignee register and that
+    // the OR-Set winner (claim_record) is deterministic across replicas.
+
+    #[test]
+    fn claim_populates_assignee_register() {
+        let peer = peer(1);
+        let claimer = agent(7);
+        let mut task = make_task(peer);
+        assert_eq!(task.assignee(), None, "precondition: unassigned");
+
+        task.claim(claimer, peer, 1).ok().unwrap();
+
+        assert_eq!(
+            task.assignee(),
+            Some(&claimer),
+            "claim must set the assignee register — clients read assignee, not Display strings"
+        );
+        let (by, at) = task.claim_record().expect("claim record exists");
+        assert_eq!(by, claimer);
+        assert!(at > 1_000_000_000_000, "claimed_at is Unix ms");
+    }
+
+    #[test]
+    fn concurrent_claims_converge_to_same_winner_on_both_replicas() {
+        let peer1 = peer(1);
+        let peer2 = peer(2);
+        let agent1 = agent(1);
+        let agent2 = agent(2);
+
+        let mut replica_a = make_task(peer1);
+        let mut replica_b = make_task(peer1);
+
+        // Two agents claim "successfully" on their own replicas.
+        replica_a.claim(agent1, peer1, 100).ok().unwrap();
+        replica_b.claim(agent2, peer2, 200).ok().unwrap();
+
+        // Full state exchange (order differs per replica).
+        let a_before = replica_a.clone();
+        replica_a.merge(&replica_b).ok().unwrap();
+        replica_b.merge(&a_before).ok().unwrap();
+
+        // Both replicas must agree on a SINGLE winner — this is the CAS-free
+        // conflict signal: exactly one agent owns the task after convergence.
+        let (winner_a, ts_a) = replica_a.claim_record().expect("winner on A");
+        let (winner_b, ts_b) = replica_b.claim_record().expect("winner on B");
+        assert_eq!(winner_a, winner_b, "replicas disagree on claim winner");
+        assert_eq!(ts_a, ts_b);
+
+        // And claimed_by derived from current_state matches that winner.
+        let state = replica_a.current_state();
+        assert_eq!(state.claimed_by(), Some(&winner_a));
+    }
+
+    #[test]
+    fn complete_sets_completion_record_and_assignee() {
+        let peer = peer(1);
+        let claimer = agent(1);
+        let completer = agent(2);
+        let mut task = make_task(peer);
+
+        task.claim(claimer, peer, 1).ok().unwrap();
+        task.complete(completer, peer, 2).ok().unwrap();
+
+        let (done_by, done_at) = task.completion_record().expect("completion record");
+        assert_eq!(done_by, completer);
+        assert!(done_at > 1_000_000_000_000, "completed_at is Unix ms");
+        assert_eq!(
+            task.assignee(),
+            Some(&completer),
+            "complete mirrors the completer into the assignee register"
+        );
+        // The original claim record survives the transition to Done.
+        let (claimed_by, _) = task.claim_record().expect("claim record survives Done");
+        assert_eq!(claimed_by, claimer);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,15 @@ pub enum IdentityError {
     /// (issuer-revocation). Third-party revocation is never accepted.
     #[error("revocation rejected: {0}")]
     Revocation(String),
+
+    /// A local write was rejected by a replicated store's access policy.
+    ///
+    /// Raised when this agent attempts to mutate a `Signed`/`Allowlisted`
+    /// KV store it is not authorized to write to, or a joined replica whose
+    /// authoritative owner is not yet known (fail closed). The API layer
+    /// maps this to HTTP 403.
+    #[error("not authorized: {0}")]
+    Unauthorized(String),
 }
 
 /// Standard Result type for x0x identity operations.

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -42,6 +42,14 @@ pub enum KvError {
     /// Unauthorized write attempt.
     #[error("unauthorized: {0}")]
     Unauthorized(String),
+
+    /// The store's authoritative owner is not yet known.
+    ///
+    /// A joined replica starts with no owner and learns it from an
+    /// owner-signed announcement on the state-sync channel. Until then,
+    /// policy-restricted writes are rejected (fail closed).
+    #[error("store owner unknown: store is read-only until the authoritative owner is learned")]
+    OwnerUnknown,
 }
 
 #[cfg(test)]

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -158,6 +158,28 @@ impl KvStore {
         }
     }
 
+    /// Create a joined replica of a store whose authoritative owner is not
+    /// yet known.
+    ///
+    /// The replica starts with the default `Signed` policy and `owner: None`,
+    /// which fails closed: no local or inbound policy-restricted write is
+    /// accepted until [`learn_ownership`](Self::learn_ownership) installs the
+    /// authoritative owner and policy from an owner-signed announcement.
+    #[must_use]
+    pub fn new_replica(id: KvStoreId, name: String) -> Self {
+        Self {
+            id,
+            keys: OrSet::new(),
+            entries: HashMap::new(),
+            name: LwwRegister::new(name),
+            policy: AccessPolicy::Signed,
+            owner: None,
+            allowed_writers: HashSet::new(),
+            version: 0,
+            seq_counter: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
     /// Get the next monotonically-increasing sequence number.
     pub fn next_seq(&self) -> u64 {
         self.seq_counter.fetch_add(1, Ordering::Relaxed) + 1
@@ -240,6 +262,84 @@ impl KvStore {
                 // the secure sync path once wired.
                 true
             }
+        }
+    }
+
+    /// Check that `writer` may perform a local mutation on this store.
+    ///
+    /// This is the local-write counterpart of the inbound check in
+    /// [`merge_delta`](Self::merge_delta): the same
+    /// [`is_authorized`](Self::is_authorized) rule is applied before a local
+    /// put/remove mutates the replica, so an unauthorized local write can
+    /// never fork
+    /// the replica away from what authorized peers accept.
+    ///
+    /// # Errors
+    ///
+    /// - [`KvError::OwnerUnknown`] if the store has a policy-restricted
+    ///   (`Signed`/`Allowlisted`) policy but its authoritative owner has not
+    ///   been learned yet (a freshly joined replica). Fail closed.
+    /// - [`KvError::Unauthorized`] if `writer` is not authorized under the
+    ///   store's policy.
+    pub fn authorize_local_write(&self, writer: &AgentId) -> Result<()> {
+        if matches!(self.policy, AccessPolicy::Encrypted { .. }) {
+            // Matches the inbound path: the reserved Encrypted policy is
+            // currently permissive at the store layer.
+            return Ok(());
+        }
+        let Some(owner) = self.owner.as_ref() else {
+            return Err(KvError::OwnerUnknown);
+        };
+        if !self.is_authorized(writer) {
+            return Err(KvError::Unauthorized(format!(
+                "store policy is {}; owner is {}",
+                self.policy,
+                hex::encode(owner.as_bytes())
+            )));
+        }
+        Ok(())
+    }
+
+    /// Install the authoritative owner and policy learned from an
+    /// owner-signed announcement.
+    ///
+    /// `verified_sender` is the cryptographically verified identity of the
+    /// peer that published the announcement (the pub/sub layer verifies the
+    /// ML-DSA-65 signature before delivery). Ownership claims are only
+    /// accepted when the sender claims *itself* as owner, so no third party
+    /// can assign ownership. Once an owner is established it is immutable;
+    /// the established owner may still refresh the policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns `KvError::Unauthorized` if `verified_sender` differs from the
+    /// claimed `owner`, or if a different owner is already established.
+    pub fn learn_ownership(
+        &mut self,
+        owner: AgentId,
+        policy: AccessPolicy,
+        verified_sender: &AgentId,
+    ) -> Result<()> {
+        if *verified_sender != owner {
+            return Err(KvError::Unauthorized(
+                "ownership announcement sender does not match claimed owner".to_string(),
+            ));
+        }
+        match self.owner {
+            None => {
+                self.owner = Some(owner);
+                self.policy = policy;
+                self.version += 1;
+                Ok(())
+            }
+            Some(existing) if existing == owner => {
+                self.policy = policy;
+                self.version += 1;
+                Ok(())
+            }
+            Some(_) => Err(KvError::Unauthorized(
+                "store owner already established; conflicting ownership claim rejected".to_string(),
+            )),
         }
     }
 
@@ -379,7 +479,7 @@ impl KvStore {
         // Access control: reject unauthorized writes
         if let Some(writer_id) = writer {
             if !self.is_authorized(writer_id) {
-                tracing::debug!(
+                tracing::warn!(
                     "rejected delta from unauthorized writer {} for store {}",
                     hex::encode(writer_id.as_bytes()),
                     self.id
@@ -393,7 +493,7 @@ impl KvStore {
             match &self.policy {
                 AccessPolicy::Encrypted { .. } => {} // OK
                 _ => {
-                    tracing::debug!(
+                    tracing::warn!(
                         "rejected anonymous delta for non-encrypted store {}",
                         self.id
                     );
@@ -916,6 +1016,149 @@ mod tests {
             .merge_delta(&delta, peer(99), None)
             .expect("silent rejection");
         assert!(store.get("anon").is_none());
+    }
+
+    // -- Local write authorization (fail closed) --
+    //
+    // WHY: a non-owner joiner that mutates its local replica creates a fork
+    // the owner's replica rejects — the local path must enforce the same
+    // policy as the inbound path.
+
+    #[test]
+    fn test_local_write_owner_authorized_on_signed_store() {
+        let owner = agent(1);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        store
+            .authorize_local_write(&owner)
+            .expect("owner must be able to write locally");
+    }
+
+    #[test]
+    fn test_local_write_non_owner_rejected_on_signed_store() {
+        let owner = agent(1);
+        let joiner = agent(2);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let err = store
+            .authorize_local_write(&joiner)
+            .expect_err("non-owner local write must be rejected, not silently applied");
+        assert!(matches!(err, KvError::Unauthorized(_)));
+        assert!(
+            format!("{err}").contains(&hex::encode(owner.as_bytes())),
+            "rejection must name the true owner so the caller can tell why"
+        );
+    }
+
+    #[test]
+    fn test_local_write_rejected_while_owner_unknown() {
+        // A joined replica must be read-only until the authoritative owner
+        // is learned — otherwise the joiner writes into a fork.
+        let joiner = agent(2);
+        let store = KvStore::new_replica(store_id(1), String::new());
+        assert!(
+            store.owner().is_none(),
+            "joined replica must not claim an owner"
+        );
+        let err = store
+            .authorize_local_write(&joiner)
+            .expect_err("write on unknown-owner store must fail closed");
+        assert!(matches!(err, KvError::OwnerUnknown));
+    }
+
+    #[test]
+    fn test_replica_rejects_inbound_deltas_until_owner_learned() {
+        // Fail closed on the inbound side too: without a known owner there
+        // is no authorized writer, so nothing merges.
+        let mut store = KvStore::new_replica(store_id(1), String::new());
+        let entry = KvEntry::new("k".to_string(), b"v".to_vec(), "text/plain".to_string());
+        let delta = KvStoreDelta::for_put("k".to_string(), entry, (peer(9), 1), 1);
+        store
+            .merge_delta(&delta, peer(9), Some(&agent(9)))
+            .expect("silent rejection");
+        assert!(store.get("k").is_none());
+    }
+
+    // -- learn_ownership: owner-signed metadata adoption --
+
+    #[test]
+    fn test_learn_ownership_requires_sender_to_be_claimed_owner() {
+        // A third party must not be able to assign ownership of a store —
+        // only a verified sender claiming itself is trusted.
+        let mut store = KvStore::new_replica(store_id(1), String::new());
+        let owner = agent(1);
+        let rogue = agent(9);
+        let err = store
+            .learn_ownership(owner, AccessPolicy::Signed, &rogue)
+            .expect_err("third-party ownership claim must be rejected");
+        assert!(matches!(err, KvError::Unauthorized(_)));
+        assert!(store.owner().is_none());
+    }
+
+    #[test]
+    fn test_learn_ownership_then_policy_enforced_both_paths() {
+        // After adoption: the joiner still cannot write locally, and the
+        // owner's deltas merge while a non-owner's are rejected.
+        let owner = agent(1);
+        let joiner = agent(2);
+        let mut store = KvStore::new_replica(store_id(1), String::new());
+        store
+            .learn_ownership(owner, AccessPolicy::Signed, &owner)
+            .expect("owner self-claim adopted");
+        assert_eq!(store.owner(), Some(&owner));
+        assert_eq!(*store.policy(), AccessPolicy::Signed);
+
+        // Local write by the joiner: still rejected.
+        assert!(matches!(
+            store.authorize_local_write(&joiner),
+            Err(KvError::Unauthorized(_))
+        ));
+
+        // Inbound owner delta: accepted.
+        let entry = KvEntry::new("ok".to_string(), b"v".to_vec(), "text/plain".to_string());
+        let delta = KvStoreDelta::for_put("ok".to_string(), entry, (peer(1), 1), 1);
+        store
+            .merge_delta(&delta, peer(1), Some(&owner))
+            .expect("owner delta merges");
+        assert!(store.get("ok").is_some());
+
+        // Inbound non-owner delta: rejected.
+        let entry = KvEntry::new("bad".to_string(), b"x".to_vec(), "text/plain".to_string());
+        let delta = KvStoreDelta::for_put("bad".to_string(), entry, (peer(2), 1), 2);
+        store
+            .merge_delta(&delta, peer(2), Some(&joiner))
+            .expect("silent rejection");
+        assert!(store.get("bad").is_none());
+    }
+
+    #[test]
+    fn test_learn_ownership_owner_is_immutable_once_established() {
+        // First verified claim wins; a later conflicting claim cannot hijack
+        // the replica.
+        let owner = agent(1);
+        let hijacker = agent(9);
+        let mut store = KvStore::new_replica(store_id(1), String::new());
+        store
+            .learn_ownership(owner, AccessPolicy::Signed, &owner)
+            .expect("adopt owner");
+        let err = store
+            .learn_ownership(hijacker, AccessPolicy::Signed, &hijacker)
+            .expect_err("conflicting ownership claim must be rejected");
+        assert!(matches!(err, KvError::Unauthorized(_)));
+        assert_eq!(store.owner(), Some(&owner));
+    }
+
+    #[test]
+    fn test_local_write_encrypted_policy_stays_permissive() {
+        // The reserved Encrypted policy is permissive at the store layer on
+        // the inbound path; the local path must match it, not diverge.
+        let store = KvStore::new(
+            store_id(1),
+            "Test".to_string(),
+            agent(1),
+            AccessPolicy::Encrypted { group_id: vec![1] },
+        );
+        store
+            .authorize_local_write(&agent(9))
+            .expect("encrypted policy is permissive at the store layer");
     }
 
     #[test]

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -5,6 +5,8 @@
 
 use crate::gossip::wire::{decode_delta, encode_delta};
 use crate::gossip::PubSubManager;
+use crate::identity::AgentId;
+use crate::kv::store::AccessPolicy;
 use crate::kv::{KvStore, KvStoreDelta, Result};
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
@@ -24,11 +26,31 @@ const STATE_SYNC_TOPIC_SUFFIX: &str = "/state-sync";
 const STATE_REQUEST_RETRY_SECS: [u64; 4] = [1, 5, 15, 30];
 
 /// Message exchanged on the state-sync side topic.
+///
+/// Wire compatibility: `StateRequest` keeps its variant index and shape, so
+/// v0.30.1 peers decode it unchanged. Older peers receiving the newer
+/// `OwnerAnnounce` variant fail to deserialize it and skip the message
+/// (their receive loop tolerates undecodable payloads), so the addition is
+/// purely additive.
 #[derive(Debug, Serialize, Deserialize)]
 enum KvSyncMessage {
     /// A peer with no local state for the store asks holders to republish
     /// their full state (as a regular delta) on the main topic.
     StateRequest { requester: PeerId },
+    /// The store owner's self-attestation of the store's authoritative
+    /// metadata, published in response to a `StateRequest`.
+    ///
+    /// Trust model: the pub/sub layer verifies the ML-DSA-65 signature of
+    /// every delivered v2 message and exposes the verified sender `AgentId`.
+    /// Receivers accept this announcement only when that verified sender IS
+    /// the claimed `owner` — an owner can only attest to its own stores, and
+    /// no third party can assign ownership.
+    OwnerAnnounce {
+        /// The owning agent (must equal the verified message sender).
+        owner: AgentId,
+        /// The store's access policy as set by the owner.
+        policy: AccessPolicy,
+    },
 }
 
 /// Synchronization wrapper for a KvStore.
@@ -48,6 +70,11 @@ pub struct KvStoreSync {
     /// This node's gossip peer id — identifies our deltas and state
     /// requests on the wire.
     local_peer_id: PeerId,
+
+    /// This node's agent id, when known. Used to decide whether this node
+    /// is the store owner (and should answer state requests with an
+    /// [`KvSyncMessage::OwnerAnnounce`]) and to ignore its own announces.
+    local_agent_id: Option<AgentId>,
 }
 
 impl KvStoreSync {
@@ -59,11 +86,15 @@ impl KvStoreSync {
     /// * `pubsub` - Pub/sub manager for gossip messaging.
     /// * `topic` - Topic name for pub/sub.
     /// * `local_peer_id` - This node's gossip peer id.
+    /// * `local_agent_id` - This node's agent id, if available. Required for
+    ///   the owner to answer state requests with an ownership announcement;
+    ///   `None` disables announcing (joined replicas can still adopt).
     pub fn new(
         store: KvStore,
         pubsub: Arc<PubSubManager>,
         topic: String,
         local_peer_id: PeerId,
+        local_agent_id: Option<AgentId>,
     ) -> Result<Self> {
         let store = Arc::new(RwLock::new(store));
 
@@ -72,6 +103,7 @@ impl KvStoreSync {
             pubsub,
             topic,
             local_peer_id,
+            local_agent_id,
         })
     }
 
@@ -133,41 +165,116 @@ impl KvStoreSync {
             }
         }));
 
-        // Responder: holders with non-empty state answer StateRequests by
-        // republishing their full state as a regular delta on the main
-        // topic. CRDT merge makes duplicate responses from multiple
-        // holders harmless (idempotent), so no response suppression is
-        // needed at current mesh sizes.
+        // Responder + ownership listener on the state-sync side topic.
+        //
+        // StateRequest: holders with non-empty state answer by republishing
+        // their full state as a regular delta on the main topic. CRDT merge
+        // makes duplicate responses from multiple holders harmless
+        // (idempotent), so no response suppression is needed at current mesh
+        // sizes. Additionally, if this node is the store OWNER it publishes
+        // an OwnerAnnounce (regardless of emptiness) so joined replicas can
+        // learn the authoritative owner and policy.
+        //
+        // OwnerAnnounce: a replica with an unknown owner adopts the owner
+        // and policy — but only when the announcement's pub/sub-verified
+        // sender is the claimed owner itself (see KvSyncMessage docs).
         let mut sync_sub = self.pubsub.subscribe(self.state_sync_topic()).await;
         let responder_store = Arc::clone(&self.store);
         let responder_pubsub = Arc::clone(&self.pubsub);
         let responder_topic = self.topic.clone();
+        let sync_topic = self.state_sync_topic();
         let local_peer_id = self.local_peer_id;
+        let local_agent_id = self.local_agent_id;
         spawn(Box::pin(async move {
             while let Some(msg) = sync_sub.recv().await {
-                let Ok(KvSyncMessage::StateRequest { requester }) =
-                    bincode::deserialize::<KvSyncMessage>(&msg.payload)
-                else {
+                let Ok(sync_msg) = bincode::deserialize::<KvSyncMessage>(&msg.payload) else {
                     continue;
                 };
-                if requester == local_peer_id {
-                    continue;
-                }
-                let full = {
-                    let s = responder_store.read().await;
-                    if s.is_empty() {
-                        continue;
+                match sync_msg {
+                    KvSyncMessage::StateRequest { requester } => {
+                        if requester == local_peer_id {
+                            continue;
+                        }
+                        // Owner: announce authoritative metadata so the
+                        // requester can adopt owner + policy.
+                        let announce = {
+                            let s = responder_store.read().await;
+                            match (local_agent_id, s.owner()) {
+                                (Some(me), Some(owner)) if me == *owner => {
+                                    Some(KvSyncMessage::OwnerAnnounce {
+                                        owner: me,
+                                        policy: s.policy().clone(),
+                                    })
+                                }
+                                _ => None,
+                            }
+                        };
+                        if let Some(announce) = announce {
+                            match bincode::serialize(&announce) {
+                                Ok(serialized) => {
+                                    if let Err(e) = responder_pubsub
+                                        .publish(sync_topic.clone(), bytes::Bytes::from(serialized))
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "KvStore owner-announce publish failed: {e}"
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!("KvStore owner-announce serialize failed: {e}");
+                                }
+                            }
+                        }
+                        let full = {
+                            let s = responder_store.read().await;
+                            if s.is_empty() {
+                                continue;
+                            }
+                            s.full_delta()
+                        };
+                        let Ok(serialized) = encode_delta(local_peer_id, &full) else {
+                            continue;
+                        };
+                        if let Err(e) = responder_pubsub
+                            .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
+                            .await
+                        {
+                            tracing::warn!("KvStore state-response publish failed: {e}");
+                        }
                     }
-                    s.full_delta()
-                };
-                let Ok(serialized) = encode_delta(local_peer_id, &full) else {
-                    continue;
-                };
-                if let Err(e) = responder_pubsub
-                    .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
-                    .await
-                {
-                    tracing::warn!("KvStore state-response publish failed: {e}");
+                    KvSyncMessage::OwnerAnnounce { owner, policy } => {
+                        // Only a signature-verified sender is trusted; the
+                        // pub/sub layer drops signed messages that fail
+                        // verification, so `sender: Some(..)` is verified.
+                        let Some(sender) = msg.sender else {
+                            tracing::warn!(
+                                "ignoring unsigned KvStore ownership announcement on {}",
+                                msg.topic
+                            );
+                            continue;
+                        };
+                        if local_agent_id.is_some_and(|me| me == sender) {
+                            continue; // our own announce echoed back
+                        }
+                        let mut s = responder_store.write().await;
+                        match s.learn_ownership(owner, policy, &sender) {
+                            Ok(()) => {
+                                tracing::info!(
+                                    "KvStore {} adopted owner {} (policy {})",
+                                    s.id(),
+                                    hex::encode(owner.as_bytes()),
+                                    s.policy()
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "rejected KvStore ownership announcement from {}: {e}",
+                                    hex::encode(sender.as_bytes())
+                                );
+                            }
+                        }
+                    }
                 }
             }
         }));
@@ -283,7 +390,8 @@ mod tests {
         let node = make_node().await;
         let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
         let store = KvStore::new(store_id(1), "Test".to_string(), agent(1), policy);
-        KvStoreSync::new(store, pubsub, topic.to_string(), peer(1)).expect("kv sync")
+        KvStoreSync::new(store, pubsub, topic.to_string(), peer(1), Some(agent(1)))
+            .expect("kv sync")
     }
 
     /// Build a `KvStoreSync` that shares its pubsub with the caller (so the
@@ -295,8 +403,14 @@ mod tests {
         let node = make_node().await;
         let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
         let store = KvStore::new(store_id(1), "Test".to_string(), agent(1), policy);
-        let sync = KvStoreSync::new(store, Arc::clone(&pubsub), topic.to_string(), peer(1))
-            .expect("kv sync");
+        let sync = KvStoreSync::new(
+            store,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(agent(1)),
+        )
+        .expect("kv sync");
         (sync, pubsub)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9786,7 +9786,25 @@ impl TaskListHandle {
         title: String,
         description: String,
     ) -> error::Result<crdt::TaskId> {
-        let (task_id, delta) = {
+        let (task_id, _version) = self.add_task_versioned(title, description).await?;
+        Ok(task_id)
+    }
+
+    /// Add a new task and report the task list's post-mutation version.
+    ///
+    /// Same as [`TaskListHandle::add_task`] but additionally returns the
+    /// list's version counter after the add, read atomically under the same
+    /// write lock as the mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the task cannot be added.
+    pub async fn add_task_versioned(
+        &self,
+        title: String,
+        description: String,
+    ) -> error::Result<(crdt::TaskId, u64)> {
+        let (task_id, version, delta) = {
             let mut list = self.sync.write().await;
             let seq = list.next_seq();
             let task_id = crdt::TaskId::new(&title, &self.agent_id, seq);
@@ -9800,14 +9818,15 @@ impl TaskListHandle {
                     )))
                 })?;
             let tag = (self.peer_id, seq);
-            let delta = crdt::TaskListDelta::for_add(task_id, task, tag, list.current_version());
-            (task_id, delta)
+            let version = list.current_version();
+            let delta = crdt::TaskListDelta::for_add(task_id, task, tag, version);
+            (task_id, version, delta)
         };
         // Best-effort replication: local mutation succeeded regardless
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
             tracing::warn!("failed to publish add_task delta: {}", e);
         }
-        Ok(task_id)
+        Ok((task_id, version))
     }
 
     /// Claim a task in the list.
@@ -9820,8 +9839,39 @@ impl TaskListHandle {
     ///
     /// Returns an error if the task cannot be claimed.
     pub async fn claim_task(&self, task_id: crdt::TaskId) -> error::Result<()> {
-        let delta = {
+        // No expected version ⇒ can never conflict.
+        self.claim_task_versioned(task_id, None).await.map(|_| ())
+    }
+
+    /// Claim a task, optionally guarded by an expected list version (CAS).
+    ///
+    /// If `expected_version` is `Some(v)` and the task list's current version
+    /// is not `v`, nothing is mutated and
+    /// [`TaskCasOutcome::VersionConflict`] is returned with the current
+    /// version. The check and the mutation happen under a single write lock.
+    ///
+    /// `Committed` means the claim was applied to the local replica and a
+    /// delta was published to peers — not that any peer has observed it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the task does not exist or the state transition
+    /// is invalid (e.g. the task is already done).
+    pub async fn claim_task_versioned(
+        &self,
+        task_id: crdt::TaskId,
+        expected_version: Option<u64>,
+    ) -> error::Result<TaskCasOutcome> {
+        let (version, delta) = {
             let mut list = self.sync.write().await;
+            if let Some(expected) = expected_version {
+                let current = list.current_version();
+                if current != expected {
+                    return Ok(TaskCasOutcome::VersionConflict {
+                        current_version: current,
+                    });
+                }
+            }
             let seq = list.next_seq();
             list.claim_task(&task_id, self.agent_id, self.peer_id, seq)
                 .map_err(|e| {
@@ -9839,12 +9889,16 @@ impl TaskListHandle {
                     ))
                 })?
                 .clone();
-            crdt::TaskListDelta::for_state_change(task_id, full_task, list.current_version())
+            let version = list.current_version();
+            (
+                version,
+                crdt::TaskListDelta::for_state_change(task_id, full_task, version),
+            )
         };
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
             tracing::warn!("failed to publish claim_task delta: {}", e);
         }
-        Ok(())
+        Ok(TaskCasOutcome::Committed { version })
     }
 
     /// Complete a task in the list.
@@ -9857,8 +9911,37 @@ impl TaskListHandle {
     ///
     /// Returns an error if the task cannot be completed.
     pub async fn complete_task(&self, task_id: crdt::TaskId) -> error::Result<()> {
-        let delta = {
+        // No expected version ⇒ can never conflict.
+        self.complete_task_versioned(task_id, None)
+            .await
+            .map(|_| ())
+    }
+
+    /// Complete a task, optionally guarded by an expected list version (CAS).
+    ///
+    /// Semantics mirror [`TaskListHandle::claim_task_versioned`]: a mismatch
+    /// between `expected_version` and the current list version returns
+    /// [`TaskCasOutcome::VersionConflict`] with no mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the task does not exist or the state transition
+    /// is invalid (e.g. the task was never claimed).
+    pub async fn complete_task_versioned(
+        &self,
+        task_id: crdt::TaskId,
+        expected_version: Option<u64>,
+    ) -> error::Result<TaskCasOutcome> {
+        let (version, delta) = {
             let mut list = self.sync.write().await;
+            if let Some(expected) = expected_version {
+                let current = list.current_version();
+                if current != expected {
+                    return Ok(TaskCasOutcome::VersionConflict {
+                        current_version: current,
+                    });
+                }
+            }
             let seq = list.next_seq();
             list.complete_task(&task_id, self.agent_id, self.peer_id, seq)
                 .map_err(|e| {
@@ -9875,12 +9958,16 @@ impl TaskListHandle {
                     ))
                 })?
                 .clone();
-            crdt::TaskListDelta::for_state_change(task_id, full_task, list.current_version())
+            let version = list.current_version();
+            (
+                version,
+                crdt::TaskListDelta::for_state_change(task_id, full_task, version),
+            )
         };
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
             tracing::warn!("failed to publish complete_task delta: {}", e);
         }
-        Ok(())
+        Ok(TaskCasOutcome::Committed { version })
     }
 
     /// List all tasks in their current order.
@@ -9893,20 +9980,55 @@ impl TaskListHandle {
     ///
     /// Returns an error if the task list cannot be read.
     pub async fn list_tasks(&self) -> error::Result<Vec<TaskSnapshot>> {
+        let (tasks, _version) = self.list_tasks_with_version().await?;
+        Ok(tasks)
+    }
+
+    /// List all tasks together with the task list's current version.
+    ///
+    /// The snapshots and the version are read atomically under a single read
+    /// lock, so the returned version is consistent with the returned tasks —
+    /// suitable as the `expected_version` for a subsequent CAS mutation via
+    /// [`TaskListHandle::claim_task_versioned`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the task list cannot be read.
+    pub async fn list_tasks_with_version(&self) -> error::Result<(Vec<TaskSnapshot>, u64)> {
         let list = self.sync.read().await;
+        let version = list.current_version();
         let tasks = list.tasks_ordered();
-        Ok(tasks
+        let snapshots = tasks
             .into_iter()
-            .map(|task| TaskSnapshot {
-                id: *task.id(),
-                title: task.title().to_string(),
-                description: task.description().to_string(),
-                state: task.current_state(),
-                assignee: task.assignee().copied(),
-                owner: None,
-                priority: task.priority(),
+            .map(|task| {
+                let claim = task.claim_record();
+                let completion = task.completion_record();
+                TaskSnapshot {
+                    id: *task.id(),
+                    title: task.title().to_string(),
+                    description: task.description().to_string(),
+                    state: task.current_state(),
+                    assignee: task.assignee().copied(),
+                    owner: None,
+                    priority: task.priority(),
+                    claimed_by: claim.map(|(agent, _)| agent),
+                    claimed_at: claim.map(|(_, ts)| ts),
+                    completed_by: completion.map(|(agent, _)| agent),
+                    completed_at: completion.map(|(_, ts)| ts),
+                }
             })
-            .collect())
+            .collect();
+        Ok((snapshots, version))
+    }
+
+    /// The task list's current version counter.
+    ///
+    /// Incremented on every local or merged mutation. Useful as the
+    /// `expected_version` for CAS mutations; prefer
+    /// [`TaskListHandle::list_tasks_with_version`] when the tasks are also
+    /// needed, to read both atomically.
+    pub async fn version(&self) -> u64 {
+        self.sync.read().await.current_version()
     }
 
     /// Reorder tasks in the list.
@@ -10295,6 +10417,36 @@ pub struct TaskSnapshot {
     pub owner: Option<identity::UserId>,
     /// Task priority (0-255, higher = more important).
     pub priority: u8,
+    /// The agent whose claim won (deterministic OR-Set winner), if claimed.
+    /// Remains set after the task transitions to Done.
+    pub claimed_by: Option<identity::AgentId>,
+    /// Unix-millisecond timestamp of the winning claim, if claimed.
+    pub claimed_at: Option<u64>,
+    /// The agent whose completion won (deterministic OR-Set winner), if done.
+    pub completed_by: Option<identity::AgentId>,
+    /// Unix-millisecond timestamp of the winning completion, if done.
+    pub completed_at: Option<u64>,
+}
+
+/// Outcome of a task-list mutation guarded by an optional expected version.
+///
+/// Returned by [`TaskListHandle::claim_task_versioned`] and
+/// [`TaskListHandle::complete_task_versioned`]. `Committed` means the
+/// mutation was applied to the **local** replica and a delta was published —
+/// it does NOT mean any peer has observed the change yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskCasOutcome {
+    /// The mutation was committed locally; `version` is the new list version.
+    Committed {
+        /// The task list's version after this mutation.
+        version: u64,
+    },
+    /// The caller's `expected_version` did not match the current list
+    /// version; nothing was mutated.
+    VersionConflict {
+        /// The task list's current (unchanged) version.
+        current_version: u64,
+    },
 }
 
 /// The x0x protocol version.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9975,6 +9975,7 @@ impl Agent {
             std::sync::Arc::clone(runtime.pubsub()),
             topic.to_string(),
             peer_id,
+            Some(self.agent_id()),
         )
         .map_err(|e| {
             error::IdentityError::Storage(std::io::Error::other(format!(
@@ -10000,9 +10001,12 @@ impl Agent {
 
     /// Join an existing key-value store by topic.
     ///
-    /// Creates an empty store that will be populated via delta sync
-    /// from peers already sharing the topic. The access policy will
-    /// be learned from the first full delta received from the owner.
+    /// Creates an empty replica that will be populated via delta sync from
+    /// peers already sharing the topic. The replica starts with **no owner**
+    /// and the default `Signed` policy, which fails closed: local writes are
+    /// rejected until the authoritative owner and policy are learned from an
+    /// owner-signed announcement on the state-sync channel (published by the
+    /// owner in response to this replica's state requests).
     ///
     /// # Errors
     ///
@@ -10015,23 +10019,17 @@ impl Agent {
         })?;
 
         let peer_id = runtime.peer_id();
+        // Local placeholder id — the replica is addressed by topic; the id
+        // is not used for merge decisions on the delta path.
         let store_id = kv::KvStoreId::from_content(topic, &self.agent_id());
-        // Use Encrypted as the most permissive default — the actual policy
-        // will be set when the first delta from the owner arrives.
-        let store = kv::KvStore::new(
-            store_id,
-            String::new(),
-            self.agent_id(),
-            kv::AccessPolicy::Encrypted {
-                group_id: Vec::new(),
-            },
-        );
+        let store = kv::KvStore::new_replica(store_id, String::new());
 
         let sync = kv::KvStoreSync::new(
             store,
             std::sync::Arc::clone(runtime.pubsub()),
             topic.to_string(),
             peer_id,
+            Some(self.agent_id()),
         )
         .map_err(|e| {
             error::IdentityError::Storage(std::io::Error::other(format!(
@@ -10083,6 +10081,18 @@ impl KvStoreHandle {
         self.peer_id
     }
 
+    /// Enforce the store's access policy for a local mutation.
+    ///
+    /// Applies the same authorization rule as the inbound delta path
+    /// (`KvStore::merge_delta`), so a local write that peers would reject
+    /// never mutates this replica (no local fork).
+    fn check_local_write(store: &kv::KvStore, writer: &identity::AgentId) -> error::Result<()> {
+        store.authorize_local_write(writer).map_err(|e| match e {
+            kv::KvError::Unauthorized(msg) => error::IdentityError::Unauthorized(msg),
+            other => error::IdentityError::Unauthorized(other.to_string()),
+        })
+    }
+
     /// Put a key-value pair into the store.
     ///
     /// If the key already exists, the value is updated. Changes are
@@ -10108,7 +10118,10 @@ impl KvStoreHandle {
     ///
     /// # Errors
     ///
-    /// Returns an error if the value exceeds the maximum inline size (64 KB).
+    /// Returns an error if the value exceeds the maximum inline size (64 KB),
+    /// or [`error::IdentityError::Unauthorized`] if this agent is not
+    /// permitted to write under the store's access policy (including a
+    /// joined replica whose authoritative owner is not yet known).
     pub async fn put_with_delta(
         &self,
         key: String,
@@ -10117,6 +10130,7 @@ impl KvStoreHandle {
     ) -> error::Result<kv::KvStoreDelta> {
         let delta = {
             let mut store = self.sync.write().await;
+            Self::check_local_write(&store, &self.agent_id)?;
             store
                 .put(
                     key.clone(),
@@ -10182,10 +10196,13 @@ impl KvStoreHandle {
     ///
     /// # Errors
     ///
-    /// Returns an error if the key does not exist.
+    /// Returns an error if the key does not exist, or
+    /// [`error::IdentityError::Unauthorized`] if this agent is not permitted
+    /// to write under the store's access policy.
     pub async fn remove_with_delta(&self, key: &str) -> error::Result<kv::KvStoreDelta> {
         let delta = {
             let mut store = self.sync.write().await;
+            Self::check_local_write(&store, &self.agent_id)?;
             store.remove(key).map_err(|e| {
                 error::IdentityError::Storage(std::io::Error::other(format!(
                     "kv remove failed: {e}",

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -1,0 +1,400 @@
+//! Persistence + startup rehydration for CRDT subscriptions (task lists and
+//! key-value stores).
+//!
+//! Fixes daemon-restart amnesia: `AppState.task_lists` / `AppState.kv_stores`
+//! were only ever populated by the REST create/join handlers, so a restarted
+//! daemon answered "task list not found" / "store not found" until the
+//! application explicitly re-created or re-joined. This module persists a
+//! small subscription manifest (`crdt-subscriptions.json`, same instance data
+//! dir as `directory-subscriptions.json`) whenever a handler registers a
+//! task list or store, and rehydrates every entry on startup by driving the
+//! SAME `Agent` create/join paths the handlers use — so the gossip topic
+//! subscription and the empty-replica state-request bootstrap both happen and
+//! mutations made while the daemon was offline are recovered from peers.
+//!
+//! Design follows the Phase C.2 directory-subscription persistence pattern
+//! (`load_directory_subscriptions` / `save_directory_subscriptions` in
+//! `src/server/mod.rs`): best-effort JSON on disk, warn-and-continue on any
+//! error, never crash startup.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use super::state::AppState;
+
+/// Manifest entry kind for a collaborative task list.
+pub(super) const KIND_TASK_LIST: &str = "task_list";
+/// Manifest entry kind for a replicated key-value store.
+pub(super) const KIND_KV_STORE: &str = "kv_store";
+/// Role recorded when this daemon created the task list / store.
+pub(super) const ROLE_CREATED: &str = "created";
+/// Role recorded when this daemon joined an existing store.
+pub(super) const ROLE_JOINED: &str = "joined";
+
+/// One persisted CRDT subscription.
+///
+/// The schema is deliberately extensible: unknown fields present in the file
+/// are captured in `extra` (via `serde(flatten)`) and preserved across
+/// load/save cycles, so a future daemon can add fields (e.g. owner/policy
+/// info for kv stores) without older builds destroying them.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(super) struct CrdtSubscriptionEntry {
+    /// Entry kind: [`KIND_TASK_LIST`] or [`KIND_KV_STORE`]. Unknown kinds are
+    /// kept on disk but skipped (with a warning) at rehydration time.
+    pub(super) kind: String,
+    /// Registration id used as the `AppState` map key (currently the topic).
+    pub(super) id: String,
+    /// Human-readable name passed to the create call.
+    pub(super) name: String,
+    /// Gossip topic the CRDT syncs on.
+    pub(super) topic: String,
+    /// [`ROLE_CREATED`] or [`ROLE_JOINED`] — selects the create vs join
+    /// `Agent` path at rehydration time.
+    pub(super) role: String,
+    /// Forward-compatibility: unknown fields survive round-trips.
+    #[serde(flatten)]
+    pub(super) extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// On-disk manifest: the full set of persisted CRDT subscriptions.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub(super) struct CrdtSubscriptionManifest {
+    /// All persisted subscriptions, in insertion order.
+    #[serde(default)]
+    pub(super) entries: Vec<CrdtSubscriptionEntry>,
+    /// Forward-compatibility: unknown top-level fields survive round-trips.
+    #[serde(flatten)]
+    pub(super) extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl CrdtSubscriptionManifest {
+    /// Insert `entry`, replacing any existing entry with the same
+    /// `(kind, id)`. Returns `true` if the manifest changed.
+    pub(super) fn upsert(&mut self, entry: CrdtSubscriptionEntry) -> bool {
+        if let Some(existing) = self
+            .entries
+            .iter_mut()
+            .find(|e| e.kind == entry.kind && e.id == entry.id)
+        {
+            if *existing == entry {
+                return false;
+            }
+            *existing = entry;
+        } else {
+            self.entries.push(entry);
+        }
+        true
+    }
+
+    /// Remove the entry with the given `(kind, id)`. Returns `true` if an
+    /// entry was removed.
+    ///
+    /// No task-list/store delete or leave REST endpoint exists today (the
+    /// endpoint registry in `src/api/mod.rs` only has `DELETE
+    /// /stores/:id/:key`, which removes a key, not the store), so production
+    /// code has no caller yet — this is the removal half of the manifest API,
+    /// ready for when such endpoints land.
+    #[allow(dead_code)]
+    pub(super) fn remove(&mut self, kind: &str, id: &str) -> bool {
+        let before = self.entries.len();
+        self.entries.retain(|e| !(e.kind == kind && e.id == id));
+        self.entries.len() != before
+    }
+}
+
+/// Read the manifest from `path` (best-effort).
+///
+/// A missing file yields an empty manifest silently; an unreadable or
+/// corrupt file yields an empty manifest with a warning — startup must never
+/// crash on a bad manifest (fail loud in logs, not in process exit).
+pub(super) async fn read_manifest(path: &Path) -> CrdtSubscriptionManifest {
+    match tokio::fs::read(path).await {
+        Ok(bytes) => match serde_json::from_slice::<CrdtSubscriptionManifest>(&bytes) {
+            Ok(manifest) => manifest,
+            Err(e) => {
+                tracing::warn!(
+                    "failed to parse CRDT subscription manifest {} (starting empty): {e}",
+                    path.display()
+                );
+                CrdtSubscriptionManifest::default()
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::debug!("no CRDT subscription manifest at {}", path.display());
+            CrdtSubscriptionManifest::default()
+        }
+        Err(e) => {
+            tracing::warn!(
+                "failed to read CRDT subscription manifest {} (starting empty): {e}",
+                path.display()
+            );
+            CrdtSubscriptionManifest::default()
+        }
+    }
+}
+
+/// Write `manifest` to `path` (best-effort, warns on failure).
+pub(super) async fn write_manifest(path: &Path, manifest: &CrdtSubscriptionManifest) {
+    match serde_json::to_vec_pretty(manifest) {
+        Ok(bytes) => {
+            if let Some(parent) = path.parent() {
+                let _ = tokio::fs::create_dir_all(parent).await;
+            }
+            if let Err(e) = tokio::fs::write(path, &bytes).await {
+                tracing::warn!(
+                    "failed to persist CRDT subscription manifest to {}: {e}",
+                    path.display()
+                );
+            }
+        }
+        Err(e) => tracing::warn!("failed to serialise CRDT subscription manifest: {e}"),
+    }
+}
+
+/// Load the persisted manifest from disk into `state.crdt_subscriptions`.
+///
+/// Called once during startup, before REST handlers can mutate the set, so a
+/// create/join arriving early merges with (rather than clobbers) the
+/// persisted entries.
+pub(super) async fn load(state: &AppState) {
+    let manifest = read_manifest(&state.crdt_subscriptions_path).await;
+    let n = manifest.entries.len();
+    *state.crdt_subscriptions.write().await = manifest;
+    if n > 0 {
+        tracing::info!(
+            "loaded {n} persisted CRDT subscriptions from {}",
+            state.crdt_subscriptions_path.display()
+        );
+    }
+}
+
+/// Record a new/updated subscription in the in-memory manifest and persist
+/// it to disk. Called by the REST create/join handlers after a successful
+/// registration.
+pub(super) async fn record(state: &AppState, entry: CrdtSubscriptionEntry) {
+    let snapshot = {
+        let mut manifest = state.crdt_subscriptions.write().await;
+        if !manifest.upsert(entry) {
+            return;
+        }
+        manifest.clone()
+    };
+    write_manifest(&state.crdt_subscriptions_path, &snapshot).await;
+}
+
+/// Rehydrate every persisted subscription by driving the same `Agent`
+/// create/join paths the REST handlers use.
+///
+/// Runs after `join_network` returns so the gossip mesh is (re)forming; the
+/// per-CRDT empty-replica state-request retry schedule then recovers state —
+/// including mutations made while this daemon was offline — from peer
+/// replicas. A failed entry is logged (warn) and skipped, never fatal, and
+/// stays in the manifest so the next restart retries it.
+pub(super) async fn rehydrate(state: Arc<AppState>) {
+    let entries = state.crdt_subscriptions.read().await.entries.clone();
+    if entries.is_empty() {
+        return;
+    }
+    let (mut restored, mut skipped) = (0usize, 0usize);
+    for entry in entries {
+        match entry.kind.as_str() {
+            KIND_TASK_LIST => {
+                if state.task_lists.read().await.contains_key(&entry.id) {
+                    continue; // already re-created via REST since startup
+                }
+                let result = match entry.role.as_str() {
+                    ROLE_JOINED => state.agent.join_task_list(&entry.topic).await,
+                    ROLE_CREATED => {
+                        state
+                            .agent
+                            .create_task_list(&entry.name, &entry.topic)
+                            .await
+                    }
+                    other => {
+                        tracing::warn!(
+                            id = %entry.id,
+                            role = other,
+                            "unknown task-list subscription role — skipping"
+                        );
+                        skipped += 1;
+                        continue;
+                    }
+                };
+                match result {
+                    Ok(handle) => {
+                        state
+                            .task_lists
+                            .write()
+                            .await
+                            .entry(entry.id.clone())
+                            .or_insert(handle);
+                        restored += 1;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            id = %entry.id,
+                            "failed to rehydrate task list after restart: {e}"
+                        );
+                        skipped += 1;
+                    }
+                }
+            }
+            KIND_KV_STORE => {
+                if state.kv_stores.read().await.contains_key(&entry.id) {
+                    continue; // already re-created/joined via REST since startup
+                }
+                let result = match entry.role.as_str() {
+                    ROLE_JOINED => state.agent.join_kv_store(&entry.topic).await,
+                    ROLE_CREATED => state.agent.create_kv_store(&entry.name, &entry.topic).await,
+                    other => {
+                        tracing::warn!(
+                            id = %entry.id,
+                            role = other,
+                            "unknown kv-store subscription role — skipping"
+                        );
+                        skipped += 1;
+                        continue;
+                    }
+                };
+                match result {
+                    Ok(handle) => {
+                        state
+                            .kv_stores
+                            .write()
+                            .await
+                            .entry(entry.id.clone())
+                            .or_insert(handle);
+                        restored += 1;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            id = %entry.id,
+                            "failed to rehydrate kv store after restart: {e}"
+                        );
+                        skipped += 1;
+                    }
+                }
+            }
+            other => {
+                tracing::warn!(
+                    id = %entry.id,
+                    kind = other,
+                    "unknown CRDT subscription kind — skipping (kept in manifest)"
+                );
+                skipped += 1;
+            }
+        }
+    }
+    tracing::info!(restored, skipped, "CRDT subscription rehydration complete");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(kind: &str, id: &str, role: &str) -> CrdtSubscriptionEntry {
+        CrdtSubscriptionEntry {
+            kind: kind.to_string(),
+            id: id.to_string(),
+            name: format!("{id}-name"),
+            topic: id.to_string(),
+            role: role.to_string(),
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    /// WHY: the whole fix rests on the manifest surviving a daemon restart —
+    /// a save/load round-trip must reproduce exactly what was recorded.
+    #[tokio::test]
+    async fn manifest_round_trips_through_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+
+        let mut manifest = CrdtSubscriptionManifest::default();
+        assert!(manifest.upsert(entry(KIND_TASK_LIST, "sprint", ROLE_CREATED)));
+        assert!(manifest.upsert(entry(KIND_KV_STORE, "party", ROLE_JOINED)));
+        // Re-upserting an identical entry is a no-op (no disk churn).
+        assert!(!manifest.upsert(entry(KIND_KV_STORE, "party", ROLE_JOINED)));
+
+        write_manifest(&path, &manifest).await;
+        let loaded = read_manifest(&path).await;
+        assert_eq!(loaded, manifest);
+
+        // Remove drops exactly the matching (kind, id) pair.
+        let mut loaded = loaded;
+        assert!(loaded.remove(KIND_KV_STORE, "party"));
+        assert!(!loaded.remove(KIND_KV_STORE, "party"));
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].id, "sprint");
+
+        write_manifest(&path, &loaded).await;
+        assert_eq!(read_manifest(&path).await, loaded);
+    }
+
+    /// WHY: upsert must replace, not duplicate, so a re-create after restart
+    /// (or a role change) cannot grow the manifest unboundedly.
+    #[test]
+    fn upsert_replaces_same_kind_and_id() {
+        let mut manifest = CrdtSubscriptionManifest::default();
+        manifest.upsert(entry(KIND_KV_STORE, "party", ROLE_JOINED));
+        manifest.upsert(entry(KIND_KV_STORE, "party", ROLE_CREATED));
+        assert_eq!(manifest.entries.len(), 1);
+        assert_eq!(manifest.entries[0].role, ROLE_CREATED);
+        // Same id under a different kind is a distinct entry.
+        manifest.upsert(entry(KIND_TASK_LIST, "party", ROLE_CREATED));
+        assert_eq!(manifest.entries.len(), 2);
+    }
+
+    /// WHY: a corrupt manifest must degrade to "no persisted subscriptions"
+    /// (fail loud in logs), never crash the daemon at startup.
+    #[tokio::test]
+    async fn corrupt_manifest_yields_empty_and_does_not_panic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+        tokio::fs::write(&path, b"{not json at all")
+            .await
+            .expect("write corrupt file");
+        let loaded = read_manifest(&path).await;
+        assert!(loaded.entries.is_empty());
+
+        // Missing file is equally tolerated.
+        let missing = dir.path().join("does-not-exist.json");
+        assert!(read_manifest(&missing).await.entries.is_empty());
+    }
+
+    /// WHY: schema extensibility is a stated requirement — unknown fields
+    /// written by a future daemon must be tolerated AND preserved across a
+    /// load/save cycle by this build.
+    #[tokio::test]
+    async fn unknown_fields_are_tolerated_and_preserved() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+        let future_schema = serde_json::json!({
+            "schema_version": 2,
+            "entries": [{
+                "kind": "kv_store",
+                "id": "party",
+                "name": "party",
+                "topic": "party",
+                "role": "joined",
+                "owner": "abcd1234",
+                "policy": { "kind": "signed" }
+            }]
+        });
+        tokio::fs::write(&path, serde_json::to_vec(&future_schema).expect("json"))
+            .await
+            .expect("write");
+
+        let loaded = read_manifest(&path).await;
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].extra["owner"], "abcd1234");
+        assert_eq!(loaded.extra["schema_version"], 2);
+
+        // Round-trip preserves the unknown fields.
+        write_manifest(&path, &loaded).await;
+        let reloaded = read_manifest(&path).await;
+        assert_eq!(reloaded, loaded);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15914,7 +15914,12 @@ async fn put_kv_value(
             (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
         }
         Err(e) => {
-            let status = if format!("{e}").contains("value too large") {
+            let status = if matches!(e, x0x::error::IdentityError::Unauthorized(_)) {
+                // Local write rejected by the store's access policy — the
+                // caller is not the owner (or an allowlisted writer), or the
+                // joined replica has not yet learned the authoritative owner.
+                StatusCode::FORBIDDEN
+            } else if format!("{e}").contains("value too large") {
                 StatusCode::PAYLOAD_TOO_LARGE
             } else {
                 StatusCode::INTERNAL_SERVER_ERROR
@@ -15978,6 +15983,9 @@ async fn delete_kv_value(
             let recipients = kv_store_delta_direct_recipients(&state).await;
             spawn_kv_store_delta_delivery(&state, recipients, &id, handle.peer_id(), &delta);
             (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
+        }
+        Err(e) if matches!(e, x0x::error::IdentityError::Unauthorized(_)) => {
+            api_error(StatusCode::FORBIDDEN, format!("{e}"))
         }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,6 +10,7 @@
 use crate as x0x;
 
 mod auth;
+mod crdt_subscriptions;
 mod routes;
 mod sse;
 mod state;
@@ -951,6 +952,8 @@ pub async fn serve_with_options(
         subscriptions: RwLock::new(HashMap::new()),
         task_lists: RwLock::new(HashMap::new()),
         kv_stores: RwLock::new(HashMap::new()),
+        crdt_subscriptions: RwLock::new(crdt_subscriptions::CrdtSubscriptionManifest::default()),
+        crdt_subscriptions_path: config.data_dir.join("crdt-subscriptions.json"),
         named_groups: RwLock::new(named_groups),
         named_groups_path,
         named_groups_persistence_lock: Mutex::new(()),
@@ -1053,6 +1056,10 @@ pub async fn serve_with_options(
     // Phase C.2: load persisted shard subscriptions and re-subscribe with
     // staggered jitter to avoid anti-entropy storms.
     bg_tasks.extend(spawn_directory_resubscribe(Arc::clone(&state)).await);
+    // Restart-amnesia fix: load the persisted task-list/kv-store subscription
+    // manifest now (before REST handlers can mutate it) — the actual
+    // re-create/re-join runs after `join_network` in the join task below.
+    crdt_subscriptions::load(&state).await;
     // Phase C.2: subscribe inbound direct messages for the
     // ListedToContacts pairwise sync channel.
     bg_tasks.extend(spawn_listed_to_contacts_listener(Arc::clone(&state)).await);
@@ -1128,6 +1135,7 @@ pub async fn serve_with_options(
         dm_inbox_kv_store_delta_route_tx,
     )));
 
+    let crdt_rehydrate_state = Arc::clone(&state);
     bg_tasks.push(tokio::spawn(async move {
         match join_agent.join_network().await {
             Ok(()) => {
@@ -1144,6 +1152,13 @@ pub async fn serve_with_options(
                 tracing::error!("Failed to join network: {e}");
             }
         }
+        // Restart-amnesia fix: re-register every persisted task-list/kv-store
+        // subscription via the same Agent create/join paths the REST handlers
+        // use, so the topic subscription + empty-replica state-request happen
+        // and offline mutations arrive from peers. Runs on BOTH join arms:
+        // even when join_network errors, the local gossip runtime exists and
+        // the subscription is what lets state recover once peers appear.
+        crdt_subscriptions::rehydrate(crdt_rehydrate_state).await;
     }));
 
     let self_published_release_manifests =
@@ -15822,6 +15837,20 @@ async fn create_kv_store(
         Ok(handle) => {
             let id = req.topic.clone();
             state.kv_stores.write().await.insert(id.clone(), handle);
+            // Persist the registration so it survives a daemon restart
+            // (rehydrated after join_network — see crdt_subscriptions).
+            crdt_subscriptions::record(
+                &state,
+                crdt_subscriptions::CrdtSubscriptionEntry {
+                    kind: crdt_subscriptions::KIND_KV_STORE.to_string(),
+                    id: id.clone(),
+                    name: req.name.clone(),
+                    topic: req.topic.clone(),
+                    role: crdt_subscriptions::ROLE_CREATED.to_string(),
+                    extra: serde_json::Map::new(),
+                },
+            )
+            .await;
             (
                 StatusCode::CREATED,
                 Json(serde_json::json!({ "ok": true, "id": id })),
@@ -15839,6 +15868,21 @@ async fn join_kv_store(
     match state.agent.join_kv_store(&id).await {
         Ok(handle) => {
             state.kv_stores.write().await.insert(id.clone(), handle);
+            // Persist the registration so it survives a daemon restart
+            // (rehydrated after join_network — see crdt_subscriptions). The
+            // join path only knows the topic, so it doubles as the name.
+            crdt_subscriptions::record(
+                &state,
+                crdt_subscriptions::CrdtSubscriptionEntry {
+                    kind: crdt_subscriptions::KIND_KV_STORE.to_string(),
+                    id: id.clone(),
+                    name: id.clone(),
+                    topic: id.clone(),
+                    role: crdt_subscriptions::ROLE_JOINED.to_string(),
+                    extra: serde_json::Map::new(),
+                },
+            )
+            .await;
             (
                 StatusCode::OK,
                 Json(serde_json::json!({ "ok": true, "id": id })),
@@ -21100,6 +21144,8 @@ mod tests {
             subscriptions: RwLock::new(HashMap::new()),
             task_lists: RwLock::new(HashMap::new()),
             kv_stores: RwLock::new(HashMap::new()),
+            crdt_subscriptions: RwLock::new(crdt_subscriptions::CrdtSubscriptionManifest::default()),
+            crdt_subscriptions_path: data_dir.join("crdt-subscriptions.json"),
             named_groups: RwLock::new(named_groups),
             named_groups_path,
             named_groups_persistence_lock: Mutex::new(()),

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -153,6 +153,11 @@ pub(in crate::server) struct AddTaskRequest {
 #[derive(Debug, Deserialize)]
 pub(in crate::server) struct UpdateTaskRequest {
     pub(in crate::server) action: String, // "claim" or "complete"
+    /// Optional optimistic-concurrency guard: if set and it does not match
+    /// the task list's current version, the mutation is rejected with 409
+    /// and nothing changes. Absent ⇒ unconditional (last-writer CRDT merge).
+    #[serde(default)]
+    pub(in crate::server) expected_version: Option<u64>,
 }
 
 /// Task list entry.
@@ -168,9 +173,19 @@ pub(in crate::server) struct TaskEntry {
     pub(in crate::server) id: String,
     pub(in crate::server) title: String,
     pub(in crate::server) description: String,
+    /// Legacy Display string ("empty" | "claimed:<hex>" | "done:<hex>").
+    /// Kept for backward compatibility — prefer the structured fields below.
     pub(in crate::server) state: String,
     pub(in crate::server) assignee: Option<String>,
     pub(in crate::server) priority: u8,
+    /// Hex AgentId of the deterministic claim winner; null if never claimed.
+    pub(in crate::server) claimed_by: Option<String>,
+    /// Unix-ms timestamp of the winning claim; null if never claimed.
+    pub(in crate::server) claimed_at: Option<u64>,
+    /// Hex AgentId of the deterministic completion winner; null unless done.
+    pub(in crate::server) completed_by: Option<String>,
+    /// Unix-ms timestamp of the winning completion; null unless done.
+    pub(in crate::server) completed_at: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -216,10 +231,16 @@ pub(in crate::server) async fn create_task_list(
     match state.agent.create_task_list(&req.name, &req.topic).await {
         Ok(handle) => {
             let id = req.topic.clone();
+            let version = handle.version().await;
             state.task_lists.write().await.insert(id.clone(), handle);
             (
                 StatusCode::CREATED,
-                Json(serde_json::json!({ "ok": true, "id": id })),
+                Json(serde_json::json!({
+                    "ok": true,
+                    "id": id,
+                    "version": version,
+                    "committed": "local",
+                })),
             )
         }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
@@ -240,8 +261,8 @@ pub(in crate::server) async fn list_tasks(
         return not_found("task list not found");
     };
 
-    match handle.list_tasks().await {
-        Ok(tasks) => {
+    match handle.list_tasks_with_version().await {
+        Ok((tasks, version)) => {
             let entries: Vec<TaskEntry> = tasks
                 .into_iter()
                 .map(|t| TaskEntry {
@@ -249,13 +270,17 @@ pub(in crate::server) async fn list_tasks(
                     title: t.title,
                     description: t.description,
                     state: format!("{}", t.state),
-                    assignee: t.assignee.map(|a| format!("{a}")),
+                    assignee: t.assignee.map(|a| hex::encode(a.as_bytes())),
                     priority: t.priority,
+                    claimed_by: t.claimed_by.map(|a| hex::encode(a.as_bytes())),
+                    claimed_at: t.claimed_at,
+                    completed_by: t.completed_by.map(|a| hex::encode(a.as_bytes())),
+                    completed_at: t.completed_at,
                 })
                 .collect();
             (
                 StatusCode::OK,
-                Json(serde_json::json!({ "ok": true, "tasks": entries })),
+                Json(serde_json::json!({ "ok": true, "version": version, "tasks": entries })),
             )
         }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
@@ -278,12 +303,17 @@ pub(in crate::server) async fn add_task(
     };
 
     match handle
-        .add_task(req.title, req.description.unwrap_or_default())
+        .add_task_versioned(req.title, req.description.unwrap_or_default())
         .await
     {
-        Ok(task_id) => (
+        Ok((task_id, version)) => (
             StatusCode::CREATED,
-            Json(serde_json::json!({ "ok": true, "task_id": format!("{task_id}") })),
+            Json(serde_json::json!({
+                "ok": true,
+                "task_id": format!("{task_id}"),
+                "version": version,
+                "committed": "local",
+            })),
         ),
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
@@ -318,15 +348,40 @@ pub(in crate::server) async fn update_task(
     let task_id = x0x::crdt::TaskId::from_bytes(task_id_bytes);
 
     let result = match req.action.as_str() {
-        "claim" => handle.claim_task(task_id).await,
-        "complete" => handle.complete_task(task_id).await,
+        "claim" => {
+            handle
+                .claim_task_versioned(task_id, req.expected_version)
+                .await
+        }
+        "complete" => {
+            handle
+                .complete_task_versioned(task_id, req.expected_version)
+                .await
+        }
         _ => {
             return bad_request("action must be 'claim' or 'complete'");
         }
     };
 
     match result {
-        Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
+        // "committed": "local" makes explicit that success = local CRDT
+        // commit + best-effort delta publish, NOT replicated observation.
+        Ok(x0x::TaskCasOutcome::Committed { version }) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "ok": true,
+                "version": version,
+                "committed": "local",
+            })),
+        ),
+        Ok(x0x::TaskCasOutcome::VersionConflict { current_version }) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": "version conflict",
+                "current_version": current_version,
+            })),
+        ),
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use crate as x0x;
 
+use super::super::crdt_subscriptions;
 use super::super::state::AppState;
 use super::super::{api_error, bad_request, forbidden, not_found};
 
@@ -217,6 +218,20 @@ pub(in crate::server) async fn create_task_list(
         Ok(handle) => {
             let id = req.topic.clone();
             state.task_lists.write().await.insert(id.clone(), handle);
+            // Persist the registration so it survives a daemon restart
+            // (rehydrated after join_network — see crdt_subscriptions).
+            crdt_subscriptions::record(
+                &state,
+                crdt_subscriptions::CrdtSubscriptionEntry {
+                    kind: crdt_subscriptions::KIND_TASK_LIST.to_string(),
+                    id: id.clone(),
+                    name: req.name.clone(),
+                    topic: req.topic.clone(),
+                    role: crdt_subscriptions::ROLE_CREATED.to_string(),
+                    extra: serde_json::Map::new(),
+                },
+            )
+            .await;
             (
                 StatusCode::CREATED,
                 Json(serde_json::json!({ "ok": true, "id": id })),

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -510,6 +510,13 @@ pub(super) struct AppState {
     pub(super) subscriptions: RwLock<HashMap<String, RestSubscription>>,
     pub(super) task_lists: RwLock<HashMap<String, TaskListHandle>>,
     pub(super) kv_stores: RwLock<HashMap<String, KvStoreHandle>>,
+    /// Persisted task-list/kv-store subscription manifest so registrations
+    /// survive a daemon restart (rehydrated after `join_network`; see
+    /// `crdt_subscriptions`).
+    pub(super) crdt_subscriptions: RwLock<super::crdt_subscriptions::CrdtSubscriptionManifest>,
+    /// Disk location for the CRDT subscription manifest (instance data dir,
+    /// alongside `directory-subscriptions.json`).
+    pub(super) crdt_subscriptions_path: PathBuf,
     pub(super) named_groups: RwLock<HashMap<String, x0x::groups::GroupInfo>>,
     pub(super) named_groups_path: PathBuf,
     /// Serializes snapshot-and-write of `named_groups.json` so an older

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -29,6 +29,7 @@ covers project-wide rules and architecture.
 | `presence_integration.rs` | Presence API surface: subscribe, cached_agent, foaf_peer_candidates |
 | `kv_store_integration.rs` | KV store CRUD, access policies, CRDT sync |
 | `kv_first_join_bootstrap.rs` | Issue #96: cold first-join state bootstrap via state-sync side topic (daemon-backed, `--ignored`) |
+| `kv_signed_store_auth.rs` | Signed-store local-write enforcement: joiner PUT/DELETE -> 403, owner learned via signed OwnerAnnounce (daemon-backed, `--ignored`) |
 | `tasklist_first_join_bootstrap.rs` | Task-list cold first-join bootstrap via state-sync side topic + LWW-clock delta merge (daemon-backed, `--ignored`) |
 | `local_topics.rs` | Issue #89: `local:` topics deliver same-daemon only, never gossipped (daemon-backed, `--ignored`) |
 | `named_group_integration.rs` | Named groups, invites, join/leave, display names |

--- a/tests/COMPREHENSIVE_TEST_PROMPT.md
+++ b/tests/COMPREHENSIVE_TEST_PROMPT.md
@@ -796,7 +796,7 @@ Trust-gated introduction card served at `GET /introduction`. Filters visible fie
 ### 11.1 General WebSocket (5×)
 | # | Interface | Action | Expected |
 |---|-----------|--------|----------|
-| 1 | curl | Connect `ws://127.0.0.1:12701/ws?token=$TOKEN` | Connected |
+| 1 | curl | Mint session via `POST /auth/session` (Bearer $TOKEN), connect `ws://127.0.0.1:12701/ws?token=$SESSION_TOKEN` (durable token in URL → 401) | Connected |
 | 2 | curl | Send message via WS | Delivered |
 | 3 | curl | Receive event via WS | Event arrives |
 | 4 | GUI | WebSocket-backed real-time updates | Live updates |

--- a/tests/convergence/README.md
+++ b/tests/convergence/README.md
@@ -1,0 +1,107 @@
+# Convergence Soak Harness
+
+Repeatable, in-repo version of the external three-machine (macOS + 2 WAN
+droplets) convergence test of v0.30.1 that exposed restart-recovery,
+claim-semantics, and signed-store defects. It spins N (default 3) local
+`x0xd` instances that bootstrap **only to each other** and drives the same
+five scenarios with independent gates, per-primitive (TaskList vs KV)
+arrival timing, and per-phase gossip-diagnostics deltas. It exists to
+verify the fixes for those defects and to keep them fixed.
+
+Python 3 stdlib only (`urllib`, never curl — curl is intercepted in some
+environments).
+
+## Running
+
+```bash
+cargo build --release --bin x0xd     # or set X0XD_TEST_BINARY
+just convergence-soak-quick          # 1 run, ~3 min
+just convergence-soak                # 10 runs (soak)
+just convergence-soak 5              # custom run count
+
+# Direct invocation with custom gates:
+python3 tests/convergence/convergence_soak.py \
+    --runs 10 --nodes 3 --live-gate 60 --expect-fixed
+```
+
+Logs, per-run `report.json`, an aggregate `report.json`, and `summary.txt`
+land under `tests/convergence/out/<timestamp>/` (gitignored). Data dirs of
+failing runs are kept for debugging; passing runs are cleaned unless
+`--keep-data`.
+
+## Topology
+
+- N local daemons `conv1..convN`, each with its own config TOML, isolated
+  `data_dir` (fresh identities per run), pinned API port (`--api-base`+i)
+  and pinned QUIC `bind_address` port (`--quic-base`+i).
+- `conv1` has `bootstrap_peers = []`; every other node lists only conv1's
+  QUIC address. The explicit (possibly empty) `bootstrap_peers` list in the
+  config overrides the hardcoded global bootstrap network, so the cluster
+  is fully isolated. `--no-hard-coded-bootstrap` is deliberately NOT used:
+  it clears config-provided peers too.
+- Rolling start: 15 s between node launches (`--stagger-secs`, a known
+  network requirement).
+- API tokens are discovered from `<data_dir>/api-token`.
+
+## Phases and gates
+
+Each phase snapshots `GET /diagnostics/gossip` on every node before and
+after, and reports the delta of `pubsub_stages.admission` counters
+(especially `dropped_critical_hard_error` and cooling) so counter growth is
+attributable per phase. Convergence is sampled every `--poll-interval`
+(default 1.5 s) with the exact arrival time recorded separately for the
+task and the KV key.
+
+| Phase | What happens | Gate (default) |
+|---|---|---|
+| `cold_join` | conv1 creates a task list + task and a store + key **before** peers exist; each peer then starts, joins, and must see both primitives | task and key visible per node within `--cold-gate` (120 s) — hard |
+| `live_propagation` | after all joined and converged, conv1 adds a task and puts a key; per-primitive latency to each peer | all arrivals within `--live-gate` (60 s) — hard |
+| `restart_recovery` | convN stopped; conv1 adds a task + key; convN restarted; state must be visible **without** explicit re-create/join | `--restart-gate` (90 s) — known-gap |
+| `restart_recovery_eventual` | if auto-recovery failed, explicit rejoin (re-POST `/task-lists` + `/stores/join`) must restore all state incl. the offline mutation | within `--cold-gate` — hard, always |
+| `concurrent_claims` | conv1 adds a task; once visible on conv2+conv3 both PATCH `{"action":"claim"}` simultaneously (thread barrier); both HTTP responses recorded; all nodes polled until they agree on one winner | convergence to a single `claimed:*` state within `--claim-gate` (60 s) — hard |
+| `concurrent_claims_structured_fields` | are structured claim fields (`claimed_by`/`claimed_at`/`version`) present on the task? | known-gap |
+| `signed_store_nonowner_write` | conv2 (joiner) PUTs a new key into conv1's Signed store | HTTP 403 and no local fork — known-gap |
+| `signed_store_no_owner_propagation` | the intruder key must never become visible on the owner within `--fork-window` (20 s) | hard, always (a propagation would be a new inbound-enforcement regression) |
+
+## Known-gap flags vs `--expect-fixed`
+
+Three defects confirmed on current main are tracked as **known-gap**
+expectations so the harness runs green pre-fix:
+
+1. `restart_recovery` — task-list/store subscriptions are not restored
+   after daemon restart (server handle maps start empty).
+2. `concurrent_claims_structured_fields` — claim ownership is only encoded
+   in the formatted `state` string; no `claimed_by`/`claimed_at`/`version`.
+3. `signed_store_nonowner_write` — non-owner PUT returns local `200` and
+   forks locally instead of `403`.
+
+Without `--expect-fixed`, observing the legacy behavior reports the phase
+as `known-gap` (tolerated, run still passes); observing the fixed behavior
+reports `fixed`. With `--expect-fixed`, all three become hard gates — use
+this mode to verify the fixes and in CI afterwards.
+
+## Soak mode and reports
+
+`--runs N` repeats the full scenario N times with fresh data dirs (fresh
+identities, fresh topic/store names). The aggregate `report.json` contains
+per-run, per-phase, per-primitive latencies, pass/known-gap/fail status,
+raw claim responses, and per-phase diagnostics deltas. `summary.txt` (also
+printed) has a min/median/p95/max latency table, gate pass rates, per-phase
+`dropped_critical_hard_error` growth, and the known gaps observed.
+
+## Acceptance criteria (fix verification)
+
+- 10 runs (`just convergence-soak`), 100% eventual convergence for
+  cold-join, live-propagation, and offline-rejoin.
+- Zero unexplained `dropped_critical_hard_error` growth in the per-phase
+  diagnostics deltas.
+- With the fixes landed: `--expect-fixed` passes 10/10 (auto restart
+  recovery, structured claim fields, non-owner PUT rejected with 403 and
+  no local fork).
+
+## Teardown
+
+Daemons are terminated (SIGTERM then SIGKILL) on any failure or exception;
+logs and reports are always kept. If a run aborts hard, check for stray
+`x0xd` processes on API ports 27810+ before re-running (the harness refuses
+to start if an API port is busy).

--- a/tests/convergence/convergence_soak.py
+++ b/tests/convergence/convergence_soak.py
@@ -1,0 +1,920 @@
+#!/usr/bin/env python3
+"""Three-node local convergence soak harness for x0xd.
+
+Repeatable, in-repo version of the ad-hoc three-machine convergence test
+that exposed the v0.30.1 defects (restart recovery, claim semantics,
+signed-store non-owner writes). Spins N local x0xd instances with isolated
+data dirs that bootstrap only to each other, then drives five phases with
+independent gates and per-primitive (TaskList vs KV) arrival timing:
+
+  1. cold-join          task+key created on node1 BEFORE peers join
+  2. live-propagation   mutation after all peers joined and converged
+  3. restart-recovery   node N stopped, creator mutates, node restarted;
+                        state must be visible WITHOUT explicit rejoin
+  4. concurrent-claims  two peers claim the same task simultaneously
+  5. signed-store non-owner write  joiner PUTs to creator's Signed store
+
+GET /diagnostics/gossip is snapshotted on every node before and after each
+phase so pubsub admission-counter growth (dropped_critical_hard_error,
+cooling) is attributable per phase.
+
+Known-gap phases (current main, pre-fix): restart auto-recovery, structured
+claim fields (claimed_by/claimed_at/version), and non-owner PUT returning
+200 instead of 403. Without --expect-fixed these are reported as
+"known-gap" and do not fail the run; --expect-fixed turns them into hard
+gates for verifying the fixes.
+
+Stdlib only (urllib, never curl — curl is intercepted in some environments).
+
+Usage:
+  python3 tests/convergence/convergence_soak.py                 # 1 run
+  python3 tests/convergence/convergence_soak.py --runs 10       # soak
+  python3 tests/convergence/convergence_soak.py --expect-fixed  # post-fix
+"""
+
+import argparse
+import base64
+import concurrent.futures
+import json
+import os
+import pathlib
+import shutil
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_OUT = pathlib.Path(__file__).resolve().parent / "out"
+
+KNOWN_GAP_NOTES = {
+    "restart_auto_recovery": (
+        "task-list/store subscriptions are not restored after daemon "
+        "restart (server handle maps start empty)"
+    ),
+    "structured_claim_fields": (
+        "claim ownership is only encoded in the formatted `state` string; "
+        "no claimed_by/claimed_at/version fields"
+    ),
+    "nonowner_put_rejected": (
+        "non-owner PUT to a Signed store returns local 200 and forks "
+        "locally instead of being rejected with 403"
+    ),
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# HTTP helpers (urllib only)
+# ──────────────────────────────────────────────────────────────────────────
+
+def http_request(base, path, method="GET", body=None, token=None, timeout=10):
+    """Return {'status': int, 'body': parsed-json-or-text}. Raises OSError
+    (incl. URLError/ConnectionError) when the daemon is unreachable."""
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(base + path, data=data, headers=headers,
+                                 method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            status = resp.status
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        status = e.code
+    try:
+        parsed = json.loads(raw) if raw else None
+    except ValueError:
+        parsed = raw.decode(errors="replace")
+    return {"status": status, "body": parsed}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Node lifecycle
+# ──────────────────────────────────────────────────────────────────────────
+
+class Node:
+    def __init__(self, name, api_port, quic_port, root_dir, x0xd, log_level):
+        self.name = name
+        self.api_port = api_port
+        self.quic_port = quic_port
+        self.base = f"http://127.0.0.1:{api_port}"
+        self.dir = root_dir / name
+        self.data_dir = self.dir / "data"
+        self.config_path = self.dir / "config.toml"
+        self.log_path = self.dir / "daemon.log"
+        self.x0xd = x0xd
+        self.log_level = log_level
+        self.proc = None
+        self.token = None
+
+    def write_config(self, bootstrap_quic_ports):
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        peers = ", ".join(f'"127.0.0.1:{p}"' for p in bootstrap_quic_ports)
+        self.config_path.write_text(
+            f'instance_name = "{self.name}"\n'
+            f'data_dir = "{self.data_dir}"\n'
+            f'api_address = "127.0.0.1:{self.api_port}"\n'
+            f'bind_address = "127.0.0.1:{self.quic_port}"\n'
+            f'log_level = "{self.log_level}"\n'
+            # Explicit list (possibly empty) overrides the hardcoded global
+            # bootstrap network, keeping the cluster fully isolated. Do NOT
+            # pass --no-hard-coded-bootstrap: it clears config peers too.
+            f'bootstrap_peers = [{peers}]\n'
+        )
+
+    def start(self):
+        log = open(self.log_path, "a")
+        self.proc = subprocess.Popen(
+            [str(self.x0xd), "--config", str(self.config_path),
+             "--skip-update-check"],
+            stdout=log, stderr=subprocess.STDOUT,
+            cwd=str(self.dir),
+        )
+        log.close()
+
+    def wait_ready(self, timeout=60):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                raise RuntimeError(
+                    f"{self.name}: x0xd exited rc={self.proc.returncode} "
+                    f"(see {self.log_path})")
+            try:
+                r = http_request(self.base, "/health", timeout=2)
+                if r["status"] == 200:
+                    break
+            except OSError:
+                pass
+            time.sleep(0.5)
+        else:
+            raise RuntimeError(f"{self.name}: /health not up in {timeout}s")
+        token_file = self.data_dir / "api-token"
+        while time.monotonic() < deadline:
+            if token_file.exists() and token_file.stat().st_size > 0:
+                self.token = token_file.read_text().strip()
+                return
+            time.sleep(0.3)
+        raise RuntimeError(f"{self.name}: api-token not written in {timeout}s")
+
+    def req(self, method, path, body=None, auth=True, timeout=10):
+        return http_request(self.base, path, method=method, body=body,
+                            token=self.token if auth else None,
+                            timeout=timeout)
+
+    def stop(self, grace=8):
+        if self.proc is None or self.proc.poll() is not None:
+            self.proc = None
+            return
+        self.proc.send_signal(signal.SIGTERM)
+        try:
+            self.proc.wait(timeout=grace)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait(timeout=5)
+        self.proc = None
+
+    @property
+    def running(self):
+        return self.proc is not None and self.proc.poll() is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Diagnostics snapshots / deltas
+# ──────────────────────────────────────────────────────────────────────────
+
+def gossip_snapshot(nodes):
+    snap = {}
+    for n in nodes:
+        if not n.running:
+            snap[n.name] = None
+            continue
+        try:
+            r = n.req("GET", "/diagnostics/gossip")
+            snap[n.name] = r["body"] if r["status"] == 200 else None
+        except OSError:
+            snap[n.name] = None
+    return snap
+
+
+def admission_counters(snapshot_body):
+    if not isinstance(snapshot_body, dict):
+        return {}
+    adm = (snapshot_body.get("pubsub_stages") or {}).get("admission") or {}
+    return {k: v for k, v in adm.items() if isinstance(v, (int, float))}
+
+
+def admission_delta(before, after):
+    deltas = {}
+    for name in set(before) | set(after):
+        b = admission_counters(before.get(name))
+        a = admission_counters(after.get(name))
+        if not b and not a:
+            deltas[name] = None
+            continue
+        deltas[name] = {k: a.get(k, 0) - b.get(k, 0)
+                        for k in sorted(set(a) | set(b))
+                        if a.get(k, 0) - b.get(k, 0) != 0}
+    return deltas
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Convergence sampling — per-primitive arrival times
+# ──────────────────────────────────────────────────────────────────────────
+
+def sample_until(checks, gate_secs, interval):
+    """checks: {metric_name: callable() -> bool}. Samples every `interval`
+    seconds until every check has passed once or `gate_secs` elapses.
+    Returns {metric_name: arrival_secs_or_None} (arrival measured from the
+    first sample loop start)."""
+    start = time.monotonic()
+    arrivals = {k: None for k in checks}
+    while True:
+        elapsed = time.monotonic() - start
+        for key, fn in checks.items():
+            if arrivals[key] is not None:
+                continue
+            try:
+                if fn():
+                    arrivals[key] = round(time.monotonic() - start, 2)
+            except OSError:
+                pass
+        if all(v is not None for v in arrivals.values()):
+            return arrivals
+        if elapsed >= gate_secs:
+            return arrivals
+        time.sleep(interval)
+
+
+def task_visible(node, topic, task_id):
+    r = node.req("GET", f"/task-lists/{topic}/tasks")
+    if r["status"] != 200 or not isinstance(r["body"], dict):
+        return False
+    return any(t.get("id") == task_id for t in r["body"].get("tasks", []))
+
+
+def key_visible(node, store, key):
+    r = node.req("GET", f"/stores/{store}/{key}")
+    return r["status"] == 200 and isinstance(r["body"], dict) \
+        and r["body"].get("ok", True)
+
+
+def get_task(node, topic, task_id):
+    r = node.req("GET", f"/task-lists/{topic}/tasks")
+    if r["status"] != 200 or not isinstance(r["body"], dict):
+        return None
+    for t in r["body"].get("tasks", []):
+        if t.get("id") == task_id:
+            return t
+    return None
+
+
+def b64(value):
+    return base64.b64encode(value.encode()).decode()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Single run
+# ──────────────────────────────────────────────────────────────────────────
+
+class Run:
+    def __init__(self, idx, args, run_dir):
+        self.idx = idx
+        self.args = args
+        self.run_dir = run_dir
+        tag = f"{int(time.time())}-r{idx}"
+        self.topic = f"x0x.convergence.soak.{tag}"
+        self.store = f"x0x-convergence-store-{tag}"
+        self.nodes = []
+        self.report = {
+            "run": idx,
+            "topic": self.topic,
+            "store": self.store,
+            "started_unix": time.time(),
+            "phases": {},
+            "diagnostics_deltas": {},
+            "pass": None,
+        }
+        self.hard_failures = []
+        self.known_gaps = []
+
+    # -- helpers -----------------------------------------------------------
+
+    def creator(self):
+        return self.nodes[0]
+
+    def phase(self, name):
+        """Context manager: snapshots /diagnostics/gossip on all nodes
+        before and after the phase body, records the admission delta."""
+        run = self
+
+        class _Ctx:
+            def __enter__(self):
+                self.before = gossip_snapshot(run.nodes)
+                self.t0 = time.monotonic()
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                after = gossip_snapshot(run.nodes)
+                run.report["diagnostics_deltas"][name] = {
+                    "elapsed_secs": round(time.monotonic() - self.t0, 1),
+                    "admission_delta": admission_delta(self.before, after),
+                    "hard_error_after": {
+                        n: admission_counters(after.get(n)).get(
+                            "dropped_critical_hard_error")
+                        for n in after
+                    },
+                }
+                return False
+
+        return _Ctx()
+
+    def gate(self, phase, ok, detail=None):
+        entry = self.report["phases"].setdefault(phase, {})
+        entry["pass"] = bool(ok)
+        if detail is not None:
+            entry.update(detail)
+        if not ok:
+            self.hard_failures.append(phase)
+        return ok
+
+    def known_gap_gate(self, phase, gap_key, fixed, observed):
+        """A gate that is a hard requirement only under --expect-fixed.
+        `fixed` True means the post-fix behavior was observed."""
+        entry = self.report["phases"].setdefault(phase, {})
+        entry["observed"] = observed
+        if fixed:
+            entry["status"] = "fixed"
+            entry["pass"] = True
+        elif self.args.expect_fixed:
+            entry["status"] = "fail"
+            entry["pass"] = False
+            self.hard_failures.append(phase)
+        else:
+            entry["status"] = "known-gap"
+            entry["pass"] = True  # tolerated pre-fix
+            entry["known_gap"] = KNOWN_GAP_NOTES[gap_key]
+            self.known_gaps.append(phase)
+        return entry["pass"]
+
+    # -- topology ----------------------------------------------------------
+
+    def start_cluster_creator_only(self):
+        a = self.args
+        for i in range(a.nodes):
+            node = Node(
+                name=f"conv{i + 1}",
+                api_port=a.api_base + i,
+                quic_port=a.quic_base + i,
+                root_dir=self.run_dir,
+                x0xd=a.x0xd,
+                log_level=a.log_level,
+            )
+            # node1 bootstraps to nobody; every other node only to node1.
+            node.write_config([] if i == 0 else [a.quic_base])
+            self.nodes.append(node)
+        creator = self.nodes[0]
+        log(f"run {self.idx}: starting {creator.name} "
+            f"(api={creator.api_port}, quic={creator.quic_port})")
+        creator.start()
+        creator.wait_ready()
+
+    def start_peer(self, node):
+        log(f"run {self.idx}: starting {node.name} "
+            f"(api={node.api_port}, quic={node.quic_port})")
+        node.start()
+        node.wait_ready()
+
+    # -- phases ------------------------------------------------------------
+
+    def phase_cold_join(self):
+        a, creator = self.args, self.creator()
+        # Creator state BEFORE any peer exists.
+        tl = creator.req("POST", "/task-lists",
+                         {"name": "convergence soak", "topic": self.topic})
+        task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
+                           {"title": "prejoin-task",
+                            "description": "must cold-start replicate"})
+        st = creator.req("POST", "/stores",
+                         {"name": "convergence manifests",
+                          "topic": self.store})
+        put = creator.req("PUT", f"/stores/{self.store}/prejoin",
+                          {"value": b64("prejoin-value"),
+                           "content_type": "text/plain"})
+        if not all(r["status"] in (200, 201)
+                   for r in (tl, task, st, put)):
+            raise RuntimeError(
+                f"creator setup failed: tl={tl} task={task} st={st} put={put}")
+        self.pre_task_id = task["body"]["task_id"]
+
+        per_node = {}
+        with self.phase("cold_join"):
+            for node in self.nodes[1:]:
+                # Rolling start: known requirement — space daemon launches.
+                log(f"run {self.idx}: rolling-start wait "
+                    f"{a.stagger_secs}s before {node.name}")
+                time.sleep(a.stagger_secs)
+                self.start_peer(node)
+                join_tl = node.req("POST", "/task-lists",
+                                   {"name": "convergence soak",
+                                    "topic": self.topic})
+                join_st = node.req("POST", f"/stores/{self.store}/join")
+                arrivals = sample_until(
+                    {
+                        "task": lambda n=node: task_visible(
+                            n, self.topic, self.pre_task_id),
+                        "kv": lambda n=node: key_visible(
+                            n, self.store, "prejoin"),
+                    },
+                    gate_secs=a.cold_gate, interval=a.poll_interval)
+                per_node[node.name] = {
+                    "join_status": {"task_list": join_tl["status"],
+                                    "store": join_st["status"]},
+                    "task_secs": arrivals["task"],
+                    "kv_secs": arrivals["kv"],
+                }
+        ok = all(v["task_secs"] is not None and v["kv_secs"] is not None
+                 for v in per_node.values())
+        self.gate("cold_join", ok,
+                  {"gate_secs": a.cold_gate, "per_node": per_node})
+        log(f"run {self.idx}: cold_join {'PASS' if ok else 'FAIL'} "
+            f"{json.dumps(per_node)}")
+
+    def phase_live_propagation(self):
+        a, creator = self.args, self.creator()
+        with self.phase("live_propagation"):
+            task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
+                               {"title": "live-task",
+                                "description": "created after all joined"})
+            live_tid = task["body"]["task_id"]
+            creator.req("PUT", f"/stores/{self.store}/live",
+                        {"value": b64("live-value"),
+                         "content_type": "text/plain"})
+            checks = {}
+            for node in self.nodes[1:]:
+                checks[f"{node.name}.task"] = (
+                    lambda n=node: task_visible(n, self.topic, live_tid))
+                checks[f"{node.name}.kv"] = (
+                    lambda n=node: key_visible(n, self.store, "live"))
+            arrivals = sample_until(checks, gate_secs=a.live_gate,
+                                    interval=a.poll_interval)
+        self.live_task_id = live_tid
+        ok = all(v is not None for v in arrivals.values())
+        self.gate("live_propagation", ok,
+                  {"gate_secs": a.live_gate, "arrivals_secs": arrivals})
+        log(f"run {self.idx}: live_propagation {'PASS' if ok else 'FAIL'} "
+            f"{json.dumps(arrivals)}")
+
+    def phase_restart_recovery(self):
+        a, creator = self.args, self.creator()
+        victim = self.nodes[-1]
+        with self.phase("restart_recovery"):
+            log(f"run {self.idx}: stopping {victim.name}")
+            victim.stop()
+            time.sleep(3)
+            task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
+                               {"title": "offline-recovery",
+                                "description": "created while peer was down"})
+            off_tid = task["body"]["task_id"]
+            creator.req("PUT", f"/stores/{self.store}/offline",
+                        {"value": b64("offline-value"),
+                         "content_type": "text/plain"})
+            log(f"run {self.idx}: restarting {victim.name}")
+            victim.start()
+            victim.wait_ready()
+            # No explicit rejoin — this is exactly what the fix must provide.
+            arrivals = sample_until(
+                {
+                    "task": lambda: task_visible(victim, self.topic, off_tid),
+                    "kv": lambda: key_visible(victim, self.store, "offline"),
+                },
+                gate_secs=a.restart_gate, interval=a.poll_interval)
+            auto = (arrivals["task"] is not None
+                    and arrivals["kv"] is not None)
+
+            rejoin = None
+            if not auto:
+                # Explicit rejoin (followup.py pattern) so later phases can
+                # run; its own convergence is a hard gate either way.
+                t0 = time.monotonic()
+                victim.req("POST", "/task-lists",
+                           {"name": "convergence soak", "topic": self.topic})
+                victim.req("POST", f"/stores/{self.store}/join")
+                r = sample_until(
+                    {
+                        "task": lambda: task_visible(
+                            victim, self.topic, off_tid),
+                        "kv": lambda: key_visible(
+                            victim, self.store, "offline"),
+                    },
+                    gate_secs=a.cold_gate, interval=a.poll_interval)
+                rejoin = {
+                    "task_secs": r["task"], "kv_secs": r["kv"],
+                    "total_secs": round(time.monotonic() - t0, 2),
+                }
+        observed = {
+            "node": victim.name,
+            "auto_recovery_arrivals_secs": arrivals,
+            "auto_recovery_gate_secs": a.restart_gate,
+            "explicit_rejoin": rejoin,
+        }
+        self.known_gap_gate("restart_recovery", "restart_auto_recovery",
+                            fixed=auto, observed=observed)
+        if not auto:
+            # Eventual convergence via explicit rejoin is ALWAYS a hard gate
+            # (acceptance criterion: 100% eventual offline-rejoin).
+            ok = (rejoin is not None and rejoin["task_secs"] is not None
+                  and rejoin["kv_secs"] is not None)
+            self.gate("restart_recovery_eventual", ok,
+                      {"explicit_rejoin": rejoin})
+        status = self.report["phases"]["restart_recovery"]["status"]
+        log(f"run {self.idx}: restart_recovery {status} "
+            f"{json.dumps(observed)}")
+
+    def phase_concurrent_claims(self):
+        a, creator = self.args, self.creator()
+        claimants = self.nodes[1:3]
+        with self.phase("concurrent_claims"):
+            task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
+                               {"title": "claim-target",
+                                "description": "two peers claim this"})
+            tid = task["body"]["task_id"]
+            vis = sample_until(
+                {n.name: (lambda n=n: task_visible(n, self.topic, tid))
+                 for n in claimants},
+                gate_secs=a.live_gate, interval=a.poll_interval)
+            if any(v is None for v in vis.values()):
+                self.gate("concurrent_claims", False,
+                          {"error": "task never visible on claimants",
+                           "visibility_secs": vis})
+                log(f"run {self.idx}: concurrent_claims FAIL (visibility)")
+                return
+
+            barrier = threading.Barrier(len(claimants))
+
+            def do_claim(node):
+                barrier.wait(timeout=10)
+                return node.req(
+                    "PATCH", f"/task-lists/{self.topic}/tasks/{tid}",
+                    {"action": "claim"})
+
+            with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=len(claimants)) as ex:
+                futs = {n.name: ex.submit(do_claim, n) for n in claimants}
+                responses = {k: f.result() for k, f in futs.items()}
+
+            t0 = time.monotonic()
+            winner, converge_secs, final_tasks = None, None, {}
+            while time.monotonic() - t0 < a.claim_gate:
+                final_tasks = {n.name: get_task(n, self.topic, tid)
+                               for n in self.nodes}
+                states = [t.get("state") if t else None
+                          for t in final_tasks.values()]
+                if (None not in states and len(set(states)) == 1
+                        and str(states[0]).startswith("claimed")):
+                    converge_secs = round(time.monotonic() - t0, 2)
+                    winner = states[0]
+                    break
+                time.sleep(a.poll_interval)
+
+        structured = {}
+        for name, t in final_tasks.items():
+            structured[name] = (
+                {k: t.get(k) for k in
+                 ("claimed_by", "claimed_at", "version") if k in t}
+                if isinstance(t, dict) else None)
+        has_structured = all(
+            isinstance(s, dict) and "claimed_by" in s
+            for s in structured.values())
+
+        converged = converge_secs is not None
+        self.gate("concurrent_claims", converged, {
+            "gate_secs": a.claim_gate,
+            "visibility_secs": vis,
+            "claim_responses": {k: {"status": v["status"], "body": v["body"]}
+                                for k, v in responses.items()},
+            "both_accepted_200": all(
+                v["status"] == 200 for v in responses.values()),
+            "converge_secs": converge_secs,
+            "winner_state": winner,
+        })
+        self.known_gap_gate(
+            "concurrent_claims_structured_fields", "structured_claim_fields",
+            fixed=has_structured,
+            observed={"structured_fields": structured})
+        log(f"run {self.idx}: concurrent_claims "
+            f"{'PASS' if converged else 'FAIL'} winner={winner!r} "
+            f"converge={converge_secs}s structured={has_structured}")
+
+    def phase_signed_store_nonowner(self):
+        a, creator = self.args, self.creator()
+        writer = self.nodes[1]
+        with self.phase("signed_store_nonowner_write"):
+            put = writer.req("PUT", f"/stores/{self.store}/unauthorized",
+                             {"value": b64("intruder-value"),
+                              "content_type": "text/plain"})
+            local = writer.req("GET", f"/stores/{self.store}/unauthorized")
+            # Observe the fork window: the key must never become visible on
+            # the creator (owner-side inbound enforcement).
+            deadline = time.monotonic() + a.fork_window
+            propagated = False
+            while time.monotonic() < deadline:
+                if key_visible(creator, self.store, "unauthorized"):
+                    propagated = True
+                    break
+                time.sleep(a.poll_interval)
+        rejected = put["status"] == 403
+        local_fork = local["status"] == 200
+        observed = {
+            "writer": writer.name,
+            "put_status": put["status"],
+            "put_body": put["body"],
+            "writer_local_read_status": local["status"],
+            "local_fork": local_fork,
+            "propagated_to_owner": propagated,
+            "fork_window_secs": a.fork_window,
+        }
+        fixed = rejected and not local_fork and not propagated
+        self.known_gap_gate("signed_store_nonowner_write",
+                            "nonowner_put_rejected", fixed=fixed,
+                            observed=observed)
+        # Propagation to the owner would be a NEW defect (inbound
+        # enforcement regression) — hard gate regardless of mode.
+        self.gate("signed_store_no_owner_propagation", not propagated,
+                  {"propagated_to_owner": propagated})
+        status = self.report["phases"]["signed_store_nonowner_write"]["status"]
+        log(f"run {self.idx}: signed_store_nonowner_write {status} "
+            f"put={put['status']} local_fork={local_fork} "
+            f"propagated={propagated}")
+
+    # -- driver ------------------------------------------------------------
+
+    def execute(self):
+        try:
+            self.start_cluster_creator_only()
+            self.phase_cold_join()
+            self.phase_live_propagation()
+            self.phase_restart_recovery()
+            self.phase_concurrent_claims()
+            self.phase_signed_store_nonowner()
+        finally:
+            for n in self.nodes:
+                try:
+                    n.stop()
+                except Exception:
+                    pass
+        self.report["finished_unix"] = time.time()
+        self.report["hard_failures"] = self.hard_failures
+        self.report["known_gaps"] = self.known_gaps
+        self.report["pass"] = not self.hard_failures
+        return self.report
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Soak orchestration + summary
+# ──────────────────────────────────────────────────────────────────────────
+
+def log(msg):
+    print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def check_port_free(port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(("127.0.0.1", port)) != 0
+
+
+def latency_series(runs):
+    """Collect named latency samples across runs."""
+    series = {}
+
+    def add(key, value):
+        if value is not None:
+            series.setdefault(key, []).append(value)
+
+    for r in runs:
+        p = r["phases"]
+        for node, v in p.get("cold_join", {}).get("per_node", {}).items():
+            add("cold_join.task", v["task_secs"])
+            add("cold_join.kv", v["kv_secs"])
+        for key, v in p.get("live_propagation", {}) \
+                .get("arrivals_secs", {}).items():
+            prim = key.rsplit(".", 1)[-1]
+            add(f"live_propagation.{prim}", v)
+        rr = p.get("restart_recovery", {}).get("observed", {})
+        auto = rr.get("auto_recovery_arrivals_secs") or {}
+        add("restart.auto.task", auto.get("task"))
+        add("restart.auto.kv", auto.get("kv"))
+        rj = rr.get("explicit_rejoin") or {}
+        add("restart.rejoin.task", rj.get("task_secs"))
+        add("restart.rejoin.kv", rj.get("kv_secs"))
+        add("claims.converge", p.get("concurrent_claims", {})
+            .get("converge_secs"))
+    return series
+
+
+def pctl(sorted_vals, q):
+    if not sorted_vals:
+        return None
+    k = max(0, min(len(sorted_vals) - 1,
+                   round(q * (len(sorted_vals) - 1))))
+    return sorted_vals[k]
+
+
+def summarize(runs, args):
+    lines = []
+    total = len(runs)
+    passed = sum(1 for r in runs if r["pass"])
+    lines.append("")
+    lines.append("=" * 72)
+    lines.append(f"CONVERGENCE SOAK SUMMARY — {total} run(s), "
+                 f"{args.nodes} nodes, mode="
+                 f"{'expect-fixed' if args.expect_fixed else 'known-gap'}")
+    lines.append("=" * 72)
+    lines.append(f"runs passed: {passed}/{total}")
+
+    # Gate pass rates
+    lines.append("")
+    lines.append(f"{'phase':<42}{'pass':>6}{'gap':>6}{'fail':>6}")
+    phase_names = []
+    for r in runs:
+        for name in r["phases"]:
+            if name not in phase_names:
+                phase_names.append(name)
+    for name in phase_names:
+        n_pass = n_gap = n_fail = 0
+        for r in runs:
+            e = r["phases"].get(name)
+            if e is None:
+                continue
+            status = e.get("status")
+            if status == "known-gap":
+                n_gap += 1
+            elif e.get("pass"):
+                n_pass += 1
+            else:
+                n_fail += 1
+        lines.append(f"{name:<42}{n_pass:>6}{n_gap:>6}{n_fail:>6}")
+
+    # Latency table
+    series = latency_series(runs)
+    lines.append("")
+    lines.append(f"{'latency (secs)':<28}{'n':>4}{'min':>8}{'median':>8}"
+                 f"{'p95':>8}{'max':>8}")
+    for key in sorted(series):
+        vals = sorted(series[key])
+        lines.append(
+            f"{key:<28}{len(vals):>4}{vals[0]:>8.1f}"
+            f"{statistics.median(vals):>8.1f}"
+            f"{pctl(vals, 0.95):>8.1f}{vals[-1]:>8.1f}")
+
+    # Diagnostics: hard-error growth per phase (summed across runs+nodes)
+    lines.append("")
+    lines.append("dropped_critical_hard_error growth per phase "
+                 "(sum across runs and nodes):")
+    growth = {}
+    for r in runs:
+        for phase, d in r.get("diagnostics_deltas", {}).items():
+            for node, delta in (d.get("admission_delta") or {}).items():
+                if delta:
+                    growth[phase] = growth.get(phase, 0) + delta.get(
+                        "dropped_critical_hard_error", 0)
+                else:
+                    growth.setdefault(phase, 0)
+    for phase, g in growth.items():
+        lines.append(f"  {phase:<40}{g:>6}")
+
+    # Known gaps observed
+    gaps = {}
+    for r in runs:
+        for name, e in r["phases"].items():
+            if e.get("status") == "known-gap":
+                gaps[name] = e.get("known_gap", "")
+    if gaps:
+        lines.append("")
+        lines.append("known gaps observed (tolerated; use --expect-fixed to "
+                     "gate on them):")
+        for name, note in gaps.items():
+            lines.append(f"  - {name}: {note}")
+
+    lines.append("")
+    lines.append(f"OVERALL: {'PASS' if passed == total else 'FAIL'}")
+    return "\n".join(lines)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="x0x three-node convergence soak harness")
+    p.add_argument("--nodes", type=int, default=3,
+                   help="number of local x0xd instances (default 3, min 3)")
+    p.add_argument("--runs", type=int, default=1,
+                   help="repeat the full scenario N times (default 1)")
+    p.add_argument("--x0xd", default=None,
+                   help="path to x0xd binary (default: $X0XD_TEST_BINARY "
+                        "or target/release/x0xd)")
+    p.add_argument("--api-base", type=int, default=27810,
+                   help="first API port; node i uses api-base+i")
+    p.add_argument("--quic-base", type=int, default=27910,
+                   help="first QUIC port; node i uses quic-base+i")
+    p.add_argument("--stagger-secs", type=float, default=15.0,
+                   help="rolling-start delay between node launches "
+                        "(default 15, a known network requirement)")
+    p.add_argument("--poll-interval", type=float, default=1.5,
+                   help="convergence sampling interval in seconds")
+    p.add_argument("--cold-gate", type=float, default=120.0,
+                   help="cold-join convergence gate per node (secs)")
+    p.add_argument("--live-gate", type=float, default=60.0,
+                   help="live-propagation gate (secs)")
+    p.add_argument("--restart-gate", type=float, default=90.0,
+                   help="restart auto-recovery gate (secs)")
+    p.add_argument("--claim-gate", type=float, default=60.0,
+                   help="concurrent-claim convergence gate (secs)")
+    p.add_argument("--fork-window", type=float, default=20.0,
+                   help="observation window for non-owner write "
+                        "propagation (secs)")
+    p.add_argument("--expect-fixed", action="store_true",
+                   help="turn known-gap expectations into hard gates "
+                        "(use to verify the fixes)")
+    p.add_argument("--log-level", default="info",
+                   help="daemon log_level (default info)")
+    p.add_argument("--out-dir", default=str(DEFAULT_OUT),
+                   help="output root for logs and reports")
+    p.add_argument("--keep-data", action="store_true",
+                   help="keep node data dirs after passing runs")
+    args = p.parse_args()
+    if args.nodes < 3:
+        p.error("--nodes must be >= 3 (claims need two non-creator peers)")
+    if args.x0xd is None:
+        args.x0xd = os.environ.get(
+            "X0XD_TEST_BINARY", str(REPO_ROOT / "target/release/x0xd"))
+    args.x0xd = pathlib.Path(args.x0xd)
+    return args
+
+
+def main():
+    args = parse_args()
+    if not args.x0xd.is_file():
+        log(f"ERROR: x0xd not found at {args.x0xd} — build with "
+            f"`cargo build --release --bin x0xd` or set X0XD_TEST_BINARY")
+        return 2
+    for i in range(args.nodes):
+        if not check_port_free(args.api_base + i):
+            log(f"ERROR: API port {args.api_base + i} already in use")
+            return 2
+
+    out_root = pathlib.Path(args.out_dir) / time.strftime("%Y%m%d-%H%M%S")
+    out_root.mkdir(parents=True, exist_ok=True)
+    log(f"output: {out_root}")
+    log(f"x0xd: {args.x0xd}")
+
+    runs = []
+    try:
+        for i in range(1, args.runs + 1):
+            run_dir = out_root / f"run-{i}"
+            run_dir.mkdir(parents=True, exist_ok=True)
+            log(f"=== run {i}/{args.runs} ===")
+            run = Run(i, args, run_dir)
+            try:
+                report = run.execute()
+            except Exception as e:  # harness/daemon failure: fail loud
+                for n in run.nodes:
+                    try:
+                        n.stop()
+                    except Exception:
+                        pass
+                report = run.report
+                report["pass"] = False
+                report["error"] = f"{type(e).__name__}: {e}"
+                report["hard_failures"] = run.hard_failures + ["exception"]
+                log(f"run {i}: EXCEPTION {e}")
+            runs.append(report)
+            (run_dir / "report.json").write_text(
+                json.dumps(report, indent=2))
+            # Fresh data dirs per run: keep logs+configs, drop key/state data
+            # unless asked to keep it (or the run failed — keep for debug).
+            if report["pass"] and not args.keep_data:
+                for n in run.nodes:
+                    shutil.rmtree(n.data_dir, ignore_errors=True)
+            time.sleep(2)  # let UDP/TCP ports drain between runs
+    finally:
+        report_path = out_root / "report.json"
+        report_path.write_text(json.dumps({
+            "args": {k: str(v) if isinstance(v, pathlib.Path) else v
+                     for k, v in vars(args).items()},
+            "runs": runs,
+        }, indent=2))
+        summary = summarize(runs, args) if runs else "(no runs completed)"
+        (out_root / "summary.txt").write_text(summary + "\n")
+        print(summary)
+        log(f"report: {report_path}")
+
+    return 0 if runs and all(r["pass"] for r in runs) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/crdt_subscription_persistence.rs
+++ b/tests/crdt_subscription_persistence.rs
@@ -1,0 +1,246 @@
+//! Regression tests for daemon-restart amnesia: task-list and kv-store
+//! registrations must survive an x0xd restart WITHOUT the application
+//! re-creating or re-joining them.
+//!
+//! Before the fix, `AppState.task_lists` / `AppState.kv_stores` were only
+//! populated by the REST create/join handlers, so a restarted daemon answered
+//! "task list not found" / "store not found" until an explicit re-create.
+//! The fix persists a subscription manifest (`crdt-subscriptions.json` in the
+//! instance data dir) and rehydrates it after `join_network` by driving the
+//! same Agent create/join paths — the empty-replica state-request bootstrap
+//! then recovers content (including offline mutations) from peer replicas.
+//!
+//! All tests are `#[ignore]` — they boot real x0xd daemons.
+//! Run with: cargo nextest run --test crdt_subscription_persistence --run-ignored all
+//! Before running: cargo build --bin x0xd (or set X0XD_TEST_BINARY)
+
+use base64::Engine;
+use std::time::Duration;
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+fn b64(s: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(s)
+}
+
+/// Poll `path` on `node` until `pred(json)` is true or the deadline passes.
+async fn poll_until(
+    node: &cluster::AgentInstance,
+    path: &str,
+    what: &str,
+    deadline_secs: u64,
+    pred: impl Fn(&serde_json::Value) -> bool,
+) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(deadline_secs);
+    let mut last = serde_json::Value::Null;
+    loop {
+        let resp = node.get(path).await;
+        if let Ok(json) = resp.json::<serde_json::Value>().await {
+            if pred(&json) {
+                return;
+            }
+            last = json;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!(
+                "{}: {what} not observed within {deadline_secs}s; last response: {last}",
+                node.name
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+fn tasks_contain(json: &serde_json::Value, title: &str) -> bool {
+    json["tasks"]
+        .as_array()
+        .is_some_and(|ts| ts.iter().any(|t| t["title"] == title))
+}
+
+/// WHY: this is the defect itself — after a restart, both a joined kv store
+/// and a created task list must be answerable via REST (registration AND
+/// content) without any re-create/re-join call. Bob is restarted because his
+/// config bootstraps to alice, so reconnection is deterministic; alice keeps
+/// the authoritative replicas that bob's rehydrated (empty) CRDTs pull state
+/// from via the state-request side channel.
+#[tokio::test]
+#[ignore]
+async fn task_list_and_kv_store_survive_daemon_restart() {
+    let mut pair = cluster::pair().await;
+    let suffix = rand::random::<u32>();
+    let list_topic = format!("restart-list-{suffix}");
+    let store_topic = format!("restart-store-{suffix}");
+
+    // Alice creates + populates both CRDTs.
+    let r = pair
+        .alice
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "restart-list", "topic": list_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates task list");
+    let r = pair
+        .alice
+        .post(
+            &format!("/task-lists/{list_topic}/tasks"),
+            serde_json::json!({ "title": "pre-restart-task" }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice adds task");
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "restart-store", "topic": store_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates store");
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{store_topic}/pre-key"),
+            serde_json::json!({ "value": b64(b"pre-restart-value") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice puts key");
+
+    // Bob replicates both: joins the store (role "joined") and creates the
+    // task list on the same topic (role "created" — the only REST path).
+    let r = pair
+        .bob
+        .post(
+            &format!("/stores/{store_topic}/join"),
+            serde_json::json!({}),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob joins store");
+    let r = pair
+        .bob
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "restart-list", "topic": list_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob creates task-list replica");
+
+    // Both registrations must be in bob's persisted manifest.
+    let manifest_path = pair.bob.data_dir().join("crdt-subscriptions.json");
+    assert!(
+        manifest_path.exists(),
+        "manifest not written at {}",
+        manifest_path.display()
+    );
+
+    // Bob converges before the restart (proves replication works at all).
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "pre-restart task replication",
+        120,
+        |json| tasks_contain(json, "pre-restart-task"),
+    )
+    .await;
+    poll_until(
+        &pair.bob,
+        &format!("/stores/{store_topic}/pre-key"),
+        "pre-restart key replication",
+        120,
+        |json| json["value"] == b64(b"pre-restart-value"),
+    )
+    .await;
+
+    // Restart bob. NO re-create/re-join calls after this point.
+    pair.bob.restart().await;
+
+    // Registration and content must come back on their own: the manifest
+    // rehydration re-subscribes, and the empty-replica state request pulls
+    // the full state from alice.
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "post-restart task list recovery (no re-create)",
+        120,
+        |json| tasks_contain(json, "pre-restart-task"),
+    )
+    .await;
+    poll_until(
+        &pair.bob,
+        &format!("/stores/{store_topic}/pre-key"),
+        "post-restart store key recovery (no re-join)",
+        120,
+        |json| json["value"] == b64(b"pre-restart-value"),
+    )
+    .await;
+}
+
+/// WHY: the point of persisting subscriptions is that mutations made while an
+/// instance is DOWN still arrive after it comes back — without the manifest,
+/// a restarted daemon has no handle, so the offline delta has nowhere to
+/// land and the app sees "task list not found" forever.
+#[tokio::test]
+#[ignore]
+async fn offline_mutation_arrives_after_restart_without_rejoin() {
+    let mut pair = cluster::pair().await;
+    let suffix = rand::random::<u32>();
+    let list_topic = format!("offline-list-{suffix}");
+
+    let r = pair
+        .alice
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "offline-list", "topic": list_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates task list");
+    let r = pair
+        .alice
+        .post(
+            &format!("/task-lists/{list_topic}/tasks"),
+            serde_json::json!({ "title": "task-before-outage" }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice adds first task");
+
+    // Bob replicates the list and converges.
+    let r = pair
+        .bob
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "offline-list", "topic": list_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob creates task-list replica");
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "pre-outage task replication",
+        120,
+        |json| tasks_contain(json, "task-before-outage"),
+    )
+    .await;
+
+    // Bob goes down; alice mutates while he is offline.
+    pair.bob.stop();
+    let r = pair
+        .alice
+        .post(
+            &format!("/task-lists/{list_topic}/tasks"),
+            serde_json::json!({ "title": "offline-task" }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice adds task while bob is down");
+
+    // Bob comes back. NO re-create call — the offline mutation must arrive
+    // via manifest rehydration + state-request recovery alone.
+    pair.bob.start().await;
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "offline mutation after restart (no rejoin)",
+        120,
+        |json| tasks_contain(json, "offline-task") && tasks_contain(json, "task-before-outage"),
+    )
+    .await;
+}

--- a/tests/daemon_api_integration.rs
+++ b/tests/daemon_api_integration.rs
@@ -1960,6 +1960,189 @@ async fn daemon_api_complete_task() -> Result<()> {
     Ok(())
 }
 
+/// PATCH a task with an arbitrary body, returning (status, body) for
+/// assertions on both success and conflict responses.
+async fn patch_task_raw(
+    d: &DaemonFixture,
+    list_id: &str,
+    task_id: &str,
+    body: Value,
+) -> Result<(StatusCode, Value)> {
+    let response = ca(d)
+        .patch(d.url(&format!("/task-lists/{list_id}/tasks/{task_id}")))
+        .json(&body)
+        .send()
+        .await?;
+    let status = response.status();
+    let body: Value = response.json().await?;
+    Ok((status, body))
+}
+
+fn task_entry<'a>(body: &'a Value, task_id: &str) -> Option<&'a Value> {
+    body["tasks"].as_array().and_then(|tasks| {
+        tasks
+            .iter()
+            .find(|task| task["id"].as_str() == Some(task_id))
+    })
+}
+
+// WHY: claiming used to return bare {"ok":true} with the task's assignee
+// null forever — ownership was only recoverable by parsing the Display
+// string "claimed:<hex>", and success gave no version or consistency
+// signal. This test pins the structured contract.
+#[tokio::test]
+#[ignore]
+async fn daemon_api_claim_returns_version_and_structured_fields() -> Result<()> {
+    let d = daemon().await;
+    let (list_id, task_id) = create_task_list_item(&d, "Structured claim").await?;
+
+    // Claim: response must carry the new list version and the explicit
+    // local-commit marker (success = local commit + publish, NOT replication).
+    let (status, body) = patch_task_raw(
+        &d,
+        &list_id,
+        &task_id,
+        serde_json::json!({"action":"claim"}),
+    )
+    .await?;
+    ensure!(status == StatusCode::OK, "claim status: {status}");
+    ensure!(body["ok"] == true, "claim response: {body:?}");
+    ensure!(body["version"].is_u64(), "claim missing version: {body:?}");
+    ensure!(
+        body["committed"] == "local",
+        "claim missing committed marker: {body:?}"
+    );
+
+    // GET: structured ownership fields must be populated, legacy state kept.
+    let listed = list_task_list_items(&d, &list_id).await?;
+    ensure!(
+        listed["version"].is_u64(),
+        "list missing version: {listed:?}"
+    );
+    let entry = task_entry(&listed, &task_id).context("task present in listing")?;
+    let claimed_by = entry["claimed_by"]
+        .as_str()
+        .context("claimed_by non-null")?;
+    ensure!(
+        claimed_by.len() == 64,
+        "claimed_by is hex AgentId: {entry:?}"
+    );
+    ensure!(
+        entry["claimed_at"]
+            .as_u64()
+            .is_some_and(|t| t > 1_000_000_000_000),
+        "claimed_at is Unix ms: {entry:?}"
+    );
+    ensure!(
+        entry["assignee"].as_str() == Some(claimed_by),
+        "assignee register populated by claim: {entry:?}"
+    );
+    ensure!(
+        entry["state"]
+            .as_str()
+            .is_some_and(|s| s.starts_with("claimed:")),
+        "legacy state string unchanged: {entry:?}"
+    );
+    ensure!(
+        entry["completed_by"].is_null() && entry["completed_at"].is_null(),
+        "completion fields null before done: {entry:?}"
+    );
+
+    // Complete: completion fields become non-null, claim record survives.
+    let (status, body) = patch_task_raw(
+        &d,
+        &list_id,
+        &task_id,
+        serde_json::json!({"action":"complete"}),
+    )
+    .await?;
+    ensure!(status == StatusCode::OK, "complete status: {status}");
+    ensure!(
+        body["version"].is_u64() && body["committed"] == "local",
+        "complete response: {body:?}"
+    );
+    let listed = list_task_list_items(&d, &list_id).await?;
+    let entry = task_entry(&listed, &task_id).context("task present after done")?;
+    ensure!(
+        entry["completed_by"]
+            .as_str()
+            .is_some_and(|s| s.len() == 64),
+        "completed_by non-null after done: {entry:?}"
+    );
+    ensure!(
+        entry["completed_at"]
+            .as_u64()
+            .is_some_and(|t| t > 1_000_000_000_000),
+        "completed_at is Unix ms: {entry:?}"
+    );
+    ensure!(
+        entry["claimed_by"].as_str() == Some(claimed_by),
+        "claim record survives completion: {entry:?}"
+    );
+    Ok(())
+}
+
+// WHY: without a CAS signal two agents could both "successfully" claim and
+// neither could detect the race. expected_version turns a stale claim into
+// a visible 409 with the current version and NO mutation.
+#[tokio::test]
+#[ignore]
+async fn daemon_api_claim_expected_version_cas() -> Result<()> {
+    let d = daemon().await;
+    let (list_id, task_id) = create_task_list_item(&d, "CAS claim").await?;
+
+    let listed = list_task_list_items(&d, &list_id).await?;
+    let version = listed["version"].as_u64().context("list version present")?;
+
+    // Stale expected_version ⇒ 409 with current_version, task untouched.
+    let (status, body) = patch_task_raw(
+        &d,
+        &list_id,
+        &task_id,
+        serde_json::json!({"action":"claim","expected_version": version + 1000}),
+    )
+    .await?;
+    ensure!(status == StatusCode::CONFLICT, "stale CAS status: {status}");
+    ensure!(body["ok"] == false, "conflict response: {body:?}");
+    ensure!(
+        body["error"] == "version conflict",
+        "conflict error: {body:?}"
+    );
+    ensure!(
+        body["current_version"].as_u64() == Some(version),
+        "conflict must report current version: {body:?}"
+    );
+    let listed = list_task_list_items(&d, &list_id).await?;
+    let entry = task_entry(&listed, &task_id).context("task still listed")?;
+    ensure!(
+        entry["state"] == "empty" && entry["claimed_by"].is_null(),
+        "409 must not mutate the task: {entry:?}"
+    );
+    ensure!(
+        listed["version"].as_u64() == Some(version),
+        "409 must not bump the version: {listed:?}"
+    );
+
+    // Fresh expected_version ⇒ 200 committed with a bumped version.
+    let (status, body) = patch_task_raw(
+        &d,
+        &list_id,
+        &task_id,
+        serde_json::json!({"action":"claim","expected_version": version}),
+    )
+    .await?;
+    ensure!(status == StatusCode::OK, "fresh CAS status: {status}");
+    ensure!(
+        body["ok"] == true && body["committed"] == "local",
+        "fresh CAS response: {body:?}"
+    );
+    ensure!(
+        body["version"].as_u64().is_some_and(|v| v > version),
+        "fresh CAS bumps version: {body:?}"
+    );
+    Ok(())
+}
+
 // ===========================================================================
 // Network (5)
 // ===========================================================================

--- a/tests/harness/src/cluster.rs
+++ b/tests/harness/src/cluster.rs
@@ -36,8 +36,20 @@ impl AgentInstance {
     }
 
     pub async fn restart(&mut self) {
+        self.stop();
+        self.start().await;
+    }
+
+    /// Kill the daemon process without restarting it. Pair with
+    /// [`Self::start`] to create a downtime window during which other
+    /// instances can mutate shared state (offline-mutation tests).
+    pub fn stop(&mut self) {
         let _ = self.process.kill();
         let _ = self.process.wait();
+    }
+
+    /// Start the daemon again after [`Self::stop`] and wait until healthy.
+    pub async fn start(&mut self) {
         self.process = Command::new(&self.binary)
             .arg("--config")
             .arg(&self.config_path)

--- a/tests/kv_signed_store_auth.rs
+++ b/tests/kv_signed_store_auth.rs
@@ -1,0 +1,138 @@
+//! Security regression test — a non-owner joiner of a `Signed` KV store
+//! must NOT be able to mutate its local replica.
+//!
+//! Previously a joiner's replica claimed the joiner itself as owner with a
+//! permissive policy, so a local PUT via REST returned `200 {"ok":true}` and
+//! forked the joiner's replica away from the state authorized peers accept
+//! (the creator rejected the joiner's deltas, but the joiner kept its junk).
+//!
+//! The fix: a joined replica starts with no owner (fail closed, read-only),
+//! learns the authoritative owner + policy from an owner-signed announcement
+//! on the state-sync side topic, and enforces the same `is_authorized` rule
+//! on local writes as on inbound deltas. REST returns 403 for rejected
+//! writes.
+//!
+//! All tests are `#[ignore]` — they boot real x0xd daemons.
+//! Run with: cargo nextest run --test kv_signed_store_auth -- --ignored
+//! Before running: cargo build --release --bin x0xd
+
+use base64::Engine;
+use std::time::{Duration, Instant};
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+fn b64(s: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(s)
+}
+
+/// Poll until `key` is visible in bob's replica, panicking after `deadline`.
+async fn wait_for_key(bob: &cluster::AgentInstance, topic: &str, key: &str, secs: u64) {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    loop {
+        let r = bob.get(&format!("/stores/{topic}/{key}")).await;
+        if r.status().is_success() {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "key {key} never replicated to the joiner within {secs}s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn joiner_put_on_signed_store_is_403_and_does_not_mutate() {
+    let pair = cluster::pair().await;
+    let topic = format!("kv-auth-{}", rand::random::<u32>());
+
+    // Alice creates the store (Signed policy, owner = alice) and writes a
+    // seed key.
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "authz", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates store");
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/seed"),
+            serde_json::json!({ "value": b64(b"owner-data") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice (owner) writes seed key");
+
+    // Bob joins. His replica must sync the seed key — which also proves he
+    // has adopted the authoritative owner, since a replica with an unknown
+    // owner rejects all inbound deltas (fail closed).
+    let r = pair
+        .bob
+        .post(&format!("/stores/{topic}/join"), serde_json::json!({}))
+        .await;
+    assert!(r.status().is_success(), "bob joins store");
+    wait_for_key(&pair.bob, &topic, "seed", 60).await;
+
+    // THE DEFECT: bob (non-owner) PUTs into the Signed store. This used to
+    // return 200 and mutate his local replica, creating a fork the creator
+    // rejects. It must now be a 403 with a distinct error body.
+    let r = pair
+        .bob
+        .put(
+            &format!("/stores/{topic}/intruder"),
+            serde_json::json!({ "value": b64(b"forked-junk") }),
+        )
+        .await;
+    assert_eq!(
+        r.status().as_u16(),
+        403,
+        "non-owner local PUT on a Signed store must be rejected with 403"
+    );
+    let body: serde_json::Value = r.json().await.expect("403 body is json");
+    assert_eq!(body["ok"], false, "error body must carry ok:false");
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("not authorized") && err.contains("owner is "),
+        "403 body must name the policy violation and the true owner; got: {err}"
+    );
+
+    // And the local replica must NOT have been mutated.
+    let r = pair.bob.get(&format!("/stores/{topic}/intruder")).await;
+    assert_eq!(
+        r.status().as_u16(),
+        404,
+        "rejected PUT must not mutate the joiner's local replica"
+    );
+
+    // Non-owner DELETE of an existing key must also be rejected without
+    // mutating the replica.
+    let r = pair.bob.delete(&format!("/stores/{topic}/seed")).await;
+    assert_eq!(
+        r.status().as_u16(),
+        403,
+        "non-owner local DELETE on a Signed store must be rejected with 403"
+    );
+    let r = pair.bob.get(&format!("/stores/{topic}/seed")).await;
+    assert!(
+        r.status().is_success(),
+        "rejected DELETE must not remove the key from the joiner's replica"
+    );
+
+    // Creator writes keep working and still replicate to the joiner.
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/post-join"),
+            serde_json::json!({ "value": b64(b"still-flows") }),
+        )
+        .await;
+    assert!(
+        r.status().is_success(),
+        "owner writes must keep working unchanged"
+    );
+    wait_for_key(&pair.bob, &topic, "post-join", 30).await;
+}


### PR DESCRIPTION
## Summary

Closes every defect from the external three-machine convergence test of v0.30.1 (evidence: `x0x-v0.30.1-convergence-evidence.zip`, three-reviewer NO-GO verdict). Integration of five reviewed work-package branches:

- **`fix/kv-signed-store-local-auth`** — Signed-store blocker: joined replicas start fail-closed (owner unknown → read-only), learn ownership via `OwnerAnnounce` on the state-sync topic (verified sender must equal claimed owner, immutable once established), and local PUT/DELETE now enforce `is_authorized` → REST **403** with owner hex. Previously a non-owner PUT returned 200 and forked local state.
- **`fix/crdt-subscription-persistence`** — task-list/KV-store subscriptions persist to `crdt-subscriptions.json` and rehydrate on daemon startup. Previously all handles were lost on restart (404 until manual re-create/join).
- **`fix/task-claim-structured-fields`** — `claimed_by`/`claimed_at`/`completed_by`/`completed_at` + populated `assignee`, task-list `version` on all reads/mutations, optional `expected_version` CAS → **409**, and `"committed":"local"` making local-commit-vs-replicated explicit.
- **`test/convergence-soak-harness`** — `tests/convergence/` 3-node soak harness (per-primitive latency, per-phase `/diagnostics/gossip` deltas, `--runs N`, `--expect-fixed`), `just convergence-soak`.
- **`docs/ws-session-token`** + example-apps fix — WebSocket/SSE/GUI examples now mint short-lived session tokens via `POST /auth/session`; durable token never in a URL (previous examples 401'd).

## Verification

- Full gate on integrated tree: fmt clean, clippy zero warnings, **2194/2194 nextest**, doc clean.
- **Local deep soak: 10/10 runs PASS in `--expect-fixed` mode** — restart auto-recovery median 1.5s (no rejoin), non-owner PUT 403 with zero forks, structured claims on every run, zero `dropped_critical_hard_error` growth in every phase.
- **Real-WAN validation (testnet NYC/Helsinki/Singapore)**: cold-join ≤4.9s, 15/15 live iterations <5.6s, restart rehydrate + resync ≤24s over WAN, claim convergence 1.64s with identical `claimed_by` on all nodes, 403 + owner-hex on non-owner PUT (proving OwnerAnnounce propagation over gossip).

## Notes

- Mixed-version: a new joiner cannot learn ownership from a v0.30.1 store owner (no announce) — stays read-only until the owner upgrades (deliberate fail-closed).
- Companion fix in saorsa-gossip (`fix/cooldown-recovery-bypass`) addresses the WAN live-propagation stall (120s suppression cooldown); lands via a future saorsa-gossip release + repin, independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes several convergence gaps across KV stores, task lists, subscriptions, and examples. The main changes are:

- Signed KV stores now fail closed on joined replicas and learn ownership through state-sync announcements.
- Task-list APIs now return versions, structured claim/completion fields, and optional conflict checks.
- CRDT task-list and KV subscriptions now persist to a restart manifest.
- WebSocket and SSE examples now mint short-lived session tokens.
- A three-node convergence soak harness and related tests were added.

<h3>Confidence Score: 4/5</h3>

The KV owner adoption, task-list CAS token, and subscription manifest persistence paths need fixes before merging.

- A joined KV replica can bind to the wrong owner if a self-signed announcement arrives first.
- Full-state task-list merges can leave the version unchanged, so stale expected-version writes can still commit.
- Concurrent CRDT registrations can write stale manifest snapshots and lose restart recovery for a subscription.

src/kv/store.rs, src/crdt/task_list.rs, src/server/crdt_subscriptions.rs

<details open><summary><h3>Security Review</h3></summary>

A KV ownership issue was identified: a joined replica can accept the first self-signed owner announcement for a store topic, which can bind the replica to the wrong owner before the real owner announces.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/kv/store.rs | Adds fail-closed replicas, local write checks, and owner adoption; the owner adoption path can bind to the first self-signed announcer. |
| src/kv/sync.rs | Adds owner announcement messages on the state-sync topic and routes them into `learn_ownership`. |
| src/crdt/task_list.rs | Full-state merges can change task data without updating the version now exposed as a CAS token. |
| src/server/crdt_subscriptions.rs | Adds manifest persistence and rehydration, but concurrent records can overwrite newer on-disk snapshots. |
| src/server/routes/tasks.rs | Exposes versioned task responses, structured claim fields, and expected-version conflict responses. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Rogue as Rogue peer
    participant Joiner as Joined replica
    participant Owner as Real owner
    Rogue->>Joiner: "OwnerAnnounce(owner=Rogue)"
    Joiner->>Joiner: owner was None, store Rogue as owner
    Owner->>Joiner: "OwnerAnnounce(owner=Owner)"
    Joiner-->>Owner: reject conflicting owner
    Owner->>Joiner: signed store delta
    Joiner->>Joiner: reject delta as unauthorized
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Rogue as Rogue peer
    participant Joiner as Joined replica
    participant Owner as Real owner
    Rogue->>Joiner: "OwnerAnnounce(owner=Rogue)"
    Joiner->>Joiner: owner was None, store Rogue as owner
    Owner->>Joiner: "OwnerAnnounce(owner=Owner)"
    Joiner-->>Owner: reject conflicting owner
    Owner->>Joiner: signed store delta
    Joiner->>Joiner: reject delta as unauthorized
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/kv/store.rs:329-331
**First Announce Captures Owner**

When a joined replica has `owner: None`, this branch accepts the first `OwnerAnnounce` whose verified sender matches the claimed owner. A peer that knows the state-sync topic can publish a self-signed announcement for itself before the real owner responds, causing the replica to store that peer as immutable owner and reject the real owner's later deltas as unauthorized.

### Issue 2 of 2
src/server/crdt_subscriptions.rs:176-184
**Concurrent Records Lose Subscriptions**

`record` clones a snapshot under the manifest lock, then releases the lock before writing it to disk. Two successful create/join requests can race their writes so the older snapshot lands last, leaving the on-disk manifest missing the newer subscription; after restart that CRDT is not rehydrated even though its registration returned success.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/fix..."](https://github.com/saorsa-labs/x0x/commit/b573441ecb21245671ca2a0cc8a2af625202074a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43647098)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->