### PR TITLE
v0.31 remediation: convergence fixes + omp security wave + memory-leak fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ NETWORK_TEST_REPORT.txt
 .pi/messenger/
 native-build.log
 wpa-build.log
+
+# Convergence soak harness output (daemon logs, per-run reports)
+tests/convergence/out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Anchored KV-store ownership + owner-signed content checkpoints.** A `KvStore`'s owner (its creator) now produces an ML-DSA-65-signed content checkpoint on every published write, binding the store topic, id, policy, a monotonic `checkpoint_seq`, and a BLAKE3 root over the active `(key, content_hash)` set. A replica already anchored on `expected_owner` verifies the owner signature and recomputes the content root independent of the relayer, so it can cold-recover a consistent snapshot from a non-owner relay while the owner is offline. Checkpoints never establish ownership — an unanchored replica rejects all of them fail-closed, and `checkpoint_seq` gates replay/downgrade. The trailing `owner_checkpoint` delta field deserializes to `None` when absent, so a legacy peer's delta still decodes on a current node.
+
+- **Advisory, authenticated task claims + restart-safe fence epoch.** `TaskItem::claim`/`complete` are advisory and non-exclusive: each records a self-attested candidate in the checkbox OR-Set (`sign_attestation` signs domain-separated bytes with the agent's ML-DSA key via `SigningContext`, requiring the element's `agent_id` to match the signing context), and concurrent claims coexist, resolving to a single deterministic winner (earliest timestamp, then lexicographic agent id) that is only stable once all replicas converge. There is no distributed lock. Local-replica fencing uses a `FenceToken` `(epoch, revision)` — the per-replica epoch is regenerated on every daemon restart, so a stale post-restart token can never ABA-match; a non-matching token rejects the mutation with `409` and changes nothing. Two daemons at the same token both accept (this is not a distributed compare-and-swap).
+
+- **Durable CRDT subscription manifest.** Task-list and KV-store registrations are persisted to `crdt-subscriptions.json` (instance data dir) and rehydrated on startup by driving the same create/join paths the REST handlers use, so subscriptions survive a daemon restart. A corrupt manifest is quarantined to a warning log and the process starts empty rather than failing to boot.
+
+- **Proactive reconnect with exponential backoff.** When a known peer disconnects, the daemon schedules a proactive reconnect with a bounded exponential backoff (first attempt after ~1 s — fast enough to cover a same-host restart without a tight retry loop on a genuinely-down peer), trying discovery addresses then the bootstrap cache. A pending reconnect is cancelled as soon as the connection returns.
+
+### Changed
+
+- **Removed dead `AlreadyClaimed` error variants.** `CrdtError::AlreadyClaimed` and `CheckboxError::AlreadyClaimed` were unreachable under advisory (additive OR-Set) claims — the production claim path adds a candidate and never rejects a re-claim except for an already-`Done` task — and have been deleted with no compatibility alias. `CheckboxState::transition_to_claimed` now permits a `Claimed → Claimed` re-claim (advisory), returning `CheckboxError::AlreadyDone` only for an immutable `Done` task; exhaustive matches and display tests were updated accordingly.
+
 ## [v0.30.1] - 2026-07-11
 
 ### Documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,11 @@ name = "gui-coverage"
 path = "src/bin/gui_coverage.rs"
 test = false
 
+[[bin]]
+name = "x0xd-forge-injector"
+path = "src/bin/x0xd_forge_injector.rs"
+test = false
+
 [[bench]]
 name = "gossip_dispatch_throughput"
 harness = false

--- a/README.md
+++ b/README.md
@@ -536,9 +536,14 @@ x0x routes
 For live data — chat messages, direct messages, events — use WebSocket. Multiple apps share one daemon through independent WebSocket sessions. `127.0.0.1:12700` is the default API address, but using `api.port` is more correct for named instances and custom configs.
 
 ```bash
-# Using $API and $TOKEN from the REST API section above
-wscat -c "ws://$API/ws?token=$TOKEN"         # General-purpose session
-wscat -c "ws://$API/ws/direct?token=$TOKEN"  # Auto-subscribe to direct messages
+# Using $API and $TOKEN from the REST API section above.
+# The durable token is never accepted in a URL — mint a short-lived
+# session token (10 min TTL) and pass THAT as ?token=:
+SESSION=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "http://$API/auth/session" | jq -r .session_token)
+
+wscat -c "ws://$API/ws?token=$SESSION"         # General-purpose session
+wscat -c "ws://$API/ws/direct?token=$SESSION"  # Auto-subscribe to direct messages
 ```
 
 **Subscribe to topics:**
@@ -587,18 +592,28 @@ A complete chat app in a single HTML file — serve it from `http://127.0.0.1` o
     const TOKEN = 'YOUR_TOKEN_HERE'; // inject from <data_dir>/api-token
     const TOPIC = 'my-chat-room';
     const API = 'http://127.0.0.1:12700';
-    const WS_URL = `ws://127.0.0.1:12700/ws?token=${TOKEN}`;
 
-    // Connect WebSocket
-    const ws = new WebSocket(WS_URL);
-    ws.onopen = () => ws.send(JSON.stringify({type:'subscribe', topics:[TOPIC]}));
-    ws.onmessage = (e) => {
-      const msg = JSON.parse(e.data);
-      if (msg.type === 'message') {
-        const div = document.getElementById('messages');
-        div.innerHTML += `<p><b>${msg.origin?.slice(0,8)}:</b> ${atob(msg.payload)}</p>`;
-      }
-    };
+    // WebSockets can't set an Authorization header, so exchange the durable
+    // token for a short-lived session token and pass that as ?token=
+    // (the durable token is rejected in query strings).
+    let ws;
+    (async () => {
+      const { session_token } = await fetch(`${API}/auth/session`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      }).then((r) => r.json());
+
+      // Connect WebSocket
+      ws = new WebSocket(`ws://127.0.0.1:12700/ws?token=${session_token}`);
+      ws.onopen = () => ws.send(JSON.stringify({type:'subscribe', topics:[TOPIC]}));
+      ws.onmessage = (e) => {
+        const msg = JSON.parse(e.data);
+        if (msg.type === 'message') {
+          const div = document.getElementById('messages');
+          div.innerHTML += `<p><b>${msg.origin?.slice(0,8)}:</b> ${atob(msg.payload)}</p>`;
+        }
+      };
+    })();
 
     // Send via REST
     function send() {

--- a/SKILL.md
+++ b/SKILL.md
@@ -185,9 +185,11 @@ x0x agent
 x0x subscribe hello-world
 x0x publish hello-world "Hello!"
 
-# REST API auth: /health and /constitution* are public; /gui, /ws, /events
-# accept the token via ?token=; every other route requires the
-# Authorization: Bearer header shown below.
+# REST API auth: /health and /constitution* are public; every other route
+# requires the Authorization: Bearer header shown below. Browser endpoints
+# (/gui, /ws, /ws/direct, /events, /direct/events) also accept
+# ?token=<session_token> — but ONLY a short-lived session token minted via
+# POST /auth/session (the durable api-token is never accepted in a URL).
 DATA_DIR="$HOME/Library/Application Support/x0x"   # macOS
 # DATA_DIR="$HOME/.local/share/x0x"                # Linux
 API=$(cat "$DATA_DIR/api.port")
@@ -246,11 +248,17 @@ curl -X POST "http://$API/mls/groups/GROUP_ID/encrypt" \
 For real-time bidirectional communication, use WebSocket instead of REST+SSE:
 
 ```bash
+# Mint a short-lived session token first — the durable api-token is
+# rejected in query strings (Bearer header only). Sessions expire after
+# 10 minutes ({"session_token": "...", "expires_in": 600}).
+SESSION=$(curl -s -X POST "http://$API/auth/session" \
+  -H "Authorization: Bearer $TOKEN" | jq -r .session_token)
+
 # Connect (general purpose)
-wscat -c "ws://$API/ws?token=$TOKEN"
+wscat -c "ws://$API/ws?token=$SESSION"
 
 # Connect with auto-subscribe to direct messages
-wscat -c "ws://$API/ws/direct?token=$TOKEN"
+wscat -c "ws://$API/ws/direct?token=$SESSION"
 
 # Check active sessions
 curl -H "Authorization: Bearer $TOKEN" "http://$API/ws/sessions"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -558,11 +558,11 @@ or
 {"action":"complete"}
 ```
 
-### Task versions, structured claim fields, and optimistic concurrency
+### Task versions, advisory claims, and local-replica fencing
 
-Every task-list response carries the list's `version` — a counter bumped on
-each local or merged mutation. Mutation responses (create list, add task,
-claim, complete) return:
+Every task-list response carries the list's `version` — a local counter bumped
+on each local or merged mutation. Mutation responses (create list, add task,
+claim, complete) return the new version plus `"committed":"local"`:
 
 ```json
 {"ok":true,"version":7,"committed":"local"}
@@ -581,26 +581,78 @@ alongside the legacy `state` string (unchanged for backward compatibility):
   to). Non-null once claimed; `claimed_by` survives completion.
 - `completed_by` / `completed_at` — same, for the winning completion; null
   unless done.
-- `assignee` — hex AgentId from the task's LWW assignee register, now
-  populated by claim/complete (was previously always null).
+- `assignee` — hex AgentId from the task's LWW assignee register, populated
+  by claim/complete.
 
-The update-task request accepts an optional `expected_version` for
-compare-and-set semantics (honored for both `claim` and `complete`):
+#### Claims are advisory, never exclusive
+
+A successful `claim` records a *candidate* in the OR-Set. It does **not**
+grant exclusive ownership and does **not** prevent another agent (on this or
+any other replica) from also claiming. Concurrent claims coexist and resolve
+to a single deterministic winner (earliest timestamp, then lexicographic
+agent id) only after convergence — a strictly earlier-timestamp candidate
+arriving via a later merge can still displace the current winner. There is no
+distributed lock.
+
+The claim/complete response makes this advisory status explicit:
 
 ```json
-{"action":"claim","expected_version":7}
+{
+  "ok": true,
+  "version": 8,
+  "fence_token": "<opaque epoch:revision — echo on next mutation>",
+  "committed": "local",
+  "resolution": {
+    "agent_id": "<hex>",
+    "locally_winning": true,
+    "current_winner": { "agent_id": "<hex>", "timestamp_ms": 1700000000000 },
+    "pending_convergence": true
+  },
+  "cas": { "scope": "local_replica" },
+  "execution": { "authorization": "advisory" },
+  "exclusive": false
+}
 ```
 
-If `expected_version` does not match the list's current version, nothing is
-mutated and the daemon returns **409 Conflict**:
+- `resolution.locally_winning` — whether the caller is the local OR-Set's
+  current deterministic winner at commit time. **Provisional**: a
+  strictly-earlier candidate arriving via merge flips it to `false`.
+- `resolution.current_winner` — the local deterministic winner (claim or
+  completion), or `null`; lets a superseded caller see who currently beats
+  them.
+- `resolution.pending_convergence` — always `true` under CRDT: a later
+  earlier-timestamp candidate may still arrive.
+- `cas.scope` — `"local_replica"`: the `fence_token` guard (below)
+  serializes ops on ONE daemon only.
+- `execution.authorization` — `"advisory"`: callers MAY begin
+  idempotent/reconcilable work and MUST re-check the winner after
+  convergence. Exactly-once side effects are NOT provided.
+- `exclusive` — always `false`.
+#### `fence_token`: restart-safe local fence, not distributed CAS
+
+The update-task request accepts an optional `fence_token` — an **opaque**
+`"epoch:revision"` string returned by GET and by every mutation. Clients echo
+it verbatim and MUST NOT construct or interpret it:
 
 ```json
-{"ok":false,"error":"version conflict","current_version":9}
+{"action":"claim","fence_token":"1779123456789:7"}
 ```
 
-Without `expected_version`, behavior is unchanged: concurrent claims from two
-agents both return 200, and the CRDT merge deterministically resolves a
-single winner (`claimed_by`) after convergence.
+This is a **local-replica fencing precondition**, not a distributed
+compare-and-swap. When it does not match THIS daemon's current
+`(epoch, revision)`, nothing is mutated and the daemon returns **409 Conflict**:
+
+```json
+{"ok":false,"error":"stale_local_version","current_version":9,"fence_token":"1779123456789:9","cas":{"scope":"local_replica"}}
+```
+
+A 409 means "this replica moved" (stale revision) or "the daemon restarted
+under you" (stale epoch) — never "a peer beat you". The epoch is regenerated
+when the daemon restarts, so a token captured before a restart can never
+ABA-match a post-restart token even if the revision counter later reaches the
+same value. Two daemons at the same token will BOTH accept, because the guard
+cannot provide cross-replica exclusion. Without `fence_token`, the mutation is
+unconditional (still advisory).
 
 ## Key-value stores
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -579,6 +579,16 @@ or
 }
 ```
 
+### Store write authorization
+
+Stores default to the `Signed` policy: only the creating agent (the owner)
+may write. `PUT` and `DELETE` on `/stores/:id/:key` return **403** with
+`{"ok":false,"error":"not authorized: store policy is signed; owner is <hex>"}`
+when this daemon's agent is not authorized — including on a joined replica
+that has not yet learned the store's authoritative owner from the
+owner-signed announcement (`"not authorized: store owner unknown: ..."`).
+Reads are always allowed.
+
 ## File transfers
 
 | Method | Endpoint | CLI | Purpose |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -558,6 +558,50 @@ or
 {"action":"complete"}
 ```
 
+### Task versions, structured claim fields, and optimistic concurrency
+
+Every task-list response carries the list's `version` — a counter bumped on
+each local or merged mutation. Mutation responses (create list, add task,
+claim, complete) return:
+
+```json
+{"ok":true,"version":7,"committed":"local"}
+```
+
+`"committed":"local"` is explicit about the consistency model: success means
+the mutation was committed to the **local** CRDT replica and a delta was
+published to peers — it does NOT mean any peer has observed it yet.
+Replication is eventual (gossip anti-entropy).
+
+Each task in `GET /task-lists/:id/tasks` includes structured ownership fields
+alongside the legacy `state` string (unchanged for backward compatibility):
+
+- `claimed_by` / `claimed_at` — hex AgentId and Unix-ms timestamp of the
+  deterministic claim winner (the OR-Set resolution both replicas converge
+  to). Non-null once claimed; `claimed_by` survives completion.
+- `completed_by` / `completed_at` — same, for the winning completion; null
+  unless done.
+- `assignee` — hex AgentId from the task's LWW assignee register, now
+  populated by claim/complete (was previously always null).
+
+The update-task request accepts an optional `expected_version` for
+compare-and-set semantics (honored for both `claim` and `complete`):
+
+```json
+{"action":"claim","expected_version":7}
+```
+
+If `expected_version` does not match the list's current version, nothing is
+mutated and the daemon returns **409 Conflict**:
+
+```json
+{"ok":false,"error":"version conflict","current_version":9}
+```
+
+Without `expected_version`, behavior is unchanged: concurrent claims from two
+agents both return 200, and the CRDT merge deterministically resolves a
+single winner (`claimed_by`) after convergence.
+
 ## Key-value stores
 
 | Method | Endpoint | CLI | Purpose |

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -22,7 +22,7 @@ For named instances (`x0xd --name alice`), the directory is `x0x-alice/` instead
 
 ## Authentication
 
-All API endpoints (except `/health` and `/gui`) require a bearer token:
+All API endpoints (except `/health` and `/constitution*`) require a bearer token:
 
 ```
 Authorization: Bearer <token>
@@ -30,10 +30,13 @@ Authorization: Bearer <token>
 
 The token is generated once on first daemon startup and persists across restarts. It's stored at `<data_dir>/api-token` with 0600 permissions (owner read/write only).
 
-WebSocket connections pass the token as a query parameter since browsers cannot set custom headers on WebSocket upgrades:
+WebSocket connections pass a token as a query parameter since browsers cannot set custom headers on WebSocket upgrades — but the durable API token is **never** accepted in a URL. Exchange it for a short-lived session token (10 min TTL) via `POST /auth/session` and pass that instead:
 
 ```
-ws://127.0.0.1:12700/ws?token=<token>
+POST /auth/session            (Authorization: Bearer <durable token>)
+  → {"session_token": "...", "expires_in": 600}
+
+ws://127.0.0.1:12700/ws?token=<session_token>
 ```
 
 ## Quick Start Examples
@@ -109,8 +112,13 @@ const headers = { Authorization: `Bearer ${apiToken}` };
 const agent = await fetch(`${base}/agent`, { headers }).then((r) => r.json());
 console.log(`Agent ID: ${agent.agent_id}`);
 
-// WebSocket with token
-const ws = new WebSocket(`ws://${apiAddr}/ws?token=${apiToken}`);
+// WebSocket: mint a short-lived session token — the durable token
+// is rejected in query strings.
+const { session_token } = await fetch(`${base}/auth/session`, {
+  method: "POST",
+  headers,
+}).then((r) => r.json());
+const ws = new WebSocket(`ws://${apiAddr}/ws?token=${session_token}`);
 ws.onmessage = (e) => console.log(JSON.parse(e.data));
 ws.onopen = () => {
   ws.send(JSON.stringify({ type: "subscribe", topics: ["my-app/events"] }));

--- a/docs/primers/apps.md
+++ b/docs/primers/apps.md
@@ -60,10 +60,15 @@ Avoid hardcoding `127.0.0.1:12700`. Use `api.port` and `api-token` from the data
 </html>
 ```
 
-For real-time features:
+For real-time features, exchange the durable token for a short-lived session token first — `?token=` only accepts session tokens minted via `POST /auth/session`, never the durable api-token:
 
 ```javascript
-const ws = new WebSocket(`ws://127.0.0.1:12700/ws?token=${TOKEN}`);
+const { session_token } = await fetch(`${apiBase}/auth/session`, {
+  method: "POST",
+  headers: { Authorization: `Bearer ${token}` }
+}).then((r) => r.json());
+
+const ws = new WebSocket(`ws://127.0.0.1:12700/ws?token=${session_token}`);
 
 ws.onopen = () => {
   ws.send(JSON.stringify({

--- a/docs/primers/messaging.md
+++ b/docs/primers/messaging.md
@@ -141,11 +141,11 @@ Important: direct events do not currently include `verified` or `trust_level`. T
 
 ## WebSocket for apps
 
-For browser or app UIs, use the WebSocket endpoints with the token in the query string:
+For browser or app UIs, use the WebSocket endpoints with a token in the query string. Only a short-lived session token is accepted there — mint one with `POST /auth/session` (durable Bearer token required; returns `{"session_token": "...", "expires_in": 600}`). The durable api-token is never valid in a URL:
 
 ```text
-ws://127.0.0.1:12700/ws?token=<TOKEN>
-ws://127.0.0.1:12700/ws/direct?token=<TOKEN>
+ws://127.0.0.1:12700/ws?token=<SESSION_TOKEN>
+ws://127.0.0.1:12700/ws/direct?token=<SESSION_TOKEN>
 ```
 
 Client messages:

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -19,7 +19,7 @@ The apps connect to `http://localhost:12700` by default. To target another daemo
 x0x-chat.html?api=http://127.0.0.1:51555&token=<api-token>
 ```
 
-The apps remember those values in `localStorage` as `x0x.apiBase` and `x0x.apiToken`. WebSocket apps derive their `ws://.../ws?token=...` endpoint from the configured API base.
+The apps remember those values in `localStorage` as `x0x.apiBase` and `x0x.apiToken`. WebSocket apps exchange the durable token for a short-lived session token (`POST /auth/session`) on every connection attempt, then connect to `ws://.../ws?token=<session_token>` — the durable token never appears in a URL.
 
 When using an authenticated daemon from a browser, serve these files from a loopback HTTP origin so the daemon CORS policy can allow the request:
 

--- a/examples/apps/x0x-chat.html
+++ b/examples/apps/x0x-chat.html
@@ -137,7 +137,19 @@ const API_URL = (CONFIG.get("api") || localStorage.getItem("x0x.apiBase") || "ht
 const API_TOKEN = CONFIG.get("token") || localStorage.getItem("x0x.apiToken") || "";
 if (CONFIG.get("api")) localStorage.setItem("x0x.apiBase", API_URL);
 if (CONFIG.get("token")) localStorage.setItem("x0x.apiToken", API_TOKEN);
-const WS_URL = API_URL.replace(/^http/, "ws") + "/ws" + (API_TOKEN ? "?token=" + encodeURIComponent(API_TOKEN) : "");
+const WS_BASE = API_URL.replace(/^http/, "ws") + "/ws";
+// The durable token must never appear in a URL; exchange it for a short-lived
+// session token (POST /auth/session) each time the WebSocket is opened.
+async function wsUrl() {
+  if (!API_TOKEN) return WS_BASE;
+  const res = await fetch(API_URL + "/auth/session", {
+    method: "POST",
+    headers: { "Authorization": "Bearer " + API_TOKEN },
+  });
+  if (!res.ok) throw new Error("session mint failed: " + res.status);
+  const body = await res.json();
+  return WS_BASE + "?token=" + encodeURIComponent(body.session_token);
+}
 
 const DEFAULT_ROOM = "x0x-chat/general";
 const RECONNECT_MS = 3000;
@@ -209,9 +221,11 @@ function subscribe(topic) {
   subscribedTopics.add(topic);
 }
 
-function connect() {
+async function connect() {
   setStatus(false, "Connecting…");
-  try { ws = new WebSocket(WS_URL); } catch { scheduleReconnect(); return; }
+  let url;
+  try { url = await wsUrl(); } catch { scheduleReconnect(); return; }
+  try { ws = new WebSocket(url); } catch { scheduleReconnect(); return; }
 
   ws.onmessage = function (ev) {
     let msg; try { msg = JSON.parse(ev.data); } catch { return; }

--- a/examples/apps/x0x-swarm.html
+++ b/examples/apps/x0x-swarm.html
@@ -96,7 +96,19 @@ const API_URL = (CONFIG.get("api") || localStorage.getItem("x0x.apiBase") || "ht
 const API_TOKEN = CONFIG.get("token") || localStorage.getItem("x0x.apiToken") || "";
 if (CONFIG.get("api")) localStorage.setItem("x0x.apiBase", API_URL);
 if (CONFIG.get("token")) localStorage.setItem("x0x.apiToken", API_TOKEN);
-const WS_URL = API_URL.replace(/^http/, "ws") + "/ws" + (API_TOKEN ? "?token=" + encodeURIComponent(API_TOKEN) : "");
+const WS_BASE = API_URL.replace(/^http/, "ws") + "/ws";
+// The durable token must never appear in a URL; exchange it for a short-lived
+// session token (POST /auth/session) each time the WebSocket is opened.
+async function wsUrl() {
+  if (!API_TOKEN) return WS_BASE;
+  const res = await fetch(API_URL + "/auth/session", {
+    method: "POST",
+    headers: { "Authorization": "Bearer " + API_TOKEN },
+  });
+  if (!res.ok) throw new Error("session mint failed: " + res.status);
+  const body = await res.json();
+  return WS_BASE + "?token=" + encodeURIComponent(body.session_token);
+}
 
 let ws = null, connected = false, myAgentId = null, sessionId = null, taskListId = null;
 let myTasks = [], feedEvents = [], agents = new Map(), taskMap = new Map();
@@ -168,9 +180,11 @@ async function ensureTaskList() {
   } catch (e) { console.warn("Could not create task list", e); }
 }
 
-function connectWs() {
+async function connectWs() {
   if (ws) try { ws.close(); } catch (e) { /* ignore */ }
-  ws = new WebSocket(WS_URL);
+  let url;
+  try { url = await wsUrl(); } catch (e) { setStatus(false, "Auth failed"); return; }
+  ws = new WebSocket(url);
   ws.onopen = () => {
     setStatus(false, "Subscribing");
   };

--- a/justfile
+++ b/justfile
@@ -108,3 +108,17 @@ bump-version VERSION:
 
 release-dryrun:
     bash scripts/release-dryrun.sh
+
+# ── Convergence soak (tests/convergence) ──────────────────────────────────
+
+# Full soak: repeat the 3-node convergence scenario (cold-join, live
+# propagation, restart recovery, concurrent claims, signed-store non-owner
+# write) with per-phase gossip-diagnostics deltas. Requires a release x0xd
+# (cargo build --release --bin x0xd) or X0XD_TEST_BINARY.
+# Usage: just convergence-soak [RUNS]
+convergence-soak RUNS="10":
+    python3 tests/convergence/convergence_soak.py --runs {{RUNS}}
+
+# Single-run smoke of the convergence harness (same phases, one pass).
+convergence-soak-quick:
+    python3 tests/convergence/convergence_soak.py --runs 1

--- a/justfile
+++ b/justfile
@@ -113,8 +113,13 @@ release-dryrun:
 
 # Full soak: repeat the 3-node convergence scenario (cold-join, live
 # propagation, restart recovery, concurrent claims, signed-store non-owner
-# write) with per-phase gossip-diagnostics deltas. Requires a release x0xd
-# (cargo build --release --bin x0xd) or X0XD_TEST_BINARY.
+# write, malformed/pre-restart fence, named new-port reconnect) with
+# per-phase gossip-diagnostics deltas, EXACT-VALUE oracles, and
+# binary/source provenance. Requires a release x0xd
+# (`cargo build --release --bin x0xd`) or X0XD_TEST_BINARY. Forwards
+# X0XD_LEGACY_BINARY to enable the mixed-version gate. This is a
+# DEVELOPMENT soak — it is NOT release-authoritative; use
+# `just convergence-release` for the gating recipe.
 # Usage: just convergence-soak [RUNS]
 convergence-soak RUNS="10":
     python3 tests/convergence/convergence_soak.py --runs {{RUNS}}
@@ -122,3 +127,19 @@ convergence-soak RUNS="10":
 # Single-run smoke of the convergence harness (same phases, one pass).
 convergence-soak-quick:
     python3 tests/convergence/convergence_soak.py --runs 1
+
+# Authoritative RELEASE convergence recipe. Self-contained: builds the daemon
+# AND the in-repo hostile gossip injector (x0xd-forge-injector) so the
+# forged-first-seen admission gate runs for real — no undocumented external
+# binary required. Requires --expect-fixed (every known-gap becomes a hard
+# gate), an AUTHENTICATED v0.30.1 legacy binary (X0XD_LEGACY_BINARY — the only
+# artifact that cannot be built from this tree; the harness verifies
+# --version == 0.30.1), and 10/10 clean runs. The harness refuses a binary
+# older than the reviewed sources. Under --expect-fixed an UNSUPPORTED or
+# unproven phase is a FAILURE, and provenance refusal fails fast. UNSUPPORTED
+# is failure: this recipe gates a release. convergence-soak-quick stays
+# available as a one-run smoke.
+convergence-release:
+    @test -n "${X0XD_LEGACY_BINARY:-}" || { echo "X0XD_LEGACY_BINARY must point at an authenticated v0.30.1 x0xd"; exit 2; }
+    cargo build --release --bin x0xd --bin x0xd-forge-injector
+    python3 tests/convergence/convergence_soak.py --runs 10 --expect-fixed

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -1102,9 +1102,16 @@ enum StoreSub {
         topic: String,
     },
     /// Join an existing store by topic.
+    ///
+    /// `--owner` (hex AgentId of the authoritative owner) is REQUIRED: a join
+    /// without an owner anchor is a dead replica. The owner anchor lets the
+    /// joiner accept the owner's deltas and write iff it is the owner.
     Join {
         /// Gossip topic.
         topic: String,
+        /// Hex-encoded AgentId of the authoritative owner (the required anchor).
+        #[arg(long)]
+        owner: String,
     },
     /// List keys in a store.
     Keys {
@@ -1766,7 +1773,9 @@ async fn run(
             Some(StoreSub::Create { name, topic }) => {
                 commands::store::create(&client, &name, &topic).await
             }
-            Some(StoreSub::Join { topic }) => commands::store::join(&client, &topic).await,
+            Some(StoreSub::Join { topic, owner }) => {
+                commands::store::join(&client, &topic, &owner).await
+            }
             Some(StoreSub::Keys { store_id }) => commands::store::keys(&client, &store_id).await,
             Some(StoreSub::Put {
                 store_id,
@@ -1984,7 +1993,7 @@ x0x (v{VERSION})
 +-- Data
 |   +-- store list         List key-value stores
 |   +-- store create       Create a KV store
-|   +-- store join         Join existing store by topic
+|   +-- store join         Join existing store by topic (--owner to anchor)
 |   +-- store keys         List keys
 |   +-- store put          Write a value
 |   +-- store get          Read a value

--- a/src/bin/x0xd_forge_injector.rs
+++ b/src/bin/x0xd_forge_injector.rs
@@ -1,0 +1,178 @@
+//! `x0xd-forge-injector` — hostile gossip injector for the forged-first-seen
+//! TaskItem admission gate (`tests/convergence/convergence_soak.py`,
+//! `forged_first_seen_task`).
+//!
+//! Crafts an unattested first-seen TaskItem — a `Claimed { victim, ts: 1 }`
+//! element in the TaskItem's checkbox OR-Set with NO matching attestation — via
+//! `x0x::crdt::forge_unattested_delta_bytes`, which returns the bincode
+//! `(PeerId, TaskListDelta)` wire bytes (the exact format the live sync path
+//! decodes). It then publishes those bytes over REAL gossip through the target
+//! daemon's `POST /publish` wire API on the task list's topic.
+//!
+//! This is a release-tooling binary, NOT a daemon. It never fakes the outcome
+//! via REST: it injects a genuine gossip message that flows through the real
+//! `decode_delta → merge_delta → admit()` path. The receiver's fail-closed
+//! admission routine must purge the forged element, leaving
+//! `current_state() == Empty`; the convergence gate asserts that non-mutation
+//! (forged task absent, no list version/fence churn) plus a legit post-attack
+//! claim still resolving.
+//!
+//! Built by `just convergence-release` (and `cargo build --release --bin
+//! x0xd-forge-injector`); located deterministically at
+//! `target/release/x0xd-forge-injector`. Its SHA-256 + `--version` are recorded
+//! in the soak's provenance.
+
+use anyhow::{anyhow, Result};
+use base64::Engine;
+use clap::Parser;
+use saorsa_gossip_types::PeerId;
+use x0x::crdt::{forge_unattested_delta_bytes, TaskId};
+use x0x::identity::AgentId;
+
+/// Hostile first-seen TaskItem injector. Publishes an unattested Claimed
+/// element over real gossip via the daemon's /publish wire API.
+#[derive(Parser, Debug)]
+#[command(
+    name = "x0xd-forge-injector",
+    about = "Hostile first-seen TaskItem gossip injector"
+)]
+struct Cli {
+    /// Target daemon API base, e.g. http://127.0.0.1:27810
+    #[arg(long)]
+    daemon: String,
+    /// API bearer token for the target daemon.
+    #[arg(long)]
+    token: String,
+    /// Task-list gossip topic to publish on (== the list id).
+    #[arg(long)]
+    topic: String,
+    /// Attack variant. Only `missing_att` is implemented at the forge seam
+    /// (the other variants — malformed-sig, attacker-key, wrong-agent,
+    /// wrong-scope — are proven at the store/CRDT regression layer).
+    #[arg(long, default_value = "missing_att")]
+    variant: String,
+    /// Hex (64 chars) AgentId being impersonated by the forged claim. Random
+    /// if omitted.
+    #[arg(long)]
+    victim_agent: Option<String>,
+    /// Hex (64 chars) TaskId for the forged task. Random if omitted.
+    #[arg(long)]
+    task_id: Option<String>,
+    /// Hex (64 chars) PeerId spoofed as the delta sender / OR-Set tag. Random
+    /// if omitted.
+    #[arg(long)]
+    spoof_peer: Option<String>,
+}
+
+/// Decode an optional 64-char hex string into a 32-byte array.
+fn hex32(s: &str) -> Option<[u8; 32]> {
+    let b = hex::decode(s).ok()?;
+    b.try_into().ok()
+}
+
+/// 32 cryptographically-random bytes.
+fn rand32() -> [u8; 32] {
+    use rand::RngCore;
+    let mut b = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut b);
+    b
+}
+
+/// Parse `host:port` from a daemon base URL (stripping any scheme + path).
+fn host_port(url: &str) -> Result<(String, u16, String)> {
+    let no_scheme = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+        .unwrap_or(url);
+    // Drop any trailing path; keep authority only.
+    let authority = no_scheme.split('/').next().unwrap_or(no_scheme);
+    let (host, port_s) = authority
+        .split_once(':')
+        .ok_or_else(|| anyhow!("daemon url must be host:port (got {url})"))?;
+    let port: u16 = port_s
+        .parse()
+        .map_err(|e| anyhow!("daemon port parse ({port_s}): {e}"))?;
+    Ok((host.to_string(), port, "/publish".to_string()))
+}
+
+/// Minimal HTTP/1.1 POST (raw TCP) — avoids requiring the `blocking` reqwest
+/// feature. Returns (status, body_text).
+fn http_post_publish(
+    host: &str,
+    port: u16,
+    path: &str,
+    token: &str,
+    body: &str,
+) -> Result<(u16, String)> {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+    let req = format!(
+        "POST {path} HTTP/1.1\r\nHost: {host}:{port}\r\n\
+         Content-Type: application/json\r\nAuthorization: Bearer {token}\r\n\
+         Content-Length: {len}\r\nConnection: close\r\n\r\n{body}",
+        len = body.len(),
+    );
+    let mut stream =
+        TcpStream::connect((host, port)).map_err(|e| anyhow!("connect {host}:{port}: {e}"))?;
+    stream.write_all(req.as_bytes())?;
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp)?;
+    let status = resp
+        .get(9..12)
+        .and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(0);
+    let body_off = resp.find("\r\n\r\n").map(|i| i + 4).unwrap_or(resp.len());
+    Ok((status, resp[body_off..].to_string()))
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let victim_bytes = cli
+        .victim_agent
+        .as_deref()
+        .and_then(hex32)
+        .unwrap_or_else(rand32);
+    let task_bytes = cli
+        .task_id
+        .as_deref()
+        .and_then(hex32)
+        .unwrap_or_else(rand32);
+    let peer_bytes = cli
+        .spoof_peer
+        .as_deref()
+        .and_then(hex32)
+        .unwrap_or_else(rand32);
+
+    let victim = AgentId(victim_bytes);
+    let spoof_peer = PeerId::new(peer_bytes);
+    let task_id = TaskId::from_bytes(task_bytes);
+
+    // The in-crate forge seam: bincode (PeerId, TaskListDelta) bytes carrying
+    // a Claimed{victim, ts:1} element with NO attestation.
+    let delta_bytes = forge_unattested_delta_bytes(victim, task_id, spoof_peer);
+    let payload_b64 = base64::engine::general_purpose::STANDARD.encode(&delta_bytes);
+
+    let (host, port, path) = host_port(&cli.daemon)?;
+    let body = serde_json::json!({ "topic": cli.topic, "payload": payload_b64 }).to_string();
+    let (status, resp_body) = http_post_publish(&host, port, &path, &cli.token, &body)?;
+
+    let published = status == 200;
+    let out = serde_json::json!({
+        "ok": published,
+        "published": published,
+        "variant": cli.variant,
+        "topic": cli.topic,
+        "forged_task_id": hex::encode(task_bytes),
+        "victim_agent": hex::encode(victim_bytes),
+        "spoof_peer": hex::encode(peer_bytes),
+        "publish_status": status,
+        "publish_body": resp_body,
+    });
+    println!("{out}");
+    // Non-zero exit when the publish itself failed (the convergence gate still
+    // reads the JSON, but a transport failure must not look like success).
+    if !published {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/src/cli/commands/store.rs
+++ b/src/cli/commands/store.rs
@@ -18,9 +18,13 @@ pub async fn create(client: &DaemonClient, name: &str, topic: &str) -> Result<()
 }
 
 /// `x0x store join` — POST /stores/:id/join.
-pub async fn join(client: &DaemonClient, topic: &str) -> Result<()> {
+///
+/// `owner` is the REQUIRED hex-encoded AgentId of the authoritative owner
+/// (the anchor). The joiner accepts the owner's deltas and writes iff it is
+/// the owner. The daemon rejects a join without an anchor (422 owner_required).
+pub async fn join(client: &DaemonClient, topic: &str, owner: &str) -> Result<()> {
     client.ensure_running().await?;
-    let body = serde_json::json!({});
+    let body = serde_json::json!({ "expected_owner": owner });
     let resp = client.post(&format!("/stores/{topic}/join"), &body).await?;
     print_value(client.format(), &resp);
     Ok(())

--- a/src/crdt/checkbox.rs
+++ b/src/crdt/checkbox.rs
@@ -16,10 +16,6 @@ pub type Result<T> = std::result::Result<T, CheckboxError>;
 /// Errors that can occur during checkbox state transitions.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum CheckboxError {
-    /// Attempted to claim an already-claimed task.
-    #[error("task already claimed by {0}")]
-    AlreadyClaimed(AgentId),
-
     /// Attempted to transition from Done state (immutable).
     #[error("task is already done and cannot be modified")]
     AlreadyDone,
@@ -185,22 +181,20 @@ impl CheckboxState {
     /// # State Transitions
     ///
     /// - `Empty -> Claimed`: OK
-    /// - `Claimed -> Claimed`: Error (already claimed)
+    /// - `Claimed -> Claimed`: OK (advisory re-claim; the production path
+    ///   accumulates candidates in an OR-Set and resolves a deterministic
+    ///   winner — see `TaskItem::claim`)
     /// - `Done -> Claimed`: Error (immutable)
     ///
     /// # Errors
     ///
-    /// Returns an error if the transition is invalid.
+    /// Returns [`CheckboxError::AlreadyDone`] if the task is already completed.
     pub fn transition_to_claimed(&self, agent_id: AgentId, timestamp: u64) -> Result<Self> {
         match self {
-            Self::Empty => Ok(Self::Claimed {
+            Self::Empty | Self::Claimed { .. } => Ok(Self::Claimed {
                 agent_id,
                 timestamp,
             }),
-            Self::Claimed {
-                agent_id: existing_agent,
-                ..
-            } => Err(CheckboxError::AlreadyClaimed(*existing_agent)),
             Self::Done { .. } => Err(CheckboxError::AlreadyDone),
         }
     }
@@ -366,14 +360,19 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_transition_claimed_to_claimed() {
+    fn test_advisory_reclaim_permitted() {
         let agent1 = agent(1);
         let agent2 = agent(2);
         let claimed = CheckboxState::claim(agent1, 1000).ok().unwrap();
 
-        let result = claimed.transition_to_claimed(agent2, 2000);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), CheckboxError::AlreadyClaimed(agent1));
+        // Advisory (non-exclusive) claims: re-claiming a claimed task
+        // succeeds. The OR-Set accumulates candidates and resolves a
+        // deterministic winner; this single-value helper returns the new
+        // Claimed state.
+        let reclaimed = claimed.transition_to_claimed(agent2, 2000).ok().unwrap();
+        assert!(reclaimed.is_claimed());
+        assert_eq!(reclaimed.claimed_by(), Some(&agent2));
+        assert_eq!(reclaimed.timestamp(), Some(2000));
     }
 
     #[test]

--- a/src/crdt/delta.rs
+++ b/src/crdt/delta.rs
@@ -173,54 +173,68 @@ impl TaskList {
     ///
     /// Returns an error if merge operations fail.
     pub fn merge_delta(&mut self, delta: &TaskListDelta, peer_id: PeerId) -> Result<()> {
-        // Apply added tasks
+        // Capture the resolved observable fingerprint BEFORE applying the
+        // delta so the local version advances exactly once iff this merge
+        // effectively changes the local snapshot. (Remote claim/complete
+        // merges must invalidate a caller's stale local token.)
+        //
+        // The body uses delta_* helpers that do NOT bump version internally;
+        // only commit_revision_if_changed advances it. This ensures an
+        // idempotent redelivery (same resolved state) does NOT advance the
+        // fence, while a real remote change advances it exactly once.
+        //
+        // NOTE (composition with the provenance gate): any unauthenticated or
+        // forged Claimed/Done element is dropped by the admission gate inside
+        // delta_upsert_task / TaskItem::merge — before it can influence
+        // resolution. Because this fingerprint wraps the entire merge body, it
+        // is computed over post-gate (authenticated) state by construction.
+        let before = self.state_fingerprint();
         for (task_id, (task, tag)) in &delta.added_tasks {
-            // If task doesn't exist, add it
+            // If task doesn't exist, add it (admit runs inside delta_upsert_task).
+            // If it exists, merge + filter (admit + membership run inside
+            // delta_merge_task).
             if self.get_task(task_id).is_none() {
-                self.add_task(task.clone(), tag.0, tag.1)?;
+                self.delta_upsert_task(task.clone(), tag.0, tag.1)?;
             } else {
-                // Task exists, merge it
-                if let Some(existing_task) = self.get_task_mut(task_id) {
-                    existing_task.merge(task)?;
-                }
+                self.delta_merge_task(task_id, task)?;
             }
         }
 
-        // Apply removed tasks
+        // Apply removed tasks (no version bump; deferred to commit_revision).
         for task_id in delta.removed_tasks.keys() {
-            // Attempt to remove (will fail silently if task doesn't exist)
-            let _ = self.remove_task(task_id);
+            self.delta_remove_task(task_id);
         }
 
         // Apply task updates (upsert: merge if exists, insert if missing).
         // The upsert is critical for out-of-order delivery — a claim/complete
         // delta may arrive before the corresponding add delta. Since the
         // TaskItem in task_updates contains full state, inserting it directly
-        // is safe and preserves the state change.
+        // is safe and preserves the state change. The admission gate runs
+        // inside delta_upsert_task / merge.
         for (task_id, updated_task) in &delta.task_updates {
-            if let Some(existing_task) = self.get_task_mut(task_id) {
-                existing_task.merge(updated_task)?;
+            if self.get_task(task_id).is_some() {
+                self.delta_merge_task(task_id, updated_task)?;
             } else {
-                // Task not yet known — insert it with a synthetic OR-Set add.
-                // Use the peer_id from the delta sender and seq=0 (the OR-Set
-                // tag just needs to exist; uniqueness is already guaranteed by
-                // the sender's monotonic counter).
-                self.add_task(updated_task.clone(), peer_id, 0)?;
+                // Task not yet known — insert it (admit runs inside).
+                self.delta_upsert_task(updated_task.clone(), peer_id, 0)?;
             }
         }
 
         // Apply ordering update via LWW (vector-clock) merge. The merged
         // ordering may reference task IDs not yet present (out-of-order
         // delivery); tasks_ordered filters those at read time.
-        if let Some(ref order_register) = delta.ordering_update {
-            self.merge_ordering(order_register);
+        if let Some(order_register) = &delta.ordering_update {
+            self.delta_merge_ordering(order_register);
         }
 
         // Apply name update via LWW (vector-clock) merge.
-        if let Some(ref name_register) = delta.name_update {
-            self.merge_name(name_register);
+        if let Some(name_register) = &delta.name_update {
+            self.delta_merge_name(name_register);
         }
 
+        // Advance the local revision exactly once iff the resolved observable
+        // snapshot changed. Idempotent re-merges (same resolutions) ⇒ no bump.
+        self.commit_revision_if_changed(before);
         Ok(())
     }
 }
@@ -527,5 +541,51 @@ mod tests {
 
         // Verify name changed
         assert_eq!(list.name(), "Updated");
+    }
+
+    #[test]
+    fn duplicate_merge_delta_advances_version_once_then_is_idempotent() {
+        // P1 fence: the TaskList version IS the local-replica fence token. A
+        // real remote change must advance it exactly once; an idempotent
+        // re-delivery of an already-resolved delta must NOT advance it (else
+        // revision churn would spuriously invalidate callers and satisfy
+        // "fence changed" gates with no real change). merge_delta must not
+        // bump version inside its sub-operations; only commit_revision_if_changed
+        // advances it, iff the resolved snapshot changed.
+        let peer = peer(1);
+        let id = list_id(1);
+        let mut list = TaskList::new(id, "L".to_string(), peer);
+        let t1 = make_task(1, peer);
+        let t2 = make_task(2, peer);
+        let id1 = *t1.id();
+        let id2 = *t2.id();
+        list.add_task(t1, peer, 1).unwrap();
+        list.add_task(t2, peer, 2).unwrap();
+
+        // A remote peer reverses the order on top of the shared history; its
+        // register causally dominates ours, so the first merge is a real change.
+        let mut order_register = list.ordering_register().clone();
+        order_register.set(vec![id2, id1], peer);
+        let mut delta = TaskListDelta::new(10);
+        delta.ordering_update = Some(order_register);
+
+        let v0 = list.version();
+        list.merge_delta(&delta, peer).unwrap();
+        let v1 = list.version();
+        assert!(
+            v1 > v0,
+            "a real remote ordering change must advance the version/fence once"
+        );
+
+        // Second identical merge: the ordering is already resolved identically
+        // ⇒ the fingerprint is unchanged ⇒ the version MUST NOT advance again.
+        list.merge_delta(&delta, peer).unwrap();
+        assert_eq!(
+            list.version(),
+            v1,
+            "duplicate delta must not advance the version/fence again"
+        );
+        // The two real tasks are still present (no spurious removal).
+        assert_eq!(list.task_count(), 2);
     }
 }

--- a/src/crdt/error.rs
+++ b/src/crdt/error.rs
@@ -1,7 +1,6 @@
 //! Error types for CRDT task list operations.
 
 use crate::crdt::{CheckboxState, TaskId};
-use crate::identity::AgentId;
 
 /// Result type for CRDT operations.
 pub type Result<T> = std::result::Result<T, CrdtError>;
@@ -21,10 +20,6 @@ pub enum CrdtError {
         /// The attempted new state.
         attempted: CheckboxState,
     },
-
-    /// Task is already claimed by another agent.
-    #[error("task already claimed by {0}")]
-    AlreadyClaimed(AgentId),
 
     /// Serialization error.
     #[error("serialization error: {0}")]
@@ -50,6 +45,7 @@ pub enum CrdtError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::identity::AgentId;
 
     fn mock_agent_id() -> AgentId {
         AgentId([42u8; 32])
@@ -110,14 +106,6 @@ mod tests {
         assert!(display.contains("invalid state transition"));
         assert!(display.contains("Empty"));
         assert!(display.contains("Done"));
-    }
-
-    #[test]
-    fn test_error_display_already_claimed() {
-        let agent = mock_agent_id();
-        let error = CrdtError::AlreadyClaimed(agent);
-        let display = format!("{}", error);
-        assert!(display.contains("already claimed"));
     }
 
     #[test]

--- a/src/crdt/mod.rs
+++ b/src/crdt/mod.rs
@@ -12,19 +12,21 @@
 //!
 //! ```ignore
 //! use x0x::crdt::{TaskList, TaskItem};
+//! use x0x::gossip::SigningContext;
 //!
 //! // Create a new task list
-//! let mut task_list = TaskList::new(list_id, "Sprint Planning", peer_id);
+//! let mut task_list = TaskList::new(list_id, "Sprint Planning".to_string(), peer_id);
 //!
 //! // Add a task
 //! let task = TaskItem::new(task_id, metadata, peer_id);
 //! task_list.add_task(task, peer_id, seq)?;
 //!
-//! // Claim a task
-//! task_list.claim_task(&task_id, agent_id, peer_id, seq)?;
+//! // Claim a task (advisory and non-exclusive: concurrent claims coexist in
+//! // the OR-Set; each is self-attested via the signing context).
+//! task_list.claim_task(&task_id, agent_id, peer_id, seq, &signing)?;
 //!
 //! // Complete a task
-//! task_list.complete_task(&task_id, agent_id, peer_id, seq)?;
+//! task_list.complete_task(&task_id, agent_id, peer_id, seq, &signing)?;
 //! ```
 
 pub mod checkbox;
@@ -32,6 +34,7 @@ pub mod delta;
 pub mod encrypted;
 pub mod error;
 pub mod persistence;
+pub mod provenance;
 pub mod sync;
 pub mod task;
 pub mod task_item;
@@ -43,7 +46,11 @@ pub use delta::TaskListDelta;
 pub use encrypted::EncryptedTaskListDelta;
 pub use error::{CrdtError, Result};
 pub use persistence::TaskListStorage;
+pub use provenance::{
+    canonical_op_bytes, purge_unattested_elements, sign_attestation, verify_attestation,
+    OpAttestation, OpKind, CLAIM_DOMAIN, COMPLETE_DOMAIN,
+};
 pub use sync::TaskListSync;
 pub use task::{TaskId, TaskMetadata};
-pub use task_item::TaskItem;
+pub use task_item::{forge_unattested_delta_bytes, TaskItem};
 pub use task_list::{TaskList, TaskListId};

--- a/src/crdt/persistence.rs
+++ b/src/crdt/persistence.rs
@@ -292,6 +292,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn attested_tasklist_roundtrips_through_disk() {
+        // On-disk path coverage: a TaskList carrying a genuinely self-attested
+        // task must survive save -> bincode -> load, INCLUDING the fail-closed
+        // admission gate `load_task_list` runs (`admit_all`). This pins that the
+        // trailing `attestations` field persists and resolves after a disk
+        // round-trip — the current-format guarantee.
+        //
+        // NOTE ON LEGACY BYTES: the trailing+tolerant field makes a *top-level*
+        // pre-attestations TaskItem decode (see task_item.rs
+        // `legacy_taskitem_without_attestations_decodes`). It does NOT recover a
+        // genuinely fieldless TaskItem nested mid-stream inside a TaskList,
+        // because bincode is positional: `task_data` is followed by `ordering`/
+        // `name`/`version`, so an absent trailing field is not at stream-EOF and
+        // the tolerant deserializer would consume the following struct's bytes.
+        // That case is intentionally out of scope (greenfield release, no
+        // pre-wave persisted lists exist); true nested-legacy compat would need
+        // a versioned/length-prefixed envelope, not EOF tolerance.
+        use crate::crdt::{TaskId, TaskItem, TaskMetadata};
+
+        let dir = tempfile::tempdir().unwrap();
+        let storage = TaskListStorage::new(dir.path().to_path_buf());
+        let list_id = test_list_id(0x78);
+        let peer = test_peer_id();
+
+        let kp = crate::identity::AgentKeypair::generate().unwrap();
+        let agent = kp.agent_id();
+        let signing = crate::gossip::SigningContext::from_keypair(&kp);
+
+        let task_id = TaskId::new("persist-me", &agent, 1000);
+        let metadata = TaskMetadata::new("persist-me", "d", 128, agent, 1000);
+        let mut task = TaskItem::new(task_id, metadata, peer);
+        task.claim(list_id, agent, peer, 1, &signing).unwrap();
+
+        let mut list = create_test_list(list_id, "attested");
+        list.add_task(task, peer, 1).unwrap();
+
+        storage.save_task_list(&list_id, &list).await.unwrap();
+        let loaded = storage.load_task_list(&list_id).await.unwrap();
+
+        let t = loaded.get_task(&task_id).expect("attested task persisted");
+        assert!(
+            t.current_state().is_claimed(),
+            "attested claim survives save/load and the admission gate"
+        );
+        assert_eq!(
+            t.claim_record().map(|(a, _)| a),
+            Some(agent),
+            "the attested claimant round-trips"
+        );
+    }
+
+    #[tokio::test]
     async fn multiple_lists_independent() {
         let dir = tempfile::tempdir().unwrap();
         let storage = TaskListStorage::new(dir.path().to_path_buf());

--- a/src/crdt/persistence.rs
+++ b/src/crdt/persistence.rs
@@ -100,7 +100,22 @@ impl TaskListStorage {
 
         let serialized = fs::read(&file_path).await?;
 
-        bincode::deserialize(&serialized).map_err(crate::crdt::error::CrdtError::Serialization)
+        let mut list: TaskList = bincode::deserialize(&serialized)
+            .map_err(crate::crdt::error::CrdtError::Serialization)?;
+
+        // Run the fail-closed admission gate on every task so a tampered or
+        // corrupted on-disk state cannot bypass provenance verification.
+        // Drops unauthenticated checkbox elements and restores attested
+        // elements censored by forged tombstones.
+        let dropped = list.admit_all();
+        if dropped > 0 {
+            tracing::warn!(
+                dropped,
+                "purged unauthenticated checkbox elements during persistence load"
+            );
+        }
+
+        Ok(list)
     }
 
     /// List all stored task lists.

--- a/src/crdt/provenance.rs
+++ b/src/crdt/provenance.rs
@@ -94,7 +94,7 @@ pub struct OpAttestation {
     /// `AgentId::from_public_key(author_public_key)` and the element's
     /// `agent_id`; checked at verification.
     pub author_agent_id: AgentId,
-    /// ML-DSA-65 public key bytes whose hash equals [`author_agent_id`].
+    /// ML-DSA-65 public key bytes whose hash equals `author_agent_id`.
     pub author_public_key: Vec<u8>,
     /// ML-DSA-65 signature over [`canonical_op_bytes`] under the matching
     /// secret key.

--- a/src/crdt/provenance.rs
+++ b/src/crdt/provenance.rs
@@ -1,0 +1,641 @@
+//! Authenticated operation provenance for task claims/completions.
+//!
+//! Without this module, the inner `TaskItem` claimant `AgentId` carried in a
+//! [`crate::crdt::TaskListDelta`] is self-asserted data: any mesh peer that can
+//! publish to the task-list topic can inject a `Claimed{victim, ts=1}` element
+//! and, under earliest-timestamp-wins resolution, steal every claim by
+//! impersonation. The signed outer transport sender is discarded at the merge
+//! boundary and may be a relay (not the author), so it cannot be the trust root.
+//!
+//! This module supplies the trust root: every `Claimed`/`Done` element that
+//! enters a `TaskItem`'s checkbox OR-Set must carry an [`OpAttestation`] signed
+//! by the ML-DSA-65 secret key whose public key hashes to the element's
+//! `agent_id` (`AgentId::from_public_key`). This is the exact "derived ==
+//! claimed" binding already used for forward attestations, group cards, and
+//! revocations elsewhere in the crate — no new cryptography.
+//!
+//! ## Layout
+//!
+//! - [`OpAttestation`] / [`OpKind`]: the attestation data carried alongside the
+//!   element (serialized within `TaskItem`, so it survives `full_delta`
+//!   historical state sync).
+//! - [`canonical_op_bytes`]: the deterministic, fixed-width byte layout that is
+//!   both signed and verified. Both ends MUST agree byte-for-byte.
+//! - [`sign_attestation`]: produce an attestation using a [`SigningContext`]
+//!   (the local agent's key material). Called by the handle on claim/complete.
+//! - [`verify_attestation`]: self-contained verification — parse the public key,
+//!   require `from_public_key == author_agent_id == element agent_id`, and
+//!   verify the signature over [`canonical_op_bytes`]. Used by the admission
+//!   gate.
+//! - [`purge_unattested_elements`]: the admission gate. Drops every checkbox
+//!   element whose attestation is missing or fails verification, so the OR-Set
+//!   is kept invariant-pure (every element is authenticated) and resolution
+//!   (`current_state` / `claim_record` / `completion_record`) operates only over
+//!   authenticated state.
+//!
+//! ## Non-goals (documented, not silently "fixed")
+//!
+//! Provenance defeats *impersonation*. It does NOT provide exactly-once
+//! execution, mutual exclusion under partition, or anti-squatting (an attacker
+//! signing under their own valid key with `ts=1` is authenticated and wins their
+//! own claim early — a fairness/liveness concern, out of scope here).
+
+use crate::crdt::{CheckboxState, CrdtError, Result, TaskId, TaskListId};
+use crate::gossip::SigningContext;
+use crate::identity::AgentId;
+use ant_quic::crypto::raw_public_keys::pqc::{verify_with_ml_dsa, MlDsaSignature};
+use ant_quic::MlDsaPublicKey;
+use saorsa_gossip_crdt_sync::OrSet;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Domain separator for claim attestations.
+///
+/// Prevents a claim signature being replayed as a completion (or as any other
+/// signed context in the crate). Pinned at v2 (binds list/topic scope); a
+/// layout change bumps the suffix so old attestations fail verification rather
+/// than silently re-binding.
+pub const CLAIM_DOMAIN: &[u8] = b"x0x.task.claim.v2";
+
+/// Domain separator for completion attestations. See [`CLAIM_DOMAIN`].
+pub const COMPLETE_DOMAIN: &[u8] = b"x0x.task.complete.v2";
+
+/// The kind of operation an attestation covers. Determines the domain separator
+/// in [`canonical_op_bytes`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OpKind {
+    /// A task claim (`Empty`/`Claimed` → `Claimed`).
+    Claim,
+    /// A task completion (`Claimed` → `Done`).
+    Complete,
+}
+
+impl OpKind {
+    /// The domain-separator bytes for this operation kind.
+    #[must_use]
+    pub fn domain(self) -> &'static [u8] {
+        match self {
+            OpKind::Claim => CLAIM_DOMAIN,
+            OpKind::Complete => COMPLETE_DOMAIN,
+        }
+    }
+}
+
+/// A self-contained attestation that `author_agent_id` authorized an operation.
+///
+/// Carried alongside the corresponding `Claimed`/`Done` checkbox element so it
+/// survives delta replication and historical state sync. Verification
+/// ([`verify_attestation`]) needs only this struct plus the element's fields —
+/// it is independent of the transport signer, so a relayed operation verifies
+/// exactly like a direct one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpAttestation {
+    /// The agent asserting the operation. MUST equal
+    /// `AgentId::from_public_key(author_public_key)` and the element's
+    /// `agent_id`; checked at verification.
+    pub author_agent_id: AgentId,
+    /// ML-DSA-65 public key bytes whose hash equals [`author_agent_id`].
+    pub author_public_key: Vec<u8>,
+    /// ML-DSA-65 signature over [`canonical_op_bytes`] under the matching
+    /// secret key.
+    pub signature: Vec<u8>,
+}
+
+/// Deterministic, fixed-width byte layout that is both signed and verified.
+///
+/// Layout: `domain || scope (32) || task_id (32) || agent_id (32) || timestamp_ms (8, BE)`.
+///
+/// All fields are fixed-width, so the encoding is unambiguous and
+/// cross-replica stable. The `peer_id`/`seq` OR-Set tag is intentionally NOT
+/// included: the attestation binds the *operation* (who claimed/completed which
+/// task at what time), not the delivery channel, so an attestation can be keyed
+/// by its `CheckboxState` value rather than by an OR-Set tag (which the OR-Set
+/// does not expose after `merge_state`).
+///
+/// **Scope binding (v2):** the list/topic scope (`TaskListId`, 32 bytes) is
+/// mixed into the signed bytes. A valid attestation signed for list A fails
+/// verification when checked against list B's scope, preventing cross-list
+/// replay of a valid claim into a different task list that happens to share the
+/// same `TaskId`.
+#[must_use]
+pub fn canonical_op_bytes(
+    kind: OpKind,
+    scope: &TaskListId,
+    task_id: &TaskId,
+    agent_id: &AgentId,
+    timestamp_ms: u64,
+) -> Vec<u8> {
+    let mut out = Vec::with_capacity(kind.domain().len() + 32 + 32 + 32 + 8);
+    out.extend_from_slice(kind.domain());
+    out.extend_from_slice(scope.as_bytes());
+    out.extend_from_slice(task_id.as_bytes());
+    out.extend_from_slice(agent_id.as_bytes());
+    out.extend_from_slice(&timestamp_ms.to_be_bytes());
+    out
+}
+
+/// Produce an attestation for an operation using the local agent's key material.
+///
+/// `agent_id` MUST be the local agent (equal to `signing.agent_id`); claims and
+/// completions are self-signed. The returned attestation's `author_agent_id` is
+/// the signing context's agent id and its public key is the context's public
+/// key, so the binding `from_public_key == author_agent_id` holds by
+/// construction.
+///
+/// # Errors
+///
+/// Returns [`CrdtError::Gossip`] if signing fails, or if `agent_id` does not
+/// match the signing context's agent (a misuse indicating the caller tried to
+/// attest as a different agent).
+pub fn sign_attestation(
+    signing: &SigningContext,
+    kind: OpKind,
+    scope: &TaskListId,
+    task_id: &TaskId,
+    agent_id: &AgentId,
+    timestamp_ms: u64,
+) -> Result<OpAttestation> {
+    // Claims/completions are self-signed: only attest as the key holder.
+    if *agent_id != signing.agent_id {
+        return Err(CrdtError::Gossip(format!(
+            "attestation agent_id mismatch: element claims {} but signing context is {}",
+            hex::encode(agent_id.as_bytes()),
+            hex::encode(signing.agent_id.as_bytes())
+        )));
+    }
+    let msg = canonical_op_bytes(kind, scope, task_id, agent_id, timestamp_ms);
+    let signature = signing
+        .sign(&msg)
+        .map_err(|e| CrdtError::Gossip(format!("attestation sign failed: {e:?}")))?;
+    Ok(OpAttestation {
+        author_agent_id: signing.agent_id,
+        author_public_key: signing.public_key_bytes.clone(),
+        signature,
+    })
+}
+
+/// Verify an attestation against an operation's fields.
+///
+/// Returns `true` only if ALL hold:
+/// 1. `author_public_key` parses as a valid ML-DSA-65 key,
+/// 2. `AgentId::from_public_key(author_public_key)` equals both
+///    `att.author_agent_id` and the element's `agent_id`,
+/// 3. `signature` verifies over [`canonical_op_bytes`] under that key.
+///
+/// Any failure (forged agent id, bad signature, malformed key) returns `false`.
+/// This function never panics.
+#[must_use]
+pub fn verify_attestation(
+    att: &OpAttestation,
+    kind: OpKind,
+    scope: &TaskListId,
+    task_id: &TaskId,
+    agent_id: &AgentId,
+    timestamp_ms: u64,
+) -> bool {
+    let Ok(pubkey) = MlDsaPublicKey::from_bytes(&att.author_public_key) else {
+        return false;
+    };
+    // Binding: the key must hash to BOTH the attestation's claimed author and
+    // the element's claimant agent_id. If either differs, the operation is
+    // forged (impersonation) and is rejected.
+    let derived = AgentId::from_public_key(&pubkey);
+    if derived != att.author_agent_id || derived != *agent_id {
+        return false;
+    }
+    let Ok(sig) = MlDsaSignature::from_bytes(&att.signature) else {
+        return false;
+    };
+    let msg = canonical_op_bytes(kind, scope, task_id, agent_id, timestamp_ms);
+    verify_with_ml_dsa(&pubkey, &msg, &sig).is_ok()
+}
+
+/// If `state` is a Claimed/Done element, return its `(kind, agent_id, ts)` so
+/// the gate can look up and verify its attestation. `Empty` is never added to
+/// the OR-Set, so it maps to `None`.
+#[must_use]
+fn provenance_fields(state: &CheckboxState) -> Option<(OpKind, AgentId, u64)> {
+    match state {
+        CheckboxState::Claimed {
+            agent_id,
+            timestamp,
+        } => Some((OpKind::Claim, *agent_id, *timestamp)),
+        CheckboxState::Done {
+            agent_id,
+            timestamp,
+        } => Some((OpKind::Complete, *agent_id, *timestamp)),
+        CheckboxState::Empty => None,
+    }
+}
+
+/// The admission gate: drop every checkbox element and attestation entry that
+/// lacks a valid attestation for `scope`.
+///
+/// # Authentication (two passes)
+///
+/// 1. **Visible-element pass:** for each `Claimed`/`Done` element currently
+///    visible in `checkbox`, require a matching attestation that
+///    [`verify_attestation`]s. Drop forged/unattested elements from both the
+///    OR-Set and the attestation map.
+///
+/// 2. **Attestation-map pass:** for every entry in `attestations` (including
+///    those hidden by forged tombstones), verify the attestation. Drop entries
+///    that fail verification. This ensures the attestation map — which is the
+///    **authoritative source** for checkbox resolution (see
+///    [`crate::crdt::TaskItem::current_state`]) — contains only authenticated
+///    operations.
+///
+/// # Tombstone defense (no tag synthesis)
+///
+/// Checkbox elements (`Claimed`/`Done`) are append-only — no legitimate code
+/// path removes one. The attestation map is the source of truth for resolution;
+/// read methods derive state from `attestations.keys()`, NOT from
+/// `checkbox.elements()`. A forged tombstone may hide an element from the
+/// OR-Set, but the element remains in the attestation map and is still visible
+/// to resolution. No per-replica tag is synthesized — the signed
+/// `CheckboxState` (agent + timestamp + kind) IS the stable operation ID,
+/// preserved verbatim on relay and immune to tombstone censorship.
+///
+/// Returns the number of unauthenticated elements/entries dropped.
+#[must_use]
+pub fn purge_unattested_elements(
+    scope: &TaskListId,
+    task_id: &TaskId,
+    checkbox: &mut OrSet<CheckboxState>,
+    attestations: &mut BTreeMap<CheckboxState, OpAttestation>,
+) -> usize {
+    let mut dropped = 0usize;
+
+    // Pass 1: drop visible OR-Set elements without valid attestations.
+    let elements: Vec<CheckboxState> = checkbox.elements().into_iter().cloned().collect();
+    for state in elements {
+        let Some((kind, agent_id, ts)) = provenance_fields(&state) else {
+            continue;
+        };
+        let authenticated = attestations
+            .get(&state)
+            .is_some_and(|att| verify_attestation(att, kind, scope, task_id, &agent_id, ts));
+        if !authenticated {
+            let _ = checkbox.remove(&state);
+            attestations.remove(&state);
+            dropped += 1;
+        }
+    }
+
+    // Pass 2: verify every attestation entry (including tombstone-hidden ones).
+    // The attestation map is authoritative for resolution; every entry must be
+    // cryptographically valid for this scope.
+    let attested: Vec<CheckboxState> = attestations.keys().cloned().collect();
+    for state in attested {
+        let Some((kind, agent_id, ts)) = provenance_fields(&state) else {
+            continue;
+        };
+        let authenticated = attestations
+            .get(&state)
+            .is_some_and(|att| verify_attestation(att, kind, scope, task_id, &agent_id, ts));
+        if !authenticated {
+            let _ = checkbox.remove(&state);
+            attestations.remove(&state);
+            dropped += 1;
+        }
+    }
+
+    dropped
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::identity::AgentKeypair;
+
+    fn fresh_signing() -> (SigningContext, AgentId) {
+        let kp = AgentKeypair::generate().unwrap();
+        let aid = kp.agent_id();
+        (SigningContext::from_keypair(&kp), aid)
+    }
+
+    fn task_id_for(agent: &AgentId) -> TaskId {
+        TaskId::new("provenance-test", agent, 1)
+    }
+
+    /// Fixed list scope for provenance unit tests (the v2 canonical bytes bind
+    /// a `TaskListId`; the value is irrelevant to these crypto-level checks).
+    fn scope() -> TaskListId {
+        TaskListId::new([0x5c; 32])
+    }
+
+    // ── canonical_op_bytes: determinism & separation ─────────────────────────
+
+    #[test]
+    fn canonical_bytes_are_deterministic() {
+        let (_, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let a = canonical_op_bytes(OpKind::Claim, &scope(), &tid, &aid, 1000);
+        let b = canonical_op_bytes(OpKind::Claim, &scope(), &tid, &aid, 1000);
+        assert_eq!(a, b, "identical inputs must produce identical bytes");
+    }
+
+    #[test]
+    fn canonical_bytes_separate_claim_from_complete() {
+        let (_, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let claim = canonical_op_bytes(OpKind::Claim, &scope(), &tid, &aid, 1000);
+        let complete = canonical_op_bytes(OpKind::Complete, &scope(), &tid, &aid, 1000);
+        assert_ne!(
+            claim, complete,
+            "claim and complete domains must not collide"
+        );
+    }
+
+    #[test]
+    fn canonical_bytes_bind_timestamp_and_task_and_agent() {
+        let (_, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let base = canonical_op_bytes(OpKind::Claim, &scope(), &tid, &aid, 1000);
+        assert_ne!(
+            base,
+            canonical_op_bytes(OpKind::Claim, &scope(), &tid, &aid, 1001),
+            "timestamp must be bound"
+        );
+        let other_task = TaskId::new("other-task", &aid, 9);
+        assert_ne!(
+            base,
+            canonical_op_bytes(OpKind::Claim, &scope(), &other_task, &aid, 1000),
+            "task_id must be bound"
+        );
+        let (_, other_agent) = fresh_signing();
+        assert_ne!(
+            base,
+            canonical_op_bytes(OpKind::Claim, &scope(), &tid, &other_agent, 1000),
+            "agent_id must be bound"
+        );
+    }
+
+    // ── sign / verify roundtrip ──────────────────────────────────────────────
+
+    #[test]
+    fn sign_then_verify_roundtrips_true() {
+        let (signing, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let att = sign_attestation(&signing, OpKind::Claim, &scope(), &tid, &aid, 5000).unwrap();
+        assert!(
+            verify_attestation(&att, OpKind::Claim, &scope(), &tid, &aid, 5000),
+            "a validly-signed attestation must verify"
+        );
+    }
+
+    // ── impersonation: forged agent_id ───────────────────────────────────────
+
+    #[test]
+    fn forged_claimant_agent_id_is_rejected() {
+        // Attacker signs the victim's canonical bytes with the attacker's own
+        // key, but tags the attestation as the victim. The derived agent
+        // (attacker) must not equal the claimed victim agent_id → rejected.
+        let (attacker_signing, attacker) = fresh_signing();
+        let (_, victim) = fresh_signing();
+        let tid = task_id_for(&victim);
+        let msg = canonical_op_bytes(OpKind::Claim, &scope(), &tid, &victim, 1);
+        let signature = attacker_signing.sign(&msg).unwrap();
+        let forged = OpAttestation {
+            author_agent_id: victim, // self-asserted victim
+            author_public_key: attacker_signing.public_key_bytes.clone(), // attacker's key
+            signature,
+        };
+        assert!(
+            !verify_attestation(&forged, OpKind::Claim, &scope(), &tid, &victim, 1),
+            "an attacker's key must not verify against a victim agent_id"
+        );
+        // Sanity: the attacker's key DOES hash to the attacker, not the victim.
+        assert_ne!(attacker, victim);
+    }
+
+    #[test]
+    fn sign_attestation_refuses_to_attest_as_another_agent() {
+        let (signing, _) = fresh_signing();
+        let (_, other) = fresh_signing();
+        let tid = task_id_for(&other);
+        let res = sign_attestation(&signing, OpKind::Claim, &scope(), &tid, &other, 1);
+        assert!(
+            res.is_err(),
+            "sign_attestation must refuse to attest as a non-local agent"
+        );
+    }
+
+    // ── forged signature / wrong key ─────────────────────────────────────────
+
+    #[test]
+    fn forged_signature_is_rejected() {
+        let (signing, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let mut att = sign_attestation(&signing, OpKind::Claim, &scope(), &tid, &aid, 7).unwrap();
+        // Flip a signature byte.
+        att.signature[0] ^= 0xff;
+        assert!(
+            !verify_attestation(&att, OpKind::Claim, &scope(), &tid, &aid, 7),
+            "a tampered signature must not verify"
+        );
+    }
+
+    #[test]
+    fn malformed_public_key_is_rejected() {
+        let (signing, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let mut att =
+            sign_attestation(&signing, OpKind::Complete, &scope(), &tid, &aid, 9).unwrap();
+        att.author_public_key = vec![0u8; 7]; // garbage
+        assert!(
+            !verify_attestation(&att, OpKind::Complete, &scope(), &tid, &aid, 9),
+            "a malformed public key must not verify"
+        );
+    }
+
+    #[test]
+    fn wrong_task_id_does_not_verify() {
+        // A valid attestation for task A must not verify against task B
+        // (no cross-task signature replay).
+        let (signing, aid) = fresh_signing();
+        let tid_a = TaskId::new("task-a", &aid, 1);
+        let tid_b = TaskId::new("task-b", &aid, 1);
+        let att = sign_attestation(&signing, OpKind::Claim, &scope(), &tid_a, &aid, 100).unwrap();
+        assert!(
+            verify_attestation(&att, OpKind::Claim, &scope(), &tid_a, &aid, 100),
+            "original task must verify"
+        );
+        assert!(
+            !verify_attestation(&att, OpKind::Claim, &scope(), &tid_b, &aid, 100),
+            "attestation must not transfer to a different task"
+        );
+    }
+
+    #[test]
+    fn wrong_timestamp_does_not_verify() {
+        let (signing, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let att = sign_attestation(&signing, OpKind::Claim, &scope(), &tid, &aid, 100).unwrap();
+        assert!(
+            !verify_attestation(&att, OpKind::Claim, &scope(), &tid, &aid, 999),
+            "a different timestamp must not verify"
+        );
+    }
+
+    // ── purge_unattested_elements: the admission gate ────────────────────────
+
+    fn claimed(agent: &AgentId, ts: u64) -> CheckboxState {
+        CheckboxState::Claimed {
+            agent_id: *agent,
+            timestamp: ts,
+        }
+    }
+
+    fn peer_tag(n: u8) -> (saorsa_gossip_types::PeerId, u64) {
+        (saorsa_gossip_types::PeerId::new([n; 32]), n as u64)
+    }
+
+    #[test]
+    fn purge_drops_unattested_keeps_attested() {
+        let (signing, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let (_, rogue) = fresh_signing();
+
+        // A legitimately-attested claim by `aid`.
+        let good = claimed(&aid, 10);
+        let good_att = sign_attestation(&signing, OpKind::Claim, &scope(), &tid, &aid, 10).unwrap();
+
+        // A claim element with NO attestation at all (simulates a legacy /
+        // unattested remote element that must be dropped under strict cutover).
+        let unattested = claimed(&rogue, 5);
+
+        let mut checkbox = OrSet::<CheckboxState>::new();
+        checkbox.add(good.clone(), peer_tag(1)).unwrap();
+        checkbox.add(unattested.clone(), peer_tag(2)).unwrap();
+
+        let mut attestations = BTreeMap::new();
+        attestations.insert(good.clone(), good_att);
+        // No entry for `unattested`.
+
+        let dropped = purge_unattested_elements(&scope(), &tid, &mut checkbox, &mut attestations);
+
+        assert_eq!(dropped, 1, "exactly the unattested element is dropped");
+        let remaining: Vec<CheckboxState> = checkbox.elements().into_iter().cloned().collect();
+        assert!(remaining.contains(&good), "attested element survives");
+        assert!(
+            !remaining.contains(&unattested),
+            "unattested element is purged"
+        );
+        assert!(attestations.contains_key(&good), "good attestation kept");
+        assert!(
+            !attestations.contains_key(&unattested),
+            "orphaned attestation removed"
+        );
+    }
+
+    #[test]
+    fn purge_drops_element_whose_attestation_fails_verification() {
+        // Element claims `victim`, but the attestation was produced by an
+        // attacker's key (impersonation): derived(attacker key) != victim →
+        // the gate drops it even though an attestation entry exists.
+        let (attacker_signing, _) = fresh_signing();
+        let (_, victim) = fresh_signing();
+        let tid = task_id_for(&victim);
+
+        let forged_element = claimed(&victim, 10);
+        let msg = canonical_op_bytes(OpKind::Claim, &scope(), &tid, &victim, 10);
+        let signature = attacker_signing.sign(&msg).unwrap();
+        let bad_att = OpAttestation {
+            author_agent_id: victim,
+            author_public_key: attacker_signing.public_key_bytes.clone(),
+            signature,
+        };
+
+        let mut checkbox = OrSet::<CheckboxState>::new();
+        checkbox.add(forged_element.clone(), peer_tag(9)).unwrap();
+        let mut attestations = BTreeMap::new();
+        attestations.insert(forged_element.clone(), bad_att);
+
+        let dropped = purge_unattested_elements(&scope(), &tid, &mut checkbox, &mut attestations);
+        assert_eq!(dropped, 1, "forged-attestation element is dropped");
+        assert!(
+            checkbox.elements().is_empty(),
+            "no element survives a fully-forged set"
+        );
+    }
+
+    // ── P1: scope binding prevents cross-list replay ───────────────────────
+    //
+    // WHY: without the list scope in the signed bytes, a validly-attested
+    // claim for list A could be replayed into list B (which happens to share
+    // the same TaskId) and verify there — letting a participant of one list
+    // inject state into another. The v2 canonical bytes mix the TaskListId in,
+    // so an attestation verifies only in its home list.
+
+    #[test]
+    fn scope_is_bound_into_canonical_bytes() {
+        // The canonical bytes differ when only the scope differs — the
+        // TaskListId is mixed into the signed payload, not just the domain.
+        let (_, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let scope_a = TaskListId::new([0xAA; 32]);
+        let scope_b = TaskListId::new([0xBB; 32]);
+        assert_ne!(
+            canonical_op_bytes(OpKind::Claim, &scope_a, &tid, &aid, 1000),
+            canonical_op_bytes(OpKind::Claim, &scope_b, &tid, &aid, 1000),
+            "different list scopes must produce different canonical bytes"
+        );
+    }
+
+    #[test]
+    fn cross_list_replay_of_a_valid_claim_is_rejected() {
+        // A claim validly attested for list A verifies in A but NOT in list B,
+        // so it cannot be replayed into a different task list sharing the same
+        // TaskId. The scope mismatch fails verification before the element can
+        // influence resolution.
+        let (signing, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let scope_a = TaskListId::new([0xAA; 32]);
+        let scope_b = TaskListId::new([0xBB; 32]);
+
+        let att = sign_attestation(&signing, OpKind::Claim, &scope_a, &tid, &aid, 1000).unwrap();
+        assert!(
+            verify_attestation(&att, OpKind::Claim, &scope_a, &tid, &aid, 1000),
+            "attestation verifies in its home list"
+        );
+        assert!(
+            !verify_attestation(&att, OpKind::Claim, &scope_b, &tid, &aid, 1000),
+            "a list-A attestation must not verify in list B (cross-list replay blocked)"
+        );
+    }
+
+    #[test]
+    fn purge_drops_element_attested_for_a_different_scope() {
+        // End-to-end at the admission gate: an element whose attestation is
+        // valid for scope_A, checked under scope_B, is purged — cross-list
+        // replay is rejected at admission, not only at the crypto predicate.
+        let (signing, aid) = fresh_signing();
+        let tid = task_id_for(&aid);
+        let scope_a = TaskListId::new([0xAA; 32]);
+        let scope_b = TaskListId::new([0xBB; 32]);
+
+        let elem = claimed(&aid, 100);
+        let att = sign_attestation(&signing, OpKind::Claim, &scope_a, &tid, &aid, 100).unwrap();
+
+        let mut checkbox = OrSet::<CheckboxState>::new();
+        checkbox.add(elem.clone(), peer_tag(1)).unwrap();
+        let mut attestations = BTreeMap::new();
+        attestations.insert(elem.clone(), att);
+
+        // Purge under scope_B: the scope-A attestation fails verification AND
+        // its attestation entry is removed, so the tombstone defense does not
+        // restore it.
+        let dropped = purge_unattested_elements(&scope_b, &tid, &mut checkbox, &mut attestations);
+        assert_eq!(dropped, 1, "cross-scope element is purged at admission");
+        assert!(
+            checkbox.elements().is_empty(),
+            "no cross-scope element survives admission"
+        );
+        assert!(
+            attestations.is_empty(),
+            "cross-scope attestation entry is removed (not restored)"
+        );
+    }
+}

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -33,6 +33,19 @@ const STATE_SYNC_TOPIC_SUFFIX: &str = "/state-sync";
 /// flooding.
 const STATE_REQUEST_RETRY_SECS: [u64; 4] = [1, 5, 15, 30];
 
+/// Persistent tail interval for the state-request bootstrap. After the
+/// aggressive front-loaded schedule exhausts (~51s), a first-time joiner
+/// whose list is STILL empty keeps asking at this interval so a slow mesh
+/// reformation — e.g. a post-restart rejoin while sibling CRDTs also recover
+/// — still converges. The loop self-terminates the moment the local list
+/// becomes non-empty.
+const STATE_REQUEST_TAIL_SECS: u64 = 30;
+
+/// Hard cap on persistent-tail state requests so a genuinely-new (forever-
+/// empty) list stops after a bounded window instead of chattering
+/// indefinitely. 20 × 30s ≈ 10 min, ample for any realistic reformation.
+const STATE_REQUEST_MAX_TAIL_ATTEMPTS: usize = 20;
+
 /// Message exchanged on the state-sync side topic.
 #[derive(Debug, Serialize, Deserialize)]
 enum TaskListSyncMessage {
@@ -212,16 +225,47 @@ impl TaskListSync {
         // Bootstrap requester: a first-time joiner starts with an empty list
         // and has no other way to learn tasks written before it subscribed
         // (the gossip message cache only replays recent deltas). Ask holders
-        // to republish over a short retry schedule. Requests and the
+        // to republish. The schedule is front-loaded for a fast mesh, then
+        // runs a persistent tail so a SLOW mesh reformation still converges —
+        // e.g. a post-restart rejoin while sibling CRDTs also recover may not
+        // finish within the aggressive window. The loop self-terminates the
+        // moment the local list becomes non-empty (converged) and is hard-
+        // capped, so a genuinely-new list (no holder answers) stops after a
+        // bounded window instead of chattering forever. Requests and the
         // full-delta responses they trigger are idempotent CRDT merges, so the
-        // extra chatter is bounded and harmless. A creator of a genuinely new
-        // list also sends these — nobody answers.
+        // extra chatter is harmless.
         if self.task_list.read().await.task_count() == 0 {
             let requester_pubsub = Arc::clone(&self.pubsub);
+            let requester_list = Arc::clone(&self.task_list);
             let sync_topic = self.state_sync_topic();
             spawn(Box::pin(async move {
+                // Aggressive front-loaded schedule for a fast mesh.
                 for delay_secs in STATE_REQUEST_RETRY_SECS {
                     tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                    if requester_list.read().await.task_count() > 0 {
+                        return; // converged — stop asking
+                    }
+                    let request = TaskListSyncMessage::StateRequest {
+                        requester: local_peer_id,
+                    };
+                    let Ok(serialized) = bincode::serialize(&request) else {
+                        return;
+                    };
+                    if let Err(e) = requester_pubsub
+                        .publish(sync_topic.clone(), bytes::Bytes::from(serialized))
+                        .await
+                    {
+                        tracing::debug!("TaskList state-request publish failed: {e}");
+                    }
+                }
+                // Persistent tail: keep asking until convergence or the cap,
+                // so a slow mesh reformation still recovers state.
+                for _ in 0..STATE_REQUEST_MAX_TAIL_ATTEMPTS {
+                    tokio::time::sleep(std::time::Duration::from_secs(STATE_REQUEST_TAIL_SECS))
+                        .await;
+                    if requester_list.read().await.task_count() > 0 {
+                        return; // converged — stop asking
+                    }
                     let request = TaskListSyncMessage::StateRequest {
                         requester: local_peer_id,
                     };

--- a/src/crdt/task_item.rs
+++ b/src/crdt/task_item.rs
@@ -165,6 +165,12 @@ impl TaskItem {
     /// Adds a Claimed state to the OR-Set. If multiple agents claim concurrently,
     /// all claims are recorded, and the earliest timestamp wins as the "current" state.
     ///
+    /// Also sets the `assignee` LWW register to the claiming agent, so the
+    /// task's assignee is observable without parsing the checkbox state.
+    /// Under truly concurrent claims the LWW register may resolve to either
+    /// claimer; the authoritative winner is [`TaskItem::claim_record`], which
+    /// derives deterministically from the OR-Set.
+    ///
     /// # Arguments
     ///
     /// * `agent_id` - The agent claiming this task
@@ -216,6 +222,11 @@ impl TaskItem {
             .add(claimed_state, tag)
             .map_err(|e| CrdtError::Merge(format!("Failed to add claimed state: {}", e)))?;
 
+        // Mirror the claim into the assignee LWW register so the assignee is
+        // directly observable (same timestamp source as update_assignee: the
+        // register's own vector clock keyed by peer_id).
+        self.assignee.set(Some(agent_id), peer_id);
+
         Ok(())
     }
 
@@ -223,6 +234,10 @@ impl TaskItem {
     ///
     /// Adds a Done state to the OR-Set. If multiple agents complete concurrently,
     /// the earliest completion wins.
+    ///
+    /// Also sets the `assignee` LWW register to the completing agent
+    /// (mirroring [`TaskItem::claim`]). The authoritative completer is
+    /// [`TaskItem::completion_record`], derived from the OR-Set.
     ///
     /// # Arguments
     ///
@@ -287,6 +302,9 @@ impl TaskItem {
         self.checkbox
             .add(done_state, tag)
             .map_err(|e| CrdtError::Merge(format!("Failed to add done state: {}", e)))?;
+
+        // Mirror the completion into the assignee LWW register (see claim).
+        self.assignee.set(Some(agent_id), peer_id);
 
         Ok(())
     }
@@ -399,6 +417,59 @@ impl TaskItem {
 
         // Otherwise empty
         CheckboxState::Empty
+    }
+
+    /// The winning claim record, if this task has ever been claimed.
+    ///
+    /// Resolves the OR-Set's `Claimed` entries to a single deterministic
+    /// winner (earliest timestamp, `CheckboxState` ordering as tiebreaker) —
+    /// the same resolution [`TaskItem::current_state`] uses. Unlike
+    /// `current_state`, the claim record remains available after the task
+    /// transitions to Done.
+    ///
+    /// # Returns
+    ///
+    /// `Some((agent_id, timestamp_ms))` for the winning claim, or `None` if
+    /// the task was never claimed.
+    #[must_use]
+    pub fn claim_record(&self) -> Option<(AgentId, u64)> {
+        self.checkbox
+            .elements()
+            .into_iter()
+            .filter(|s| s.is_claimed())
+            .min()
+            .and_then(|s| match s {
+                CheckboxState::Claimed {
+                    agent_id,
+                    timestamp,
+                } => Some((*agent_id, *timestamp)),
+                _ => None,
+            })
+    }
+
+    /// The winning completion record, if this task has been completed.
+    ///
+    /// Resolves the OR-Set's `Done` entries to a single deterministic winner
+    /// (earliest timestamp, `CheckboxState` ordering as tiebreaker).
+    ///
+    /// # Returns
+    ///
+    /// `Some((agent_id, timestamp_ms))` for the winning completion, or `None`
+    /// if the task is not done.
+    #[must_use]
+    pub fn completion_record(&self) -> Option<(AgentId, u64)> {
+        self.checkbox
+            .elements()
+            .into_iter()
+            .filter(|s| s.is_done())
+            .min()
+            .and_then(|s| match s {
+                CheckboxState::Done {
+                    agent_id,
+                    timestamp,
+                } => Some((*agent_id, *timestamp)),
+                _ => None,
+            })
     }
 
     /// Merge another TaskItem into this one.
@@ -768,6 +839,87 @@ mod tests {
             CrdtError::Merge(_) => {}
             _ => panic!("Expected Merge error"),
         }
+    }
+
+    // ── Structured claim/completion semantics (task-claim API fix) ─────────
+    //
+    // WHY: the REST API used to return bare {"ok":true} on claim and the
+    // assignee register stayed None forever — ownership was only recoverable
+    // by parsing the Display string "claimed:<hex>". These tests pin the
+    // contract that claim/complete populate the assignee register and that
+    // the OR-Set winner (claim_record) is deterministic across replicas.
+
+    #[test]
+    fn claim_populates_assignee_register() {
+        let peer = peer(1);
+        let claimer = agent(7);
+        let mut task = make_task(peer);
+        assert_eq!(task.assignee(), None, "precondition: unassigned");
+
+        task.claim(claimer, peer, 1).ok().unwrap();
+
+        assert_eq!(
+            task.assignee(),
+            Some(&claimer),
+            "claim must set the assignee register — clients read assignee, not Display strings"
+        );
+        let (by, at) = task.claim_record().expect("claim record exists");
+        assert_eq!(by, claimer);
+        assert!(at > 1_000_000_000_000, "claimed_at is Unix ms");
+    }
+
+    #[test]
+    fn concurrent_claims_converge_to_same_winner_on_both_replicas() {
+        let peer1 = peer(1);
+        let peer2 = peer(2);
+        let agent1 = agent(1);
+        let agent2 = agent(2);
+
+        let mut replica_a = make_task(peer1);
+        let mut replica_b = make_task(peer1);
+
+        // Two agents claim "successfully" on their own replicas.
+        replica_a.claim(agent1, peer1, 100).ok().unwrap();
+        replica_b.claim(agent2, peer2, 200).ok().unwrap();
+
+        // Full state exchange (order differs per replica).
+        let a_before = replica_a.clone();
+        replica_a.merge(&replica_b).ok().unwrap();
+        replica_b.merge(&a_before).ok().unwrap();
+
+        // Both replicas must agree on a SINGLE winner — this is the CAS-free
+        // conflict signal: exactly one agent owns the task after convergence.
+        let (winner_a, ts_a) = replica_a.claim_record().expect("winner on A");
+        let (winner_b, ts_b) = replica_b.claim_record().expect("winner on B");
+        assert_eq!(winner_a, winner_b, "replicas disagree on claim winner");
+        assert_eq!(ts_a, ts_b);
+
+        // And claimed_by derived from current_state matches that winner.
+        let state = replica_a.current_state();
+        assert_eq!(state.claimed_by(), Some(&winner_a));
+    }
+
+    #[test]
+    fn complete_sets_completion_record_and_assignee() {
+        let peer = peer(1);
+        let claimer = agent(1);
+        let completer = agent(2);
+        let mut task = make_task(peer);
+
+        task.claim(claimer, peer, 1).ok().unwrap();
+        task.complete(completer, peer, 2).ok().unwrap();
+
+        let (done_by, done_at) = task.completion_record().expect("completion record");
+        assert_eq!(done_by, completer);
+        assert!(done_at > 1_000_000_000_000, "completed_at is Unix ms");
+        assert_eq!(
+            task.assignee(),
+            Some(&completer),
+            "complete mirrors the completer into the assignee register"
+        );
+        // The original claim record survives the transition to Done.
+        let (claimed_by, _) = task.claim_record().expect("claim record survives Done");
+        assert_eq!(claimed_by, claimer);
     }
 
     #[test]

--- a/src/crdt/task_item.rs
+++ b/src/crdt/task_item.rs
@@ -17,6 +17,7 @@
 //!
 //! ```ignore
 //! use x0x::crdt::{TaskItem, TaskId, TaskMetadata, CheckboxState};
+//! use x0x::gossip::SigningContext;
 //! use saorsa_gossip_types::PeerId;
 //!
 //! let peer_id = PeerId::from_bytes([1u8; 32]);
@@ -25,18 +26,24 @@
 //!
 //! let mut task = TaskItem::new(task_id, metadata, peer_id);
 //!
-//! // Claim the task
-//! task.claim(agent_id, peer_id, 1)?;
+//! // Claim the task (advisory: a claim records a self-attested candidate in
+//! // the OR-Set and does not prevent a concurrent claim by another agent).
+//! task.claim(list_id, agent_id, peer_id, 1, &signing)?;
 //!
 //! // Complete the task
-//! task.complete(agent_id, peer_id, 2)?;
+//! task.complete(list_id, agent_id, peer_id, 2, &signing)?;
 //! ```
 
-use crate::crdt::{CheckboxState, CrdtError, Result, TaskId, TaskMetadata};
+use crate::crdt::{
+    purge_unattested_elements, sign_attestation, CheckboxState, CrdtError, OpAttestation, OpKind,
+    Result, TaskId, TaskListId, TaskMetadata,
+};
+use crate::gossip::SigningContext;
 use crate::identity::AgentId;
 use saorsa_gossip_crdt_sync::{LwwRegister, OrSet};
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashSet};
 
 /// A task item in a collaborative task list.
 ///
@@ -54,8 +61,22 @@ pub struct TaskItem {
     /// Checkbox state using OR-Set semantics.
     ///
     /// Allows concurrent claims to coexist. The "current" state is
-    /// determined by taking the minimum (earliest timestamp wins).
+    /// determined by taking the minimum (earliest timestamp wins). Every
+    /// `Claimed`/`Done` element here carries a matching attestation in
+    /// [`TaskItem::attestations`]; the provenance admission gate
+    /// ([`purge_unattested_elements`]) keeps this invariant pure by dropping
+    /// any element whose attestation is missing or fails verification.
     checkbox: OrSet<CheckboxState>,
+
+    /// Per-element operation attestations, keyed by the `CheckboxState` value.
+    ///
+    /// Each `Claimed`/`Done` element in `checkbox` MUST have an entry here that
+    /// [`crate::crdt::verify_attestation`]s against the element's
+    /// `(kind, agent_id, timestamp)`. Serialized with the task so attestations
+    /// survive delta replication and historical (`full_delta`) state sync.
+    /// Merged as a union (same key ⇒ content-addressed identical attestation).
+    #[serde(default)]
+    attestations: BTreeMap<CheckboxState, OpAttestation>,
 
     /// Task title (LWW semantics).
     title: LwwRegister<String>,
@@ -109,6 +130,7 @@ impl TaskItem {
         Self {
             id,
             checkbox: OrSet::new(),
+            attestations: BTreeMap::new(),
             title: LwwRegister::new(metadata.title),
             description: LwwRegister::new(metadata.description),
             assignee: LwwRegister::new(None),
@@ -162,8 +184,19 @@ impl TaskItem {
 
     /// Claim this task.
     ///
-    /// Adds a Claimed state to the OR-Set. If multiple agents claim concurrently,
-    /// all claims are recorded, and the earliest timestamp wins as the "current" state.
+    /// **Advisory, non-exclusive.** A successful return records a *candidate*
+    /// in the OR-Set; it does NOT grant exclusive ownership and does NOT
+    /// prevent another agent (on this or any other replica) from also
+    /// claiming. Concurrent claims coexist — see [`TaskItem::claims`] — and
+    /// resolve to a single deterministic winner (earliest timestamp, then
+    /// lexicographic agent id) observable via [`TaskItem::claim_record`]. That
+    /// winner is only stable once all replicas have converged; a strictly
+    /// earlier-timestamp candidate arriving via a later merge will displace
+    /// it. There is no distributed lock or compare-and-swap here.
+    ///
+    /// Adds a `Claimed` candidate to the OR-Set. If multiple agents claim
+    /// concurrently, all candidates are recorded, and the earliest timestamp
+    /// wins as the "current" state.
     ///
     /// Also sets the `assignee` LWW register to the claiming agent, so the
     /// task's assignee is observable without parsing the checkbox state.
@@ -190,10 +223,17 @@ impl TaskItem {
     ///
     /// ```ignore
     /// let mut task = TaskItem::new(id, metadata, peer_id);
-    /// task.claim(agent_id, peer_id, 1)?;
+    /// task.claim(list_id, agent_id, peer_id, 1)?;
     /// assert!(task.current_state().is_claimed());
     /// ```
-    pub fn claim(&mut self, agent_id: AgentId, peer_id: PeerId, seq: u64) -> Result<()> {
+    pub fn claim(
+        &mut self,
+        scope: TaskListId,
+        agent_id: AgentId,
+        peer_id: PeerId,
+        seq: u64,
+        signing: &SigningContext,
+    ) -> Result<()> {
         // Generate Unix timestamp for conflict resolution (globally comparable)
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -212,6 +252,18 @@ impl TaskItem {
             });
         }
 
+        // Provenance: self-sign the operation so receivers can authenticate
+        // the claimant. sign_attestation requires agent_id == signing.agent_id
+        // (you can only claim as yourself); any mismatch is a hard error.
+        let att = sign_attestation(
+            signing,
+            OpKind::Claim,
+            &scope,
+            &self.id,
+            &agent_id,
+            timestamp,
+        )?;
+
         // Add the claimed state to the OR-Set with Unix timestamp for LWW
         let claimed_state = CheckboxState::Claimed {
             agent_id,
@@ -219,8 +271,9 @@ impl TaskItem {
         };
         let tag = (peer_id, seq); // seq used for OR-Set uniqueness
         self.checkbox
-            .add(claimed_state, tag)
+            .add(claimed_state.clone(), tag)
             .map_err(|e| CrdtError::Merge(format!("Failed to add claimed state: {}", e)))?;
+        self.attestations.insert(claimed_state, att);
 
         // Mirror the claim into the assignee LWW register so the assignee is
         // directly observable (same timestamp source as update_assignee: the
@@ -258,11 +311,18 @@ impl TaskItem {
     ///
     /// ```ignore
     /// let mut task = TaskItem::new(id, metadata, peer_id);
-    /// task.claim(agent_id, peer_id, 1)?;
-    /// task.complete(agent_id, peer_id, 2)?;
+    /// task.claim(list_id, agent_id, peer_id, 1)?;
+    /// task.complete(list_id, agent_id, peer_id, 2)?;
     /// assert!(task.current_state().is_done());
     /// ```
-    pub fn complete(&mut self, agent_id: AgentId, peer_id: PeerId, seq: u64) -> Result<()> {
+    pub fn complete(
+        &mut self,
+        scope: TaskListId,
+        agent_id: AgentId,
+        peer_id: PeerId,
+        seq: u64,
+        signing: &SigningContext,
+    ) -> Result<()> {
         // Generate Unix timestamp for conflict resolution (globally comparable)
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -293,6 +353,16 @@ impl TaskItem {
             });
         }
 
+        // Provenance: self-sign the completion (agent_id == signing.agent_id).
+        let att = sign_attestation(
+            signing,
+            OpKind::Complete,
+            &scope,
+            &self.id,
+            &agent_id,
+            timestamp,
+        )?;
+
         // Add the done state to the OR-Set with Unix timestamp for LWW
         let done_state = CheckboxState::Done {
             agent_id,
@@ -300,8 +370,9 @@ impl TaskItem {
         };
         let tag = (peer_id, seq); // seq used for OR-Set uniqueness
         self.checkbox
-            .add(done_state, tag)
+            .add(done_state.clone(), tag)
             .map_err(|e| CrdtError::Merge(format!("Failed to add done state: {}", e)))?;
+        self.attestations.insert(done_state, att);
 
         // Mirror the completion into the assignee LWW register (see claim).
         self.assignee.set(Some(agent_id), peer_id);
@@ -377,16 +448,21 @@ impl TaskItem {
     /// let mut task = TaskItem::new(id, metadata, peer_id);
     /// assert!(task.current_state().is_empty());
     ///
-    /// task.claim(agent_id, peer_id, 1)?;
+    /// task.claim(list_id, agent_id, peer_id, 1)?;
+    ///
     /// assert!(task.current_state().is_claimed());
     ///
-    /// task.complete(agent_id, peer_id, 2)?;
+    /// task.complete(list_id, agent_id, peer_id, 2)?;
     /// assert!(task.current_state().is_done());
     /// ```
     #[must_use]
     pub fn current_state(&self) -> CheckboxState {
-        // Get all states from the OR-Set
-        let states = self.checkbox.elements();
+        // Derive from the attestation map — the authoritative source for
+        // checkbox resolution. The OR-Set is a delivery transport; forged
+        // tombstones may hide elements from it but cannot censor them here.
+        // After admission (purge), every entry in attestations is
+        // cryptographically valid for this list's scope.
+        let states: Vec<&CheckboxState> = self.attestations.keys().collect();
 
         if states.is_empty() {
             return CheckboxState::Empty;
@@ -396,22 +472,22 @@ impl TaskItem {
         // Within same variant, earliest timestamp wins
 
         // First check for any Done states
-        let done_states: Vec<_> = states.iter().filter(|s| s.is_done()).collect();
+        let done_states: Vec<_> = states.iter().copied().filter(|s| s.is_done()).collect();
         if !done_states.is_empty() {
             return done_states
                 .into_iter()
                 .min()
-                .map(|s| (*s).clone())
+                .cloned()
                 .unwrap_or(CheckboxState::Empty);
         }
 
         // Then check for any Claimed states
-        let claimed_states: Vec<_> = states.iter().filter(|s| s.is_claimed()).collect();
+        let claimed_states: Vec<_> = states.iter().copied().filter(|s| s.is_claimed()).collect();
         if !claimed_states.is_empty() {
             return claimed_states
                 .into_iter()
                 .min()
-                .map(|s| (*s).clone())
+                .cloned()
                 .unwrap_or(CheckboxState::Empty);
         }
 
@@ -428,14 +504,9 @@ impl TaskItem {
     /// transitions to Done.
     ///
     /// # Returns
-    ///
-    /// `Some((agent_id, timestamp_ms))` for the winning claim, or `None` if
-    /// the task was never claimed.
-    #[must_use]
     pub fn claim_record(&self) -> Option<(AgentId, u64)> {
-        self.checkbox
-            .elements()
-            .into_iter()
+        self.attestations
+            .keys()
             .filter(|s| s.is_claimed())
             .min()
             .and_then(|s| match s {
@@ -445,6 +516,32 @@ impl TaskItem {
                 } => Some((*agent_id, *timestamp)),
                 _ => None,
             })
+    }
+
+    /// All recorded claim candidates (every `Claimed` OR-Set element).
+    ///
+    /// Claims are **additive**: every successful local claim appends a distinct
+    /// candidate here, regardless of who the deterministic winner is. This
+    /// makes the non-exclusive nature of claims observable — a task may carry
+    /// many coexisting claimants. Use [`TaskItem::claim_record`] for the
+    /// single deterministic winner.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec` of `(agent_id, unix_ms_timestamp)` for every observed claim
+    /// candidate. Order is unspecified.
+    #[must_use]
+    pub fn claims(&self) -> Vec<(AgentId, u64)> {
+        self.attestations
+            .keys()
+            .filter_map(|s| match s {
+                CheckboxState::Claimed {
+                    agent_id,
+                    timestamp,
+                } => Some((*agent_id, *timestamp)),
+                _ => None,
+            })
+            .collect()
     }
 
     /// The winning completion record, if this task has been completed.
@@ -458,9 +555,8 @@ impl TaskItem {
     /// if the task is not done.
     #[must_use]
     pub fn completion_record(&self) -> Option<(AgentId, u64)> {
-        self.checkbox
-            .elements()
-            .into_iter()
+        self.attestations
+            .keys()
             .filter(|s| s.is_done())
             .min()
             .and_then(|s| match s {
@@ -495,13 +591,13 @@ impl TaskItem {
     /// let mut task1 = TaskItem::new(id, metadata, peer1);
     /// let mut task2 = TaskItem::new(id, metadata, peer2);
     ///
-    /// task1.claim(agent1, peer1, 1)?;
+    /// task1.claim(list_id, agent1, peer1, 1)?;
     /// task2.update_title("New title".to_string(), peer2);
     ///
-    /// task1.merge(&task2)?;
+    /// task1.merge(list_id, &task2)?;
     /// // task1 now has both the claim and the title update
     /// ```
-    pub fn merge(&mut self, other: &TaskItem) -> Result<()> {
+    pub fn merge(&mut self, scope: TaskListId, other: &TaskItem) -> Result<()> {
         // Can only merge tasks with the same ID
         if self.id != other.id {
             return Err(CrdtError::Merge(format!(
@@ -515,6 +611,14 @@ impl TaskItem {
             .merge_state(&other.checkbox)
             .map_err(|e| CrdtError::Merge(format!("Failed to merge checkbox states: {}", e)))?;
 
+        // Union attestations (same CheckboxState key ⇒ content-addressed
+        // identical attestation, so union is idempotent).
+        for (state, att) in &other.attestations {
+            self.attestations
+                .entry(state.clone())
+                .or_insert_with(|| att.clone());
+        }
+
         // Merge LWW-Registers (metadata)
         self.title.merge(&other.title);
         self.description.merge(&other.description);
@@ -523,8 +627,118 @@ impl TaskItem {
 
         // created_by and created_at are immutable, no merge needed
 
+        // Provenance admission gate (LAST step): drop every checkbox element
+        // whose attestation is missing or fails verification. Keeps the OR-Set
+        // invariant-pure (every element authenticated) so resolution operates
+        // only over authenticated state; a forged/unattested element shipped in
+        // a delta or full_delta is dropped before it can influence resolution.
+        let dropped =
+            purge_unattested_elements(&scope, &self.id, &mut self.checkbox, &mut self.attestations);
+        if dropped > 0 {
+            tracing::debug!(
+                dropped,
+                "purged unauthenticated task checkbox elements during merge"
+            );
+        }
+
         Ok(())
     }
+
+    /// Fail-closed admission gate: purge every checkbox element and attestation
+    /// entry whose attestation is missing or fails verification for `scope`.
+    ///
+    /// The attestation map is the **authoritative source** for checkbox
+    /// resolution — read methods (`current_state`, `claim_record`, etc.)
+    /// derive from `attestations.keys()`, not from the OR-Set. A forged
+    /// tombstone may hide an element from the OR-Set, but the attested entry
+    /// remains in the map and is still visible to resolution. No per-replica
+    /// tag is synthesized; the signed `CheckboxState` is the stable op ID.
+    ///
+    /// This is the **single** admission routine for a `TaskItem`. It MUST be
+    /// called before every first insert (when a remote task arrives as a
+    /// first-seen element via merge, `merge_delta`, or cold `full_delta`) and
+    /// after every merge/full-snapshot/update. [`TaskItem::merge`] calls it
+    /// internally as its last step; first-seen insertion paths that bypass
+    /// `merge` MUST call this explicitly.
+    ///
+    /// Returns the number of unauthenticated elements dropped.
+    #[must_use]
+    pub fn admit(&mut self, scope: TaskListId) -> usize {
+        purge_unattested_elements(&scope, &self.id, &mut self.checkbox, &mut self.attestations)
+    }
+
+    /// Drop checkbox elements whose attesting agent is not in `authorized`.
+    ///
+    /// Applies group authorization at CRDT admission: a validly-signed
+    /// operation from an agent who is not an authorized member of this list's
+    /// group is rejected. This complements the REST-layer membership check —
+    /// a remote peer who subscribes to the topic but is not a group member
+    /// cannot inject claims/completions even with a valid signature.
+    ///
+    /// No-op when the element is not a Claimed/Done (Empty is never in the
+    /// OR-Set). Returns the count of nonmember elements dropped.
+    #[must_use]
+    pub fn filter_unauthorized(&mut self, authorized: &HashSet<AgentId>) -> usize {
+        // Iterate the attestation map (authoritative source), not the OR-Set,
+        // so tombstone-hidden nonmember elements are also filtered.
+        let attested: Vec<CheckboxState> = self.attestations.keys().cloned().collect();
+        let mut dropped = 0usize;
+        for state in attested {
+            let agent_id = match &state {
+                CheckboxState::Claimed { agent_id, .. } | CheckboxState::Done { agent_id, .. } => {
+                    *agent_id
+                }
+                CheckboxState::Empty => continue,
+            };
+            if !authorized.contains(&agent_id) {
+                let _ = self.checkbox.remove(&state);
+                self.attestations.remove(&state);
+                dropped += 1;
+            }
+        }
+        dropped
+    }
+}
+
+/// Craft bincode bytes of a `TaskListDelta` containing an unattested
+/// first-seen `TaskItem`, for security validation (release oracle / hostile
+/// injector).
+///
+/// The returned bytes are a bincode-serialized `(PeerId, TaskListDelta)` pair
+/// ready to publish on the task list's gossip topic. The receiver's admission
+/// gate (`TaskItem::admit`) MUST purge the forged element, leaving
+/// `current_state() == Empty`.
+///
+/// The forged `TaskItem` carries a `Claimed { victim, ts: 1 }` element in its
+/// checkbox OR-Set with NO matching attestation — the simplest first-seen
+/// bypass attack from the independent review.
+///
+/// # Arguments
+///
+/// * `victim` - The agent ID being impersonated in the forged claim
+/// * `task_id` - The target task ID
+/// * `spoof_peer` - The PeerId to use as the delta sender and OR-Set tag
+#[must_use]
+pub fn forge_unattested_delta_bytes(
+    victim: AgentId,
+    task_id: TaskId,
+    spoof_peer: PeerId,
+) -> Vec<u8> {
+    let metadata =
+        crate::crdt::TaskMetadata::new("forged".to_string(), String::new(), 0, victim, 1);
+    let mut task = TaskItem::new(task_id, metadata, spoof_peer);
+    // Inject the forged element directly into the checkbox OR-Set without
+    // an attestation — simulating a hostile publisher.
+    let forged_state = CheckboxState::Claimed {
+        agent_id: victim,
+        timestamp: 1,
+    };
+    let _ = task.checkbox.add(forged_state, (spoof_peer, 1));
+    // Deliberately do NOT add an attestation — this is the attack.
+
+    let delta = crate::crdt::TaskListDelta::for_state_change(task_id, task, 0);
+    crate::gossip::wire::encode_delta(spoof_peer, &delta)
+        .expect("encode_delta must not fail for a well-formed delta")
 }
 
 #[cfg(test)]
@@ -539,11 +753,31 @@ mod tests {
         PeerId::new([n; 32])
     }
 
+    /// Real (key-derived) agent identity + matching signing context for a
+    /// claim/complete caller. `sign_attestation` self-signs
+    /// (`agent_id == signing.agent_id`), so callers cannot use the fixed
+    /// `AgentId([n;32])`; the agent id MUST be the keypair's derived id.
+    fn signing_for(_n: u8) -> (AgentId, crate::gossip::SigningContext) {
+        let kp = crate::identity::AgentKeypair::generate().expect("agent keygen");
+        (
+            kp.agent_id(),
+            crate::gossip::SigningContext::from_keypair(&kp),
+        )
+    }
+
     fn make_task(peer: PeerId) -> TaskItem {
         let agent = agent(1);
         let task_id = TaskId::new("Test task", &agent, 1000);
         let metadata = TaskMetadata::new("Test", "Description", 128, agent, 1000);
         TaskItem::new(task_id, metadata, peer)
+    }
+
+    /// Arbitrary list scope for TaskItem-level unit tests. `claim`/`complete`/
+    /// `merge` now bind a `TaskListId` into the signed canonical bytes; the
+    /// value is irrelevant at the item level, only that it is consistent
+    /// within a test.
+    fn item_scope() -> crate::crdt::TaskListId {
+        crate::crdt::TaskListId::new([0x5c; 32])
     }
 
     #[test]
@@ -568,10 +802,10 @@ mod tests {
     #[test]
     fn test_claim_from_empty() {
         let peer = peer(1);
-        let agent = agent(1);
+        let (agent, signing) = signing_for(1);
         let mut task = make_task(peer);
 
-        let result = task.claim(agent, peer, 1);
+        let result = task.claim(item_scope(), agent, peer, 1, &signing);
         assert!(result.is_ok());
         assert!(task.current_state().is_claimed());
         assert_eq!(task.current_state().claimed_by(), Some(&agent));
@@ -580,15 +814,19 @@ mod tests {
     #[test]
     fn test_cannot_claim_done_task() {
         let peer = peer(1);
-        let agent = agent(1);
+        let (agent, signing) = signing_for(1);
         let mut task = make_task(peer);
 
         // Claim and complete
-        task.claim(agent, peer, 1).ok().unwrap();
-        task.complete(agent, peer, 2).ok().unwrap();
+        task.claim(item_scope(), agent, peer, 1, &signing)
+            .ok()
+            .unwrap();
+        task.complete(item_scope(), agent, peer, 2, &signing)
+            .ok()
+            .unwrap();
 
         // Try to claim again
-        let result = task.claim(agent, peer, 3);
+        let result = task.claim(item_scope(), agent, peer, 3, &signing);
         assert!(result.is_err());
         match result.unwrap_err() {
             CrdtError::InvalidStateTransition { .. } => {}
@@ -599,11 +837,13 @@ mod tests {
     #[test]
     fn test_complete_from_claimed() {
         let peer = peer(1);
-        let agent = agent(1);
+        let (agent, signing) = signing_for(1);
         let mut task = make_task(peer);
 
-        task.claim(agent, peer, 1).ok().unwrap();
-        let result = task.complete(agent, peer, 2);
+        task.claim(item_scope(), agent, peer, 1, &signing)
+            .ok()
+            .unwrap();
+        let result = task.complete(item_scope(), agent, peer, 2, &signing);
         assert!(result.is_ok());
         assert!(task.current_state().is_done());
     }
@@ -611,10 +851,10 @@ mod tests {
     #[test]
     fn test_cannot_complete_empty_task() {
         let peer = peer(1);
-        let agent = agent(1);
+        let (agent, signing) = signing_for(1);
         let mut task = make_task(peer);
 
-        let result = task.complete(agent, peer, 1);
+        let result = task.complete(item_scope(), agent, peer, 1, &signing);
         assert!(result.is_err());
         match result.unwrap_err() {
             CrdtError::InvalidStateTransition { .. } => {}
@@ -625,14 +865,18 @@ mod tests {
     #[test]
     fn test_cannot_complete_done_task() {
         let peer = peer(1);
-        let agent = agent(1);
+        let (agent, signing) = signing_for(1);
         let mut task = make_task(peer);
 
-        task.claim(agent, peer, 1).ok().unwrap();
-        task.complete(agent, peer, 2).ok().unwrap();
+        task.claim(item_scope(), agent, peer, 1, &signing)
+            .ok()
+            .unwrap();
+        task.complete(item_scope(), agent, peer, 2, &signing)
+            .ok()
+            .unwrap();
 
         // Try to complete again
-        let result = task.complete(agent, peer, 3);
+        let result = task.complete(item_scope(), agent, peer, 3, &signing);
         assert!(result.is_err());
         match result.unwrap_err() {
             CrdtError::InvalidStateTransition { .. } => {}
@@ -644,18 +888,24 @@ mod tests {
     fn test_concurrent_claims() {
         let peer1 = peer(1);
         let peer2 = peer(2);
-        let agent1 = agent(1);
-        let agent2 = agent(2);
+        let (agent1, signing1) = signing_for(1);
+        let (agent2, signing2) = signing_for(2);
 
         let mut task1 = make_task(peer1);
         let mut task2 = make_task(peer1);
 
         // Concurrent claims (timestamps generated internally using SystemTime)
-        task1.claim(agent1, peer1, 100).ok().unwrap();
-        task2.claim(agent2, peer2, 200).ok().unwrap();
+        task1
+            .claim(item_scope(), agent1, peer1, 100, &signing1)
+            .ok()
+            .unwrap();
+        task2
+            .claim(item_scope(), agent2, peer2, 200, &signing2)
+            .ok()
+            .unwrap();
 
         // Merge
-        task1.merge(&task2).ok().unwrap();
+        task1.merge(item_scope(), &task2).ok().unwrap();
 
         // One of the claims wins (deterministically based on Unix timestamp + agent_id tiebreaker)
         let state = task1.current_state();
@@ -669,22 +919,34 @@ mod tests {
     fn test_concurrent_completes() {
         let peer1 = peer(1);
         let peer2 = peer(2);
-        let agent1 = agent(1);
-        let agent2 = agent(2);
+        let (agent1, signing1) = signing_for(1);
+        let (agent2, signing2) = signing_for(2);
 
         let mut task1 = make_task(peer1);
         let mut task2 = make_task(peer1);
 
         // Both claim (timestamps generated internally using SystemTime)
-        task1.claim(agent1, peer1, 50).ok().unwrap();
-        task2.claim(agent1, peer1, 50).ok().unwrap();
+        task1
+            .claim(item_scope(), agent1, peer1, 50, &signing1)
+            .ok()
+            .unwrap();
+        task2
+            .claim(item_scope(), agent1, peer1, 50, &signing1)
+            .ok()
+            .unwrap();
 
         // Concurrent completes (timestamps generated internally)
-        task1.complete(agent1, peer1, 100).ok().unwrap();
-        task2.complete(agent2, peer2, 200).ok().unwrap();
+        task1
+            .complete(item_scope(), agent1, peer1, 100, &signing1)
+            .ok()
+            .unwrap();
+        task2
+            .complete(item_scope(), agent2, peer2, 200, &signing2)
+            .ok()
+            .unwrap();
 
         // Merge
-        task1.merge(&task2).ok().unwrap();
+        task1.merge(item_scope(), &task2).ok().unwrap();
 
         // One of the completes wins (deterministically based on Unix timestamp + agent_id)
         let state = task1.current_state();
@@ -692,6 +954,162 @@ mod tests {
         assert!(state.claimed_by().is_some());
         // Timestamp is Unix time in milliseconds (reasonable range check)
         assert!(state.timestamp().unwrap() > 1_000_000_000_000); // After year 2001
+    }
+
+    // ── Honest (advisory) claim semantics ───────────────────────────────
+    //
+    // A claim is NOT a mutex. These tests pin the three honesty invariants
+    // the claim contract depends on:
+    //   1. Additivity — claiming an already-claimed task succeeds (no mutual
+    //      exclusion); the only hard reject is Done.
+    //   2. Coexistence — concurrent claims from different replicas both
+    //      survive a merge, observable via `claims()` (>1 candidate).
+    //   3. Deterministic resolution — all replicas converge to ONE winner via
+    //      `claim_record()` (earliest timestamp, then lexicographic agent id).
+    // Together they prove two replicas at the "same version" can never be
+    // misread as a single globally-accepted exclusive claim.
+
+    #[test]
+    fn test_claims_accessor_empty_then_populated() {
+        let peer = peer(1);
+        let (agent, signing) = signing_for(1);
+        let mut task = make_task(peer);
+
+        assert!(task.claims().is_empty(), "no candidates before any claim");
+
+        task.claim(item_scope(), agent, peer, 1, &signing)
+            .expect("claim");
+        let claims = task.claims();
+        assert_eq!(claims.len(), 1, "one candidate after a single claim");
+        assert_eq!(claims[0].0, agent);
+        assert!(claims[0].1 > 1_000_000_000_000, "candidate carries Unix ms");
+    }
+
+    #[test]
+    fn test_claim_is_advisory_claiming_already_claimed_succeeds() {
+        // No mutual exclusion: a second agent may claim a task the first
+        // agent already claimed. Both candidates coexist. (Only Done rejects.)
+        let peer1 = peer(1);
+        let peer2 = peer(2);
+        let (agent1, signing1) = signing_for(1);
+        let (agent2, signing2) = signing_for(2);
+        let mut task = make_task(peer1);
+
+        task.claim(item_scope(), agent1, peer1, 1, &signing1)
+            .expect("first claim");
+        // A concurrent claim by a different agent does NOT error — it records
+        // a second candidate rather than excluding the second claimer.
+        task.claim(item_scope(), agent2, peer2, 2, &signing2)
+            .expect("second concurrent claim");
+
+        assert_eq!(
+            task.claims().len(),
+            2,
+            "both candidates coexist (advisory, non-exclusive)"
+        );
+    }
+
+    #[test]
+    fn test_concurrent_same_version_claims_coexist_with_single_winner() {
+        // Two replicas at the "same version" (neither knows of the other)
+        // each commit a local claim. Neither is a globally-accepted exclusive
+        // claim: after merge BOTH candidates are present, yet there is exactly
+        // one deterministic winner observable via `claim_record()`.
+        let peer1 = peer(1);
+        let peer2 = peer(2);
+        let (agent1, signing1) = signing_for(1);
+        let (agent2, signing2) = signing_for(2);
+
+        let mut replica_a = make_task(peer1);
+        let mut replica_b = make_task(peer1); // same task id as replica_a
+
+        // Each replica commits a local claim, unaware of the other.
+        replica_a
+            .claim(item_scope(), agent1, peer1, 10, &signing1)
+            .expect("replica A claims");
+        replica_b
+            .claim(item_scope(), agent2, peer2, 20, &signing2)
+            .expect("replica B claims");
+        // Before merge each replica sees only its own candidate.
+        assert_eq!(replica_a.claims().len(), 1);
+        assert_eq!(replica_b.claims().len(), 1);
+
+        // Convergence.
+        replica_a.merge(item_scope(), &replica_b).expect("merge");
+
+        // After merge BOTH candidates are present — proof the two same-version
+        // commits were not a single exclusive claim.
+        let merged_claims = replica_a.claims();
+        assert_eq!(
+            merged_claims.len(),
+            2,
+            "both candidates survive merge: {merged_claims:?}"
+        );
+
+        // Exactly one deterministic winner, and it is the earliest-timestamp
+        // candidate (independent of which agent's wall clock ran first).
+        let winner = replica_a
+            .claim_record()
+            .expect("deterministic winner exists post-merge");
+        let min_ts = merged_claims.iter().map(|(_, t)| *t).min().unwrap();
+        assert_eq!(winner.1, min_ts, "winner has the earliest timestamp");
+        let agents: Vec<_> = merged_claims.iter().map(|(a, _)| *a).collect();
+        assert!(
+            agents.contains(&winner.0),
+            "winner must be one of the recorded candidates: {winner:?}"
+        );
+        // current_state agrees with claim_record's winner.
+        assert!(replica_a.current_state().is_claimed());
+
+        // Convergence is symmetric: the other replica resolves identically.
+        replica_b
+            .merge(item_scope(), &replica_a)
+            .expect("reverse merge");
+        assert_eq!(
+            replica_b.claim_record(),
+            Some(winner),
+            "both replicas converge to the same deterministic winner"
+        );
+    }
+
+    #[test]
+    fn test_earlier_timestamp_candidate_via_merge_displaces_winner() {
+        // Monotone re-resolution: once a candidate exists, a strictly-earlier-
+        // timestamp candidate arriving via a later merge displaces the winner.
+        // (The resolved winner timestamp is monotone non-increasing.) Because
+        // `claim()` derives timestamps from the wall clock, we force ordering
+        // by claiming in sequence: the first claim gets the earliest ts and
+        // remains the winner after a later claim merges in.
+        let peer1 = peer(1);
+        let peer2 = peer(2);
+        let (agent1, signing1) = signing_for(1);
+        let (agent2, signing2) = signing_for(2);
+
+        let mut replica_a = make_task(peer1);
+        replica_a
+            .claim(item_scope(), agent1, peer1, 1, &signing1)
+            .expect("earliest claim");
+        let first_winner = replica_a.claim_record().expect("winner after first claim");
+
+        // A later claim on a divergent replica (wall clock has advanced, so
+        // its ts is strictly greater) must NOT displace the existing winner.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let mut replica_b = make_task(peer1);
+        replica_b
+            .claim(item_scope(), agent2, peer2, 2, &signing2)
+            .expect("later claim");
+
+        replica_a
+            .merge(item_scope(), &replica_b)
+            .expect("merge later claim");
+        let resolved = replica_a.claim_record().expect("winner after merge");
+        assert_eq!(
+            resolved, first_winner,
+            "earlier-ts winner is stable against a later (greater-ts) candidate"
+        );
+        // Both candidates still coexist — the later claimer was recorded, not
+        // excluded; it simply did not win.
+        assert_eq!(replica_a.claims().len(), 2);
     }
 
     #[test]
@@ -757,7 +1175,7 @@ mod tests {
         task2.update_title("Title from peer2".to_string(), peer2);
 
         // Merge - LWW should pick the later update
-        task1.merge(&task2).ok().unwrap();
+        task1.merge(item_scope(), &task2).ok().unwrap();
 
         // The exact winner depends on vector clock implementation
         // Both values are valid depending on clock ordering
@@ -770,20 +1188,23 @@ mod tests {
     #[test]
     fn test_merge_is_idempotent() {
         let peer = peer(1);
-        let agent = agent(1);
+        let (agent, signing) = signing_for(1);
 
         let mut task1 = make_task(peer);
         let mut task2 = make_task(peer);
 
-        task1.claim(agent, peer, 100).ok().unwrap();
+        task1
+            .claim(item_scope(), agent, peer, 100, &signing)
+            .ok()
+            .unwrap();
         task1.update_title("Title".to_string(), peer);
 
-        task2.merge(&task1).ok().unwrap();
+        task2.merge(item_scope(), &task1).ok().unwrap();
         let state_after_first = task2.current_state();
         let title_after_first = task2.title().to_string();
 
         // Merge again (idempotent)
-        task2.merge(&task1).ok().unwrap();
+        task2.merge(item_scope(), &task1).ok().unwrap();
         let state_after_second = task2.current_state();
         let title_after_second = task2.title().to_string();
 
@@ -795,23 +1216,26 @@ mod tests {
     fn test_merge_is_commutative() {
         let peer1 = peer(1);
         let peer2 = peer(2);
-        let agent1 = agent(1);
+        let (agent1, signing1) = signing_for(1);
         let _agent2 = agent(2);
 
         let mut task_a = make_task(peer1);
         let mut task_b = make_task(peer1);
 
         // Make different changes
-        task_a.claim(agent1, peer1, 100).ok().unwrap();
+        task_a
+            .claim(item_scope(), agent1, peer1, 100, &signing1)
+            .ok()
+            .unwrap();
         task_b.update_title("New Title".to_string(), peer2);
 
         // Merge A <- B
         let mut result1 = task_a.clone();
-        result1.merge(&task_b).ok().unwrap();
+        result1.merge(item_scope(), &task_b).ok().unwrap();
 
         // Merge B <- A
         let mut result2 = task_b.clone();
-        result2.merge(&task_a).ok().unwrap();
+        result2.merge(item_scope(), &task_a).ok().unwrap();
 
         // Both should converge to the same state
         assert_eq!(result1.current_state(), result2.current_state());
@@ -833,7 +1257,7 @@ mod tests {
         let mut task1 = TaskItem::new(task_id1, metadata1, peer);
         let task2 = TaskItem::new(task_id2, metadata2, peer);
 
-        let result = task1.merge(&task2);
+        let result = task1.merge(item_scope(), &task2);
         assert!(result.is_err());
         match result.unwrap_err() {
             CrdtError::Merge(_) => {}
@@ -852,11 +1276,13 @@ mod tests {
     #[test]
     fn claim_populates_assignee_register() {
         let peer = peer(1);
-        let claimer = agent(7);
+        let (claimer, signing) = signing_for(7);
         let mut task = make_task(peer);
         assert_eq!(task.assignee(), None, "precondition: unassigned");
 
-        task.claim(claimer, peer, 1).ok().unwrap();
+        task.claim(item_scope(), claimer, peer, 1, &signing)
+            .ok()
+            .unwrap();
 
         assert_eq!(
             task.assignee(),
@@ -872,20 +1298,26 @@ mod tests {
     fn concurrent_claims_converge_to_same_winner_on_both_replicas() {
         let peer1 = peer(1);
         let peer2 = peer(2);
-        let agent1 = agent(1);
-        let agent2 = agent(2);
+        let (agent1, signing1) = signing_for(1);
+        let (agent2, signing2) = signing_for(2);
 
         let mut replica_a = make_task(peer1);
         let mut replica_b = make_task(peer1);
 
         // Two agents claim "successfully" on their own replicas.
-        replica_a.claim(agent1, peer1, 100).ok().unwrap();
-        replica_b.claim(agent2, peer2, 200).ok().unwrap();
+        replica_a
+            .claim(item_scope(), agent1, peer1, 100, &signing1)
+            .ok()
+            .unwrap();
+        replica_b
+            .claim(item_scope(), agent2, peer2, 200, &signing2)
+            .ok()
+            .unwrap();
 
         // Full state exchange (order differs per replica).
         let a_before = replica_a.clone();
-        replica_a.merge(&replica_b).ok().unwrap();
-        replica_b.merge(&a_before).ok().unwrap();
+        replica_a.merge(item_scope(), &replica_b).ok().unwrap();
+        replica_b.merge(item_scope(), &a_before).ok().unwrap();
 
         // Both replicas must agree on a SINGLE winner — this is the CAS-free
         // conflict signal: exactly one agent owns the task after convergence.
@@ -902,12 +1334,16 @@ mod tests {
     #[test]
     fn complete_sets_completion_record_and_assignee() {
         let peer = peer(1);
-        let claimer = agent(1);
-        let completer = agent(2);
+        let (claimer, signing_claim) = signing_for(1);
+        let (completer, signing_complete) = signing_for(2);
         let mut task = make_task(peer);
 
-        task.claim(claimer, peer, 1).ok().unwrap();
-        task.complete(completer, peer, 2).ok().unwrap();
+        task.claim(item_scope(), claimer, peer, 1, &signing_claim)
+            .ok()
+            .unwrap();
+        task.complete(item_scope(), completer, peer, 2, &signing_complete)
+            .ok()
+            .unwrap();
 
         let (done_by, done_at) = task.completion_record().expect("completion record");
         assert_eq!(done_by, completer);
@@ -925,10 +1361,12 @@ mod tests {
     #[test]
     fn test_serialization_roundtrip() {
         let peer = peer(1);
-        let agent = agent(42);
+        let (agent, signing) = signing_for(42);
         let mut task = make_task(peer);
 
-        task.claim(agent, peer, 100).ok().unwrap();
+        task.claim(item_scope(), agent, peer, 100, &signing)
+            .ok()
+            .unwrap();
         task.update_title("Serialized Task".to_string(), peer);
         task.update_priority(200, peer);
 
@@ -939,5 +1377,530 @@ mod tests {
         assert_eq!(task.title(), deserialized.title());
         assert_eq!(task.priority(), deserialized.priority());
         assert_eq!(task.current_state(), deserialized.current_state());
+    }
+
+    // ── Provenance admission gate: integration into TaskItem::merge ──────────
+    //
+    // The crypto-level gate (provenance.rs) is unit-tested in isolation.
+    // These tests pin that the gate runs as the LAST step of `merge`, so a
+    // forged / unattested Claimed element arriving via a remote merge is
+    // dropped BEFORE it can influence resolution — the strict-cutover
+    // invariant (legacy/forged unattested elements are dropped, not tolerated).
+
+    #[test]
+    fn merge_drops_unattested_claim_element_before_resolution() {
+        // A legitimate, self-signed claim.
+        let (agent_a, signing_a) = signing_for(1);
+        let peer = peer(1);
+        let mut legit = make_task(peer);
+        legit
+            .claim(item_scope(), agent_a, peer, 1, &signing_a)
+            .expect("legit claim");
+        let legit_ts = legit.claim_record().expect("winner exists").1;
+        assert!(legit_ts > 1_000_000_000_000, "legit claim carries Unix-ms");
+
+        // A rogue replica fabricates a Claimed element with timestamp 1
+        // (which would WIN earliest-ts resolution if it survived) but
+        // attaches NO attestation — the v0.30.1 unattested / injection shape.
+        let mut rogue = make_task(peer); // identical task id
+        let forged = CheckboxState::Claimed {
+            agent_id: agent_a,
+            timestamp: 1,
+        };
+        rogue
+            .checkbox
+            .add(forged.clone(), (peer, 999))
+            .expect("add forged element");
+        // Deliberately NO attestation entry for `forged`.
+
+        // Merge rogue → legit. The gate must drop the forged element.
+        legit.merge(item_scope(), &rogue).expect("merge");
+
+        // Only the attested claim survives; the forged ts=1 element did NOT
+        // steal the claim.
+        assert_eq!(
+            legit.claims().len(),
+            1,
+            "forged unattested element purged on merge"
+        );
+        let winner = legit.claim_record().expect("attested winner survives");
+        assert_eq!(winner.0, agent_a);
+        assert_eq!(
+            winner.1, legit_ts,
+            "resolution uses the attested claim, not the forged ts=1 element"
+        );
+    }
+
+    #[test]
+    fn merge_drops_claim_whose_attestation_was_signed_by_an_attacker() {
+        // Impersonation via merge: the element claims `victim`, but the
+        // attestation was produced by an attacker's key
+        // (derived(attacker) != victim) → the gate drops it even though an
+        // attestation entry EXISTS, so the forged claim cannot steal the task.
+        let (victim, victim_signing) = signing_for(1);
+        let (_attacker, attacker_signing) = signing_for(2);
+        let peer = peer(1);
+
+        // Legit victim claim.
+        let mut legit = make_task(peer);
+        legit
+            .claim(item_scope(), victim, peer, 1, &victim_signing)
+            .expect("victim claim");
+        let legit_winner = legit.claim_record().expect("winner");
+
+        // Rogue replica injects an impersonating element: claims `victim` at
+        // ts=1 (earlier, to try to win) but attested by the attacker's key.
+        let mut rogue = make_task(peer);
+        let forged_state = CheckboxState::Claimed {
+            agent_id: victim,
+            timestamp: 1,
+        };
+        rogue
+            .checkbox
+            .add(forged_state.clone(), (peer, 7))
+            .expect("add");
+        let msg =
+            crate::crdt::canonical_op_bytes(OpKind::Claim, &item_scope(), legit.id(), &victim, 1);
+        let sig = attacker_signing.sign(&msg).expect("attacker sign");
+        rogue.attestations.insert(
+            forged_state,
+            OpAttestation {
+                author_agent_id: victim,
+                author_public_key: attacker_signing.public_key_bytes.clone(),
+                signature: sig,
+            },
+        );
+
+        // Merge rogue → legit: the forged (attacker-attested) element is dropped.
+        legit.merge(item_scope(), &rogue).expect("merge");
+
+        // Only the victim's legitimately-attested claim survives.
+        assert_eq!(
+            legit.claims().len(),
+            1,
+            "attacker-attested impersonation element purged on merge"
+        );
+        assert_eq!(
+            legit.claim_record().expect("winner"),
+            legit_winner,
+            "victim's attested claim wins; impersonation rejected"
+        );
+    }
+    // ── P0: first-seen TaskItem admission across every insertion path ──────
+    //
+    // WHY: `TaskItem::merge` runs the provenance gate as its last step, so a
+    // forged/unattested Claimed element is dropped when it arrives via a MERGE
+    // (proven above). But a FIRST-SEEN task used to bypass merge entirely:
+    // full-list `TaskList::merge` cloned the unknown task in directly,
+    // `merge_delta`'s `added_tasks`/`task_updates` inserted via `add_task`,
+    // and a cold `full_delta` snapshot flowed through the same paths. A hostile
+    // publisher could make `Claimed { victim, ts: 1 }` a receiver's first
+    // observation and, under earliest-timestamp-wins resolution, steal the
+    // claim. The fix routes every first-seen insertion through the same
+    // fail-closed admission routine as merge.
+    //
+    // These tests live in THIS module (not task_list's) because forging a
+    // TaskItem with a bare/unattested checkbox element requires private access
+    // to `checkbox`/`attestations` — the public `claim()` always self-signs
+    // correctly and cannot produce the attack shape.
+    //
+    // Semantics asserted (matching the existing merge-path gate): admission
+    // PURGES unattested elements and keeps the task, so a forged-only
+    // first-seen task lands with `current_state() == Empty`.
+
+    #[derive(Debug, Clone, Copy)]
+    enum BadAttestation {
+        Missing,
+        MalformedKey,
+        AttackerKey,
+        WrongAgent,
+    }
+
+    /// Build a TaskItem for `task_id` whose only checkbox element is
+    /// `Claimed { victim, ts }`, with the attestation in the chosen mode. White-
+    /// box: pokes private `checkbox`/`attestations` directly so the element is
+    /// exactly what a hostile publisher ships — never produced by `claim()`.
+    /// `ts` is intentionally small (1) so the forged element would WIN
+    /// earliest-timestamp resolution if it survived.
+    fn task_with_forged_claim(
+        task_id: TaskId,
+        victim: AgentId,
+        ts: u64,
+        mode: BadAttestation,
+    ) -> TaskItem {
+        // Scope under which the forged signature is produced. Every admission
+        // test uses list id [1u8;32]; the scope must match the receiver's so
+        // the forged signature is well-formed for that list — it then rejects
+        // via the agent binding (attacker key / wrong agent), not the scope.
+        let scope = crate::crdt::TaskListId::new([1u8; 32]);
+        let p = peer(1);
+        let metadata = TaskMetadata::new("forged", "d", 1, victim, 0);
+        let mut task = TaskItem::new(task_id, metadata, p);
+        let elem = CheckboxState::Claimed {
+            agent_id: victim,
+            timestamp: ts,
+        };
+        task.checkbox
+            .add(elem.clone(), (p, 9001))
+            .expect("add forged element");
+        match mode {
+            BadAttestation::Missing => {
+                // No attestation entry at all — the unattested injection shape.
+            }
+            BadAttestation::MalformedKey => {
+                task.attestations.insert(
+                    elem,
+                    OpAttestation {
+                        author_agent_id: victim,
+                        author_public_key: vec![0u8; 5], // not a valid ML-DSA key
+                        signature: vec![0u8; 16],
+                    },
+                );
+            }
+            BadAttestation::AttackerKey => {
+                // Attacker signs the victim's canonical bytes with the
+                // attacker's own key, then tags the attestation as the victim.
+                // derived(attacker key) != victim ⇒ rejected.
+                let (_, atk_signing) = signing_for(8);
+                let msg =
+                    crate::crdt::canonical_op_bytes(OpKind::Claim, &scope, &task_id, &victim, ts);
+                let sig = atk_signing.sign(&msg).expect("attacker sign");
+                task.attestations.insert(
+                    elem,
+                    OpAttestation {
+                        author_agent_id: victim,
+                        author_public_key: atk_signing.public_key_bytes.clone(),
+                        signature: sig,
+                    },
+                );
+            }
+            BadAttestation::WrongAgent => {
+                // A different valid agent self-attests correctly, but the
+                // element claims `victim` ⇒ author_agent_id != element agent_id.
+                let (other, other_signing) = signing_for(9);
+                let att = crate::crdt::sign_attestation(
+                    &other_signing,
+                    OpKind::Claim,
+                    &scope,
+                    &task_id,
+                    &other,
+                    ts,
+                )
+                .expect("self-sign as other");
+                task.attestations.insert(elem, att);
+            }
+        }
+        task
+    }
+
+    #[test]
+    fn first_seen_unattested_claim_via_full_list_merge_is_purged() {
+        // Full-list path: a hostile replica's only task carries an unattested
+        // Claimed{ts:1}. A clean receiver that merges the whole list must purge
+        // the forged element — it must not become the resolved claim.
+        let id = crate::crdt::TaskListId::new([1u8; 32]);
+        let task_id = TaskId::from_bytes([7u8; 32]);
+        let victim = agent(9);
+
+        let mut hostile = crate::crdt::TaskList::new(id, "L".to_string(), peer(1));
+        let forged = task_with_forged_claim(task_id, victim, 1, BadAttestation::Missing);
+        hostile.add_task(forged, peer(1), 1).unwrap();
+
+        let mut receiver = crate::crdt::TaskList::new(id, "L".to_string(), peer(2));
+        receiver.merge(&hostile).unwrap();
+
+        let t = receiver.get_task(&task_id).expect("task admitted");
+        assert!(
+            t.current_state().is_empty(),
+            "forged first-seen claim purged"
+        );
+        assert!(
+            t.claim_record().is_none(),
+            "no claim_record for a purged element"
+        );
+        assert!(t.claims().is_empty(), "no surviving claim candidates");
+    }
+
+    #[test]
+    fn first_seen_unattested_claim_via_added_tasks_delta_is_purged() {
+        // Live delta path (the actual gossip route): an added_tasks delta
+        // carries a first-seen task with an unattested Claimed{ts:1}.
+        let id = crate::crdt::TaskListId::new([1u8; 32]);
+        let task_id = TaskId::from_bytes([7u8; 32]);
+        let victim = agent(9);
+
+        let forged = task_with_forged_claim(task_id, victim, 1, BadAttestation::Missing);
+        let mut delta = crate::crdt::TaskListDelta::new(1);
+        delta.added_tasks.insert(task_id, (forged, (peer(1), 1)));
+
+        let mut receiver = crate::crdt::TaskList::new(id, "L".to_string(), peer(2));
+        receiver.merge_delta(&delta, peer(1)).unwrap();
+
+        let t = receiver.get_task(&task_id).expect("task admitted");
+        assert!(
+            t.current_state().is_empty(),
+            "added-tasks forged claim purged"
+        );
+        assert!(t.claim_record().is_none());
+    }
+
+    #[test]
+    fn first_seen_unattested_claim_via_out_of_order_update_is_purged() {
+        // Out-of-order delivery: a claim/complete delta arrives BEFORE the add
+        // delta, so `task_updates` upserts a task the receiver has never seen.
+        let id = crate::crdt::TaskListId::new([1u8; 32]);
+        let task_id = TaskId::from_bytes([7u8; 32]);
+        let victim = agent(9);
+
+        let forged = task_with_forged_claim(task_id, victim, 1, BadAttestation::Missing);
+        let mut delta = crate::crdt::TaskListDelta::new(1);
+        delta.task_updates.insert(task_id, forged);
+
+        let mut receiver = crate::crdt::TaskList::new(id, "L".to_string(), peer(2));
+        receiver.merge_delta(&delta, peer(3)).unwrap();
+
+        let t = receiver
+            .get_task(&task_id)
+            .expect("task admitted via upsert");
+        assert!(
+            t.current_state().is_empty(),
+            "out-of-order forged claim purged"
+        );
+        assert!(t.claim_record().is_none());
+    }
+
+    #[test]
+    fn first_seen_unattested_claim_via_cold_full_delta_is_purged() {
+        // Cold start: a holder answers a StateRequest with full_delta(). If the
+        // holder's task carries a forged element, the joiner's merge_delta must
+        // purge it before it can influence resolution.
+        let id = crate::crdt::TaskListId::new([1u8; 32]);
+        let task_id = TaskId::from_bytes([7u8; 32]);
+        let victim = agent(9);
+
+        let mut holder = crate::crdt::TaskList::new(id, "L".to_string(), peer(1));
+        let forged = task_with_forged_claim(task_id, victim, 1, BadAttestation::Missing);
+        holder.add_task(forged, peer(1), 1).unwrap();
+        let snapshot = holder.full_delta();
+
+        let mut joiner = crate::crdt::TaskList::new(id, String::new(), peer(2));
+        joiner.merge_delta(&snapshot, peer(1)).unwrap();
+
+        let t = joiner.get_task(&task_id).expect("task transferred");
+        assert!(
+            t.current_state().is_empty(),
+            "cold-start forged claim purged"
+        );
+        assert!(t.claim_record().is_none());
+    }
+
+    #[test]
+    fn first_seen_admission_drops_every_bad_attestation_mode() {
+        // The first-seen invariant must hold for EVERY way an attestation can
+        // be invalid, not just "missing". None may let Claimed{ts:1} steal the
+        // claim when shipped first-seen via an added_tasks delta.
+        let id = crate::crdt::TaskListId::new([1u8; 32]);
+        let task_id = TaskId::from_bytes([7u8; 32]);
+        let victim = agent(9);
+
+        let modes = [
+            BadAttestation::Missing,
+            BadAttestation::MalformedKey,
+            BadAttestation::AttackerKey,
+            BadAttestation::WrongAgent,
+        ];
+        for mode in modes {
+            let forged = task_with_forged_claim(task_id, victim, 1, mode);
+            let mut delta = crate::crdt::TaskListDelta::new(1);
+            delta.added_tasks.insert(task_id, (forged, (peer(1), 1)));
+
+            let mut receiver = crate::crdt::TaskList::new(id, "L".to_string(), peer(2));
+            receiver.merge_delta(&delta, peer(1)).unwrap();
+
+            let t = receiver
+                .get_task(&task_id)
+                .expect("task admitted (purge-keeps-task semantics)");
+            assert!(
+                t.current_state().is_empty(),
+                "{mode:?}: forged claim must be purged, got {:?}",
+                t.current_state()
+            );
+            assert!(t.claim_record().is_none(), "{mode:?}: no claim_record");
+            assert!(t.claims().is_empty(), "{mode:?}: no surviving candidates");
+        }
+    }
+
+    #[test]
+    fn validly_attested_first_seen_claim_converges_via_delta() {
+        // Positive contract — admission must not OVER-reject. A genuinely
+        // self-attested claim shipped first-seen via a delta MUST survive and
+        // resolve, so valid relayed history still converges end to end. (This
+        // is the teeth check for the purge tests above: the gate rejects
+        // forged elements specifically, not every first-seen task.)
+        let id = crate::crdt::TaskListId::new([1u8; 32]);
+        let p = peer(1);
+        let (claimer, signing) = signing_for(5);
+
+        let task_id = TaskId::from_bytes([7u8; 32]);
+        let metadata = TaskMetadata::new("real", "d", 1, claimer, 0);
+        let mut task = TaskItem::new(task_id, metadata, p);
+        task.claim(id, claimer, p, 1, &signing)
+            .expect("legit claim");
+        let claimed_ts = task.claim_record().expect("claim recorded").1;
+
+        let mut delta = crate::crdt::TaskListDelta::new(1);
+        delta.added_tasks.insert(task_id, (task, (p, 1)));
+
+        let mut receiver = crate::crdt::TaskList::new(id, "L".to_string(), peer(2));
+        receiver.merge_delta(&delta, p).unwrap();
+
+        let t = receiver.get_task(&task_id).expect("valid task admitted");
+        assert!(
+            t.current_state().is_claimed(),
+            "valid first-seen claim resolves"
+        );
+        let (by, ts) = t.claim_record().expect("claim_record present");
+        assert_eq!(by, claimer, "valid claimant is the winner");
+        assert_eq!(ts, claimed_ts, "claim timestamp preserved across admission");
+    }
+
+    // ── P1: forged-tombstone anti-censorship ───────────────────────────────
+    //
+    // WHY: a hostile participant could try to censor an authenticated claim by
+    // shipping a tombstone that removes its checkbox element. Checkbox elements
+    // are append-only (no legitimate removal), so any tombstone is forged. The
+    // read methods treat the attestation map as authoritative, so an attested
+    // claim remains observable via `claim_record()` even after the element is
+    // tombstoned out of the checkbox. Admission re-establishes visibility.
+
+    #[test]
+    fn forged_tombstone_does_not_censor_an_attested_claim() {
+        let peer = peer(1);
+        let (agent, signing) = signing_for(1);
+
+        let mut task = make_task(peer);
+        task.claim(item_scope(), agent, peer, 1, &signing)
+            .expect("legit claim");
+        let claim = task.claim_record().expect("claim recorded before attack");
+
+        // Hostile: forge a tombstone on the attested checkbox element.
+        let claimed_state = CheckboxState::Claimed {
+            agent_id: claim.0,
+            timestamp: claim.1,
+        };
+        let _ = task.checkbox.remove(&claimed_state);
+
+        // Admission runs the gate; the attested element is NOT dropped (its
+        // attestation verifies for this scope) and remains observable.
+        let _dropped = task.admit(item_scope());
+
+        assert_eq!(
+            task.claim_record(),
+            Some(claim),
+            "an attested claim survives a forged tombstone"
+        );
+        assert!(
+            task.current_state().is_claimed(),
+            "current_state still reflects the attested claim after a forged tombstone"
+        );
+    }
+
+    // ── P1: group-membership authorization at CRDT admission ──────────────
+    //
+    // WHY: provenance authenticates the SIGNER, not group membership. Without
+    // a membership check at admission, a remote peer subscribed to a group-
+    // scoped topic (but not a member) could inject validly-signed claims.
+    // `filter_unauthorized` drops checkbox elements whose agent is not in the
+    // authorized set — a valid-signature nonmember is rejected at the CRDT
+    // layer, complementing the REST membership check.
+
+    #[test]
+    fn valid_signature_nonmember_is_dropped_by_filter_unauthorized() {
+        let peer = peer(1);
+        let (member, member_signing) = signing_for(1);
+        let (outsider, outsider_signing) = signing_for(2);
+
+        // Two tasks (same id), each validly claimed by a different agent.
+        let mut task_m = make_task(peer);
+        task_m
+            .claim(item_scope(), member, peer, 1, &member_signing)
+            .expect("member claim");
+        let mut task_o = make_task(peer);
+        task_o
+            .claim(item_scope(), outsider, peer, 1, &outsider_signing)
+            .expect("outsider claim");
+
+        // Authorized set contains ONLY the member.
+        let mut authorized = HashSet::<AgentId>::new();
+        authorized.insert(member);
+
+        // The member's valid claim survives; the outsider's is dropped even
+        // though its signature is cryptographically valid.
+        let dropped_m = task_m.filter_unauthorized(&authorized);
+        assert_eq!(dropped_m, 0, "member's valid claim is authorized");
+        assert!(task_m.claim_record().is_some(), "member claim survives");
+
+        let dropped_o = task_o.filter_unauthorized(&authorized);
+        assert_eq!(dropped_o, 1, "valid-signature nonmember is dropped");
+        assert!(
+            task_o.claim_record().is_none(),
+            "outsider claim removed despite a valid signature"
+        );
+        assert!(
+            task_o.current_state().is_empty(),
+            "nonmember's claim did not survive admission"
+        );
+    }
+
+    // ── P1: admission is order-independent (both merge orders converge) ────
+
+    #[test]
+    fn admission_converges_identically_in_both_merge_orders() {
+        // A replica holding a validly-attested claim and one carrying a forged
+        // unattested Claimed{ts:1} must converge to the SAME safe state
+        // regardless of merge direction — only the attested claim survives in
+        // both, so the gate is order-independent and valid relayed history
+        // converges.
+        let peer = peer(1);
+        let (agent_id, signing) = signing_for(1);
+        let task_id = TaskId::from_bytes([7u8; 32]);
+
+        // honest: a real, self-attested claim under the same task id.
+        let metadata = TaskMetadata::new("t", "d", 1, agent_id, 0);
+        let mut honest = TaskItem::new(task_id, metadata, peer);
+        honest
+            .claim(item_scope(), agent_id, peer, 1, &signing)
+            .expect("honest claim");
+        let honest_winner = honest.claim_record().expect("winner");
+
+        // hostile: forged unattested Claimed{ts:1} (would win earliest-ts if it
+        // survived the gate).
+        let hostile = task_with_forged_claim(task_id, agent(9), 1, BadAttestation::Missing);
+
+        // Order 1: honest absorbs hostile.
+        let mut order1 = honest.clone();
+        order1
+            .merge(item_scope(), &hostile)
+            .expect("merge hostile into honest");
+        // Order 2: hostile absorbs honest.
+        let mut order2 = hostile.clone();
+        order2
+            .merge(item_scope(), &honest)
+            .expect("merge honest into hostile");
+
+        // Both directions keep exactly the attested claim; the forged element is
+        // purged and never steals the claim in either order.
+        assert_eq!(
+            order1.claim_record(),
+            Some(honest_winner),
+            "order1 keeps the attested winner"
+        );
+        assert_eq!(
+            order2.claim_record(),
+            Some(honest_winner),
+            "order2 keeps the attested winner"
+        );
+        assert_eq!(order1.claims().len(), 1, "forged element purged in order1");
+        assert_eq!(order2.claims().len(), 1, "forged element purged in order2");
     }
 }

--- a/src/crdt/task_item.rs
+++ b/src/crdt/task_item.rs
@@ -68,16 +68,6 @@ pub struct TaskItem {
     /// any element whose attestation is missing or fails verification.
     checkbox: OrSet<CheckboxState>,
 
-    /// Per-element operation attestations, keyed by the `CheckboxState` value.
-    ///
-    /// Each `Claimed`/`Done` element in `checkbox` MUST have an entry here that
-    /// [`crate::crdt::verify_attestation`]s against the element's
-    /// `(kind, agent_id, timestamp)`. Serialized with the task so attestations
-    /// survive delta replication and historical (`full_delta`) state sync.
-    /// Merged as a union (same key ⇒ content-addressed identical attestation).
-    #[serde(default)]
-    attestations: BTreeMap<CheckboxState, OpAttestation>,
-
     /// Task title (LWW semantics).
     title: LwwRegister<String>,
 
@@ -99,6 +89,46 @@ pub struct TaskItem {
 
     /// When this task was created (immutable, Unix milliseconds).
     created_at: u64,
+
+    /// Per-element operation attestations, keyed by the `CheckboxState` value.
+    ///
+    /// Each `Claimed`/`Done` element in `checkbox` MUST have an entry here that
+    /// [`crate::crdt::verify_attestation`]s against the element's
+    /// `(kind, agent_id, timestamp)`. Serialized with the task so attestations
+    /// survive delta replication and historical (`full_delta`) state sync.
+    /// Merged as a union (same key ⇒ content-addressed identical attestation).
+    ///
+    /// This is the **trailing** serialized field. bincode (the wire and disk
+    /// format) is positional and non-self-describing, so `#[serde(default)]`
+    /// alone would not save a blob written without it — a mid-struct absence
+    /// misaligns every following field. Kept last with a tolerant deserializer
+    /// so a blob whose bytes END before this field (a pre-provenance /
+    /// differently-shaped TaskItem at the tail of the stream) decodes to an
+    /// empty map instead of an EOF error. An empty map resolves to
+    /// `current_state() == Empty`, i.e. no attested elements — fail-closed,
+    /// never fail-open. The tolerance is genuine only at stream-EOF: a fieldless
+    /// TaskItem nested mid-stream inside a larger bincode value cannot be
+    /// recovered positionally. New fields MUST be added after this one.
+    #[serde(default, deserialize_with = "deserialize_attestations")]
+    attestations: BTreeMap<CheckboxState, OpAttestation>,
+}
+
+/// Deserialize the trailing per-element attestation map, tolerating its
+/// absence. A blob written by a struct shape lacking this field (e.g. a
+/// pre-provenance TaskItem) simply ends before it; bincode would then hit EOF.
+/// This mirrors the KvStoreDelta `owner_checkpoint` pattern: decode the value
+/// if present, otherwise (EOF or any malformed value) yield an empty map. An
+/// empty attestation map is the fail-closed default — the provenance admission
+/// gate treats it as "no attested elements", so nothing is admitted on the
+/// strength of missing bytes.
+fn deserialize_attestations<'de, D>(
+    deserializer: D,
+) -> std::result::Result<BTreeMap<CheckboxState, OpAttestation>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    Ok(BTreeMap::<CheckboxState, OpAttestation>::deserialize(deserializer).unwrap_or_default())
 }
 
 impl TaskItem {
@@ -130,13 +160,13 @@ impl TaskItem {
         Self {
             id,
             checkbox: OrSet::new(),
-            attestations: BTreeMap::new(),
             title: LwwRegister::new(metadata.title),
             description: LwwRegister::new(metadata.description),
             assignee: LwwRegister::new(None),
             priority: LwwRegister::new(metadata.priority),
             created_by: metadata.created_by,
             created_at: metadata.created_at,
+            attestations: BTreeMap::new(),
         }
     }
 
@@ -1377,6 +1407,117 @@ mod tests {
         assert_eq!(task.title(), deserialized.title());
         assert_eq!(task.priority(), deserialized.priority());
         assert_eq!(task.current_state(), deserialized.current_state());
+    }
+
+    // ── bincode wire/disk compatibility: attestations is a TRAILING field ────
+    //
+    // WHY: `attestations` was originally inserted mid-struct (field #3, between
+    // `checkbox` and `title`) with only `#[serde(default)]`. bincode is
+    // positional and non-self-describing — `#[serde(default)]` does nothing for
+    // it — so a blob written by any struct shape lacking that exact field at
+    // that exact position (a pre-provenance TaskItem, or an older peer/disk
+    // record) misaligns at field #3 and the WHOLE decode errors with EOF.
+    // Because TaskItem is nested in TaskListDelta maps, one bad item fails the
+    // entire delta and a persisted TaskList cannot load. The fix moves
+    // `attestations` to the LAST serialized field with a tolerant deserializer,
+    // so a blob that simply ends before it decodes to an empty map.
+    //
+    // This test reconstructs the EXACT pre-wave byte layout via a local
+    // `LegacyTaskItemV0` (the v0.30.1 field order, no `attestations`). If the
+    // field were ever moved back mid-struct, or lost its tolerant deserializer,
+    // this decode fails — that is the whole point of the test.
+
+    #[test]
+    fn legacy_taskitem_without_attestations_decodes() {
+        let peer = peer(1);
+        let (agent, signing) = signing_for(1);
+        let mut task = make_task(peer);
+        // A real claim so the checkbox OR-Set and LWW registers are non-trivial.
+        task.claim(item_scope(), agent, peer, 1, &signing)
+            .expect("claim");
+        task.update_title("Legacy".to_string(), peer);
+
+        // Mirror the pre-provenance-wave TaskItem field layout exactly (see
+        // `git show b573441:src/crdt/task_item.rs`): the 8 fields in declaration
+        // order, with NO `attestations`. bincode is positional, so serializing
+        // this is byte-identical to what a pre-wave node wrote for this task.
+        #[derive(Serialize)]
+        struct LegacyTaskItemV0 {
+            id: TaskId,
+            checkbox: OrSet<CheckboxState>,
+            title: LwwRegister<String>,
+            description: LwwRegister<String>,
+            assignee: LwwRegister<Option<AgentId>>,
+            priority: LwwRegister<u8>,
+            created_by: AgentId,
+            created_at: u64,
+        }
+        let legacy = LegacyTaskItemV0 {
+            id: task.id,
+            checkbox: task.checkbox.clone(),
+            title: task.title.clone(),
+            description: task.description.clone(),
+            assignee: task.assignee.clone(),
+            priority: task.priority.clone(),
+            created_by: task.created_by,
+            created_at: task.created_at,
+        };
+
+        let bytes = bincode::serialize(&legacy).expect("serialize legacy shape");
+        let restored: TaskItem = bincode::deserialize(&bytes)
+            .expect("legacy TaskItem (no attestations bytes) must decode");
+
+        // The trailing field defaults to an empty map instead of erroring.
+        assert!(
+            restored.attestations.is_empty(),
+            "absent trailing field decodes to an empty attestation map"
+        );
+        // Every other field survives intact (proves alignment, not just non-error).
+        assert_eq!(restored.id(), task.id());
+        assert_eq!(restored.title(), "Legacy");
+        assert_eq!(restored.description(), task.description());
+        assert_eq!(restored.priority(), task.priority());
+        assert_eq!(restored.created_by(), task.created_by());
+        assert_eq!(restored.created_at(), task.created_at());
+        // Resolution is fail-closed: with an empty attestation map (the
+        // authoritative source), a legacy claim element in the OR-Set does NOT
+        // resolve — the task reads Empty rather than admitting an unattested op.
+        assert!(
+            restored.current_state().is_empty(),
+            "no attestation ⇒ fail-closed Empty even though the OR-Set carries a claim element"
+        );
+    }
+
+    #[test]
+    fn taskitem_roundtrip_preserves_populated_attestations() {
+        let peer = peer(1);
+        let (agent, signing) = signing_for(1);
+        let mut task = make_task(peer);
+        task.claim(item_scope(), agent, peer, 1, &signing)
+            .expect("claim");
+        task.complete(item_scope(), agent, peer, 2, &signing)
+            .expect("complete");
+        task.update_title("Roundtrip".to_string(), peer);
+        assert!(
+            !task.attestations.is_empty(),
+            "precondition: a claim + complete populate the attestation map"
+        );
+
+        let bytes = bincode::serialize(&task).expect("serialize");
+        let restored: TaskItem = bincode::deserialize(&bytes).expect("deserialize");
+
+        // The populated trailing map round-trips byte-for-byte.
+        assert_eq!(
+            restored.attestations, task.attestations,
+            "populated attestation map survives the round-trip"
+        );
+        assert_eq!(restored.id(), task.id());
+        assert_eq!(restored.title(), task.title());
+        assert_eq!(restored.current_state(), task.current_state());
+        assert!(
+            restored.current_state().is_done(),
+            "attested Done state resolves after round-trip"
+        );
     }
 
     // ── Provenance admission gate: integration into TaskItem::merge ──────────

--- a/src/crdt/task_list.rs
+++ b/src/crdt/task_list.rs
@@ -53,6 +53,23 @@ impl TaskListId {
         let hash = hasher.finalize();
         Self(*hash.as_bytes())
     }
+
+    /// Deterministic id for a task list reached via the gossip `topic`.
+    ///
+    /// Every replica that creates or joins the same logical list does so via
+    /// the same topic, so the id MUST derive from the topic ALONE. It must not
+    /// fold in per-node data (e.g. the local agent id) or per-call data (a
+    /// name, a timestamp): the id is the attestation `scope` bound into every
+    /// claim/complete signature ([`TaskItem::admit`]), so if two replicas
+    /// derived different ids their scope-bound attestations would fail to
+    /// verify across the wire and claims would never converge.
+    #[must_use]
+    pub fn from_topic(topic: &str) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"x0x.tasklist.id.v1");
+        hasher.update(topic.as_bytes());
+        Self(*hasher.finalize().as_bytes())
+    }
 }
 
 impl std::fmt::Display for TaskListId {
@@ -1194,6 +1211,25 @@ mod tests {
 
         let id3 = TaskListId::from_content("Different", &agent, 1000);
         assert_ne!(id1, id3); // Different content
+    }
+
+    #[test]
+    fn from_topic_is_deterministic_and_agent_independent() {
+        // Regression guard: every replica that creates or joins a list via the
+        // same topic MUST derive the SAME id, regardless of which agent does it
+        // — the id is the attestation scope bound into claim/complete
+        // signatures, so a per-node id makes cross-replica claims fail to
+        // verify and claims never converge. `from_topic` takes no agent/name,
+        // so two different agents joining the same topic agree by construction.
+        let t = "team-sprint";
+        assert_eq!(TaskListId::from_topic(t), TaskListId::from_topic(t));
+        assert_ne!(TaskListId::from_topic(t), TaskListId::from_topic("other"));
+        // Distinct from the (per-node) content derivation it replaced, so a
+        // stale from_content-based replica cannot silently share scope.
+        assert_ne!(
+            TaskListId::from_topic(t),
+            TaskListId::from_content(t, &agent(1), 0)
+        );
     }
 
     #[test]

--- a/src/crdt/task_list.rs
+++ b/src/crdt/task_list.rs
@@ -19,7 +19,7 @@ use crate::identity::AgentId;
 use saorsa_gossip_crdt_sync::{LwwRegister, OrSet};
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -105,6 +105,16 @@ pub struct TaskList {
     /// counters from 0; uniqueness comes from the `PeerId` component.
     #[serde(skip, default = "default_seq_counter")]
     seq_counter: Arc<AtomicU64>,
+
+    /// Optional authorized-member set for group-scoped lists.
+    ///
+    /// When set, the admission gate rejects checkbox elements whose attesting
+    /// agent is not in this set, applying group authorization at replication
+    /// admission (not just at REST). None for non-group-scoped lists — all
+    /// validly-attested operations are admitted. Not serialized; set at
+    /// runtime by the handle from the group service.
+    #[serde(skip, default)]
+    authorized_agents: Option<Arc<HashSet<AgentId>>>,
 }
 
 impl TaskList {
@@ -129,15 +139,97 @@ impl TaskList {
             name: LwwRegister::new(name),
             version: 0,
             seq_counter: Arc::new(AtomicU64::new(0)),
+            authorized_agents: None,
         }
+    }
+
+    /// Set the authorized-member set for group-scoped lists.
+    ///
+    /// When set, the admission gate ([`TaskList::admit_all`] and the merge
+    /// paths) drops checkbox elements whose attesting agent is not in this
+    /// set. This applies group authorization at replication admission, not
+    /// just at REST. Pass an empty set to deny ALL remote claims/completions
+    /// (fail-closed for a group with no active members). Call before starting
+    /// the sync listener to avoid a race window.
+    pub fn set_authorized_agents(&mut self, agents: HashSet<AgentId>) {
+        self.authorized_agents = Some(Arc::new(agents));
+    }
+
+    /// Clear the authorized-member set (revert to open admission for all
+    /// validly-attested operations).
+    pub fn clear_authorized_agents(&mut self) {
+        self.authorized_agents = None;
     }
 
     /// Get the current version counter.
     ///
-    /// Incremented on every mutation (add, remove, claim, complete, reorder, rename).
+    /// Incremented on every effective local snapshot change — local mutations
+    /// (add/remove/claim/complete/reorder/rename) AND remote merges that
+    /// change the resolved observable state. A merge that is a no-op (e.g.
+    /// re-applying an already-known delta) does NOT bump it. This makes the
+    /// counter a correct local-replica fencing token: a caller that captured
+    /// `version` before a remote claim merged in observes a mismatch and is
+    /// rejected. It is still LOCAL only (per-replica); it is not a distributed
+    /// CAS.
     #[must_use]
     pub fn current_version(&self) -> u64 {
         self.version
+    }
+
+    /// Deterministic fingerprint of the resolved observable state.
+    ///
+    /// Hashes the *resolution* of every task (current state, claim/completion
+    /// winners, title, description, assignee, priority) plus list ordering and
+    /// name, iterated in sorted task-id order. Because it is based on resolved
+    /// values (order-independent minima over the OR-Set) and sorted iteration,
+    /// it is:
+    /// - **deterministic** — identical resolved state yields an identical
+    ///   fingerprint; and
+    /// - **idempotent-stable** — re-merging an already-known delta leaves the
+    ///   resolutions unchanged, so the fingerprint (and thus `version`) does
+    ///   not change.
+    ///
+    /// Used by [`TaskList::merge`] and [`TaskList::merge_delta`] to advance
+    /// `version` exactly once per effective local snapshot change. Cost is
+    /// O(tasks); task lists are small.
+    #[must_use]
+    pub(crate) fn state_fingerprint(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        // Sorted task-id iteration ⇒ deterministic regardless of HashMap
+        // randomization.
+        let mut ids: Vec<&TaskId> = self.task_data.keys().collect();
+        ids.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        for id in &ids {
+            let task = &self.task_data[*id];
+            hasher.write(id.as_bytes());
+            task.title().hash(&mut hasher);
+            task.description().hash(&mut hasher);
+            task.priority().hash(&mut hasher);
+            task.current_state().hash(&mut hasher);
+            task.claim_record().hash(&mut hasher);
+            task.completion_record().hash(&mut hasher);
+            task.assignee().hash(&mut hasher);
+        }
+        for tid in self.ordering.get() {
+            hasher.write(tid.as_bytes());
+        }
+        hasher.write(self.name.get().as_bytes());
+        hasher.finish()
+    }
+
+    /// Advance the local revision iff the resolved observable fingerprint has
+    /// changed since `before_fingerprint`.
+    ///
+    /// Idempotent-stable: a merge that leaves the resolutions unchanged (e.g.
+    /// re-applying an already-known delta) does not bump `version`, so it
+    /// causes no spurious false conflict. This is the single entry point both
+    /// [`TaskList::merge`] and [`TaskList::merge_delta`] use to keep the
+    /// local-replica fence token honest.
+    pub(crate) fn commit_revision_if_changed(&mut self, before_fingerprint: u64) {
+        if self.state_fingerprint() != before_fingerprint {
+            self.version += 1;
+        }
     }
 
     /// Return the next monotonically-increasing sequence number.
@@ -177,7 +269,21 @@ impl TaskList {
     ///
     /// Returns an error if the OR-Set operation fails.
     pub fn add_task(&mut self, task: TaskItem, peer_id: PeerId, seq: u64) -> Result<()> {
+        self.add_task_core(task, peer_id, seq)?;
+        self.version += 1;
+        Ok(())
+    }
+
+    /// Core add-task logic (OR-Set add, task_data merge/admit, ordering
+    /// append) shared by the public [`add_task`] (local mutation, bumps
+    /// version) and the delta-merge path ([`Self::delta_upsert_task`], which
+    /// defers the version bump to [`Self::commit_revision_if_changed`]).
+    fn add_task_core(&mut self, task: TaskItem, peer_id: PeerId, seq: u64) -> Result<()> {
         let task_id = *task.id();
+        // Snapshot scope + authorized set before any mutable borrow of
+        // task_data so the admission gate can run without borrow conflicts.
+        let scope = self.id;
+        let authorized = self.authorized_agents.clone();
 
         // Add to OR-Set
         let tag = (peer_id, seq);
@@ -188,9 +294,30 @@ impl TaskList {
         // Store or merge task data
         if let Some(existing) = self.task_data.get_mut(&task_id) {
             // Task already exists - merge CRDT state instead of overwriting
-            existing.merge(&task)?;
+            existing.merge(scope, &task)?;
+            // Apply group-authorization filter on the merged result so a
+            // nonmember's claim/complete arriving via merge is rejected.
+            if let Some(members) = &authorized {
+                let dropped = existing.filter_unauthorized(members);
+                if dropped > 0 {
+                    tracing::debug!(dropped, "dropped nonmember elements during merge-add");
+                }
+            }
         } else {
-            // New task - insert
+            // New task — run the fail-closed admission gate before inserting
+            // so a first-seen forged/unattested element is purged before it
+            // can influence resolution. This closes the first-seen bypass.
+            let mut task = task;
+            let mut dropped = task.admit(scope);
+            if let Some(members) = &authorized {
+                dropped += task.filter_unauthorized(members);
+            }
+            if dropped > 0 {
+                tracing::debug!(
+                    dropped,
+                    "purged unauthenticated/nonmember checkbox elements during first-seen add_task"
+                );
+            }
             self.task_data.insert(task_id, task);
         }
 
@@ -201,7 +328,65 @@ impl TaskList {
             self.ordering.set(current_order, peer_id);
         }
 
-        self.version += 1;
+        Ok(())
+    }
+
+    // ── Delta-merge internal helpers (no version bump) ───────────────────
+    //
+    // These mirror the public mutators but do NOT advance `self.version`.
+    // `merge_delta` wraps the entire body in a fingerprint snapshot and calls
+    // `commit_revision_if_changed` exactly once at the end, so the version
+    // advances iff the resolved observable state actually changed. If these
+    // helpers bumped version internally, an idempotent redelivery would
+    // advance the fence despite no effective state change.
+
+    /// Upsert a task during delta merge without bumping version.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn delta_upsert_task(
+        &mut self,
+        task: TaskItem,
+        peer_id: PeerId,
+        seq: u64,
+    ) -> Result<()> {
+        self.add_task_core(task, peer_id, seq)
+    }
+
+    /// Remove a task during delta merge without bumping version. No-op if the
+    /// task does not exist locally.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn delta_remove_task(&mut self, task_id: &TaskId) {
+        if self.task_data.contains_key(task_id) {
+            let _ = self.tasks.remove(task_id);
+            self.task_data.remove(task_id);
+        }
+    }
+
+    /// Merge a remote ordering register during delta merge without bumping
+    /// version.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn delta_merge_ordering(&mut self, other: &LwwRegister<Vec<TaskId>>) {
+        self.ordering.merge(other);
+    }
+
+    /// Merge a remote name register during delta merge without bumping version.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn delta_merge_name(&mut self, other: &LwwRegister<String>) {
+        self.name.merge(other);
+    }
+
+    /// Merge a remote task into an existing local task during delta merge,
+    /// then apply the authentication and membership admission gates. Does NOT
+    /// bump version (deferred to `commit_revision_if_changed`).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn delta_merge_task(&mut self, task_id: &TaskId, other: &TaskItem) -> Result<()> {
+        let scope = self.id;
+        let authorized = self.authorized_agents.clone();
+        if let Some(existing) = self.task_data.get_mut(task_id) {
+            existing.merge(scope, other)?;
+            if let Some(members) = &authorized {
+                let _dropped = existing.filter_unauthorized(members);
+            }
+        }
         Ok(())
     }
 
@@ -262,13 +447,14 @@ impl TaskList {
         agent_id: AgentId,
         peer_id: PeerId,
         seq: u64,
+        signing: &crate::gossip::SigningContext,
     ) -> Result<()> {
         let task = self
             .task_data
             .get_mut(task_id)
             .ok_or(CrdtError::TaskNotFound(*task_id))?;
 
-        task.claim(agent_id, peer_id, seq)?;
+        task.claim(self.id, agent_id, peer_id, seq, signing)?;
         self.version += 1;
         Ok(())
     }
@@ -297,13 +483,14 @@ impl TaskList {
         agent_id: AgentId,
         peer_id: PeerId,
         seq: u64,
+        signing: &crate::gossip::SigningContext,
     ) -> Result<()> {
         let task = self
             .task_data
             .get_mut(task_id)
             .ok_or(CrdtError::TaskNotFound(*task_id))?;
 
-        task.complete(agent_id, peer_id, seq)?;
+        task.complete(self.id, agent_id, peer_id, seq, signing)?;
         self.version += 1;
         Ok(())
     }
@@ -399,6 +586,15 @@ impl TaskList {
             )));
         }
 
+        // Capture the resolved observable fingerprint BEFORE merging so the
+        // local version advances exactly once iff this merge effectively
+        // changes the local snapshot. Without this, a remote claim that
+        // merges in would not advance `version` and a caller's stale token
+        // would still be accepted — defeating the local-replica fence.
+        let before = self.state_fingerprint();
+        let scope = self.id;
+        let authorized = self.authorized_agents.clone();
+
         // Merge OR-Set (task membership)
         self.tasks
             .merge_state(&other.tasks)
@@ -409,10 +605,26 @@ impl TaskList {
         for (task_id, other_task) in &other.task_data {
             if let Some(our_task) = self.task_data.get_mut(task_id) {
                 // Merge existing task
-                our_task.merge(other_task)?;
+                our_task.merge(scope, other_task)?;
+                if let Some(members) = &authorized {
+                    let _dropped = our_task.filter_unauthorized(members);
+                }
             } else {
-                // Add new task
-                self.task_data.insert(*task_id, other_task.clone());
+                // Add new task — run the admission gate so a first-seen
+                // forged/unattested element is purged before it can influence
+                // resolution.
+                let mut new_task = other_task.clone();
+                let mut dropped = new_task.admit(scope);
+                if let Some(members) = &authorized {
+                    dropped += new_task.filter_unauthorized(members);
+                }
+                if dropped > 0 {
+                    tracing::debug!(
+                        dropped,
+                        "purged unauthenticated/nonmember checkbox elements during first-seen merge"
+                    );
+                }
+                self.task_data.insert(*task_id, new_task);
             }
         }
 
@@ -420,6 +632,11 @@ impl TaskList {
         self.ordering.merge(&other.ordering);
         self.name.merge(&other.name);
 
+        // Advance the local revision exactly once iff the resolved snapshot
+        // changed. Idempotent re-merges leave the fingerprint unchanged ⇒ no
+        // bump (fixes spurious false conflicts from repeated full-state
+        // merges).
+        self.commit_revision_if_changed(before);
         Ok(())
     }
 
@@ -468,6 +685,25 @@ impl TaskList {
         self.version += 1;
     }
 
+    /// Run the fail-closed admission gate on every task in this list.
+    ///
+    /// Drops unauthenticated checkbox elements (missing/malformed/wrong-agent/
+    /// attacker signatures) and restores attested elements censored by forged
+    /// tombstones. Called after deserializing from persistent storage so a
+    /// corrupted/tampered on-disk state cannot bypass the admission gate.
+    pub fn admit_all(&mut self) -> usize {
+        let scope = self.id;
+        let authorized = self.authorized_agents.clone();
+        let mut total_dropped = 0usize;
+        for task in self.task_data.values_mut() {
+            total_dropped += task.admit(scope);
+            if let Some(members) = &authorized {
+                total_dropped += task.filter_unauthorized(members);
+            }
+        }
+        total_dropped
+    }
+
     /// Get the number of tasks in the list.
     #[must_use]
     pub fn task_count(&self) -> usize {
@@ -497,6 +733,18 @@ mod tests {
 
     fn peer(n: u8) -> PeerId {
         PeerId::new([n; 32])
+    }
+
+    /// Real (key-derived) agent identity + matching signing context for a
+    /// claim/complete caller. `sign_attestation` self-signs
+    /// (`agent_id == signing.agent_id`), so callers cannot use the fixed
+    /// `AgentId([n;32])`; the agent id MUST be the keypair's derived id.
+    fn signing_for(_n: u8) -> (AgentId, crate::gossip::SigningContext) {
+        let kp = crate::identity::AgentKeypair::generate().expect("agent keygen");
+        (
+            kp.agent_id(),
+            crate::gossip::SigningContext::from_keypair(&kp),
+        )
     }
 
     fn list_id(n: u8) -> TaskListId {
@@ -581,7 +829,7 @@ mod tests {
     #[test]
     fn test_claim_task() {
         let peer = peer(1);
-        let agent = agent(1);
+        let (agent, signing) = signing_for(1);
         let id = list_id(1);
         let mut list = TaskList::new(id, "My List".to_string(), peer);
 
@@ -590,7 +838,7 @@ mod tests {
 
         list.add_task(task, peer, 1).ok().unwrap();
 
-        let result = list.claim_task(&task_id, agent, peer, 2);
+        let result = list.claim_task(&task_id, agent, peer, 2, &signing);
         assert!(result.is_ok());
 
         let task = list.get_task(&task_id).unwrap();
@@ -600,7 +848,7 @@ mod tests {
     #[test]
     fn test_complete_task() {
         let peer = peer(1);
-        let agent = agent(1);
+        let (agent, signing) = signing_for(1);
         let id = list_id(1);
         let mut list = TaskList::new(id, "My List".to_string(), peer);
 
@@ -608,9 +856,11 @@ mod tests {
         let task_id = *task.id();
 
         list.add_task(task, peer, 1).ok().unwrap();
-        list.claim_task(&task_id, agent, peer, 2).ok().unwrap();
+        list.claim_task(&task_id, agent, peer, 2, &signing)
+            .ok()
+            .unwrap();
 
-        let result = list.complete_task(&task_id, agent, peer, 3);
+        let result = list.complete_task(&task_id, agent, peer, 3, &signing);
         assert!(result.is_ok());
 
         let task = list.get_task(&task_id).unwrap();
@@ -707,7 +957,7 @@ mod tests {
     fn test_merge_with_concurrent_task_modifications() {
         let peer1 = peer(1);
         let peer2 = peer(2);
-        let agent1 = agent(1);
+        let (agent1, signing1) = signing_for(1);
         let _agent2 = agent(2);
         let id = list_id(1);
 
@@ -723,7 +973,10 @@ mod tests {
         list2.add_task(task2, peer2, 1).ok().unwrap();
 
         // list1 claims the task
-        list1.claim_task(&task_id, agent1, peer1, 2).ok().unwrap();
+        list1
+            .claim_task(&task_id, agent1, peer1, 2, &signing1)
+            .ok()
+            .unwrap();
 
         // list2 updates the title
         list2
@@ -740,6 +993,140 @@ mod tests {
         // Title update depends on vector clock ordering
     }
 
+    // ── Local-fence version invariants (review §3 P0/P1) ────────────────
+
+    #[test]
+    fn test_remote_claim_merge_advances_version_invalidating_stale_token() {
+        // P0: a remote claim merged in must advance the local version so a
+        // caller that captured an earlier version (its local-replica fence
+        // token) is rejected. Without this the fence is defeated.
+        let peer1 = peer(1);
+        let peer2 = peer(2);
+        let id = list_id(1);
+
+        let mut list_a = TaskList::new(id, "List".to_string(), peer1);
+        let mut list_b = TaskList::new(id, "List".to_string(), peer2);
+
+        // Both add the same task.
+        let task_a = make_task(1, peer1);
+        let task_b = make_task(1, peer2);
+        let task_id = *task_a.id();
+        list_a.add_task(task_a, peer1, 1).unwrap();
+        list_b.add_task(task_b, peer2, 1).unwrap();
+
+        // B reads its snapshot + version (its local fence token).
+        let token_b = list_b.current_version();
+        assert_eq!(token_b, 1, "version after one local add");
+        assert!(!list_b
+            .get_task(&task_id)
+            .unwrap()
+            .current_state()
+            .is_claimed());
+
+        // A claims the task (advances A's version, not B's).
+        let (agent, signing) = signing_for(1);
+        list_a
+            .claim_task(&task_id, agent, peer1, 2, &signing)
+            .unwrap();
+
+        // B merges A's state. B's resolved snapshot now shows A's claim, and
+        // B's version MUST have advanced past `token_b`.
+        list_b.merge(&list_a).unwrap();
+        assert!(
+            list_b
+                .get_task(&task_id)
+                .unwrap()
+                .current_state()
+                .is_claimed(),
+            "B observed A's claim after merge"
+        );
+        assert!(
+            list_b.current_version() > token_b,
+            "remote claim merge must advance the local version (fence invalidated): {} > {}",
+            list_b.current_version(),
+            token_b
+        );
+    }
+
+    #[test]
+    fn test_merge_delta_remote_claim_advances_version() {
+        // P0 via the delta path (the actual inbound gossip route): a state-
+        // change delta merged through `merge_delta` must also advance version.
+        let peer1 = peer(1);
+        let peer2 = peer(2);
+        let id = list_id(1);
+        let mut list_a = TaskList::new(id, "List".to_string(), peer1);
+        let mut list_b = TaskList::new(id, "List".to_string(), peer2);
+        let task_a = make_task(1, peer1);
+        let task_b = make_task(1, peer2);
+        let task_id = *task_a.id();
+        list_a.add_task(task_a, peer1, 1).unwrap();
+        list_b.add_task(task_b, peer2, 1).unwrap();
+
+        let token_b = list_b.current_version();
+
+        // A claims and produces a state-change delta.
+        let (agent, signing) = signing_for(1);
+        list_a
+            .claim_task(&task_id, agent, peer1, 2, &signing)
+            .unwrap();
+        let claimed_task = list_a.get_task(&task_id).unwrap().clone();
+        let delta = crate::crdt::TaskListDelta::for_state_change(
+            task_id,
+            claimed_task,
+            list_a.current_version(),
+        );
+
+        // B applies the delta over the gossip path.
+        list_b.merge_delta(&delta, peer1).unwrap();
+        assert!(
+            list_b
+                .get_task(&task_id)
+                .unwrap()
+                .current_state()
+                .is_claimed(),
+            "delta merge applied the claim"
+        );
+        assert!(
+            list_b.current_version() > token_b,
+            "remote state-change delta must advance local version"
+        );
+    }
+
+    #[test]
+    fn test_idempotent_merge_does_not_bump_version() {
+        // P1: re-merging an already-known delta leaves the resolved snapshot
+        // (and thus the version) unchanged — no spurious false conflicts.
+        let peer1 = peer(1);
+        let peer2 = peer(2);
+        let id = list_id(1);
+        let mut list_a = TaskList::new(id, "List".to_string(), peer1);
+        let mut list_b = TaskList::new(id, "List".to_string(), peer2);
+        let task_a = make_task(1, peer1);
+        let task_b = make_task(1, peer2);
+        let task_id = *task_a.id();
+        list_a.add_task(task_a, peer1, 1).unwrap();
+        list_b.add_task(task_b, peer2, 1).unwrap();
+
+        // B claims → its snapshot changes.
+        let (agent, signing) = signing_for(1);
+        list_b
+            .claim_task(&task_id, agent, peer2, 2, &signing)
+            .unwrap();
+
+        // First merge brings B's claim into A ⇒ A's version advances once.
+        list_a.merge(&list_b).unwrap();
+        let v1 = list_a.current_version();
+        assert!(v1 > 1, "effective merge (claim) must bump version: {v1}");
+
+        // Second identical merge: A already resolved B's claim ⇒ no change.
+        list_a.merge(&list_b).unwrap();
+        assert_eq!(
+            list_a.current_version(),
+            v1,
+            "idempotent re-merge must not bump the version"
+        );
+    }
     #[test]
     fn test_merge_different_list_ids_fails() {
         let peer = peer(1);

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,15 @@ pub enum IdentityError {
     /// (issuer-revocation). Third-party revocation is never accepted.
     #[error("revocation rejected: {0}")]
     Revocation(String),
+
+    /// A local write was rejected by a replicated store's access policy.
+    ///
+    /// Raised when this agent attempts to mutate a `Signed`/`Allowlisted`
+    /// KV store it is not authorized to write to, or a joined replica whose
+    /// authoritative owner is not yet known (fail closed). The API layer
+    /// maps this to HTTP 403.
+    #[error("not authorized: {0}")]
+    Unauthorized(String),
 }
 
 /// Standard Result type for x0x identity operations.

--- a/src/kv/delta.rs
+++ b/src/kv/delta.rs
@@ -13,6 +13,21 @@ use std::collections::{HashMap, HashSet};
 /// Unique tag for OR-Set elements: (PeerId, sequence_number).
 pub type UniqueTag = (PeerId, u64);
 
+/// Deserialize an optional owner checkpoint, tolerating its absence (trailing
+/// field). A legacy peer's delta omits this field entirely; decoding it on a
+/// current node yields `None` instead of an EOF error, preserving cross-version
+/// delta compatibility. A malformed value is also treated as `None` (the delta
+/// then falls back to sender-auth).
+pub(crate) fn deserialize_checkpoint_opt<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<crate::kv::store::OwnerCheckpoint>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    Ok(Option::<crate::kv::store::OwnerCheckpoint>::deserialize(deserializer).unwrap_or(None))
+}
+
 /// Delta representing changes to a KvStore.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KvStoreDelta {
@@ -38,6 +53,15 @@ pub struct KvStoreDelta {
 
     /// Version number of this delta.
     pub version: u64,
+
+    /// Owner-signed checkpoint carried by owner-published deltas and relays.
+    /// Replicas cache it; an anchored receiver verifies the owner signature +
+    /// recomputed content root and adopts the proven entries independent of
+    /// the relayer. `None` uses the existing sender-auth path. The field is
+    /// trailing and deserializes to `None` if absent (so a legacy pre-checkpoint
+    /// peer's 7-field delta still decodes on a current node).
+    #[serde(default, deserialize_with = "deserialize_checkpoint_opt")]
+    pub owner_checkpoint: Option<crate::kv::store::OwnerCheckpoint>,
 }
 
 impl KvStoreDelta {
@@ -52,6 +76,7 @@ impl KvStoreDelta {
             allowlist_additions: None,
             allowlist_removals: None,
             version,
+            owner_checkpoint: None,
         }
     }
 
@@ -72,7 +97,6 @@ impl KvStoreDelta {
     }
 
     /// Check if this delta is empty.
-    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.added.is_empty()
             && self.removed.is_empty()
@@ -80,6 +104,7 @@ impl KvStoreDelta {
             && self.name_update.is_none()
             && self.allowlist_additions.is_none()
             && self.allowlist_removals.is_none()
+            && self.owner_checkpoint.is_none()
     }
 }
 
@@ -245,5 +270,37 @@ mod tests {
         assert_eq!(delta.version, restored.version);
         assert!(restored.allowlist_additions.is_some());
         assert_eq!(restored.allowlist_additions.as_ref().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn test_legacy_delta_without_checkpoint_decodes() {
+        // A pre-checkpoint (legacy / v0.30.1) delta omits the owner_checkpoint
+        // field entirely. It must still decode on a current node, with the
+        // checkpoint defaulting to None — otherwise cross-version Signed-store
+        // convergence (legacy owner -> current joiner) would break.
+        #[derive(Serialize)]
+        struct LegacyDelta {
+            added: HashMap<String, (KvEntry, UniqueTag)>,
+            removed: HashMap<String, HashSet<UniqueTag>>,
+            updated: HashMap<String, KvEntry>,
+            name_update: Option<LwwRegister<String>>,
+            allowlist_additions: Option<Vec<AgentId>>,
+            allowlist_removals: Option<Vec<AgentId>>,
+            version: u64,
+        }
+        let legacy = LegacyDelta {
+            added: HashMap::new(),
+            removed: HashMap::new(),
+            updated: HashMap::new(),
+            name_update: None,
+            allowlist_additions: None,
+            allowlist_removals: None,
+            version: 7,
+        };
+        let bytes = bincode::serialize(&legacy).expect("serialize legacy");
+        let restored: KvStoreDelta =
+            bincode::deserialize(&bytes).expect("legacy delta must decode");
+        assert_eq!(restored.version, 7);
+        assert!(restored.owner_checkpoint.is_none());
     }
 }

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -1,5 +1,7 @@
 //! Error types for KvStore operations.
 
+use crate::identity::AgentId;
+
 /// Result type for KvStore operations.
 pub type Result<T> = std::result::Result<T, KvError>;
 
@@ -43,13 +45,40 @@ pub enum KvError {
     #[error("unauthorized: {0}")]
     Unauthorized(String),
 
-    /// The store's authoritative owner is not yet known.
+    /// The store has no anchored owner.
     ///
-    /// A joined replica starts with no owner and learns it from an
-    /// owner-signed announcement on the state-sync channel. Until then,
-    /// policy-restricted writes are rejected (fail closed).
-    #[error("store owner unknown: store is read-only until the authoritative owner is learned")]
+    /// Ownership is established ONLY at construction from trusted out-of-band
+    /// input (the creator, or an explicit `expected_owner` at join). A replica
+    /// that joined without an anchor has no owner and is permanently read-only
+    /// by design — the protocol never derives ownership from an untrusted
+    /// network announce, so there is no silent path from `None` to `Some`.
+    /// Policy-restricted writes (and the local-write counterpart) fail closed.
+    #[error("store owner unknown: no anchored owner — store is read-only; supply expected_owner at join")]
     OwnerUnknown,
+
+    /// The established owner disagrees with a received ownership announcement.
+    ///
+    /// Ownership is immutable once anchored. An announce whose claimed owner
+    /// differs from the anchored owner is a conflict (possible takeover
+    /// attempt or genuine misconfiguration): it is rejected, the anchored
+    /// owner is unchanged, and the conflict is surfaced for auditability.
+    #[error("ownership conflict: anchored owner {anchored} != announced owner {claimed}")]
+    OwnershipConflict {
+        /// The anchored (construction-time) owner.
+        anchored: AgentId,
+        /// The conflicting owner claimed by the announce.
+        claimed: AgentId,
+    },
+
+    /// An ownership announcement is not a valid basis for establishing or
+    /// refreshing ownership.
+    ///
+    /// Covers: a sender that does not match the claimed owner (third-party
+    /// assignment), an attempt to establish ownership on a store that has none
+    /// (first-self-capture guard — ownership is construction-only), and a
+    /// stale/replayed policy refresh. The store state is unchanged.
+    #[error("invalid ownership token: {0}")]
+    OwnerTokenInvalid(String),
 }
 
 #[cfg(test)]

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -42,6 +42,14 @@ pub enum KvError {
     /// Unauthorized write attempt.
     #[error("unauthorized: {0}")]
     Unauthorized(String),
+
+    /// The store's authoritative owner is not yet known.
+    ///
+    /// A joined replica starts with no owner and learns it from an
+    /// owner-signed announcement on the state-sync channel. Until then,
+    /// policy-restricted writes are rejected (fail closed).
+    #[error("store owner unknown: store is read-only until the authoritative owner is learned")]
+    OwnerUnknown,
 }
 
 #[cfg(test)]

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -31,5 +31,7 @@ pub mod sync;
 pub use delta::KvStoreDelta;
 pub use entry::KvEntry;
 pub use error::{KvError, Result};
-pub use store::{AccessPolicy, KvStore, KvStoreId};
+pub use store::{
+    AccessPolicy, AnchorChannel, KvStore, KvStoreId, OwnershipSource, OwnershipStatus,
+};
 pub use sync::KvStoreSync;

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -429,39 +429,6 @@ pub struct KvStore {
     #[serde(default)]
     owner: Option<AgentId>,
 
-    /// How the owner was anchored (audit metadata); meaningful only when
-    /// `owner` is `Some`.
-    #[serde(default)]
-    anchor_channel: AnchorChannel,
-
-    /// Monotonic freshness counter for owner-announced policy refreshes.
-    ///
-    /// A policy refresh from [`learn_ownership`](Self::learn_ownership) is
-    /// applied only when the announce carries a strictly greater
-    /// `policy_version`, which blocks a replayed authentic-but-stale announce
-    /// from downgrading policy. This is owner-local metadata; it is NOT a
-    /// CRDT-merged value.
-    #[serde(default)]
-    policy_version: u64,
-
-    /// The last announce whose claimed owner conflicted with the anchored
-    /// owner (audit only). Cleared when the anchored owner itself refreshes
-    /// via a matching forward-version announce. `None` when no conflict has
-    /// been observed (or it has been cleared).
-    #[serde(default)]
-    ownership_conflict: Option<(AgentId, AgentId)>,
-
-    /// Latest owner-signed checkpoint this replica has merged or produced.
-    /// Persisted (serde default) so owner restarts never regress the
-    /// checkpoint sequence; old data without this field deserializes to
-    /// `None` (safe forward default).
-    #[serde(default)]
-    pub(crate) latest_checkpoint: Option<OwnerCheckpoint>,
-    /// Highest `checkpoint_seq` adopted (replay/downgrade high-water mark).
-    /// Persisted so owner restarts never regress the checkpoint sequence.
-    #[serde(default)]
-    pub(crate) highest_checkpoint_seq: u64,
-
     /// Agents allowed to write (for Allowlisted policy).
     /// The owner is implicitly allowed and does not need to be in this set.
     #[serde(default)]
@@ -471,9 +438,75 @@ pub struct KvStore {
     #[serde(default)]
     version: u64,
 
+    // ---------------------------------------------------------------------
+    // TRAILING FIELDS — added after the original `KvStore` shape.
+    //
+    // bincode (wire + disk format) is positional and non-self-describing.
+    // Plain `#[serde(default)]` does NOT tolerate a missing field there:
+    // bincode returns an EOF *error* (not `Ok(None)`) at stream end, so serde
+    // never applies the default. Every field below is therefore (a) declared
+    // LAST, after the original `id..version` shape, and (b) decoded with
+    // `de_tolerant`, a custom deserializer that catches EOF/short streams and
+    // yields the field's `Default`. This lets a blob written by the original
+    // (pre-ownership, pre-checkpoint) `KvStore` shape — whose bytes END at
+    // `version` — deserialize with these fields defaulted instead of failing.
+    //
+    // INVARIANT: any NEW persisted field MUST be appended at the end of this
+    // block with the same `de_tolerant` treatment. Never insert a persisted
+    // field mid-struct, or older blobs will misalign and fail to decode.
+    // ---------------------------------------------------------------------
+    /// Latest owner-signed checkpoint this replica has merged or produced.
+    /// Persisted so owner restarts never regress the checkpoint sequence; a
+    /// blob written before this field existed decodes to `None`.
+    #[serde(default, deserialize_with = "de_tolerant")]
+    pub(crate) latest_checkpoint: Option<OwnerCheckpoint>,
+
+    /// Highest `checkpoint_seq` adopted (replay/downgrade high-water mark).
+    /// Persisted so owner restarts never regress the checkpoint sequence.
+    #[serde(default, deserialize_with = "de_tolerant")]
+    pub(crate) highest_checkpoint_seq: u64,
+
+    /// How the owner was anchored (audit metadata); meaningful only when
+    /// `owner` is `Some`.
+    #[serde(default, deserialize_with = "de_tolerant")]
+    anchor_channel: AnchorChannel,
+
+    /// Monotonic freshness counter for owner-announced policy refreshes.
+    ///
+    /// A policy refresh from [`learn_ownership`](Self::learn_ownership) is
+    /// applied only when the announce carries a strictly greater
+    /// `policy_version`, which blocks a replayed authentic-but-stale announce
+    /// from downgrading policy. This is owner-local metadata; it is NOT a
+    /// CRDT-merged value.
+    #[serde(default, deserialize_with = "de_tolerant")]
+    policy_version: u64,
+
+    /// The last announce whose claimed owner conflicted with the anchored
+    /// owner (audit only). Cleared when the anchored owner itself refreshes
+    /// via a matching forward-version announce. `None` when no conflict has
+    /// been observed (or it has been cleared).
+    #[serde(default, deserialize_with = "de_tolerant")]
+    ownership_conflict: Option<(AgentId, AgentId)>,
+
     /// Monotonic sequence counter for unique OR-Set tags.
     #[serde(skip, default = "default_seq_counter")]
     seq_counter: Arc<AtomicU64>,
+}
+
+/// Deserialize a trailing, defaultable `KvStore` field, tolerating its absence.
+///
+/// bincode is positional and non-self-describing: a blob written by an older
+/// `KvStore` shape simply ends before these trailing fields, so bincode hits
+/// EOF when asked to read them. Decoding the value if present, or falling back
+/// to `T::default()` on EOF / any malformed tail, makes such a blob load with
+/// the newer fields defaulted rather than failing outright. Only sound at
+/// stream-EOF for genuinely trailing fields (see the struct's TRAILING note).
+fn de_tolerant<'de, D, T>(deserializer: D) -> std::result::Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de> + Default,
+{
+    Ok(T::deserialize(deserializer).unwrap_or_default())
 }
 
 fn default_policy() -> AccessPolicy {
@@ -1505,6 +1538,81 @@ mod tests {
         assert_eq!(store.id(), restored.id());
         assert_eq!(store.name(), restored.name());
         assert_eq!(store.len(), restored.len());
+    }
+
+    #[test]
+    fn pre_wave_kvstore_blob_decodes_with_trailing_fields_defaulted() {
+        // Regression guard for the mid-struct bincode footgun. The ownership
+        // (anchor_channel, policy_version, ownership_conflict) and checkpoint
+        // (latest_checkpoint, highest_checkpoint_seq) fields were added by the
+        // security wave. bincode is positional, so those fields MUST be trailing
+        // AND decoded with `de_tolerant`; otherwise a blob written by the
+        // original `KvStore` shape (id..version) fails with UnexpectedEof.
+        //
+        // This mirror is the EXACT original serialized shape at commit b573441:
+        // id, keys, entries, name, policy, owner, allowed_writers, version.
+        #[derive(Serialize)]
+        struct PreWaveKvStore<'a> {
+            id: &'a KvStoreId,
+            keys: &'a OrSet<String>,
+            entries: &'a HashMap<String, KvEntry>,
+            name: &'a LwwRegister<String>,
+            policy: &'a AccessPolicy,
+            owner: &'a Option<AgentId>,
+            allowed_writers: &'a HashSet<AgentId>,
+            version: u64,
+        }
+
+        let owner = agent(1);
+        let mut store = KvStore::new(
+            store_id(1),
+            "Legacy".to_string(),
+            owner,
+            AccessPolicy::Signed,
+        );
+        store
+            .put(
+                "k".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+
+        let legacy = PreWaveKvStore {
+            id: &store.id,
+            keys: &store.keys,
+            entries: &store.entries,
+            name: &store.name,
+            policy: &store.policy,
+            owner: &store.owner,
+            allowed_writers: &store.allowed_writers,
+            version: store.version,
+        };
+        let bytes = bincode::serialize(&legacy).expect("serialize pre-wave shape");
+        let restored: KvStore =
+            bincode::deserialize(&bytes).expect("pre-wave blob (id..version) must decode");
+
+        // Original content survives.
+        assert_eq!(restored.id(), store.id(), "id preserved");
+        assert_eq!(restored.len(), 1, "entries preserved");
+        assert_eq!(restored.owner, store.owner, "owner preserved");
+        // All five wave-added trailing fields default cleanly.
+        assert!(
+            restored.latest_checkpoint.is_none(),
+            "latest_checkpoint defaults"
+        );
+        assert_eq!(restored.highest_checkpoint_seq, 0, "high-water defaults");
+        assert_eq!(
+            restored.anchor_channel,
+            AnchorChannel::default(),
+            "anchor_channel defaults"
+        );
+        assert_eq!(restored.policy_version, 0, "policy_version defaults");
+        assert!(
+            restored.ownership_conflict.is_none(),
+            "ownership_conflict defaults"
+        );
     }
 
     #[test]

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -158,6 +158,28 @@ impl KvStore {
         }
     }
 
+    /// Create a joined replica of a store whose authoritative owner is not
+    /// yet known.
+    ///
+    /// The replica starts with the default `Signed` policy and `owner: None`,
+    /// which fails closed: no local or inbound policy-restricted write is
+    /// accepted until [`learn_ownership`](Self::learn_ownership) installs the
+    /// authoritative owner and policy from an owner-signed announcement.
+    #[must_use]
+    pub fn new_replica(id: KvStoreId, name: String) -> Self {
+        Self {
+            id,
+            keys: OrSet::new(),
+            entries: HashMap::new(),
+            name: LwwRegister::new(name),
+            policy: AccessPolicy::Signed,
+            owner: None,
+            allowed_writers: HashSet::new(),
+            version: 0,
+            seq_counter: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
     /// Get the next monotonically-increasing sequence number.
     pub fn next_seq(&self) -> u64 {
         self.seq_counter.fetch_add(1, Ordering::Relaxed) + 1
@@ -240,6 +262,84 @@ impl KvStore {
                 // the secure sync path once wired.
                 true
             }
+        }
+    }
+
+    /// Check that `writer` may perform a local mutation on this store.
+    ///
+    /// This is the local-write counterpart of the inbound check in
+    /// [`merge_delta`](Self::merge_delta): the same
+    /// [`is_authorized`](Self::is_authorized) rule is applied before a local
+    /// put/remove mutates the replica, so an unauthorized local write can
+    /// never fork
+    /// the replica away from what authorized peers accept.
+    ///
+    /// # Errors
+    ///
+    /// - [`KvError::OwnerUnknown`] if the store has a policy-restricted
+    ///   (`Signed`/`Allowlisted`) policy but its authoritative owner has not
+    ///   been learned yet (a freshly joined replica). Fail closed.
+    /// - [`KvError::Unauthorized`] if `writer` is not authorized under the
+    ///   store's policy.
+    pub fn authorize_local_write(&self, writer: &AgentId) -> Result<()> {
+        if matches!(self.policy, AccessPolicy::Encrypted { .. }) {
+            // Matches the inbound path: the reserved Encrypted policy is
+            // currently permissive at the store layer.
+            return Ok(());
+        }
+        let Some(owner) = self.owner.as_ref() else {
+            return Err(KvError::OwnerUnknown);
+        };
+        if !self.is_authorized(writer) {
+            return Err(KvError::Unauthorized(format!(
+                "store policy is {}; owner is {}",
+                self.policy,
+                hex::encode(owner.as_bytes())
+            )));
+        }
+        Ok(())
+    }
+
+    /// Install the authoritative owner and policy learned from an
+    /// owner-signed announcement.
+    ///
+    /// `verified_sender` is the cryptographically verified identity of the
+    /// peer that published the announcement (the pub/sub layer verifies the
+    /// ML-DSA-65 signature before delivery). Ownership claims are only
+    /// accepted when the sender claims *itself* as owner, so no third party
+    /// can assign ownership. Once an owner is established it is immutable;
+    /// the established owner may still refresh the policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns `KvError::Unauthorized` if `verified_sender` differs from the
+    /// claimed `owner`, or if a different owner is already established.
+    pub fn learn_ownership(
+        &mut self,
+        owner: AgentId,
+        policy: AccessPolicy,
+        verified_sender: &AgentId,
+    ) -> Result<()> {
+        if *verified_sender != owner {
+            return Err(KvError::Unauthorized(
+                "ownership announcement sender does not match claimed owner".to_string(),
+            ));
+        }
+        match self.owner {
+            None => {
+                self.owner = Some(owner);
+                self.policy = policy;
+                self.version += 1;
+                Ok(())
+            }
+            Some(existing) if existing == owner => {
+                self.policy = policy;
+                self.version += 1;
+                Ok(())
+            }
+            Some(_) => Err(KvError::Unauthorized(
+                "store owner already established; conflicting ownership claim rejected".to_string(),
+            )),
         }
     }
 
@@ -379,7 +479,7 @@ impl KvStore {
         // Access control: reject unauthorized writes
         if let Some(writer_id) = writer {
             if !self.is_authorized(writer_id) {
-                tracing::debug!(
+                tracing::warn!(
                     "rejected delta from unauthorized writer {} for store {}",
                     hex::encode(writer_id.as_bytes()),
                     self.id
@@ -393,7 +493,7 @@ impl KvStore {
             match &self.policy {
                 AccessPolicy::Encrypted { .. } => {} // OK
                 _ => {
-                    tracing::debug!(
+                    tracing::warn!(
                         "rejected anonymous delta for non-encrypted store {}",
                         self.id
                     );
@@ -916,6 +1016,149 @@ mod tests {
             .merge_delta(&delta, peer(99), None)
             .expect("silent rejection");
         assert!(store.get("anon").is_none());
+    }
+
+    // -- Local write authorization (fail closed) --
+    //
+    // WHY: a non-owner joiner that mutates its local replica creates a fork
+    // the owner's replica rejects — the local path must enforce the same
+    // policy as the inbound path.
+
+    #[test]
+    fn test_local_write_owner_authorized_on_signed_store() {
+        let owner = agent(1);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        store
+            .authorize_local_write(&owner)
+            .expect("owner must be able to write locally");
+    }
+
+    #[test]
+    fn test_local_write_non_owner_rejected_on_signed_store() {
+        let owner = agent(1);
+        let joiner = agent(2);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let err = store
+            .authorize_local_write(&joiner)
+            .expect_err("non-owner local write must be rejected, not silently applied");
+        assert!(matches!(err, KvError::Unauthorized(_)));
+        assert!(
+            format!("{err}").contains(&hex::encode(owner.as_bytes())),
+            "rejection must name the true owner so the caller can tell why"
+        );
+    }
+
+    #[test]
+    fn test_local_write_rejected_while_owner_unknown() {
+        // A joined replica must be read-only until the authoritative owner
+        // is learned — otherwise the joiner writes into a fork.
+        let joiner = agent(2);
+        let store = KvStore::new_replica(store_id(1), String::new());
+        assert!(
+            store.owner().is_none(),
+            "joined replica must not claim an owner"
+        );
+        let err = store
+            .authorize_local_write(&joiner)
+            .expect_err("write on unknown-owner store must fail closed");
+        assert!(matches!(err, KvError::OwnerUnknown));
+    }
+
+    #[test]
+    fn test_replica_rejects_inbound_deltas_until_owner_learned() {
+        // Fail closed on the inbound side too: without a known owner there
+        // is no authorized writer, so nothing merges.
+        let mut store = KvStore::new_replica(store_id(1), String::new());
+        let entry = KvEntry::new("k".to_string(), b"v".to_vec(), "text/plain".to_string());
+        let delta = KvStoreDelta::for_put("k".to_string(), entry, (peer(9), 1), 1);
+        store
+            .merge_delta(&delta, peer(9), Some(&agent(9)))
+            .expect("silent rejection");
+        assert!(store.get("k").is_none());
+    }
+
+    // -- learn_ownership: owner-signed metadata adoption --
+
+    #[test]
+    fn test_learn_ownership_requires_sender_to_be_claimed_owner() {
+        // A third party must not be able to assign ownership of a store —
+        // only a verified sender claiming itself is trusted.
+        let mut store = KvStore::new_replica(store_id(1), String::new());
+        let owner = agent(1);
+        let rogue = agent(9);
+        let err = store
+            .learn_ownership(owner, AccessPolicy::Signed, &rogue)
+            .expect_err("third-party ownership claim must be rejected");
+        assert!(matches!(err, KvError::Unauthorized(_)));
+        assert!(store.owner().is_none());
+    }
+
+    #[test]
+    fn test_learn_ownership_then_policy_enforced_both_paths() {
+        // After adoption: the joiner still cannot write locally, and the
+        // owner's deltas merge while a non-owner's are rejected.
+        let owner = agent(1);
+        let joiner = agent(2);
+        let mut store = KvStore::new_replica(store_id(1), String::new());
+        store
+            .learn_ownership(owner, AccessPolicy::Signed, &owner)
+            .expect("owner self-claim adopted");
+        assert_eq!(store.owner(), Some(&owner));
+        assert_eq!(*store.policy(), AccessPolicy::Signed);
+
+        // Local write by the joiner: still rejected.
+        assert!(matches!(
+            store.authorize_local_write(&joiner),
+            Err(KvError::Unauthorized(_))
+        ));
+
+        // Inbound owner delta: accepted.
+        let entry = KvEntry::new("ok".to_string(), b"v".to_vec(), "text/plain".to_string());
+        let delta = KvStoreDelta::for_put("ok".to_string(), entry, (peer(1), 1), 1);
+        store
+            .merge_delta(&delta, peer(1), Some(&owner))
+            .expect("owner delta merges");
+        assert!(store.get("ok").is_some());
+
+        // Inbound non-owner delta: rejected.
+        let entry = KvEntry::new("bad".to_string(), b"x".to_vec(), "text/plain".to_string());
+        let delta = KvStoreDelta::for_put("bad".to_string(), entry, (peer(2), 1), 2);
+        store
+            .merge_delta(&delta, peer(2), Some(&joiner))
+            .expect("silent rejection");
+        assert!(store.get("bad").is_none());
+    }
+
+    #[test]
+    fn test_learn_ownership_owner_is_immutable_once_established() {
+        // First verified claim wins; a later conflicting claim cannot hijack
+        // the replica.
+        let owner = agent(1);
+        let hijacker = agent(9);
+        let mut store = KvStore::new_replica(store_id(1), String::new());
+        store
+            .learn_ownership(owner, AccessPolicy::Signed, &owner)
+            .expect("adopt owner");
+        let err = store
+            .learn_ownership(hijacker, AccessPolicy::Signed, &hijacker)
+            .expect_err("conflicting ownership claim must be rejected");
+        assert!(matches!(err, KvError::Unauthorized(_)));
+        assert_eq!(store.owner(), Some(&owner));
+    }
+
+    #[test]
+    fn test_local_write_encrypted_policy_stays_permissive() {
+        // The reserved Encrypted policy is permissive at the store layer on
+        // the inbound path; the local path must match it, not diverge.
+        let store = KvStore::new(
+            store_id(1),
+            "Test".to_string(),
+            agent(1),
+            AccessPolicy::Encrypted { group_id: vec![1] },
+        );
+        store
+            .authorize_local_write(&agent(9))
+            .expect("encrypted policy is permissive at the store layer");
     }
 
     #[test]

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -80,6 +80,26 @@ impl KvStoreId {
         hasher.update(creator.as_bytes());
         Self(*hasher.finalize().as_bytes())
     }
+
+    /// Derive a store ID that cryptographically binds a `topic` to its
+    /// authoritative `owner`.
+    ///
+    /// Used by BOTH the create and join paths so a creator and an anchored
+    /// joiner compute the *same* id — the id is the verifiable topic→owner
+    /// binding. A different owner yields a different id, so a rogue cannot
+    /// collide with a legitimate store's id by choosing the same topic.
+    ///
+    /// Uses a distinct domain tag (`x0x.store.v2`) from the legacy
+    /// [`from_content`](Self::from_content) (`x0x.store`) so the two
+    /// derivations never accidentally agree.
+    #[must_use]
+    pub fn for_topic_owner(topic: &str, owner: &AgentId) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"x0x.store.v2");
+        hasher.update(topic.as_bytes());
+        hasher.update(owner.as_bytes());
+        Self(*hasher.finalize().as_bytes())
+    }
 }
 
 impl std::fmt::Display for KvStoreId {
@@ -90,6 +110,287 @@ impl std::fmt::Display for KvStoreId {
 
 fn default_seq_counter() -> Arc<AtomicU64> {
     Arc::new(AtomicU64::new(0))
+}
+
+/// The authenticated channel through which a store's owner was anchored.
+///
+/// Pure audit metadata: the security property is the anchored `owner` itself
+/// (set at construction), not which channel supplied it. Recording the channel
+/// makes a misconfigured or unauthenticated anchor source visible rather than
+/// silent.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AnchorChannel {
+    /// This node created the store (`owner = self`).
+    Creator,
+    /// Owner supplied via a REST/CLI `expected_owner` parameter (the local
+    /// user/operator is the trust root).
+    RestParam,
+    /// Owner replayed from the persisted manifest after a restart. Stores
+    /// deserialized from a pre-ownership-source format use this honest label.
+    #[default]
+    Persistence,
+}
+
+/// How a store's ownership was established — surfaced on reads for
+/// auditability. See the module-level "Access Policies" docs and
+/// [`KvStore::learn_ownership`] for the construction-only ownership invariant.
+///
+/// This is a *derived view* of the authoritative `owner` field plus the last
+/// observed conflict, not an independent source of truth: writes are gated on
+/// `owner`/`policy`, never on this enum.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OwnershipSource {
+    /// Owner supplied out-of-band at construction. This is the only state
+    /// that permits writes; it converges against any owner version (v0.30.1
+    /// included) because no announce is consulted on the data path.
+    Anchored {
+        /// The anchored owner.
+        owner: AgentId,
+        /// How the owner was supplied.
+        channel: AnchorChannel,
+    },
+    /// No owner anchored. Fail-closed read-only by design — writes return
+    /// [`KvError::OwnerUnknown`]. The protocol refuses to derive ownership
+    /// from the network, so this is permanent, not a pending state.
+    Unknown,
+    /// The anchored owner disagrees with a received announce. The store stays
+    /// on the anchored owner (writes by it still work); the conflict is
+    /// surfaced so a takeover attempt or misconfiguration is visible.
+    Conflict {
+        /// The anchored (construction-time) owner.
+        anchored: AgentId,
+        /// The owner claimed by the rejected announce.
+        announced: AgentId,
+    },
+}
+
+/// Wire-friendly ownership discriminant for REST/audit surfaces.
+///
+/// Unlike [`OwnershipSource`] (which carries `AgentId` detail for in-process
+/// audit), this carries only the status tag; the owner/announced identities
+/// travel as hex strings alongside it in DTOs. Strongly typed (not a string)
+/// per the ownership-source design decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnershipStatus {
+    /// Owner anchored at construction; writes permitted for the owner.
+    Anchored,
+    /// No owner anchored — permanently read-only by design.
+    Unknown,
+    /// Anchored owner disagrees with a received announce; owner unchanged.
+    Conflict,
+}
+
+/// Domain-separation tag for owner-checkpoint signatures.
+const CHECKPOINT_SIG_DOMAIN: &[u8] = b"x0x.store.checkpoint.sig.v1";
+/// Domain-separation tag for content-root hashing.
+const CHECKPOINT_ROOT_DOMAIN: &[u8] = b"x0x.store.checkpoint.root.v2";
+
+/// Owner-signed content provenance for a store snapshot.
+///
+/// Decouples "who relays" from "who authored": the signature is content-level
+/// (the owner's ML-DSA-65 key), so a re-wrapping replica cannot strip it. This
+/// lets an anchored joiner cold-recover a Signed store from a non-owner
+/// replica while the owner is offline — the replica relays
+/// `(checkpoint + entries)` and the joiner verifies the owner's signature and
+/// recomputes the content root, independent of the relayer.
+///
+/// **Never establishes ownership.** A checkpoint can only be adopted by a
+/// replica already anchored on `expected_owner`; it proves data provenance,
+/// not ownership. An unanchored replica rejects all checkpoints (fail-closed).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OwnerCheckpoint {
+    /// Store topic this checkpoint binds (cross-topic replay defense).
+    pub topic: String,
+    /// Store id (must equal `for_topic_owner(topic, owner)`).
+    pub store_id: KvStoreId,
+    /// Owner's ML-DSA-65 public key bytes (self-proving).
+    pub owner_pubkey: Vec<u8>,
+    /// Policy at checkpoint time.
+    pub policy: AccessPolicy,
+    /// Policy freshness counter at checkpoint time.
+    pub policy_version: u64,
+    /// Monotonic checkpoint sequence (owner-incremented). Replay/downgrade gate.
+    pub checkpoint_seq: u64,
+    /// Canonical BLAKE3 root over every security-relevant field of the active
+    /// entry set — see [`content_root`].
+    pub content_root: [u8; 32],
+    /// Unix ms (skew/freshness logging only; `checkpoint_seq` is authoritative).
+    pub timestamp: u64,
+    /// ML-DSA-65 signature over [`signing_bytes`](Self::signing_bytes).
+    pub signature: Vec<u8>,
+}
+
+impl OwnerCheckpoint {
+    /// The forgeable bytes covered by the signature (everything except the
+    /// signature itself).
+    #[must_use]
+    pub fn signing_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(256);
+        buf.extend_from_slice(CHECKPOINT_SIG_DOMAIN);
+        buf.extend_from_slice(self.topic.as_bytes());
+        buf.extend_from_slice(self.store_id.as_bytes());
+        buf.extend_from_slice(&self.owner_pubkey);
+        // Policy is bincode-encoded so nested variants are unambiguous.
+        buf.extend_from_slice(&bincode::serialize(&self.policy).unwrap_or_default());
+        buf.extend_from_slice(&self.policy_version.to_le_bytes());
+        buf.extend_from_slice(&self.checkpoint_seq.to_le_bytes());
+        buf.extend_from_slice(&self.content_root);
+        buf.extend_from_slice(&self.timestamp.to_le_bytes());
+        buf
+    }
+
+    /// Verify owner binding, store binding, and signature against the anchored
+    /// `expected_owner`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KvError::OwnerTokenInvalid`] if the public key does not parse,
+    /// does not derive to `expected_owner`, or the signature is invalid.
+    pub fn verify(&self, expected_owner: &AgentId) -> Result<()> {
+        use ant_quic::crypto::raw_public_keys::pqc::{verify_with_ml_dsa, MlDsaSignature};
+        let pubkey = ant_quic::MlDsaPublicKey::from_bytes(&self.owner_pubkey)
+            .map_err(|e| KvError::OwnerTokenInvalid(format!("bad owner pubkey: {e:?}")))?;
+        // Owner binding: the pubkey must derive to the anchored owner.
+        let derived = AgentId::from_public_key(&pubkey);
+        if &derived != expected_owner {
+            return Err(KvError::OwnerTokenInvalid(
+                "checkpoint owner_pubkey does not derive to the anchored owner".to_string(),
+            ));
+        }
+        let sig = MlDsaSignature::from_bytes(&self.signature)
+            .map_err(|e| KvError::OwnerTokenInvalid(format!("bad signature: {e:?}")))?;
+        verify_with_ml_dsa(&pubkey, &self.signing_bytes(), &sig).map_err(|e| {
+            KvError::OwnerTokenInvalid(format!("invalid checkpoint signature: {e:?}"))
+        })?;
+        Ok(())
+    }
+}
+
+/// Deterministic canonical BLAKE3 root over the store name and active entry
+/// set.
+///
+/// Computable identically by the owner (at checkpoint time) and a receiver
+/// (from a relay), so a relayer cannot tamper with the store name or any
+/// entry field without breaking the root. Each entry is encoded canonically
+/// with length-delimited fields covering the outer map key and **every**
+/// security-relevant field (inner key, value, content_hash, content_type,
+/// metadata, timestamps). The store name is length-delimited and hashed
+/// before the entries. Entries are sorted by outer key for determinism.
+#[must_use]
+pub fn content_root(store_id: &KvStoreId, name: &str, entries: &[(&str, &KvEntry)]) -> [u8; 32] {
+    let mut h = blake3::Hasher::new();
+    h.update(CHECKPOINT_ROOT_DOMAIN);
+    h.update(store_id.as_bytes());
+    // Store name: length-delimited so it cannot collide with entry data.
+    h.update(&(name.len() as u64).to_le_bytes());
+    h.update(name.as_bytes());
+    let mut sorted = entries.to_vec();
+    sorted.sort_by(|a, b| a.0.cmp(b.0));
+    for (outer_key, entry) in &sorted {
+        h.update(&entry_commitment_bytes(outer_key, entry));
+    }
+    *h.finalize().as_bytes()
+}
+
+/// Canonical length-delimited encoding of a single entry's security-relevant
+/// fields for checkpoint commitment.
+///
+/// Every variable-length field is prefixed with its byte length as a 64-bit
+/// little-endian integer so the encoding is unambiguous (no field-boundary
+/// collisions). The outer map key is included alongside the entry's inner key
+/// so a relay cannot swap an entry between map slots.
+fn entry_commitment_bytes(outer_key: &str, entry: &KvEntry) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(256);
+    lp_bytes(&mut buf, outer_key.as_bytes());
+    lp_bytes(&mut buf, entry.key.as_bytes());
+    lp_bytes(&mut buf, &entry.value);
+    lp_bytes(&mut buf, &entry.content_hash);
+    lp_bytes(&mut buf, entry.content_type.as_bytes());
+    // Metadata: canonicalize by sorting key-value pairs.
+    let mut meta: Vec<_> = entry.metadata.iter().collect();
+    meta.sort_by(|a, b| a.0.cmp(b.0));
+    buf.extend_from_slice(&(meta.len() as u64).to_le_bytes());
+    for (mk, mv) in &meta {
+        lp_bytes(&mut buf, mk.as_bytes());
+        lp_bytes(&mut buf, mv.as_bytes());
+    }
+    buf.extend_from_slice(&entry.created_at.to_le_bytes());
+    buf.extend_from_slice(&entry.updated_at.to_le_bytes());
+    buf
+}
+
+/// Write a length-prefixed byte slice (64-bit LE length + data).
+fn lp_bytes(buf: &mut Vec<u8>, data: &[u8]) {
+    buf.extend_from_slice(&(data.len() as u64).to_le_bytes());
+    buf.extend_from_slice(data);
+}
+
+/// Validate that a relayed entry is internally consistent before adoption.
+///
+/// Independently enforces:
+/// - `outer_key == entry.key` (the entry has not been moved between map slots)
+/// - `content_hash == blake3(value)` (the value matches its claimed hash)
+///
+/// Called before any mutation or high-water update caused by checkpoint
+/// adoption. Failures reject the entire checkpoint adoption (fail-closed).
+fn validate_entry_integrity(outer_key: &str, entry: &KvEntry) -> Result<()> {
+    if outer_key != entry.key {
+        return Err(KvError::Merge(format!(
+            "checkpoint entry outer key {outer_key:?} != inner key {:?}",
+            entry.key
+        )));
+    }
+    let computed = *blake3::hash(&entry.value).as_bytes();
+    if computed != entry.content_hash {
+        return Err(KvError::Merge(
+            "checkpoint entry content_hash != blake3(value)".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Inputs required to build an owner-signed checkpoint.
+pub struct OwnerCheckpointParams<'a> {
+    pub topic: &'a str,
+    pub store_id: &'a KvStoreId,
+    pub secret_key: &'a ant_quic::MlDsaSecretKey,
+    pub public_key: &'a ant_quic::MlDsaPublicKey,
+    pub policy: &'a AccessPolicy,
+    pub policy_version: u64,
+    pub checkpoint_seq: u64,
+    pub content_root: [u8; 32],
+    pub timestamp: u64,
+}
+
+/// Build and sign an [`OwnerCheckpoint`] with the owner's key.
+///
+/// This is the production side (owner only). Replicas never call this — they
+/// only cache and relay checkpoints produced by the owner.
+///
+/// # Errors
+///
+/// Returns [`KvError::Gossip`] if checkpoint signing fails.
+pub fn make_owner_checkpoint(params: OwnerCheckpointParams<'_>) -> Result<OwnerCheckpoint> {
+    use ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa;
+    let owner_pubkey = params.public_key.as_bytes().to_vec();
+    let cp = OwnerCheckpoint {
+        topic: params.topic.to_string(),
+        store_id: *params.store_id,
+        owner_pubkey,
+        policy: params.policy.clone(),
+        policy_version: params.policy_version,
+        checkpoint_seq: params.checkpoint_seq,
+        content_root: params.content_root,
+        timestamp: params.timestamp,
+        signature: Vec::new(),
+    };
+    let bytes = cp.signing_bytes();
+    let sig = sign_with_ml_dsa(params.secret_key, &bytes)
+        .map_err(|e| KvError::Gossip(format!("owner checkpoint sign failed: {e:?}")))?;
+    let mut cp = cp;
+    cp.signature = sig.as_bytes().to_vec();
+    Ok(cp)
 }
 
 /// A replicated key-value store using CRDTs with access control.
@@ -118,10 +419,48 @@ pub struct KvStore {
     policy: AccessPolicy,
 
     /// Store owner (the agent that created it).
+    ///
+    /// Ownership is established ONLY at construction — either by the creator
+    /// ([`new`](Self::new)) or from trusted out-of-band input at join
+    /// ([`new_replica`](Self::new_replica)). It is **never** adopted from an
+    /// untrusted network announce (see [`learn_ownership`](Self::learn_ownership)).
     /// For Signed and Allowlisted policies, only the owner (and allowlisted
     /// writers) can write.
     #[serde(default)]
     owner: Option<AgentId>,
+
+    /// How the owner was anchored (audit metadata); meaningful only when
+    /// `owner` is `Some`.
+    #[serde(default)]
+    anchor_channel: AnchorChannel,
+
+    /// Monotonic freshness counter for owner-announced policy refreshes.
+    ///
+    /// A policy refresh from [`learn_ownership`](Self::learn_ownership) is
+    /// applied only when the announce carries a strictly greater
+    /// `policy_version`, which blocks a replayed authentic-but-stale announce
+    /// from downgrading policy. This is owner-local metadata; it is NOT a
+    /// CRDT-merged value.
+    #[serde(default)]
+    policy_version: u64,
+
+    /// The last announce whose claimed owner conflicted with the anchored
+    /// owner (audit only). Cleared when the anchored owner itself refreshes
+    /// via a matching forward-version announce. `None` when no conflict has
+    /// been observed (or it has been cleared).
+    #[serde(default)]
+    ownership_conflict: Option<(AgentId, AgentId)>,
+
+    /// Latest owner-signed checkpoint this replica has merged or produced.
+    /// Persisted (serde default) so owner restarts never regress the
+    /// checkpoint sequence; old data without this field deserializes to
+    /// `None` (safe forward default).
+    #[serde(default)]
+    pub(crate) latest_checkpoint: Option<OwnerCheckpoint>,
+    /// Highest `checkpoint_seq` adopted (replay/downgrade high-water mark).
+    /// Persisted so owner restarts never regress the checkpoint sequence.
+    #[serde(default)]
+    pub(crate) highest_checkpoint_seq: u64,
 
     /// Agents allowed to write (for Allowlisted policy).
     /// The owner is implicitly allowed and does not need to be in this set.
@@ -143,37 +482,72 @@ fn default_policy() -> AccessPolicy {
 
 impl KvStore {
     /// Create a new empty KvStore with the given access policy.
+    /// Create a new empty KvStore owned by `owner` with the given access
+    /// policy.
+    ///
+    /// This is the **creator** path: ownership is anchored on `owner` at
+    /// construction (channel [`AnchorChannel::Creator`]) and is immutable for
+    /// the life of the store.
     #[must_use]
     pub fn new(id: KvStoreId, name: String, owner: AgentId, policy: AccessPolicy) -> Self {
+        let mut name_reg = LwwRegister::new(name.clone());
+        // Stamp the creator-set name with a non-empty clock so it wins LWW
+        // merge against replicas initialized with empty names and empty
+        // clocks (which would otherwise be concurrent and hash-tiebroken).
+        name_reg.set(name, PeerId::new(owner.0));
         Self {
             id,
             keys: OrSet::new(),
             entries: HashMap::new(),
-            name: LwwRegister::new(name),
+            name: name_reg,
             policy,
             owner: Some(owner),
+            anchor_channel: AnchorChannel::Creator,
+            policy_version: 0,
+            ownership_conflict: None,
+            latest_checkpoint: None,
+            highest_checkpoint_seq: 0,
             allowed_writers: HashSet::new(),
             version: 0,
             seq_counter: Arc::new(AtomicU64::new(0)),
         }
     }
 
-    /// Create a joined replica of a store whose authoritative owner is not
-    /// yet known.
+    /// Create a joined replica of a store, anchoring ownership from trusted
+    /// out-of-band input.
     ///
-    /// The replica starts with the default `Signed` policy and `owner: None`,
-    /// which fails closed: no local or inbound policy-restricted write is
-    /// accepted until [`learn_ownership`](Self::learn_ownership) installs the
-    /// authoritative owner and policy from an owner-signed announcement.
+    /// Ownership is established ONLY here, at construction:
+    /// - `expected_owner = Some(o)` → the replica is **anchored** on `o`
+    ///   (`OwnershipSource::Anchored`). It accepts `o`'s deltas and (if this
+    ///   node *is* `o`) its own local writes, converging against any owner
+    ///   version — including a v0.30.1 owner that never announces — because
+    ///   the data path never consults an announce.
+    /// - `expected_owner = None` → the replica has **no owner**
+    ///   (`OwnershipSource::Unknown`) and is permanently read-only by design:
+    ///   every policy-restricted write returns [`KvError::OwnerUnknown`]. This
+    ///   is explicit incompatibility, never a silent deadlock and never a
+    ///   permissive first-writer fallback.
+    ///
+    /// `channel` records how the anchor was supplied (audit metadata).
     #[must_use]
-    pub fn new_replica(id: KvStoreId, name: String) -> Self {
+    pub fn new_replica(
+        id: KvStoreId,
+        name: String,
+        expected_owner: Option<AgentId>,
+        channel: AnchorChannel,
+    ) -> Self {
         Self {
             id,
             keys: OrSet::new(),
             entries: HashMap::new(),
             name: LwwRegister::new(name),
             policy: AccessPolicy::Signed,
-            owner: None,
+            owner: expected_owner,
+            anchor_channel: channel,
+            policy_version: 0,
+            ownership_conflict: None,
+            latest_checkpoint: None,
+            highest_checkpoint_seq: 0,
             allowed_writers: HashSet::new(),
             version: 0,
             seq_counter: Arc::new(AtomicU64::new(0)),
@@ -223,6 +597,39 @@ impl KvStore {
     #[must_use]
     pub fn owner(&self) -> Option<&AgentId> {
         self.owner.as_ref()
+    }
+
+    /// Get the policy-version freshness counter.
+    #[must_use]
+    pub fn policy_version(&self) -> u64 {
+        self.policy_version
+    }
+
+    /// Get the channel through which the owner was anchored.
+    #[must_use]
+    pub fn anchor_channel(&self) -> AnchorChannel {
+        self.anchor_channel
+    }
+
+    /// Derive the store's ownership status for auditability.
+    ///
+    /// This is a *view* of the authoritative `owner` field plus the last
+    /// observed conflict — writes are gated on `owner`/`policy`, never on
+    /// this value.
+    #[must_use]
+    pub fn ownership_source(&self) -> OwnershipSource {
+        match (&self.owner, &self.ownership_conflict) {
+            (None, _) => OwnershipSource::Unknown,
+            (Some(owner), None) => OwnershipSource::Anchored {
+                owner: *owner,
+                channel: self.anchor_channel,
+            },
+            (Some(owner), Some((_anchored, announced))) => OwnershipSource::Conflict {
+                // `anchored` is the current authoritative owner by construction.
+                anchored: *owner,
+                announced: *announced,
+            },
+        }
     }
 
     /// Get the set of allowed writers.
@@ -300,47 +707,84 @@ impl KvStore {
         Ok(())
     }
 
-    /// Install the authoritative owner and policy learned from an
-    /// owner-signed announcement.
+    /// Apply an owner-announced policy refresh / detect a conflict.
     ///
     /// `verified_sender` is the cryptographically verified identity of the
     /// peer that published the announcement (the pub/sub layer verifies the
-    /// ML-DSA-65 signature before delivery). Ownership claims are only
-    /// accepted when the sender claims *itself* as owner, so no third party
-    /// can assign ownership. Once an owner is established it is immutable;
-    /// the established owner may still refresh the policy.
+    /// ML-DSA-65 signature before delivery). The `claimed_owner` must equal
+    /// `verified_sender`: an announce can only attest to *oneself*, blocking
+    /// third-party ownership assignment.
+    ///
+    /// **Ownership is NEVER established here.** Ownership is anchored only at
+    /// construction ([`new`](Self::new) / [`new_replica`](Self::new_replica)).
+    /// The `verified_sender == claimed_owner` check blocks third-party
+    /// assignment but is *trivially* satisfied by any self-claim, so accepting
+    /// an announce to go `None → Some(owner)` would let any agent that speaks
+    /// first about a topic seize it (first-self-capture). That path is removed
+    /// by construction.
+    ///
+    /// This method therefore only ever:
+    /// - **refreshes policy** when the claimed owner equals the already-anchored
+    ///   owner AND `policy_version` is strictly newer than the last applied
+    ///   refresh (blocking a replayed authentic-but-stale announce from
+    ///   downgrading policy); or
+    /// - **records a conflict** when the claimed owner differs from the
+    ///   anchored owner (the anchored owner is unchanged; the conflict is
+    ///   surfaced via [`ownership_source`](Self::ownership_source)).
     ///
     /// # Errors
     ///
-    /// Returns `KvError::Unauthorized` if `verified_sender` differs from the
-    /// claimed `owner`, or if a different owner is already established.
+    /// - [`KvError::OwnerTokenInvalid`] if `verified_sender != claimed_owner`,
+    ///   or if the store has no anchored owner (`None` — ownership cannot be
+    ///   learned from an untrusted announce; the caller must supply
+    ///   `expected_owner` at join).
+    /// - [`KvError::OwnershipConflict`] if a different owner is anchored.
     pub fn learn_ownership(
         &mut self,
-        owner: AgentId,
+        claimed_owner: AgentId,
         policy: AccessPolicy,
+        policy_version: u64,
         verified_sender: &AgentId,
     ) -> Result<()> {
-        if *verified_sender != owner {
-            return Err(KvError::Unauthorized(
+        if *verified_sender != claimed_owner {
+            return Err(KvError::OwnerTokenInvalid(
                 "ownership announcement sender does not match claimed owner".to_string(),
             ));
         }
-        match self.owner {
-            None => {
-                self.owner = Some(owner);
-                self.policy = policy;
-                self.version += 1;
-                Ok(())
-            }
-            Some(existing) if existing == owner => {
-                self.policy = policy;
-                self.version += 1;
-                Ok(())
-            }
-            Some(_) => Err(KvError::Unauthorized(
-                "store owner already established; conflicting ownership claim rejected".to_string(),
-            )),
+        let Some(existing) = self.owner else {
+            // No anchored owner. Ownership is construction-only: refuse to
+            // derive it from an untrusted announce. Remain read-only.
+            return Err(KvError::OwnerTokenInvalid(
+                "ownership cannot be learned from an announcement; supply expected_owner at join"
+                    .to_string(),
+            ));
+        };
+        if existing != claimed_owner {
+            // Immutable owner: record the conflict for auditability and reject.
+            self.ownership_conflict = Some((existing, claimed_owner));
+            self.version += 1;
+            return Err(KvError::OwnershipConflict {
+                anchored: existing,
+                claimed: claimed_owner,
+            });
         }
+        // Anchored owner matches. Apply the policy refresh when it is at least
+        // as fresh as the last applied one. `>=` (not strict `>`) is required
+        // so a fresh replica at version 0 adopts the owner's initial (version
+        // 0) policy — otherwise a non-Signed store would stay at the default
+        // Signed and reject legitimate writers. Equal-version replay is safe:
+        // a legitimate owner assigns each policy a unique monotonic version,
+        // so an equal version carries the same policy, and a forgery with a
+        // different policy at the same version cannot be signed by the owner.
+        // An older replay (version < current) is still dropped, preventing a
+        // downgrade. A matching forward refresh clears a recorded conflict.
+        if policy_version >= self.policy_version {
+            self.policy = policy;
+            self.policy_version = policy_version;
+            self.ownership_conflict = None;
+            self.version += 1;
+        }
+        Ok(())
     }
 
     /// Add an agent to the allowlist (owner-only operation).
@@ -355,6 +799,9 @@ impl KvStore {
             ));
         }
         self.allowed_writers.insert(writer);
+        // Bump the policy freshness counter so the owner's next announce
+        // carries a newer version (blocks replay of a pre-change announce).
+        self.policy_version = self.policy_version.saturating_add(1);
         self.version += 1;
         Ok(())
     }
@@ -371,6 +818,7 @@ impl KvStore {
             ));
         }
         self.allowed_writers.remove(writer);
+        self.policy_version = self.policy_version.saturating_add(1);
         self.version += 1;
         Ok(())
     }
@@ -459,6 +907,16 @@ impl KvStore {
             .collect()
     }
 
+    /// Active entries paired with their outer map keys, for canonical
+    /// checkpoint root computation. Borrows from `self` — no cloning.
+    pub(crate) fn checkpoint_pairs(&self) -> Vec<(&str, &KvEntry)> {
+        self.keys
+            .elements()
+            .into_iter()
+            .filter_map(|k| self.entries.get(k).map(|e| (k.as_str(), e)))
+            .collect()
+    }
+
     /// Update the store name.
     pub fn update_name(&mut self, name: String, peer_id: PeerId) {
         self.name.set(name, peer_id);
@@ -476,6 +934,18 @@ impl KvStore {
         peer_id: PeerId,
         writer: Option<&AgentId>,
     ) -> Result<()> {
+        // Authoritative full-snapshot checkpoint adoption (cold-recovery path):
+        // if the checkpoint's content root matches the relayed entry set, adopt
+        // as owner-proven independent of the relayer. An incremental delta's
+        // single-entry set won't match a full-state root, so it falls through
+        // to the sender-auth path below (where the owner is authorized as
+        // writer==owner), and the checkpoint is cached afterward by
+        // maybe_cache_checkpoint if the resulting state matches.
+        if let Some(cp) = delta.owner_checkpoint.as_ref() {
+            if self.try_adopt_full_snapshot(delta, peer_id, cp) {
+                return Ok(());
+            }
+        }
         // Access control: reject unauthorized writes
         if let Some(writer_id) = writer {
             if !self.is_authorized(writer_id) {
@@ -554,9 +1024,173 @@ impl KvStore {
         if let Some(ref name_register) = delta.name_update {
             self.name.merge(name_register);
         }
+        // After an incremental mutation, cache the checkpoint if the resulting
+        // complete state matches the checkpoint's content root. This ensures a
+        // relay always carries the latest checkpoint after normal
+        // multi-write/update/delete operations, so a fresh anchored joiner can
+        // cold-recover the exact final state from a non-owner relay.
+        if let Some(cp) = delta.owner_checkpoint.as_ref() {
+            self.maybe_cache_checkpoint(cp);
+        }
 
         self.version += 1;
         Ok(())
+    }
+
+    /// Try to adopt an owner-signed checkpoint as an authoritative full
+    /// snapshot.
+    ///
+    /// Returns `true` only when the checkpoint fully validates AND its content
+    /// root matches the delta's relayed entry set (a full-state relay). Every
+    /// relayed entry is independently integrity-checked (`outer_key ==
+    /// entry.key`, `content_hash == blake3(value)`) before any mutation.
+    /// Removals/tombstones are applied, the checkpoint is cached, and the
+    /// high-water mark is updated. This is what lets an anchored joiner
+    /// cold-recover a Signed store from a non-owner replica while the owner is
+    /// offline.
+    ///
+    /// Returns `false` otherwise (unanchored, bad sig/owner, stale seq,
+    /// cross-store, entry integrity failure, root mismatch / incremental
+    /// delta / tamper), in which case [`merge_delta`] falls through to the
+    /// normal sender-auth path. Never establishes ownership (anchor gate).
+    fn try_adopt_full_snapshot(
+        &mut self,
+        delta: &KvStoreDelta,
+        peer_id: PeerId,
+        cp: &OwnerCheckpoint,
+    ) -> bool {
+        // 1. Anchor gate: never learn the owner from a relay.
+        let Some(expected_owner) = self.owner else {
+            tracing::warn!("rejected owner checkpoint for unanchored store {}", self.id);
+            return false;
+        };
+        // 2. Owner binding + signature.
+        if let Err(e) = cp.verify(&expected_owner) {
+            tracing::warn!("rejected owner checkpoint for store {}: {e}", self.id);
+            return false;
+        }
+        // 3. Store/topic binding — store_id = for_topic_owner(topic, owner)
+        //    binds both, and the signature covers topic + store_id, so a
+        //    cross-store replay either mismatches the id or fails verification.
+        if cp.store_id != self.id {
+            tracing::warn!(
+                "rejected owner checkpoint: store_id mismatch for {}",
+                self.id
+            );
+            return false;
+        }
+        // 4. Replay/downgrade gate (monotonic checkpoint sequence).
+        if cp.checkpoint_seq <= self.highest_checkpoint_seq {
+            return false; // stale replay — ignore, fall through
+        }
+        // 5. Validate every relayed entry's integrity before any mutation.
+        //    Fail-closed: a single malformed/inconsistent entry rejects the
+        //    entire checkpoint adoption.
+        for (key, (entry, _)) in &delta.added {
+            if let Err(e) = validate_entry_integrity(key, entry) {
+                tracing::warn!("rejected checkpoint entry for store {}: {e}", self.id);
+                return false;
+            }
+        }
+        for (key, entry) in &delta.updated {
+            if let Err(e) = validate_entry_integrity(key, entry) {
+                tracing::warn!("rejected checkpoint entry for store {}: {e}", self.id);
+                return false;
+            }
+        }
+        // 6. Content integrity: the canonical root over the relayed entry set
+        //    must match. This only holds for a full-state relay; an incremental
+        //    delta's single entry set won't match a full-state checkpoint root,
+        //    so the checkpoint doesn't apply and we fall through to sender-auth.
+        let mut relayed: Vec<(&str, &KvEntry)> = delta
+            .added
+            .iter()
+            .map(|(k, (e, _))| (k.as_str(), e))
+            .collect();
+        relayed.extend(delta.updated.iter().map(|(k, e)| (k.as_str(), e)));
+        let relayed_name: &str = delta
+            .name_update
+            .as_ref()
+            .map(|r| r.get().as_str())
+            .unwrap_or("");
+        if content_root(&self.id, relayed_name, &relayed) != cp.content_root {
+            return false; // tamper / truncation / subset / incremental — fall through
+        }
+        // 7. Adopt: merge the entries as owner-authorized (bypass sender-auth).
+        for (key, (entry, tag)) in &delta.added {
+            let _ = self.keys.add(key.clone(), *tag);
+            if let Some(existing) = self.entries.get_mut(key) {
+                existing.merge(entry);
+            } else {
+                self.entries.insert(key.clone(), entry.clone());
+            }
+        }
+        for (key, entry) in &delta.updated {
+            if let Some(existing) = self.entries.get_mut(key) {
+                existing.merge(entry);
+            } else {
+                let _ = self.keys.add(key.clone(), (peer_id, 0));
+                self.entries.insert(key.clone(), entry.clone());
+            }
+        }
+        // 8. Apply removals/tombstones — critical for delete-to-empty so the
+        //    checkpoint path does not return early without removing keys.
+        for key in delta.removed.keys() {
+            let _ = self.keys.remove(&key.to_string());
+            self.entries.remove(key.as_str());
+        }
+        // 9. Apply name update.
+        if let Some(name_register) = &delta.name_update {
+            self.name.merge(name_register);
+        }
+        // 10. Refresh policy (forward only) and cache the checkpoint.
+        if cp.policy_version >= self.policy_version {
+            self.policy = cp.policy.clone();
+            self.policy_version = cp.policy_version;
+        }
+        self.latest_checkpoint = Some(cp.clone());
+        self.highest_checkpoint_seq = cp.checkpoint_seq;
+        self.version += 1;
+        true
+    }
+
+    /// After applying an incremental mutation via the sender-auth path, cache
+    /// the checkpoint if the resulting complete state matches the checkpoint's
+    /// content root.
+    ///
+    /// This ensures a relay always carries the latest checkpoint after normal
+    /// multi-write/update/delete operations: after the owner publishes an
+    /// incremental delta (single-entry), the relay applies it, then
+    /// recomputes the root over its *complete* state. If it matches the
+    /// checkpoint root, the relay caches the checkpoint — so a subsequent
+    /// `full_delta` relays the correct, up-to-date checkpoint.
+    ///
+    /// Does not mutate entries (already applied by the caller); only updates
+    /// `latest_checkpoint` and `highest_checkpoint_seq`.
+    fn maybe_cache_checkpoint(&mut self, cp: &OwnerCheckpoint) {
+        // Only advance for strictly newer checkpoints.
+        if cp.checkpoint_seq <= self.highest_checkpoint_seq {
+            return;
+        }
+        // Verify owner binding + signature (the checkpoint must be genuine).
+        let Some(expected_owner) = self.owner else {
+            return;
+        };
+        if cp.verify(&expected_owner).is_err() {
+            return;
+        }
+        if cp.store_id != self.id {
+            return;
+        }
+        // Cache only if the resulting complete state matches the checkpoint.
+        let matches = {
+            let pairs = self.checkpoint_pairs();
+            content_root(&self.id, self.name(), &pairs) == cp.content_root
+        };
+        if matches {
+            self.latest_checkpoint = Some(cp.clone());
+            self.highest_checkpoint_seq = cp.checkpoint_seq;
+        }
     }
 
     /// Merge another store into this one.
@@ -607,7 +1241,10 @@ impl KvStore {
         if !self.allowed_writers.is_empty() {
             delta.allowlist_additions = Some(self.allowed_writers.iter().copied().collect());
         }
-
+        // Relay the latest owner-signed checkpoint so an anchored joiner can
+        // cold-recover this store's content even when relayed by a non-owner
+        // (the checkpoint's owner signature survives re-wrap).
+        delta.owner_checkpoint = self.latest_checkpoint.clone();
         delta
     }
 }
@@ -1049,26 +1686,29 @@ mod tests {
     }
 
     #[test]
-    fn test_local_write_rejected_while_owner_unknown() {
-        // A joined replica must be read-only until the authoritative owner
-        // is learned — otherwise the joiner writes into a fork.
+    fn test_no_anchor_join_is_read_only_unknown() {
+        // A joined replica with no expected owner is permanently read-only by
+        // design — the protocol never derives ownership from the network.
         let joiner = agent(2);
-        let store = KvStore::new_replica(store_id(1), String::new());
+        let store =
+            KvStore::new_replica(store_id(1), String::new(), None, AnchorChannel::Persistence);
         assert!(
             store.owner().is_none(),
-            "joined replica must not claim an owner"
+            "no-anchor replica must not claim an owner"
         );
+        assert!(matches!(store.ownership_source(), OwnershipSource::Unknown));
         let err = store
             .authorize_local_write(&joiner)
-            .expect_err("write on unknown-owner store must fail closed");
+            .expect_err("write on no-anchor store must fail closed");
         assert!(matches!(err, KvError::OwnerUnknown));
     }
 
     #[test]
-    fn test_replica_rejects_inbound_deltas_until_owner_learned() {
-        // Fail closed on the inbound side too: without a known owner there
-        // is no authorized writer, so nothing merges.
-        let mut store = KvStore::new_replica(store_id(1), String::new());
+    fn test_no_anchor_replica_rejects_inbound_deltas() {
+        // Fail closed on the inbound side too: without an anchored owner there
+        // is no authorized writer, so nothing merges (no silent mutation).
+        let mut store =
+            KvStore::new_replica(store_id(1), String::new(), None, AnchorChannel::Persistence);
         let entry = KvEntry::new("k".to_string(), b"v".to_vec(), "text/plain".to_string());
         let delta = KvStoreDelta::for_put("k".to_string(), entry, (peer(9), 1), 1);
         store
@@ -1077,36 +1717,68 @@ mod tests {
         assert!(store.get("k").is_none());
     }
 
-    // -- learn_ownership: owner-signed metadata adoption --
+    // -- learn_ownership: ownership is construction-only; announce can only
+    //    refresh policy or record a conflict. It can NEVER establish ownership. --
 
     #[test]
-    fn test_learn_ownership_requires_sender_to_be_claimed_owner() {
-        // A third party must not be able to assign ownership of a store —
-        // only a verified sender claiming itself is trusted.
-        let mut store = KvStore::new_replica(store_id(1), String::new());
+    fn test_learn_ownership_rejects_third_party_assignment() {
+        // A third party must not assign ownership: the verified sender must
+        // equal the claimed owner.
+        let mut store =
+            KvStore::new_replica(store_id(1), String::new(), None, AnchorChannel::Persistence);
         let owner = agent(1);
         let rogue = agent(9);
         let err = store
-            .learn_ownership(owner, AccessPolicy::Signed, &rogue)
+            .learn_ownership(owner, AccessPolicy::Signed, 0, &rogue)
             .expect_err("third-party ownership claim must be rejected");
-        assert!(matches!(err, KvError::Unauthorized(_)));
+        assert!(matches!(err, KvError::OwnerTokenInvalid(_)));
         assert!(store.owner().is_none());
     }
 
     #[test]
-    fn test_learn_ownership_then_policy_enforced_both_paths() {
-        // After adoption: the joiner still cannot write locally, and the
-        // owner's deltas merge while a non-owner's are rejected.
+    fn test_learn_ownership_rejects_none_to_some_first_capture_guard() {
+        // THE REGRESSION GUARD: even a verified SELF-claim must NOT establish
+        // ownership on a store that has none. `verified_sender == owner` is
+        // trivially satisfied by any self-claim, so allowing None→Some would
+        // let any agent that speaks first seize the topic (first-self-capture).
+        let mut store =
+            KvStore::new_replica(store_id(1), String::new(), None, AnchorChannel::Persistence);
+        let rogue = agent(9);
+        let err = store
+            .learn_ownership(rogue, AccessPolicy::Signed, 0, &rogue)
+            .expect_err("self-claim must not establish ownership on a no-anchor store");
+        assert!(matches!(err, KvError::OwnerTokenInvalid(_)));
+        assert!(
+            store.owner().is_none(),
+            "ownership must remain unestablished"
+        );
+        assert!(matches!(store.ownership_source(), OwnershipSource::Unknown));
+    }
+
+    #[test]
+    fn test_anchored_join_merges_owner_deltas_rejects_rogue() {
+        // Legitimate expected owner: anchored at construction. The owner's
+        // deltas merge; a rogue's are rejected. This also covers the
+        // v0.30.1-owner path — no announce is consulted on the data path.
         let owner = agent(1);
         let joiner = agent(2);
-        let mut store = KvStore::new_replica(store_id(1), String::new());
-        store
-            .learn_ownership(owner, AccessPolicy::Signed, &owner)
-            .expect("owner self-claim adopted");
+        let rogue = agent(9);
+        let mut store = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner),
+            AnchorChannel::RestParam,
+        );
         assert_eq!(store.owner(), Some(&owner));
-        assert_eq!(*store.policy(), AccessPolicy::Signed);
+        assert!(matches!(
+            store.ownership_source(),
+            OwnershipSource::Anchored {
+                owner: _,
+                channel: AnchorChannel::RestParam
+            }
+        ));
 
-        // Local write by the joiner: still rejected.
+        // Local write by the joiner (not the owner): rejected.
         assert!(matches!(
             store.authorize_local_write(&joiner),
             Err(KvError::Unauthorized(_))
@@ -1120,30 +1792,182 @@ mod tests {
             .expect("owner delta merges");
         assert!(store.get("ok").is_some());
 
-        // Inbound non-owner delta: rejected.
+        // Inbound rogue delta: rejected.
         let entry = KvEntry::new("bad".to_string(), b"x".to_vec(), "text/plain".to_string());
-        let delta = KvStoreDelta::for_put("bad".to_string(), entry, (peer(2), 1), 2);
+        let delta = KvStoreDelta::for_put("bad".to_string(), entry, (peer(9), 1), 2);
         store
-            .merge_delta(&delta, peer(2), Some(&joiner))
+            .merge_delta(&delta, peer(9), Some(&rogue))
             .expect("silent rejection");
         assert!(store.get("bad").is_none());
     }
 
     #[test]
-    fn test_learn_ownership_owner_is_immutable_once_established() {
-        // First verified claim wins; a later conflicting claim cannot hijack
-        // the replica.
+    fn test_first_capture_impossible_against_anchored_joiner() {
+        // An anchored joiner ignores a rogue's self-announce that arrives
+        // first; the legitimate owner's later announce refreshes policy only.
+        let owner = agent(1);
+        let rogue = agent(9);
+        let mut store = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner),
+            AnchorChannel::RestParam,
+        );
+
+        // Rogue speaks first, attesting to itself.
+        let err = store
+            .learn_ownership(rogue, AccessPolicy::Allowlisted, 5, &rogue)
+            .expect_err("rogue self-claim against anchored owner must conflict");
+        assert!(
+            matches!(err, KvError::OwnershipConflict { anchored, claimed } if anchored == owner && claimed == rogue)
+        );
+        assert_eq!(store.owner(), Some(&owner), "anchored owner unchanged");
+        assert!(matches!(
+            store.ownership_source(),
+            OwnershipSource::Conflict { anchored, announced }
+                if anchored == owner && announced == rogue
+        ));
+
+        // Legitimate owner announces with a forward policy_version: refresh is
+        // applied and the recorded conflict is cleared.
+        store
+            .learn_ownership(owner, AccessPolicy::Allowlisted, 1, &owner)
+            .expect("owner policy refresh");
+        assert_eq!(*store.policy(), AccessPolicy::Allowlisted);
+        assert!(matches!(
+            store.ownership_source(),
+            OwnershipSource::Anchored {
+                owner: _,
+                channel: AnchorChannel::RestParam
+            }
+        ));
+    }
+
+    #[test]
+    fn test_ownership_immutable_conflict() {
+        // Once anchored, ownership is immutable; a conflicting claim is
+        // rejected and the conflict surfaced (ownership_status: conflict).
         let owner = agent(1);
         let hijacker = agent(9);
-        let mut store = KvStore::new_replica(store_id(1), String::new());
-        store
-            .learn_ownership(owner, AccessPolicy::Signed, &owner)
-            .expect("adopt owner");
+        let mut store = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner),
+            AnchorChannel::RestParam,
+        );
         let err = store
-            .learn_ownership(hijacker, AccessPolicy::Signed, &hijacker)
+            .learn_ownership(hijacker, AccessPolicy::Signed, 0, &hijacker)
             .expect_err("conflicting ownership claim must be rejected");
-        assert!(matches!(err, KvError::Unauthorized(_)));
+        assert!(
+            matches!(err, KvError::OwnershipConflict { anchored, claimed } if anchored == owner && claimed == hijacker)
+        );
         assert_eq!(store.owner(), Some(&owner));
+        assert!(matches!(
+            store.ownership_source(),
+            OwnershipSource::Conflict { anchored, announced }
+                if anchored == owner && announced == hijacker
+        ));
+    }
+
+    #[test]
+    fn test_policy_refresh_monotonic_blocks_replay_downgrade() {
+        // A forward policy_version refresh applies; a replayed older one is
+        // dropped (no downgrade).
+        let owner = agent(1);
+        let mut store = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner),
+            AnchorChannel::RestParam,
+        );
+        // Owner refreshes to Allowlisted at version 2.
+        store
+            .learn_ownership(owner, AccessPolicy::Allowlisted, 2, &owner)
+            .expect("forward refresh applies");
+        assert_eq!(*store.policy(), AccessPolicy::Allowlisted);
+        assert_eq!(store.policy_version(), 2);
+
+        // Replayed older announce (version 1, Signed) must NOT downgrade.
+        store
+            .learn_ownership(owner, AccessPolicy::Signed, 1, &owner)
+            .expect("stale replay dropped without error");
+        assert_eq!(
+            *store.policy(),
+            AccessPolicy::Allowlisted,
+            "policy not downgraded"
+        );
+        assert_eq!(store.policy_version(), 2);
+    }
+
+    #[test]
+    fn test_store_id_for_topic_owner_binds_owner() {
+        // for_topic_owner is the verifiable topic→owner binding: creator and
+        // anchored joiner agree, and a different owner yields a different id.
+        let owner = agent(1);
+        let rogue = agent(9);
+        let creator_id = KvStoreId::for_topic_owner("store/x", &owner);
+        let joiner_id = KvStoreId::for_topic_owner("store/x", &owner);
+        assert_eq!(creator_id, joiner_id, "creator and joiner agree on id");
+        assert_ne!(
+            KvStoreId::for_topic_owner("store/x", &owner),
+            KvStoreId::for_topic_owner("store/x", &rogue),
+            "different owner => different id"
+        );
+        // Distinct from the legacy from_content domain.
+        assert_ne!(
+            KvStoreId::for_topic_owner("store/x", &owner),
+            KvStoreId::from_content("store/x", &owner)
+        );
+    }
+
+    #[test]
+    fn test_v0_30_1_owner_converges_with_anchored_joiner_no_announce() {
+        // A v0.30.1 owner NEVER announces ownership. An anchored v0.31 joiner
+        // still converges because the data path (merge_delta) authorizes
+        // against the construction-time owner — no announce is consulted.
+        let owner = agent(1);
+        let joiner_agent = agent(2);
+        // Owner-side store with a written key, republished as a full delta
+        // (exactly what a holder — including a v0.30.1 owner — sends on a
+        // StateRequest).
+        let mut owner_store =
+            KvStore::new(store_id(1), "S".to_string(), owner, AccessPolicy::Signed);
+        owner_store
+            .put(
+                "k".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner put");
+        let full = owner_store.full_delta();
+        // Anchored joiner — no learn_ownership / announce ever happens.
+        let mut joiner = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner),
+            AnchorChannel::RestParam,
+        );
+        joiner
+            .merge_delta(&full, peer(1), Some(&owner))
+            .expect("owner full-delta merges on an anchored joiner");
+        assert!(
+            joiner.get("k").is_some(),
+            "anchored joiner converges against a v0.30.1 owner with no announce"
+        );
+        // The joiner is not the owner, so it still cannot write locally.
+        assert!(matches!(
+            joiner.authorize_local_write(&joiner_agent),
+            Err(KvError::Unauthorized(_))
+        ));
+        // And a no-anchor joiner in the same scenario stays empty (fail
+        // closed) — explicit incompatibility, not a silent deadlock.
+        let mut unanchored =
+            KvStore::new_replica(store_id(1), String::new(), None, AnchorChannel::Persistence);
+        unanchored
+            .merge_delta(&full, peer(1), Some(&owner))
+            .expect("silent rejection");
+        assert!(unanchored.get("k").is_none());
     }
 
     #[test]
@@ -1174,5 +1998,704 @@ mod tests {
             ),
             "encrypted"
         );
+    }
+
+    // -- Owner-signed checkpoint protocol (cold-recovery while owner offline) --
+
+    /// Build an owner-signed checkpoint for a store's current content.
+    fn checkpoint_for(
+        store: &KvStore,
+        topic: &str,
+        kp: &crate::identity::AgentKeypair,
+        seq: u64,
+    ) -> OwnerCheckpoint {
+        let pairs = store.checkpoint_pairs();
+        let root = content_root(store.id(), store.name(), &pairs);
+        make_owner_checkpoint(OwnerCheckpointParams {
+            topic,
+            store_id: store.id(),
+            secret_key: kp.secret_key(),
+            public_key: kp.public_key(),
+            policy: store.policy(),
+            policy_version: store.policy_version(),
+            checkpoint_seq: seq,
+            content_root: root,
+            timestamp: 0,
+        })
+        .expect("sign checkpoint")
+    }
+
+    #[test]
+    fn cold_join_from_replica_with_owner_offline() {
+        // Owner writes + checkpoints, then is offline. A non-owner replica
+        // relays full_delta + checkpoint. An anchored joiner verifies the
+        // owner signature + content root and adopts — independent of relayer.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let relayer = agent(9);
+        let topic = "store/cold";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        owner_store
+            .put(
+                "k".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+        let cp = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut delta = owner_store.full_delta();
+        delta.owner_checkpoint = Some(cp.clone());
+
+        // Anchored joiner; the relayer is NOT the owner.
+        let mut joiner =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner
+            .merge_delta(&delta, peer(9), Some(&relayer))
+            .expect("checkpoint-gated merge");
+        assert!(joiner.get("k").is_some(), "adopted relayed owner content");
+        assert_eq!(joiner.highest_checkpoint_seq, 1);
+    }
+
+    #[test]
+    fn relay_tamper_rejected() {
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/tamper";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        owner_store
+            .put(
+                "k".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+        let cp = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut delta = owner_store.full_delta();
+        // Tamper: mutate value AND recompute content_hash (an honest re-hash).
+        // The recomputed content_root no longer matches the checkpoint root.
+        if let Some((e, _)) = delta.added.get_mut("k") {
+            e.value = b"TAMPERED".to_vec();
+            e.content_hash = *blake3::hash(b"TAMPERED").as_bytes();
+        }
+        delta.owner_checkpoint = Some(cp);
+        let mut joiner =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner
+            .merge_delta(&delta, peer(9), Some(&agent(9)))
+            .expect("no error");
+        assert!(
+            joiner.get("k").is_none(),
+            "tampered relay must not be adopted"
+        );
+        assert_eq!(joiner.highest_checkpoint_seq, 0);
+    }
+
+    #[test]
+    fn checkpoint_replay_downgrade_rejected() {
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/replay";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+        let owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let cp_old = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut joiner =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner.highest_checkpoint_seq = 5; // already adopted a newer checkpoint
+        let mut delta = KvStoreDelta::new(0);
+        delta.owner_checkpoint = Some(cp_old);
+        joiner
+            .merge_delta(&delta, peer(9), Some(&agent(9)))
+            .expect("no error");
+        assert_eq!(joiner.highest_checkpoint_seq, 5, "stale replay dropped");
+    }
+
+    #[test]
+    fn unanchored_joiner_rejects_checkpoint() {
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/unanchored";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+        let owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let cp = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut delta = KvStoreDelta::new(0);
+        delta.owner_checkpoint = Some(cp);
+        // No-anchor replica: must never learn the owner from a relay.
+        let mut joiner = KvStore::new_replica(id, String::new(), None, AnchorChannel::Persistence);
+        joiner
+            .merge_delta(&delta, peer(9), Some(&agent(9)))
+            .expect("no error");
+        assert!(
+            joiner.owner().is_none(),
+            "owner never learned from checkpoint"
+        );
+        assert!(joiner.get("k").is_none());
+    }
+
+    #[test]
+    fn cross_store_checkpoint_replay_rejected() {
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic_a = "store/A";
+        let id_a = KvStoreId::for_topic_owner(topic_a, &owner);
+        let owner_store = KvStore::new(id_a, "A".to_string(), owner, AccessPolicy::Signed);
+        let cp = checkpoint_for(&owner_store, topic_a, &kp, 1);
+        // Replay onto a different store B (different topic -> different id).
+        let id_b = KvStoreId::for_topic_owner("store/B", &owner);
+        let mut delta = KvStoreDelta::new(0);
+        delta.owner_checkpoint = Some(cp);
+        let mut joiner_b =
+            KvStore::new_replica(id_b, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner_b
+            .merge_delta(&delta, peer(9), Some(&agent(9)))
+            .expect("no error");
+        assert_eq!(
+            joiner_b.highest_checkpoint_seq, 0,
+            "cross-store replay rejected"
+        );
+    }
+
+    #[test]
+    fn checkpoint_verify_rejects_forged_owner() {
+        // A checkpoint signed by a rogue key claiming a different owner must
+        // fail verification (owner binding + signature).
+        let owner = agent(1);
+        let rogue_kp = crate::identity::AgentKeypair::generate().expect("rogue keypair");
+        let topic = "store/forged";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+        // Rogue signs a checkpoint whose owner_pubkey is the ROGUE's key.
+        let cp = make_owner_checkpoint(OwnerCheckpointParams {
+            topic,
+            store_id: &id,
+            secret_key: rogue_kp.secret_key(),
+            public_key: rogue_kp.public_key(),
+            policy: &AccessPolicy::Signed,
+            policy_version: 0,
+            checkpoint_seq: 1,
+            content_root: [0u8; 32],
+            timestamp: 0,
+        })
+        .expect("sign");
+        // Verify against the REAL owner -> must fail (rogue pubkey != owner).
+        let err = cp.verify(&owner).expect_err("forged checkpoint rejected");
+        assert!(matches!(err, KvError::OwnerTokenInvalid(_)));
+    }
+
+    #[test]
+    fn owner_returns_advances_high_water_mark() {
+        // After a relay-adopt at seq N, a live owner delta (sender-auth) at a
+        // higher checkpoint seq merges and advances the high-water mark. No
+        // conflict between relay-adopt and live owner writes.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/return";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        owner_store
+            .put(
+                "k".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+        let cp1 = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut relay = owner_store.full_delta();
+        relay.owner_checkpoint = Some(cp1);
+        // Joiner adopts the relay at seq 1.
+        let mut joiner =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner
+            .merge_delta(&relay, peer(9), Some(&agent(9)))
+            .expect("relay adopt");
+        assert_eq!(joiner.highest_checkpoint_seq, 1);
+        // Owner writes a new key, then republishes its FULL state with a
+        // forward checkpoint at seq 2. The joiner re-verifies the owner sig +
+        // content root and adopts, advancing the high-water mark. (An
+        // incremental live delta would merge via sender-auth but not advance
+        // the mark, since the mark reflects root-verified full state.)
+        owner_store
+            .put(
+                "k2".to_string(),
+                b"v2".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+        let cp2 = checkpoint_for(&owner_store, topic, &kp, 2);
+        let mut full2 = owner_store.full_delta();
+        full2.owner_checkpoint = Some(cp2);
+        joiner
+            .merge_delta(&full2, peer(9), Some(&agent(9)))
+            .expect("full relay adopt");
+        assert!(joiner.get("k2").is_some());
+        assert_eq!(joiner.highest_checkpoint_seq, 2);
+    }
+    // ====================================================================
+    // P0/P1 regression suite — owner-checkpoint relay integrity, full-state
+    // reconciliation, and durable high-water mark.
+    //
+    // These target the FIXED contract (v2 content_root binding every adopted
+    // field; content_hash==blake3(value) & outer_key==inner_key enforced
+    // before any mutation; incremental vs full-snapshot reconciliation;
+    // persisted checkpoint epoch). Each fails on the pre-fix tree and passes
+    // only with the complete commitment + full-snapshot reconciliation.
+    // ====================================================================
+
+    /// Deterministic (key, value, content_hash) view of a store's active state,
+    /// sorted by key, so two stores can be compared for EXACT equality
+    /// independent of HashMap iteration order.
+    fn snapshot(s: &KvStore) -> Vec<(String, Vec<u8>, [u8; 32])> {
+        let active = s.active_entries();
+        let mut v: Vec<_> = active
+            .iter()
+            .map(|e| (e.key.clone(), e.value.clone(), e.content_hash))
+            .collect();
+        v.sort_by(|a, b| a.0.cmp(&b.0));
+        v
+    }
+
+    /// Mirror of `Daemon::put_with_delta` + `produce_checkpoint`: perform an
+    /// owner local write, then build the incremental put-delta carrying an
+    /// owner-signed full-state checkpoint at the next sequence — exactly what
+    /// the live sync path publishes.
+    #[allow(clippy::too_many_arguments)]
+    fn owner_put_delta(
+        owner: &mut KvStore,
+        key: &str,
+        value: &[u8],
+        content_type: &str,
+        topic: &str,
+        kp: &crate::identity::AgentKeypair,
+        seq: u64,
+        p: PeerId,
+    ) -> KvStoreDelta {
+        owner
+            .put(key.to_string(), value.to_vec(), content_type.to_string(), p)
+            .expect("owner put");
+        let entry = owner.get(key).cloned().expect("entry readable after put");
+        let version = owner.current_version();
+        let mut delta =
+            KvStoreDelta::for_put(key.to_string(), entry, (p, owner.next_seq()), version);
+        delta.owner_checkpoint = Some(checkpoint_for(owner, topic, kp, seq));
+        // Attach the owner's authoritative name so a fresh replica (name="")
+        // learns it from the incremental delta before maybe_cache_checkpoint
+        // recomputes the root — mirrors the lib.rs put_with_delta fix.
+        delta.name_update = Some(owner.name_register().clone());
+        delta
+    }
+
+    /// Mirror of `Daemon::remove_with_delta` + `produce_checkpoint`: remove a
+    /// key and build the incremental remove-delta carrying an owner-signed
+    /// full-state checkpoint at the next sequence.
+    fn owner_remove_delta(
+        owner: &mut KvStore,
+        key: &str,
+        topic: &str,
+        kp: &crate::identity::AgentKeypair,
+        seq: u64,
+    ) -> KvStoreDelta {
+        owner.remove(key).expect("owner remove");
+        let mut d = KvStoreDelta::new(owner.current_version());
+        d.removed
+            .insert(key.to_string(), std::collections::HashSet::new());
+        d.owner_checkpoint = Some(checkpoint_for(owner, topic, kp, seq));
+        // Attach the owner's authoritative name (mirrors remove_with_delta).
+        d.name_update = Some(owner.name_register().clone());
+        d
+    }
+
+    #[test]
+    fn relay_forgery_per_field_tamper_rejected() {
+        // P0: a non-owner relay copies a valid full-snapshot checkpoint and
+        // mutates a SINGLE field the old content_root did not bind. The v2
+        // commitment (outer+inner key, value, content_hash, content_type,
+        // metadata, timestamps, name) plus the independent
+        // content_hash==blake3(value) / outer_key==inner_key checks must reject
+        // every variant WITHOUT mutating entries, policy, the checkpoint cache,
+        // or the high-water mark. The OR-Set `UniqueTag` is deliberately NOT
+        // bound (it is add/remove bookkeeping, not content provenance, and
+        // removals work by key), so a tag-only tamper is out of scope here.
+        //
+        // The pre-existing `relay_tamper_rejected` test mutated value AND
+        // recomputed content_hash (an honest re-hash); it therefore never
+        // exercised the actual exploit — swapping value while LEAVING
+        // content_hash untouched. This closes that gap and binds the rest.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/forgery";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store = KvStore::new(id, "Legit".to_string(), owner, AccessPolicy::Signed);
+        owner_store
+            .put(
+                "k".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner put");
+        let cp = checkpoint_for(&owner_store, topic, &kp, 1);
+
+        // Legit control: an un-tampered non-owner relay IS adopted. This proves
+        // every rejection below is tamper detection, not the relayer identity.
+        {
+            let mut legit = owner_store.full_delta();
+            legit.owner_checkpoint = Some(cp.clone());
+            let mut j =
+                KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+            j.merge_delta(&legit, peer(9), Some(&agent(9)))
+                .expect("legit adopt");
+            assert!(j.get("k").is_some(), "legit relay must adopt");
+            assert_eq!(j.highest_checkpoint_seq, 1);
+        }
+
+        #[allow(clippy::type_complexity)]
+        let mutators: Vec<(&str, Box<dyn FnOnce(&mut KvStoreDelta)>)> = vec![
+            // The real exploit: swap value, KEEP content_hash unchanged.
+            (
+                "value_swap_unchanged_hash",
+                Box::new(|d| {
+                    d.added.get_mut("k").unwrap().0.value = b"PWNED".to_vec();
+                }),
+            ),
+            (
+                "content_type",
+                Box::new(|d| {
+                    d.added.get_mut("k").unwrap().0.content_type = "evil/x".to_string();
+                }),
+            ),
+            (
+                "metadata",
+                Box::new(|d| {
+                    d.added
+                        .get_mut("k")
+                        .unwrap()
+                        .0
+                        .metadata
+                        .insert("injected".to_string(), "yes".to_string());
+                }),
+            ),
+            (
+                "created_at",
+                Box::new(|d| {
+                    d.added.get_mut("k").unwrap().0.created_at = 0;
+                }),
+            ),
+            (
+                "updated_at",
+                Box::new(|d| {
+                    d.added.get_mut("k").unwrap().0.updated_at = 0;
+                }),
+            ),
+            (
+                "outer_key",
+                Box::new(|d| {
+                    let pair = d.added.remove("k").unwrap();
+                    d.added.insert("k2".to_string(), pair);
+                }),
+            ),
+            (
+                "inner_key",
+                Box::new(|d| {
+                    d.added.get_mut("k").unwrap().0.key = "k2".to_string();
+                }),
+            ),
+            // OR-Set `UniqueTag` is intentionally NOT a case here: it is not
+            // bound by the checkpoint (removals work by key, not tag), so a
+            // tag-only tamper cannot forge owner-attributed content.
+            (
+                "store_name",
+                Box::new(|d| {
+                    d.name_update
+                        .as_mut()
+                        .unwrap()
+                        .set("EVIL".to_string(), peer(9));
+                }),
+            ),
+        ];
+
+        for (name, mutate) in mutators {
+            let mut delta = owner_store.full_delta();
+            delta.owner_checkpoint = Some(cp.clone());
+            mutate(&mut delta);
+
+            let mut joiner =
+                KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+            joiner
+                .merge_delta(&delta, peer(9), Some(&agent(9)))
+                .expect("silent rejection never errors");
+
+            assert!(
+                joiner.get("k").is_none(),
+                "{name}: forged entry not adopted"
+            );
+            assert!(
+                joiner.get("k2").is_none(),
+                "{name}: forged outer-key entry not adopted"
+            );
+            assert!(joiner.entries.is_empty(), "{name}: entries untouched");
+            assert_eq!(
+                *joiner.policy(),
+                AccessPolicy::Signed,
+                "{name}: policy unchanged"
+            );
+            assert!(
+                joiner.latest_checkpoint.is_none(),
+                "{name}: checkpoint cache empty"
+            );
+            assert_eq!(
+                joiner.highest_checkpoint_seq, 0,
+                "{name}: high-water mark unchanged"
+            );
+            assert_ne!(joiner.name(), "EVIL", "{name}: store name not forged");
+        }
+    }
+
+    #[test]
+    fn relay_matches_owner_through_put_update_delete_sequence() {
+        // P0: checkpoint recovery must not break after normal multi-write /
+        // update / delete use. The relay receives the owner's published
+        // incremental deltas (each carrying an owner-signed full-state
+        // checkpoint) and must (a) match the owner's exact state after every
+        // step and (b) cache each checkpoint via maybe_cache_checkpoint.
+        // Pre-fix, an incremental put-delta carried a full-state root that did
+        // not match its single-entry set, so the checkpoint was never cached
+        // and a delete-to-empty short-circuited without applying `removed`.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/relay-exact";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+        let p = peer(1);
+
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut relay =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+
+        let d1 = owner_put_delta(
+            &mut owner_store,
+            "k1",
+            b"v1",
+            "text/plain",
+            topic,
+            &kp,
+            1,
+            p,
+        );
+        relay.merge_delta(&d1, p, Some(&owner)).expect("relay k1");
+        assert_eq!(snapshot(&owner_store), snapshot(&relay), "after k1");
+        assert_eq!(
+            relay.highest_checkpoint_seq, 1,
+            "seq1 caches on a fresh replica (name propagated via the incremental delta)"
+        );
+        assert_eq!(
+            relay.name(),
+            "S",
+            "owner's real name propagated to the fresh replica"
+        );
+
+        let d2 = owner_put_delta(
+            &mut owner_store,
+            "k2",
+            b"v2",
+            "text/plain",
+            topic,
+            &kp,
+            2,
+            p,
+        );
+        relay.merge_delta(&d2, p, Some(&owner)).expect("relay k2");
+        assert_eq!(snapshot(&owner_store), snapshot(&relay), "after k2");
+        assert_eq!(
+            relay.highest_checkpoint_seq, 2,
+            "relay cached cp2 after incremental write (maybe_cache_checkpoint)"
+        );
+
+        let d3 = owner_put_delta(
+            &mut owner_store,
+            "k1",
+            b"v1b",
+            "application/json",
+            topic,
+            &kp,
+            3,
+            p,
+        );
+        relay
+            .merge_delta(&d3, p, Some(&owner))
+            .expect("relay update k1");
+        assert_eq!(snapshot(&owner_store), snapshot(&relay), "after update k1");
+        assert_eq!(relay.highest_checkpoint_seq, 3, "relay cached cp3");
+
+        let d4 = owner_remove_delta(&mut owner_store, "k1", topic, &kp, 4);
+        relay
+            .merge_delta(&d4, p, Some(&owner))
+            .expect("relay delete k1");
+        assert_eq!(snapshot(&owner_store), snapshot(&relay), "after delete k1");
+        assert!(relay.get("k1").is_none());
+        assert_eq!(relay.highest_checkpoint_seq, 4, "relay cached cp4");
+
+        // Delete down to empty — the case where the empty resulting root
+        // matched the empty relayed set and pre-fix short-circuited without
+        // applying `removed`, leaving replicas retaining the deleted key.
+        let d5 = owner_remove_delta(&mut owner_store, "k2", topic, &kp, 5);
+        relay
+            .merge_delta(&d5, p, Some(&owner))
+            .expect("relay delete k2");
+        assert_eq!(snapshot(&owner_store), snapshot(&relay), "after delete k2");
+        assert!(
+            relay.get("k2").is_none(),
+            "delete-to-empty reconciled on the checkpoint path"
+        );
+        assert!(
+            relay.active_entries().is_empty(),
+            "relay is empty, exactly matching the owner"
+        );
+        assert_eq!(relay.highest_checkpoint_seq, 5, "relay cached cp5");
+    }
+
+    #[test]
+    fn offline_anchored_joiner_recovers_multikey_state_from_relay() {
+        // P0: while the owner is offline, a fresh anchored joiner connected only
+        // to a non-owner relay must recover the owner's exact multi-key final
+        // state from the relayed owner checkpoint. Pre-fix, the relay never
+        // cached the post-second-write checkpoint (it held a stale one-key
+        // root), so its full delta's root mismatched the two-key relayed set
+        // and the joiner rejected recovery, ending empty.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/offline-recovery";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+        let p = peer(1);
+
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut relay =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+
+        let d1 = owner_put_delta(
+            &mut owner_store,
+            "k1",
+            b"v1",
+            "text/plain",
+            topic,
+            &kp,
+            1,
+            p,
+        );
+        relay.merge_delta(&d1, p, Some(&owner)).expect("relay k1");
+        let d2 = owner_put_delta(
+            &mut owner_store,
+            "k2",
+            b"v2",
+            "text/plain",
+            topic,
+            &kp,
+            2,
+            p,
+        );
+        relay.merge_delta(&d2, p, Some(&owner)).expect("relay k2");
+        assert_eq!(
+            relay.highest_checkpoint_seq, 2,
+            "relay cached the two-key checkpoint"
+        );
+
+        // Owner offline: only the relay serves a full delta.
+        let relay_full = relay.full_delta();
+        assert!(
+            relay_full.owner_checkpoint.is_some(),
+            "relay carries a cached owner checkpoint for cold recovery"
+        );
+        let mut joiner =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner
+            .merge_delta(&relay_full, peer(9), Some(&agent(9)))
+            .expect("cold-recovery merge");
+
+        assert_eq!(
+            snapshot(&joiner),
+            snapshot(&owner_store),
+            "joiner recovers the exact owner state from the relay"
+        );
+        assert_eq!(joiner.highest_checkpoint_seq, 2);
+    }
+
+    #[test]
+    fn checkpoint_high_water_mark_survives_restart_and_rejects_replay() {
+        // P0 durability: the checkpoint epoch / high-water mark must be durable.
+        // Pre-fix `highest_checkpoint_seq` and `latest_checkpoint` were
+        // `#[serde(skip)]`, so a restart reset them to 0 / None; a replayed
+        // already-adopted checkpoint was then treated as fresh and re-adopted.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/restart-replay";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+        let p = peer(1);
+
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        owner_store
+            .put("k".to_string(), b"v".to_vec(), "text/plain".to_string(), p)
+            .expect("owner put");
+        let cp1 = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut snap1 = owner_store.full_delta();
+        snap1.owner_checkpoint = Some(cp1);
+
+        let mut replica =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        replica
+            .merge_delta(&snap1, peer(9), Some(&agent(9)))
+            .expect("adopt full snapshot");
+        assert_eq!(replica.highest_checkpoint_seq, 1);
+        assert!(replica.latest_checkpoint.is_some());
+        assert!(replica.get("k").is_some());
+
+        // Restart modeled as a durable bincode reload.
+        let bytes = bincode::serialize(&replica).expect("serialize");
+        let mut restarted: KvStore = bincode::deserialize(&bytes).expect("deserialize");
+
+        assert_eq!(
+            restarted.highest_checkpoint_seq, 1,
+            "highest_checkpoint_seq persisted across restart (no longer serde(skip))"
+        );
+        assert!(
+            restarted.latest_checkpoint.is_some(),
+            "latest_checkpoint persisted across restart"
+        );
+
+        // Replay the exact same full snapshot (seq 1): must be a stale no-op.
+        let v_before = restarted.current_version();
+        restarted
+            .merge_delta(&snap1, peer(9), Some(&agent(9)))
+            .expect("no error");
+        assert_eq!(
+            restarted.current_version(),
+            v_before,
+            "replay of already-adopted checkpoint must not mutate after restart"
+        );
+        assert_eq!(restarted.highest_checkpoint_seq, 1);
+
+        // A monotonically newer owner checkpoint still advances the mark.
+        owner_store
+            .put(
+                "k2".to_string(),
+                b"v2".to_vec(),
+                "text/plain".to_string(),
+                p,
+            )
+            .expect("owner put k2");
+        let cp2 = checkpoint_for(&owner_store, topic, &kp, 2);
+        let mut snap2 = owner_store.full_delta();
+        snap2.owner_checkpoint = Some(cp2);
+        restarted
+            .merge_delta(&snap2, peer(9), Some(&agent(9)))
+            .expect("adopt newer");
+        assert_eq!(
+            restarted.highest_checkpoint_seq, 2,
+            "newer checkpoint advances"
+        );
+        assert!(restarted.get("k2").is_some());
     }
 }

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -1166,18 +1166,32 @@ impl KvStore {
                 self.entries.insert(key.clone(), entry.clone());
             }
         }
-        // 8. Apply removals/tombstones — critical for delete-to-empty and
-        //    delete-recovery so a cold-recovering joiner reflects owner
-        //    deletions (the owner relays the post-delete checkpoint alongside
-        //    the removal tombstones). NOTE: a relay-injected `removed` can
-        //    currently truncate a subset of owner-signed state during first
-        //    delivery (contained/self-healing MEDIUM — see docs follow-up); the
-        //    correct fix is full-replace-to-signed-set adoption, not rejecting
-        //    the whole checkpoint (which strands delete-recovery, resurrecting
-        //    deleted keys).
-        for key in delta.removed.keys() {
-            let _ = self.keys.remove(&key.to_string());
-            self.entries.remove(key.as_str());
+        // 8. Full-replace to the owner-signed set. Step 6 proved the relayed
+        //    (added ∪ updated) keys ARE the owner's complete signed state, so
+        //    the store's state after adoption must be EXACTLY that set. Drop any
+        //    local key not in it — that reflects owner deletions on a
+        //    cold-recovering joiner WITHOUT trusting the untrusted `delta.removed`
+        //    field. This is the authoritative full-replace: a relay-injected
+        //    `removed` cannot truncate (it is ignored; the signed set wins), and
+        //    a relay cannot resurrect or hide keys (a stale/mismatched relayed
+        //    set fails step 6 and never reaches here). `delta.removed` is
+        //    deliberately NOT consulted on the checkpoint-adopt path.
+        let signed_keys: std::collections::HashSet<&str> = delta
+            .added
+            .keys()
+            .map(String::as_str)
+            .chain(delta.updated.keys().map(String::as_str))
+            .collect();
+        let stale: Vec<String> = self
+            .keys
+            .elements()
+            .into_iter()
+            .filter(|k| !signed_keys.contains(k.as_str()))
+            .cloned()
+            .collect();
+        for key in stale {
+            let _ = self.keys.remove(&key);
+            self.entries.remove(&key);
         }
         // 9. Apply name update.
         if let Some(name_register) = &delta.name_update {
@@ -2172,6 +2186,101 @@ mod tests {
             .expect("checkpoint-gated merge");
         assert!(joiner.get("k").is_some(), "adopted relayed owner content");
         assert_eq!(joiner.highest_checkpoint_seq, 1);
+    }
+
+    #[test]
+    fn full_replace_ignores_relay_injected_removed() {
+        // A non-owner relay copies the owner's valid full-snapshot checkpoint of
+        // {k} and injects removed={k}. The full-replace adopt path IGNORES the
+        // untrusted `delta.removed` — the owner-signed set {k} is authoritative —
+        // so the injection cannot truncate the joiner's recovered state.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/inject";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        owner_store
+            .put(
+                "k".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+        let cp = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut delta = owner_store.full_delta();
+        delta.owner_checkpoint = Some(cp);
+        let mut tags = std::collections::HashSet::new();
+        tags.insert((peer(9), 1));
+        delta.removed.insert("k".to_string(), tags);
+
+        let mut joiner =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner
+            .merge_delta(&delta, peer(9), Some(&agent(9)))
+            .expect("merge");
+        assert!(
+            joiner.get("k").is_some(),
+            "injected removed must not truncate the owner-signed set"
+        );
+        assert_eq!(joiner.highest_checkpoint_seq, 1, "checkpoint adopted");
+    }
+
+    #[test]
+    fn full_replace_drops_keys_absent_from_newer_checkpoint() {
+        // A replica holding {k1,k2} (from a seq-1 checkpoint) adopts a NEWER
+        // seq-2 checkpoint whose signed set is {k1} — the owner deleted k2.
+        // Full-replace drops k2; it is NOT resurrected. Proves checkpoint
+        // adoption is authoritative full-state, not additive (the exact
+        // delete-recovery invariant the soak's owner_offline gate exercises).
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/delrec";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        owner_store
+            .put(
+                "k1".to_string(),
+                b"a".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put k1");
+        owner_store
+            .put(
+                "k2".to_string(),
+                b"b".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put k2");
+        let cp1 = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut d1 = owner_store.full_delta();
+        d1.owner_checkpoint = Some(cp1);
+        let mut joiner =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner
+            .merge_delta(&d1, peer(9), Some(&agent(9)))
+            .expect("adopt cp1");
+        assert!(
+            joiner.get("k1").is_some() && joiner.get("k2").is_some(),
+            "joiner recovered both keys from cp1"
+        );
+
+        // Owner deletes k2 and cuts a newer checkpoint over {k1}.
+        owner_store.remove("k2").expect("delete k2");
+        let cp2 = checkpoint_for(&owner_store, topic, &kp, 2);
+        let mut d2 = owner_store.full_delta();
+        d2.owner_checkpoint = Some(cp2);
+        joiner
+            .merge_delta(&d2, peer(9), Some(&agent(9)))
+            .expect("adopt cp2");
+        assert!(joiner.get("k1").is_some(), "k1 survives");
+        assert!(
+            joiner.get("k2").is_none(),
+            "k2 dropped by full-replace, not resurrected"
+        );
+        assert_eq!(joiner.highest_checkpoint_seq, 2);
     }
 
     #[test]

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -1116,21 +1116,6 @@ impl KvStore {
         if cp.checkpoint_seq <= self.highest_checkpoint_seq {
             return false; // stale replay — ignore, fall through
         }
-        // 4b. Reject injected removals. The signed `content_root` binds only the
-        //     surviving (added+updated) set, NOT `delta.removed`. An honest
-        //     full-state relay never carries removals (`full_delta` populates
-        //     only `added`), so a non-empty `removed` here is a relay injecting
-        //     deletions the owner never signed — which would silently truncate a
-        //     cold-recovering joiner's state. Fail closed and fall through to the
-        //     sender-auth path (which requires owner authorization for a Signed
-        //     store), so the injection is rejected outright.
-        if !delta.removed.is_empty() {
-            tracing::warn!(
-                "rejected owner checkpoint with injected removals for store {}",
-                self.id
-            );
-            return false;
-        }
         // 5. Validate every relayed entry's integrity before any mutation.
         //    Fail-closed: a single malformed/inconsistent entry rejects the
         //    entire checkpoint adoption.
@@ -1181,10 +1166,15 @@ impl KvStore {
                 self.entries.insert(key.clone(), entry.clone());
             }
         }
-        // 8. Apply removals/tombstones. Guaranteed empty here by gate 4b (a
-        //    full-state checkpoint never carries removals); retained as a
-        //    defensive no-op so the loop is correct if that invariant ever
-        //    changes. Legitimate deletions replicate via the sender-auth path.
+        // 8. Apply removals/tombstones — critical for delete-to-empty and
+        //    delete-recovery so a cold-recovering joiner reflects owner
+        //    deletions (the owner relays the post-delete checkpoint alongside
+        //    the removal tombstones). NOTE: a relay-injected `removed` can
+        //    currently truncate a subset of owner-signed state during first
+        //    delivery (contained/self-healing MEDIUM — see docs follow-up); the
+        //    correct fix is full-replace-to-signed-set adoption, not rejecting
+        //    the whole checkpoint (which strands delete-recovery, resurrecting
+        //    deleted keys).
         for key in delta.removed.keys() {
             let _ = self.keys.remove(&key.to_string());
             self.entries.remove(key.as_str());
@@ -2579,61 +2569,6 @@ mod tests {
             );
             assert_ne!(joiner.name(), "EVIL", "{name}: store name not forged");
         }
-    }
-
-    #[test]
-    fn relay_injected_removed_key_cannot_truncate_recovery() {
-        // MEDIUM: `content_root` binds only the surviving (added+updated) set,
-        // not `delta.removed`. A non-owner relay takes the owner's valid
-        // full-snapshot checkpoint and injects `removed = {k}` for a key that IS
-        // in `added`. Without gate 4b the adopt path would add `k` then delete
-        // it, leaving the cold-recovering joiner with a silently truncated
-        // subset of owner-signed state (a relay privilege escalation). The gate
-        // must reject the adoption entirely and leave the joiner unmutated so it
-        // falls through to sender-auth (which a non-owner relay cannot satisfy).
-        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
-        let owner = kp.agent_id();
-        let topic = "store/removed-injection";
-        let id = KvStoreId::for_topic_owner(topic, &owner);
-
-        let mut owner_store = KvStore::new(id, "Legit".to_string(), owner, AccessPolicy::Signed);
-        owner_store
-            .put(
-                "k".to_string(),
-                b"v".to_vec(),
-                "text/plain".to_string(),
-                peer(1),
-            )
-            .expect("owner put");
-        let cp = checkpoint_for(&owner_store, topic, &kp, 1);
-
-        let mut delta = owner_store.full_delta();
-        delta.owner_checkpoint = Some(cp);
-        // Inject a deletion the owner never signed.
-        let mut tags = std::collections::HashSet::new();
-        tags.insert((peer(9), 1));
-        delta.removed.insert("k".to_string(), tags);
-
-        let mut joiner =
-            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
-        joiner
-            .merge_delta(&delta, peer(9), Some(&agent(9)))
-            .expect("silent rejection never errors");
-
-        // Adoption rejected: the joiner adopts neither the add nor the injected
-        // removal — it stays empty rather than converging to a truncated subset.
-        assert!(
-            joiner.entries.is_empty(),
-            "injected removal must reject the whole adoption, not truncate"
-        );
-        assert_eq!(
-            joiner.highest_checkpoint_seq, 0,
-            "high-water mark unchanged after rejected adoption"
-        );
-        assert!(
-            joiner.latest_checkpoint.is_none(),
-            "checkpoint cache empty after rejected adoption"
-        );
     }
 
     #[test]

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -1083,6 +1083,21 @@ impl KvStore {
         if cp.checkpoint_seq <= self.highest_checkpoint_seq {
             return false; // stale replay — ignore, fall through
         }
+        // 4b. Reject injected removals. The signed `content_root` binds only the
+        //     surviving (added+updated) set, NOT `delta.removed`. An honest
+        //     full-state relay never carries removals (`full_delta` populates
+        //     only `added`), so a non-empty `removed` here is a relay injecting
+        //     deletions the owner never signed — which would silently truncate a
+        //     cold-recovering joiner's state. Fail closed and fall through to the
+        //     sender-auth path (which requires owner authorization for a Signed
+        //     store), so the injection is rejected outright.
+        if !delta.removed.is_empty() {
+            tracing::warn!(
+                "rejected owner checkpoint with injected removals for store {}",
+                self.id
+            );
+            return false;
+        }
         // 5. Validate every relayed entry's integrity before any mutation.
         //    Fail-closed: a single malformed/inconsistent entry rejects the
         //    entire checkpoint adoption.
@@ -1133,8 +1148,10 @@ impl KvStore {
                 self.entries.insert(key.clone(), entry.clone());
             }
         }
-        // 8. Apply removals/tombstones — critical for delete-to-empty so the
-        //    checkpoint path does not return early without removing keys.
+        // 8. Apply removals/tombstones. Guaranteed empty here by gate 4b (a
+        //    full-state checkpoint never carries removals); retained as a
+        //    defensive no-op so the loop is correct if that invariant ever
+        //    changes. Legitimate deletions replicate via the sender-auth path.
         for key in delta.removed.keys() {
             let _ = self.keys.remove(&key.to_string());
             self.entries.remove(key.as_str());
@@ -2454,6 +2471,61 @@ mod tests {
             );
             assert_ne!(joiner.name(), "EVIL", "{name}: store name not forged");
         }
+    }
+
+    #[test]
+    fn relay_injected_removed_key_cannot_truncate_recovery() {
+        // MEDIUM: `content_root` binds only the surviving (added+updated) set,
+        // not `delta.removed`. A non-owner relay takes the owner's valid
+        // full-snapshot checkpoint and injects `removed = {k}` for a key that IS
+        // in `added`. Without gate 4b the adopt path would add `k` then delete
+        // it, leaving the cold-recovering joiner with a silently truncated
+        // subset of owner-signed state (a relay privilege escalation). The gate
+        // must reject the adoption entirely and leave the joiner unmutated so it
+        // falls through to sender-auth (which a non-owner relay cannot satisfy).
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/removed-injection";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store = KvStore::new(id, "Legit".to_string(), owner, AccessPolicy::Signed);
+        owner_store
+            .put(
+                "k".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner put");
+        let cp = checkpoint_for(&owner_store, topic, &kp, 1);
+
+        let mut delta = owner_store.full_delta();
+        delta.owner_checkpoint = Some(cp);
+        // Inject a deletion the owner never signed.
+        let mut tags = std::collections::HashSet::new();
+        tags.insert((peer(9), 1));
+        delta.removed.insert("k".to_string(), tags);
+
+        let mut joiner =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner
+            .merge_delta(&delta, peer(9), Some(&agent(9)))
+            .expect("silent rejection never errors");
+
+        // Adoption rejected: the joiner adopts neither the add nor the injected
+        // removal — it stays empty rather than converging to a truncated subset.
+        assert!(
+            joiner.entries.is_empty(),
+            "injected removal must reject the whole adoption, not truncate"
+        );
+        assert_eq!(
+            joiner.highest_checkpoint_seq, 0,
+            "high-water mark unchanged after rejected adoption"
+        );
+        assert!(
+            joiner.latest_checkpoint.is_none(),
+            "checkpoint cache empty after rejected adoption"
+        );
     }
 
     #[test]

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -5,6 +5,8 @@
 
 use crate::gossip::wire::{decode_delta, encode_delta};
 use crate::gossip::PubSubManager;
+use crate::identity::AgentId;
+use crate::kv::store::AccessPolicy;
 use crate::kv::{KvStore, KvStoreDelta, Result};
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
@@ -24,11 +26,31 @@ const STATE_SYNC_TOPIC_SUFFIX: &str = "/state-sync";
 const STATE_REQUEST_RETRY_SECS: [u64; 4] = [1, 5, 15, 30];
 
 /// Message exchanged on the state-sync side topic.
+///
+/// Wire compatibility: `StateRequest` keeps its variant index and shape, so
+/// v0.30.1 peers decode it unchanged. Older peers receiving the newer
+/// `OwnerAnnounce` variant fail to deserialize it and skip the message
+/// (their receive loop tolerates undecodable payloads), so the addition is
+/// purely additive.
 #[derive(Debug, Serialize, Deserialize)]
 enum KvSyncMessage {
     /// A peer with no local state for the store asks holders to republish
     /// their full state (as a regular delta) on the main topic.
     StateRequest { requester: PeerId },
+    /// The store owner's self-attestation of the store's authoritative
+    /// metadata, published in response to a `StateRequest`.
+    ///
+    /// Trust model: the pub/sub layer verifies the ML-DSA-65 signature of
+    /// every delivered v2 message and exposes the verified sender `AgentId`.
+    /// Receivers accept this announcement only when that verified sender IS
+    /// the claimed `owner` — an owner can only attest to its own stores, and
+    /// no third party can assign ownership.
+    OwnerAnnounce {
+        /// The owning agent (must equal the verified message sender).
+        owner: AgentId,
+        /// The store's access policy as set by the owner.
+        policy: AccessPolicy,
+    },
 }
 
 /// Synchronization wrapper for a KvStore.
@@ -48,6 +70,11 @@ pub struct KvStoreSync {
     /// This node's gossip peer id — identifies our deltas and state
     /// requests on the wire.
     local_peer_id: PeerId,
+
+    /// This node's agent id, when known. Used to decide whether this node
+    /// is the store owner (and should answer state requests with an
+    /// [`KvSyncMessage::OwnerAnnounce`]) and to ignore its own announces.
+    local_agent_id: Option<AgentId>,
 }
 
 impl KvStoreSync {
@@ -59,11 +86,15 @@ impl KvStoreSync {
     /// * `pubsub` - Pub/sub manager for gossip messaging.
     /// * `topic` - Topic name for pub/sub.
     /// * `local_peer_id` - This node's gossip peer id.
+    /// * `local_agent_id` - This node's agent id, if available. Required for
+    ///   the owner to answer state requests with an ownership announcement;
+    ///   `None` disables announcing (joined replicas can still adopt).
     pub fn new(
         store: KvStore,
         pubsub: Arc<PubSubManager>,
         topic: String,
         local_peer_id: PeerId,
+        local_agent_id: Option<AgentId>,
     ) -> Result<Self> {
         let store = Arc::new(RwLock::new(store));
 
@@ -72,6 +103,7 @@ impl KvStoreSync {
             pubsub,
             topic,
             local_peer_id,
+            local_agent_id,
         })
     }
 
@@ -133,41 +165,116 @@ impl KvStoreSync {
             }
         }));
 
-        // Responder: holders with non-empty state answer StateRequests by
-        // republishing their full state as a regular delta on the main
-        // topic. CRDT merge makes duplicate responses from multiple
-        // holders harmless (idempotent), so no response suppression is
-        // needed at current mesh sizes.
+        // Responder + ownership listener on the state-sync side topic.
+        //
+        // StateRequest: holders with non-empty state answer by republishing
+        // their full state as a regular delta on the main topic. CRDT merge
+        // makes duplicate responses from multiple holders harmless
+        // (idempotent), so no response suppression is needed at current mesh
+        // sizes. Additionally, if this node is the store OWNER it publishes
+        // an OwnerAnnounce (regardless of emptiness) so joined replicas can
+        // learn the authoritative owner and policy.
+        //
+        // OwnerAnnounce: a replica with an unknown owner adopts the owner
+        // and policy — but only when the announcement's pub/sub-verified
+        // sender is the claimed owner itself (see KvSyncMessage docs).
         let mut sync_sub = self.pubsub.subscribe(self.state_sync_topic()).await;
         let responder_store = Arc::clone(&self.store);
         let responder_pubsub = Arc::clone(&self.pubsub);
         let responder_topic = self.topic.clone();
+        let sync_topic = self.state_sync_topic();
         let local_peer_id = self.local_peer_id;
+        let local_agent_id = self.local_agent_id;
         spawn(Box::pin(async move {
             while let Some(msg) = sync_sub.recv().await {
-                let Ok(KvSyncMessage::StateRequest { requester }) =
-                    bincode::deserialize::<KvSyncMessage>(&msg.payload)
-                else {
+                let Ok(sync_msg) = bincode::deserialize::<KvSyncMessage>(&msg.payload) else {
                     continue;
                 };
-                if requester == local_peer_id {
-                    continue;
-                }
-                let full = {
-                    let s = responder_store.read().await;
-                    if s.is_empty() {
-                        continue;
+                match sync_msg {
+                    KvSyncMessage::StateRequest { requester } => {
+                        if requester == local_peer_id {
+                            continue;
+                        }
+                        // Owner: announce authoritative metadata so the
+                        // requester can adopt owner + policy.
+                        let announce = {
+                            let s = responder_store.read().await;
+                            match (local_agent_id, s.owner()) {
+                                (Some(me), Some(owner)) if me == *owner => {
+                                    Some(KvSyncMessage::OwnerAnnounce {
+                                        owner: me,
+                                        policy: s.policy().clone(),
+                                    })
+                                }
+                                _ => None,
+                            }
+                        };
+                        if let Some(announce) = announce {
+                            match bincode::serialize(&announce) {
+                                Ok(serialized) => {
+                                    if let Err(e) = responder_pubsub
+                                        .publish(sync_topic.clone(), bytes::Bytes::from(serialized))
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "KvStore owner-announce publish failed: {e}"
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!("KvStore owner-announce serialize failed: {e}");
+                                }
+                            }
+                        }
+                        let full = {
+                            let s = responder_store.read().await;
+                            if s.is_empty() {
+                                continue;
+                            }
+                            s.full_delta()
+                        };
+                        let Ok(serialized) = encode_delta(local_peer_id, &full) else {
+                            continue;
+                        };
+                        if let Err(e) = responder_pubsub
+                            .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
+                            .await
+                        {
+                            tracing::warn!("KvStore state-response publish failed: {e}");
+                        }
                     }
-                    s.full_delta()
-                };
-                let Ok(serialized) = encode_delta(local_peer_id, &full) else {
-                    continue;
-                };
-                if let Err(e) = responder_pubsub
-                    .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
-                    .await
-                {
-                    tracing::warn!("KvStore state-response publish failed: {e}");
+                    KvSyncMessage::OwnerAnnounce { owner, policy } => {
+                        // Only a signature-verified sender is trusted; the
+                        // pub/sub layer drops signed messages that fail
+                        // verification, so `sender: Some(..)` is verified.
+                        let Some(sender) = msg.sender else {
+                            tracing::warn!(
+                                "ignoring unsigned KvStore ownership announcement on {}",
+                                msg.topic
+                            );
+                            continue;
+                        };
+                        if local_agent_id.is_some_and(|me| me == sender) {
+                            continue; // our own announce echoed back
+                        }
+                        let mut s = responder_store.write().await;
+                        match s.learn_ownership(owner, policy, &sender) {
+                            Ok(()) => {
+                                tracing::info!(
+                                    "KvStore {} adopted owner {} (policy {})",
+                                    s.id(),
+                                    hex::encode(owner.as_bytes()),
+                                    s.policy()
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "rejected KvStore ownership announcement from {}: {e}",
+                                    hex::encode(sender.as_bytes())
+                                );
+                            }
+                        }
+                    }
                 }
             }
         }));
@@ -283,7 +390,8 @@ mod tests {
         let node = make_node().await;
         let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
         let store = KvStore::new(store_id(1), "Test".to_string(), agent(1), policy);
-        KvStoreSync::new(store, pubsub, topic.to_string(), peer(1)).expect("kv sync")
+        KvStoreSync::new(store, pubsub, topic.to_string(), peer(1), Some(agent(1)))
+            .expect("kv sync")
     }
 
     /// Build a `KvStoreSync` that shares its pubsub with the caller (so the
@@ -295,8 +403,14 @@ mod tests {
         let node = make_node().await;
         let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
         let store = KvStore::new(store_id(1), "Test".to_string(), agent(1), policy);
-        let sync = KvStoreSync::new(store, Arc::clone(&pubsub), topic.to_string(), peer(1))
-            .expect("kv sync");
+        let sync = KvStoreSync::new(
+            store,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(agent(1)),
+        )
+        .expect("kv sync");
         (sync, pubsub)
     }
 

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -42,14 +42,22 @@ enum KvSyncMessage {
     ///
     /// Trust model: the pub/sub layer verifies the ML-DSA-65 signature of
     /// every delivered v2 message and exposes the verified sender `AgentId`.
-    /// Receivers accept this announcement only when that verified sender IS
-    /// the claimed `owner` — an owner can only attest to its own stores, and
-    /// no third party can assign ownership.
+    /// The verified sender must equal the claimed `owner` — an owner can only
+    /// attest to its own stores, and no third party can assign ownership.
+    ///
+    /// **Ownership is never established from this message.** A receiver's
+    /// owner is anchored only at construction (see `KvStore::new_replica`).
+    /// The announce can solely refresh policy (when the owner matches AND
+    /// `policy_version` is strictly newer, blocking a replayed stale announce
+    /// from downgrading policy) or record a conflict.
     OwnerAnnounce {
         /// The owning agent (must equal the verified message sender).
         owner: AgentId,
         /// The store's access policy as set by the owner.
         policy: AccessPolicy,
+        /// Monotonic freshness counter — a refresh applies only when this is
+        /// strictly greater than the receiver's current `policy_version`.
+        policy_version: u64,
     },
 }
 
@@ -144,9 +152,25 @@ impl KvStoreSync {
     {
         let mut sub = self.pubsub.subscribe(self.topic.clone()).await;
         let store = Arc::clone(&self.store);
+        // Capture emptiness BEFORE any listener can merge a cached delta.
+        // Otherwise a partial cache replay landing between subscribe and this
+        // check would make the store non-empty and skip the bootstrap
+        // state-request schedule — aged/pruned keys would never arrive.
+        let bootstrap_needed = store.read().await.is_empty();
+        // Defense in depth against cross-topic replay: the v2 signature covers
+        // the embedded topic, but pub/sub delivery does not re-check it against
+        // this subscription, so a raw-mesh participant could place a valid
+        // owner-signed envelope from store A under topic B. Each listener binds
+        // to the exact topic it subscribed to.
+        let main_topic = self.topic.clone();
 
         spawn(Box::pin(async move {
             while let Some(msg) = sub.recv().await {
+                if msg.topic != main_topic {
+                    // Cross-topic replay defense: ignore envelopes not on our
+                    // subscribed topic (see start_with_spawner).
+                    continue;
+                }
                 let decoded = decode_delta::<KvStoreDelta>(&msg.payload);
                 match decoded {
                     Ok((peer_id, delta)) => {
@@ -187,6 +211,10 @@ impl KvStoreSync {
         let local_agent_id = self.local_agent_id;
         spawn(Box::pin(async move {
             while let Some(msg) = sync_sub.recv().await {
+                if msg.topic != sync_topic {
+                    // Cross-topic replay defense (see start_with_spawner).
+                    continue;
+                }
                 let Ok(sync_msg) = bincode::deserialize::<KvSyncMessage>(&msg.payload) else {
                     continue;
                 };
@@ -195,8 +223,10 @@ impl KvStoreSync {
                         if requester == local_peer_id {
                             continue;
                         }
-                        // Owner: announce authoritative metadata so the
-                        // requester can adopt owner + policy.
+                        // Owner: announce authoritative metadata so anchored
+                        // joiners can refresh policy / confirm ownership.
+                        // (Ownership itself is never learned from this — a
+                        // joiner anchors its owner at construction.)
                         let announce = {
                             let s = responder_store.read().await;
                             match (local_agent_id, s.owner()) {
@@ -204,6 +234,7 @@ impl KvStoreSync {
                                     Some(KvSyncMessage::OwnerAnnounce {
                                         owner: me,
                                         policy: s.policy().clone(),
+                                        policy_version: s.policy_version(),
                                     })
                                 }
                                 _ => None,
@@ -243,7 +274,11 @@ impl KvStoreSync {
                             tracing::warn!("KvStore state-response publish failed: {e}");
                         }
                     }
-                    KvSyncMessage::OwnerAnnounce { owner, policy } => {
+                    KvSyncMessage::OwnerAnnounce {
+                        owner,
+                        policy,
+                        policy_version,
+                    } => {
                         // Only a signature-verified sender is trusted; the
                         // pub/sub layer drops signed messages that fail
                         // verification, so `sender: Some(..)` is verified.
@@ -258,13 +293,17 @@ impl KvStoreSync {
                             continue; // our own announce echoed back
                         }
                         let mut s = responder_store.write().await;
-                        match s.learn_ownership(owner, policy, &sender) {
+                        // learn_ownership can only refresh policy (when the
+                        // owner matches and policy_version is forward) or
+                        // record a conflict; it never establishes ownership.
+                        match s.learn_ownership(owner, policy, policy_version, &sender) {
                             Ok(()) => {
                                 tracing::info!(
-                                    "KvStore {} adopted owner {} (policy {})",
+                                    "KvStore {} processed owner announce from {} (policy {}, version {})",
                                     s.id(),
                                     hex::encode(owner.as_bytes()),
-                                    s.policy()
+                                    s.policy(),
+                                    s.policy_version()
                                 );
                             }
                             Err(e) => {
@@ -290,7 +329,7 @@ impl KvStoreSync {
         // full-delta responses they trigger are idempotent CRDT merges,
         // so the extra chatter is bounded and harmless. A creator of a
         // genuinely new store also sends these — nobody answers.
-        if self.store.read().await.is_empty() {
+        if bootstrap_needed {
             let requester_pubsub = Arc::clone(&self.pubsub);
             let sync_topic = self.state_sync_topic();
             spawn(Box::pin(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6518,9 +6518,14 @@ impl Agent {
                 // PlumTree topic trees once the QUIC connection is established.
                 if announcement.agent_id != own_agent_id
                     && !auto_connect_addresses.is_empty()
-                    && !auto_connect_attempted.contains(&announcement.agent_id)
+                    && (!auto_connect_attempted.contains(&announcement.agent_id)
+                        || (if let Some(net) = &network {
+                            !net.is_connected(&ant_quic::PeerId(announcement.machine_id.0)).await
+                        } else {
+                            false
+                        }))
                 {
-                    if let Some(ref net) = &network {
+                    if let Some(net) = &network {
                         let ant_peer = ant_quic::PeerId(announcement.machine_id.0);
                         if !net.is_connected(&ant_peer).await {
                             auto_connect_attempted.insert(announcement.agent_id);
@@ -7574,14 +7579,30 @@ impl Agent {
         match subject {
             revocation::RevokedSubject::Agent(agent_id) => {
                 // Remove from identity cache, which also starves the verified annotation.
-                let mut cache = self.identity_discovery_cache.write().await;
-                if let Some(entry) = cache.remove(agent_id) {
+                let revoked_machine = {
+                    let mut cache = self.identity_discovery_cache.write().await;
+                    let m = cache.remove(agent_id).map(|entry| entry.machine_id);
+                    drop(cache);
+                    m
+                };
+                if let Some(machine_id) = revoked_machine {
                     // Also evict the linked machine so it cannot be dialed.
-                    drop(cache);
                     let mut mcache = self.machine_discovery_cache.write().await;
-                    mcache.remove(&entry.machine_id);
-                } else {
-                    drop(cache);
+                    mcache.remove(&machine_id);
+                    drop(mcache);
+                    // Suppress redial and tear down any live connection to the
+                    // revoked machine (final review P1: never redial
+                    // revocation). disconnect_with_reason records the tombstone
+                    // regardless of connect state, so a later transport close
+                    // or stale lifecycle Closed cannot redial it either.
+                    if let Some(net) = &self.network {
+                        let _ = net
+                            .disconnect_with_reason(
+                                &ant_quic::PeerId(machine_id.0),
+                                network::DisconnectReason::Revocation,
+                            )
+                            .await;
+                    }
                 }
                 // Best-effort: mark as Blocked in the contact store so that
                 // trust evaluation also refuses the agent on any late-arriving path.
@@ -7601,6 +7622,18 @@ impl Agent {
                 // Also evict any agents linked to this machine.
                 let mut cache = self.identity_discovery_cache.write().await;
                 cache.retain(|_, agent| agent.machine_id != *machine_id);
+                drop(cache);
+                // Suppress redial and tear down any live connection (final
+                // review P1: never redial revocation). The tombstone is set
+                // inside disconnect_with_reason regardless of connect state.
+                if let Some(net) = &self.network {
+                    let _ = net
+                        .disconnect_with_reason(
+                            &ant_quic::PeerId(machine_id.0),
+                            network::DisconnectReason::Revocation,
+                        )
+                        .await;
+                }
                 tracing::info!(
                     machine = %hex::encode(machine_id.as_bytes()),
                     "evicted revoked machine from discovery cache"
@@ -8034,7 +8067,12 @@ impl Agent {
         let lifecycle_dm = std::sync::Arc::clone(&dm);
         let event_token = self.shutdown_token.clone();
         let lifecycle_token = self.shutdown_token.clone();
-
+        let machine_cache = std::sync::Arc::clone(&self.machine_discovery_cache);
+        let active_reconnects: ReconnectTracker =
+            std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        // Clones for the lifecycle watcher task (Task 1 moves the originals).
+        let lifecycle_machine_cache = std::sync::Arc::clone(&machine_cache);
+        let lifecycle_reconnects = std::sync::Arc::clone(&active_reconnects);
         self.spawn_tracked(async move {
             let mut rx = network.subscribe();
             tracing::info!("Network event reconciliation listener started");
@@ -8072,8 +8110,15 @@ impl Agent {
                         if let Some(agent_id) = agent_id {
                             dm.mark_connected(agent_id, machine_id).await;
                         }
+                        // Cancel any pending proactive reconnect for this peer
+                        // — the connection is back, no need to keep trying.
+                        if let Ok(mut tracker) = active_reconnects.lock() {
+                            if let Some(handle) = tracker.remove(&peer_id) {
+                                handle.abort();
+                            }
+                        }
                     }
-                    network::NetworkEvent::PeerDisconnected { peer_id } => {
+                    network::NetworkEvent::PeerDisconnected { peer_id, reason } => {
                         let machine_id = identity::MachineId(peer_id);
                         let cached_agent_id = {
                             let cache = cache.read().await;
@@ -8088,6 +8133,22 @@ impl Agent {
                         };
                         if let Some(agent_id) = agent_id {
                             dm.mark_disconnected(&agent_id).await;
+                        }
+                        // Schedule a bounded backoff reconnect only for
+                        // transport-level disconnects (idle timeout, remote
+                        // daemon restart, network failure). Policy rejection,
+                        // pool eviction, admin teardown, revocation, and
+                        // shutdown carry a non-transport reason and must never
+                        // be redialed — otherwise proactive reconnect undoes a
+                        // security/eviction decision (final review P1).
+                        if reason.reconnect_eligible() {
+                            schedule_reconnect(
+                                std::sync::Arc::clone(&network),
+                                std::sync::Arc::clone(&machine_cache),
+                                event_token.clone(),
+                                peer_id,
+                                std::sync::Arc::clone(&active_reconnects),
+                            );
                         }
                     }
                     _ => {}
@@ -8136,6 +8197,28 @@ impl Agent {
                             Some(generation),
                             format!("closed: {reason}"),
                         );
+                        // Transport-level close (e.g. remote daemon restart, QUIC
+                        // idle timeout). Schedule a bounded backoff reconnect so
+                        // a known/mDNS-discovered peer is re-dialed without
+                        // waiting for a new external trigger. This is the
+                        // primary fix for the post-restart transport failure.
+                        //
+                        // A non-transport disconnect (policy rejection, LRU/idle
+                        // eviction, admin, revocation) records a suppression
+                        // tombstone *before* it closes the connection, so the
+                        // `Closed` event fired by that close must not redial —
+                        // this is the second event stream the review flagged.
+                        // Genuine transport closes leave no tombstone and are
+                        // reconnect-eligible (the named-node restart path).
+                        if !lifecycle_network.is_reconnect_suppressed(peer_id.0) {
+                            schedule_reconnect(
+                                std::sync::Arc::clone(&lifecycle_network),
+                                std::sync::Arc::clone(&lifecycle_machine_cache),
+                                lifecycle_token.clone(),
+                                peer_id.0,
+                                std::sync::Arc::clone(&lifecycle_reconnects),
+                            );
+                        }
                     }
                     ant_quic::PeerLifecycleEvent::ReaderExited { generation } => {
                         tracing::debug!(
@@ -8999,6 +9082,10 @@ impl Agent {
             sync,
             agent_id: self.agent_id(),
             peer_id,
+            replica_epoch: TaskListHandle::fresh_epoch(),
+            signing: std::sync::Arc::new(gossip::SigningContext::from_keypair(
+                self.identity.agent_keypair(),
+            )),
         })
     }
 
@@ -9063,8 +9150,223 @@ impl Agent {
             sync,
             agent_id: self.agent_id(),
             peer_id,
+            replica_epoch: TaskListHandle::fresh_epoch(),
+            signing: std::sync::Arc::new(gossip::SigningContext::from_keypair(
+                self.identity.agent_keypair(),
+            )),
         })
     }
+}
+
+// ─── Proactive peer reconnect (post-disconnect / post-restart) ──────────────
+
+/// Exponential backoff delays for proactive reconnect attempts after a known
+/// peer disconnects. Each delay is the wait *before* the attempt, so the first
+/// attempt fires after 1 s — fast enough for a daemon restart on the same host
+/// while avoiding a tight retry loop on a genuinely-down peer.
+const RECONNECT_BACKOFF_DELAYS: &[std::time::Duration] = &[
+    std::time::Duration::from_secs(1),
+    std::time::Duration::from_secs(2),
+    std::time::Duration::from_secs(4),
+    std::time::Duration::from_secs(8),
+    std::time::Duration::from_secs(16),
+];
+
+/// Type alias for the single-flight reconnect tracker shared between the
+/// network-event listener and the peer-lifecycle watcher.
+type ReconnectTracker = std::sync::Arc<
+    std::sync::Mutex<std::collections::HashMap<[u8; 32], tokio::task::JoinHandle<()>>>,
+>;
+
+/// Schedule a bounded, backoff reconnect for a peer that just disconnected.
+///
+/// This closes the gap identified in the post-restart transport failure: when a
+/// known/mDNS-discovered peer's direct QUIC connection drops (daemon restart,
+/// transport idle timeout), x0x previously observed the disconnect and did
+/// nothing — no redial. CRDT state requests then exhausted against a peer that
+/// was still mDNS-visible.
+///
+/// The spawned task:
+/// - Tries **discovery-cache addresses** first (these include LAN/loopback
+///   when `allow_local_scope`, which the public-only bootstrap cache drops).
+/// - Falls back to **bootstrap-cache addresses** via `connect_cached_peer`.
+///   The bootstrap cache retains the raw connection address (including
+///   LAN/loopback) from every successful connect/accept, so Phase 2 covers
+///   the default global-bootstrap config where `allow_local_scope=FALSE`
+///   filters loopback out of the discovery cache (CR-HOST-1).
+/// - Self-cancels when the peer reconnects (checked via `is_connected` on each
+///   attempt) or when the shutdown token fires.
+/// - Is **single-flight** per peer: only one reconnect task runs at a time,
+///   tracked in `active_reconnects`. A `PeerConnected` event aborts the pending
+///   task.
+/// - Is **bounded** to `RECONNECT_BACKOFF_DELAYS.len()` attempts with
+///   exponential backoff, preventing reconnect storms.
+fn schedule_reconnect(
+    network: std::sync::Arc<network::NetworkNode>,
+    machine_cache: std::sync::Arc<
+        tokio::sync::RwLock<std::collections::HashMap<identity::MachineId, DiscoveredMachine>>,
+    >,
+    shutdown_token: tokio_util::sync::CancellationToken,
+    peer_id_bytes: [u8; 32],
+    active_reconnects: ReconnectTracker,
+) {
+    // Single-flight: hold the lock across check + spawn + insert so two
+    // concurrent callers cannot both start a reconnect for the same peer.
+    let mut tracker = match active_reconnects.lock() {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    if tracker.contains_key(&peer_id_bytes) {
+        return;
+    }
+
+    let tracker_clone = std::sync::Arc::clone(&active_reconnects);
+    let handle = tokio::spawn(async move {
+        let peer_id = ant_quic::PeerId(peer_id_bytes);
+        let machine_id = identity::MachineId(peer_id_bytes);
+        let prefix = network::hex_prefix(&peer_id_bytes, 4);
+
+        // Candidate discovery-cache addresses are refreshed on every attempt
+        // (see the per-attempt read inside the loop) so a named daemon that
+        // restarted on a different ephemeral port is rediscovered once it
+        // re-announces, rather than pinned to a stale one-time snapshot.
+        tracing::info!(
+            target: "x0x::connect",
+            peer_id_prefix = %prefix,
+            "scheduling proactive reconnect for disconnected peer",
+        );
+
+        for (attempt, &delay) in RECONNECT_BACKOFF_DELAYS.iter().enumerate() {
+            // Wait with cancellation before each attempt.
+            tokio::select! {
+                _ = shutdown_token.cancelled() => break,
+                _ = tokio::time::sleep(delay) => {}
+            }
+
+            // Another path (mDNS auto-connect, inbound dial, announcement
+            // auto-connect) may have already recovered the connection.
+            if network.is_connected(&peer_id).await {
+                tracing::debug!(
+                    target: "x0x::connect",
+                    peer_id_prefix = %prefix,
+                    attempt,
+                    "reconnect cancelled: peer already connected",
+                );
+                break;
+            }
+
+            // Refresh discovery-cache candidate addresses on EVERY attempt
+            // (not a one-time snapshot). These include LAN/loopback addresses
+            // when allow_local_scope is active (same-host scenario). A named
+            // daemon that restarted on a different ephemeral port re-announces;
+            // its new address is merged into the cache (upsert_discovered_
+            // machine is append-only) and picked up on this backoff tick. A
+            // one-time snapshot would pin the stale old port and never
+            // rediscover the peer (final review: named restart on a new port).
+            let candidate_addrs = {
+                let cache = machine_cache.read().await;
+                cache
+                    .get(&machine_id)
+                    .map(|m| m.addresses.clone())
+                    .unwrap_or_default()
+            };
+
+            tracing::info!(
+                target: "x0x::connect",
+                peer_id_prefix = %prefix,
+                attempt = attempt + 1,
+                max_attempts = RECONNECT_BACKOFF_DELAYS.len(),
+                candidate_addrs = candidate_addrs.len(),
+                "proactive reconnect attempt",
+            );
+
+            let mut connected = false;
+
+            // Phase 1: discovery-cache addresses (LAN/loopback for same-host).
+            for addr in &candidate_addrs {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    network.connect_addr(*addr),
+                )
+                .await
+                {
+                    Ok(Ok(connected_peer)) if connected_peer == peer_id => {
+                        tracing::info!(
+                            target: "x0x::connect",
+                            peer_id_prefix = %prefix,
+                            attempt = attempt + 1,
+                            addr = %addr,
+                            "proactive reconnect succeeded via discovery address",
+                        );
+                        connected = true;
+                        break;
+                    }
+                    Ok(Ok(other)) => {
+                        tracing::warn!(
+                            target: "x0x::connect",
+                            peer_id_prefix = %prefix,
+                            addr = %addr,
+                            "reconnect resolved to unexpected peer {:?}",
+                            other,
+                        );
+                    }
+                    Ok(Err(e)) => {
+                        tracing::debug!(
+                            target: "x0x::connect",
+                            peer_id_prefix = %prefix,
+                            addr = %addr,
+                            error = %e,
+                            "reconnect attempt at discovery address failed",
+                        );
+                    }
+                    Err(_) => {
+                        tracing::debug!(
+                            target: "x0x::connect",
+                            peer_id_prefix = %prefix,
+                            addr = %addr,
+                            "reconnect attempt at discovery address timed out",
+                        );
+                    }
+                }
+            }
+
+            // Phase 2: bootstrap-cache fallback (public addresses for remote
+            // peers that may have NAT-stable endpoints).
+            if !connected {
+                match network.connect_cached_peer(peer_id).await {
+                    Ok(_) => {
+                        tracing::info!(
+                            target: "x0x::connect",
+                            peer_id_prefix = %prefix,
+                            attempt = attempt + 1,
+                            "proactive reconnect succeeded via bootstrap cache",
+                        );
+                        connected = true;
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            target: "x0x::connect",
+                            peer_id_prefix = %prefix,
+                            error = %e,
+                            "reconnect via bootstrap cache failed",
+                        );
+                    }
+                }
+            }
+
+            if connected {
+                break;
+            }
+        }
+
+        // Remove ourselves from the single-flight tracker. If a PeerConnected
+        // event already aborted us and removed the entry, this is a no-op.
+        if let Ok(mut t) = tracker_clone.lock() {
+            t.remove(&peer_id_bytes);
+        }
+    });
+
+    tracker.insert(peer_id_bytes, handle);
 }
 
 impl AgentBuilder {
@@ -9755,6 +10057,15 @@ pub struct TaskListHandle {
     sync: std::sync::Arc<crdt::TaskListSync>,
     agent_id: identity::AgentId,
     peer_id: saorsa_gossip_types::PeerId,
+    /// Per-replica fencing epoch. Regenerated when the handle is (re)built —
+    /// i.e. on daemon restart — so a numeric fence token captured before a
+    /// restart can never ABA-match a post-restart token (the epoch differs).
+    /// See [`FenceToken`].
+    replica_epoch: u64,
+    /// Signing context for self-signing claim/complete operations
+    /// (authenticated operation provenance). Threaded from the agent's
+    /// keypair at construction; the secret key never leaves the handle.
+    signing: std::sync::Arc<crate::gossip::SigningContext>,
 }
 
 impl std::fmt::Debug for TaskListHandle {
@@ -9763,6 +10074,83 @@ impl std::fmt::Debug for TaskListHandle {
             .field("agent_id", &self.agent_id)
             .field("peer_id", &self.peer_id)
             .finish_non_exhaustive()
+    }
+}
+
+impl TaskListHandle {
+    /// Generate a fresh per-replica epoch at handle construction.
+    ///
+    /// Uses a CSPRNG incarnation nonce (64-bit random from `OsRng`) so a
+    /// pre-restart fence token can never ABA-match a post-restart one (the
+    /// epoch component differs with overwhelming probability). Unlike
+    /// wall-clock nanoseconds, a random nonce is not predictable and does not
+    /// depend on monotonic clock behaviour across restarts. `OsRng` never
+    /// blocks on a functioning system; if it fails (catastrophic entropy
+    /// failure), we fall back to wall-clock nanoseconds (still advances across
+    /// restart). Epoch 0 is reserved as "uninitialized" and is never returned.
+    fn fresh_epoch() -> u64 {
+        use rand::RngCore;
+        let mut bytes = [0u8; 8];
+        match rand::rngs::OsRng.try_fill_bytes(&mut bytes) {
+            Ok(()) => {
+                let epoch = u64::from_le_bytes(bytes);
+                if epoch == 0 {
+                    1
+                } else {
+                    epoch
+                }
+            }
+            Err(_) => std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as u64)
+                .unwrap_or(1)
+                .max(1),
+        }
+    }
+
+    /// Build the current fence token for this replica at the given revision.
+    fn current_fence(&self, revision: u64) -> FenceToken {
+        FenceToken {
+            epoch: self.replica_epoch,
+            revision,
+        }
+    }
+
+    /// Set the authorized-member set for group-scoped task lists.
+    ///
+    /// When set, remote CRDT admission rejects checkbox elements (claims/
+    /// completions) whose attesting agent is not in this set — applying group
+    /// authorization at replication admission, not just at REST. The server
+    /// layer should call this when creating/joining a group-scoped list and
+    /// when group membership changes.
+    ///
+    /// This is a best-effort consistency measure: the set is not persisted and
+    /// must be re-established after a restart (before the sync listener starts
+    /// to avoid a race window).
+    pub async fn set_authorized_agents(
+        &self,
+        agents: std::collections::HashSet<identity::AgentId>,
+    ) {
+        let mut list = self.sync.write().await;
+        list.set_authorized_agents(agents);
+    }
+
+    /// Clear the authorized-member set (revert to open admission for all
+    /// validly-attested operations).
+    pub async fn clear_authorized_agents(&self) {
+        let mut list = self.sync.write().await;
+        list.clear_authorized_agents();
+    }
+
+    /// Test-only: override the per-replica epoch so a pre-restart fence token
+    /// can be simulated in-process without a real daemon restart.
+    ///
+    /// Two handles sharing the same `Arc<TaskListSync>` but with different
+    /// epochs exercise the restart-ABA rejection: a token captured at epoch E1
+    /// is rejected when the handle's epoch is E2.
+    #[cfg(test)]
+    pub fn set_replica_epoch_for_testing(&mut self, epoch: u64) {
+        self.replica_epoch = epoch;
     }
 }
 
@@ -9839,19 +10227,30 @@ impl TaskListHandle {
     ///
     /// Returns an error if the task cannot be claimed.
     pub async fn claim_task(&self, task_id: crdt::TaskId) -> error::Result<()> {
-        // No expected version ⇒ can never conflict.
+        // No local-version guard ⇒ unconditional (still advisory; concurrent
+        // remote claims coexist in the CRDT regardless).
         self.claim_task_versioned(task_id, None).await.map(|_| ())
     }
 
-    /// Claim a task, optionally guarded by an expected list version (CAS).
+    /// Claim a task, optionally guarded by an expected list version.
     ///
-    /// If `expected_version` is `Some(v)` and the task list's current version
-    /// is not `v`, nothing is mutated and
-    /// [`TaskCasOutcome::VersionConflict`] is returned with the current
-    /// version. The check and the mutation happen under a single write lock.
+    /// `expected_version` is a **local-replica fencing precondition**, not a
+    /// distributed compare-and-swap: when `Some(v)` and this replica's local
+    /// version counter is not `v`, nothing is mutated and
+    /// [`TaskMutationOutcome::StaleLocalVersion`] is returned. Two replicas
+    /// that both happen to be at version `v` will BOTH pass — this guard
+    /// cannot provide cross-replica exclusion. The check and the mutation
+    /// happen under a single local write lock.
     ///
-    /// `Committed` means the claim was applied to the local replica and a
-    /// delta was published to peers — not that any peer has observed it.
+    /// The claim itself is **advisory**: it records a `Claimed` candidate in
+    /// the OR-Set and publishes a delta. Concurrent claims (on this or other
+    /// replicas) coexist; the deterministic winner resolves at convergence.
+    /// The returned [`AdvisoryOwnership`] reports the local snapshot at commit
+    /// time and is provisional.
+    ///
+    /// `Committed` means applied to the local replica + best-effort delta
+    /// publish — not that any peer observed it, nor that the caller won
+    /// exclusively.
     ///
     /// # Errors
     ///
@@ -9860,45 +10259,52 @@ impl TaskListHandle {
     pub async fn claim_task_versioned(
         &self,
         task_id: crdt::TaskId,
-        expected_version: Option<u64>,
-    ) -> error::Result<TaskCasOutcome> {
-        let (version, delta) = {
+        expected: Option<FenceToken>,
+    ) -> error::Result<TaskMutationOutcome> {
+        let (fence, delta, advisory) = {
             let mut list = self.sync.write().await;
-            if let Some(expected) = expected_version {
+            if let Some(expected) = expected {
                 let current = list.current_version();
-                if current != expected {
-                    return Ok(TaskCasOutcome::VersionConflict {
-                        current_version: current,
+                // Reject if either the epoch (restart-ABA) or the revision
+                // (stale local snapshot) mismatches. Both are local-only.
+                if expected.epoch != self.replica_epoch || expected.revision != current {
+                    return Ok(TaskMutationOutcome::StaleLocalVersion {
+                        current: self.current_fence(current),
                     });
                 }
             }
             let seq = list.next_seq();
-            list.claim_task(&task_id, self.agent_id, self.peer_id, seq)
+            list.claim_task(&task_id, self.agent_id, self.peer_id, seq, &self.signing)
                 .map_err(|e| {
                     error::IdentityError::Storage(std::io::Error::other(format!(
                         "claim_task failed: {}",
                         e
                     )))
                 })?;
+            // Read back the task once (under the same lock) to compute the
+            // advisory ownership snapshot and the delta payload atomically.
+            let task = list.get_task(&task_id).ok_or_else(|| {
+                error::IdentityError::Storage(std::io::Error::other("task disappeared after claim"))
+            })?;
+            let winner = task.claim_record();
+            let advisory = AdvisoryOwnership {
+                agent: self.agent_id,
+                locally_winning: winner.is_some_and(|(a, _)| a == self.agent_id),
+                current_winner: winner,
+            };
             // Include full task so receivers can upsert if add hasn't arrived yet
-            let full_task = list
-                .get_task(&task_id)
-                .ok_or_else(|| {
-                    error::IdentityError::Storage(std::io::Error::other(
-                        "task disappeared after claim",
-                    ))
-                })?
-                .clone();
+            let full_task = task.clone();
             let version = list.current_version();
             (
-                version,
+                self.current_fence(version),
                 crdt::TaskListDelta::for_state_change(task_id, full_task, version),
+                advisory,
             )
         };
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
             tracing::warn!("failed to publish claim_task delta: {}", e);
         }
-        Ok(TaskCasOutcome::Committed { version })
+        Ok(TaskMutationOutcome::Committed { fence, advisory })
     }
 
     /// Complete a task in the list.
@@ -9911,17 +10317,20 @@ impl TaskListHandle {
     ///
     /// Returns an error if the task cannot be completed.
     pub async fn complete_task(&self, task_id: crdt::TaskId) -> error::Result<()> {
-        // No expected version ⇒ can never conflict.
+        // No local-version guard ⇒ unconditional (still advisory).
         self.complete_task_versioned(task_id, None)
             .await
             .map(|_| ())
     }
 
-    /// Complete a task, optionally guarded by an expected list version (CAS).
+    /// Complete a task, optionally guarded by an expected list version.
     ///
-    /// Semantics mirror [`TaskListHandle::claim_task_versioned`]: a mismatch
-    /// between `expected_version` and the current list version returns
-    /// [`TaskCasOutcome::VersionConflict`] with no mutation.
+    /// Semantics mirror [`TaskListHandle::claim_task_versioned`]:
+    /// `expected_version` is a **local-replica** fencing precondition (not a
+    /// distributed CAS); a mismatch returns
+    /// [`TaskMutationOutcome::StaleLocalVersion`] with no mutation. The
+    /// completion is advisory; the returned [`AdvisoryOwnership`] reports the
+    /// local `completion_record()` snapshot at commit time and is provisional.
     ///
     /// # Errors
     ///
@@ -9930,44 +10339,49 @@ impl TaskListHandle {
     pub async fn complete_task_versioned(
         &self,
         task_id: crdt::TaskId,
-        expected_version: Option<u64>,
-    ) -> error::Result<TaskCasOutcome> {
-        let (version, delta) = {
+        expected: Option<FenceToken>,
+    ) -> error::Result<TaskMutationOutcome> {
+        let (fence, delta, advisory) = {
             let mut list = self.sync.write().await;
-            if let Some(expected) = expected_version {
+            if let Some(expected) = expected {
                 let current = list.current_version();
-                if current != expected {
-                    return Ok(TaskCasOutcome::VersionConflict {
-                        current_version: current,
+                if expected.epoch != self.replica_epoch || expected.revision != current {
+                    return Ok(TaskMutationOutcome::StaleLocalVersion {
+                        current: self.current_fence(current),
                     });
                 }
             }
             let seq = list.next_seq();
-            list.complete_task(&task_id, self.agent_id, self.peer_id, seq)
+            list.complete_task(&task_id, self.agent_id, self.peer_id, seq, &self.signing)
                 .map_err(|e| {
                     error::IdentityError::Storage(std::io::Error::other(format!(
                         "complete_task failed: {}",
                         e
                     )))
                 })?;
-            let full_task = list
-                .get_task(&task_id)
-                .ok_or_else(|| {
-                    error::IdentityError::Storage(std::io::Error::other(
-                        "task disappeared after complete",
-                    ))
-                })?
-                .clone();
+            let task = list.get_task(&task_id).ok_or_else(|| {
+                error::IdentityError::Storage(std::io::Error::other(
+                    "task disappeared after complete",
+                ))
+            })?;
+            let winner = task.completion_record();
+            let advisory = AdvisoryOwnership {
+                agent: self.agent_id,
+                locally_winning: winner.is_some_and(|(a, _)| a == self.agent_id),
+                current_winner: winner,
+            };
+            let full_task = task.clone();
             let version = list.current_version();
             (
-                version,
+                self.current_fence(version),
                 crdt::TaskListDelta::for_state_change(task_id, full_task, version),
+                advisory,
             )
         };
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
             tracing::warn!("failed to publish complete_task delta: {}", e);
         }
-        Ok(TaskCasOutcome::Committed { version })
+        Ok(TaskMutationOutcome::Committed { fence, advisory })
     }
 
     /// List all tasks in their current order.
@@ -9988,13 +10402,14 @@ impl TaskListHandle {
     ///
     /// The snapshots and the version are read atomically under a single read
     /// lock, so the returned version is consistent with the returned tasks —
-    /// suitable as the `expected_version` for a subsequent CAS mutation via
+    /// suitable as the `expected_version` (a local-replica fencing
+    /// precondition, not a distributed CAS) for a subsequent mutation via
     /// [`TaskListHandle::claim_task_versioned`].
     ///
     /// # Errors
     ///
     /// Returns an error if the task list cannot be read.
-    pub async fn list_tasks_with_version(&self) -> error::Result<(Vec<TaskSnapshot>, u64)> {
+    pub async fn list_tasks_with_version(&self) -> error::Result<(Vec<TaskSnapshot>, FenceToken)> {
         let list = self.sync.read().await;
         let version = list.current_version();
         let tasks = list.tasks_ordered();
@@ -10018,17 +10433,19 @@ impl TaskListHandle {
                 }
             })
             .collect();
-        Ok((snapshots, version))
+        Ok((snapshots, self.current_fence(version)))
     }
 
     /// The task list's current version counter.
     ///
     /// Incremented on every local or merged mutation. Useful as the
-    /// `expected_version` for CAS mutations; prefer
+    /// `expected_version` (a local-replica fencing precondition, not a
+    /// distributed CAS) for mutations; prefer
     /// [`TaskListHandle::list_tasks_with_version`] when the tasks are also
     /// needed, to read both atomically.
-    pub async fn version(&self) -> u64 {
-        self.sync.read().await.current_version()
+    pub async fn version(&self) -> FenceToken {
+        let revision = self.sync.read().await.current_version();
+        self.current_fence(revision)
     }
 
     /// Reorder tasks in the list.
@@ -10084,7 +10501,7 @@ impl Agent {
         })?;
 
         let peer_id = runtime.peer_id();
-        let store_id = kv::KvStoreId::from_content(name, &self.agent_id());
+        let store_id = kv::KvStoreId::for_topic_owner(topic, &self.agent_id());
         let store = kv::KvStore::new(
             store_id,
             name.to_string(),
@@ -10114,26 +10531,45 @@ impl Agent {
                 )))
             })?;
 
+        // The creator is the owner: capture signing material so each write
+        // produces an owner-signed content checkpoint (cold-recovery provenance).
+        let (pk_bytes, sk_bytes) = self.identity().agent_keypair().to_bytes();
         Ok(KvStoreHandle {
             sync,
             agent_id: self.agent_id(),
             peer_id,
+            owner_signing: Some(std::sync::Arc::new(OwnerSigningMaterial {
+                public_key_bytes: pk_bytes,
+                secret_key_bytes: sk_bytes,
+            })),
         })
     }
 
-    /// Join an existing key-value store by topic.
+    /// Join an existing key-value store by topic, anchoring ownership on the
+    /// trusted out-of-band `owner`.
     ///
-    /// Creates an empty replica that will be populated via delta sync from
-    /// peers already sharing the topic. The replica starts with **no owner**
-    /// and the default `Signed` policy, which fails closed: local writes are
-    /// rejected until the authoritative owner and policy are learned from an
-    /// owner-signed announcement on the state-sync channel (published by the
-    /// owner in response to this replica's state requests).
+    /// The owner anchor is **required** on every public join path: a replica
+    /// with no anchor can never accept policy-restricted data, so an unanchored
+    /// join is a dead replica, not a successful join. Callers MUST supply the
+    /// authoritative owner (an Agent Card, invite, explicit REST/CLI param, or
+    /// persisted manifest entry). The replica is anchored on `owner`: it accepts
+    /// `owner`'s deltas and (if this node *is* `owner`) its own local writes,
+    /// converging against any owner version — including a v0.30.1 owner that
+    /// never announces — because the data path never consults an announce.
+    ///
+    /// `channel` records how the anchor was supplied (audit metadata); pass
+    /// [`kv::store::AnchorChannel::RestParam`] for client-initiated joins and
+    /// [`kv::store::AnchorChannel::Persistence`] for manifest replay.
     ///
     /// # Errors
     ///
     /// Returns an error if the gossip runtime is not initialized.
-    pub async fn join_kv_store(&self, topic: &str) -> error::Result<KvStoreHandle> {
+    pub async fn join_kv_store(
+        &self,
+        topic: &str,
+        owner: identity::AgentId,
+        channel: kv::store::AnchorChannel,
+    ) -> error::Result<KvStoreHandle> {
         let runtime = self.gossip_runtime.as_ref().ok_or_else(|| {
             error::IdentityError::Storage(std::io::Error::other(
                 "gossip runtime not initialized - configure agent with network first",
@@ -10141,10 +10577,10 @@ impl Agent {
         })?;
 
         let peer_id = runtime.peer_id();
-        // Local placeholder id — the replica is addressed by topic; the id
-        // is not used for merge decisions on the delta path.
-        let store_id = kv::KvStoreId::from_content(topic, &self.agent_id());
-        let store = kv::KvStore::new_replica(store_id, String::new());
+        // The store id is the verifiable topic→owner binding; it agrees with
+        // the creator's id (both derive for_topic_owner(topic, owner)).
+        let store_id = kv::KvStoreId::for_topic_owner(topic, &owner);
+        let store = kv::KvStore::new_replica(store_id, String::new(), Some(owner), channel);
 
         let sync = kv::KvStoreSync::new(
             store,
@@ -10172,6 +10608,9 @@ impl Agent {
             sync,
             agent_id: self.agent_id(),
             peer_id,
+            // A joiner is not the owner and never produces checkpoints; it
+            // only caches + relays owner-produced ones.
+            owner_signing: None,
         })
     }
 }
@@ -10185,6 +10624,20 @@ pub struct KvStoreHandle {
     sync: std::sync::Arc<kv::KvStoreSync>,
     agent_id: identity::AgentId,
     peer_id: saorsa_gossip_types::PeerId,
+    /// Owner signing material, present only when this node is the store owner
+    /// (creator path). Used to produce owner-signed content checkpoints on
+    /// each write so replicas can cold-recover while the owner is offline.
+    owner_signing: Option<std::sync::Arc<OwnerSigningMaterial>>,
+}
+
+/// Serialized owner keypair for checkpoint signing (held only by the owner's
+/// handle). The bytes are reconstructed into keys at sign time.
+#[derive(Clone)]
+pub struct OwnerSigningMaterial {
+    /// ML-DSA-65 public key bytes.
+    pub public_key_bytes: Vec<u8>,
+    /// ML-DSA-65 secret key bytes.
+    pub secret_key_bytes: Vec<u8>,
 }
 
 impl std::fmt::Debug for KvStoreHandle {
@@ -10201,6 +10654,80 @@ impl KvStoreHandle {
     #[must_use]
     pub fn peer_id(&self) -> saorsa_gossip_types::PeerId {
         self.peer_id
+    }
+
+    /// Return the store's ownership/policy/version metadata for auditability.
+    ///
+    /// Reads are never gated on ownership — only writes are — so this always
+    /// succeeds and surfaces the anchored owner (or `None` for a read-only
+    /// no-anchor replica), the policy, the freshness version, and the derived
+    /// [`kv::OwnershipSource`].
+    pub async fn ownership_info(&self) -> KvStoreOwnershipInfo {
+        let s = self.sync.read().await;
+        let src = s.ownership_source();
+        let (status, announced) = match &src {
+            kv::OwnershipSource::Anchored { .. } => (kv::OwnershipStatus::Anchored, None),
+            kv::OwnershipSource::Unknown => (kv::OwnershipStatus::Unknown, None),
+            kv::OwnershipSource::Conflict { announced, .. } => (
+                kv::OwnershipStatus::Conflict,
+                Some(hex::encode(announced.as_bytes())),
+            ),
+        };
+        KvStoreOwnershipInfo {
+            owner: s.owner().map(|o| hex::encode(o.as_bytes())),
+            policy: s.policy().to_string(),
+            version: s.current_version(),
+            // The owner-announce freshness counter — distinct from the general
+            // mutation `version`. Surfaced so callers can observe the policy
+            // freshness invariant (not just store churn).
+            policy_version: s.policy_version(),
+            ownership_status: status,
+            announced_owner: announced,
+        }
+    }
+
+    /// Produce and install an owner-signed content checkpoint, returning it
+    /// for attachment to the published delta.
+    ///
+    /// Only the owner produces checkpoints (it holds the signing key). The
+    /// checkpoint binds the post-write content root so replicas can
+    /// cold-recover this state from a non-owner relay while the owner is
+    /// offline. Returns `None` for non-owners or if signing is unavailable.
+    fn produce_checkpoint(&self, store: &mut kv::KvStore) -> Option<kv::store::OwnerCheckpoint> {
+        let signing = self.owner_signing.as_ref()?;
+        // Only the owner signs; a joiner (even one anchored on itself, which is
+        // unusual) without signing material does not produce checkpoints.
+        if store.owner() != Some(&self.agent_id) {
+            return None;
+        }
+        let topic = self.sync.topic();
+        let id = *store.id();
+        let pairs = store.checkpoint_pairs();
+        let root = kv::store::content_root(&id, store.name(), &pairs);
+        let seq = store.highest_checkpoint_seq.checked_add(1)?;
+        let policy_version = store.policy_version();
+        let policy = store.policy().clone();
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let pubkey = ant_quic::MlDsaPublicKey::from_bytes(&signing.public_key_bytes).ok()?;
+        let seckey = ant_quic::MlDsaSecretKey::from_bytes(&signing.secret_key_bytes).ok()?;
+        let cp = kv::store::make_owner_checkpoint(kv::store::OwnerCheckpointParams {
+            topic,
+            store_id: &id,
+            secret_key: &seckey,
+            public_key: &pubkey,
+            policy: &policy,
+            policy_version,
+            checkpoint_seq: seq,
+            content_root: root,
+            timestamp: ts,
+        })
+        .ok()?;
+        store.latest_checkpoint = Some(cp.clone());
+        store.highest_checkpoint_seq = seq;
+        Some(cp)
     }
 
     /// Enforce the store's access policy for a local mutation.
@@ -10267,7 +10794,7 @@ impl KvStoreHandle {
                 })?;
             let entry = store.get(&key).cloned();
             let version = store.current_version();
-            match entry {
+            let mut delta = match entry {
                 Some(e) => {
                     kv::KvStoreDelta::for_put(key, e, (self.peer_id, store.next_seq()), version)
                 }
@@ -10276,7 +10803,16 @@ impl KvStoreHandle {
                         "kv put succeeded but entry was not readable",
                     )));
                 }
+            };
+            // Owner: attach an owner-signed checkpoint for relay-based recovery.
+            if let Some(cp) = self.produce_checkpoint(&mut store) {
+                delta.owner_checkpoint = Some(cp);
+                // Carry the authoritative owner name so a relay whose local
+                // name hasn't synced yet can still cache the checkpoint
+                // (content_root binds the store name).
+                delta.name_update = Some(store.name_register().clone());
             }
+            delta
         };
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta.clone()).await {
             tracing::warn!("failed to publish kv put delta: {e}");
@@ -10333,6 +10869,13 @@ impl KvStoreHandle {
             let mut d = kv::KvStoreDelta::new(store.current_version());
             d.removed
                 .insert(key.to_string(), std::collections::HashSet::new());
+            // Owner: attach an owner-signed checkpoint for the post-remove state.
+            if let Some(cp) = self.produce_checkpoint(&mut store) {
+                d.owner_checkpoint = Some(cp);
+                // Carry the authoritative owner name alongside the checkpoint
+                // so a relay can cache it regardless of local name state.
+                d.name_update = Some(store.name_register().clone());
+            }
             d
         };
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta.clone()).await {
@@ -10414,6 +10957,28 @@ pub struct KvEntrySnapshot {
     pub updated_at: u64,
 }
 
+/// Ownership/policy/version metadata for a store, for auditability.
+///
+/// Returned by [`KvStoreHandle::ownership_info`]. `owner` is the hex-encoded
+/// anchored owner, or `None` for a read-only no-anchor replica.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct KvStoreOwnershipInfo {
+    /// Hex-encoded anchored owner, or `None` when no owner is anchored
+    /// (read-only by design).
+    pub owner: Option<String>,
+    /// Access policy (`"signed"` / `"allowlisted"` / `"encrypted"`).
+    pub policy: String,
+    /// Store version (monotonic, bumped on every mutation).
+    pub version: u64,
+    /// Owner-announce policy freshness counter (distinct from `version`).
+    pub policy_version: u64,
+    /// Strongly-typed ownership discriminant (`"anchored"` / `"unknown"` /
+    /// `"conflict"`).
+    pub ownership_status: kv::OwnershipStatus,
+    /// Hex-encoded owner claimed by a rejected announce (`conflict` only).
+    pub announced_owner: Option<String>,
+}
+
 /// Read-only snapshot of a task's current state.
 ///
 /// This is returned by `TaskListHandle::list_tasks()` and hides CRDT
@@ -10445,25 +11010,127 @@ pub struct TaskSnapshot {
     pub completed_at: Option<u64>,
 }
 
-/// Outcome of a task-list mutation guarded by an optional expected version.
+/// Outcome of a task-list mutation (claim or complete).
 ///
 /// Returned by [`TaskListHandle::claim_task_versioned`] and
-/// [`TaskListHandle::complete_task_versioned`]. `Committed` means the
-/// mutation was applied to the **local** replica and a delta was published —
-/// it does NOT mean any peer has observed the change yet.
+/// [`TaskListHandle::complete_task_versioned`].
+///
+/// `Committed` means the mutation was applied to the **local** replica and a
+/// delta was best-effort published — it does NOT mean any peer has observed
+/// the change, and it does NOT grant exclusive ownership. Claims and
+/// completions are **advisory**: concurrent operations on other replicas
+/// coexist in the CRDT and resolve to a single deterministic winner (earliest
+/// timestamp, then lexicographic agent id) only after convergence.
+///
+/// `StaleLocalVersion` means the caller's fence token did not match this
+/// replica's current `(epoch, revision)` — a LOCAL fencing signal. It is NOT
+/// a distributed conflict: two replicas at the same token both pass, so the
+/// fence cannot provide cross-replica exclusion. A mismatch may be a stale
+/// revision (the local snapshot moved) OR a stale epoch (the daemon restarted
+/// and the caller's token predates it — the restart-ABA case).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TaskCasOutcome {
-    /// The mutation was committed locally; `version` is the new list version.
+pub enum TaskMutationOutcome {
+    /// The mutation was committed locally; `fence` is the new local token.
     Committed {
-        /// The task list's version after this mutation.
-        version: u64,
+        /// The task list's fence token after this mutation (epoch + revision).
+        fence: FenceToken,
+        /// Advisory ownership snapshot computed from the local OR-Set at
+        /// commit time. Advisory — see [`AdvisoryOwnership`].
+        advisory: AdvisoryOwnership,
     },
-    /// The caller's `expected_version` did not match the current list
-    /// version; nothing was mutated.
-    VersionConflict {
-        /// The task list's current (unchanged) version.
-        current_version: u64,
+    /// The caller's fence token did not match this replica's current token;
+    /// nothing was mutated. Local staleness guard (stale revision) or a
+    /// restart-epoch mismatch — never a distributed conflict.
+    StaleLocalVersion {
+        /// The task list's current (unchanged) local fence token.
+        current: FenceToken,
     },
+}
+
+/// Opaque local-replica fencing token.
+///
+/// Combines a per-replica `epoch` (regenerated when the handle is rebuilt —
+/// i.e. on daemon restart) with the local `revision` (the TaskList version
+/// counter, which advances on every effective local snapshot change,
+/// including remote merges). The token is **opaque** over the wire: clients
+/// must echo it verbatim and MUST NOT interpret or construct it.
+///
+/// ABA safety: because the epoch changes across restart, a token captured
+/// before a restart can never match a post-restart token even if the revision
+/// counter later reaches the same value. This closes the restart-ABA window
+/// without persisting task state.
+///
+/// This is a LOCAL fence only (per-replica): two replicas at the same
+/// `(epoch, revision)` can both accept. It is not a distributed CAS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FenceToken {
+    /// Per-replica epoch; regenerated on restart.
+    pub epoch: u64,
+    /// Local revision = TaskList version counter.
+    pub revision: u64,
+}
+
+impl FenceToken {
+    /// Opaque wire encoding: `"epoch:revision"`. Clients echo this verbatim.
+    #[must_use]
+    pub fn to_wire(&self) -> String {
+        format!("{}:{}", self.epoch, self.revision)
+    }
+
+    /// Parse an opaque wire token.
+    ///
+    /// Returns `Ok(token)` for a well-formed `"epoch:revision"` string, or
+    /// `Err(&'static str)` if the token is malformed (missing colon,
+    /// non-numeric, or integer overflow). Callers MUST distinguish **absent**
+    /// (`fence_token: None` → unconditional advisory commit) from **present but
+    /// malformed** (`Err` → reject with 400/409 without mutation). Collapsing
+    /// the two into `None` would let a corrupt/legacy/attacker token silently
+    /// downgrade a fenced request to an unfenced one.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the string is not exactly two colon-separated `u64`
+    /// fields.
+    pub fn from_wire(s: &str) -> Result<Self, &'static str> {
+        let (epoch, revision) = s
+            .split_once(':')
+            .ok_or("malformed fence token: expected 'epoch:revision'")?;
+        let epoch = epoch
+            .parse()
+            .map_err(|_| "malformed fence token: epoch is not a valid u64")?;
+        let revision = revision
+            .parse()
+            .map_err(|_| "malformed fence token: revision is not a valid u64")?;
+        Ok(Self { epoch, revision })
+    }
+}
+
+/// Advisory ownership snapshot reported after a local claim/complete commit.
+///
+/// "Advisory" means this reflects the local replica's CRDT resolution at the
+/// instant of commit. It is **not** a distributed lock and **not** a promise
+/// of final ownership:
+///
+/// - `locally_winning` is provisional. A strictly-earlier-timestamp candidate
+///   arriving via a later merge will flip it to `false` (the resolved winner
+///   timestamp is monotone non-increasing).
+/// - Final ownership is only determinable after all replicas have converged,
+///   and is always non-exclusive — every candidate remains recorded in the
+///   OR-Set (see [`crdt::TaskItem::claims`]).
+///
+/// `current_winner` lets a superseded caller see who currently beats them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdvisoryOwnership {
+    /// The agent that performed this mutation (the caller's own candidate).
+    pub agent: identity::AgentId,
+    /// Whether `agent` is the local OR-Set's current deterministic winner for
+    /// this operation (claim → [`crdt::TaskItem::claim_record`], complete →
+    /// [`crdt::TaskItem::completion_record`]). Provisional; may flip on merge.
+    pub locally_winning: bool,
+    /// The local OR-Set's current deterministic winner `(agent, unix_ms)`, or
+    /// `None` if no candidate exists. When `!locally_winning`, this is the
+    /// agent that currently beats `agent`.
+    pub current_winner: Option<(identity::AgentId, u64)>,
 }
 
 /// The x0x protocol version.
@@ -11259,6 +11926,92 @@ mod tests {
         }
     }
 
+    /// P1 fence (restart-ABA): a fence token captured before an incarnation
+    /// change (daemon restart) must be rejected even when submitted at the
+    /// SAME revision afterwards — the per-replica epoch component differs, so
+    /// the token cannot ABA-match the post-restart one. A token captured after
+    /// the epoch change at the same revision is accepted (teeth: the gate
+    /// rejects the stale epoch, not everything).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn pre_restart_fence_token_rejected_at_same_revision_after_epoch_change() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("agent");
+
+        let mut handle = agent
+            .create_task_list("restart-fence", "restart-fence-topic")
+            .await
+            .expect("create task list");
+        let (task_id, _added_version) = handle
+            .add_task_versioned("task".to_string(), "d".to_string())
+            .await
+            .expect("add task");
+
+        // Token captured at epoch E1, revision R (before the "restart").
+        let pre_restart_token = handle.version().await;
+        let revision = pre_restart_token.revision;
+
+        // Simulate a restart: a new incarnation epoch, revision UNCHANGED.
+        handle.set_replica_epoch_for_testing(pre_restart_token.epoch.wrapping_add(1));
+
+        // The pre-restart token at the same revision MUST be rejected — the
+        // epoch differs, so it cannot ABA-match. Nothing mutates.
+        let outcome = handle
+            .claim_task_versioned(task_id, Some(pre_restart_token))
+            .await
+            .expect("claim call");
+        match outcome {
+            crate::TaskMutationOutcome::StaleLocalVersion { current } => {
+                assert_eq!(
+                    current.revision, revision,
+                    "a rejected fence must not change the revision"
+                );
+                assert_ne!(
+                    current.epoch, pre_restart_token.epoch,
+                    "the echoed current token carries the new (post-restart) epoch"
+                );
+            }
+            other => panic!("expected StaleLocalVersion, got {other:?}"),
+        }
+
+        // Non-mutation: the task is still unclaimed.
+        let tasks = handle.list_tasks().await.expect("list tasks");
+        let t = tasks
+            .iter()
+            .find(|t| t.id == task_id)
+            .expect("task present after rejection");
+        assert!(
+            t.state.is_empty(),
+            "a rejected fence must not mutate the task: {:?}",
+            t.state
+        );
+
+        // Teeth: a token captured AFTER the epoch change, at the same revision,
+        // is accepted — the gate rejects the stale epoch specifically.
+        let post_restart_token = handle.version().await;
+        assert_ne!(
+            post_restart_token.epoch, pre_restart_token.epoch,
+            "post-restart token carries the new epoch"
+        );
+        let outcome2 = handle
+            .claim_task_versioned(task_id, Some(post_restart_token))
+            .await
+            .expect("claim call 2");
+        assert!(
+            matches!(outcome2, crate::TaskMutationOutcome::Committed { .. }),
+            "a post-restart token at the current revision must commit"
+        );
+
+        agent.shutdown().await;
+    }
+
     // ========================================================================
     // #124 / WS1.3 tranche 4 — shutdown ordering invariants.
     //
@@ -11512,6 +12265,690 @@ mod tests {
             .direct_messaging()
             .lifecycle_block_reason(&bob.machine_id())
             .is_none());
+    }
+
+    /// Proactive reconnect: after a known peer's connection is dropped
+    /// (simulating a daemon restart / transport idle timeout), x0x must
+    /// schedule bounded backoff reconnect attempts and recover a direct
+    /// connection without a new external trigger.
+    ///
+    /// This is the focused test for the post-restart transport failure fix:
+    /// GAP 1-4 (mDNS discovery never feeds the dialer, announcement
+    /// auto-connect is one-shot, PeerDisconnected does not reconnect,
+    /// send-path reconnect dials public-only addresses).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn proactive_reconnect_recovers_dropped_same_host_peer() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("alice");
+        let bob = Agent::builder()
+            .with_machine_key(dir.path().join("bob-machine.key"))
+            .with_agent_key_path(dir.path().join("bob-agent.key"))
+            .with_contact_store_path(dir.path().join("bob-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("bob-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("bob");
+
+        // Start the network event listener so the proactive reconnect
+        // scheduler is active. In production this is started by
+        // join_network(); here we invoke it directly for a focused test.
+        alice.start_network_event_listener();
+
+        let bob_network = bob.network().expect("bob network");
+        let bob_addr = normalize_loopback_addr(bob_network.bound_addr().await.expect("bob bound"));
+        let alice_network = alice.network().expect("alice network");
+        let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+
+        // Phase 1: connect alice → bob.
+        let connected_peer = alice_network
+            .connect_addr(bob_addr)
+            .await
+            .expect("alice connects to bob");
+        assert_eq!(connected_peer.0, bob.machine_id().0);
+
+        // Wait for the connection to register on both sides.
+        let connected_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < connected_deadline {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await,
+            "alice should be connected to bob after initial dial"
+        );
+
+        // Phase 2: force a disconnect (simulates the QUIC transport drop
+        // that occurs when the remote daemon restarts or the idle timeout
+        // fires). This emits PeerDisconnected, which triggers
+        // schedule_reconnect.
+        alice_network
+            .disconnect(&bob_peer)
+            .await
+            .expect("disconnect bob");
+
+        // Give the disconnect time to propagate.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            !alice_network.is_connected(&bob_peer).await,
+            "alice should be disconnected after explicit disconnect"
+        );
+
+        // Phase 3: wait for the proactive reconnect to recover the
+        // connection. The first backoff delay is 1 s; allow generous
+        // headroom for CI scheduling jitter.
+        let reconnect_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+        while tokio::time::Instant::now() < reconnect_deadline {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await,
+            "alice should have proactively reconnected to bob \
+             within the backoff window"
+        );
+
+        // Phase 4: verify a subsequent DM succeeds over the recovered
+        // connection. Mark connected (the PeerConnected handler does this
+        // in production, but may race with our assertion in the test).
+        alice
+            .direct_messaging()
+            .mark_connected(bob.agent_id(), bob.machine_id())
+            .await;
+
+        let receipt = alice
+            .send_direct_with_config(
+                &bob.agent_id(),
+                b"post-reconnect-probe".to_vec(),
+                dm::DmSendConfig {
+                    prefer_raw_quic_if_connected: true,
+                    ..dm::DmSendConfig::default()
+                },
+            )
+            .await
+            .expect("DM should succeed over the recovered connection");
+        assert_eq!(
+            receipt.path,
+            dm::DmPath::RawQuic,
+            "DM should use the raw QUIC path over the recovered connection"
+        );
+    }
+
+    /// Default global-bootstrap config (allow_local_scope=FALSE): same-host
+    /// reconnect must still work because the bootstrap cache retains the raw
+    /// loopback address from the initial connection and Phase 2 of
+    /// `schedule_reconnect` dials it via `connect_cached_peer` (CR-HOST-1).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn proactive_reconnect_default_global_bootstrap_same_host() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+
+        // A non-local bootstrap node forces allow_local_scope=FALSE so the
+        // discovery cache will NOT retain LAN/loopback addresses. The reconnect
+        // must therefore rely on Phase 2 (bootstrap cache), which stores the
+        // raw connection address unfiltered.
+        let global_cfg = network::NetworkConfig {
+            bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr")),
+            bootstrap_nodes: vec!["142.93.199.50:5483".parse().expect("wan seed")],
+            ..network::NetworkConfig::default()
+        };
+        assert!(
+            !allow_local_discovery_addresses(&global_cfg),
+            "test precondition: config must have allow_local_scope=FALSE"
+        );
+
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(global_cfg.clone())
+            .build()
+            .await
+            .expect("alice");
+        let bob = Agent::builder()
+            .with_machine_key(dir.path().join("bob-machine.key"))
+            .with_agent_key_path(dir.path().join("bob-agent.key"))
+            .with_contact_store_path(dir.path().join("bob-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("bob-peers"))
+            .with_network_config(global_cfg)
+            .build()
+            .await
+            .expect("bob");
+
+        alice.start_network_event_listener();
+
+        let bob_network = bob.network().expect("bob network");
+        let bob_addr = normalize_loopback_addr(bob_network.bound_addr().await.expect("bob bound"));
+        let alice_network = alice.network().expect("alice network");
+        let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+
+        // Connect alice → bob.
+        let connected = alice_network
+            .connect_addr(bob_addr)
+            .await
+            .expect("alice connects to bob");
+        assert_eq!(connected.0, bob.machine_id().0);
+
+        // Wait for connection to register.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await,
+            "alice should be connected to bob"
+        );
+
+        // CR-HOST-1 assertion: the bootstrap cache retains the raw loopback
+        // address from the successful connection. connect_cached_peer must
+        // return that address, proving Phase 2 can redial it after a drop.
+        let cached_addr = alice_network
+            .connect_cached_peer(bob_peer)
+            .await
+            .expect("bootstrap cache should retain bob's loopback address");
+        // CR-HOST-1 assertion: the bootstrap cache retains the raw loopback
+        // address from the successful connection. connect_cached_peer must
+        // return a loopback address at bob's port, proving Phase 2 can redial
+        // it after a drop. (Dual-stack QUIC may report IPv4-mapped IPv6, so we
+        // compare port + loopback-ness rather than exact address equality.)
+        assert_eq!(
+            cached_addr.port(),
+            bob_addr.port(),
+            "connect_cached_peer must return bob's port — \
+             confirms bootstrap cache retains the connection address"
+        );
+        assert!(
+            match cached_addr.ip() {
+                std::net::IpAddr::V4(v4) => v4.is_loopback(),
+                std::net::IpAddr::V6(v6) => {
+                    v6.is_loopback() || v6.to_ipv4().is_some_and(|v4| v4.is_loopback())
+                }
+            },
+            "connect_cached_peer must return a loopback address — \
+             confirms bootstrap cache does not scope-filter (got {cached_addr})"
+        );
+
+        // Force disconnect (simulates transport drop / restart).
+        alice_network
+            .disconnect(&bob_peer)
+            .await
+            .expect("disconnect bob");
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            !alice_network.is_connected(&bob_peer).await,
+            "alice should be disconnected"
+        );
+
+        // Wait for proactive reconnect via Phase 2 (bootstrap cache).
+        let reconnect_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+        while tokio::time::Instant::now() < reconnect_deadline {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await,
+            "alice should have reconnected to bob via bootstrap cache \
+             even with allow_local_scope=FALSE"
+        );
+
+        // Verify DM succeeds over the recovered connection.
+        alice
+            .direct_messaging()
+            .mark_connected(bob.agent_id(), bob.machine_id())
+            .await;
+        let receipt = alice
+            .send_direct_with_config(
+                &bob.agent_id(),
+                b"post-reconnect-global-bootstrap".to_vec(),
+                dm::DmSendConfig {
+                    prefer_raw_quic_if_connected: true,
+                    ..dm::DmSendConfig::default()
+                },
+            )
+            .await
+            .expect("DM should succeed over the recovered connection");
+        assert_eq!(receipt.path, dm::DmPath::RawQuic);
+    }
+    // ─── Reconnect-policy suppression regression tests ─────────────────────
+    //
+    // These defend the invariant from the final independent review: a peer
+    // disconnected for a NON-transport reason (policy rejection, pool
+    // eviction, admin teardown, revocation, shutdown) must never be
+    // proactively redialed. Pre-fix every `PeerDisconnected` was generic and
+    // `schedule_reconnect` restored the peer via the bootstrap-cache fallback
+    // within the first backoff attempt (~1 s), undoing the security/eviction
+    // decision. `DisconnectReason` now carries reconnect eligibility through
+    // both event streams and records a suppression tombstone.
+
+    /// Positive control: a Transport-level disconnect (QUIC idle timeout /
+    /// remote restart) is reconnect-eligible — the suppression machinery must
+    /// not over-fire and starve genuine transport recovery. `disconnect()`
+    /// defaults to Transport, preserving the existing happy-path semantics.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn transport_disconnect_is_reconnect_eligible_and_recovers() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("alice");
+        alice.start_network_event_listener();
+        let alice_network = alice.network().expect("alice network");
+
+        let bob = Agent::builder()
+            .with_machine_key(dir.path().join("bob-machine.key"))
+            .with_agent_key_path(dir.path().join("bob-agent.key"))
+            .with_contact_store_path(dir.path().join("bob-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("bob-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("bob");
+        let bob_addr = normalize_loopback_addr(
+            bob.network()
+                .expect("bob net")
+                .bound_addr()
+                .await
+                .expect("bob bound"),
+        );
+        let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+
+        let connected = alice_network
+            .connect_addr(bob_addr)
+            .await
+            .expect("alice connects to bob");
+        assert_eq!(connected.0, bob.machine_id().0);
+        let reg = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < reg {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await,
+            "bob connected before transport disconnect"
+        );
+
+        assert!(
+            network::DisconnectReason::Transport.reconnect_eligible(),
+            "Transport is the only reconnect-eligible reason"
+        );
+
+        alice_network
+            .disconnect_with_reason(&bob_peer, network::DisconnectReason::Transport)
+            .await
+            .expect("transport disconnect");
+        assert!(
+            !alice_network.is_reconnect_suppressed(bob.machine_id().0),
+            "Transport disconnect must NOT set a tombstone"
+        );
+        assert!(
+            !alice_network.is_connected(&bob_peer).await,
+            "bob disconnected after transport disconnect"
+        );
+
+        // Proactive reconnect must recover bob within the backoff window.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+        while tokio::time::Instant::now() < deadline {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await,
+            "Transport disconnect must be redialed within the backoff window"
+        );
+    }
+
+    /// Admin teardown, revocation, and shutdown must suppress proactive
+    /// reconnect. For each reason: alice connects bob (so bob is in alice's
+    /// bootstrap cache — the Phase-2 fallback path that restored rejected
+    /// peers pre-fix), issues the disconnect with the reason, and asserts the
+    /// tombstone is set immediately AND bob stays disconnected past the first
+    /// two backoff attempts (1 s + 2 s), which is where the pre-fix
+    /// cache-fallback redial would have re-established the connection.
+    /// `PolicyRejection` (full backoff window) and `PoolEviction` (real
+    /// eviction) have dedicated tests below.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn admin_revocation_shutdown_disconnect_suppresses_proactive_reconnect() {
+        let reasons = [
+            network::DisconnectReason::Admin,
+            network::DisconnectReason::Revocation,
+            network::DisconnectReason::Shutdown,
+        ];
+
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("alice");
+        // Arm the proactive-reconnect scheduler so the gating is exercised for
+        // real, not just the tombstone lookup.
+        alice.start_network_event_listener();
+        let alice_network = alice.network().expect("alice network");
+
+        for reason in reasons {
+            // Fresh bob per reason: Revocation/Shutdown tombstones are
+            // permanent, so a suppressed bob can never be reused.
+            let tag = format!("{reason:?}");
+            let bob = Agent::builder()
+                .with_machine_key(dir.path().join(format!("{tag}-machine.key")))
+                .with_agent_key_path(dir.path().join(format!("{tag}-agent.key")))
+                .with_contact_store_path(dir.path().join(format!("{tag}-contacts.json")))
+                .with_peer_cache_dir(dir.path().join(format!("{tag}-peers")))
+                .with_network_config(loopback_network_config())
+                .build()
+                .await
+                .expect("bob");
+            let bob_network = bob.network().expect("bob network");
+            let bob_addr =
+                normalize_loopback_addr(bob_network.bound_addr().await.expect("bob bound"));
+            let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+            let bob_id = bob.machine_id().0;
+
+            // Establish a real connection so bob lands in alice's bootstrap
+            // cache — the exact fallback that restored rejected peers pre-fix.
+            let connected = alice_network
+                .connect_addr(bob_addr)
+                .await
+                .expect("alice connects to bob");
+            assert_eq!(connected.0, bob.machine_id().0, "{tag}: connected to bob");
+            let reg = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+            while tokio::time::Instant::now() < reg {
+                if alice_network.is_connected(&bob_peer).await {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+            assert!(
+                alice_network.is_connected(&bob_peer).await,
+                "{tag}: alice connected to bob before disconnect"
+            );
+            assert!(
+                !alice_network.is_reconnect_suppressed(bob_id),
+                "{tag}: no tombstone before disconnect"
+            );
+            assert!(
+                !reason.reconnect_eligible(),
+                "{tag}: non-transport reasons are not reconnect-eligible"
+            );
+
+            // The security/lifecycle teardown — the single production seam.
+            alice_network
+                .disconnect_with_reason(&bob_peer, reason)
+                .await
+                .expect("disconnect_with_reason");
+
+            assert!(
+                !alice_network.is_connected(&bob_peer).await,
+                "{tag}: bob disconnected immediately"
+            );
+            assert!(
+                alice_network.is_reconnect_suppressed(bob_id),
+                "{tag}: suppression tombstone set"
+            );
+
+            // Teeth: poll past the first two backoff attempts (1 s + 2 s).
+            // Pre-fix the generic PeerDisconnected fired schedule_reconnect
+            // and restored bob via the bootstrap cache within ~1 s. bob is
+            // still listening, so a redial WOULD succeed if the gate failed.
+            let guard = tokio::time::Instant::now() + std::time::Duration::from_secs(6);
+            let mut redialed = false;
+            while tokio::time::Instant::now() < guard {
+                if alice_network.is_connected(&bob_peer).await {
+                    redialed = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+            assert!(
+                !redialed,
+                "{tag}: suppressed peer must not be redialed within the backoff window"
+            );
+            // bob dropped here; the next iteration builds a fresh bob.
+        }
+    }
+
+    /// A peer rejected by pinned-bootstrap policy must stay disconnected for
+    /// the ENTIRE proactive-reconnect backoff window (1+2+4+8+16 s), even
+    /// though it remains in the bootstrap cache and would be restored by the
+    /// cache-fallback redial under the pre-fix generic-event code. This is the
+    /// acceptance gate from the final independent review: "Test a wrong pinned
+    /// peer for the full backoff window."
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn wrong_pinned_peer_stays_disconnected_for_full_backoff_window() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("alice");
+        alice.start_network_event_listener();
+        let alice_network = alice.network().expect("alice network");
+
+        // The imposter: alice connects it first so it lands in alice's
+        // bootstrap cache — the exact Phase-2 fallback path that restored a
+        // policy-rejected peer pre-fix.
+        let imposter = Agent::builder()
+            .with_machine_key(dir.path().join("imp-machine.key"))
+            .with_agent_key_path(dir.path().join("imp-agent.key"))
+            .with_contact_store_path(dir.path().join("imp-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("imp-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("imposter");
+        let imp_network = imposter.network().expect("imposter network");
+        let imp_addr = normalize_loopback_addr(imp_network.bound_addr().await.expect("imp bound"));
+        let imp_peer = ant_quic::PeerId(imposter.machine_id().0);
+
+        let connected = alice_network
+            .connect_addr(imp_addr)
+            .await
+            .expect("alice connects to imposter");
+        assert_eq!(connected.0, imposter.machine_id().0);
+        let reg = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < reg {
+            if alice_network.is_connected(&imp_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            alice_network.is_connected(&imp_peer).await,
+            "imposter connected before rejection"
+        );
+
+        // Reject the imposter for pinned-bootstrap policy — the exact seam the
+        // real dial_bootstrap / peer-mismatch paths call.
+        alice_network
+            .disconnect_with_reason(&imp_peer, network::DisconnectReason::PolicyRejection)
+            .await
+            .expect("policy reject");
+        assert!(
+            !alice_network.is_connected(&imp_peer).await,
+            "imposter disconnected after policy rejection"
+        );
+        assert!(
+            alice_network.is_reconnect_suppressed(imposter.machine_id().0),
+            "PolicyRejection sets a permanent tombstone"
+        );
+
+        // Poll the FULL backoff window. The imposter is still listening (so a
+        // redial WOULD succeed) and still in the bootstrap cache; under the
+        // pre-fix code schedule_reconnect's Phase 2 (connect_cached_peer)
+        // restored it within the first attempt (~1 s). It must never reappear.
+        // Sum of RECONNECT_BACKOFF_DELAYS (1+2+4+8+16) = 31 s; add margin.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(34);
+        while tokio::time::Instant::now() < deadline {
+            assert!(
+                !alice_network.is_connected(&imp_peer).await,
+                "wrong pinned peer must stay disconnected for the full backoff \
+                 window despite being in the bootstrap cache"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
+    }
+
+    /// A connection-pool eviction (LRU over `max_connections`) must not
+    /// trigger a redial that immediately reconnects the evicted peer — the
+    /// evict/redial churn loop flagged in the final review. This exercises the
+    /// GENUINE eviction path: alice's pool is capped at one connection, so
+    /// connecting charlie evicts bob via the real `disconnect_pool_candidates`
+    /// path with a `PoolEviction` reason. The tombstone must keep bob from
+    /// being redialed while alice holds charlie — pre-fix the eviction emitted
+    /// a generic `PeerDisconnected`, schedule_reconnect redialed bob, the pool
+    /// re-evicted charlie to readmit bob, and the cycle repeated.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn pool_cap_eviction_does_not_churn_redial() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        // Cap the pool at one connection so a second peer forces a real LRU
+        // eviction through disconnect_pool_candidates (PoolEviction).
+        let mut one_conn_cfg = loopback_network_config();
+        one_conn_cfg.max_connections = 1;
+
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(one_conn_cfg)
+            .build()
+            .await
+            .expect("alice");
+        alice.start_network_event_listener();
+        let alice_network = alice.network().expect("alice network");
+
+        let bob = Agent::builder()
+            .with_machine_key(dir.path().join("bob-machine.key"))
+            .with_agent_key_path(dir.path().join("bob-agent.key"))
+            .with_contact_store_path(dir.path().join("bob-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("bob-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("bob");
+        let charlie = Agent::builder()
+            .with_machine_key(dir.path().join("charlie-machine.key"))
+            .with_agent_key_path(dir.path().join("charlie-agent.key"))
+            .with_contact_store_path(dir.path().join("charlie-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("charlie-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("charlie");
+
+        let bob_addr = normalize_loopback_addr(
+            bob.network()
+                .expect("bob net")
+                .bound_addr()
+                .await
+                .expect("bob bound"),
+        );
+        let charlie_addr = normalize_loopback_addr(
+            charlie
+                .network()
+                .expect("charlie net")
+                .bound_addr()
+                .await
+                .expect("charlie bound"),
+        );
+        let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+        let charlie_peer = ant_quic::PeerId(charlie.machine_id().0);
+
+        // alice → bob fills the single pool slot.
+        let cb = alice_network
+            .connect_addr(bob_addr)
+            .await
+            .expect("connect bob");
+        assert_eq!(cb.0, bob.machine_id().0);
+        let reg = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < reg {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await,
+            "bob connected before eviction"
+        );
+
+        // alice → charlie: the real LRU eviction path fires — bob is evicted
+        // with PoolEviction via note_connection_pool_activity.
+        let cc = alice_network
+            .connect_addr(charlie_addr)
+            .await
+            .expect("connect charlie");
+        assert_eq!(cc.0, charlie.machine_id().0);
+
+        // Wait for the eviction to land (bob disconnected + tombstoned).
+        let evict_dl = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < evict_dl {
+            if !alice_network.is_connected(&bob_peer).await
+                && alice_network.is_reconnect_suppressed(bob.machine_id().0)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(
+            alice_network.is_reconnect_suppressed(bob.machine_id().0),
+            "evicted bob must carry a PoolEviction tombstone"
+        );
+        assert!(
+            !alice_network.is_connected(&bob_peer).await,
+            "evicted bob must be disconnected"
+        );
+
+        // Teeth: bob must NOT be redialed (which would evict charlie and
+        // churn). charlie stays put — proof the loop is broken. Poll past the
+        // first two backoff attempts.
+        let guard = tokio::time::Instant::now() + std::time::Duration::from_secs(6);
+        while tokio::time::Instant::now() < guard {
+            assert!(
+                !alice_network.is_connected(&bob_peer).await,
+                "evicted bob must not be redialed (churn)"
+            );
+            assert!(
+                alice_network.is_connected(&charlie_peer).await,
+                "charlie must stay connected — no churn displacement"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
     }
 
     #[tokio::test]
@@ -13247,4 +14684,113 @@ fn deserialize_identity_announcement_rejects_garbage() {
 fn deserialize_machine_announcement_rejects_garbage() {
     let result = deserialize_machine_announcement(b"not-a-valid-bincode");
     assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Restart-safe FenceToken: restart-epoch ABA fence (unit tests)
+// ---------------------------------------------------------------------------
+//
+// FenceToken combines a per-replica epoch (regenerated on daemon restart via
+// `fresh_epoch`) with the local revision. The handle accepts a caller's token
+// only when BOTH match its current `(epoch, revision)` — i.e. exactly when
+// `expected == current`. These tests pin that equality contract: an identical
+// revision under a DIFFERENT epoch is rejected (closes the restart-ABA window
+// without persisting task state), and a moved revision at the same epoch is
+// rejected (stale local snapshot). The wire encoding is opaque to clients.
+
+#[cfg(test)]
+mod fence_token_tests {
+    use crate::FenceToken;
+
+    #[test]
+    fn wire_roundtrip_preserves_epoch_and_revision() {
+        let token = FenceToken {
+            epoch: 123,
+            revision: 456,
+        };
+        let wire = token.to_wire();
+        let back = FenceToken::from_wire(&wire).expect("roundtrip parses");
+        assert_eq!(back, token);
+    }
+
+    #[test]
+    fn from_wire_returns_err_for_malformed_and_overflow_tokens() {
+        // `from_wire` returns Result: a present-but-malformed/overflow token is
+        // `Err`, which the PATCH handler maps to 400 BAD_REQUEST (non-mutating).
+        // This is distinct from an ABSENT token (still a valid unfenced advisory
+        // commit). A corrupt/legacy/overflow token can never bypass the guard or
+        // silently downgrade to "no fence".
+        assert!(FenceToken::from_wire("").is_err());
+        assert!(FenceToken::from_wire("no-colon").is_err());
+        assert!(FenceToken::from_wire(":5").is_err(), "missing epoch");
+        assert!(FenceToken::from_wire("1:").is_err(), "missing revision");
+        assert!(FenceToken::from_wire("1:2:3").is_err(), "too many parts");
+        assert!(FenceToken::from_wire("abc:2").is_err(), "non-numeric epoch");
+        assert!(
+            FenceToken::from_wire("1:xyz").is_err(),
+            "non-numeric revision"
+        );
+        // Integer overflow beyond u64 must be Err, not wrapped/truncated to a
+        // bogus token that could ABA-match a real one.
+        assert!(
+            FenceToken::from_wire("999999999999999999999999999999:1").is_err(),
+            "epoch overflow must be rejected"
+        );
+        assert!(
+            FenceToken::from_wire("1:999999999999999999999999999999").is_err(),
+            "revision overflow must be rejected"
+        );
+        // Teeth check: a well-formed token still parses to Ok, so the parser
+        // rejects malformed input specifically, not all input.
+        let ok = FenceToken::from_wire("123:456");
+        assert!(ok.is_ok(), "well-formed token must parse");
+        assert_eq!(
+            ok.unwrap(),
+            FenceToken {
+                epoch: 123,
+                revision: 456
+            }
+        );
+    }
+
+    #[test]
+    fn same_revision_different_epoch_is_stale_the_restart_aba_breaker() {
+        // The handle regenerates its epoch on restart (fresh_epoch). A token
+        // captured BEFORE a restart carries the pre-restart epoch; even if the
+        // revision counter later reaches the SAME value post-restart, the
+        // epoch differs ⇒ the token is rejected. This is the restart-ABA fence.
+        let pre_restart = FenceToken {
+            epoch: 100,
+            revision: 42,
+        };
+        let post_restart_same_revision = FenceToken {
+            epoch: 999,
+            revision: 42,
+        };
+        assert_ne!(
+            pre_restart, post_restart_same_revision,
+            "epoch differs ⇒ stale even at an identical revision (ABA safe)"
+        );
+        // An exact (epoch, revision) match is accepted.
+        let current = FenceToken {
+            epoch: 999,
+            revision: 42,
+        };
+        assert_eq!(post_restart_same_revision, current, "exact match accepts");
+    }
+
+    #[test]
+    fn stale_revision_at_same_epoch_is_stale() {
+        // Within one epoch (no restart), a moved local snapshot (revision
+        // advanced) also rejects the caller's stale token.
+        let stale = FenceToken {
+            epoch: 7,
+            revision: 3,
+        };
+        let current = FenceToken {
+            epoch: 7,
+            revision: 4,
+        };
+        assert_ne!(stale, current, "revision moved ⇒ token is stale");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9067,7 +9067,10 @@ impl Agent {
         })?;
 
         let peer_id = runtime.peer_id();
-        let list_id = crdt::TaskListId::from_content(name, &self.agent_id(), 0);
+        // The id MUST derive from the shared topic alone (not name/agent_id) so
+        // every replica of this list agrees on it — it is the attestation scope
+        // bound into claim/complete signatures. See TaskListId::from_topic.
+        let list_id = crdt::TaskListId::from_topic(topic);
         let task_list = crdt::TaskList::new(list_id, name.to_string(), peer_id);
 
         let sync = crdt::TaskListSync::new(
@@ -9134,8 +9137,11 @@ impl Agent {
         })?;
 
         let peer_id = runtime.peer_id();
-        // Create empty task list; it will be populated via delta sync
-        let list_id = crdt::TaskListId::from_content(topic, &self.agent_id(), 0);
+        // Create empty task list; it will be populated via delta sync. The id
+        // MUST match the creator's — derive it from the shared topic alone (see
+        // create_task_list / TaskListId::from_topic), otherwise the scope bound
+        // into remote claim attestations won't verify and claims never converge.
+        let list_id = crdt::TaskListId::from_topic(topic);
         let task_list = crdt::TaskList::new(list_id, String::new(), peer_id);
 
         let sync = crdt::TaskListSync::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9786,7 +9786,25 @@ impl TaskListHandle {
         title: String,
         description: String,
     ) -> error::Result<crdt::TaskId> {
-        let (task_id, delta) = {
+        let (task_id, _version) = self.add_task_versioned(title, description).await?;
+        Ok(task_id)
+    }
+
+    /// Add a new task and report the task list's post-mutation version.
+    ///
+    /// Same as [`TaskListHandle::add_task`] but additionally returns the
+    /// list's version counter after the add, read atomically under the same
+    /// write lock as the mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the task cannot be added.
+    pub async fn add_task_versioned(
+        &self,
+        title: String,
+        description: String,
+    ) -> error::Result<(crdt::TaskId, u64)> {
+        let (task_id, version, delta) = {
             let mut list = self.sync.write().await;
             let seq = list.next_seq();
             let task_id = crdt::TaskId::new(&title, &self.agent_id, seq);
@@ -9800,14 +9818,15 @@ impl TaskListHandle {
                     )))
                 })?;
             let tag = (self.peer_id, seq);
-            let delta = crdt::TaskListDelta::for_add(task_id, task, tag, list.current_version());
-            (task_id, delta)
+            let version = list.current_version();
+            let delta = crdt::TaskListDelta::for_add(task_id, task, tag, version);
+            (task_id, version, delta)
         };
         // Best-effort replication: local mutation succeeded regardless
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
             tracing::warn!("failed to publish add_task delta: {}", e);
         }
-        Ok(task_id)
+        Ok((task_id, version))
     }
 
     /// Claim a task in the list.
@@ -9820,8 +9839,39 @@ impl TaskListHandle {
     ///
     /// Returns an error if the task cannot be claimed.
     pub async fn claim_task(&self, task_id: crdt::TaskId) -> error::Result<()> {
-        let delta = {
+        // No expected version ⇒ can never conflict.
+        self.claim_task_versioned(task_id, None).await.map(|_| ())
+    }
+
+    /// Claim a task, optionally guarded by an expected list version (CAS).
+    ///
+    /// If `expected_version` is `Some(v)` and the task list's current version
+    /// is not `v`, nothing is mutated and
+    /// [`TaskCasOutcome::VersionConflict`] is returned with the current
+    /// version. The check and the mutation happen under a single write lock.
+    ///
+    /// `Committed` means the claim was applied to the local replica and a
+    /// delta was published to peers — not that any peer has observed it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the task does not exist or the state transition
+    /// is invalid (e.g. the task is already done).
+    pub async fn claim_task_versioned(
+        &self,
+        task_id: crdt::TaskId,
+        expected_version: Option<u64>,
+    ) -> error::Result<TaskCasOutcome> {
+        let (version, delta) = {
             let mut list = self.sync.write().await;
+            if let Some(expected) = expected_version {
+                let current = list.current_version();
+                if current != expected {
+                    return Ok(TaskCasOutcome::VersionConflict {
+                        current_version: current,
+                    });
+                }
+            }
             let seq = list.next_seq();
             list.claim_task(&task_id, self.agent_id, self.peer_id, seq)
                 .map_err(|e| {
@@ -9839,12 +9889,16 @@ impl TaskListHandle {
                     ))
                 })?
                 .clone();
-            crdt::TaskListDelta::for_state_change(task_id, full_task, list.current_version())
+            let version = list.current_version();
+            (
+                version,
+                crdt::TaskListDelta::for_state_change(task_id, full_task, version),
+            )
         };
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
             tracing::warn!("failed to publish claim_task delta: {}", e);
         }
-        Ok(())
+        Ok(TaskCasOutcome::Committed { version })
     }
 
     /// Complete a task in the list.
@@ -9857,8 +9911,37 @@ impl TaskListHandle {
     ///
     /// Returns an error if the task cannot be completed.
     pub async fn complete_task(&self, task_id: crdt::TaskId) -> error::Result<()> {
-        let delta = {
+        // No expected version ⇒ can never conflict.
+        self.complete_task_versioned(task_id, None)
+            .await
+            .map(|_| ())
+    }
+
+    /// Complete a task, optionally guarded by an expected list version (CAS).
+    ///
+    /// Semantics mirror [`TaskListHandle::claim_task_versioned`]: a mismatch
+    /// between `expected_version` and the current list version returns
+    /// [`TaskCasOutcome::VersionConflict`] with no mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the task does not exist or the state transition
+    /// is invalid (e.g. the task was never claimed).
+    pub async fn complete_task_versioned(
+        &self,
+        task_id: crdt::TaskId,
+        expected_version: Option<u64>,
+    ) -> error::Result<TaskCasOutcome> {
+        let (version, delta) = {
             let mut list = self.sync.write().await;
+            if let Some(expected) = expected_version {
+                let current = list.current_version();
+                if current != expected {
+                    return Ok(TaskCasOutcome::VersionConflict {
+                        current_version: current,
+                    });
+                }
+            }
             let seq = list.next_seq();
             list.complete_task(&task_id, self.agent_id, self.peer_id, seq)
                 .map_err(|e| {
@@ -9875,12 +9958,16 @@ impl TaskListHandle {
                     ))
                 })?
                 .clone();
-            crdt::TaskListDelta::for_state_change(task_id, full_task, list.current_version())
+            let version = list.current_version();
+            (
+                version,
+                crdt::TaskListDelta::for_state_change(task_id, full_task, version),
+            )
         };
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta).await {
             tracing::warn!("failed to publish complete_task delta: {}", e);
         }
-        Ok(())
+        Ok(TaskCasOutcome::Committed { version })
     }
 
     /// List all tasks in their current order.
@@ -9893,20 +9980,55 @@ impl TaskListHandle {
     ///
     /// Returns an error if the task list cannot be read.
     pub async fn list_tasks(&self) -> error::Result<Vec<TaskSnapshot>> {
+        let (tasks, _version) = self.list_tasks_with_version().await?;
+        Ok(tasks)
+    }
+
+    /// List all tasks together with the task list's current version.
+    ///
+    /// The snapshots and the version are read atomically under a single read
+    /// lock, so the returned version is consistent with the returned tasks —
+    /// suitable as the `expected_version` for a subsequent CAS mutation via
+    /// [`TaskListHandle::claim_task_versioned`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the task list cannot be read.
+    pub async fn list_tasks_with_version(&self) -> error::Result<(Vec<TaskSnapshot>, u64)> {
         let list = self.sync.read().await;
+        let version = list.current_version();
         let tasks = list.tasks_ordered();
-        Ok(tasks
+        let snapshots = tasks
             .into_iter()
-            .map(|task| TaskSnapshot {
-                id: *task.id(),
-                title: task.title().to_string(),
-                description: task.description().to_string(),
-                state: task.current_state(),
-                assignee: task.assignee().copied(),
-                owner: None,
-                priority: task.priority(),
+            .map(|task| {
+                let claim = task.claim_record();
+                let completion = task.completion_record();
+                TaskSnapshot {
+                    id: *task.id(),
+                    title: task.title().to_string(),
+                    description: task.description().to_string(),
+                    state: task.current_state(),
+                    assignee: task.assignee().copied(),
+                    owner: None,
+                    priority: task.priority(),
+                    claimed_by: claim.map(|(agent, _)| agent),
+                    claimed_at: claim.map(|(_, ts)| ts),
+                    completed_by: completion.map(|(agent, _)| agent),
+                    completed_at: completion.map(|(_, ts)| ts),
+                }
             })
-            .collect())
+            .collect();
+        Ok((snapshots, version))
+    }
+
+    /// The task list's current version counter.
+    ///
+    /// Incremented on every local or merged mutation. Useful as the
+    /// `expected_version` for CAS mutations; prefer
+    /// [`TaskListHandle::list_tasks_with_version`] when the tasks are also
+    /// needed, to read both atomically.
+    pub async fn version(&self) -> u64 {
+        self.sync.read().await.current_version()
     }
 
     /// Reorder tasks in the list.
@@ -10295,6 +10417,36 @@ pub struct TaskSnapshot {
     pub owner: Option<identity::UserId>,
     /// Task priority (0-255, higher = more important).
     pub priority: u8,
+    /// The agent whose claim won (deterministic OR-Set winner), if claimed.
+    /// Remains set after the task transitions to Done.
+    pub claimed_by: Option<identity::AgentId>,
+    /// Unix-millisecond timestamp of the winning claim, if claimed.
+    pub claimed_at: Option<u64>,
+    /// The agent whose completion won (deterministic OR-Set winner), if done.
+    pub completed_by: Option<identity::AgentId>,
+    /// Unix-millisecond timestamp of the winning completion, if done.
+    pub completed_at: Option<u64>,
+}
+
+/// Outcome of a task-list mutation guarded by an optional expected version.
+///
+/// Returned by [`TaskListHandle::claim_task_versioned`] and
+/// [`TaskListHandle::complete_task_versioned`]. `Committed` means the
+/// mutation was applied to the **local** replica and a delta was published —
+/// it does NOT mean any peer has observed the change yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskCasOutcome {
+    /// The mutation was committed locally; `version` is the new list version.
+    Committed {
+        /// The task list's version after this mutation.
+        version: u64,
+    },
+    /// The caller's `expected_version` did not match the current list
+    /// version; nothing was mutated.
+    VersionConflict {
+        /// The task list's current (unchanged) version.
+        current_version: u64,
+    },
 }
 
 /// The x0x protocol version.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6527,7 +6527,16 @@ impl Agent {
                 {
                     if let Some(net) = &network {
                         let ant_peer = ant_quic::PeerId(announcement.machine_id.0);
-                        if !net.is_connected(&ant_peer).await {
+                        // Security gate: a peer that was revoked, policy-rejected,
+                        // admin-disconnected, or capacity-evicted carries a
+                        // reconnect-suppression tombstone. Such a peer may keep
+                        // broadcasting identity announcements over gossip; if we
+                        // auto-connected on those, we would silently undo the
+                        // security/eviction decision. Skip the dial (and do not
+                        // record an attempt) while the tombstone is live.
+                        let suppressed = net.is_reconnect_suppressed(announcement.machine_id.0);
+                        let connected = net.is_connected(&ant_peer).await;
+                        if announcement_should_auto_connect(suppressed, connected) {
                             auto_connect_attempted.insert(announcement.agent_id);
                             let net = std::sync::Arc::clone(net);
                             let addresses = auto_connect_addresses.clone();
@@ -6550,6 +6559,12 @@ impl Agent {
                                     addresses.len(),
                                 );
                             });
+                        } else if suppressed {
+                            tracing::debug!(
+                                target: "x0x::connect",
+                                peer_id_prefix = %network::hex_prefix(&announcement.machine_id.0, 4),
+                                "skipping announcement auto-connect for reconnect-suppressed peer",
+                            );
                         }
                     }
                 }
@@ -9172,6 +9187,33 @@ const RECONNECT_BACKOFF_DELAYS: &[std::time::Duration] = &[
     std::time::Duration::from_secs(16),
 ];
 
+/// Whether a discovered peer's identity announcement should trigger an
+/// auto-connect dial.
+///
+/// Returns `false` when the peer's reconnect is suppressed — it was revoked,
+/// policy-rejected, admin-disconnected, or capacity-evicted — so that a
+/// suppressed peer which keeps broadcasting identity announcements is not
+/// silently reconnected (which would undo the security/eviction decision), and
+/// `false` when the peer is already connected. Extracted as a pure predicate so
+/// the security invariant is unit-testable independently of the gossip stack.
+fn announcement_should_auto_connect(reconnect_suppressed: bool, already_connected: bool) -> bool {
+    !reconnect_suppressed && !already_connected
+}
+
+/// Apply bounded ±20% random jitter to a reconnect backoff delay.
+///
+/// Fixed backoff delays cause N peers that disconnected together (e.g. a shared
+/// bootstrap node restart) to redial in lockstep, producing synchronized
+/// connection storms. Scaling each delay by a random factor in `[0.8, 1.2)`
+/// decorrelates those redials while preserving the intended exponential
+/// backoff shape. The jitter is for load-spreading only, so a fast non-crypto
+/// RNG is sufficient.
+fn jittered_backoff_delay(delay: std::time::Duration) -> std::time::Duration {
+    // factor ∈ [0.8, 1.2): rand::random::<f64>() yields [0.0, 1.0).
+    let factor = 0.8 + rand::random::<f64>() * 0.4;
+    delay.mul_f64(factor)
+}
+
 /// Type alias for the single-flight reconnect tracker shared between the
 /// network-event listener and the peer-lifecycle watcher.
 type ReconnectTracker = std::sync::Arc<
@@ -9210,6 +9252,15 @@ fn schedule_reconnect(
     peer_id_bytes: [u8; 32],
     active_reconnects: ReconnectTracker,
 ) {
+    // Defense in depth: never schedule a reconnect for a peer whose redial is
+    // suppressed (revocation, policy rejection, admin teardown, capacity
+    // eviction). The call sites already gate on this, but re-checking here
+    // keeps the scheduler authoritative if a future call site forgets — a
+    // suppressed peer must never be proactively redialed.
+    if network.is_reconnect_suppressed(peer_id_bytes) {
+        return;
+    }
+
     // Single-flight: hold the lock across check + spawn + insert so two
     // concurrent callers cannot both start a reconnect for the same peer.
     let mut tracker = match active_reconnects.lock() {
@@ -9236,11 +9287,28 @@ fn schedule_reconnect(
             "scheduling proactive reconnect for disconnected peer",
         );
 
-        for (attempt, &delay) in RECONNECT_BACKOFF_DELAYS.iter().enumerate() {
-            // Wait with cancellation before each attempt.
+        'attempts: for (attempt, &delay) in RECONNECT_BACKOFF_DELAYS.iter().enumerate() {
+            // Wait with cancellation before each attempt. Apply bounded jitter
+            // so peers that disconnected together do not redial in lockstep.
             tokio::select! {
                 _ = shutdown_token.cancelled() => break,
-                _ = tokio::time::sleep(delay) => {}
+                _ = tokio::time::sleep(jittered_backoff_delay(delay)) => {}
+            }
+
+            // Re-check suppression on every attempt: a peer that was revoked,
+            // policy-rejected, admin-disconnected, or evicted *during* the
+            // backoff sequence must stop being redialed mid-flight. Re-checked
+            // again immediately before each dial below, since the intervening
+            // `is_connected`/cache-read awaits give a concurrent
+            // `disconnect_with_reason` a window to set the tombstone.
+            if network.is_reconnect_suppressed(peer_id_bytes) {
+                tracing::debug!(
+                    target: "x0x::connect",
+                    peer_id_prefix = %prefix,
+                    attempt,
+                    "reconnect cancelled: peer reconnect-suppressed",
+                );
+                break;
             }
 
             // Another path (mDNS auto-connect, inbound dial, announcement
@@ -9284,6 +9352,18 @@ fn schedule_reconnect(
 
             // Phase 1: discovery-cache addresses (LAN/loopback for same-host).
             for addr in &candidate_addrs {
+                // Final suppression gate immediately before the dial: closes the
+                // TOCTOU window left open by the awaits above (and by prior dials
+                // in this same loop), so a peer revoked/evicted mid-backoff is
+                // never actually redialed.
+                if network.is_reconnect_suppressed(peer_id_bytes) {
+                    tracing::debug!(
+                        target: "x0x::connect",
+                        peer_id_prefix = %prefix,
+                        "reconnect aborted before dial: peer reconnect-suppressed",
+                    );
+                    break 'attempts;
+                }
                 match tokio::time::timeout(
                     std::time::Duration::from_secs(5),
                     network.connect_addr(*addr),
@@ -9333,6 +9413,15 @@ fn schedule_reconnect(
             // Phase 2: bootstrap-cache fallback (public addresses for remote
             // peers that may have NAT-stable endpoints).
             if !connected {
+                // Final suppression gate before the fallback dial (see Phase 1).
+                if network.is_reconnect_suppressed(peer_id_bytes) {
+                    tracing::debug!(
+                        target: "x0x::connect",
+                        peer_id_prefix = %prefix,
+                        "reconnect aborted before bootstrap-cache dial: peer reconnect-suppressed",
+                    );
+                    break 'attempts;
+                }
                 match network.connect_cached_peer(peer_id).await {
                     Ok(_) => {
                         tracing::info!(
@@ -12735,6 +12824,107 @@ mod tests {
                 "{tag}: suppressed peer must not be redialed within the backoff window"
             );
             // bob dropped here; the next iteration builds a fresh bob.
+        }
+    }
+
+    /// The announcement auto-connect gate must refuse to dial a peer whose
+    /// reconnect is suppressed. WHY: a revoked / policy-rejected / admin-
+    /// disconnected / evicted peer can keep broadcasting identity announcements
+    /// over gossip. If the auto-connect path dialed on those, it would silently
+    /// undo the security/eviction decision (the ungated hole). This exercises
+    /// the exact production predicate (`announcement_should_auto_connect`) with
+    /// live network state: a real revocation tombstone set via the production
+    /// `disconnect_with_reason` seam.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn suppressed_peer_announcement_is_not_auto_connected() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("alice");
+        let alice_network = alice.network().expect("alice network");
+
+        let bob = Agent::builder()
+            .with_machine_key(dir.path().join("bob-machine.key"))
+            .with_agent_key_path(dir.path().join("bob-agent.key"))
+            .with_contact_store_path(dir.path().join("bob-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("bob-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("bob");
+        let bob_network = bob.network().expect("bob network");
+        let bob_addr = normalize_loopback_addr(bob_network.bound_addr().await.expect("bob bound"));
+        let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+        let bob_id = bob.machine_id().0;
+
+        // Connect so bob is known, then revoke him. The tombstone is what the
+        // announcement gate consults.
+        alice_network
+            .connect_addr(bob_addr)
+            .await
+            .expect("alice connects bob");
+        let reg = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < reg {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        alice_network
+            .disconnect_with_reason(&bob_peer, network::DisconnectReason::Revocation)
+            .await
+            .expect("revoke bob");
+        assert!(
+            alice_network.is_reconnect_suppressed(bob_id),
+            "revoked bob must carry a suppression tombstone"
+        );
+
+        // The exact production decision an inbound announcement from bob would
+        // reach: suppressed=true, so no auto-connect regardless of connect
+        // state. Compute both inputs from live network state (not literals).
+        let suppressed = alice_network.is_reconnect_suppressed(bob_id);
+        let connected = alice_network.is_connected(&bob_peer).await;
+        assert!(
+            !announcement_should_auto_connect(suppressed, connected),
+            "a suppressed peer's announcement must not trigger auto-connect"
+        );
+    }
+
+    /// The auto-connect predicate only dials an un-suppressed, not-yet-connected
+    /// peer. Encodes the security invariant directly: suppression always wins,
+    /// and an already-connected peer is never redundantly dialed.
+    #[test]
+    fn announcement_auto_connect_predicate_truth_table() {
+        // (suppressed, connected) -> should_dial
+        assert!(announcement_should_auto_connect(false, false));
+        assert!(!announcement_should_auto_connect(false, true));
+        assert!(!announcement_should_auto_connect(true, false));
+        assert!(!announcement_should_auto_connect(true, true));
+    }
+
+    /// Jittered backoff must stay within ±20% of each base delay. WHY: the
+    /// jitter decorrelates synchronized redials, but it must not shrink or
+    /// inflate the exponential backoff beyond the intended envelope, or a
+    /// genuinely-down peer would be hammered (too small) or recovery would lag
+    /// (too large). Sampled across all base delays.
+    #[test]
+    fn jittered_backoff_stays_within_bounds() {
+        for &base in RECONNECT_BACKOFF_DELAYS {
+            let lower = base.mul_f64(0.8);
+            let upper = base.mul_f64(1.2);
+            for _ in 0..10_000 {
+                let j = jittered_backoff_delay(base);
+                assert!(
+                    j >= lower && j <= upper,
+                    "jittered delay {j:?} out of [{lower:?}, {upper:?}] for base {base:?}"
+                );
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9975,6 +9975,7 @@ impl Agent {
             std::sync::Arc::clone(runtime.pubsub()),
             topic.to_string(),
             peer_id,
+            Some(self.agent_id()),
         )
         .map_err(|e| {
             error::IdentityError::Storage(std::io::Error::other(format!(
@@ -10000,9 +10001,12 @@ impl Agent {
 
     /// Join an existing key-value store by topic.
     ///
-    /// Creates an empty store that will be populated via delta sync
-    /// from peers already sharing the topic. The access policy will
-    /// be learned from the first full delta received from the owner.
+    /// Creates an empty replica that will be populated via delta sync from
+    /// peers already sharing the topic. The replica starts with **no owner**
+    /// and the default `Signed` policy, which fails closed: local writes are
+    /// rejected until the authoritative owner and policy are learned from an
+    /// owner-signed announcement on the state-sync channel (published by the
+    /// owner in response to this replica's state requests).
     ///
     /// # Errors
     ///
@@ -10015,23 +10019,17 @@ impl Agent {
         })?;
 
         let peer_id = runtime.peer_id();
+        // Local placeholder id — the replica is addressed by topic; the id
+        // is not used for merge decisions on the delta path.
         let store_id = kv::KvStoreId::from_content(topic, &self.agent_id());
-        // Use Encrypted as the most permissive default — the actual policy
-        // will be set when the first delta from the owner arrives.
-        let store = kv::KvStore::new(
-            store_id,
-            String::new(),
-            self.agent_id(),
-            kv::AccessPolicy::Encrypted {
-                group_id: Vec::new(),
-            },
-        );
+        let store = kv::KvStore::new_replica(store_id, String::new());
 
         let sync = kv::KvStoreSync::new(
             store,
             std::sync::Arc::clone(runtime.pubsub()),
             topic.to_string(),
             peer_id,
+            Some(self.agent_id()),
         )
         .map_err(|e| {
             error::IdentityError::Storage(std::io::Error::other(format!(
@@ -10083,6 +10081,18 @@ impl KvStoreHandle {
         self.peer_id
     }
 
+    /// Enforce the store's access policy for a local mutation.
+    ///
+    /// Applies the same authorization rule as the inbound delta path
+    /// (`KvStore::merge_delta`), so a local write that peers would reject
+    /// never mutates this replica (no local fork).
+    fn check_local_write(store: &kv::KvStore, writer: &identity::AgentId) -> error::Result<()> {
+        store.authorize_local_write(writer).map_err(|e| match e {
+            kv::KvError::Unauthorized(msg) => error::IdentityError::Unauthorized(msg),
+            other => error::IdentityError::Unauthorized(other.to_string()),
+        })
+    }
+
     /// Put a key-value pair into the store.
     ///
     /// If the key already exists, the value is updated. Changes are
@@ -10108,7 +10118,10 @@ impl KvStoreHandle {
     ///
     /// # Errors
     ///
-    /// Returns an error if the value exceeds the maximum inline size (64 KB).
+    /// Returns an error if the value exceeds the maximum inline size (64 KB),
+    /// or [`error::IdentityError::Unauthorized`] if this agent is not
+    /// permitted to write under the store's access policy (including a
+    /// joined replica whose authoritative owner is not yet known).
     pub async fn put_with_delta(
         &self,
         key: String,
@@ -10117,6 +10130,7 @@ impl KvStoreHandle {
     ) -> error::Result<kv::KvStoreDelta> {
         let delta = {
             let mut store = self.sync.write().await;
+            Self::check_local_write(&store, &self.agent_id)?;
             store
                 .put(
                     key.clone(),
@@ -10182,10 +10196,13 @@ impl KvStoreHandle {
     ///
     /// # Errors
     ///
-    /// Returns an error if the key does not exist.
+    /// Returns an error if the key does not exist, or
+    /// [`error::IdentityError::Unauthorized`] if this agent is not permitted
+    /// to write under the store's access policy.
     pub async fn remove_with_delta(&self, key: &str) -> error::Result<kv::KvStoreDelta> {
         let delta = {
             let mut store = self.sync.write().await;
+            Self::check_local_write(&store, &self.agent_id)?;
             store.remove(key).map_err(|e| {
                 error::IdentityError::Storage(std::io::Error::other(format!(
                     "kv remove failed: {e}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5916,9 +5916,14 @@ impl Agent {
                 Revocation(crate::gossip::PubSubMessage),
             }
 
-            // Track agents we've already initiated auto-connect to, preventing
-            // duplicate connection attempts from concurrent announcements.
-            let mut auto_connect_attempted = std::collections::HashSet::<identity::AgentId>::new();
+            // Track when we last initiated an auto-connect dial per agent.
+            // Prevents duplicate attempts from concurrent announcements AND
+            // rate-limits redials to an announcing-but-unreachable peer: every
+            // failed dial accumulates ant-quic NAT-traversal/connection state,
+            // so dialing on each received announcement copy leaks memory
+            // without bound (see ANNOUNCEMENT_AUTO_CONNECT_RETRY_COOLDOWN).
+            let mut auto_connect_attempts =
+                std::collections::HashMap::<identity::AgentId, std::time::Instant>::new();
 
             // One-shot dedup for re-broadcast: (agent_id, announced_at)
             // → first-rebroadcast Instant. Bounds each fresh announcement to at
@@ -6518,12 +6523,10 @@ impl Agent {
                 // PlumTree topic trees once the QUIC connection is established.
                 if announcement.agent_id != own_agent_id
                     && !auto_connect_addresses.is_empty()
-                    && (!auto_connect_attempted.contains(&announcement.agent_id)
-                        || (if let Some(net) = &network {
-                            !net.is_connected(&ant_quic::PeerId(announcement.machine_id.0)).await
-                        } else {
-                            false
-                        }))
+                    && announcement_auto_connect_retry_allowed(
+                        auto_connect_attempts.get(&announcement.agent_id).copied(),
+                        std::time::Instant::now(),
+                    )
                 {
                     if let Some(net) = &network {
                         let ant_peer = ant_quic::PeerId(announcement.machine_id.0);
@@ -6537,7 +6540,8 @@ impl Agent {
                         let suppressed = net.is_reconnect_suppressed(announcement.machine_id.0);
                         let connected = net.is_connected(&ant_peer).await;
                         if announcement_should_auto_connect(suppressed, connected) {
-                            auto_connect_attempted.insert(announcement.agent_id);
+                            auto_connect_attempts
+                                .insert(announcement.agent_id, std::time::Instant::now());
                             let net = std::sync::Arc::clone(net);
                             let addresses = auto_connect_addresses.clone();
                             tokio::spawn(async move {
@@ -9216,6 +9220,33 @@ const RECONNECT_FAILURE_COOLDOWN: std::time::Duration = std::time::Duration::fro
 /// the security invariant is unit-testable independently of the gossip stack.
 fn announcement_should_auto_connect(reconnect_suppressed: bool, already_connected: bool) -> bool {
     !reconnect_suppressed && !already_connected
+}
+
+/// Minimum interval between auto-connect dials to the same announcing agent.
+///
+/// A peer that announces but is unreachable (behind NAT, blackholed, or dead
+/// with its announcements still circulating) would otherwise be redialed on
+/// EVERY received announcement copy — and rebroadcast fan-out delivers each
+/// fresh announcement many times within seconds. Every failed dial drives
+/// ant-quic NAT traversal/hole-punch and accumulates connection state
+/// (~2.5 MB per failed dial measured on a loopback replay repro), which is
+/// unbounded growth on a churning mesh. One dial per cooldown window per agent
+/// bounds that; a first-ever announcement still dials immediately.
+const ANNOUNCEMENT_AUTO_CONNECT_RETRY_COOLDOWN: std::time::Duration =
+    std::time::Duration::from_secs(60);
+
+/// Whether the per-agent auto-connect rate limit allows another dial attempt.
+///
+/// Pure so the anti-storm invariant (at most one dial per
+/// [`ANNOUNCEMENT_AUTO_CONNECT_RETRY_COOLDOWN`] per agent) is unit-testable
+/// independently of the gossip stack.
+fn announcement_auto_connect_retry_allowed(
+    last_attempt: Option<std::time::Instant>,
+    now: std::time::Instant,
+) -> bool {
+    last_attempt.is_none_or(|last| {
+        now.saturating_duration_since(last) >= ANNOUNCEMENT_AUTO_CONNECT_RETRY_COOLDOWN
+    })
 }
 
 /// Apply bounded ±20% random jitter to a reconnect backoff delay.
@@ -12941,6 +12972,37 @@ mod tests {
         assert!(!announcement_should_auto_connect(false, true));
         assert!(!announcement_should_auto_connect(true, false));
         assert!(!announcement_should_auto_connect(true, true));
+    }
+
+    /// The per-agent auto-connect rate limit must allow a first-ever dial
+    /// immediately, refuse a redial inside the cooldown window, and allow it
+    /// again once the window has elapsed. WHY: an announcing-but-unreachable
+    /// peer is redialed per received announcement copy; every failed dial
+    /// accumulates ant-quic NAT-traversal state (~2.5 MB measured), so an
+    /// unbounded dial rate is an unbounded memory leak (v0.31 testnet OOM).
+    #[test]
+    fn announcement_auto_connect_retry_cooldown_gates_redials() {
+        let now = std::time::Instant::now();
+        // First-ever announcement: dial immediately.
+        assert!(announcement_auto_connect_retry_allowed(None, now));
+        // Same instant as the last attempt: refuse.
+        assert!(!announcement_auto_connect_retry_allowed(Some(now), now));
+        // Just inside the window: refuse.
+        let inside =
+            now + ANNOUNCEMENT_AUTO_CONNECT_RETRY_COOLDOWN - std::time::Duration::from_millis(1);
+        assert!(!announcement_auto_connect_retry_allowed(Some(now), inside));
+        // At/after the window boundary: allow.
+        let at_boundary = now + ANNOUNCEMENT_AUTO_CONNECT_RETRY_COOLDOWN;
+        assert!(announcement_auto_connect_retry_allowed(
+            Some(now),
+            at_boundary
+        ));
+        // Clock going backwards (last_attempt in the "future") must not panic
+        // and must refuse the dial.
+        assert!(!announcement_auto_connect_retry_allowed(
+            Some(at_boundary),
+            now
+        ));
     }
 
     /// Jittered backoff must stay within ±20% of each base delay. WHY: the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9193,6 +9193,18 @@ const RECONNECT_BACKOFF_DELAYS: &[std::time::Duration] = &[
     std::time::Duration::from_secs(16),
 ];
 
+/// After a reconnect sequence exhausts all attempts WITHOUT reconnecting, hold
+/// the single-flight tracker slot for this long before releasing it. A
+/// genuinely dead/unreachable peer keeps emitting transport-close lifecycle
+/// events; without this cooldown each one immediately re-triggers a new
+/// reconnect sequence, and every attempt drives ant-quic NAT
+/// traversal/hole-punch to the dead endpoint — a tight loop that accumulates
+/// connection state and leaks memory (~1 MB/s observed on a churning mesh).
+/// Holding the slot means the existing single-flight guard suppresses
+/// re-scheduling for the cooldown window. A real recovery (PeerConnected)
+/// removes+aborts the entry, ending the cooldown immediately.
+const RECONNECT_FAILURE_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Whether a discovered peer's identity announcement should trigger an
 /// auto-connect dial.
 ///
@@ -9451,6 +9463,23 @@ fn schedule_reconnect(
 
             if connected {
                 break;
+            }
+        }
+
+        // Circuit breaker: if every attempt failed (peer genuinely
+        // dead/unreachable), hold the single-flight tracker slot for a cooldown
+        // before releasing it. A dead peer keeps emitting transport-close
+        // lifecycle events; each would otherwise immediately re-trigger a new
+        // reconnect sequence, and every attempt drives ant-quic NAT
+        // traversal/hole-punch to the dead endpoint — a tight loop that
+        // accumulates connection state and leaks memory. Keeping the entry
+        // present makes the existing single-flight guard suppress re-scheduling
+        // for the window. A genuine recovery via any path (PeerConnected aborts
+        // this task and removes the entry) ends the cooldown early.
+        if !network.is_connected(&peer_id).await {
+            tokio::select! {
+                _ = shutdown_token.cancelled() => {}
+                _ = tokio::time::sleep(RECONNECT_FAILURE_COOLDOWN) => {}
             }
         }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -1281,14 +1281,33 @@ async fn disconnect_pool_candidates(
     node: &Node,
     event_sender: &broadcast::Sender<NetworkEvent>,
     connection_pool: &ConnectionPool,
+    reconnect_suppressions: &Mutex<HashMap<[u8; 32], ReconnectSuppression>>,
     peer_ids: Vec<AntPeerId>,
     reason: &'static str,
 ) {
     for peer_id in peer_ids {
+        // Set the PoolEviction tombstone BEFORE the close so the ant-quic
+        // peer-lifecycle `Closed` watcher observes it regardless of event
+        // ordering, and so the NetworkEvent listener's PeerDisconnected
+        // arm sees a non-transport reason. Without this, proactive redial
+        // would immediately undo the LRU/idle eviction (review: "eviction
+        // does not churn").
+        if let Ok(mut map) = reconnect_suppressions.lock() {
+            map.insert(
+                peer_id.0,
+                ReconnectSuppression {
+                    reason: DisconnectReason::PoolEviction,
+                    set_at: Instant::now(),
+                },
+            );
+        }
         match node.disconnect(&peer_id).await {
             Ok(()) => {
                 connection_pool.record_disconnected(&peer_id);
-                let _ = event_sender.send(NetworkEvent::PeerDisconnected { peer_id: peer_id.0 });
+                let _ = event_sender.send(NetworkEvent::PeerDisconnected {
+                    peer_id: peer_id.0,
+                    reason: DisconnectReason::PoolEviction,
+                });
                 tracing::info!(
                     target: "x0x::connect",
                     peer_id_prefix = %hex_prefix(&peer_id.0, 4),
@@ -1354,6 +1373,14 @@ pub struct NetworkNode {
     liveness_last_ready: Arc<Mutex<HashMap<AntPeerId, Instant>>>,
     /// Daemon-local cap for concurrent pre-send probe/reconnect work.
     liveness_repair_semaphore: Arc<Semaphore>,
+    /// Reconnect-suppression tombstones, keyed by peer id. Set when a peer is
+    /// disconnected for a non-transport reason (policy rejection, pool
+    /// eviction, admin, revocation, shutdown) so neither the proactive
+    /// reconnect scheduler nor the ant-quic lifecycle `Closed` watcher redials
+    /// it — undoing a security rejection, churning an LRU eviction, or
+    /// ignoring an operator teardown. See [`DisconnectReason`] and
+    /// [`NetworkNode::is_reconnect_suppressed`].
+    reconnect_suppressions: Arc<Mutex<HashMap<[u8; 32], ReconnectSuppression>>>,
     /// Handles to the background tasks spawned at construction (receiver, accept
     /// loop, connection-pool eviction).
     ///
@@ -1482,6 +1509,7 @@ impl NetworkNode {
             liveness_locks: Arc::new(Mutex::new(HashMap::new())),
             liveness_last_ready: Arc::new(Mutex::new(HashMap::new())),
             liveness_repair_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_LIVENESS_REPAIRS)),
+            reconnect_suppressions: Arc::new(Mutex::new(HashMap::new())),
             background_tasks: Arc::new(Mutex::new(Vec::new())),
         };
 
@@ -1745,6 +1773,7 @@ impl NetworkNode {
             &node,
             &self.event_sender,
             &self.connection_pool,
+            self.reconnect_suppressions.as_ref(),
             peer_ids,
             reason,
         )
@@ -2342,27 +2371,101 @@ impl NetworkNode {
 
     /// Disconnect from a peer.
     ///
+    /// Defaults to [`DisconnectReason::Transport`] semantics: the caller
+    /// treats this as a transient drop that may be recovered (send-path zombie
+    /// teardown, or a test simulating a remote restart). Such a disconnect
+    /// remains reconnect-eligible.
+    ///
+    /// Callers that must suppress proactive redial — security rejection,
+    /// capacity eviction, revocation, explicit admin teardown — use
+    /// [`Self::disconnect_with_reason`] with the appropriate
+    /// [`DisconnectReason`].
+    ///
     /// # Arguments
     ///
     /// * `peer_id` - The peer's ID.
-    ///
-    /// # Returns
-    ///
-    /// Ok on successful disconnection.
     ///
     /// # Errors
     ///
     /// Returns `NetworkError` if disconnection fails.
     pub async fn disconnect(&self, peer_id: &AntPeerId) -> NetworkResult<()> {
+        self.disconnect_with_reason(peer_id, DisconnectReason::Transport)
+            .await
+    }
+
+    /// Disconnect from a peer carrying a structured [`DisconnectReason`].
+    ///
+    /// For any non-transport reason this records a suppression tombstone
+    /// *before* closing the connection, so that both the `NetworkEvent`
+    /// listener (which receives [`NetworkEvent::PeerDisconnected`] with the
+    /// reason) and the ant-quic peer-lifecycle `Closed` watcher (which
+    /// receives only a string reason) observe the suppression regardless of
+    /// event ordering. This closes the hole where a policy-rejected or
+    /// evicted peer was immediately redialed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NetworkError` if the underlying node is unavailable or the
+    /// transport disconnect fails.
+    pub async fn disconnect_with_reason(
+        &self,
+        peer_id: &AntPeerId,
+        reason: DisconnectReason,
+    ) -> NetworkResult<()> {
+        self.suppress_reconnect(peer_id.0, reason);
+
         let node = self.require_node().await?;
         node.disconnect(peer_id)
             .await
             .map_err(|e| NetworkError::ConnectionFailed(e.to_string()))?;
 
-        self.emit_event(NetworkEvent::PeerDisconnected { peer_id: peer_id.0 });
+        self.emit_event(NetworkEvent::PeerDisconnected {
+            peer_id: peer_id.0,
+            reason,
+        });
         self.connection_pool.record_disconnected(peer_id);
 
         Ok(())
+    }
+
+    /// Record a reconnect-suppression tombstone for `peer_id`.
+    ///
+    /// Idempotent: re-recording refreshes `set_at`. A no-op for
+    /// [`DisconnectReason::Transport`] (transport closes are reconnect-
+    /// eligible by definition and never tombstoned).
+    fn suppress_reconnect(&self, peer_id: [u8; 32], reason: DisconnectReason) {
+        if reason.reconnect_eligible() {
+            return;
+        }
+        if let Ok(mut map) = self.reconnect_suppressions.lock() {
+            map.insert(
+                peer_id,
+                ReconnectSuppression {
+                    reason,
+                    set_at: Instant::now(),
+                },
+            );
+        }
+    }
+
+    /// Returns `true` iff a live suppression tombstone currently blocks
+    /// proactive redial of `peer_id`.
+    ///
+    /// Expired bounded tombstones (eviction/admin past their TTL) are pruned
+    /// as they are observed; permanent tombstones (policy rejection,
+    /// revocation, shutdown) never expire.
+    #[must_use]
+    pub fn is_reconnect_suppressed(&self, peer_id: [u8; 32]) -> bool {
+        let mut map = match self.reconnect_suppressions.lock() {
+            Ok(m) => m,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let now = Instant::now();
+        let live = map.get(&peer_id).is_some_and(|s| s.is_live(now));
+        if !live {
+            map.remove(&peer_id);
+        }
+        live
     }
 
     /// Get list of connected peer IDs.
@@ -3002,8 +3105,9 @@ impl NetworkNode {
         let node = Arc::clone(&self.node);
         let event_sender = self.event_sender.clone();
         let bootstrap_cache = self.bootstrap_cache.clone();
-        let inbound_allowlist = self.config.inbound_allowlist.clone();
+        let reconnect_suppressions = Arc::clone(&self.reconnect_suppressions);
         let connection_pool = Arc::clone(&self.connection_pool);
+        let inbound_allowlist = self.config.inbound_allowlist.clone();
 
         tokio::spawn(async move {
             debug!("NetworkNode accept loop started");
@@ -3058,6 +3162,7 @@ impl NetworkNode {
                                 node_ref,
                                 &event_sender,
                                 connection_pool.as_ref(),
+                                reconnect_suppressions.as_ref(),
                                 evicted,
                                 "lru",
                             )
@@ -3078,6 +3183,7 @@ impl NetworkNode {
     fn spawn_connection_pool_eviction(&self) -> tokio::task::JoinHandle<()> {
         let node = Arc::clone(&self.node);
         let event_sender = self.event_sender.clone();
+        let reconnect_suppressions = Arc::clone(&self.reconnect_suppressions);
         let connection_pool = Arc::clone(&self.connection_pool);
 
         tokio::spawn(async move {
@@ -3101,16 +3207,19 @@ impl NetworkNode {
                     &node_ref,
                     &event_sender,
                     connection_pool.as_ref(),
+                    reconnect_suppressions.as_ref(),
                     lru_evicted,
                     "lru",
                 )
                 .await;
 
                 let idle_evicted = connection_pool.evict_idle(Instant::now());
+
                 disconnect_pool_candidates(
                     &node_ref,
                     &event_sender,
                     connection_pool.as_ref(),
+                    reconnect_suppressions.as_ref(),
                     idle_evicted,
                     "idle",
                 )
@@ -3172,6 +3281,13 @@ impl saorsa_gossip_transport::GossipTransport for NetworkNode {
                 "SECURITY: Peer mismatch - expected {:?}, got {:?}",
                 peer, connected_peer
             );
+            // The wrong identity is now connected (and cached by connect_addr).
+            // Tear it down with a PolicyRejection tombstone so neither the
+            // proactive reconnect scheduler nor the lifecycle Closed watcher
+            // redials it (review: wrong pinned peers stay disconnected).
+            let _ = self
+                .disconnect_with_reason(&connected_peer, DisconnectReason::PolicyRejection)
+                .await;
             return Err(anyhow::anyhow!(
                 "Connected to unexpected peer {:?} when dialing {:?}",
                 connected_peer,
@@ -3196,7 +3312,9 @@ impl saorsa_gossip_transport::GossipTransport for NetworkNode {
                 "SECURITY: Bootstrap peer at {} has unexpected ID {:?} — not in pinned set",
                 addr, ant_peer_id
             );
-            let _ = self.disconnect(&ant_peer_id).await;
+            let _ = self
+                .disconnect_with_reason(&ant_peer_id, DisconnectReason::PolicyRejection)
+                .await;
             return Err(anyhow::anyhow!(
                 "Bootstrap peer at {} has unpinned ID {:?}",
                 addr,
@@ -3304,6 +3422,91 @@ impl saorsa_gossip_transport::GossipTransport for NetworkNode {
     }
 }
 
+/// Why a peer disconnected, carried on [`NetworkEvent::PeerDisconnected`].
+///
+/// The proactive-reconnect scheduler keys off this value: only
+/// [`DisconnectReason::Transport`] is eligible for automatic redial. Every
+/// other reason records a suppression tombstone (see
+/// [`NetworkNode::is_reconnect_suppressed`]) so that a security rejection,
+/// capacity eviction, explicit teardown, revocation, or local shutdown is not
+/// immediately undone by a redial — the gap flagged in the final independent
+/// review ("Proactive reconnect can undo security/eviction decisions").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisconnectReason {
+    /// Transport-level close not initiated by the local policy layer: QUIC
+    /// idle timeout, remote daemon restart, or network failure. This is the
+    /// *only* reason eligible for automatic proactive redial.
+    Transport,
+    /// A pinned-bootstrap, peer-identity, or inbound-allowlist policy rejected
+    /// the peer. Never redial — the peer is untrusted or the wrong identity.
+    PolicyRejection,
+    /// The connection pool evicted the peer over capacity (LRU/idle). A redial
+    /// would immediately churn against the eviction decision.
+    PoolEviction,
+    /// Explicit operator/API teardown of an otherwise-healthy connection.
+    Admin,
+    /// The peer's identity was revoked. Never redial.
+    Revocation,
+    /// Local node shutdown. Redial is meaningless (the node is going away);
+    /// the lifecycle listeners also stop on the shutdown token.
+    Shutdown,
+}
+
+impl DisconnectReason {
+    /// Returns `true` iff the proactive-reconnect scheduler may redial a peer
+    /// disconnected for this reason.
+    #[must_use]
+    pub fn reconnect_eligible(self) -> bool {
+        matches!(self, Self::Transport)
+    }
+
+    /// Returns the suppression-tombstone lifetime for this reason.
+    ///
+    /// `None` means the tombstone is permanent (the peer must never be
+    /// proactively redialed again). `Some(zero)` means the reason does not
+    /// suppress at all (only [`DisconnectReason::Transport`]).
+    fn suppression_ttl(self) -> Option<Duration> {
+        match self {
+            // Transport closes are reconnect-eligible; never tombstoned.
+            Self::Transport => Some(Duration::ZERO),
+            // Security-relevant: permanent suppression.
+            Self::PolicyRejection | Self::Revocation | Self::Shutdown => None,
+            // Capacity/operator intent: outlive the bounded reconnect backoff
+            // window (sum of RECONNECT_BACKOFF_DELAYS + per-attempt dial
+            // timeouts) so the proactive task has fully exited before the
+            // tombstone expires and no new transport event can re-arm it.
+            Self::PoolEviction | Self::Admin => Some(RECONNECT_SUPPRESSION_BOUNDED_TTL),
+        }
+    }
+}
+
+/// How long a bounded suppression tombstone (eviction/admin) stays live.
+///
+/// Generous relative to the proactive-reconnect backoff window so a tombstoned
+/// peer is not re-dialed by a lingering scheduled task. After expiry there is
+/// no new disconnect event to re-arm the proactive path, so the peer only
+/// returns via explicit demand (send-path reconnect, auto-connect).
+const RECONNECT_SUPPRESSION_BOUNDED_TTL: Duration = Duration::from_secs(120);
+
+/// Reconnect-suppression tombstone for a peer.
+#[derive(Debug, Clone, Copy)]
+struct ReconnectSuppression {
+    reason: DisconnectReason,
+    set_at: Instant,
+}
+
+impl ReconnectSuppression {
+    /// Returns `true` iff this tombstone still blocks proactive redial at
+    /// `now`. Permanent reasons never expire; bounded reasons expire after
+    /// their TTL.
+    fn is_live(&self, now: Instant) -> bool {
+        match self.reason.suppression_ttl() {
+            None => true,
+            Some(ttl) => now.duration_since(self.set_at) < ttl,
+        }
+    }
+}
+
 /// Events emitted by the network node.
 #[derive(Debug, Clone)]
 pub enum NetworkEvent {
@@ -3319,6 +3522,9 @@ pub enum NetworkEvent {
     PeerDisconnected {
         /// The peer's ID.
         peer_id: [u8; 32],
+        /// Why the peer disconnected. Drives proactive-reconnect
+        /// eligibility: only [`DisconnectReason::Transport`] is redialed.
+        reason: DisconnectReason,
     },
 
     /// NAT type was detected.

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -1,0 +1,400 @@
+//! Persistence + startup rehydration for CRDT subscriptions (task lists and
+//! key-value stores).
+//!
+//! Fixes daemon-restart amnesia: `AppState.task_lists` / `AppState.kv_stores`
+//! were only ever populated by the REST create/join handlers, so a restarted
+//! daemon answered "task list not found" / "store not found" until the
+//! application explicitly re-created or re-joined. This module persists a
+//! small subscription manifest (`crdt-subscriptions.json`, same instance data
+//! dir as `directory-subscriptions.json`) whenever a handler registers a
+//! task list or store, and rehydrates every entry on startup by driving the
+//! SAME `Agent` create/join paths the handlers use — so the gossip topic
+//! subscription and the empty-replica state-request bootstrap both happen and
+//! mutations made while the daemon was offline are recovered from peers.
+//!
+//! Design follows the Phase C.2 directory-subscription persistence pattern
+//! (`load_directory_subscriptions` / `save_directory_subscriptions` in
+//! `src/server/mod.rs`): best-effort JSON on disk, warn-and-continue on any
+//! error, never crash startup.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use super::state::AppState;
+
+/// Manifest entry kind for a collaborative task list.
+pub(super) const KIND_TASK_LIST: &str = "task_list";
+/// Manifest entry kind for a replicated key-value store.
+pub(super) const KIND_KV_STORE: &str = "kv_store";
+/// Role recorded when this daemon created the task list / store.
+pub(super) const ROLE_CREATED: &str = "created";
+/// Role recorded when this daemon joined an existing store.
+pub(super) const ROLE_JOINED: &str = "joined";
+
+/// One persisted CRDT subscription.
+///
+/// The schema is deliberately extensible: unknown fields present in the file
+/// are captured in `extra` (via `serde(flatten)`) and preserved across
+/// load/save cycles, so a future daemon can add fields (e.g. owner/policy
+/// info for kv stores) without older builds destroying them.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(super) struct CrdtSubscriptionEntry {
+    /// Entry kind: [`KIND_TASK_LIST`] or [`KIND_KV_STORE`]. Unknown kinds are
+    /// kept on disk but skipped (with a warning) at rehydration time.
+    pub(super) kind: String,
+    /// Registration id used as the `AppState` map key (currently the topic).
+    pub(super) id: String,
+    /// Human-readable name passed to the create call.
+    pub(super) name: String,
+    /// Gossip topic the CRDT syncs on.
+    pub(super) topic: String,
+    /// [`ROLE_CREATED`] or [`ROLE_JOINED`] — selects the create vs join
+    /// `Agent` path at rehydration time.
+    pub(super) role: String,
+    /// Forward-compatibility: unknown fields survive round-trips.
+    #[serde(flatten)]
+    pub(super) extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// On-disk manifest: the full set of persisted CRDT subscriptions.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub(super) struct CrdtSubscriptionManifest {
+    /// All persisted subscriptions, in insertion order.
+    #[serde(default)]
+    pub(super) entries: Vec<CrdtSubscriptionEntry>,
+    /// Forward-compatibility: unknown top-level fields survive round-trips.
+    #[serde(flatten)]
+    pub(super) extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl CrdtSubscriptionManifest {
+    /// Insert `entry`, replacing any existing entry with the same
+    /// `(kind, id)`. Returns `true` if the manifest changed.
+    pub(super) fn upsert(&mut self, entry: CrdtSubscriptionEntry) -> bool {
+        if let Some(existing) = self
+            .entries
+            .iter_mut()
+            .find(|e| e.kind == entry.kind && e.id == entry.id)
+        {
+            if *existing == entry {
+                return false;
+            }
+            *existing = entry;
+        } else {
+            self.entries.push(entry);
+        }
+        true
+    }
+
+    /// Remove the entry with the given `(kind, id)`. Returns `true` if an
+    /// entry was removed.
+    ///
+    /// No task-list/store delete or leave REST endpoint exists today (the
+    /// endpoint registry in `src/api/mod.rs` only has `DELETE
+    /// /stores/:id/:key`, which removes a key, not the store), so production
+    /// code has no caller yet — this is the removal half of the manifest API,
+    /// ready for when such endpoints land.
+    #[allow(dead_code)]
+    pub(super) fn remove(&mut self, kind: &str, id: &str) -> bool {
+        let before = self.entries.len();
+        self.entries.retain(|e| !(e.kind == kind && e.id == id));
+        self.entries.len() != before
+    }
+}
+
+/// Read the manifest from `path` (best-effort).
+///
+/// A missing file yields an empty manifest silently; an unreadable or
+/// corrupt file yields an empty manifest with a warning — startup must never
+/// crash on a bad manifest (fail loud in logs, not in process exit).
+pub(super) async fn read_manifest(path: &Path) -> CrdtSubscriptionManifest {
+    match tokio::fs::read(path).await {
+        Ok(bytes) => match serde_json::from_slice::<CrdtSubscriptionManifest>(&bytes) {
+            Ok(manifest) => manifest,
+            Err(e) => {
+                tracing::warn!(
+                    "failed to parse CRDT subscription manifest {} (starting empty): {e}",
+                    path.display()
+                );
+                CrdtSubscriptionManifest::default()
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::debug!("no CRDT subscription manifest at {}", path.display());
+            CrdtSubscriptionManifest::default()
+        }
+        Err(e) => {
+            tracing::warn!(
+                "failed to read CRDT subscription manifest {} (starting empty): {e}",
+                path.display()
+            );
+            CrdtSubscriptionManifest::default()
+        }
+    }
+}
+
+/// Write `manifest` to `path` (best-effort, warns on failure).
+pub(super) async fn write_manifest(path: &Path, manifest: &CrdtSubscriptionManifest) {
+    match serde_json::to_vec_pretty(manifest) {
+        Ok(bytes) => {
+            if let Some(parent) = path.parent() {
+                let _ = tokio::fs::create_dir_all(parent).await;
+            }
+            if let Err(e) = tokio::fs::write(path, &bytes).await {
+                tracing::warn!(
+                    "failed to persist CRDT subscription manifest to {}: {e}",
+                    path.display()
+                );
+            }
+        }
+        Err(e) => tracing::warn!("failed to serialise CRDT subscription manifest: {e}"),
+    }
+}
+
+/// Load the persisted manifest from disk into `state.crdt_subscriptions`.
+///
+/// Called once during startup, before REST handlers can mutate the set, so a
+/// create/join arriving early merges with (rather than clobbers) the
+/// persisted entries.
+pub(super) async fn load(state: &AppState) {
+    let manifest = read_manifest(&state.crdt_subscriptions_path).await;
+    let n = manifest.entries.len();
+    *state.crdt_subscriptions.write().await = manifest;
+    if n > 0 {
+        tracing::info!(
+            "loaded {n} persisted CRDT subscriptions from {}",
+            state.crdt_subscriptions_path.display()
+        );
+    }
+}
+
+/// Record a new/updated subscription in the in-memory manifest and persist
+/// it to disk. Called by the REST create/join handlers after a successful
+/// registration.
+pub(super) async fn record(state: &AppState, entry: CrdtSubscriptionEntry) {
+    let snapshot = {
+        let mut manifest = state.crdt_subscriptions.write().await;
+        if !manifest.upsert(entry) {
+            return;
+        }
+        manifest.clone()
+    };
+    write_manifest(&state.crdt_subscriptions_path, &snapshot).await;
+}
+
+/// Rehydrate every persisted subscription by driving the same `Agent`
+/// create/join paths the REST handlers use.
+///
+/// Runs after `join_network` returns so the gossip mesh is (re)forming; the
+/// per-CRDT empty-replica state-request retry schedule then recovers state —
+/// including mutations made while this daemon was offline — from peer
+/// replicas. A failed entry is logged (warn) and skipped, never fatal, and
+/// stays in the manifest so the next restart retries it.
+pub(super) async fn rehydrate(state: Arc<AppState>) {
+    let entries = state.crdt_subscriptions.read().await.entries.clone();
+    if entries.is_empty() {
+        return;
+    }
+    let (mut restored, mut skipped) = (0usize, 0usize);
+    for entry in entries {
+        match entry.kind.as_str() {
+            KIND_TASK_LIST => {
+                if state.task_lists.read().await.contains_key(&entry.id) {
+                    continue; // already re-created via REST since startup
+                }
+                let result = match entry.role.as_str() {
+                    ROLE_JOINED => state.agent.join_task_list(&entry.topic).await,
+                    ROLE_CREATED => {
+                        state
+                            .agent
+                            .create_task_list(&entry.name, &entry.topic)
+                            .await
+                    }
+                    other => {
+                        tracing::warn!(
+                            id = %entry.id,
+                            role = other,
+                            "unknown task-list subscription role — skipping"
+                        );
+                        skipped += 1;
+                        continue;
+                    }
+                };
+                match result {
+                    Ok(handle) => {
+                        state
+                            .task_lists
+                            .write()
+                            .await
+                            .entry(entry.id.clone())
+                            .or_insert(handle);
+                        restored += 1;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            id = %entry.id,
+                            "failed to rehydrate task list after restart: {e}"
+                        );
+                        skipped += 1;
+                    }
+                }
+            }
+            KIND_KV_STORE => {
+                if state.kv_stores.read().await.contains_key(&entry.id) {
+                    continue; // already re-created/joined via REST since startup
+                }
+                let result = match entry.role.as_str() {
+                    ROLE_JOINED => state.agent.join_kv_store(&entry.topic).await,
+                    ROLE_CREATED => state.agent.create_kv_store(&entry.name, &entry.topic).await,
+                    other => {
+                        tracing::warn!(
+                            id = %entry.id,
+                            role = other,
+                            "unknown kv-store subscription role — skipping"
+                        );
+                        skipped += 1;
+                        continue;
+                    }
+                };
+                match result {
+                    Ok(handle) => {
+                        state
+                            .kv_stores
+                            .write()
+                            .await
+                            .entry(entry.id.clone())
+                            .or_insert(handle);
+                        restored += 1;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            id = %entry.id,
+                            "failed to rehydrate kv store after restart: {e}"
+                        );
+                        skipped += 1;
+                    }
+                }
+            }
+            other => {
+                tracing::warn!(
+                    id = %entry.id,
+                    kind = other,
+                    "unknown CRDT subscription kind — skipping (kept in manifest)"
+                );
+                skipped += 1;
+            }
+        }
+    }
+    tracing::info!(restored, skipped, "CRDT subscription rehydration complete");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(kind: &str, id: &str, role: &str) -> CrdtSubscriptionEntry {
+        CrdtSubscriptionEntry {
+            kind: kind.to_string(),
+            id: id.to_string(),
+            name: format!("{id}-name"),
+            topic: id.to_string(),
+            role: role.to_string(),
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    /// WHY: the whole fix rests on the manifest surviving a daemon restart —
+    /// a save/load round-trip must reproduce exactly what was recorded.
+    #[tokio::test]
+    async fn manifest_round_trips_through_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+
+        let mut manifest = CrdtSubscriptionManifest::default();
+        assert!(manifest.upsert(entry(KIND_TASK_LIST, "sprint", ROLE_CREATED)));
+        assert!(manifest.upsert(entry(KIND_KV_STORE, "party", ROLE_JOINED)));
+        // Re-upserting an identical entry is a no-op (no disk churn).
+        assert!(!manifest.upsert(entry(KIND_KV_STORE, "party", ROLE_JOINED)));
+
+        write_manifest(&path, &manifest).await;
+        let loaded = read_manifest(&path).await;
+        assert_eq!(loaded, manifest);
+
+        // Remove drops exactly the matching (kind, id) pair.
+        let mut loaded = loaded;
+        assert!(loaded.remove(KIND_KV_STORE, "party"));
+        assert!(!loaded.remove(KIND_KV_STORE, "party"));
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].id, "sprint");
+
+        write_manifest(&path, &loaded).await;
+        assert_eq!(read_manifest(&path).await, loaded);
+    }
+
+    /// WHY: upsert must replace, not duplicate, so a re-create after restart
+    /// (or a role change) cannot grow the manifest unboundedly.
+    #[test]
+    fn upsert_replaces_same_kind_and_id() {
+        let mut manifest = CrdtSubscriptionManifest::default();
+        manifest.upsert(entry(KIND_KV_STORE, "party", ROLE_JOINED));
+        manifest.upsert(entry(KIND_KV_STORE, "party", ROLE_CREATED));
+        assert_eq!(manifest.entries.len(), 1);
+        assert_eq!(manifest.entries[0].role, ROLE_CREATED);
+        // Same id under a different kind is a distinct entry.
+        manifest.upsert(entry(KIND_TASK_LIST, "party", ROLE_CREATED));
+        assert_eq!(manifest.entries.len(), 2);
+    }
+
+    /// WHY: a corrupt manifest must degrade to "no persisted subscriptions"
+    /// (fail loud in logs), never crash the daemon at startup.
+    #[tokio::test]
+    async fn corrupt_manifest_yields_empty_and_does_not_panic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+        tokio::fs::write(&path, b"{not json at all")
+            .await
+            .expect("write corrupt file");
+        let loaded = read_manifest(&path).await;
+        assert!(loaded.entries.is_empty());
+
+        // Missing file is equally tolerated.
+        let missing = dir.path().join("does-not-exist.json");
+        assert!(read_manifest(&missing).await.entries.is_empty());
+    }
+
+    /// WHY: schema extensibility is a stated requirement — unknown fields
+    /// written by a future daemon must be tolerated AND preserved across a
+    /// load/save cycle by this build.
+    #[tokio::test]
+    async fn unknown_fields_are_tolerated_and_preserved() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+        let future_schema = serde_json::json!({
+            "schema_version": 2,
+            "entries": [{
+                "kind": "kv_store",
+                "id": "party",
+                "name": "party",
+                "topic": "party",
+                "role": "joined",
+                "owner": "abcd1234",
+                "policy": { "kind": "signed" }
+            }]
+        });
+        tokio::fs::write(&path, serde_json::to_vec(&future_schema).expect("json"))
+            .await
+            .expect("write");
+
+        let loaded = read_manifest(&path).await;
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].extra["owner"], "abcd1234");
+        assert_eq!(loaded.extra["schema_version"], 2);
+
+        // Round-trip preserves the unknown fields.
+        write_manifest(&path, &loaded).await;
+        let reloaded = read_manifest(&path).await;
+        assert_eq!(reloaded, loaded);
+    }
+}

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -17,10 +17,11 @@
 //! `src/server/mod.rs`): best-effort JSON on disk, warn-and-continue on any
 //! error, never crash startup.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, RwLock};
 
 use super::state::AppState;
 
@@ -72,16 +73,36 @@ pub(super) struct CrdtSubscriptionManifest {
 impl CrdtSubscriptionManifest {
     /// Insert `entry`, replacing any existing entry with the same
     /// `(kind, id)`. Returns `true` if the manifest changed.
+    ///
+    /// Forward-compatibility: when replacing, unknown `extra` fields already
+    /// on the existing entry that the incoming entry does not provide are
+    /// preserved, so a re-registration by an older handler (or a rollback/
+    /// upgrade) cannot delete future schema fields (e.g. owner epoch/policy).
+    /// Known fields (`name`, `topic`, `role`) take the incoming value.
     pub(super) fn upsert(&mut self, entry: CrdtSubscriptionEntry) -> bool {
         if let Some(existing) = self
             .entries
             .iter_mut()
             .find(|e| e.kind == entry.kind && e.id == entry.id)
         {
-            if *existing == entry {
+            // Incoming `extra` wins for keys it sets; existing-only extra
+            // keys (future/unknown fields) are carried forward untouched.
+            let mut merged_extra = entry.extra.clone();
+            for (k, v) in &existing.extra {
+                merged_extra.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+            let merged = CrdtSubscriptionEntry {
+                kind: existing.kind.clone(),
+                id: existing.id.clone(),
+                name: entry.name,
+                topic: entry.topic,
+                role: entry.role,
+                extra: merged_extra,
+            };
+            if *existing == merged {
                 return false;
             }
-            *existing = entry;
+            *existing = merged;
         } else {
             self.entries.push(entry);
         }
@@ -135,22 +156,164 @@ pub(super) async fn read_manifest(path: &Path) -> CrdtSubscriptionManifest {
     }
 }
 
-/// Write `manifest` to `path` (best-effort, warns on failure).
-pub(super) async fn write_manifest(path: &Path, manifest: &CrdtSubscriptionManifest) {
-    match serde_json::to_vec_pretty(manifest) {
-        Ok(bytes) => {
-            if let Some(parent) = path.parent() {
-                let _ = tokio::fs::create_dir_all(parent).await;
-            }
-            if let Err(e) = tokio::fs::write(path, &bytes).await {
-                tracing::warn!(
-                    "failed to persist CRDT subscription manifest to {}: {e}",
-                    path.display()
-                );
-            }
-        }
-        Err(e) => tracing::warn!("failed to serialise CRDT subscription manifest: {e}"),
+/// Write `manifest` to `path` crash-safely.
+///
+/// The manifest is serialised, written to a same-directory temp file,
+/// `sync_all`'d, and atomically renamed over `path` — mirroring
+/// `write_named_groups_json_atomic` in `src/server/mod.rs`. A crash or
+/// failure mid-write leaves the previous (good) manifest untouched. Returns
+/// `Err` on serialise or write failure so callers (via `record`) can refuse to
+/// acknowledge a non-durable registration; unknown/forward-compatible `extra`
+/// fields pass through unchanged.
+pub(super) async fn write_manifest(
+    path: &Path,
+    manifest: &CrdtSubscriptionManifest,
+) -> std::io::Result<()> {
+    let bytes = serde_json::to_vec_pretty(manifest)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    if let Some(parent) = path.parent() {
+        let _ = tokio::fs::create_dir_all(parent).await;
     }
+    write_manifest_atomic(path, &bytes).await
+}
+
+/// Crash-safe single-file write: temp file in the same directory, `sync_all`,
+/// then atomic rename. Same pattern as `write_named_groups_json_atomic`. On
+/// failure OR task cancellation the temp file is reclaimed by a guard, so a
+/// failed/cancelled write leaves no debris and never replaces the last good
+/// manifest with a partial file.
+async fn write_manifest_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    // Same directory as the target so the rename is atomic on one filesystem.
+    let mut temp_os = path.as_os_str().to_owned();
+    temp_os.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
+    let temp_path = PathBuf::from(temp_os);
+
+    // RAII: removes the temp file on drop unless disarmed after a successful
+    // rename. Covers both error returns and task cancellation mid-write.
+    let mut temp = TempFile::new(temp_path.clone());
+
+    let result = async {
+        let mut file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+            .await?;
+        file.write_all(bytes).await?;
+        file.sync_all().await?;
+        drop(file);
+        tokio::fs::rename(&temp_path, path).await?;
+        // Parent-directory fsync is REQUIRED for durable acknowledgement:
+        // a rename without a successful dir fsync may not survive power
+        // loss. We propagate the error so the caller (via persist_recorded's
+        // stage-then-commit) never falsely acknowledges durability. Memory
+        // stays at its pre-write state; an identical retry re-stages from old
+        // memory and rewrites — the file content is idempotent. The rename
+        // itself succeeded (file is at `path`), so the TempFile guard's
+        // drop-cleanup harmlessly no-ops (temp no longer exists).
+        if let Err(e) = sync_parent_dir(path) {
+            tracing::warn!(
+                "parent-directory fsync failed for {}: refusing to \
+                 acknowledge durability after successful rename ({e})",
+                path.display()
+            );
+            return Err(e);
+        }
+        Ok::<(), std::io::Error>(())
+    }
+    .await;
+
+    match result {
+        Ok(()) => {
+            temp.disarm(); // consumed by the rename
+            Ok(())
+        }
+        Err(e) => Err(e), // guard drops and removes the temp file
+    }
+}
+
+/// RAII guard that removes a temp file on drop unless disarmed (after a
+/// successful rename consumes it). Uses blocking `std::fs` because `Drop`
+/// cannot await — appropriate for a single-file cleanup.
+struct TempFile {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFile {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+// Test-injection flag: when set, `sync_parent_dir` returns a synthetic
+// `Err` so tests can verify that a dir-fsync failure propagates as a
+// non-acknowledged durable write (the rename succeeds but the caller
+// refuses to treat it as durable). Compiled out in release builds.
+#[cfg(test)]
+thread_local! {
+    static INJECT_DIR_FSYNC_FAILURE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// RAII guard that enables the dir-fsync failure injection for the duration
+/// of a test. Drop resets the flag so parallel or subsequent tests are
+/// unaffected. Compiled out in release builds.
+#[cfg(test)]
+pub(super) struct DirFsyncFailureGuard;
+
+#[cfg(test)]
+impl DirFsyncFailureGuard {
+    /// Enable dir-fsync failure injection. Reset happens automatically on
+    /// drop of the returned guard.
+    pub(super) fn enable() -> Self {
+        INJECT_DIR_FSYNC_FAILURE.with(|c| c.set(true));
+        DirFsyncFailureGuard
+    }
+}
+
+#[cfg(test)]
+impl Drop for DirFsyncFailureGuard {
+    fn drop(&mut self) {
+        INJECT_DIR_FSYNC_FAILURE.with(|c| c.set(false));
+    }
+}
+
+/// `fsync` of the directory containing `path` so a rename within it is
+/// durable across power loss. Returns `Err` on failure — `write_manifest_atomic`
+/// propagates this so the caller never falsely acknowledges durability. The
+/// rename itself is already committed (file is at `path`); the error means
+/// the rename may not survive a power-loss crash. `Ok(())` where directory
+/// fsync is unavailable (non-Unix).
+#[cfg(unix)]
+fn sync_parent_dir(path: &Path) -> std::io::Result<()> {
+    // Test injection: simulate a dir-fsync failure to verify the caller
+    // refuses to acknowledge durability.
+    #[cfg(test)]
+    if INJECT_DIR_FSYNC_FAILURE.with(|c| c.get()) {
+        return Err(std::io::Error::other("injected dir-fsync failure"));
+    }
+    if let Some(parent) = path.parent() {
+        let dir = std::fs::File::open(parent)?;
+        dir.sync_all()?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_path: &Path) -> std::io::Result<()> {
+    Ok(())
 }
 
 /// Load the persisted manifest from disk into `state.crdt_subscriptions`.
@@ -170,18 +333,116 @@ pub(super) async fn load(state: &AppState) {
     }
 }
 
-/// Record a new/updated subscription in the in-memory manifest and persist
-/// it to disk. Called by the REST create/join handlers after a successful
-/// registration.
-pub(super) async fn record(state: &AppState, entry: CrdtSubscriptionEntry) {
-    let snapshot = {
-        let mut manifest = state.crdt_subscriptions.write().await;
-        if !manifest.upsert(entry) {
-            return;
+/// Record a new/updated subscription in the in-memory manifest and durably
+/// persist it to disk. Called by the REST create/join handlers after a
+/// successful registration.
+///
+/// This is a durable transaction (see `persist_recorded`): the manifest is
+/// staged in a clone, durably written, and then committed to live memory —
+/// only if the write reaches disk. The whole stage → write → commit sequence
+/// is serialised by `crdt_subscriptions_persistence_lock`. Returns `Err` if
+/// the manifest could not be made durable, so the handler can refuse to
+/// acknowledge a non-durable registration. On `Err` or cancellation the
+/// in-memory manifest is untouched (it was never mutated), so memory always
+/// matches durable state and an identical retry re-stages and re-writes.
+pub(super) async fn record(state: &AppState, entry: CrdtSubscriptionEntry) -> std::io::Result<()> {
+    persist_recorded(
+        &state.crdt_subscriptions,
+        &state.crdt_subscriptions_persistence_lock,
+        &state.crdt_subscriptions_path,
+        entry,
+    )
+    .await
+}
+
+/// Snapshot-and-write core of [`record`], factored out so the durable
+/// transaction is unit-testable without a full `AppState`.
+///
+/// `persistence_lock` serialises the whole stage → durable-write → commit
+/// sequence; `manifest` is the live in-memory state; `path` is the on-disk
+/// manifest location.
+///
+/// **Stage-then-commit** (cancellation-safe): the upsert is applied to a
+/// *clone* under a read lock; `write_manifest` is awaited on that clone;
+/// only after `Ok` is the clone committed to live memory via `write()`.
+/// On `Err` — or if the future is dropped (cancelled) during the disk-write
+/// await — live memory was never touched, so there is nothing to roll back
+/// and nothing diverges from disk. An identical retry sees the entry absent
+/// from the (unchanged) live manifest, re-stages, and re-writes — never a
+/// silent no-op. The old mutate-then-rollback path is gone: the only
+/// cancellable `.await` (the disk write) happens *before* any memory
+/// mutation.
+async fn persist_recorded(
+    manifest: &RwLock<CrdtSubscriptionManifest>,
+    persistence_lock: &Mutex<()>,
+    path: &Path,
+    entry: CrdtSubscriptionEntry,
+) -> std::io::Result<()> {
+    let _guard = persistence_lock.lock().await;
+    // Stage the upsert in a clone — do NOT touch live memory yet. The
+    // persistence_lock serialises all recorders, so nothing else mutates
+    // `manifest` between this read and the commit write below.
+    let staged = {
+        let current = manifest.read().await;
+        let mut candidate = current.clone();
+        if !candidate.upsert(entry) {
+            // Already current in memory. Because memory is only ever committed
+            // AFTER a durable write succeeds (see commit below), "current in
+            // memory" honestly implies "current on disk" — this is a durable
+            // no-op.
+            return Ok(());
         }
-        manifest.clone()
+        candidate
     };
-    write_manifest(&state.crdt_subscriptions_path, &snapshot).await;
+    // Durably persist the staged snapshot. If this await returns Err OR is
+    // cancelled (future dropped), live memory is untouched — it still matches
+    // what is on disk. No rollback is needed because nothing was mutated.
+    write_manifest(path, &staged).await?;
+    // Commit: the durable write succeeded, so it is now safe to update
+    // in-memory state. This write-lock acquisition + store cannot be
+    // cancelled in a way that diverges memory from disk (it is a
+    // synchronous in-process lock + pointer swap).
+    *manifest.write().await = staged;
+    Ok(())
+}
+
+/// Get-or-create the per-`(kind, id)` reservation lock for a CRDT
+/// subscription handle+manifest transaction.
+///
+/// The caller must `.lock().await` the returned [`Arc`] and hold the guard
+/// for the entire create/join → insert-handle → persist-manifest sequence,
+/// then drop it. This serialises concurrent same-`(kind,id)` REST requests
+/// and REST-vs-rehydrate races so that:
+///
+/// - a failing transaction removes only its own handle (no other same-ID
+///   request could have interleaved an insert under the same reservation);
+/// - duplicate long-lived sync listeners cannot be spawned (the loser sees
+///   the winner's handle and no-ops).
+///
+/// Keyed by `"{kind}:{id}"` — the kinds (`task_list`, `kv_store`) are fixed
+/// and never contain `:`, so the composite key is unique per pair regardless
+/// of what characters appear in `id`.
+pub(super) async fn handle_reservation(state: &AppState, kind: &str, id: &str) -> Arc<Mutex<()>> {
+    let key = format!("{kind}:{id}");
+    let mut locks = state.crdt_handle_locks.write().await;
+    locks
+        .entry(key)
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+/// Parse a hex-encoded `AgentId` (64 hex chars → 32 bytes) from a manifest
+/// `expected_owner` field. Returns `None` if the value is not valid hex or not
+/// exactly 32 bytes — the caller treats that as migration-required.
+fn parse_owner_hex(hex_str: &str) -> Option<crate::identity::AgentId> {
+    let bytes = hex::decode(hex_str).ok()?;
+    if bytes.len() == crate::identity::PEER_ID_LENGTH {
+        let mut arr = [0u8; crate::identity::PEER_ID_LENGTH];
+        arr.copy_from_slice(&bytes);
+        Some(crate::identity::AgentId(arr))
+    } else {
+        None
+    }
 }
 
 /// Rehydrate every persisted subscription by driving the same `Agent`
@@ -192,102 +453,190 @@ pub(super) async fn record(state: &AppState, entry: CrdtSubscriptionEntry) {
 /// including mutations made while this daemon was offline — from peer
 /// replicas. A failed entry is logged (warn) and skipped, never fatal, and
 /// stays in the manifest so the next restart retries it.
+///
+/// Entries are rehydrated CONCURRENTLY (not sequentially) so that a slow or
+/// blocked entry — e.g. a joined KV store whose owner-anchored Signed
+/// bootstrap awaits a slow subscription — cannot starve or delay the
+/// rehydration of an unrelated entry (e.g. a task list). Each create/join
+/// subscribes to its own topic and schedules its own background state-request
+/// retry loop; running them concurrently lets every topic's recovery start
+/// without waiting on the others. State recovery is per-topic and idempotent,
+/// so concurrent rehydration is safe.
 pub(super) async fn rehydrate(state: Arc<AppState>) {
     let entries = state.crdt_subscriptions.read().await.entries.clone();
     if entries.is_empty() {
         return;
     }
+    let results = futures::future::join_all(
+        entries
+            .into_iter()
+            .map(|entry| rehydrate_one(Arc::clone(&state), entry)),
+    )
+    .await;
     let (mut restored, mut skipped) = (0usize, 0usize);
-    for entry in entries {
-        match entry.kind.as_str() {
-            KIND_TASK_LIST => {
-                if state.task_lists.read().await.contains_key(&entry.id) {
-                    continue; // already re-created via REST since startup
-                }
-                let result = match entry.role.as_str() {
-                    ROLE_JOINED => state.agent.join_task_list(&entry.topic).await,
-                    ROLE_CREATED => {
-                        state
-                            .agent
-                            .create_task_list(&entry.name, &entry.topic)
-                            .await
-                    }
-                    other => {
-                        tracing::warn!(
-                            id = %entry.id,
-                            role = other,
-                            "unknown task-list subscription role — skipping"
-                        );
-                        skipped += 1;
-                        continue;
-                    }
-                };
-                match result {
-                    Ok(handle) => {
-                        state
-                            .task_lists
-                            .write()
-                            .await
-                            .entry(entry.id.clone())
-                            .or_insert(handle);
-                        restored += 1;
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            id = %entry.id,
-                            "failed to rehydrate task list after restart: {e}"
-                        );
-                        skipped += 1;
-                    }
-                }
-            }
-            KIND_KV_STORE => {
-                if state.kv_stores.read().await.contains_key(&entry.id) {
-                    continue; // already re-created/joined via REST since startup
-                }
-                let result = match entry.role.as_str() {
-                    ROLE_JOINED => state.agent.join_kv_store(&entry.topic).await,
-                    ROLE_CREATED => state.agent.create_kv_store(&entry.name, &entry.topic).await,
-                    other => {
-                        tracing::warn!(
-                            id = %entry.id,
-                            role = other,
-                            "unknown kv-store subscription role — skipping"
-                        );
-                        skipped += 1;
-                        continue;
-                    }
-                };
-                match result {
-                    Ok(handle) => {
-                        state
-                            .kv_stores
-                            .write()
-                            .await
-                            .entry(entry.id.clone())
-                            .or_insert(handle);
-                        restored += 1;
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            id = %entry.id,
-                            "failed to rehydrate kv store after restart: {e}"
-                        );
-                        skipped += 1;
-                    }
-                }
-            }
-            other => {
-                tracing::warn!(
-                    id = %entry.id,
-                    kind = other,
-                    "unknown CRDT subscription kind — skipping (kept in manifest)"
-                );
-                skipped += 1;
-            }
+    for outcome in results {
+        match outcome {
+            RehydrateOutcome::Restored => restored += 1,
+            RehydrateOutcome::Skipped => skipped += 1,
+            RehydrateOutcome::AlreadyPresent => {}
         }
     }
     tracing::info!(restored, skipped, "CRDT subscription rehydration complete");
+}
+
+/// Outcome of rehydrating a single manifest entry.
+enum RehydrateOutcome {
+    /// A new handle was created and inserted.
+    Restored,
+    /// Rehydration failed or was not applicable (logged); the entry stays in
+    /// the manifest for the next restart to retry.
+    Skipped,
+    /// A live handle already existed (re-created via REST since startup).
+    AlreadyPresent,
+}
+
+/// Rehydrate a single persisted subscription. See [`rehydrate`] for the
+/// concurrency rationale; this preserves the same per-kind/per-role logic and
+/// warn-and-skip behaviour as the original sequential loop.
+///
+/// Acquires the per-`(kind,id)` reservation ([`handle_reservation`]) BEFORE
+/// the check-then-create so a concurrent REST create/join for the same
+/// `(kind,id)` cannot interleave and spawn a duplicate long-lived sync
+/// listener: the loser of the race sees the winner's handle and returns
+/// [`RehydrateOutcome::AlreadyPresent`].
+async fn rehydrate_one(state: Arc<AppState>, entry: CrdtSubscriptionEntry) -> RehydrateOutcome {
+    // Acquire the per-(kind,id) reservation before the check-then-create so
+    // a concurrent REST create/join cannot spawn a duplicate listener.
+    let reservation = handle_reservation(&state, &entry.kind, &entry.id).await;
+    let _guard = reservation.lock().await;
+
+    match entry.kind.as_str() {
+        KIND_TASK_LIST => {
+            if state.task_lists.read().await.contains_key(&entry.id) {
+                return RehydrateOutcome::AlreadyPresent; // re-created via REST since startup
+            }
+            let result = match entry.role.as_str() {
+                ROLE_JOINED => state.agent.join_task_list(&entry.topic).await,
+                ROLE_CREATED => {
+                    state
+                        .agent
+                        .create_task_list(&entry.name, &entry.topic)
+                        .await
+                }
+                other => {
+                    tracing::warn!(
+                        id = %entry.id,
+                        role = other,
+                        "unknown task-list subscription role — skipping"
+                    );
+                    return RehydrateOutcome::Skipped;
+                }
+            };
+            match result {
+                Ok(handle) => {
+                    // Apply group authorization at the CRDT layer so remote
+                    // admission rejects nonmember operations for group-scoped
+                    // lists. Must run before insertion so the sync listener
+                    // starts with the correct authorized set.
+                    super::routes::apply_group_authorization(&state, &entry.id, &handle).await;
+                    state
+                        .task_lists
+                        .write()
+                        .await
+                        .entry(entry.id.clone())
+                        .or_insert(handle);
+                    RehydrateOutcome::Restored
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        id = %entry.id,
+                        "failed to rehydrate task list after restart: {e}"
+                    );
+                    RehydrateOutcome::Skipped
+                }
+            }
+        }
+        KIND_KV_STORE => {
+            if state.kv_stores.read().await.contains_key(&entry.id) {
+                return RehydrateOutcome::AlreadyPresent; // re-created/joined via REST since startup
+            }
+            let result = match entry.role.as_str() {
+                ROLE_JOINED => {
+                    // The owner anchor is REQUIRED: a join without it is a
+                    // dead replica, not a successful rehydration. A legacy
+                    // entry with no stored anchor, or a malformed one, is
+                    // migration-required — skip it loudly rather than
+                    // creating a read-only handle that can never accept
+                    // Signed state.
+                    let owner = match entry.extra.get("expected_owner").and_then(|v| v.as_str()) {
+                        Some(hex_str) => match parse_owner_hex(hex_str) {
+                            Some(id) => id,
+                            None => {
+                                tracing::warn!(
+                                    id = %entry.id,
+                                    "stored expected_owner is malformed; \
+                                     skipping rehydration (migration_required)"
+                                );
+                                return RehydrateOutcome::Skipped;
+                            }
+                        },
+                        None => {
+                            tracing::warn!(
+                                id = %entry.id,
+                                "no stored expected_owner for joined store; \
+                                 skipping rehydration (migration_required). \
+                                 Re-join with an owner anchor to recover."
+                            );
+                            return RehydrateOutcome::Skipped;
+                        }
+                    };
+                    state
+                        .agent
+                        .join_kv_store(
+                            &entry.topic,
+                            owner,
+                            crate::kv::store::AnchorChannel::Persistence,
+                        )
+                        .await
+                }
+                ROLE_CREATED => state.agent.create_kv_store(&entry.name, &entry.topic).await,
+                other => {
+                    tracing::warn!(
+                        id = %entry.id,
+                        role = other,
+                        "unknown kv-store subscription role — skipping"
+                    );
+                    return RehydrateOutcome::Skipped;
+                }
+            };
+            match result {
+                Ok(handle) => {
+                    state
+                        .kv_stores
+                        .write()
+                        .await
+                        .entry(entry.id.clone())
+                        .or_insert(handle);
+                    RehydrateOutcome::Restored
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        id = %entry.id,
+                        "failed to rehydrate kv store after restart: {e}"
+                    );
+                    RehydrateOutcome::Skipped
+                }
+            }
+        }
+        other => {
+            tracing::warn!(
+                id = %entry.id,
+                kind = other,
+                "unknown CRDT subscription kind — skipping (kept in manifest)"
+            );
+            RehydrateOutcome::Skipped
+        }
+    }
 }
 
 #[cfg(test)]
@@ -318,7 +667,9 @@ mod tests {
         // Re-upserting an identical entry is a no-op (no disk churn).
         assert!(!manifest.upsert(entry(KIND_KV_STORE, "party", ROLE_JOINED)));
 
-        write_manifest(&path, &manifest).await;
+        write_manifest(&path, &manifest)
+            .await
+            .expect("write manifest");
         let loaded = read_manifest(&path).await;
         assert_eq!(loaded, manifest);
 
@@ -329,7 +680,9 @@ mod tests {
         assert_eq!(loaded.entries.len(), 1);
         assert_eq!(loaded.entries[0].id, "sprint");
 
-        write_manifest(&path, &loaded).await;
+        write_manifest(&path, &loaded)
+            .await
+            .expect("write manifest");
         assert_eq!(read_manifest(&path).await, loaded);
     }
 
@@ -393,8 +746,677 @@ mod tests {
         assert_eq!(loaded.extra["schema_version"], 2);
 
         // Round-trip preserves the unknown fields.
-        write_manifest(&path, &loaded).await;
+        write_manifest(&path, &loaded)
+            .await
+            .expect("write manifest");
         let reloaded = read_manifest(&path).await;
         assert_eq!(reloaded, loaded);
+    }
+
+    /// WHY: crash-safety — concurrent writers must never leave a torn or
+    /// corrupt manifest on disk. Each write goes through a same-directory
+    /// temp file + `sync_all` + atomic rename, so the final file is always
+    /// exactly one of the written manifests (never a blend), and no `.tmp`
+    /// debris remains.
+    #[tokio::test]
+    async fn concurrent_manifest_writes_never_corrupt() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+
+        let mut written = Vec::new();
+        let mut handles = Vec::new();
+        for i in 0..32u32 {
+            let mut manifest = CrdtSubscriptionManifest::default();
+            manifest.upsert(entry(KIND_KV_STORE, &format!("store-{i}"), ROLE_CREATED));
+            written.push(manifest.clone());
+            let path = path.clone();
+            handles.push(tokio::spawn(async move {
+                let _ = write_manifest(&path, &manifest).await;
+            }));
+        }
+        for handle in handles {
+            handle.await.expect("writer task panicked");
+        }
+
+        // The file must parse and equal exactly ONE written manifest — never a
+        // torn blend that matches none.
+        let loaded = read_manifest(&path).await;
+        assert!(
+            written.contains(&loaded),
+            "concurrent writes corrupted the manifest: {loaded:?}"
+        );
+
+        // No temp-file debris left behind by failed/aborted renames.
+        let debris = std::fs::read_dir(dir.path())
+            .expect("read_dir")
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .count();
+        assert_eq!(debris, 0, "temp-file debris left after concurrent writes");
+    }
+
+    /// WHY: a write that fails partway must not replace the last good
+    /// manifest — the atomic temp+rename means only a fully-written, fsync'd
+    /// file ever reaches the destination path. The old `tokio::fs::write`
+    /// could truncate the destination mid-write on a crash.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_write_leaves_last_good_manifest_intact() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+
+        // Establish the last good manifest on disk.
+        let mut good = CrdtSubscriptionManifest::default();
+        good.upsert(entry(KIND_KV_STORE, "good", ROLE_CREATED));
+        write_manifest(&path, &good)
+            .await
+            .expect("write good manifest");
+        assert_eq!(read_manifest(&path).await, good);
+
+        // A strictly newer manifest that WOULD land if the write succeeded.
+        let mut newer = CrdtSubscriptionManifest::default();
+        newer.upsert(entry(KIND_KV_STORE, "newer", ROLE_CREATED));
+
+        // Make the directory non-writable so the temp file cannot be created.
+        let mut perms = tokio::fs::metadata(dir.path())
+            .await
+            .expect("stat dir")
+            .permissions();
+        perms.set_mode(0o500);
+        tokio::fs::set_permissions(dir.path(), perms)
+            .await
+            .expect("chmod read-only");
+
+        // Root bypasses Unix permission bits; probe whether the write is
+        // actually blocked and only enforce the assertion when it is.
+        let probe = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(dir.path().join("__probe__"))
+            .await;
+        let enforced = probe.is_err();
+        if let Ok(file) = probe {
+            drop(file);
+            let _ = tokio::fs::remove_file(dir.path().join("__probe__")).await;
+        }
+
+        if enforced {
+            assert!(
+                write_manifest(&path, &newer).await.is_err(),
+                "blocked write must return Err, not silently succeed"
+            );
+            assert_eq!(
+                read_manifest(&path).await,
+                good,
+                "failed write replaced the last good manifest"
+            );
+        }
+
+        // Restore writability so the tempdir can clean up.
+        let mut perms = tokio::fs::metadata(dir.path())
+            .await
+            .expect("stat dir")
+            .permissions();
+        perms.set_mode(0o700);
+        tokio::fs::set_permissions(dir.path(), perms)
+            .await
+            .expect("chmod restore");
+    }
+
+    /// WHY: this is the defect itself — `record()` used to snapshot the
+    /// manifest, release the data lock, then write, so a slower OLDER
+    /// snapshot could rename over a faster NEWER one (lost update). Now the
+    /// persistence lock is held across snapshot + durable write, so every
+    /// concurrent record survives to disk.
+    #[tokio::test]
+    async fn concurrent_records_cannot_regress_disk_state() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+        let manifest = Arc::new(RwLock::new(CrdtSubscriptionManifest::default()));
+        let lock = Arc::new(Mutex::new(()));
+
+        const N: u32 = 48;
+        let mut handles = Vec::new();
+        for i in 0..N {
+            let (manifest, lock) = (Arc::clone(&manifest), Arc::clone(&lock));
+            let path = path.clone();
+            handles.push(tokio::spawn(async move {
+                persist_recorded(
+                    &manifest,
+                    &lock,
+                    &path,
+                    entry(KIND_KV_STORE, &format!("store-{i}"), ROLE_CREATED),
+                )
+                .await
+            }));
+        }
+        for handle in handles {
+            handle
+                .await
+                .expect("record task panicked")
+                .expect("persist_recorded should succeed");
+        }
+
+        // No regression: every recorded entry must be present on disk. With
+        // the old snapshot-after-unlock code a slower older snapshot would win
+        // and silently drop later entries.
+        let loaded = read_manifest(&path).await;
+        let mut ids: Vec<String> = loaded.entries.iter().map(|e| e.id.clone()).collect();
+        ids.sort();
+        let mut expected: Vec<String> = (0..N).map(|i| format!("store-{i}")).collect();
+        expected.sort();
+        assert_eq!(
+            ids, expected,
+            "lost update: not all concurrent records survived to disk"
+        );
+    }
+
+    /// WHY (review test 20): a failed durable write must not be acknowledged,
+    /// and the rollback must let an identical retry actually re-attempt the
+    /// write. Before the fix, `persist_recorded` left the entry in memory
+    /// after a failed write, so a retry saw `upsert == false` and skipped
+    /// writing — the entry was silently lost from disk forever.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_failure_then_identical_retry() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+        let manifest = Arc::new(RwLock::new(CrdtSubscriptionManifest::default()));
+        let lock = Arc::new(Mutex::new(()));
+        let make_entry = || entry(KIND_KV_STORE, "rollback-store", ROLE_CREATED);
+
+        // Make the directory non-writable so the durable write fails.
+        let mut perms = tokio::fs::metadata(dir.path())
+            .await
+            .expect("stat dir")
+            .permissions();
+        perms.set_mode(0o500);
+        tokio::fs::set_permissions(dir.path(), perms)
+            .await
+            .expect("chmod read-only");
+
+        // Root bypasses permission bits; probe and only enforce when blocked.
+        let probe = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(dir.path().join("__probe__"))
+            .await;
+        let enforced = probe.is_err();
+        if let Ok(f) = probe {
+            drop(f);
+            let _ = tokio::fs::remove_file(dir.path().join("__probe__")).await;
+        }
+
+        if enforced {
+            // 1. Failed write: must return Err AND roll back the in-memory
+            //    upsert so the entry is not retained as if it were durable.
+            let result = persist_recorded(&manifest, &lock, &path, make_entry()).await;
+            assert!(result.is_err(), "failed durable write must return Err");
+            assert!(
+                manifest.read().await.entries.is_empty(),
+                "in-memory manifest must roll back after a failed durable write"
+            );
+            assert!(
+                read_manifest(&path).await.entries.is_empty(),
+                "disk must not contain an entry whose write failed"
+            );
+
+            // Restore writability.
+            let mut perms = tokio::fs::metadata(dir.path())
+                .await
+                .expect("stat dir")
+                .permissions();
+            perms.set_mode(0o700);
+            tokio::fs::set_permissions(dir.path(), perms)
+                .await
+                .expect("chmod restore");
+
+            // 2. Identical retry: because rollback reverted the in-memory
+            //    change, the retry re-upserts and actually writes. Without
+            //    rollback this would be a silent no-op and disk would stay
+            //    empty.
+            persist_recorded(&manifest, &lock, &path, make_entry())
+                .await
+                .expect("retry after removing the failure must succeed");
+            let loaded = read_manifest(&path).await;
+            assert_eq!(
+                loaded.entries.len(),
+                1,
+                "identical retry after rollback must persist the entry"
+            );
+            assert_eq!(loaded.entries[0].id, "rollback-store");
+        } else {
+            // Restore writability for tempdir cleanup even when skipped.
+            let mut perms = tokio::fs::metadata(dir.path())
+                .await
+                .expect("stat dir")
+                .permissions();
+            perms.set_mode(0o700);
+            tokio::fs::set_permissions(dir.path(), perms)
+                .await
+                .expect("chmod restore");
+        }
+    }
+
+    /// WHY (review test 21): forward-compatible `extra` fields written by a
+    /// future daemon must survive a re-registration by an older handler that
+    /// doesn't know about them. Before the fix, `upsert` replaced the whole
+    /// entry, deleting any future fields (e.g. owner epoch/policy) on
+    /// re-create/re-join — dangerous for rollback/upgrade of the owner anchor.
+    #[tokio::test]
+    async fn future_fields_survive_upsert_and_rollback() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+
+        // A "future" entry carrying fields this build doesn't know about.
+        let mut future = entry(KIND_KV_STORE, "party", ROLE_CREATED);
+        future.extra.insert(
+            "owner_epoch".to_string(),
+            serde_json::json!({ "epoch": 7, "hash": "deadbeef" }),
+        );
+        future
+            .extra
+            .insert("policy_version".to_string(), serde_json::json!(3));
+        let mut manifest = CrdtSubscriptionManifest::default();
+        assert!(manifest.upsert(future));
+        write_manifest(&path, &manifest)
+            .await
+            .expect("write future manifest");
+
+        // Re-register the same (kind, id) through an "older" handler that only
+        // knows `expected_owner` — it does NOT mention the future fields.
+        let mut older = entry(KIND_KV_STORE, "party", ROLE_CREATED);
+        older
+            .extra
+            .insert("expected_owner".to_string(), serde_json::json!("abcd1234"));
+        // Upsert must MERGE: known fields take the new value; existing-only
+        // future extra fields are preserved.
+        assert!(
+            manifest.upsert(older),
+            "re-registration providing a new extra field must change the manifest"
+        );
+        let merged = &manifest.entries[0];
+        assert_eq!(
+            merged.extra["expected_owner"],
+            serde_json::json!("abcd1234")
+        );
+        assert_eq!(merged.extra["policy_version"], serde_json::json!(3));
+        assert_eq!(merged.extra["owner_epoch"]["epoch"], 7);
+
+        // Round-trip through disk preserves the merged future fields.
+        write_manifest(&path, &manifest)
+            .await
+            .expect("write merged");
+        let reloaded = read_manifest(&path).await;
+        assert_eq!(
+            reloaded.entries[0].extra["expected_owner"],
+            serde_json::json!("abcd1234")
+        );
+        assert_eq!(
+            reloaded.entries[0].extra["policy_version"],
+            serde_json::json!(3)
+        );
+        assert_eq!(reloaded.entries[0].extra["owner_epoch"]["epoch"], 7);
+
+        // An identical re-registration (no new info) is a durable no-op: merge
+        // yields the same entry, so upsert returns false (no disk churn, future
+        // fields still intact).
+        let mut older_again = entry(KIND_KV_STORE, "party", ROLE_CREATED);
+        older_again
+            .extra
+            .insert("expected_owner".to_string(), serde_json::json!("abcd1234"));
+        assert!(
+            !manifest.upsert(older_again),
+            "identical re-registration must be a no-op"
+        );
+    }
+
+    /// WHY (review test 19): deterministic proof that record serializes
+    /// through the persistence lock — not timing-based. While the lock is
+    /// held, a concurrent recorder can neither snapshot nor write; once
+    /// released, it lands its entry. Uses the lock itself as the barrier, so
+    /// the outcome is independent of scheduler timing.
+    #[tokio::test]
+    async fn record_serializes_through_persistence_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+        let manifest = Arc::new(RwLock::new(CrdtSubscriptionManifest::default()));
+        let lock = Arc::new(Mutex::new(()));
+
+        // Hold the persistence lock: a concurrent recorder must NOT be able to
+        // snapshot or write until it is released.
+        let held = lock.lock().await;
+        let recorder = tokio::spawn({
+            let (manifest, lock, path) = (Arc::clone(&manifest), Arc::clone(&lock), path.clone());
+            async move {
+                persist_recorded(
+                    &manifest,
+                    &lock,
+                    &path,
+                    entry(KIND_KV_STORE, "blocked", ROLE_CREATED),
+                )
+                .await
+            }
+        });
+        // Let the scheduler run the recorder up to its lock await.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        assert!(
+            read_manifest(&path).await.entries.is_empty(),
+            "recorder must not write while the persistence lock is held"
+        );
+        assert!(
+            !recorder.is_finished(),
+            "recorder must be blocked on the persistence lock"
+        );
+
+        // Release the lock; the recorder proceeds and lands its entry.
+        drop(held);
+        recorder
+            .await
+            .expect("recorder panicked")
+            .expect("persist_recorded should succeed");
+        let loaded = read_manifest(&path).await;
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].id, "blocked");
+    }
+
+    /// WHY (P1 manifest cancellation hole): `persist_recorded` MUST NOT mutate
+    /// live in-memory state before the durable write completes. The old code
+    /// upserted into the live manifest, released the data lock, THEN awaited
+    /// `write_manifest`; a cancellation (HTTP client disconnect, shutdown, or
+    /// task abort) during that await dropped the future before the Err-rollback
+    /// ran, leaving the entry in memory but not on disk. An identical retry
+    /// then saw `upsert == false` and returned `Ok(())` WITHOUT writing — the
+    /// registration was silently lost from disk forever.
+    ///
+    /// The fix stages the upsert in a clone and commits live memory only after
+    /// `write_manifest` returns `Ok`, so a drop at ANY await point (including
+    /// the disk write) leaves memory == disk == pre-call state and an identical
+    /// retry re-stages and re-writes.
+    ///
+    /// Deterministic — no sleeps, no timing: `biased` select! polls
+    /// `persist_recorded` first. It advances synchronously through the
+    /// uncontended locks and the in-memory stage until its FIRST blocking
+    /// await (the `tokio::fs` disk op, which dispatches to the blocking pool
+    /// and returns `Pending`). At that suspension point the OLD code had
+    /// already mutated live memory; the fixed code has not. `yield_now` then
+    /// wins the select and drops the future mid-write — exactly the
+    /// cancellation-before-rename window.
+    #[tokio::test]
+    async fn cancel_before_rename_leaves_memory_clean_and_retry_writes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+        let manifest = Arc::new(RwLock::new(CrdtSubscriptionManifest::default()));
+        let lock = Arc::new(Mutex::new(()));
+        let make_entry = || entry(KIND_KV_STORE, "cancel-store", ROLE_CREATED);
+
+        // Drive persist_recorded until it suspends at its first disk await,
+        // then cancel (drop) it — the cancellation-before-rename hole.
+        let cancelled = tokio::select! {
+            biased;
+            // Polled first: runs through the locks + in-memory stage and
+            // suspends at the blocking `tokio::fs` write.
+            res = persist_recorded(&manifest, &lock, &path, make_entry()) => {
+                // A genuine completion is not the scenario under test; assert
+                // it at least succeeded so the assertions below stay coherent.
+                assert!(res.is_ok(), "if persist completed it must succeed");
+                false
+            }
+            _ = tokio::task::yield_now() => true,
+        };
+        assert!(
+            cancelled,
+            "persist_recorded must still be suspended in its disk write when \
+             cancelled; if it completed, the cancellation hole was not exercised"
+        );
+
+        // After cancellation: live memory and disk must both be clean. The OLD
+        // code left the entry in live memory here (mutated before the write).
+        assert!(
+            manifest.read().await.entries.is_empty(),
+            "cancellation mid-write must not leave an un-persisted entry in memory"
+        );
+        assert!(
+            read_manifest(&path).await.entries.is_empty(),
+            "cancellation mid-write must not leave a partial manifest on disk"
+        );
+        // No temp-file debris from the aborted rename (TempFile guard).
+        let debris = std::fs::read_dir(dir.path())
+            .expect("read_dir")
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .count();
+        assert_eq!(debris, 0, "cancelled write left temp-file debris");
+
+        // Identical retry: because memory was never advanced, the retry
+        // re-stages and actually writes. The OLD code's no-op-on-retry (entry
+        // already in memory ⇒ upsert == false ⇒ return Ok without writing)
+        // would leave disk empty forever.
+        persist_recorded(&manifest, &lock, &path, make_entry())
+            .await
+            .expect("identical retry after cancellation must persist");
+        let loaded = read_manifest(&path).await;
+        assert_eq!(loaded.entries.len(), 1, "retry must land the entry on disk");
+        assert_eq!(loaded.entries[0].id, "cancel-store");
+        assert_eq!(
+            manifest.read().await.entries.len(),
+            1,
+            "memory and disk must agree after retry"
+        );
+    }
+
+    /// WHY (P1 parent-directory fsync failure → refused durability): a rename
+    /// is not durable across power loss until the containing directory is
+    /// fsync'd. The OLD `sync_parent_dir` swallowed that error behind a
+    /// `let _`, so `persist_recorded` acknowledged a registration as durable
+    /// when a power loss could lose the rename. The fix makes a dir-fsync
+    /// failure propagate as `Err` from `write_manifest_atomic` →
+    /// `persist_recorded`, which (stage-then-commit) refuses to commit live
+    /// memory — so a non-durable write is never acknowledged. An identical
+    /// retry re-stages from the unchanged memory and rewrites.
+    ///
+    /// Deterministic via the `DirFsyncFailureGuard` test hook: it forces
+    /// `sync_parent_dir` to return a synthetic `Err` for the guard's lifetime
+    /// (thread-local, auto-reset on drop), with no filesystem dependency, no
+    /// root-bypass, and no permission juggling. Runs on the current-thread
+    /// test runtime so the thread-local flag is visible where the future
+    /// resumes after the rename await.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dir_fsync_failure_refuses_durability_and_leaves_memory_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+        let manifest = Arc::new(RwLock::new(CrdtSubscriptionManifest::default()));
+        let lock = Arc::new(Mutex::new(()));
+        let make_entry = || entry(KIND_KV_STORE, "fsync-store", ROLE_CREATED);
+
+        // Inject a dir-fsync failure: the rename succeeds but the parent-dir
+        // fsync returns Err, so durability must NOT be acknowledged.
+        let _fail = DirFsyncFailureGuard::enable();
+        let result = persist_recorded(&manifest, &lock, &path, make_entry()).await;
+        assert!(
+            result.is_err(),
+            "a parent-directory fsync failure must surface as Err, not be \
+             acknowledged as durable"
+        );
+        // Stage-then-commit: live memory was never advanced, so the in-memory
+        // manifest does not lie about durability. A "commit-then-fsync"
+        // regression would leave the entry committed here while returning Err.
+        assert!(
+            manifest.read().await.entries.is_empty(),
+            "live memory must not commit a write whose dir-fsync failed"
+        );
+
+        // Drop the injection: an identical retry re-stages from the (still
+        // unchanged) memory and rewrites, now succeeding and committing, so
+        // memory and disk converge.
+        drop(_fail);
+        persist_recorded(&manifest, &lock, &path, make_entry())
+            .await
+            .expect("retry after removing the fsync failure must persist");
+        let loaded = read_manifest(&path).await;
+        assert_eq!(loaded.entries.len(), 1, "retry must land the entry on disk");
+        assert_eq!(loaded.entries[0].id, "fsync-store");
+        assert_eq!(
+            manifest.read().await.entries.len(),
+            1,
+            "memory and disk must agree after retry"
+        );
+    }
+
+    /// WHY (P1 one-shot failure isolation): a durable-write failure for one
+    /// subscription must not clobber a sibling that already committed, and the
+    /// failed entry must remain retryable. A regression that rolled back to a
+    /// stale/global snapshot, or that committed-then-failed, would lose or
+    /// cross-contaminate entries. This pins the invariant across an
+    /// interleaving of task create, kv create, and a different-owner kv join
+    /// (the manifest-level analog of the route-level mix), with a real one-shot
+    /// fs failure injected between them: memory == disk at every step, the
+    /// committed sibling survives, and the failed entries retry cleanly.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn interleaved_failure_does_not_clobber_sibling_entries() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("crdt-subscriptions.json");
+        let manifest = Arc::new(RwLock::new(CrdtSubscriptionManifest::default()));
+        let lock = Arc::new(Mutex::new(()));
+
+        // Root bypasses Unix permission bits; probe and only inject the failure
+        // when the permission model is actually enforced.
+        let probe = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(dir.path().join("__probe__"))
+            .await;
+        let enforced = probe.is_err();
+        if let Ok(f) = probe {
+            drop(f);
+            let _ = tokio::fs::remove_file(dir.path().join("__probe__")).await;
+        }
+
+        // A: task-list create — commits to memory + disk.
+        persist_recorded(
+            &manifest,
+            &lock,
+            &path,
+            entry(KIND_TASK_LIST, "alpha", ROLE_CREATED),
+        )
+        .await
+        .expect("A (task create) persists");
+
+        // Different-owner kv join entry: a joined store anchored on a hex owner
+        // (64 hex chars ⇒ 32-byte AgentId), the role a public join records.
+        let owner_hex = "deadbeef".repeat(8);
+        let join_entry = || {
+            let mut e = entry(KIND_KV_STORE, "delta", ROLE_JOINED);
+            e.extra
+                .insert("expected_owner".to_string(), serde_json::json!(owner_hex));
+            e
+        };
+
+        if enforced {
+            let mut perms = tokio::fs::metadata(dir.path())
+                .await
+                .expect("stat")
+                .permissions();
+            perms.set_mode(0o500);
+            tokio::fs::set_permissions(dir.path(), perms)
+                .await
+                .expect("chmod read-only");
+
+            // B (kv create) and D (different-owner kv join) both fail: neither
+            // may commit, and A must survive in memory AND on disk.
+            assert!(
+                persist_recorded(
+                    &manifest,
+                    &lock,
+                    &path,
+                    entry(KIND_KV_STORE, "beta", ROLE_CREATED)
+                )
+                .await
+                .is_err(),
+                "B fails under a read-only directory"
+            );
+            assert!(
+                persist_recorded(&manifest, &lock, &path, join_entry())
+                    .await
+                    .is_err(),
+                "D fails under a read-only directory"
+            );
+            assert_eq!(
+                manifest.read().await.entries.len(),
+                1,
+                "memory retains only A after failed B/D"
+            );
+            let disk_after_fail = read_manifest(&path).await;
+            assert_eq!(
+                disk_after_fail.entries.len(),
+                1,
+                "disk retains only A after failed B/D"
+            );
+            assert_eq!(disk_after_fail.entries[0].id, "alpha");
+
+            let mut perms = tokio::fs::metadata(dir.path())
+                .await
+                .expect("stat")
+                .permissions();
+            perms.set_mode(0o700);
+            tokio::fs::set_permissions(dir.path(), perms)
+                .await
+                .expect("chmod restore");
+        }
+
+        // C: a second task-list create — commits after the failure window.
+        persist_recorded(
+            &manifest,
+            &lock,
+            &path,
+            entry(KIND_TASK_LIST, "gamma", ROLE_CREATED),
+        )
+        .await
+        .expect("C (task create) persists after restore");
+
+        // Retry B and D — they now succeed; their earlier failure left no trace.
+        persist_recorded(
+            &manifest,
+            &lock,
+            &path,
+            entry(KIND_KV_STORE, "beta", ROLE_CREATED),
+        )
+        .await
+        .expect("B retry persists");
+        persist_recorded(&manifest, &lock, &path, join_entry())
+            .await
+            .expect("D retry persists");
+
+        // Final invariant: memory == disk, exactly {alpha, beta, delta, gamma},
+        // and the join retained its owner anchor through fail + retry.
+        let mem = manifest.read().await.clone();
+        let disk = read_manifest(&path).await;
+        assert_eq!(
+            mem, disk,
+            "memory and disk must agree after interleaved failures"
+        );
+        let mut ids: Vec<String> = disk.entries.iter().map(|e| e.id.clone()).collect();
+        ids.sort();
+        let expected: Vec<String> = ["alpha", "beta", "delta", "gamma"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(ids, expected);
+        let joined = disk
+            .entries
+            .iter()
+            .find(|e| e.id == "delta")
+            .expect("delta present");
+        assert_eq!(joined.role, ROLE_JOINED);
+        assert_eq!(joined.extra["expected_owner"], serde_json::json!(owner_hex));
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15914,7 +15914,12 @@ async fn put_kv_value(
             (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
         }
         Err(e) => {
-            let status = if format!("{e}").contains("value too large") {
+            let status = if matches!(e, x0x::error::IdentityError::Unauthorized(_)) {
+                // Local write rejected by the store's access policy — the
+                // caller is not the owner (or an allowlisted writer), or the
+                // joined replica has not yet learned the authoritative owner.
+                StatusCode::FORBIDDEN
+            } else if format!("{e}").contains("value too large") {
                 StatusCode::PAYLOAD_TOO_LARGE
             } else {
                 StatusCode::INTERNAL_SERVER_ERROR
@@ -15978,6 +15983,9 @@ async fn delete_kv_value(
             let recipients = kv_store_delta_direct_recipients(&state).await;
             spawn_kv_store_delta_delivery(&state, recipients, &id, handle.peer_id(), &delta);
             (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
+        }
+        Err(e) if matches!(e, x0x::error::IdentityError::Unauthorized(_)) => {
+            api_error(StatusCode::FORBIDDEN, format!("{e}"))
         }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,6 +10,7 @@
 use crate as x0x;
 
 mod auth;
+mod crdt_subscriptions;
 mod routes;
 mod sse;
 mod state;
@@ -951,6 +952,8 @@ pub async fn serve_with_options(
         subscriptions: RwLock::new(HashMap::new()),
         task_lists: RwLock::new(HashMap::new()),
         kv_stores: RwLock::new(HashMap::new()),
+        crdt_subscriptions: RwLock::new(crdt_subscriptions::CrdtSubscriptionManifest::default()),
+        crdt_subscriptions_path: config.data_dir.join("crdt-subscriptions.json"),
         named_groups: RwLock::new(named_groups),
         named_groups_path,
         named_groups_persistence_lock: Mutex::new(()),
@@ -1053,6 +1056,10 @@ pub async fn serve_with_options(
     // Phase C.2: load persisted shard subscriptions and re-subscribe with
     // staggered jitter to avoid anti-entropy storms.
     bg_tasks.extend(spawn_directory_resubscribe(Arc::clone(&state)).await);
+    // Restart-amnesia fix: load the persisted task-list/kv-store subscription
+    // manifest now (before REST handlers can mutate it) — the actual
+    // re-create/re-join runs after `join_network` in the join task below.
+    crdt_subscriptions::load(&state).await;
     // Phase C.2: subscribe inbound direct messages for the
     // ListedToContacts pairwise sync channel.
     bg_tasks.extend(spawn_listed_to_contacts_listener(Arc::clone(&state)).await);
@@ -1128,6 +1135,7 @@ pub async fn serve_with_options(
         dm_inbox_kv_store_delta_route_tx,
     )));
 
+    let crdt_rehydrate_state = Arc::clone(&state);
     bg_tasks.push(tokio::spawn(async move {
         match join_agent.join_network().await {
             Ok(()) => {
@@ -1144,6 +1152,13 @@ pub async fn serve_with_options(
                 tracing::error!("Failed to join network: {e}");
             }
         }
+        // Restart-amnesia fix: re-register every persisted task-list/kv-store
+        // subscription via the same Agent create/join paths the REST handlers
+        // use, so the topic subscription + empty-replica state-request happen
+        // and offline mutations arrive from peers. Runs on BOTH join arms:
+        // even when join_network errors, the local gossip runtime exists and
+        // the subscription is what lets state recover once peers appear.
+        crdt_subscriptions::rehydrate(crdt_rehydrate_state).await;
     }));
 
     let self_published_release_manifests =
@@ -15822,6 +15837,20 @@ async fn create_kv_store(
         Ok(handle) => {
             let id = req.topic.clone();
             state.kv_stores.write().await.insert(id.clone(), handle);
+            // Persist the registration so it survives a daemon restart
+            // (rehydrated after join_network — see crdt_subscriptions).
+            crdt_subscriptions::record(
+                &state,
+                crdt_subscriptions::CrdtSubscriptionEntry {
+                    kind: crdt_subscriptions::KIND_KV_STORE.to_string(),
+                    id: id.clone(),
+                    name: req.name.clone(),
+                    topic: req.topic.clone(),
+                    role: crdt_subscriptions::ROLE_CREATED.to_string(),
+                    extra: serde_json::Map::new(),
+                },
+            )
+            .await;
             (
                 StatusCode::CREATED,
                 Json(serde_json::json!({ "ok": true, "id": id })),
@@ -15839,6 +15868,21 @@ async fn join_kv_store(
     match state.agent.join_kv_store(&id).await {
         Ok(handle) => {
             state.kv_stores.write().await.insert(id.clone(), handle);
+            // Persist the registration so it survives a daemon restart
+            // (rehydrated after join_network — see crdt_subscriptions). The
+            // join path only knows the topic, so it doubles as the name.
+            crdt_subscriptions::record(
+                &state,
+                crdt_subscriptions::CrdtSubscriptionEntry {
+                    kind: crdt_subscriptions::KIND_KV_STORE.to_string(),
+                    id: id.clone(),
+                    name: id.clone(),
+                    topic: id.clone(),
+                    role: crdt_subscriptions::ROLE_JOINED.to_string(),
+                    extra: serde_json::Map::new(),
+                },
+            )
+            .await;
             (
                 StatusCode::OK,
                 Json(serde_json::json!({ "ok": true, "id": id })),
@@ -21100,6 +21144,8 @@ mod tests {
             subscriptions: RwLock::new(HashMap::new()),
             task_lists: RwLock::new(HashMap::new()),
             kv_stores: RwLock::new(HashMap::new()),
+            crdt_subscriptions: RwLock::new(crdt_subscriptions::CrdtSubscriptionManifest::default()),
+            crdt_subscriptions_path: data_dir.join("crdt-subscriptions.json"),
             named_groups: RwLock::new(named_groups),
             named_groups_path,
             named_groups_persistence_lock: Mutex::new(()),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -954,6 +954,8 @@ pub async fn serve_with_options(
         kv_stores: RwLock::new(HashMap::new()),
         crdt_subscriptions: RwLock::new(crdt_subscriptions::CrdtSubscriptionManifest::default()),
         crdt_subscriptions_path: config.data_dir.join("crdt-subscriptions.json"),
+        crdt_subscriptions_persistence_lock: Mutex::new(()),
+        crdt_handle_locks: RwLock::new(HashMap::new()),
         named_groups: RwLock::new(named_groups),
         named_groups_path,
         named_groups_persistence_lock: Mutex::new(()),
@@ -15808,23 +15810,57 @@ struct PutValueRequest {
     content_type: Option<String>,
 }
 
+/// Request body for POST /stores/:id/join.
+///
+/// `expected_owner` is the optional hex-encoded AgentId of the authoritative
+/// owner, supplied out-of-band (the local user/operator is the trust root).
+/// Omitting it yields a permanently read-only replica (no permissive fallback).
+#[derive(Debug, Default, Deserialize)]
+struct JoinStoreRequest {
+    expected_owner: Option<String>,
+}
+
 /// Response entry for GET /stores.
 #[derive(Debug, Serialize)]
 struct StoreListEntry {
     id: String,
     topic: String,
+    /// Hex-encoded anchored owner, or `null` for a read-only no-anchor store.
+    owner: Option<String>,
+    /// Access policy string.
+    policy: String,
+    /// Store version.
+    version: u64,
+    /// Owner-announce policy freshness counter.
+    policy_version: u64,
+    /// Strongly-typed ownership discriminant.
+    ownership_status: x0x::kv::OwnershipStatus,
 }
 
 /// GET /stores
 async fn list_kv_stores(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let stores = state.kv_stores.read().await;
-    let entries: Vec<StoreListEntry> = stores
-        .keys()
-        .map(|id| StoreListEntry {
-            id: id.clone(),
+    // Snapshot (id, handle) pairs without holding the read lock across the
+    // per-store ownership_info() awaits.
+    let pairs: Vec<(String, x0x::KvStoreHandle)> = {
+        let stores = state.kv_stores.read().await;
+        stores
+            .iter()
+            .map(|(id, h)| (id.clone(), h.clone()))
+            .collect()
+    };
+    let mut entries = Vec::with_capacity(pairs.len());
+    for (id, handle) in pairs {
+        let info = handle.ownership_info().await;
+        entries.push(StoreListEntry {
             topic: id.clone(),
-        })
-        .collect();
+            id,
+            owner: info.owner,
+            policy: info.policy,
+            version: info.version,
+            policy_version: info.policy_version,
+            ownership_status: info.ownership_status,
+        });
+    }
     Json(serde_json::json!({ "ok": true, "stores": entries }))
 }
 
@@ -15833,13 +15869,34 @@ async fn create_kv_store(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateStoreRequest>,
 ) -> impl IntoResponse {
+    let id = req.topic.clone();
+    // Reserve the entire handle+manifest transaction for this (kind,id) so
+    // a concurrent create/rehydrate for the same id cannot interleave handle
+    // insertion with failure rollback, or spawn a duplicate listener.
+    let reservation =
+        crdt_subscriptions::handle_reservation(&state, crdt_subscriptions::KIND_KV_STORE, &id)
+            .await;
+    let _guard = reservation.lock().await;
+    // Under the reservation: if a handle already exists (created by a prior
+    // successful request or rehydration), return conflict rather than
+    // overwriting it and leaking the existing sync listener.
+    if state.kv_stores.read().await.contains_key(&id) {
+        return api_error(StatusCode::CONFLICT, "store already exists");
+    }
     match state.agent.create_kv_store(&req.name, &req.topic).await {
         Ok(handle) => {
-            let id = req.topic.clone();
+            let info = handle.ownership_info().await;
             state.kv_stores.write().await.insert(id.clone(), handle);
             // Persist the registration so it survives a daemon restart
             // (rehydrated after join_network — see crdt_subscriptions).
-            crdt_subscriptions::record(
+            // Record the owner so a restarted creator re-anchors on itself.
+            let owner_hex = hex::encode(state.agent.agent_id().as_bytes());
+            let mut extra = serde_json::Map::new();
+            extra.insert(
+                "expected_owner".to_string(),
+                serde_json::Value::String(owner_hex),
+            );
+            if let Err(e) = crdt_subscriptions::record(
                 &state,
                 crdt_subscriptions::CrdtSubscriptionEntry {
                     kind: crdt_subscriptions::KIND_KV_STORE.to_string(),
@@ -15847,14 +15904,26 @@ async fn create_kv_store(
                     name: req.name.clone(),
                     topic: req.topic.clone(),
                     role: crdt_subscriptions::ROLE_CREATED.to_string(),
-                    extra: serde_json::Map::new(),
+                    extra,
                 },
             )
-            .await;
-            (
-                StatusCode::CREATED,
-                Json(serde_json::json!({ "ok": true, "id": id })),
-            )
+            .await
+            {
+                // Durable write failed: roll back the live handle so success is
+                // not acknowledged for an un-persisted registration.
+                tracing::error!("failed to persist kv store registration {id}: {e}");
+                state.kv_stores.write().await.remove(&id);
+                return api_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("failed to persist subscription registration: {e}"),
+                );
+            }
+            let mut resp = serde_json::to_value(&info).unwrap_or_else(|_| serde_json::json!({}));
+            if let Some(obj) = resp.as_object_mut() {
+                obj.insert("ok".to_string(), serde_json::Value::Bool(true));
+                obj.insert("id".to_string(), serde_json::Value::String(id));
+            }
+            (StatusCode::CREATED, Json(resp))
         }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
@@ -15864,14 +15933,55 @@ async fn create_kv_store(
 async fn join_kv_store(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
+    body: Option<Json<JoinStoreRequest>>,
 ) -> impl IntoResponse {
-    match state.agent.join_kv_store(&id).await {
+    // The out-of-band owner anchor is REQUIRED: a replica with no anchor can
+    // never accept policy-restricted data, so an unanchored join is a dead
+    // replica, not a successful join. The local user/operator is the trust
+    // root for this param.
+    let owner: AgentId = match body.and_then(|Json(r)| r.expected_owner) {
+        Some(hex_owner) => match parse_agent_id_hex(&hex_owner) {
+            Ok(agent) => agent,
+            Err(e) => return bad_request(format!("invalid expected_owner: {e}")),
+        },
+        None => {
+            return api_error(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "owner_required: an expected_owner anchor is required to join a store",
+            )
+        }
+    };
+    // Reserve the entire handle+manifest transaction for this (kind,id) so
+    // a concurrent join/rehydrate for the same id cannot interleave handle
+    // insertion with failure rollback, or spawn a duplicate listener.
+    let reservation =
+        crdt_subscriptions::handle_reservation(&state, crdt_subscriptions::KIND_KV_STORE, &id)
+            .await;
+    let _guard = reservation.lock().await;
+    // Under the reservation: if a handle already exists (created by a prior
+    // successful request or rehydration), return conflict rather than
+    // overwriting it and leaking the existing sync listener.
+    if state.kv_stores.read().await.contains_key(&id) {
+        return api_error(StatusCode::CONFLICT, "store already joined");
+    }
+    match state
+        .agent
+        .join_kv_store(&id, owner, x0x::kv::store::AnchorChannel::RestParam)
+        .await
+    {
         Ok(handle) => {
+            let info = handle.ownership_info().await;
             state.kv_stores.write().await.insert(id.clone(), handle);
             // Persist the registration so it survives a daemon restart
             // (rehydrated after join_network — see crdt_subscriptions). The
             // join path only knows the topic, so it doubles as the name.
-            crdt_subscriptions::record(
+            // Record the anchor so rehydrate re-anchors on the same owner.
+            let mut extra = serde_json::Map::new();
+            extra.insert(
+                "expected_owner".to_string(),
+                serde_json::Value::String(hex::encode(owner.as_bytes())),
+            );
+            if let Err(e) = crdt_subscriptions::record(
                 &state,
                 crdt_subscriptions::CrdtSubscriptionEntry {
                     kind: crdt_subscriptions::KIND_KV_STORE.to_string(),
@@ -15879,14 +15989,26 @@ async fn join_kv_store(
                     name: id.clone(),
                     topic: id.clone(),
                     role: crdt_subscriptions::ROLE_JOINED.to_string(),
-                    extra: serde_json::Map::new(),
+                    extra,
                 },
             )
-            .await;
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({ "ok": true, "id": id })),
-            )
+            .await
+            {
+                // Durable write failed: roll back the live handle so success is
+                // not acknowledged for an un-persisted registration.
+                tracing::error!("failed to persist kv store join {id}: {e}");
+                state.kv_stores.write().await.remove(&id);
+                return api_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("failed to persist subscription registration: {e}"),
+                );
+            }
+            let mut resp = serde_json::to_value(&info).unwrap_or_else(|_| serde_json::json!({}));
+            if let Some(obj) = resp.as_object_mut() {
+                obj.insert("ok".to_string(), serde_json::Value::Bool(true));
+                obj.insert("id".to_string(), serde_json::Value::String(id));
+            }
+            (StatusCode::OK, Json(resp))
         }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
@@ -21154,6 +21276,8 @@ mod tests {
             kv_stores: RwLock::new(HashMap::new()),
             crdt_subscriptions: RwLock::new(crdt_subscriptions::CrdtSubscriptionManifest::default()),
             crdt_subscriptions_path: data_dir.join("crdt-subscriptions.json"),
+            crdt_subscriptions_persistence_lock: Mutex::new(()),
+            crdt_handle_locks: RwLock::new(HashMap::new()),
             named_groups: RwLock::new(named_groups),
             named_groups_path,
             named_groups_persistence_lock: Mutex::new(()),

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -25,4 +25,6 @@ pub(super) use machines::{
     add_machine, delete_machine, discovered_machine, discovered_machines, list_machines,
     machines_by_user_handler, pin_machine, unpin_machine,
 };
-pub(super) use tasks::{add_task, create_task_list, list_task_lists, list_tasks, update_task};
+pub(super) use tasks::{
+    add_task, apply_group_authorization, create_task_list, list_task_lists, list_tasks, update_task,
+};

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -153,6 +153,11 @@ pub(in crate::server) struct AddTaskRequest {
 #[derive(Debug, Deserialize)]
 pub(in crate::server) struct UpdateTaskRequest {
     pub(in crate::server) action: String, // "claim" or "complete"
+    /// Optional optimistic-concurrency guard: if set and it does not match
+    /// the task list's current version, the mutation is rejected with 409
+    /// and nothing changes. Absent ⇒ unconditional (last-writer CRDT merge).
+    #[serde(default)]
+    pub(in crate::server) expected_version: Option<u64>,
 }
 
 /// Task list entry.
@@ -168,9 +173,19 @@ pub(in crate::server) struct TaskEntry {
     pub(in crate::server) id: String,
     pub(in crate::server) title: String,
     pub(in crate::server) description: String,
+    /// Legacy Display string ("empty" | "claimed:<hex>" | "done:<hex>").
+    /// Kept for backward compatibility — prefer the structured fields below.
     pub(in crate::server) state: String,
     pub(in crate::server) assignee: Option<String>,
     pub(in crate::server) priority: u8,
+    /// Hex AgentId of the deterministic claim winner; null if never claimed.
+    pub(in crate::server) claimed_by: Option<String>,
+    /// Unix-ms timestamp of the winning claim; null if never claimed.
+    pub(in crate::server) claimed_at: Option<u64>,
+    /// Hex AgentId of the deterministic completion winner; null unless done.
+    pub(in crate::server) completed_by: Option<String>,
+    /// Unix-ms timestamp of the winning completion; null unless done.
+    pub(in crate::server) completed_at: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -216,10 +231,16 @@ pub(in crate::server) async fn create_task_list(
     match state.agent.create_task_list(&req.name, &req.topic).await {
         Ok(handle) => {
             let id = req.topic.clone();
+            let version = handle.version().await;
             state.task_lists.write().await.insert(id.clone(), handle);
             (
                 StatusCode::CREATED,
-                Json(serde_json::json!({ "ok": true, "id": id })),
+                Json(serde_json::json!({
+                    "ok": true,
+                    "id": id,
+                    "version": version,
+                    "committed": "local",
+                })),
             )
         }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
@@ -240,8 +261,8 @@ pub(in crate::server) async fn list_tasks(
         return not_found("task list not found");
     };
 
-    match handle.list_tasks().await {
-        Ok(tasks) => {
+    match handle.list_tasks_with_version().await {
+        Ok((tasks, version)) => {
             let entries: Vec<TaskEntry> = tasks
                 .into_iter()
                 .map(|t| TaskEntry {
@@ -249,13 +270,17 @@ pub(in crate::server) async fn list_tasks(
                     title: t.title,
                     description: t.description,
                     state: format!("{}", t.state),
-                    assignee: t.assignee.map(|a| format!("{a}")),
+                    assignee: t.assignee.map(|a| hex::encode(a.as_bytes())),
                     priority: t.priority,
+                    claimed_by: t.claimed_by.map(|a| hex::encode(a.as_bytes())),
+                    claimed_at: t.claimed_at,
+                    completed_by: t.completed_by.map(|a| hex::encode(a.as_bytes())),
+                    completed_at: t.completed_at,
                 })
                 .collect();
             (
                 StatusCode::OK,
-                Json(serde_json::json!({ "ok": true, "tasks": entries })),
+                Json(serde_json::json!({ "ok": true, "version": version, "tasks": entries })),
             )
         }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
@@ -278,12 +303,17 @@ pub(in crate::server) async fn add_task(
     };
 
     match handle
-        .add_task(req.title, req.description.unwrap_or_default())
+        .add_task_versioned(req.title, req.description.unwrap_or_default())
         .await
     {
-        Ok(task_id) => (
+        Ok((task_id, version)) => (
             StatusCode::CREATED,
-            Json(serde_json::json!({ "ok": true, "task_id": format!("{task_id}") })),
+            Json(serde_json::json!({
+                "ok": true,
+                "task_id": format!("{task_id}"),
+                "version": version,
+                "committed": "local",
+            })),
         ),
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
@@ -318,15 +348,40 @@ pub(in crate::server) async fn update_task(
     let task_id = x0x::crdt::TaskId::from_bytes(task_id_bytes);
 
     let result = match req.action.as_str() {
-        "claim" => handle.claim_task(task_id).await,
-        "complete" => handle.complete_task(task_id).await,
+        "claim" => {
+            handle
+                .claim_task_versioned(task_id, req.expected_version)
+                .await
+        }
+        "complete" => {
+            handle
+                .complete_task_versioned(task_id, req.expected_version)
+                .await
+        }
         _ => {
             return bad_request("action must be 'claim' or 'complete'");
         }
     };
 
     match result {
-        Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
+        // "committed": "local" makes explicit that success = local CRDT
+        // commit + best-effort delta publish, NOT replicated observation.
+        Ok(x0x::TaskCasOutcome::Committed { version }) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "ok": true,
+                "version": version,
+                "committed": "local",
+            })),
+        ),
+        Ok(x0x::TaskCasOutcome::VersionConflict { current_version }) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": "version conflict",
+                "current_version": current_version,
+            })),
+        ),
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
     }
 }

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use crate as x0x;
 
+use super::super::crdt_subscriptions;
 use super::super::state::AppState;
 use super::super::{api_error, bad_request, forbidden, not_found};
 
@@ -217,6 +218,20 @@ pub(in crate::server) async fn create_task_list(
         Ok(handle) => {
             let id = req.topic.clone();
             state.task_lists.write().await.insert(id.clone(), handle);
+            // Persist the registration so it survives a daemon restart
+            // (rehydrated after join_network — see crdt_subscriptions).
+            crdt_subscriptions::record(
+                &state,
+                crdt_subscriptions::CrdtSubscriptionEntry {
+                    kind: crdt_subscriptions::KIND_TASK_LIST.to_string(),
+                    id: id.clone(),
+                    name: req.name.clone(),
+                    topic: req.topic.clone(),
+                    role: crdt_subscriptions::ROLE_CREATED.to_string(),
+                    extra: serde_json::Map::new(),
+                },
+            )
+            .await;
             (
                 StatusCode::CREATED,
                 Json(serde_json::json!({ "ok": true, "id": id })),

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -453,7 +453,10 @@ pub(in crate::server) async fn update_task(
         Some(s) => match x0x::FenceToken::from_wire(s) {
             Ok(token) => Some(token),
             Err(_) => {
-                return bad_request("malformed fence token");
+                // Machine-readable error code — the API contract (and
+                // daemon_api_claim_malformed_fence_token_is_rejected_non_mutating)
+                // matches on this exact string.
+                return bad_request("malformed_fence_token");
             }
         },
     };

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -131,6 +131,48 @@ pub(in crate::server) async fn ensure_task_list_access(
     }
 }
 
+/// Apply group authorization to a task list handle at the CRDT layer.
+///
+/// If the list `id` is group-scoped (`x0x.group.<gid>.symphony.<lid>`), look
+/// up the group's active members and call `set_authorized_agents` so remote
+/// CRDT admission rejects claims/completions from non-members. For plain
+/// (non-scoped) lists this is a no-op.
+///
+/// This closes the gap where group membership was enforced at REST but not at
+/// replication admission: a remote peer who subscribes to the topic but is not
+/// a group member cannot inject operations even with a valid signature.
+pub(in crate::server) async fn apply_group_authorization(
+    state: &Arc<AppState>,
+    id: &str,
+    handle: &x0x::TaskListHandle,
+) {
+    let Some(scoped) = parse_group_scoped_task_list_id(id) else {
+        return; // plain list — no group authorization
+    };
+    if scoped.is_malformed() {
+        return;
+    }
+    let mut agents = std::collections::HashSet::new();
+    {
+        let groups = state.named_groups.read().await;
+        let Some(info) = groups.get(&scoped.group_id) else {
+            return; // unknown group — can't authorize; leave open
+        };
+        for (agent_hex, member) in &info.members_v2 {
+            if matches!(member.state, x0x::groups::GroupMemberState::Active) {
+                if let Ok(bytes) = hex::decode(agent_hex) {
+                    if bytes.len() == x0x::identity::PEER_ID_LENGTH {
+                        let mut arr = [0u8; x0x::identity::PEER_ID_LENGTH];
+                        arr.copy_from_slice(&bytes);
+                        agents.insert(x0x::identity::AgentId(arr));
+                    }
+                }
+            }
+        }
+    }
+    handle.set_authorized_agents(agents).await;
+}
+
 // ---------------------------------------------------------------------------
 // Request / response DTOs
 // ---------------------------------------------------------------------------
@@ -152,13 +194,18 @@ pub(in crate::server) struct AddTaskRequest {
 
 /// PATCH /task-lists/:id/tasks/:tid request body.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(in crate::server) struct UpdateTaskRequest {
     pub(in crate::server) action: String, // "claim" or "complete"
-    /// Optional optimistic-concurrency guard: if set and it does not match
-    /// the task list's current version, the mutation is rejected with 409
-    /// and nothing changes. Absent ⇒ unconditional (last-writer CRDT merge).
+    /// Optional **local-replica** fencing precondition (opaque token). Echo
+    /// the `fence_token` from a prior GET/mutation verbatim. If it does not
+    /// match THIS daemon's current `(epoch, revision)`, the mutation is
+    /// rejected with 409 and nothing changes. This is NOT a distributed
+    /// compare-and-swap: two daemons at the same token both accept. A token
+    /// captured before a daemon restart never matches post-restart (the epoch
+    /// differs), closing the restart-ABA window.
     #[serde(default)]
-    pub(in crate::server) expected_version: Option<u64>,
+    pub(in crate::server) fence_token: Option<String>,
 }
 
 /// Task list entry.
@@ -229,31 +276,59 @@ pub(in crate::server) async fn create_task_list(
     if let Err(denied) = ensure_task_list_access(&state, &req.topic).await {
         return denied;
     }
+    let id = req.topic.clone();
+    // Reserve the entire handle+manifest transaction for this (kind,id) so
+    // a concurrent create/rehydrate for the same id cannot interleave handle
+    // insertion with failure rollback, or spawn a duplicate listener.
+    let reservation =
+        crdt_subscriptions::handle_reservation(&state, crdt_subscriptions::KIND_TASK_LIST, &id)
+            .await;
+    let _guard = reservation.lock().await;
+    // Under the reservation: if a handle already exists (created by a prior
+    // successful request or rehydration), return conflict rather than
+    // overwriting it and leaking the existing sync listener.
+    if state.task_lists.read().await.contains_key(&id) {
+        return api_error(StatusCode::CONFLICT, "task list already exists");
+    }
     match state.agent.create_task_list(&req.name, &req.topic).await {
         Ok(handle) => {
-            let id = req.topic.clone();
             let version = handle.version().await;
+            // Apply group authorization at the CRDT layer so remote admission
+            // rejects nonmember operations for group-scoped lists. Runs inside
+            // the reservation guard (serialized per (kind,id)).
+            apply_group_authorization(&state, &id, &handle).await;
             state.task_lists.write().await.insert(id.clone(), handle);
             // Persist the registration so it survives a daemon restart
-            // (rehydrated after join_network — see crdt_subscriptions).
-            crdt_subscriptions::record(
-                &state,
-                crdt_subscriptions::CrdtSubscriptionEntry {
-                    kind: crdt_subscriptions::KIND_TASK_LIST.to_string(),
-                    id: id.clone(),
-                    name: req.name.clone(),
-                    topic: req.topic.clone(),
-                    role: crdt_subscriptions::ROLE_CREATED.to_string(),
-                    extra: serde_json::Map::new(),
-                },
-            )
-            .await;
+            // (rehydrated after join_network — see crdt_subscriptions). This
+            // is a durable transaction: if the manifest write fails we roll
+            // back the just-inserted live handle and surface the error, so the
+            // registration is never acknowledged as durable when it is not.
+            let entry = crdt_subscriptions::CrdtSubscriptionEntry {
+                kind: crdt_subscriptions::KIND_TASK_LIST.to_string(),
+                id: id.clone(),
+                name: req.name.clone(),
+                topic: req.topic.clone(),
+                role: crdt_subscriptions::ROLE_CREATED.to_string(),
+                extra: serde_json::Map::new(),
+            };
+            if let Err(e) = crdt_subscriptions::record(&state, entry).await {
+                tracing::error!(
+                    topic = %req.topic,
+                    "failed to persist task-list subscription registration: {e}"
+                );
+                state.task_lists.write().await.remove(&id);
+                return api_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "failed to persist subscription registration",
+                );
+            }
             (
                 StatusCode::CREATED,
                 Json(serde_json::json!({
                     "ok": true,
                     "id": id,
-                    "version": version,
+                    "version": version.revision,
+                    "fence_token": version.to_wire(),
                     "committed": "local",
                 })),
             )
@@ -277,7 +352,7 @@ pub(in crate::server) async fn list_tasks(
     };
 
     match handle.list_tasks_with_version().await {
-        Ok((tasks, version)) => {
+        Ok((tasks, fence)) => {
             let entries: Vec<TaskEntry> = tasks
                 .into_iter()
                 .map(|t| TaskEntry {
@@ -295,7 +370,12 @@ pub(in crate::server) async fn list_tasks(
                 .collect();
             (
                 StatusCode::OK,
-                Json(serde_json::json!({ "ok": true, "version": version, "tasks": entries })),
+                Json(serde_json::json!({
+                    "ok": true,
+                    "version": fence.revision,
+                    "fence_token": fence.to_wire(),
+                    "tasks": entries,
+                })),
             )
         }
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
@@ -362,39 +442,72 @@ pub(in crate::server) async fn update_task(
     };
     let task_id = x0x::crdt::TaskId::from_bytes(task_id_bytes);
 
+    // Parse the opaque fence token.
+    //
+    // Distinguish **absent** (None ⇒ unconditional advisory commit) from
+    // **present but malformed** (parse error ⇒ 400 BAD_REQUEST, non-mutating).
+    // Collapsing the two would let a corrupt/legacy/attacker token silently
+    // downgrade a fenced request to an unfenced mutation.
+    let expected = match req.fence_token.as_deref() {
+        None => None,
+        Some(s) => match x0x::FenceToken::from_wire(s) {
+            Ok(token) => Some(token),
+            Err(_) => {
+                return bad_request("malformed fence token");
+            }
+        },
+    };
+
     let result = match req.action.as_str() {
-        "claim" => {
-            handle
-                .claim_task_versioned(task_id, req.expected_version)
-                .await
-        }
-        "complete" => {
-            handle
-                .complete_task_versioned(task_id, req.expected_version)
-                .await
-        }
+        "claim" => handle.claim_task_versioned(task_id, expected).await,
+        "complete" => handle.complete_task_versioned(task_id, expected).await,
         _ => {
             return bad_request("action must be 'claim' or 'complete'");
         }
     };
 
     match result {
-        // "committed": "local" makes explicit that success = local CRDT
-        // commit + best-effort delta publish, NOT replicated observation.
-        Ok(x0x::TaskCasOutcome::Committed { version }) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "ok": true,
-                "version": version,
-                "committed": "local",
-            })),
-        ),
-        Ok(x0x::TaskCasOutcome::VersionConflict { current_version }) => (
+        // `committed:"local"` makes explicit that success = local CRDT
+        // commit + best-effort delta publish — NOT replicated observation and
+        // NOT exclusive ownership. The `resolution` block reports the local
+        // OR-Set snapshot at commit time; the deterministic winner may change
+        // when concurrent operations from other replicas merge in. `cas.scope`
+        // localizes the version guard; `execution.authorization:"advisory"`
+        // and `exclusive:false` make the non-exclusive status unambiguous, so
+        Ok(x0x::TaskMutationOutcome::Committed { fence, advisory }) => {
+            let current_winner = advisory.current_winner.map(|(agent, ts)| {
+                serde_json::json!({
+                    "agent_id": hex::encode(agent.as_bytes()),
+                    "timestamp_ms": ts,
+                })
+            });
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "ok": true,
+                    "version": fence.revision,
+                    "fence_token": fence.to_wire(),
+                    "committed": "local",
+                    "resolution": {
+                        "agent_id": hex::encode(advisory.agent.as_bytes()),
+                        "locally_winning": advisory.locally_winning,
+                        "current_winner": current_winner,
+                        "pending_convergence": true,
+                    },
+                    "cas": { "scope": "local_replica" },
+                    "execution": { "authorization": "advisory" },
+                    "exclusive": false,
+                })),
+            )
+        }
+        Ok(x0x::TaskMutationOutcome::StaleLocalVersion { current }) => (
             StatusCode::CONFLICT,
             Json(serde_json::json!({
                 "ok": false,
-                "error": "version conflict",
-                "current_version": current_version,
+                "error": "stale_local_version",
+                "current_version": current.revision,
+                "fence_token": current.to_wire(),
+                "cas": { "scope": "local_replica" },
             })),
         ),
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
@@ -471,5 +584,41 @@ mod tests {
         let empty_list = parse_group_scoped_task_list_id("x0x.group.acme.symphony.");
         let scoped = empty_list.expect("scoped shape with empty list is Some");
         assert!(scoped.is_malformed(), "empty list_id ⇒ malformed ⇒ deny");
+    }
+
+    // ── UpdateTaskRequest strict parsing: no silent fence downgrade ────────
+    //
+    // The PATCH claim/complete body must reject unknown fields. The pre-fence
+    // API used `expected_version`; a client still sending it MUST get a 4xx
+    // (serde reject → axum Json extractor), NOT a silent ignore that drops the
+    // field and downgrades the request to fence_token=None (unfenced) — which
+    // would let a stale claim commit 200. `deny_unknown_fields` enforces this.
+
+    #[test]
+    fn update_task_request_rejects_obsolete_expected_version_field() {
+        // The obsolete pre-fence field is now unknown → rejected, not ignored.
+        let obsolete =
+            serde_json::from_str::<UpdateTaskRequest>(r#"{"action":"claim","expected_version":3}"#);
+        assert!(
+            obsolete.is_err(),
+            "obsolete expected_version must be rejected (4xx), not silently \
+             downgraded to an unfenced claim"
+        );
+    }
+
+    #[test]
+    fn update_task_request_accepts_current_contract_and_rejects_typos() {
+        // fence_token provided (fenced) parses.
+        let fenced =
+            serde_json::from_str::<UpdateTaskRequest>(r#"{"action":"claim","fence_token":"1:2"}"#);
+        assert!(fenced.is_ok(), "fenced request parses");
+        // fence_token omitted (unfenced) is still a valid shape — strictness is
+        // about UNKNOWN fields, not requiring a fence.
+        let unfenced = serde_json::from_str::<UpdateTaskRequest>(r#"{"action":"claim"}"#);
+        assert!(unfenced.is_ok(), "unfenced request parses");
+        // A typo'd field name is also rejected (defense in depth).
+        let typo =
+            serde_json::from_str::<UpdateTaskRequest>(r#"{"action":"claim","fence_tokn":"1:2"}"#);
+        assert!(typo.is_err(), "typo'd field name must be rejected");
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -517,6 +517,18 @@ pub(super) struct AppState {
     /// Disk location for the CRDT subscription manifest (instance data dir,
     /// alongside `directory-subscriptions.json`).
     pub(super) crdt_subscriptions_path: PathBuf,
+    /// Serializes snapshot-and-write of `crdt-subscriptions.json` so an older
+    /// in-memory snapshot cannot rename over a newer one after a concurrent
+    /// `crdt_subscriptions::record` (the snapshot-after-unlock lost update).
+    /// Mirrors `named_groups_persistence_lock`.
+    pub(super) crdt_subscriptions_persistence_lock: Mutex<()>,
+    /// Per-`(kind,id)` reservation locks serialising the full
+    /// create/join → insert-handle → persist-manifest transaction for CRDT
+    /// subscriptions. Shared by REST handlers and rehydration so concurrent
+    /// same-`(kind,id)` requests cannot interleave handle insertion with
+    /// failure rollback, and REST-vs-rehydrate cannot spawn duplicate
+    /// long-lived sync listeners. Keyed by `"{kind}:{id}"`.
+    pub(super) crdt_handle_locks: RwLock<HashMap<String, Arc<Mutex<()>>>>,
     pub(super) named_groups: RwLock<HashMap<String, x0x::groups::GroupInfo>>,
     pub(super) named_groups_path: PathBuf,
     /// Serializes snapshot-and-write of `named_groups.json` so an older

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -510,6 +510,13 @@ pub(super) struct AppState {
     pub(super) subscriptions: RwLock<HashMap<String, RestSubscription>>,
     pub(super) task_lists: RwLock<HashMap<String, TaskListHandle>>,
     pub(super) kv_stores: RwLock<HashMap<String, KvStoreHandle>>,
+    /// Persisted task-list/kv-store subscription manifest so registrations
+    /// survive a daemon restart (rehydrated after `join_network`; see
+    /// `crdt_subscriptions`).
+    pub(super) crdt_subscriptions: RwLock<super::crdt_subscriptions::CrdtSubscriptionManifest>,
+    /// Disk location for the CRDT subscription manifest (instance data dir,
+    /// alongside `directory-subscriptions.json`).
+    pub(super) crdt_subscriptions_path: PathBuf,
     pub(super) named_groups: RwLock<HashMap<String, x0x::groups::GroupInfo>>,
     pub(super) named_groups_path: PathBuf,
     /// Serializes snapshot-and-write of `named_groups.json` so an older

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -29,6 +29,7 @@ covers project-wide rules and architecture.
 | `presence_integration.rs` | Presence API surface: subscribe, cached_agent, foaf_peer_candidates |
 | `kv_store_integration.rs` | KV store CRUD, access policies, CRDT sync |
 | `kv_first_join_bootstrap.rs` | Issue #96: cold first-join state bootstrap via state-sync side topic (daemon-backed, `--ignored`) |
+| `kv_signed_store_auth.rs` | Signed-store local-write enforcement: joiner PUT/DELETE -> 403, owner learned via signed OwnerAnnounce (daemon-backed, `--ignored`) |
 | `tasklist_first_join_bootstrap.rs` | Task-list cold first-join bootstrap via state-sync side topic + LWW-clock delta merge (daemon-backed, `--ignored`) |
 | `local_topics.rs` | Issue #89: `local:` topics deliver same-daemon only, never gossipped (daemon-backed, `--ignored`) |
 | `named_group_integration.rs` | Named groups, invites, join/leave, display names |

--- a/tests/COMPREHENSIVE_TEST_PROMPT.md
+++ b/tests/COMPREHENSIVE_TEST_PROMPT.md
@@ -796,7 +796,7 @@ Trust-gated introduction card served at `GET /introduction`. Filters visible fie
 ### 11.1 General WebSocket (5×)
 | # | Interface | Action | Expected |
 |---|-----------|--------|----------|
-| 1 | curl | Connect `ws://127.0.0.1:12701/ws?token=$TOKEN` | Connected |
+| 1 | curl | Mint session via `POST /auth/session` (Bearer $TOKEN), connect `ws://127.0.0.1:12701/ws?token=$SESSION_TOKEN` (durable token in URL → 401) | Connected |
 | 2 | curl | Send message via WS | Delivered |
 | 3 | curl | Receive event via WS | Event arrives |
 | 4 | GUI | WebSocket-backed real-time updates | Live updates |

--- a/tests/convergence/README.md
+++ b/tests/convergence/README.md
@@ -15,11 +15,13 @@ environments).
 
 ```bash
 cargo build --release --bin x0xd     # or set X0XD_TEST_BINARY
-just convergence-soak-quick          # 1 run, ~3 min
-just convergence-soak                # 10 runs (soak)
+just convergence-soak-quick          # 1-run smoke (~3 min, NON-authoritative)
+just convergence-soak                # 10-run dev soak (NON-authoritative)
 just convergence-soak 5              # custom run count
+just convergence-release             # AUTHORITATIVE release gate (needs X0XD_LEGACY_BINARY)
 
 # Direct invocation with custom gates:
+X0XD_LEGACY_BINARY=/path/to/x0xd-0.30.1 \
 python3 tests/convergence/convergence_soak.py \
     --runs 10 --nodes 3 --live-gate 60 --expect-fixed
 ```
@@ -42,6 +44,11 @@ failing runs are kept for debugging; passing runs are cleaned unless
 - Rolling start: 15 s between node launches (`--stagger-secs`, a known
   network requirement).
 - API tokens are discovered from `<data_dir>/api-token`.
+- Once the cluster is up the harness records each node's identity for the
+  report: AgentId (`GET /agent`), PeerId (`GET /diagnostics/connectivity`),
+  API/QUIC addresses, `data_dir`, and bootstrap siblings. These are used to
+  attribute the deterministic claim winner (`claimed_by`) and the store
+  owner to a real node.
 
 ## Phases and gates
 
@@ -52,52 +59,219 @@ attributable per phase. Convergence is sampled every `--poll-interval`
 (default 1.5 s) with the exact arrival time recorded separately for the
 task and the KV key.
 
+Each KV convergence gate asserts EXACT decoded bytes (and records the
+owner-signed `content_hash`), not mere key presence; the report also records
+each node's actual connected peer set and reconnect path (from
+`/diagnostics/connectivity`), not just the configured bootstrap list.
+
 | Phase | What happens | Gate (default) |
 |---|---|---|
 | `cold_join` | conv1 creates a task list + task and a store + key **before** peers exist; each peer then starts, joins, and must see both primitives | task and key visible per node within `--cold-gate` (120 s) — hard |
 | `live_propagation` | after all joined and converged, conv1 adds a task and puts a key; per-primitive latency to each peer | all arrivals within `--live-gate` (60 s) — hard |
 | `restart_recovery` | convN stopped; conv1 adds a task + key; convN restarted; state must be visible **without** explicit re-create/join | `--restart-gate` (90 s) — known-gap |
 | `restart_recovery_eventual` | if auto-recovery failed, explicit rejoin (re-POST `/task-lists` + `/stores/join`) must restore all state incl. the offline mutation | within `--cold-gate` — hard, always |
-| `concurrent_claims` | conv1 adds a task; once visible on conv2+conv3 both PATCH `{"action":"claim"}` simultaneously (thread barrier); both HTTP responses recorded; all nodes polled until they agree on one winner | convergence to a single `claimed:*` state within `--claim-gate` (60 s) — hard |
-| `concurrent_claims_structured_fields` | are structured claim fields (`claimed_by`/`claimed_at`/`version`) present on the task? | known-gap |
-| `signed_store_nonowner_write` | conv2 (joiner) PUTs a new key into conv1's Signed store | HTTP 403 and no local fork — known-gap |
+| `concurrent_claims` | conv1 adds a task; once visible on conv2+conv3 both PATCH `{"action":"claim","fence_token":F_i}` simultaneously (thread barrier), where each F_i is the claimant's OWN local fence_token read right after the barrier; all nodes polled until they agree on one deterministic winner (`claimed_by`) | convergence to a single winner within `--claim-gate` (60 s); winner attributable to a real claimant — hard |
+| `concurrent_claims_advisory_both_commit` | each claimant used its own local fence_token, so BOTH must commit (200) — two replicas at their own current token both pass the local fence (advisory). A 409 would mean the fence fired on cross-replica skew and masked the contract. | known-gap |
+| `concurrent_claims_structured_fields` | are `claimed_by` (hex AgentId), `claimed_at` (Unix-ms), and list `version` present, and the winner ∈ claimants? | known-gap |
+| `concurrent_claims_honest_semantics` | no commit response POSITIVELY claims exclusivity (a top-level `exclusive:false` negation is honest); every 200 carries `committed:"local"`; positive honesty signals (`exclusive`/`execution.authorization`/`cas.scope`/`resolution`) if present must be correct | known-gap |
+| `concurrent_claims_cas_fence` | on ONE replica: read F, claim with `fence_token=F` (commits, token→F'), then claim with the now-stale `fence_token=F` — must NOT mutate (non-200, echoes `fence_token`). Asserts non-mutation, never the literal error string. | known-gap |
+| `concurrent_claims_remote_invalidation` | the local fence must reject a token invalidated by a merged REMOTE delta: a peer adds a NAMED task, the harness waits for THAT task to be visible on local AND for the fence to advance (not just any revision churn), then a local claim guarded by the pre-merge token is rejected | known-gap |
+| `signed_store_nonowner_write` | conv2 (joiner, anchored to conv1) PUTs a new key into conv1's Signed store | HTTP 403 and no local fork — known-gap |
+| `signed_store_owner_binding` | joins pin `expected_owner`=creator; creator + joiner both `ownership_status:"anchored"` with `owner`==creator. First-self-claim impossible by construction. **Hard gate** (owner/policy/version/ownership_status now exposed). | hard |
 | `signed_store_no_owner_propagation` | the intruder key must never become visible on the owner within `--fork-window` (20 s) | hard, always (a propagation would be a new inbound-enforcement regression) |
+
+| `fence_malformed_rejected` | a malformed `fence_token` (u64 overflow, non-token string) is PATCHed; must be rejected (non-200) WITHOUT mutating the list — present-but-invalid must not collapse to 'absent' | known-gap |
+| `fence_pre_restart_rejected` | a `fence_token` captured before a daemon restart is PATCHed after restart; must be rejected (the fence epoch is a fresh incarnation) | known-gap |
+| `named_new_port_reconnect` | a peer is restarted on a FORCED different QUIC port (same MachineId, no manual rejoin); must reconnect to the creator (actual peer set) and recover the down-window task | known-gap |
+| `owner_offline_checkpoint_recovery` *(prereq)* | owner multi-writes/updates/deletes (incl. delete-to-empty); replicas match EXACT bytes each step; owner OFFLINE, a fresh anchored joiner via relay-only recovers the exact final state with no key resurrection | prerequisite gate (P0; fail ⇒ run fail) |
+| `forged_first_seen_task` *(prereq)* | the in-repo `x0xd-forge-injector` publishes an unattested first-seen TaskItem (`Claimed{victim,ts:1}`, no attestation) over real gossip; the receiver's `admit()` must purge it (forged task absent, no version/fence churn, legit post-attack claim still resolves) | prerequisite gate (in-repo injector; fail ⇒ run fail) |
+
+## Claim semantics (advisory — read this before reading the gates)
+
+Claims are an **advisory** CRDT OR-Set, not a distributed lock. `fence_token`
+is a **local fence only**: two replicas that both read token F can BOTH pass the
+guard and BOTH commit locally — that is correct, not a bug. The single
+deterministic winner (earliest timestamp) is resolved at convergence and read
+from `claimed_by`. Accordingly:
+
+- `concurrent_claims` asserts convergence to **one** winner and that the winner is
+  a real claimant — it does **not** assert "only one claim succeeded".
+- `concurrent_claims_cas_fence` tests the fence on a **single replica** where the
+  token has already advanced; it asserts non-mutation + `fence_token` echo,
+  never the literal error string (the wording is intentionally in flux).
+- `concurrent_claims_honest_semantics` asserts no commit response misrepresents
+  advisory local commit as exclusive ownership.
 
 ## Known-gap flags vs `--expect-fixed`
 
-Three defects confirmed on current main are tracked as **known-gap**
-expectations so the harness runs green pre-fix:
+Defects confirmed on current main are tracked as **known-gap** expectations so
+the harness runs green pre-fix:
 
-1. `restart_recovery` — task-list/store subscriptions are not restored
-   after daemon restart (server handle maps start empty).
-2. `concurrent_claims_structured_fields` — claim ownership is only encoded
-   in the formatted `state` string; no `claimed_by`/`claimed_at`/`version`.
-3. `signed_store_nonowner_write` — non-owner PUT returns local `200` and
-   forks locally instead of `403`.
+1. `restart_recovery` — task-list/store subscriptions are not restored after
+   daemon restart (server handle maps start empty).
+2. `concurrent_claims_advisory_both_commit` — a 409 on a same-version local
+   claim masked the advisory contract (now each claimant uses its own local
+   version and both must commit).
+3. `concurrent_claims_structured_fields` — `claimed_by`/`claimed_at`/`version`
+   absent (ownership only in the formatted `state` string).
+4. `concurrent_claims_honest_semantics` — a commit response implying exclusive
+   ownership the protocol cannot provide.
+5. `concurrent_claims_cas_fence` — a stale `fence_token` still mutates.
+6. `concurrent_claims_remote_invalidation` — the local fence ignored a token
+   invalidated by a merged remote delta.
+7. `signed_store_nonowner_write` — non-owner PUT returns local `200` and forks
+   instead of `403`.
+8. `fence_malformed_rejected` — a malformed fence_token collapsed to 'absent'
+   and mutated unconditionally.
+9. `fence_pre_restart_rejected` — a pre-restart fence_token was still accepted
+   after restart (the epoch was wall-clock, not a durable incarnation nonce).
+10. `named_new_port_reconnect` — proactive reconnect / CRDT recovery on a new
+    port was not established.
 
-Without `--expect-fixed`, observing the legacy behavior reports the phase
-as `known-gap` (tolerated, run still passes); observing the fixed behavior
-reports `fixed`. With `--expect-fixed`, all three become hard gates — use
-this mode to verify the fixes and in CI afterwards.
+(`signed_store_owner_binding` is now a **hard** gate — owner/policy/version/
+`ownership_status` are exposed and joins pin `expected_owner`=creator.)
+
+Without `--expect-fixed`, observing the legacy behavior reports the phase as
+`known-gap` (tolerated, run still passes); observing the fixed behavior reports
+`fixed`. With `--expect-fixed`, all of the above become hard gates — use this
+mode to verify the fixes and in CI afterwards.
 
 ## Soak mode and reports
 
 `--runs N` repeats the full scenario N times with fresh data dirs (fresh
 identities, fresh topic/store names). The aggregate `report.json` contains
-per-run, per-phase, per-primitive latencies, pass/known-gap/fail status,
-raw claim responses, and per-phase diagnostics deltas. `summary.txt` (also
-printed) has a min/median/p95/max latency table, gate pass rates, per-phase
-`dropped_critical_hard_error` growth, and the known gaps observed.
+per-run `topology` (each node's AgentId, PeerId, addresses, bootstrap
+siblings), per-phase, per-primitive latencies, pass/known-gap/fail status,
+raw claim responses (with `fence_token`), fence observations,
+store owner/policy/version probes, per-phase diagnostics deltas, and each
+node's connected peer set; plus top-level `provenance` (binary SHA-256 +
+`--version` + git HEAD/dirty-tree/source cutoff), `release_environment`
+(hard-error growth + mDNS contamination), and `provenance_errors`, alongside
+the `prerequisite_gates` array. `summary.txt` (also printed) has a
+min/median/p95/max latency table, gate pass rates (pass/gap/unsupp/fail),
+per-phase `dropped_critical_hard_error` growth, the known gaps observed, the
+same-host topology, and the prerequisite-gate statuses.
+
+## Version-skew, hostile-announce, checkpoint & forged-first-seen gates
+
+Threats the single-version same-host soak cannot cover on its own.
+
+### Release-oracle provenance
+
+Every run records and (under `--expect-fixed`) **verifies** binary/source
+provenance — attesting the release from digests and a source cutoff rather
+than paths alone:
+
+- **current binary** — SHA-256, `--version`, and mtime; the oracle REFUSES a
+  binary whose mtime predates the newest reviewed source file (rebuild
+  required).
+- **legacy binary** — SHA-256 + `--version`; must be EXACTLY `v0.30.1`. File
+  existence alone is not authentication — a wrong-version "legacy"
+  hard-fails both mixed-version directions.
+- **git source cutoff** — HEAD, `HEAD^{tree}`, branch, a dirty-tree
+  fingerprint (sha256 of `git diff HEAD` + `git status`), and the HEAD
+  commit timestamp, so the report binds to the exact working tree.
+- **actual peer set + reconnect path** — each node's connected PeerIds and
+  connection-pool counters (from `/diagnostics/connectivity`), recorded in
+  topology and before/after restart for attribution.
+
+Under `--expect-fixed` a provenance refusal (stale binary / wrong legacy
+version) fails fast. Without it the refusals are warnings (smoke stays
+available).
+
+### `mixed_version_skew` (load-bearing + degraded) — needs a real v0.30.1 binary
+
+- **`mixed_version_skew_load_bearing`** — a real v0.30.1 binary is the OWNER
+  (creates+writes); the current binary is the anchored joiner that pins
+  `expected_owner`=<legacy owner> and MUST recover the historical key and a
+  live key with EXACT decoded bytes (+ owner-signed `content_hash`).
+  Online-owner convergence-with-anchor across skew.
+- **`mixed_version_skew_degraded`** — current owner + legacy v0.30.1 joiner.
+  The owner's key replicates to the legacy joiner with EXACT bytes, AND the
+  legacy non-owner write must NOT propagate to the current owner (no
+  unauthorized propagation) while owner state stays exact. Degraded-safety is
+  proven by the ABSENCE of the rogue write — not by mere liveness.
+
+Both directions need a REAL legacy binary; the skew is never faked by
+degrading the current binary. `--expect-fixed` requires BOTH; UNSUPPORTED
+fails the run under `--expect-fixed`.
+
+### `malicious_owner_announce` (in-repo, no external binary)
+
+A rogue daemon self-claims the SAME store topic; its sync loop publishes a
+genuine `OwnerAnnounce{owner: rogue}`. PASS requires a **positive** attack
+receipt — a `conflict` status observed with the rogue identity — PLUS a
+stable legit owner (never flips to rogue), NO rogue content on the joiner
+(exact bytes), and a legitimate **post-attack** write the joiner recovers
+(proving the anchor is not wedged). Anchored-alone is not enough: the gate
+must prove the rogue announce arrived and was rejected.
+
+### `owner_offline_checkpoint_recovery` (P0, in-repo)
+
+Owner multi-writes/updates/deletes (including delete-to-empty); replicas must
+match EXACT bytes after each step. Then the owner is STOPPED and a fresh
+anchored joiner bootstrapping ONLY to a relay (not the owner) recovers the
+EXACT final state with no key resurrection. Exercises checkpoint epoch
+persistence, content-root integrity, and delete reconciliation end to end.
+
+### `forged_first_seen_task` (in-repo injector)
+
+A hostile gossip publisher ships a first-seen TaskItem carrying a
+`Claimed{victim,ts:1}` element with NO matching attestation. The in-repo
+`x0xd-forge-injector` binary crafts it via
+`x0x::crdt::forge_unattested_delta_bytes` (the exact bincode `(PeerId,
+TaskListDelta)` wire bytes) and publishes over REAL gossip through the daemon's
+`/publish` wire API — never faked via REST. The receiver's fail-closed
+admission (`admit()`) must purge it: the forged task never appears, the list
+version/fence does not churn, and a legit post-attack claim still resolves.
+Built by `just convergence-release` (and `cargo build --release --bin
+x0xd-forge-injector`); a missing injector is a hard setup failure (UNSUPPORTED,
+FAIL under `--expect-fixed`). The other variants (malformed-sig, attacker-key,
+wrong-agent, wrong-scope) are proven at the store/CRDT regression layer.
+
+## Release-environment gates (hard-error + mDNS)
+
+Two environmental signals are gated, not merely reported:
+
+- **`dropped_critical_hard_error` growth** — any per-phase growth across the
+  soak. Under `--expect-fixed` growth FAILS the run (a critical pubsub
+  admission failure is never acceptable); reported otherwise.
+- **mDNS mesh contamination** — non-zero `discovered_peers` on the isolated
+  cluster (stray x0xd daemons on the host). Under `--expect-fixed` a
+  contaminated mesh FAILS the run; for a clean release, ensure no other x0xd
+  daemons are active.
+
+A gate that runs and **fails** always fails the harness.
+`malicious_owner_announce` and `owner_offline_checkpoint_recovery` always run
+(in-repo); under `--expect-fixed` they must PASS. `mixed_version_skew` and
+`forged_first_seen_task` are UNSUPPORTED without their prerequisites; that
+does not fail the run by default — **except under `--expect-fixed`**, where
+UNSUPPORTED FAILS: the release recipe demands every phase be exercised, never
+silently skipped.
+
+## Release recipe (authoritative) vs one-run smoke
+
+- **`just convergence-release`** is the AUTHORITATIVE release gate: it
+  requires `--expect-fixed` (every known-gap becomes a hard gate), an
+  authenticated v0.30.1 legacy binary (`X0XD_LEGACY_BINARY`), and 10/10 clean
+  runs. UNSUPPORTED or unproven phases are NO-GO; provenance refusal fails
+  fast. **This is the recipe that gates a release.**
+- **`just convergence-soak-quick`** (1 run) and **`just convergence-soak`**
+  (10 runs) remain available as non-authoritative smokes / dev soaks.
 
 ## Acceptance criteria (fix verification)
 
-- 10 runs (`just convergence-soak`), 100% eventual convergence for
-  cold-join, live-propagation, and offline-rejoin.
-- Zero unexplained `dropped_critical_hard_error` growth in the per-phase
-  diagnostics deltas.
-- With the fixes landed: `--expect-fixed` passes 10/10 (auto restart
-  recovery, structured claim fields, non-owner PUT rejected with 403 and
-  no local fork).
+- 10 runs (`just convergence-release`), 100% eventual convergence for
+  cold-join, live-propagation, and offline-rejoin, with EXACT decoded KV
+  values (not presence).
+- Zero `dropped_critical_hard_error` growth; clean (uncontaminated) mDNS mesh.
+- With the fixes landed: `--expect-fixed` passes 10/10 — auto restart
+  recovery, structured claim fields, honest claim semantics, CAS local fence,
+  remote-invalidation by a NAMED mutation, malformed/pre-restart fence
+  rejection, non-owner PUT rejected with 403 and no local fork, store owner
+  bound to the creator, owner-offline checkpoint/delete recovery, named
+  new-port reconnect, positive hostile-announce conflict, and exact-value
+  mixed-version interop with no degraded-direction propagation.
 
 ## Teardown
 

--- a/tests/convergence/README.md
+++ b/tests/convergence/README.md
@@ -1,0 +1,107 @@
+# Convergence Soak Harness
+
+Repeatable, in-repo version of the external three-machine (macOS + 2 WAN
+droplets) convergence test of v0.30.1 that exposed restart-recovery,
+claim-semantics, and signed-store defects. It spins N (default 3) local
+`x0xd` instances that bootstrap **only to each other** and drives the same
+five scenarios with independent gates, per-primitive (TaskList vs KV)
+arrival timing, and per-phase gossip-diagnostics deltas. It exists to
+verify the fixes for those defects and to keep them fixed.
+
+Python 3 stdlib only (`urllib`, never curl — curl is intercepted in some
+environments).
+
+## Running
+
+```bash
+cargo build --release --bin x0xd     # or set X0XD_TEST_BINARY
+just convergence-soak-quick          # 1 run, ~3 min
+just convergence-soak                # 10 runs (soak)
+just convergence-soak 5              # custom run count
+
+# Direct invocation with custom gates:
+python3 tests/convergence/convergence_soak.py \
+    --runs 10 --nodes 3 --live-gate 60 --expect-fixed
+```
+
+Logs, per-run `report.json`, an aggregate `report.json`, and `summary.txt`
+land under `tests/convergence/out/<timestamp>/` (gitignored). Data dirs of
+failing runs are kept for debugging; passing runs are cleaned unless
+`--keep-data`.
+
+## Topology
+
+- N local daemons `conv1..convN`, each with its own config TOML, isolated
+  `data_dir` (fresh identities per run), pinned API port (`--api-base`+i)
+  and pinned QUIC `bind_address` port (`--quic-base`+i).
+- `conv1` has `bootstrap_peers = []`; every other node lists only conv1's
+  QUIC address. The explicit (possibly empty) `bootstrap_peers` list in the
+  config overrides the hardcoded global bootstrap network, so the cluster
+  is fully isolated. `--no-hard-coded-bootstrap` is deliberately NOT used:
+  it clears config-provided peers too.
+- Rolling start: 15 s between node launches (`--stagger-secs`, a known
+  network requirement).
+- API tokens are discovered from `<data_dir>/api-token`.
+
+## Phases and gates
+
+Each phase snapshots `GET /diagnostics/gossip` on every node before and
+after, and reports the delta of `pubsub_stages.admission` counters
+(especially `dropped_critical_hard_error` and cooling) so counter growth is
+attributable per phase. Convergence is sampled every `--poll-interval`
+(default 1.5 s) with the exact arrival time recorded separately for the
+task and the KV key.
+
+| Phase | What happens | Gate (default) |
+|---|---|---|
+| `cold_join` | conv1 creates a task list + task and a store + key **before** peers exist; each peer then starts, joins, and must see both primitives | task and key visible per node within `--cold-gate` (120 s) — hard |
+| `live_propagation` | after all joined and converged, conv1 adds a task and puts a key; per-primitive latency to each peer | all arrivals within `--live-gate` (60 s) — hard |
+| `restart_recovery` | convN stopped; conv1 adds a task + key; convN restarted; state must be visible **without** explicit re-create/join | `--restart-gate` (90 s) — known-gap |
+| `restart_recovery_eventual` | if auto-recovery failed, explicit rejoin (re-POST `/task-lists` + `/stores/join`) must restore all state incl. the offline mutation | within `--cold-gate` — hard, always |
+| `concurrent_claims` | conv1 adds a task; once visible on conv2+conv3 both PATCH `{"action":"claim"}` simultaneously (thread barrier); both HTTP responses recorded; all nodes polled until they agree on one winner | convergence to a single `claimed:*` state within `--claim-gate` (60 s) — hard |
+| `concurrent_claims_structured_fields` | are structured claim fields (`claimed_by`/`claimed_at`/`version`) present on the task? | known-gap |
+| `signed_store_nonowner_write` | conv2 (joiner) PUTs a new key into conv1's Signed store | HTTP 403 and no local fork — known-gap |
+| `signed_store_no_owner_propagation` | the intruder key must never become visible on the owner within `--fork-window` (20 s) | hard, always (a propagation would be a new inbound-enforcement regression) |
+
+## Known-gap flags vs `--expect-fixed`
+
+Three defects confirmed on current main are tracked as **known-gap**
+expectations so the harness runs green pre-fix:
+
+1. `restart_recovery` — task-list/store subscriptions are not restored
+   after daemon restart (server handle maps start empty).
+2. `concurrent_claims_structured_fields` — claim ownership is only encoded
+   in the formatted `state` string; no `claimed_by`/`claimed_at`/`version`.
+3. `signed_store_nonowner_write` — non-owner PUT returns local `200` and
+   forks locally instead of `403`.
+
+Without `--expect-fixed`, observing the legacy behavior reports the phase
+as `known-gap` (tolerated, run still passes); observing the fixed behavior
+reports `fixed`. With `--expect-fixed`, all three become hard gates — use
+this mode to verify the fixes and in CI afterwards.
+
+## Soak mode and reports
+
+`--runs N` repeats the full scenario N times with fresh data dirs (fresh
+identities, fresh topic/store names). The aggregate `report.json` contains
+per-run, per-phase, per-primitive latencies, pass/known-gap/fail status,
+raw claim responses, and per-phase diagnostics deltas. `summary.txt` (also
+printed) has a min/median/p95/max latency table, gate pass rates, per-phase
+`dropped_critical_hard_error` growth, and the known gaps observed.
+
+## Acceptance criteria (fix verification)
+
+- 10 runs (`just convergence-soak`), 100% eventual convergence for
+  cold-join, live-propagation, and offline-rejoin.
+- Zero unexplained `dropped_critical_hard_error` growth in the per-phase
+  diagnostics deltas.
+- With the fixes landed: `--expect-fixed` passes 10/10 (auto restart
+  recovery, structured claim fields, non-owner PUT rejected with 403 and
+  no local fork).
+
+## Teardown
+
+Daemons are terminated (SIGTERM then SIGKILL) on any failure or exception;
+logs and reports are always kept. If a run aborts hard, check for stray
+`x0xd` processes on API ports 27810+ before re-running (the harness refuses
+to start if an API port is busy).

--- a/tests/convergence/convergence_soak.py
+++ b/tests/convergence/convergence_soak.py
@@ -1,0 +1,920 @@
+#!/usr/bin/env python3
+"""Three-node local convergence soak harness for x0xd.
+
+Repeatable, in-repo version of the ad-hoc three-machine convergence test
+that exposed the v0.30.1 defects (restart recovery, claim semantics,
+signed-store non-owner writes). Spins N local x0xd instances with isolated
+data dirs that bootstrap only to each other, then drives five phases with
+independent gates and per-primitive (TaskList vs KV) arrival timing:
+
+  1. cold-join          task+key created on node1 BEFORE peers join
+  2. live-propagation   mutation after all peers joined and converged
+  3. restart-recovery   node N stopped, creator mutates, node restarted;
+                        state must be visible WITHOUT explicit rejoin
+  4. concurrent-claims  two peers claim the same task simultaneously
+  5. signed-store non-owner write  joiner PUTs to creator's Signed store
+
+GET /diagnostics/gossip is snapshotted on every node before and after each
+phase so pubsub admission-counter growth (dropped_critical_hard_error,
+cooling) is attributable per phase.
+
+Known-gap phases (current main, pre-fix): restart auto-recovery, structured
+claim fields (claimed_by/claimed_at/version), and non-owner PUT returning
+200 instead of 403. Without --expect-fixed these are reported as
+"known-gap" and do not fail the run; --expect-fixed turns them into hard
+gates for verifying the fixes.
+
+Stdlib only (urllib, never curl — curl is intercepted in some environments).
+
+Usage:
+  python3 tests/convergence/convergence_soak.py                 # 1 run
+  python3 tests/convergence/convergence_soak.py --runs 10       # soak
+  python3 tests/convergence/convergence_soak.py --expect-fixed  # post-fix
+"""
+
+import argparse
+import base64
+import concurrent.futures
+import json
+import os
+import pathlib
+import shutil
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_OUT = pathlib.Path(__file__).resolve().parent / "out"
+
+KNOWN_GAP_NOTES = {
+    "restart_auto_recovery": (
+        "task-list/store subscriptions are not restored after daemon "
+        "restart (server handle maps start empty)"
+    ),
+    "structured_claim_fields": (
+        "claim ownership is only encoded in the formatted `state` string; "
+        "no claimed_by/claimed_at/version fields"
+    ),
+    "nonowner_put_rejected": (
+        "non-owner PUT to a Signed store returns local 200 and forks "
+        "locally instead of being rejected with 403"
+    ),
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# HTTP helpers (urllib only)
+# ──────────────────────────────────────────────────────────────────────────
+
+def http_request(base, path, method="GET", body=None, token=None, timeout=10):
+    """Return {'status': int, 'body': parsed-json-or-text}. Raises OSError
+    (incl. URLError/ConnectionError) when the daemon is unreachable."""
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(base + path, data=data, headers=headers,
+                                 method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            status = resp.status
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        status = e.code
+    try:
+        parsed = json.loads(raw) if raw else None
+    except ValueError:
+        parsed = raw.decode(errors="replace")
+    return {"status": status, "body": parsed}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Node lifecycle
+# ──────────────────────────────────────────────────────────────────────────
+
+class Node:
+    def __init__(self, name, api_port, quic_port, root_dir, x0xd, log_level):
+        self.name = name
+        self.api_port = api_port
+        self.quic_port = quic_port
+        self.base = f"http://127.0.0.1:{api_port}"
+        self.dir = root_dir / name
+        self.data_dir = self.dir / "data"
+        self.config_path = self.dir / "config.toml"
+        self.log_path = self.dir / "daemon.log"
+        self.x0xd = x0xd
+        self.log_level = log_level
+        self.proc = None
+        self.token = None
+
+    def write_config(self, bootstrap_quic_ports):
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        peers = ", ".join(f'"127.0.0.1:{p}"' for p in bootstrap_quic_ports)
+        self.config_path.write_text(
+            f'instance_name = "{self.name}"\n'
+            f'data_dir = "{self.data_dir}"\n'
+            f'api_address = "127.0.0.1:{self.api_port}"\n'
+            f'bind_address = "127.0.0.1:{self.quic_port}"\n'
+            f'log_level = "{self.log_level}"\n'
+            # Explicit list (possibly empty) overrides the hardcoded global
+            # bootstrap network, keeping the cluster fully isolated. Do NOT
+            # pass --no-hard-coded-bootstrap: it clears config peers too.
+            f'bootstrap_peers = [{peers}]\n'
+        )
+
+    def start(self):
+        log = open(self.log_path, "a")
+        self.proc = subprocess.Popen(
+            [str(self.x0xd), "--config", str(self.config_path),
+             "--skip-update-check"],
+            stdout=log, stderr=subprocess.STDOUT,
+            cwd=str(self.dir),
+        )
+        log.close()
+
+    def wait_ready(self, timeout=60):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                raise RuntimeError(
+                    f"{self.name}: x0xd exited rc={self.proc.returncode} "
+                    f"(see {self.log_path})")
+            try:
+                r = http_request(self.base, "/health", timeout=2)
+                if r["status"] == 200:
+                    break
+            except OSError:
+                pass
+            time.sleep(0.5)
+        else:
+            raise RuntimeError(f"{self.name}: /health not up in {timeout}s")
+        token_file = self.data_dir / "api-token"
+        while time.monotonic() < deadline:
+            if token_file.exists() and token_file.stat().st_size > 0:
+                self.token = token_file.read_text().strip()
+                return
+            time.sleep(0.3)
+        raise RuntimeError(f"{self.name}: api-token not written in {timeout}s")
+
+    def req(self, method, path, body=None, auth=True, timeout=10):
+        return http_request(self.base, path, method=method, body=body,
+                            token=self.token if auth else None,
+                            timeout=timeout)
+
+    def stop(self, grace=8):
+        if self.proc is None or self.proc.poll() is not None:
+            self.proc = None
+            return
+        self.proc.send_signal(signal.SIGTERM)
+        try:
+            self.proc.wait(timeout=grace)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait(timeout=5)
+        self.proc = None
+
+    @property
+    def running(self):
+        return self.proc is not None and self.proc.poll() is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Diagnostics snapshots / deltas
+# ──────────────────────────────────────────────────────────────────────────
+
+def gossip_snapshot(nodes):
+    snap = {}
+    for n in nodes:
+        if not n.running:
+            snap[n.name] = None
+            continue
+        try:
+            r = n.req("GET", "/diagnostics/gossip")
+            snap[n.name] = r["body"] if r["status"] == 200 else None
+        except OSError:
+            snap[n.name] = None
+    return snap
+
+
+def admission_counters(snapshot_body):
+    if not isinstance(snapshot_body, dict):
+        return {}
+    adm = (snapshot_body.get("pubsub_stages") or {}).get("admission") or {}
+    return {k: v for k, v in adm.items() if isinstance(v, (int, float))}
+
+
+def admission_delta(before, after):
+    deltas = {}
+    for name in set(before) | set(after):
+        b = admission_counters(before.get(name))
+        a = admission_counters(after.get(name))
+        if not b and not a:
+            deltas[name] = None
+            continue
+        deltas[name] = {k: a.get(k, 0) - b.get(k, 0)
+                        for k in sorted(set(a) | set(b))
+                        if a.get(k, 0) - b.get(k, 0) != 0}
+    return deltas
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Convergence sampling — per-primitive arrival times
+# ──────────────────────────────────────────────────────────────────────────
+
+def sample_until(checks, gate_secs, interval):
+    """checks: {metric_name: callable() -> bool}. Samples every `interval`
+    seconds until every check has passed once or `gate_secs` elapses.
+    Returns {metric_name: arrival_secs_or_None} (arrival measured from the
+    first sample loop start)."""
+    start = time.monotonic()
+    arrivals = {k: None for k in checks}
+    while True:
+        elapsed = time.monotonic() - start
+        for key, fn in checks.items():
+            if arrivals[key] is not None:
+                continue
+            try:
+                if fn():
+                    arrivals[key] = round(time.monotonic() - start, 2)
+            except OSError:
+                pass
+        if all(v is not None for v in arrivals.values()):
+            return arrivals
+        if elapsed >= gate_secs:
+            return arrivals
+        time.sleep(interval)
+
+
+def task_visible(node, topic, task_id):
+    r = node.req("GET", f"/task-lists/{topic}/tasks")
+    if r["status"] != 200 or not isinstance(r["body"], dict):
+        return False
+    return any(t.get("id") == task_id for t in r["body"].get("tasks", []))
+
+
+def key_visible(node, store, key):
+    r = node.req("GET", f"/stores/{store}/{key}")
+    return r["status"] == 200 and isinstance(r["body"], dict) \
+        and r["body"].get("ok", True)
+
+
+def get_task(node, topic, task_id):
+    r = node.req("GET", f"/task-lists/{topic}/tasks")
+    if r["status"] != 200 or not isinstance(r["body"], dict):
+        return None
+    for t in r["body"].get("tasks", []):
+        if t.get("id") == task_id:
+            return t
+    return None
+
+
+def b64(value):
+    return base64.b64encode(value.encode()).decode()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Single run
+# ──────────────────────────────────────────────────────────────────────────
+
+class Run:
+    def __init__(self, idx, args, run_dir):
+        self.idx = idx
+        self.args = args
+        self.run_dir = run_dir
+        tag = f"{int(time.time())}-r{idx}"
+        self.topic = f"x0x.convergence.soak.{tag}"
+        self.store = f"x0x-convergence-store-{tag}"
+        self.nodes = []
+        self.report = {
+            "run": idx,
+            "topic": self.topic,
+            "store": self.store,
+            "started_unix": time.time(),
+            "phases": {},
+            "diagnostics_deltas": {},
+            "pass": None,
+        }
+        self.hard_failures = []
+        self.known_gaps = []
+
+    # -- helpers -----------------------------------------------------------
+
+    def creator(self):
+        return self.nodes[0]
+
+    def phase(self, name):
+        """Context manager: snapshots /diagnostics/gossip on all nodes
+        before and after the phase body, records the admission delta."""
+        run = self
+
+        class _Ctx:
+            def __enter__(self):
+                self.before = gossip_snapshot(run.nodes)
+                self.t0 = time.monotonic()
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                after = gossip_snapshot(run.nodes)
+                run.report["diagnostics_deltas"][name] = {
+                    "elapsed_secs": round(time.monotonic() - self.t0, 1),
+                    "admission_delta": admission_delta(self.before, after),
+                    "hard_error_after": {
+                        n: admission_counters(after.get(n)).get(
+                            "dropped_critical_hard_error")
+                        for n in after
+                    },
+                }
+                return False
+
+        return _Ctx()
+
+    def gate(self, phase, ok, detail=None):
+        entry = self.report["phases"].setdefault(phase, {})
+        entry["pass"] = bool(ok)
+        if detail is not None:
+            entry.update(detail)
+        if not ok:
+            self.hard_failures.append(phase)
+        return ok
+
+    def known_gap_gate(self, phase, gap_key, fixed, observed):
+        """A gate that is a hard requirement only under --expect-fixed.
+        `fixed` True means the post-fix behavior was observed."""
+        entry = self.report["phases"].setdefault(phase, {})
+        entry["observed"] = observed
+        if fixed:
+            entry["status"] = "fixed"
+            entry["pass"] = True
+        elif self.args.expect_fixed:
+            entry["status"] = "fail"
+            entry["pass"] = False
+            self.hard_failures.append(phase)
+        else:
+            entry["status"] = "known-gap"
+            entry["pass"] = True  # tolerated pre-fix
+            entry["known_gap"] = KNOWN_GAP_NOTES[gap_key]
+            self.known_gaps.append(phase)
+        return entry["pass"]
+
+    # -- topology ----------------------------------------------------------
+
+    def start_cluster_creator_only(self):
+        a = self.args
+        for i in range(a.nodes):
+            node = Node(
+                name=f"conv{i + 1}",
+                api_port=a.api_base + i,
+                quic_port=a.quic_base + i,
+                root_dir=self.run_dir,
+                x0xd=a.x0xd,
+                log_level=a.log_level,
+            )
+            # node1 bootstraps to nobody; every other node only to node1.
+            node.write_config([] if i == 0 else [a.quic_base])
+            self.nodes.append(node)
+        creator = self.nodes[0]
+        log(f"run {self.idx}: starting {creator.name} "
+            f"(api={creator.api_port}, quic={creator.quic_port})")
+        creator.start()
+        creator.wait_ready()
+
+    def start_peer(self, node):
+        log(f"run {self.idx}: starting {node.name} "
+            f"(api={node.api_port}, quic={node.quic_port})")
+        node.start()
+        node.wait_ready()
+
+    # -- phases ------------------------------------------------------------
+
+    def phase_cold_join(self):
+        a, creator = self.args, self.creator()
+        # Creator state BEFORE any peer exists.
+        tl = creator.req("POST", "/task-lists",
+                         {"name": "convergence soak", "topic": self.topic})
+        task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
+                           {"title": "prejoin-task",
+                            "description": "must cold-start replicate"})
+        st = creator.req("POST", "/stores",
+                         {"name": "convergence manifests",
+                          "topic": self.store})
+        put = creator.req("PUT", f"/stores/{self.store}/prejoin",
+                          {"value": b64("prejoin-value"),
+                           "content_type": "text/plain"})
+        if not all(r["status"] in (200, 201)
+                   for r in (tl, task, st, put)):
+            raise RuntimeError(
+                f"creator setup failed: tl={tl} task={task} st={st} put={put}")
+        self.pre_task_id = task["body"]["task_id"]
+
+        per_node = {}
+        with self.phase("cold_join"):
+            for node in self.nodes[1:]:
+                # Rolling start: known requirement — space daemon launches.
+                log(f"run {self.idx}: rolling-start wait "
+                    f"{a.stagger_secs}s before {node.name}")
+                time.sleep(a.stagger_secs)
+                self.start_peer(node)
+                join_tl = node.req("POST", "/task-lists",
+                                   {"name": "convergence soak",
+                                    "topic": self.topic})
+                join_st = node.req("POST", f"/stores/{self.store}/join")
+                arrivals = sample_until(
+                    {
+                        "task": lambda n=node: task_visible(
+                            n, self.topic, self.pre_task_id),
+                        "kv": lambda n=node: key_visible(
+                            n, self.store, "prejoin"),
+                    },
+                    gate_secs=a.cold_gate, interval=a.poll_interval)
+                per_node[node.name] = {
+                    "join_status": {"task_list": join_tl["status"],
+                                    "store": join_st["status"]},
+                    "task_secs": arrivals["task"],
+                    "kv_secs": arrivals["kv"],
+                }
+        ok = all(v["task_secs"] is not None and v["kv_secs"] is not None
+                 for v in per_node.values())
+        self.gate("cold_join", ok,
+                  {"gate_secs": a.cold_gate, "per_node": per_node})
+        log(f"run {self.idx}: cold_join {'PASS' if ok else 'FAIL'} "
+            f"{json.dumps(per_node)}")
+
+    def phase_live_propagation(self):
+        a, creator = self.args, self.creator()
+        with self.phase("live_propagation"):
+            task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
+                               {"title": "live-task",
+                                "description": "created after all joined"})
+            live_tid = task["body"]["task_id"]
+            creator.req("PUT", f"/stores/{self.store}/live",
+                        {"value": b64("live-value"),
+                         "content_type": "text/plain"})
+            checks = {}
+            for node in self.nodes[1:]:
+                checks[f"{node.name}.task"] = (
+                    lambda n=node: task_visible(n, self.topic, live_tid))
+                checks[f"{node.name}.kv"] = (
+                    lambda n=node: key_visible(n, self.store, "live"))
+            arrivals = sample_until(checks, gate_secs=a.live_gate,
+                                    interval=a.poll_interval)
+        self.live_task_id = live_tid
+        ok = all(v is not None for v in arrivals.values())
+        self.gate("live_propagation", ok,
+                  {"gate_secs": a.live_gate, "arrivals_secs": arrivals})
+        log(f"run {self.idx}: live_propagation {'PASS' if ok else 'FAIL'} "
+            f"{json.dumps(arrivals)}")
+
+    def phase_restart_recovery(self):
+        a, creator = self.args, self.creator()
+        victim = self.nodes[-1]
+        with self.phase("restart_recovery"):
+            log(f"run {self.idx}: stopping {victim.name}")
+            victim.stop()
+            time.sleep(3)
+            task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
+                               {"title": "offline-recovery",
+                                "description": "created while peer was down"})
+            off_tid = task["body"]["task_id"]
+            creator.req("PUT", f"/stores/{self.store}/offline",
+                        {"value": b64("offline-value"),
+                         "content_type": "text/plain"})
+            log(f"run {self.idx}: restarting {victim.name}")
+            victim.start()
+            victim.wait_ready()
+            # No explicit rejoin — this is exactly what the fix must provide.
+            arrivals = sample_until(
+                {
+                    "task": lambda: task_visible(victim, self.topic, off_tid),
+                    "kv": lambda: key_visible(victim, self.store, "offline"),
+                },
+                gate_secs=a.restart_gate, interval=a.poll_interval)
+            auto = (arrivals["task"] is not None
+                    and arrivals["kv"] is not None)
+
+            rejoin = None
+            if not auto:
+                # Explicit rejoin (followup.py pattern) so later phases can
+                # run; its own convergence is a hard gate either way.
+                t0 = time.monotonic()
+                victim.req("POST", "/task-lists",
+                           {"name": "convergence soak", "topic": self.topic})
+                victim.req("POST", f"/stores/{self.store}/join")
+                r = sample_until(
+                    {
+                        "task": lambda: task_visible(
+                            victim, self.topic, off_tid),
+                        "kv": lambda: key_visible(
+                            victim, self.store, "offline"),
+                    },
+                    gate_secs=a.cold_gate, interval=a.poll_interval)
+                rejoin = {
+                    "task_secs": r["task"], "kv_secs": r["kv"],
+                    "total_secs": round(time.monotonic() - t0, 2),
+                }
+        observed = {
+            "node": victim.name,
+            "auto_recovery_arrivals_secs": arrivals,
+            "auto_recovery_gate_secs": a.restart_gate,
+            "explicit_rejoin": rejoin,
+        }
+        self.known_gap_gate("restart_recovery", "restart_auto_recovery",
+                            fixed=auto, observed=observed)
+        if not auto:
+            # Eventual convergence via explicit rejoin is ALWAYS a hard gate
+            # (acceptance criterion: 100% eventual offline-rejoin).
+            ok = (rejoin is not None and rejoin["task_secs"] is not None
+                  and rejoin["kv_secs"] is not None)
+            self.gate("restart_recovery_eventual", ok,
+                      {"explicit_rejoin": rejoin})
+        status = self.report["phases"]["restart_recovery"]["status"]
+        log(f"run {self.idx}: restart_recovery {status} "
+            f"{json.dumps(observed)}")
+
+    def phase_concurrent_claims(self):
+        a, creator = self.args, self.creator()
+        claimants = self.nodes[1:3]
+        with self.phase("concurrent_claims"):
+            task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
+                               {"title": "claim-target",
+                                "description": "two peers claim this"})
+            tid = task["body"]["task_id"]
+            vis = sample_until(
+                {n.name: (lambda n=n: task_visible(n, self.topic, tid))
+                 for n in claimants},
+                gate_secs=a.live_gate, interval=a.poll_interval)
+            if any(v is None for v in vis.values()):
+                self.gate("concurrent_claims", False,
+                          {"error": "task never visible on claimants",
+                           "visibility_secs": vis})
+                log(f"run {self.idx}: concurrent_claims FAIL (visibility)")
+                return
+
+            barrier = threading.Barrier(len(claimants))
+
+            def do_claim(node):
+                barrier.wait(timeout=10)
+                return node.req(
+                    "PATCH", f"/task-lists/{self.topic}/tasks/{tid}",
+                    {"action": "claim"})
+
+            with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=len(claimants)) as ex:
+                futs = {n.name: ex.submit(do_claim, n) for n in claimants}
+                responses = {k: f.result() for k, f in futs.items()}
+
+            t0 = time.monotonic()
+            winner, converge_secs, final_tasks = None, None, {}
+            while time.monotonic() - t0 < a.claim_gate:
+                final_tasks = {n.name: get_task(n, self.topic, tid)
+                               for n in self.nodes}
+                states = [t.get("state") if t else None
+                          for t in final_tasks.values()]
+                if (None not in states and len(set(states)) == 1
+                        and str(states[0]).startswith("claimed")):
+                    converge_secs = round(time.monotonic() - t0, 2)
+                    winner = states[0]
+                    break
+                time.sleep(a.poll_interval)
+
+        structured = {}
+        for name, t in final_tasks.items():
+            structured[name] = (
+                {k: t.get(k) for k in
+                 ("claimed_by", "claimed_at", "version") if k in t}
+                if isinstance(t, dict) else None)
+        has_structured = all(
+            isinstance(s, dict) and "claimed_by" in s
+            for s in structured.values())
+
+        converged = converge_secs is not None
+        self.gate("concurrent_claims", converged, {
+            "gate_secs": a.claim_gate,
+            "visibility_secs": vis,
+            "claim_responses": {k: {"status": v["status"], "body": v["body"]}
+                                for k, v in responses.items()},
+            "both_accepted_200": all(
+                v["status"] == 200 for v in responses.values()),
+            "converge_secs": converge_secs,
+            "winner_state": winner,
+        })
+        self.known_gap_gate(
+            "concurrent_claims_structured_fields", "structured_claim_fields",
+            fixed=has_structured,
+            observed={"structured_fields": structured})
+        log(f"run {self.idx}: concurrent_claims "
+            f"{'PASS' if converged else 'FAIL'} winner={winner!r} "
+            f"converge={converge_secs}s structured={has_structured}")
+
+    def phase_signed_store_nonowner(self):
+        a, creator = self.args, self.creator()
+        writer = self.nodes[1]
+        with self.phase("signed_store_nonowner_write"):
+            put = writer.req("PUT", f"/stores/{self.store}/unauthorized",
+                             {"value": b64("intruder-value"),
+                              "content_type": "text/plain"})
+            local = writer.req("GET", f"/stores/{self.store}/unauthorized")
+            # Observe the fork window: the key must never become visible on
+            # the creator (owner-side inbound enforcement).
+            deadline = time.monotonic() + a.fork_window
+            propagated = False
+            while time.monotonic() < deadline:
+                if key_visible(creator, self.store, "unauthorized"):
+                    propagated = True
+                    break
+                time.sleep(a.poll_interval)
+        rejected = put["status"] == 403
+        local_fork = local["status"] == 200
+        observed = {
+            "writer": writer.name,
+            "put_status": put["status"],
+            "put_body": put["body"],
+            "writer_local_read_status": local["status"],
+            "local_fork": local_fork,
+            "propagated_to_owner": propagated,
+            "fork_window_secs": a.fork_window,
+        }
+        fixed = rejected and not local_fork and not propagated
+        self.known_gap_gate("signed_store_nonowner_write",
+                            "nonowner_put_rejected", fixed=fixed,
+                            observed=observed)
+        # Propagation to the owner would be a NEW defect (inbound
+        # enforcement regression) — hard gate regardless of mode.
+        self.gate("signed_store_no_owner_propagation", not propagated,
+                  {"propagated_to_owner": propagated})
+        status = self.report["phases"]["signed_store_nonowner_write"]["status"]
+        log(f"run {self.idx}: signed_store_nonowner_write {status} "
+            f"put={put['status']} local_fork={local_fork} "
+            f"propagated={propagated}")
+
+    # -- driver ------------------------------------------------------------
+
+    def execute(self):
+        try:
+            self.start_cluster_creator_only()
+            self.phase_cold_join()
+            self.phase_live_propagation()
+            self.phase_restart_recovery()
+            self.phase_concurrent_claims()
+            self.phase_signed_store_nonowner()
+        finally:
+            for n in self.nodes:
+                try:
+                    n.stop()
+                except Exception:
+                    pass
+        self.report["finished_unix"] = time.time()
+        self.report["hard_failures"] = self.hard_failures
+        self.report["known_gaps"] = self.known_gaps
+        self.report["pass"] = not self.hard_failures
+        return self.report
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Soak orchestration + summary
+# ──────────────────────────────────────────────────────────────────────────
+
+def log(msg):
+    print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def check_port_free(port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(("127.0.0.1", port)) != 0
+
+
+def latency_series(runs):
+    """Collect named latency samples across runs."""
+    series = {}
+
+    def add(key, value):
+        if value is not None:
+            series.setdefault(key, []).append(value)
+
+    for r in runs:
+        p = r["phases"]
+        for node, v in p.get("cold_join", {}).get("per_node", {}).items():
+            add("cold_join.task", v["task_secs"])
+            add("cold_join.kv", v["kv_secs"])
+        for key, v in p.get("live_propagation", {}) \
+                .get("arrivals_secs", {}).items():
+            prim = key.rsplit(".", 1)[-1]
+            add(f"live_propagation.{prim}", v)
+        rr = p.get("restart_recovery", {}).get("observed", {})
+        auto = rr.get("auto_recovery_arrivals_secs") or {}
+        add("restart.auto.task", auto.get("task"))
+        add("restart.auto.kv", auto.get("kv"))
+        rj = rr.get("explicit_rejoin") or {}
+        add("restart.rejoin.task", rj.get("task_secs"))
+        add("restart.rejoin.kv", rj.get("kv_secs"))
+        add("claims.converge", p.get("concurrent_claims", {})
+            .get("converge_secs"))
+    return series
+
+
+def pctl(sorted_vals, q):
+    if not sorted_vals:
+        return None
+    k = max(0, min(len(sorted_vals) - 1,
+                   round(q * (len(sorted_vals) - 1))))
+    return sorted_vals[k]
+
+
+def summarize(runs, args):
+    lines = []
+    total = len(runs)
+    passed = sum(1 for r in runs if r["pass"])
+    lines.append("")
+    lines.append("=" * 72)
+    lines.append(f"CONVERGENCE SOAK SUMMARY — {total} run(s), "
+                 f"{args.nodes} nodes, mode="
+                 f"{'expect-fixed' if args.expect_fixed else 'known-gap'}")
+    lines.append("=" * 72)
+    lines.append(f"runs passed: {passed}/{total}")
+
+    # Gate pass rates
+    lines.append("")
+    lines.append(f"{'phase':<42}{'pass':>6}{'gap':>6}{'fail':>6}")
+    phase_names = []
+    for r in runs:
+        for name in r["phases"]:
+            if name not in phase_names:
+                phase_names.append(name)
+    for name in phase_names:
+        n_pass = n_gap = n_fail = 0
+        for r in runs:
+            e = r["phases"].get(name)
+            if e is None:
+                continue
+            status = e.get("status")
+            if status == "known-gap":
+                n_gap += 1
+            elif e.get("pass"):
+                n_pass += 1
+            else:
+                n_fail += 1
+        lines.append(f"{name:<42}{n_pass:>6}{n_gap:>6}{n_fail:>6}")
+
+    # Latency table
+    series = latency_series(runs)
+    lines.append("")
+    lines.append(f"{'latency (secs)':<28}{'n':>4}{'min':>8}{'median':>8}"
+                 f"{'p95':>8}{'max':>8}")
+    for key in sorted(series):
+        vals = sorted(series[key])
+        lines.append(
+            f"{key:<28}{len(vals):>4}{vals[0]:>8.1f}"
+            f"{statistics.median(vals):>8.1f}"
+            f"{pctl(vals, 0.95):>8.1f}{vals[-1]:>8.1f}")
+
+    # Diagnostics: hard-error growth per phase (summed across runs+nodes)
+    lines.append("")
+    lines.append("dropped_critical_hard_error growth per phase "
+                 "(sum across runs and nodes):")
+    growth = {}
+    for r in runs:
+        for phase, d in r.get("diagnostics_deltas", {}).items():
+            for node, delta in (d.get("admission_delta") or {}).items():
+                if delta:
+                    growth[phase] = growth.get(phase, 0) + delta.get(
+                        "dropped_critical_hard_error", 0)
+                else:
+                    growth.setdefault(phase, 0)
+    for phase, g in growth.items():
+        lines.append(f"  {phase:<40}{g:>6}")
+
+    # Known gaps observed
+    gaps = {}
+    for r in runs:
+        for name, e in r["phases"].items():
+            if e.get("status") == "known-gap":
+                gaps[name] = e.get("known_gap", "")
+    if gaps:
+        lines.append("")
+        lines.append("known gaps observed (tolerated; use --expect-fixed to "
+                     "gate on them):")
+        for name, note in gaps.items():
+            lines.append(f"  - {name}: {note}")
+
+    lines.append("")
+    lines.append(f"OVERALL: {'PASS' if passed == total else 'FAIL'}")
+    return "\n".join(lines)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="x0x three-node convergence soak harness")
+    p.add_argument("--nodes", type=int, default=3,
+                   help="number of local x0xd instances (default 3, min 3)")
+    p.add_argument("--runs", type=int, default=1,
+                   help="repeat the full scenario N times (default 1)")
+    p.add_argument("--x0xd", default=None,
+                   help="path to x0xd binary (default: $X0XD_TEST_BINARY "
+                        "or target/release/x0xd)")
+    p.add_argument("--api-base", type=int, default=27810,
+                   help="first API port; node i uses api-base+i")
+    p.add_argument("--quic-base", type=int, default=27910,
+                   help="first QUIC port; node i uses quic-base+i")
+    p.add_argument("--stagger-secs", type=float, default=15.0,
+                   help="rolling-start delay between node launches "
+                        "(default 15, a known network requirement)")
+    p.add_argument("--poll-interval", type=float, default=1.5,
+                   help="convergence sampling interval in seconds")
+    p.add_argument("--cold-gate", type=float, default=120.0,
+                   help="cold-join convergence gate per node (secs)")
+    p.add_argument("--live-gate", type=float, default=60.0,
+                   help="live-propagation gate (secs)")
+    p.add_argument("--restart-gate", type=float, default=90.0,
+                   help="restart auto-recovery gate (secs)")
+    p.add_argument("--claim-gate", type=float, default=60.0,
+                   help="concurrent-claim convergence gate (secs)")
+    p.add_argument("--fork-window", type=float, default=20.0,
+                   help="observation window for non-owner write "
+                        "propagation (secs)")
+    p.add_argument("--expect-fixed", action="store_true",
+                   help="turn known-gap expectations into hard gates "
+                        "(use to verify the fixes)")
+    p.add_argument("--log-level", default="info",
+                   help="daemon log_level (default info)")
+    p.add_argument("--out-dir", default=str(DEFAULT_OUT),
+                   help="output root for logs and reports")
+    p.add_argument("--keep-data", action="store_true",
+                   help="keep node data dirs after passing runs")
+    args = p.parse_args()
+    if args.nodes < 3:
+        p.error("--nodes must be >= 3 (claims need two non-creator peers)")
+    if args.x0xd is None:
+        args.x0xd = os.environ.get(
+            "X0XD_TEST_BINARY", str(REPO_ROOT / "target/release/x0xd"))
+    args.x0xd = pathlib.Path(args.x0xd)
+    return args
+
+
+def main():
+    args = parse_args()
+    if not args.x0xd.is_file():
+        log(f"ERROR: x0xd not found at {args.x0xd} — build with "
+            f"`cargo build --release --bin x0xd` or set X0XD_TEST_BINARY")
+        return 2
+    for i in range(args.nodes):
+        if not check_port_free(args.api_base + i):
+            log(f"ERROR: API port {args.api_base + i} already in use")
+            return 2
+
+    out_root = pathlib.Path(args.out_dir) / time.strftime("%Y%m%d-%H%M%S")
+    out_root.mkdir(parents=True, exist_ok=True)
+    log(f"output: {out_root}")
+    log(f"x0xd: {args.x0xd}")
+
+    runs = []
+    try:
+        for i in range(1, args.runs + 1):
+            run_dir = out_root / f"run-{i}"
+            run_dir.mkdir(parents=True, exist_ok=True)
+            log(f"=== run {i}/{args.runs} ===")
+            run = Run(i, args, run_dir)
+            try:
+                report = run.execute()
+            except Exception as e:  # harness/daemon failure: fail loud
+                for n in run.nodes:
+                    try:
+                        n.stop()
+                    except Exception:
+                        pass
+                report = run.report
+                report["pass"] = False
+                report["error"] = f"{type(e).__name__}: {e}"
+                report["hard_failures"] = run.hard_failures + ["exception"]
+                log(f"run {i}: EXCEPTION {e}")
+            runs.append(report)
+            (run_dir / "report.json").write_text(
+                json.dumps(report, indent=2))
+            # Fresh data dirs per run: keep logs+configs, drop key/state data
+            # unless asked to keep it (or the run failed — keep for debug).
+            if report["pass"] and not args.keep_data:
+                for n in run.nodes:
+                    shutil.rmtree(n.data_dir, ignore_errors=True)
+            time.sleep(2)  # let UDP/TCP ports drain between runs
+    finally:
+        report_path = out_root / "report.json"
+        report_path.write_text(json.dumps({
+            "args": {k: str(v) if isinstance(v, pathlib.Path) else v
+                     for k, v in vars(args).items()},
+            "runs": runs,
+        }, indent=2))
+        summary = summarize(runs, args) if runs else "(no runs completed)"
+        (out_root / "summary.txt").write_text(summary + "\n")
+        print(summary)
+        log(f"report: {report_path}")
+
+    return 0 if runs and all(r["pass"] for r in runs) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/convergence/convergence_soak.py
+++ b/tests/convergence/convergence_soak.py
@@ -2238,6 +2238,12 @@ def run_forged_first_seen_gate(args, out_dir):
                              "description": "must survive the forged delta"})
         legit_tid = legit["body"].get("task_id") if isinstance(
             legit.get("body"), dict) else None
+        # The receiver MUST join the task list (subscribe to the topic) or it
+        # receives neither the legit task nor the forged delta — which would
+        # make the security check vacuous (sees nothing) and the liveness check
+        # fail. Join uses the same POST /task-lists as the core cold-join phase.
+        receiver.req("POST", "/task-lists",
+                     {"name": "forged admission", "topic": topic})
         # Baseline convergence; snapshot receiver list state BEFORE attack.
         sample_until({"t": lambda: task_visible(receiver, topic, legit_tid)},
                      gate_secs=args.cold_gate, interval=args.poll_interval)

--- a/tests/convergence/convergence_soak.py
+++ b/tests/convergence/convergence_soak.py
@@ -11,18 +11,52 @@ independent gates and per-primitive (TaskList vs KV) arrival timing:
   2. live-propagation   mutation after all peers joined and converged
   3. restart-recovery   node N stopped, creator mutates, node restarted;
                         state must be visible WITHOUT explicit rejoin
-  4. concurrent-claims  two peers claim the same task simultaneously
-  5. signed-store non-owner write  joiner PUTs to creator's Signed store
+  4. concurrent-claims  two peers claim the same task simultaneously; the
+                       oracle uses fence_token (LOCAL fence, not
+                       distributed exclusion), requires structured
+                       claimed_by/claimed_at/version, attributes the
+                       deterministic OR-Set winner to a real claimant, and
+                       asserts no commit response misrepresents advisory
+                       local commit as exclusive ownership
+  5. signed-store non-owner write  joiner PUTs to creator's Signed store;
+                       plus an ownership-binding oracle (owner == creator,
+                       no first-self-claim takeover by the joiner)
 
 GET /diagnostics/gossip is snapshotted on every node before and after each
 phase so pubsub admission-counter growth (dropped_critical_hard_error,
-cooling) is attributable per phase.
+cooling) is attributable per phase. Same-host topology (per-node AgentId via
+GET /agent, PeerId via GET /diagnostics/connectivity, addresses, bootstrap
+siblings) is recorded once the cluster is up for claim-winner / store-owner
+attribution.
+
+Claim semantics are ADVISORY: fence_token fences locally only — two
+replicas at the same version can both commit, and the single deterministic
+winner is resolved at convergence (claimed_by). No response may imply
+distributed atomic exclusion the protocol cannot provide.
 
 Known-gap phases (current main, pre-fix): restart auto-recovery, structured
-claim fields (claimed_by/claimed_at/version), and non-owner PUT returning
-200 instead of 403. Without --expect-fixed these are reported as
-"known-gap" and do not fail the run; --expect-fixed turns them into hard
-gates for verifying the fixes.
+claim fields, claim CAS local-fence, claim exclusivity honesty, non-owner
+PUT rejected, and store owner binding. Without --expect-fixed these are
+reported as "known-gap" and do not fail the run; --expect-fixed turns them
+into hard gates for verifying the fixes.
+
+Beyond the soak, the release ORACLE records and (under --expect-fixed) verifies
+binary/source PROVENANCE — current+legacy SHA-256 and --version, Git HEAD +
+dirty-tree fingerprint + source cutoff, and the actual peer set / reconnect
+path — refusing a binary older than the reviewed sources or a legacy binary
+that is not exactly v0.30.1 (file existence is not authentication). Additional
+prerequisite gates run once per invocation and cover threats the single-version
+soak cannot: mixed-version skew (needs a real v0.30.1 --legacy-binary, else
+UNSUPPORTED — never faked), the hostile OwnerAnnounce injection (in-repo via
+public REST), owner-offline checkpoint/delete recovery, and forged first-seen
+task admission (driven by the in-repo x0xd-forge-injector, which publishes an
+unattested first-seen TaskItem over real gossip; absent injector ⇒ UNSUPPORTED).
+In-soak gates also cover malformed/pre-restart fence rejection
+and named new-port reconnect. Under --expect-fixed UNSUPPORTED or unproven
+phases FAIL the run, and critical hard-error growth / mDNS contamination are
+hard gates. `just convergence-release` is the authoritative recipe (--expect-fixed
++ authenticated v0.30.1 legacy + 10/10); `convergence-soak-quick` stays as a
+one-run smoke.
 
 Stdlib only (urllib, never curl — curl is intercepted in some environments).
 
@@ -30,10 +64,13 @@ Usage:
   python3 tests/convergence/convergence_soak.py                 # 1 run
   python3 tests/convergence/convergence_soak.py --runs 10       # soak
   python3 tests/convergence/convergence_soak.py --expect-fixed  # post-fix
+  python3 tests/convergence/convergence_soak.py --help          # all gates
 """
 
 import argparse
 import base64
+import hashlib
+import re
 import concurrent.futures
 import json
 import os
@@ -57,13 +94,81 @@ KNOWN_GAP_NOTES = {
         "task-list/store subscriptions are not restored after daemon "
         "restart (server handle maps start empty)"
     ),
-    "structured_claim_fields": (
-        "claim ownership is only encoded in the formatted `state` string; "
-        "no claimed_by/claimed_at/version fields"
-    ),
     "nonowner_put_rejected": (
         "non-owner PUT to a Signed store returns local 200 and forks "
         "locally instead of being rejected with 403"
+    ),
+    # ── Strengthened oracles (convergence blockers) ───────────────────────
+    # These were tolerated under the old string-only `state` oracle. The
+    # harness now asserts them as structured-field contracts; pre-fix they
+    # surface as known-gap so a regression is loud rather than invisible.
+    "claim_structured_fields": (
+        "claimed_by/claimed_at/version absent on a claimed task — the "
+        "deterministic OR-Set winner is not observable without parsing the "
+        "formatted `state` string"
+    ),
+    "claim_cas_local_fence": (
+        "PATCH with a stale fence_token still mutates — the local fence "
+        "guard does not fence (fence_token is advisory/local, not exclusive)"
+    ),
+    "claim_exclusivity_honesty": (
+        "a claim commit response misrepresents advisory local CRDT commit as "
+        "exclusive ownership (e.g. an exclusive 'won/winner/owner' field, or "
+        "committed != \"local\") — the protocol cannot provide distributed "
+        "atomic exclusion"
+    ),
+    "store_owner_binding": (
+        "the store's authoritative owner is not exposed/bound to the "
+        "creator, so a first-self-claim takeover by a joiner is not "
+        "detectable at the API"
+    ),
+    "fence_malformed": (
+        "a malformed fence_token (non-token / overflow) collapses to "
+        "'absent' and mutates unconditionally instead of being rejected "
+        "with 400/409 — present-but-invalid must be distinct from absent"
+    ),
+    "fence_pre_restart": (
+        "a fence_token captured before a daemon restart is still accepted "
+        "after restart — the fence epoch is wall-clock/zero, not a durable "
+        "incarnation nonce, so a pre-restart token is not invalidated"
+    ),
+    "named_new_port_reconnect": (
+        "a killed named peer restarted on a forced different QUIC port with "
+        "the same MachineId does not proactively reconnect / recover CRDT "
+        "state without a manual rejoin"
+    ),
+}
+
+# Gates that cannot run because an external prerequisite is missing. These are
+# NOT tolerated defects (known-gap) — they are explicitly UNSUPPORTED until the
+# named prerequisite is supplied, so CI/users know exactly what to provide
+# rather than the harness silently skipping them.
+#
+# Note: malicious_owner_announce is NO LONGER a prerequisite gate — it runs
+# in-repo via public REST create/join APIs (a rogue daemon self-claims the
+# same store topic; its sync loop publishes a genuine OwnerAnnounce). Only
+# mixed_version_skew remains prerequisite-gated (needs a real legacy binary).
+UNSUPPORTED_PREREQ_NOTES = {
+    "mixed_version_skew": (
+        "requires a legacy x0xd binary (v0.30.1) to run alongside the "
+        "current build; set X0XD_LEGACY_BINARY (or --legacy-binary) to a "
+        "path to that release's x0xd. Without it the mixed-version "
+        "load-bearing (legacy-owner + current-anchored-joiner) and degraded "
+        "directions cannot be exercised — do NOT fake it by downgrading "
+        "protocol fields on the current binary, which would not reproduce "
+        "the real skew."
+    ),
+    "forged_first_seen_task": (
+        "requires the in-repo x0xd-forge-injector binary to publish an "
+        "unattested first-seen TaskItem (Claimed{victim,ts:1}, no "
+        "attestation) over the real live-sync gossip path. The convergence "
+        "harness speaks REST only and a legitimate daemon always self-"
+        "attests, so the injector crafts the wire bytes via "
+        "x0x::crdt::forge_unattested_delta_bytes and publishes them through "
+        "the daemon's /publish API. Build it with `cargo build --release "
+        "--bin x0xd-forge-injector` (the release recipe provisions it). The "
+        "other variants (malformed-sig, attacker-key, wrong-agent, "
+        "wrong-scope) are proven at the store/CRDT regression layer"
     ),
 }
 
@@ -128,6 +233,15 @@ class Node:
             # pass --no-hard-coded-bootstrap: it clears config peers too.
             f'bootstrap_peers = [{peers}]\n'
         )
+
+    def reconfigure_port(self, new_quic_port, bootstrap_quic_ports):
+        """Rewrite the config to bind a FORCED DIFFERENT QUIC port, keeping
+        the same data_dir (⇒ same MachineId/identity/PeerId) and the same
+        API port. Used by the named-new-port reconnect gate: the cached old
+        endpoint is invalid, so reconnection must use a refreshed candidate
+        address and recover CRDT state without a manual rejoin."""
+        self.quic_port = new_quic_port
+        self.write_config(bootstrap_quic_ports)
 
     def start(self):
         log = open(self.log_path, "a")
@@ -278,6 +392,446 @@ def get_task(node, topic, task_id):
 def b64(value):
     return base64.b64encode(value.encode()).decode()
 
+# ──────────────────────────────────────────────────────────────────────────
+# Release-oracle provenance + exact-value + peer-set helpers
+# ──────────────────────────────────────────────────────────────────────────
+#
+# The independent review established that the prior oracle attested a release
+# from PATHS alone (binary path, no digest/version), accepted a "legacy"
+# binary by file existence, checked KV convergence by PRESENCE (not exact
+# bytes/hash), and never recorded the actual peer set or reconnect path. The
+# helpers below close each of those false positives: the oracle now records
+# binary SHA-256 + --version, Git HEAD + dirty-tree fingerprint + source
+# cutoff, exact decoded KV values/hashes, and the real connected peer set.
+
+# Source files the independent review pinned as the security/correctness
+# surface. The release binary MUST be no older than the newest of these — a
+# binary built before the last edit to a reviewed file is stale and the
+# oracle refuses to attest it (refuse a binary older than reviewed sources).
+REVIEWED_SOURCES = [
+    "src/kv/store.rs", "src/kv/entry.rs",
+    "src/crdt/provenance.rs", "src/crdt/task_item.rs",
+    "src/crdt/task_list.rs", "src/crdt/delta.rs", "src/crdt/sync.rs",
+    "src/server/crdt_subscriptions.rs", "src/server/routes/tasks.rs",
+    "src/server/mod.rs", "src/lib.rs", "src/network.rs",
+    "src/bin/x0xd.rs",
+]
+LEGACY_REQUIRED_VERSION = "0.30.1"
+
+
+def sha256_file(path):
+    """Streaming SHA-256 hex digest of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def binary_version(x0xd):
+    """Run `x0xd --version` and return the stripped stdout (e.g.
+    'x0xd 0.30.1'), or None on failure. Never raises."""
+    try:
+        out = subprocess.run(
+            [str(x0xd), "--version"],
+            capture_output=True, text=True, timeout=10)
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def parse_version(version_str):
+    """Extract the dotted 'major.minor.patch' from a 'x0xd 0.30.1'-style
+    string, or None."""
+    if not isinstance(version_str, str):
+        return None
+    m = re.search(r"(\d+\.\d+\.\d+)", version_str)
+    return m.group(1) if m else None
+
+
+def git_provenance():
+    """Capture HEAD, HEAD^{tree}, branch, dirty flag, a dirty-tree
+    fingerprint (source cutoff beyond the commit), and the HEAD commit
+    timestamp. Best-effort; missing git → None fields."""
+    def run(*cmd):
+        try:
+            out = subprocess.run(cmd, capture_output=True, text=True,
+                                 timeout=10, cwd=str(REPO_ROOT))
+            return out.stdout.strip() if out.returncode == 0 else None
+        except Exception:
+            return None
+    head = run("git", "rev-parse", "HEAD")
+    head_tree = run("git", "rev-parse", "HEAD^{tree}")
+    branch = run("git", "rev-parse", "--abbrev-ref", "HEAD")
+    diff = run("git", "diff", "HEAD") or ""
+    status = run("git", "status", "--porcelain") or ""
+    dirty = bool(diff or status)
+    dirty_tree_hash = hashlib.sha256(
+        (diff + "\n" + status).encode()).hexdigest() if dirty else None
+    commit_unix = None
+    iso = run("git", "show", "-s", "--format=%ct", "HEAD")
+    if iso:
+        try:
+            commit_unix = int(iso)
+        except ValueError:
+            commit_unix = None
+    return {
+        "head": head, "head_tree": head_tree, "branch": branch,
+        "dirty": dirty, "dirty_tree_hash": dirty_tree_hash,
+        "commit_unix": commit_unix,
+    }
+
+
+def record_and_verify_provenance(args):
+    """Record binary/source provenance and REFUSE to attest a release from a
+    stale binary or a non-v0.30.1 legacy. Returns (provenance, errors).
+    `errors` non-empty ⇒ the oracle cannot certify this tree; under
+    --expect-fixed the caller fails the run (release authority). Without
+    --expect-fixed the errors are recorded as warnings so the one-run smoke
+    stays available."""
+    errors = []
+    cur = {"path": str(args.x0xd)}
+    try:
+        cur["sha256"] = sha256_file(args.x0xd)
+    except Exception as e:
+        cur["sha256"] = None
+        errors.append(f"current binary unreadable: {e}")
+    cur["version_raw"] = binary_version(args.x0xd)
+    cur["version"] = parse_version(cur["version_raw"])
+    try:
+        cur["mtime_unix"] = int(args.x0xd.stat().st_mtime)
+    except Exception:
+        cur["mtime_unix"] = None
+    # Stale-binary floor: binary mtime must be >= the newest reviewed source.
+    newest_src = 0
+    for rel in REVIEWED_SOURCES:
+        try:
+            newest_src = max(newest_src, int((REPO_ROOT / rel).stat().st_mtime))
+        except Exception:
+            pass
+    cur["newest_reviewed_source_mtime_unix"] = newest_src or None
+    if cur["mtime_unix"] and newest_src and cur["mtime_unix"] < newest_src:
+        errors.append(
+            f"current binary mtime ({cur['mtime_unix']}) predates the newest "
+            f"reviewed source ({newest_src}); rebuild "
+            f"`cargo build --release --bin x0xd` before attesting a release")
+    if not cur["version"]:
+        errors.append("current binary reports no parseable --version")
+    legacy = None
+    if args.legacy_binary:
+        legacy = {"path": str(args.legacy_binary)}
+        try:
+            legacy["sha256"] = sha256_file(args.legacy_binary)
+        except Exception as e:
+            legacy["sha256"] = None
+            errors.append(f"legacy binary unreadable: {e}")
+        legacy["version_raw"] = binary_version(args.legacy_binary)
+        legacy["version"] = parse_version(legacy["version_raw"])
+        if legacy["version"] != LEGACY_REQUIRED_VERSION:
+            errors.append(
+                f"legacy binary must be exactly v{LEGACY_REQUIRED_VERSION} "
+                f"(got {legacy['version_raw']!r}); file existence alone is "
+                f"not authentication — supply an authenticated v0.30.1 x0xd")
+    forge = {"path": str(args.forge_injector)}
+    if pathlib.Path(args.forge_injector).is_file():
+        try:
+            forge["sha256"] = sha256_file(args.forge_injector)
+        except Exception:
+            forge["sha256"] = None
+        forge["version"] = binary_version(args.forge_injector)
+    else:
+        forge["sha256"] = None
+        forge["version"] = None
+    return {
+        "current_binary": cur, "legacy_binary": legacy,
+        "forge_injector": forge,
+        "git": git_provenance(),
+        "review_cutoff_sources": REVIEWED_SOURCES,
+        "legacy_required_version": LEGACY_REQUIRED_VERSION,
+    }, errors
+
+
+def key_record(node, store, key):
+    """Full GET /stores/:id/:key body, or None if absent/unreadable."""
+    r = node.req("GET", f"/stores/{store}/{key}")
+    if r["status"] == 200 and isinstance(r["body"], dict) \
+            and r["body"].get("ok") is not False:
+        return r["body"]
+    return None
+
+
+def key_value_bytes(node, store, key):
+    """Decoded value bytes for `key`, or None. Closes the presence-only KV
+    false positive: convergence is asserted on EXACT decoded bytes."""
+    rec = key_record(node, store, key)
+    if rec is None:
+        return None
+    raw = rec.get("value")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return base64.b64decode(raw)
+    except Exception:
+        return None
+
+
+def key_value_matches(node, store, key, expected_plain):
+    """True iff `key` is present with EXACT decoded value == expected_plain."""
+    got = key_value_bytes(node, store, key)
+    return got is not None and got == expected_plain.encode()
+
+
+def key_content_hash(node, store, key):
+    """Owner-signed content_hash (blake3) for `key`, or None."""
+    rec = key_record(node, store, key)
+    if rec is None:
+        return None
+    h = rec.get("content_hash")
+    return h if isinstance(h, str) else None
+
+
+def connectivity_snapshot(node):
+    """GET /diagnostics/connectivity body, or None."""
+    try:
+        r = node.req("GET", "/diagnostics/connectivity")
+    except OSError:
+        return None
+    if r["status"] == 200 and isinstance(r["body"], dict):
+        return r["body"]
+    return None
+
+
+def node_connected_peer_ids(node):
+    """Actual connected peer set (hex PeerIds) from per_peer_transport rows.
+    This is the real mesh edges, not the configured bootstrap list."""
+    snap = connectivity_snapshot(node)
+    if not snap:
+        return set()
+    ids = set()
+    for row in snap.get("per_peer_transport", []) or []:
+        if isinstance(row, dict) and row.get("peer_id") and \
+                row.get("connected") is not False:
+            ids.add(row["peer_id"])
+    return ids
+
+
+def node_connection_pool(node):
+    """Connection-pool counters (active_connections, lru_evictions_total,
+    establish_failures_total) used for reconnect/eviction attribution."""
+    snap = connectivity_snapshot(node)
+    if not snap:
+        return None
+    cp = snap.get("connection_pool")
+    return cp if isinstance(cp, dict) else None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Identity / topology / store-metadata probes (read-only)
+# ──────────────────────────────────────────────────────────────────────────
+
+def node_agent_id(node):
+    """Local agent id (hex) via GET /agent. Read-only, no side effects.
+    The server's ApiResponse flattens its data payload, so `agent_id` is a
+    top-level key (not nested under `data`). Cached on the node after first
+    lookup."""
+    if getattr(node, "agent_id", None):
+        return node.agent_id
+    r = node.req("GET", "/agent")
+    if r["status"] == 200 and isinstance(r["body"], dict):
+        aid = r["body"].get("agent_id")
+        if isinstance(aid, str) and aid:
+            node.agent_id = aid
+            return aid
+    return None
+
+
+def node_peer_id(node):
+    """Local QUIC peer id (hex) via GET /diagnostics/connectivity. Read-only.
+    Cached on the node after first lookup."""
+    if getattr(node, "peer_id", None):
+        return node.peer_id
+    try:
+        r = node.req("GET", "/diagnostics/connectivity")
+    except OSError:
+        return None
+    if r["status"] == 200 and isinstance(r["body"], dict):
+        pid = r["body"].get("peer_id")
+        if isinstance(pid, str) and pid:
+            node.peer_id = pid
+            return pid
+    return None
+
+
+def node_mdns(node):
+    """Local mDNS discovery state via GET /diagnostics/connectivity.
+    Returns {browsing, advertising, discovered_peers} or None. Same call as
+    node_peer_id; cached on the node. discovered_peers > 0 on an isolated
+    same-host cluster signals mesh contamination (stray x0xd daemons on the
+    host advertising via mDNS)."""
+    if getattr(node, "mdns", None) is not None:
+        return node.mdns
+    try:
+        r = node.req("GET", "/diagnostics/connectivity")
+    except OSError:
+        return None
+    mdns = None
+    if r["status"] == 200 and isinstance(r["body"], dict):
+        mdns = r["body"].get("mdns")
+    if isinstance(mdns, dict):
+        node.mdns = mdns
+        return mdns
+    return None
+
+
+def store_meta(node, store):
+    """Best-effort store metadata for `store`.
+
+    Captures {owner, policy, version, ownership_status}. The finalized
+    contract exposes these on GET /stores list entries (and a possible
+    GET /stores/:id detail). Probes defensively so the oracle works whether
+    the field lands on the list entry or a detail route; any field not yet
+    exposed is None and `exposed` is False (the caller treats a missing field
+    as a known-gap, not a failure).
+
+    ownership_status is "anchored" (owner cryptographically bound at
+    construction), "unknown" (no anchor — read-only), or "conflict" (anchored
+    owner differs from an announced owner)."""
+    meta = {"owner": None, "policy": None, "version": None,
+            "ownership_status": None, "exposed": False}
+    # Prefer the list endpoint (always present); fall back to a detail route.
+    candidates = []
+    r = node.req("GET", "/stores")
+    if r["status"] == 200 and isinstance(r["body"], dict):
+        for entry in r["body"].get("stores", []):
+            if isinstance(entry, dict) and (entry.get("id") == store
+                    or entry.get("topic") == store):
+                candidates.append(entry)
+                break
+    if not candidates:
+        rd = node.req("GET", f"/stores/{store}")
+        if rd["status"] == 200 and isinstance(rd["body"], dict):
+            candidates.append(rd["body"])
+    for entry in candidates:
+        if not isinstance(entry, dict):
+            continue
+        for k in ("owner", "policy", "version", "ownership_status"):
+            if entry.get(k) is not None:
+                meta[k] = entry.get(k)
+                meta["exposed"] = True
+    return meta
+
+
+def task_list_version(node, topic):
+    """Current task-list revision (u64) from GET /task-lists/:id/tasks, or
+    None if absent. Reported for observability; the fencing input is the
+    opaque `fence_token` (see task_list_fence), not this revision."""
+    r = node.req("GET", f"/task-lists/{topic}/tasks")
+    if r["status"] == 200 and isinstance(r["body"], dict):
+        v = r["body"].get("version")
+        if isinstance(v, int):
+            return v
+    return None
+
+
+def task_list_fence(node, topic):
+    """Opaque local-replica fence token (string) from GET /task-lists/:id/tasks,
+    or None if absent. Echo this verbatim as `fence_token` on a subsequent
+    PATCH; if it does not match the daemon's current (epoch, revision) the
+    mutation is rejected with 409 and nothing changes. This is LOCAL fencing
+    (two daemons at the same token both accept), NOT distributed CAS."""
+    r = node.req("GET", f"/task-lists/{topic}/tasks")
+    if r["status"] == 200 and isinstance(r["body"], dict):
+        tok = r["body"].get("fence_token")
+        if isinstance(tok, str) and tok:
+            return tok
+    return None
+
+
+# Claim-oracle helpers. Claims are ADVISORY (CRDT OR-Set): the deterministic
+# winner is resolved at convergence and read from `claimed_by`; no response
+# may imply distributed atomic exclusion the protocol cannot provide.
+
+def claimed_by_of(task):
+    """Hex AgentId of the deterministic claim winner, or None."""
+    if isinstance(task, dict):
+        cb = task.get("claimed_by")
+        if isinstance(cb, str) and cb:
+            return cb
+    return None
+
+
+def claimed_at_of(task):
+    """Unix-ms timestamp of the winning claim, or None."""
+    if isinstance(task, dict):
+        ca = task.get("claimed_at")
+        if isinstance(ca, int) and ca > 0:
+            return ca
+    return None
+
+
+def state_str_of(task):
+    """Legacy formatted state string (empty|claimed:<hex>|done:<hex>)."""
+    if isinstance(task, dict):
+        s = task.get("state")
+        return str(s) if s is not None else None
+    return None
+
+
+# A response LEAKS when it positively asserts exclusive ownership the
+# advisory CRDT cannot guarantee. A top-level NEGATION is honest, not a leak:
+# the finalized contract carries `exclusive:false`. Provisional/local fields
+# (resolution.locally_winning, resolution.current_winner, pending_convergence)
+# are explicitly non-final and nested, so they are not leaks either.
+_POSITIVE_EXCLUSIVITY_KEYS = frozenset({
+    "won", "winner", "owner", "acquired", "granted", "locked", "primary",
+})
+
+
+def claims_exclusivity(body):
+    """True iff the body POSITIVELY asserts exclusive ownership the advisory
+    CRDT cannot guarantee. `exclusive:false` (a negation) is HONEST and is
+    NOT reported as a leak."""
+    if not isinstance(body, dict):
+        return False
+    if body.get("exclusive") is True:
+        return True
+    for k in _POSITIVE_EXCLUSIVITY_KEYS:
+        if k in body and body.get(k):
+            return True
+    return False
+
+
+def honesty_fields_ok(body):
+    """Check the finalized contract's POSITIVE honesty signals. Each is
+    optional (the response may predate the field), but when PRESENT it must
+    be honest. Returns (ok, details).
+
+    Contract (PATCH commit 200): committed=="local"; exclusive==false (if
+    present); execution.authorization=="advisory" (if present);
+    cas.scope=="local_replica" (if present); resolution.pending_convergence
+    ==true (if present)."""
+    if not isinstance(body, dict):
+        return True, {}
+    details = {}
+    if "exclusive" in body:
+        details["exclusive_is_false"] = body.get("exclusive") is False
+    res = body.get("resolution")
+    if isinstance(res, dict) and "pending_convergence" in res:
+        details["pending_convergence_is_true"] = \
+            res.get("pending_convergence") is True
+    cas = body.get("cas")
+    if isinstance(cas, dict) and "scope" in cas:
+        details["cas_scope_is_local_replica"] = \
+            cas.get("scope") == "local_replica"
+    ex = body.get("execution")
+    if isinstance(ex, dict) and "authorization" in ex:
+        details["authorization_is_advisory"] = \
+            ex.get("authorization") == "advisory"
+    ok = all(details.values()) if details else True
+    return ok, details
+
 
 # ──────────────────────────────────────────────────────────────────────────
 # Single run
@@ -299,10 +853,13 @@ class Run:
             "started_unix": time.time(),
             "phases": {},
             "diagnostics_deltas": {},
+            "topology": {},          # per-node agent_id/peer_id/paths/siblings
+            "unsupported": [],       # gates skipped for a missing prerequisite
             "pass": None,
         }
         self.hard_failures = []
         self.known_gaps = []
+        self.unsupported_gates = []
 
     # -- helpers -----------------------------------------------------------
 
@@ -363,6 +920,22 @@ class Run:
             self.known_gaps.append(phase)
         return entry["pass"]
 
+    def unsupported_gate(self, phase, prereq_key, detail=None):
+        """Record a gate that cannot run because an external prerequisite is
+        missing (e.g. a legacy binary). Never a hard failure and never a
+        tolerated defect — the gate is explicitly UNSUPPORTED and the exact
+        prerequisite is reported so it can be supplied. Distinct from
+        known-gap (a real defect we tolerate) and from a hard failure."""
+        entry = self.report["phases"].setdefault(phase, {})
+        entry["status"] = "unsupported"
+        entry["pass"] = True  # does not fail the run; reported separately
+        entry["unsupported"] = UNSUPPORTED_PREREQ_NOTES[prereq_key]
+        if detail is not None:
+            entry.update(detail)
+        self.unsupported_gates.append(phase)
+        self.report["unsupported"].append(phase)
+        return entry["pass"]
+
     # -- topology ----------------------------------------------------------
 
     def start_cluster_creator_only(self):
@@ -391,6 +964,52 @@ class Run:
         node.start()
         node.wait_ready()
 
+    def _record_topology(self):
+        """Capture each node's agent_id, peer_id, addresses, data dir, and
+        bootstrap siblings once the whole cluster is up. Same-host topology
+        (who-is-who and who bootstraps to whom) is needed to attribute the
+        deterministic claim winner and to reproduce same-host fan-out. The
+        PeerId is the QUIC identity (`GET /diagnostics/connectivity`); the
+        AgentId (`GET /agent`) is what `claimed_by`/store `owner` resolve to.
+        """
+        a = self.args
+        creator = self.nodes[0]
+        creator_pid = node_peer_id(creator)
+        mesh_peers = []
+        for i, node in enumerate(self.nodes):
+            # node1 bootstraps to nobody; every other node lists only node1.
+            targets = ([{"quic_addr": f"127.0.0.1:{a.quic_base}",
+                         "peer_id": creator_pid,
+                         "agent_id": node_agent_id(creator)}]
+                       if i > 0 else [])
+            mdns = node_mdns(node) or {}
+            disc = mdns.get("discovered_peers")
+            if isinstance(disc, int):
+                mesh_peers.append(disc)
+        self.report["topology"][node.name] = {
+            "api_addr": node.base,
+            "quic_addr": f"127.0.0.1:{node.quic_port}",
+            "data_dir": str(node.data_dir),
+            "agent_id": node_agent_id(node),
+            "peer_id": node_peer_id(node),
+            "bootstrap_siblings": targets,
+            "mdns": mdns,
+            # Actual mesh edges (connected PeerIds) + pool counters, so the
+            # report records the REAL peer set and reconnect/eviction path —
+            # not just the configured bootstrap list.
+            "connected_peer_ids": sorted(node_connected_peer_ids(node)),
+            "connection_pool": node_connection_pool(node),
+        }
+        # Surface same-host mDNS mesh contamination: bootstrap_peers isolates
+        # QUIC, not mDNS, so stray x0xd daemons on the host can appear as
+        # discovered peers. Non-zero on an isolated cluster ⇒ contamination
+        # (the convergence assertions still hold via unique topics, but this
+        # makes the environmental assumption observable, not silent).
+        self.report["mesh_contamination"] = {
+            "max_mdns_discovered_peers": max(mesh_peers) if mesh_peers else None,
+            "contaminated": bool(mesh_peers and max(mesh_peers) > 0),
+        }
+
     # -- phases ------------------------------------------------------------
 
     def phase_cold_join(self):
@@ -412,6 +1031,10 @@ class Run:
             raise RuntimeError(
                 f"creator setup failed: tl={tl} task={task} st={st} put={put}")
         self.pre_task_id = task["body"]["task_id"]
+        # Discover the creator's AgentId now so peer store joins can pin it
+        # as expected_owner — the cryptographic/out-of-band owner binding that
+        # anchors the joiner to the creator at join time (no first-self-claim).
+        self.creator_aid = node_agent_id(creator)
 
         per_node = {}
         with self.phase("cold_join"):
@@ -424,18 +1047,21 @@ class Run:
                 join_tl = node.req("POST", "/task-lists",
                                    {"name": "convergence soak",
                                     "topic": self.topic})
-                join_st = node.req("POST", f"/stores/{self.store}/join")
+                join_st = node.req("POST", f"/stores/{self.store}/join",
+                                   ({"expected_owner": self.creator_aid}
+                                    if self.creator_aid else {}))
                 arrivals = sample_until(
                     {
                         "task": lambda n=node: task_visible(
                             n, self.topic, self.pre_task_id),
-                        "kv": lambda n=node: key_visible(
-                            n, self.store, "prejoin"),
+                        "kv": lambda n=node: key_value_matches(
+                            n, self.store, "prejoin", "prejoin-value"),
                     },
                     gate_secs=a.cold_gate, interval=a.poll_interval)
                 per_node[node.name] = {
                     "join_status": {"task_list": join_tl["status"],
                                     "store": join_st["status"]},
+                    "store_join_body": join_st.get("body"),
                     "task_secs": arrivals["task"],
                     "kv_secs": arrivals["kv"],
                 }
@@ -445,6 +1071,10 @@ class Run:
                   {"gate_secs": a.cold_gate, "per_node": per_node})
         log(f"run {self.idx}: cold_join {'PASS' if ok else 'FAIL'} "
             f"{json.dumps(per_node)}")
+        # All nodes are up now — capture same-host topology (agent_id,
+        # peer_id, addresses, bootstrap siblings) for the report and for
+        # claim-winner / store-owner attribution in later phases.
+        self._record_topology()
 
     def phase_live_propagation(self):
         a, creator = self.args, self.creator()
@@ -461,7 +1091,8 @@ class Run:
                 checks[f"{node.name}.task"] = (
                     lambda n=node: task_visible(n, self.topic, live_tid))
                 checks[f"{node.name}.kv"] = (
-                    lambda n=node: key_visible(n, self.store, "live"))
+                    lambda n=node: key_value_matches(
+                        n, self.store, "live", "live-value"))
             arrivals = sample_until(checks, gate_secs=a.live_gate,
                                     interval=a.poll_interval)
         self.live_task_id = live_tid
@@ -476,6 +1107,7 @@ class Run:
         victim = self.nodes[-1]
         with self.phase("restart_recovery"):
             log(f"run {self.idx}: stopping {victim.name}")
+            pre_restart_fence = task_list_fence(victim, self.topic)
             victim.stop()
             time.sleep(3)
             task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
@@ -492,7 +1124,8 @@ class Run:
             arrivals = sample_until(
                 {
                     "task": lambda: task_visible(victim, self.topic, off_tid),
-                    "kv": lambda: key_visible(victim, self.store, "offline"),
+                    "kv": lambda: key_value_matches(
+                        victim, self.store, "offline", "offline-value"),
                 },
                 gate_secs=a.restart_gate, interval=a.poll_interval)
             auto = (arrivals["task"] is not None
@@ -510,8 +1143,8 @@ class Run:
                     {
                         "task": lambda: task_visible(
                             victim, self.topic, off_tid),
-                        "kv": lambda: key_visible(
-                            victim, self.store, "offline"),
+                        "kv": lambda: key_value_matches(
+                            victim, self.store, "offline", "offline-value"),
                     },
                     gate_secs=a.cold_gate, interval=a.poll_interval)
                 rejoin = {
@@ -537,9 +1170,19 @@ class Run:
         log(f"run {self.idx}: restart_recovery {status} "
             f"{json.dumps(observed)}")
 
+        if victim.running:
+            prf = self._fence_pre_restart_rejected(victim, pre_restart_fence)
+            self.known_gap_gate("fence_pre_restart_rejected",
+                                "fence_pre_restart", fixed=prf["fenced"],
+                                observed=prf)
+
     def phase_concurrent_claims(self):
         a, creator = self.args, self.creator()
         claimants = self.nodes[1:3]
+        # Resolve claimant AgentIds so the deterministic winner is
+        # attributable to a real claimant (not a phantom/too-short id).
+        claimant_aids = {n.name: node_agent_id(n) for n in claimants}
+        known_aids = {v for v in claimant_aids.values() if v}
         with self.phase("concurrent_claims"):
             task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
                                {"title": "claim-target",
@@ -556,65 +1199,390 @@ class Run:
                 log(f"run {self.idx}: concurrent_claims FAIL (visibility)")
                 return
 
+            # Each claimant reads its OWN local fence_token (right after the
+            # barrier, minimizing the window for a background delta to advance
+            # it) and echoes it as fence_token. fence_token is a LOCAL fence:
+            # two replicas each at their own current token BOTH commit — that
+            # is the advisory property. Do NOT read one replica's token and
+            # reuse it for the other: cross-replica skew can spuriously 409
+            # the second and mask the contract.
+            used_tokens = {}
+
             barrier = threading.Barrier(len(claimants))
 
             def do_claim(node):
                 barrier.wait(timeout=10)
+                f_local = task_list_fence(node, self.topic)
+                used_tokens[node.name] = f_local
                 return node.req(
                     "PATCH", f"/task-lists/{self.topic}/tasks/{tid}",
-                    {"action": "claim"})
+                    {"action": "claim", "fence_token": f_local})
 
             with concurrent.futures.ThreadPoolExecutor(
                     max_workers=len(claimants)) as ex:
                 futs = {n.name: ex.submit(do_claim, n) for n in claimants}
                 responses = {k: f.result() for k, f in futs.items()}
 
+            # Converge: all nodes agree on the deterministic winner. Prefer
+            # the structured `claimed_by`; fall back to the legacy `state`
+            # string only when structured fields are entirely absent, so the
+            # hard convergence gate still fires pre-fix.
             t0 = time.monotonic()
-            winner, converge_secs, final_tasks = None, None, {}
+            winner_aid, converge_secs, final_tasks = None, None, {}
             while time.monotonic() - t0 < a.claim_gate:
                 final_tasks = {n.name: get_task(n, self.topic, tid)
                                for n in self.nodes}
-                states = [t.get("state") if t else None
-                          for t in final_tasks.values()]
-                if (None not in states and len(set(states)) == 1
-                        and str(states[0]).startswith("claimed")):
+                aids = [claimed_by_of(t) for t in final_tasks.values()]
+                states = [state_str_of(t) for t in final_tasks.values()]
+                present = all(final_tasks.values())
+                if present and len(set(aids)) == 1 and aids[0] is not None:
+                    winner_aid = aids[0]
                     converge_secs = round(time.monotonic() - t0, 2)
-                    winner = states[0]
+                    break
+                if (present and all(x is None for x in aids)
+                        and len(set(states)) == 1
+                        and (states[0] or "").startswith("claimed")):
+                    converge_secs = round(time.monotonic() - t0, 2)
                     break
                 time.sleep(a.poll_interval)
 
+        # ── Structured-field oracle (claimed_by / claimed_at / version) ─────
         structured = {}
         for name, t in final_tasks.items():
-            structured[name] = (
-                {k: t.get(k) for k in
-                 ("claimed_by", "claimed_at", "version") if k in t}
-                if isinstance(t, dict) else None)
+            if isinstance(t, dict):
+                structured[name] = {
+                    "claimed_by": claimed_by_of(t),
+                    "claimed_at": claimed_at_of(t),
+                    "state": state_str_of(t),
+                }
+            else:
+                structured[name] = None
         has_structured = all(
-            isinstance(s, dict) and "claimed_by" in s
+            isinstance(s, dict) and s.get("claimed_by") is not None
+            and s.get("claimed_at") is not None
             for s in structured.values())
+        # The deterministic winner must be one of the claimants (hex AgentId
+        # present in the topology). Skipped if agent ids were undiscoverable.
+        winner_attributable = (winner_aid is None or not known_aids
+                               or winner_aid in known_aids)
 
         converged = converge_secs is not None
-        self.gate("concurrent_claims", converged, {
+        self.gate("concurrent_claims", converged and winner_attributable, {
             "gate_secs": a.claim_gate,
             "visibility_secs": vis,
+            "fence_tokens_used": used_tokens,
+            "claimant_agent_ids": claimant_aids,
             "claim_responses": {k: {"status": v["status"], "body": v["body"]}
                                 for k, v in responses.items()},
-            "both_accepted_200": all(
-                v["status"] == 200 for v in responses.values()),
             "converge_secs": converge_secs,
-            "winner_state": winner,
+            "winner_agent_id": winner_aid,
+            "winner_attributable": winner_attributable,
         })
+        # Advisory race gate: each claimant used its OWN local version, so
+        # BOTH must commit (200) — two replicas at their own current version
+        # both pass the local fence. A 409 here would mean the fence fired
+        # on cross-replica skew, which masks the advisory contract.
+        both_committed = all(
+            v["status"] == 200 for v in responses.values())
         self.known_gap_gate(
-            "concurrent_claims_structured_fields", "structured_claim_fields",
-            fixed=has_structured,
-            observed={"structured_fields": structured})
+            "concurrent_claims_advisory_both_commit",
+            "claim_cas_local_fence", fixed=both_committed,
+            observed={"fence_tokens_used": used_tokens,
+                      "claim_statuses": {k: v["status"]
+                                         for k, v in responses.items()},
+                      "both_committed": both_committed})
+        # No commit response may POSITIVELY claim exclusivity the advisory
+        # CRDT cannot provide (a top-level negation like exclusive:false is
+        # honest, not a leak); every 200 commit must be labeled "local"; and
+        # any present honesty signal (exclusive/execution/cas/resolution)
+        # must be correct.
+        exclusivity_leak = {
+            k: claims_exclusivity(v.get("body"))
+            for k, v in responses.items()
+        }
+        local_labeled = {
+            k: (isinstance(v.get("body"), dict)
+                and v["body"].get("committed") == "local")
+            for k, v in responses.items() if v["status"] == 200
+        }
+        honesty_fields = {}
+        for k, v in responses.items():
+            if v["status"] == 200:
+                ok, det = honesty_fields_ok(v.get("body"))
+                honesty_fields[k] = {"ok": ok, "details": det}
+        honest = (not any(exclusivity_leak.values())
+                  and all(local_labeled.values())
+                  and all(h["ok"] for h in honesty_fields.values()))
+        self.known_gap_gate(
+            "concurrent_claims_honest_semantics", "claim_exclusivity_honesty",
+            fixed=honest,
+            observed={"exclusivity_leak": exclusivity_leak,
+                      "local_labeled": local_labeled,
+                      "honesty_fields": honesty_fields})
+        self.known_gap_gate(
+            "concurrent_claims_structured_fields", "claim_structured_fields",
+            fixed=has_structured and winner_attributable,
+            observed={"structured_fields": structured,
+                      "winner_agent_id": winner_aid,
+                      "claimant_agent_ids": claimant_aids})
+
+        # ── CAS local-fence oracle (single replica) ────────────────────────
+        # On ONE replica, a stale fence_token must NOT mutate. This is
+        # the honest local fence; it is NOT distributed exclusion (two
+        # replicas at the same version can both commit — see above).
+        cas = self._claim_cas_local_fence(creator)
+        self.known_gap_gate(
+            "concurrent_claims_cas_fence", "claim_cas_local_fence",
+            fixed=cas["fenced"], observed=cas)
+
+        # ── Malformed fence-token oracle ──────────────────────────────────
+        # A supplied-but-MALFORMED fence_token must be rejected (non-200)
+        # WITHOUT mutating the list — present-but-invalid must NOT collapse
+        # to 'absent' (unconditional mutation).
+        mal = self._fence_malformed_rejected(creator)
+        self.known_gap_gate("fence_malformed_rejected", "fence_malformed",
+                            fixed=mal["fenced"], observed=mal)
+
+        # ── Remote-invalidation CAS oracle ─────────────────────────────────
+        # The local fence must also reject a claim whose fence_token a
+        # SINCE-MERGED REMOTE delta has invalidated — not only local
+        # mutations. A remote peer mutates the shared list; once that delta
+        # merges into the local replica (version advances), a local claim
+        # guarded by the pre-merge version MUST be rejected (non-mutation).
+        rinv = self._claim_remote_invalidation(creator, self.nodes[1])
+        self.known_gap_gate(
+            "concurrent_claims_remote_invalidation",
+            "claim_cas_local_fence", fixed=rinv["fenced"], observed=rinv)
+
         log(f"run {self.idx}: concurrent_claims "
-            f"{'PASS' if converged else 'FAIL'} winner={winner!r} "
-            f"converge={converge_secs}s structured={has_structured}")
+            f"{'PASS' if converged else 'FAIL'} winner={winner_aid!r} "
+            f"converge={converge_secs}s structured={has_structured} "
+            f"both_committed={both_committed} cas_fenced={cas['fenced']} "
+            f"remote_inv_fenced={rinv['fenced']}")
+
+    def _claim_cas_local_fence(self, node):
+        """Single-replica fence oracle on a fresh task.
+
+        Sequence on ONE node: read the opaque fence_token F0, claim echoing
+        fence_token=F0 (commits, token advances to F1), then claim again with
+        the now-stale fence_token=F0. The stale attempt MUST NOT mutate (token
+        stays F1) and MUST return a non-200 conflict echoing the current
+        fence_token. We assert the *behavior* (non-mutation + token echo),
+        never the literal error string. fence_token is a LOCAL fence (epoch,
+        revision): two daemons at the same token both accept — not a
+        distributed CAS, and a token captured before a restart never matches
+        post-restart (epoch differs), closing the restart-ABA window.
+        """
+        task = node.req("POST", f"/task-lists/{self.topic}/tasks",
+                        {"title": "cas-target",
+                         "description": "fence_token local fence"})
+        if task["status"] not in (200, 201) or not isinstance(
+                task.get("body"), dict):
+            return {"fenced": False, "error": "cas task create failed",
+                    "create_response": task}
+        tid = task["body"].get("task_id")
+        f0 = task_list_fence(node, self.topic)
+        commit = node.req("PATCH", f"/task-lists/{self.topic}/tasks/{tid}",
+                          {"action": "claim", "fence_token": f0})
+        # The commit response carries the new fence_token; fall back to a GET.
+        f1 = None
+        if isinstance(commit.get("body"), dict):
+            f1 = commit["body"].get("fence_token")
+        if not isinstance(f1, str):
+            f1 = task_list_fence(node, self.topic)
+        stale = node.req("PATCH", f"/task-lists/{self.topic}/tasks/{tid}",
+                         {"action": "claim", "fence_token": f0})
+        f2 = task_list_fence(node, self.topic)
+        echoed = None
+        if isinstance(stale.get("body"), dict):
+            echoed = stale["body"].get("fence_token")
+        committed_ok = (commit["status"] == 200 and isinstance(f0, str)
+                        and isinstance(f1, str) and f1 != f0)
+        # Honest fence: stale attempt did not advance the token, was not a
+        # 200 commit, and (if exposed) echoed the unchanged current token.
+        stale_non_mutating = (isinstance(f1, str) and isinstance(f2, str)
+                              and f2 == f1 and stale["status"] != 200)
+        echoed_ok = (echoed is None or echoed == f1)
+        return {
+            "fenced": committed_ok and stale_non_mutating and echoed_ok,
+            "task_id": tid,
+            "fence_before": f0, "fence_after_commit": f1,
+            "fence_after_stale": f2,
+            "commit_status": commit["status"],
+            "stale_status": stale["status"],
+            "stale_echoed_fence_token": echoed,
+            "stale_body": stale["body"],
+            "note": ("fence_token fences locally only; two replicas at the "
+                     "same token can both commit"),
+        }
+
+    def _fence_malformed_rejected(self, node):
+        """Malformed fence-token rejection oracle.
+
+        A supplied-but-MALFORMED fence_token (u64 overflow, non-token
+        string) must be rejected (non-200) WITHOUT mutating the task list —
+        present-but-invalid must NOT collapse to 'absent'. Asserts behavior
+        (non-200 + fence unchanged across every attempt), never the literal
+        error string or status code."""
+        task = node.req("POST", f"/task-lists/{self.topic}/tasks",
+                        {"title": "malformed-fence-target",
+                         "description": "malformed token must reject, "
+                         "not mutate"})
+        if task["status"] not in (200, 201) or not isinstance(
+                task.get("body"), dict):
+            return {"fenced": False,
+                    "error": "malformed-fence task create failed",
+                    "create_response": task}
+        tid = task["body"].get("task_id")
+        # 2^64 (u64 overflow) and a non-token string are unambiguously
+        # malformed — neither is 'absent'.
+        malformed = ["18446744073709551616", "!!!not-a-real-token!!!"]
+        rejected_all = True
+        non_mutating = True
+        attempts = []
+        for tok in malformed:
+            f_before = task_list_fence(node, self.topic)
+            r = node.req("PATCH", f"/task-lists/{self.topic}/tasks/{tid}",
+                         {"action": "claim", "fence_token": tok})
+            f_after = task_list_fence(node, self.topic)
+            attempts.append({
+                "token_repr": tok, "status": r["status"],
+                "fence_changed": (f_before != f_after),
+            })
+            if r["status"] == 200:
+                rejected_all = False
+            if f_before != f_after:
+                non_mutating = False
+        return {"fenced": rejected_all and non_mutating,
+                "task_id": tid, "attempts": attempts}
+
+    def _fence_pre_restart_rejected(self, node, pre_restart_fence):
+        """Pre-restart fence-token rejection oracle.
+
+        A fence_token captured BEFORE a daemon restart must NOT be accepted
+        after the restart: the fence epoch is a fresh incarnation, so the old
+        token is invalid. Post-restart the node creates a task and PATCHes it
+        with the captured pre-restart token — it MUST be rejected (non-200,
+        non-mutating). Closes the restart-ABA window the wall-clock epoch
+        left open."""
+        if not isinstance(pre_restart_fence, str) or not pre_restart_fence:
+            return {"fenced": False, "error": "no pre-restart fence captured"}
+        task = node.req("POST", f"/task-lists/{self.topic}/tasks",
+                        {"title": "pre-restart-fence-target",
+                         "description": "stale pre-restart token must reject"})
+        if task["status"] not in (200, 201) or not isinstance(
+                task.get("body"), dict):
+            return {"fenced": False,
+                    "error": "pre-restart task create failed",
+                    "create_response": task}
+        tid = task["body"].get("task_id")
+        f_before = task_list_fence(node, self.topic)
+        stale = node.req("PATCH", f"/task-lists/{self.topic}/tasks/{tid}",
+                         {"action": "claim",
+                          "fence_token": pre_restart_fence})
+        f_after = task_list_fence(node, self.topic)
+        echoed = None
+        if isinstance(stale.get("body"), dict):
+            echoed = stale["body"].get("fence_token")
+        non_mutating = (isinstance(f_before, str) and isinstance(f_after, str)
+                        and f_after == f_before)
+        rejected = stale["status"] != 200
+        echoed_ok = (echoed is None or echoed == f_before)
+        return {
+            "fenced": rejected and non_mutating and echoed_ok,
+            "task_id": tid,
+            "pre_restart_fence": pre_restart_fence,
+            "post_restart_fence_before": f_before,
+            "fence_after_stale": f_after,
+            "stale_status": stale["status"],
+            "stale_echoed_fence_token": echoed,
+            "stale_body": stale["body"],
+        }
+
+    def _claim_remote_invalidation(self, local, remote):
+        """Remote-invalidation fence oracle.
+
+        A local claim guarded by a fence_token that a SINCE-MERGED REMOTE
+        delta has invalidated MUST NOT mutate. The fence must observe merged
+        remote state, not only local mutations. Sequence:
+          1. local creates a claim target task T and reads fence_token F_before;
+          2. remote peer adds a different task (delta published);
+          3. wait for that delta to merge into local (token changes);
+          4. local claims T with fence_token=F_before → must be rejected.
+        Asserts non-mutation + current fence_token echo, never the literal
+        error string.
+        """
+        a = self.args
+        task = local.req("POST", f"/task-lists/{self.topic}/tasks",
+                         {"title": "rinv-target",
+                          "description": "remote invalidation target"})
+        if task["status"] not in (200, 201) or not isinstance(
+                task.get("body"), dict):
+            return {"fenced": False, "error": "rinv task create failed",
+                    "create_response": task}
+        tid = task["body"].get("task_id")
+        f_before = task_list_fence(local, self.topic)
+        # Remote mutation on the shared list.
+        rtask = remote.req("POST", f"/task-lists/{self.topic}/tasks",
+                           {"title": "rinv-remote-delta",
+                            "description": "merged delta advances version"})
+        if rtask["status"] not in (200, 201):
+            return {"fenced": False, "error": "remote task create failed",
+                    "fence_before": f_before, "remote_response": rtask}
+        # Wait for the NAMED remote mutation to be visible on local AND to
+        # advance the fence. Requiring the specific task to be visible (not
+        # just any fence change) closes the idempotent-churn false positive:
+        # bare revision churn from a redelivered/no-op delta must NOT satisfy
+        # this gate — only the named remote mutation does.
+        rtid = rtask["body"].get("task_id") if isinstance(
+            rtask.get("body"), dict) else None
+        t0 = time.monotonic()
+        f_merged = f_before
+        named_visible = False
+        while time.monotonic() - t0 < a.live_gate:
+            f_merged = task_list_fence(local, self.topic)
+            named_visible = (rtid is not None
+                             and task_visible(local, self.topic, rtid))
+            if named_visible and f_merged is not None \
+                    and f_merged != f_before:
+                break
+            time.sleep(a.poll_interval)
+        merged = (named_visible and f_merged is not None
+                  and f_merged != f_before)
+        if not merged:
+            return {"fenced": False, "error": "named remote mutation never "
+                    "merged (visible + fence advance)",
+                    "named_remote_task_id": rtid,
+                    "named_remote_visible": named_visible,
+                    "fence_before": f_before, "fence_merged": f_merged}
+        # Local claim guarded by the pre-merge token must be rejected.
+        stale = local.req("PATCH", f"/task-lists/{self.topic}/tasks/{tid}",
+                          {"action": "claim", "fence_token": f_before})
+        f_after = task_list_fence(local, self.topic)
+        echoed = None
+        if isinstance(stale.get("body"), dict):
+            echoed = stale["body"].get("fence_token")
+        stale_non_mutating = (f_after == f_merged and stale["status"] != 200)
+        echoed_ok = (echoed is None or echoed == f_merged)
+        return {
+            "fenced": stale_non_mutating and echoed_ok,
+            "task_id": tid,
+            "named_remote_task_id": rtid,
+            "named_remote_visible": named_visible,
+            "fence_before": f_before, "fence_merged": f_merged,
+            "fence_after_stale": f_after,
+            "stale_status": stale["status"],
+            "stale_echoed_fence_token": echoed,
+            "stale_body": stale["body"],
+            "note": ("local fence rejects a token invalidated by a merged "
+                     "remote delta"),
+        }
 
     def phase_signed_store_nonowner(self):
         a, creator = self.args, self.creator()
         writer = self.nodes[1]
+        creator_aid = node_agent_id(creator)
+        writer_aid = node_agent_id(writer)
         with self.phase("signed_store_nonowner_write"):
             put = writer.req("PUT", f"/stores/{self.store}/unauthorized",
                              {"value": b64("intruder-value"),
@@ -625,7 +1593,8 @@ class Run:
             deadline = time.monotonic() + a.fork_window
             propagated = False
             while time.monotonic() < deadline:
-                if key_visible(creator, self.store, "unauthorized"):
+                if key_value_matches(creator, self.store, "unauthorized",
+                                     "intruder-value"):
                     propagated = True
                     break
                 time.sleep(a.poll_interval)
@@ -633,6 +1602,8 @@ class Run:
         local_fork = local["status"] == 200
         observed = {
             "writer": writer.name,
+            "creator_agent_id": creator_aid,
+            "writer_agent_id": writer_aid,
             "put_status": put["status"],
             "put_body": put["body"],
             "writer_local_read_status": local["status"],
@@ -644,6 +1615,44 @@ class Run:
         self.known_gap_gate("signed_store_nonowner_write",
                             "nonowner_put_rejected", fixed=fixed,
                             observed=observed)
+
+        # ── Ownership-binding oracle — HARD gate (finalized contract) ──────
+        # Ownership is set ONLY at construction; the soak joiner pins
+        # expected_owner=creator at join, so it anchors to the creator
+        # IMMEDIATELY (no async race, no first-self-claim possible). Both the
+        # creator and the joiner must be "anchored" with owner == creator.
+        owner_creator = store_meta(creator, self.store)
+        owner_writer = store_meta(writer, self.store)
+        owner_exposed = owner_creator["exposed"] and owner_writer["exposed"]
+        binding_ok = True
+        if creator_aid:
+            # Creator created this Signed store ⇒ owner == creator, anchored.
+            binding_ok = binding_ok and owner_creator["owner"] == creator_aid
+            if owner_creator["ownership_status"] is not None:
+                binding_ok = binding_ok and (
+                    owner_creator["ownership_status"] == "anchored")
+        if writer_aid:
+            # Joiner pinned expected_owner=creator ⇒ anchored to creator,
+            # NEVER self-claimed. owner != writer; status "anchored";
+            # owner == creator. A forged OwnerAnnounce cannot flip this.
+            wo, wst = owner_writer["owner"], owner_writer["ownership_status"]
+            binding_ok = binding_ok and wo != writer_aid
+            if wst is not None:
+                binding_ok = binding_ok and wst == "anchored"
+            if wo is not None:
+                binding_ok = binding_ok and wo == creator_aid
+        self.gate("signed_store_owner_binding",
+                  owner_exposed and binding_ok,
+                  {"owner_field_exposed": owner_exposed,
+                   "store_meta_creator": owner_creator,
+                   "store_meta_writer": owner_writer,
+                   "creator_agent_id": creator_aid,
+                   "writer_agent_id": writer_aid,
+                   "binding_ok": binding_ok,
+                   "note": ("hard gate: owner/policy/version/ownership_status "
+                            "exposed; join anchors to creator via "
+                            "expected_owner. Deep forged-OwnerAnnounce "
+                            "injection is the malicious_owner_announce gate")})
         # Propagation to the owner would be a NEW defect (inbound
         # enforcement regression) — hard gate regardless of mode.
         self.gate("signed_store_no_owner_propagation", not propagated,
@@ -651,7 +1660,90 @@ class Run:
         status = self.report["phases"]["signed_store_nonowner_write"]["status"]
         log(f"run {self.idx}: signed_store_nonowner_write {status} "
             f"put={put['status']} local_fork={local_fork} "
-            f"propagated={propagated}")
+            f"propagated={propagated} owner_exposed={owner_exposed}")
+
+    def phase_named_new_port_reconnect(self):
+        """Named-node new-port reconnect gate (P1 proactive reconnect).
+
+        Stop a running peer and restart it on a FORCED DIFFERENT QUIC port
+        (same data_dir ⇒ same MachineId/PeerId), bootstrapping to the still-
+        running creator, with NO manual rejoin. Require:
+          (a) same identity — post-restart PeerId == pre-restart PeerId;
+          (b) transport-path reconnect — the restarted node's ACTUAL
+              connected peer set (per_peer_transport, not the cached
+              identical endpoint — the port changed) includes the creator's
+              PeerId;
+          (c) CRDT recovery — a task created while the peer was down becomes
+              visible on the restarted node WITHOUT an explicit rejoin.
+        """
+        a, creator = self.args, self.creator()
+        victim = self.nodes[-1]
+        creator_pid = node_peer_id(creator)
+        victim_pid_before = node_peer_id(victim)
+        peers_before = sorted(node_connected_peer_ids(victim))
+        old_port = victim.quic_port
+        new_port = a.quic_base + 200 + self.idx  # well clear, per-run
+        with self.phase("named_new_port_reconnect"):
+            log(f"run {self.idx}: stopping {victim.name} for new-port "
+                f"restart")
+            victim.stop()
+            time.sleep(2)
+            # Creator mutates while the peer is DOWN.
+            task = creator.req("POST", f"/task-lists/{self.topic}/tasks",
+                               {"title": "newport-task",
+                                "description": "created while peer down; "
+                                "no manual rejoin"})
+            np_tid = task["body"].get("task_id") if isinstance(
+                task.get("body"), dict) else None
+            # Restart on a FORCED different port, same data_dir (same
+            # MachineId), bootstrapping to the creator only.
+            victim.reconfigure_port(new_port, [creator.quic_port])
+            log(f"run {self.idx}: restarting {victim.name} on new quic "
+                f"port {new_port} (was {old_port})")
+            victim.start()
+            victim.wait_ready()
+            # Wait for transport reconnect to the creator AND CRDT recovery
+            # of the down-window task, with no explicit rejoin.
+            t0 = time.monotonic()
+            reconnected = False
+            recovered = False
+            while time.monotonic() - t0 < a.restart_gate:
+                if creator_pid and creator_pid in \
+                        node_connected_peer_ids(victim):
+                    reconnected = True
+                if np_tid and task_visible(victim, self.topic, np_tid):
+                    recovered = True
+                if reconnected and recovered:
+                    break
+                time.sleep(a.poll_interval)
+        # Read post-restart PeerId FRESH (node_peer_id caches); this verifies
+        # the daemon actually reports the same identity on the new port.
+        victim_pid_after = (connectivity_snapshot(victim) or {}).get("peer_id")
+        peers_after = sorted(node_connected_peer_ids(victim))
+        same_identity = (bool(victim_pid_before) and bool(victim_pid_after)
+                         and victim_pid_before == victim_pid_after)
+        observed = {
+            "node": victim.name,
+            "creator_peer_id": creator_pid,
+            "victim_peer_id_before": victim_pid_before,
+            "victim_peer_id_after": victim_pid_after,
+            "same_identity": same_identity,
+            "old_quic_port": old_port,
+            "new_quic_port": new_port,
+            "connected_peers_before": peers_before,
+            "connected_peers_after": peers_after,
+            "reconnected_to_creator": reconnected,
+            "down_window_task_id": np_tid,
+            "crdt_recovered_without_rejoin": recovered,
+            "gate_secs": a.restart_gate,
+        }
+        fixed = same_identity and reconnected and recovered
+        self.known_gap_gate("named_new_port_reconnect",
+                            "named_new_port_reconnect", fixed=fixed,
+                            observed=observed)
+        log(f"run {self.idx}: named_new_port_reconnect "
+            f"{'fixed' if fixed else 'gap'} same_id={same_identity} "
+            f"reconnected={reconnected} recovered={recovered}")
 
     # -- driver ------------------------------------------------------------
 
@@ -663,6 +1755,7 @@ class Run:
             self.phase_restart_recovery()
             self.phase_concurrent_claims()
             self.phase_signed_store_nonowner()
+            self.phase_named_new_port_reconnect()
         finally:
             for n in self.nodes:
                 try:
@@ -674,6 +1767,701 @@ class Run:
         self.report["known_gaps"] = self.known_gaps
         self.report["pass"] = not self.hard_failures
         return self.report
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Prerequisite-gated security/skew gates
+# ──────────────────────────────────────────────────────────────────────────
+#
+# These gates cover threats the single-version same-host soak CANNOT: real
+# protocol version skew (needs a legacy binary) and forged OwnerAnnounce
+# injection (needs a gossip-level harness, not a REST backdoor). Each runs for
+# real when its prerequisite binary is supplied, otherwise it reports
+# UNSUPPORTED with the exact missing prerequisite — never silently skipped and
+# never faked by degrading the current binary.
+
+def _spawn_isolated_node(name, api_port, quic_port, root_dir, x0xd,
+                        log_level, bootstrap_quic_ports):
+    """Build, configure, and start a single isolated node, returning it once
+    /health is up and the api token is written. Used by the prerequisite
+    gates which need bespoke topologies/binaries outside the soak Run."""
+    node = Node(name, api_port, quic_port, root_dir, x0xd, log_level)
+    node.write_config(bootstrap_quic_ports)
+    log(f"starting {name} (api={api_port}, quic={quic_port}, "
+        f"binary={x0xd})")
+    node.start()
+    node.wait_ready()
+    return node
+
+
+def run_mixed_version_gate(args, out_dir):
+    """Mixed-version (current + legacy v0.30.1) interop gate — BOTH directions.
+
+    LOAD-BEARING (legacy v0.30.1 owner + current anchored joiner): the real
+    legacy owner creates+writes; the current joiner pins expected_owner and
+    must recover historical + live values. This is the convergence-with-anchor
+    case — the load-bearing direction for ownership/version skew.
+    DEGRADED (current owner + legacy joiner): OwnerAnnounce-additive / safe
+    interop characterization.
+
+    Both need a REAL legacy binary (X0XD_LEGACY_BINARY); the skew is NEVER
+    faked by degrading the current binary. --expect-fixed requires BOTH.
+    Returns a list of two gate dicts.
+    """
+    legacy = args.legacy_binary
+    if not legacy or not pathlib.Path(legacy).is_file():
+        note = UNSUPPORTED_PREREQ_NOTES["mixed_version_skew"]
+        lb = {"name": "mixed_version_skew_load_bearing",
+              "status": "unsupported", "unsupported": note,
+              "legacy_binary": str(legacy) if legacy else None}
+        dg = {"name": "mixed_version_skew_degraded",
+              "status": "unsupported", "unsupported": note,
+              "legacy_binary": str(legacy) if legacy else None}
+        log("mixed_version_skew: UNSUPPORTED (both directions) — set "
+            "X0XD_LEGACY_BINARY (or --legacy-binary) to a v0.30.1 x0xd")
+        return [lb, dg]
+    legacy = pathlib.Path(legacy)
+    # File existence is NOT authentication: the legacy binary must be EXACTLY
+    # v0.30.1. A wrong-version "legacy" is a hard FAIL of both directions —
+    # not UNSUPPORTED (the prerequisite was supplied, just wrong), and never a
+    # silent green. The release-oracle provenance check enforces the same.
+    lver = parse_version(binary_version(legacy))
+    if lver != LEGACY_REQUIRED_VERSION:
+        err = (f"legacy binary is v{lver}, must be exactly "
+               f"v{LEGACY_REQUIRED_VERSION}; file existence alone is not "
+               f"authentication — supply an authenticated v0.30.1 x0xd")
+        log(f"mixed_version_skew: FAIL — {err}")
+        return [
+            {"name": "mixed_version_skew_load_bearing", "status": "fail",
+             "error": err, "legacy_version": lver,
+             "legacy_binary": str(legacy)},
+            {"name": "mixed_version_skew_degraded", "status": "fail",
+             "error": err, "legacy_version": lver,
+             "legacy_binary": str(legacy)},
+        ]
+    return [_mixed_version_load_bearing(args, out_dir, legacy),
+            _mixed_version_degraded(args, out_dir, legacy)]
+
+
+def _mixed_version_load_bearing(args, out_dir, legacy):
+    """LOAD-BEARING direction: legacy v0.30.1 owner + current anchored joiner
+    (ONLINE-owner convergence across version skew).
+
+    The legacy owner (ONLINE) creates the Signed store and writes a historical
+    key; the current-binary joiner pins expected_owner=<legacy owner AgentId>
+    at join and MUST recover both the historical key and a live key the owner
+    writes after join. The historical key recovers via the owner's republished
+    full_delta, whose sender-auth passes BECAUSE the owner is the sender — so
+    this proves online-owner convergence-with-anchor across skew (blueprint §6
+    row-1), NOT offline-owner relay recovery.
+
+    Scope (do NOT over-claim): offline-owner relay recovery (owner DOWN, a
+    replica relays a cached owner-signed checkpoint) is NOT exercised here —
+    it is store-layer-only (checkpoint T11) and defended by content-root
+    verification (a relayed value whose recomputed root != the owner-signed
+    checkpoint is rejected). The impossible no-anchor-against-v0.30.1-owner
+    case (§6 row-2 / T3) is likewise NOT asserted here — covered at the
+    store/unit layer and documented as impossible; the harness does not
+    fake-cover either.
+    """
+    gate = {"name": "mixed_version_skew_load_bearing"}
+    mv_dir = out_dir / "mv-load-bearing"
+    mv_dir.mkdir(parents=True, exist_ok=True)
+    store = f"x0x-convergence-mv-lb-{int(time.time())}"
+    nodes = []
+    try:
+        # Legacy binary = OWNER/creator; current binary = anchored joiner.
+        owner = _spawn_isolated_node(
+            "mv-lb-owner", args.api_base + 10, args.quic_base + 10,
+            mv_dir, legacy, args.log_level, [])
+        nodes.append(owner)
+        time.sleep(args.stagger_secs)
+        joiner = _spawn_isolated_node(
+            "mv-lb-joiner", args.api_base + 11, args.quic_base + 11,
+            mv_dir, args.x0xd, args.log_level, [args.quic_base + 10])
+        nodes.append(joiner)
+
+        # Legacy owner creates the store and writes a HISTORICAL key.
+        owner.req("POST", "/stores",
+                  {"name": "mv lb manifests", "topic": store})
+        owner.req("PUT", f"/stores/{store}/historical",
+                  {"value": b64("owner-historical"),
+                   "content_type": "text/plain"})
+        owner_aid = node_agent_id(owner)  # v0.30.1 /agent shape
+        # Current joiner pins expected_owner = legacy owner; must anchor.
+        joiner.req("POST", f"/stores/{store}/join",
+                   ({"expected_owner": owner_aid} if owner_aid else {}))
+        # Historical recovery: joiner recovers the pre-join key with EXACT
+        # decoded bytes (presence alone is not convergence).
+        hist = sample_until(
+            {"key": lambda: key_value_matches(
+                joiner, store, "historical", "owner-historical")},
+            gate_secs=args.cold_gate, interval=args.poll_interval)
+        hist_hash = key_content_hash(joiner, store, "historical")
+        # Live recovery: owner writes AFTER join; joiner must see it too,
+        # again with EXACT decoded bytes + owner-signed content_hash.
+        owner.req("PUT", f"/stores/{store}/live",
+                  {"value": b64("owner-live"),
+                   "content_type": "text/plain"})
+        live = sample_until(
+            {"key": lambda: key_value_matches(
+                joiner, store, "live", "owner-live")},
+            gate_secs=args.live_gate, interval=args.poll_interval)
+        live_hash = key_content_hash(joiner, store, "live")
+        jm = store_meta(joiner, store)
+        anchored = (jm["ownership_status"] == "anchored"
+                    and (owner_aid is None or jm["owner"] == owner_aid))
+        owner_alive = (owner.running
+                       and owner.req("GET", "/health")["status"] == 200)
+        gate.update({
+            "status": ("pass" if hist["key"] is not None
+                       and live["key"] is not None and anchored and owner_alive
+                       else "fail"),
+            "historical_content_hash": hist_hash,
+            "live_content_hash": live_hash,
+            "store": store,
+            "owner_agent_id": owner_aid,
+            "historical_recovery_secs": hist["key"],
+            "live_recovery_secs": live["key"],
+            "joiner_anchored": anchored,
+            "joiner_store_meta": jm,
+            "legacy_owner_alive": owner_alive,
+            "owner_binary": str(legacy),
+            "joiner_binary": str(args.x0xd),
+            "scope": ("online_owner_convergence_across_skew; historical "
+                      "key recovers via owner-republished full_delta "
+                      "(sender-auth: owner IS sender). offline-owner relay "
+                      "recovery is store-layer (checkpoint T11) + "
+                      "content_root verification, NOT daemon-gated"),
+        })
+        log(f"mixed_version_skew_load_bearing: {gate['status']} "
+            f"hist={hist['key']}s live={live['key']}s anchored={anchored}")
+    except Exception as e:
+        gate["status"] = "fail"
+        gate["error"] = f"{type(e).__name__}: {e}"
+        log(f"mixed_version_skew_load_bearing: EXCEPTION {e}")
+    finally:
+        for n in nodes:
+            try:
+                n.stop()
+            except Exception:
+                pass
+    return gate
+
+
+def _mixed_version_degraded(args, out_dir, legacy):
+    """DEGRADED direction: current owner + legacy v0.30.1 joiner.
+
+    Characterization coverage (less load-bearing): OwnerAnnounce is ADDITIVE —
+    the legacy joiner that cannot decode the new variant skips it without
+    crashing — and the owner's key replicates. The legacy version predates
+    expected_owner, so its join sends no anchor; we record the observed PUT
+    status rather than asserting a specific code.
+    """
+    gate = {"name": "mixed_version_skew_degraded"}
+    mv_dir = out_dir / "mv-degraded"
+    mv_dir.mkdir(parents=True, exist_ok=True)
+    store = f"x0x-convergence-mv-dg-{int(time.time())}"
+    nodes = []
+    try:
+        # Current binary = owner/creator; legacy binary = joiner.
+        owner = _spawn_isolated_node(
+            "mv-dg-owner", args.api_base + 12, args.quic_base + 12,
+            mv_dir, args.x0xd, args.log_level, [])
+        nodes.append(owner)
+        time.sleep(args.stagger_secs)
+        joiner = _spawn_isolated_node(
+            "mv-dg-joiner", args.api_base + 13, args.quic_base + 13,
+            mv_dir, legacy, args.log_level, [args.quic_base + 12])
+        nodes.append(joiner)
+
+        owner.req("POST", "/stores",
+                  {"name": "mv dg manifests", "topic": store})
+        owner.req("PUT", f"/stores/{store}/owned",
+                  {"value": b64("owner-value"),
+                   "content_type": "text/plain"})
+        joiner.req("POST", f"/stores/{store}/join")
+        arrivals = sample_until(
+            {"key": lambda: key_value_matches(
+                joiner, store, "owned", "owner-value")},
+            gate_secs=args.cold_gate, interval=args.poll_interval)
+        owned_hash = key_content_hash(joiner, store, "owned")
+        legacy_alive = (joiner.running
+                        and joiner.req("GET", "/health")["status"] == 200)
+        # The legacy joiner (non-owner; it predates expected_owner) attempts a
+        # write. Safe DEGRADED interop means this NON-OWNER write must NOT
+        # propagate to the current owner — inbound enforcement holds even
+        # against a legacy peer. PASS requires NO unauthorized propagation.
+        jput = joiner.req("PUT", f"/stores/{store}/from-legacy",
+                          {"value": b64("legacy-write"),
+                           "content_type": "text/plain"})
+        jlocal = joiner.req("GET", f"/stores/{store}/from-legacy")
+        propagated = False
+        deadline = time.monotonic() + args.fork_window
+        while time.monotonic() < deadline:
+            if key_value_matches(owner, store, "from-legacy",
+                                 "legacy-write"):
+                propagated = True
+                break
+            time.sleep(args.poll_interval)
+        # Owner state must stay EXACT: it keeps its own key (exact bytes) and
+        # never acquires the legacy non-owner write.
+        owner_kept_owned = key_value_matches(owner, store, "owned",
+                                             "owner-value")
+        owner_clean = not key_value_bytes(owner, store, "from-legacy")
+        gate.update({
+            "status": ("pass" if arrivals["key"] is not None and legacy_alive
+                       and not propagated and owner_kept_owned and owner_clean
+                       else "fail"),
+            "store": store,
+            "interop_key_secs": arrivals["key"],
+            "owned_content_hash": owned_hash,
+            "legacy_joiner_alive": legacy_alive,
+            "legacy_joiner_put_status": jput["status"],
+            "legacy_local_fork": jlocal["status"] == 200,
+            "legacy_write_propagated_to_owner": propagated,
+            "owner_kept_owned_exact": owner_kept_owned,
+            "owner_clean_of_legacy_write": owner_clean,
+            "owner_binary": str(args.x0xd),
+            "legacy_binary": str(legacy),
+            "scope": ("degraded interop: owner's key replicates to the legacy "
+                      "joiner with EXACT bytes; the legacy non-owner write "
+                      "must NOT propagate to the owner (no unauthorized "
+                      "propagation) and owner state stays exact"),
+        })
+        log(f"mixed_version_skew_degraded: {gate['status']} "
+            f"interop={arrivals['key']}s legacy_alive={legacy_alive} "
+            f"propagated={propagated}")
+    except Exception as e:
+        gate["status"] = "fail"
+        gate["error"] = f"{type(e).__name__}: {e}"
+        log(f"mixed_version_skew_degraded: EXCEPTION {e}")
+    finally:
+        for n in nodes:
+            try:
+                n.stop()
+            except Exception:
+                pass
+    return gate
+
+
+def run_malicious_owner_announce_gate(args, out_dir):
+    """Hostile OwnerAnnounce injection gate (in-repo, no external binary).
+
+    A rogue daemon self-claims ownership of the SAME store topic: creating the
+    store locally makes it the owner of its own replica (store_id =
+    for_topic_owner(topic, rogue)), so its background sync loop publishes a
+    GENUINE OwnerAnnounce{owner: rogue} on the shared <topic>/state-sync side
+    channel in response to the joiner's StateRequest — signed by the rogue, so
+    sender == claimed owner and it passes the pub/sub sender check. It races
+    this self-claim against the legitimate owner.
+
+    The anchored joiner (joined with expected_owner=legit) MUST stay bound to
+    the legit owner and NEVER flip to the rogue: ownership is set only at
+    construction, so learn_ownership() rejects the conflicting announce. The
+    rogue's deltas are also rejected (different store_id). This is driven
+    ENTIRELY via public REST create/join APIs — no fake write-path backdoor,
+    no crate-private injection, no bincode crafting.
+    """
+    gate = {"name": "malicious_owner_announce"}
+    mv_dir = out_dir / "malicious-announce"
+    mv_dir.mkdir(parents=True, exist_ok=True)
+    store = f"x0x-convergence-mal-{int(time.time())}"
+    nodes = []
+    try:
+        legit = _spawn_isolated_node(
+            "mal-legit", args.api_base + 20, args.quic_base + 20,
+            mv_dir, args.x0xd, args.log_level, [])
+        nodes.append(legit)
+        time.sleep(args.stagger_secs)
+        # Rogue bootstraps to legit and is started BEFORE the joiner so its
+        # sync loop is registered and ready to race its self-claim.
+        rogue = _spawn_isolated_node(
+            "mal-rogue", args.api_base + 21, args.quic_base + 21,
+            mv_dir, args.x0xd, args.log_level, [args.quic_base + 20])
+        nodes.append(rogue)
+
+        legit_aid = node_agent_id(legit)
+        rogue_aid = node_agent_id(rogue)
+        # Legit owner creates the store and writes a key.
+        legit.req("POST", "/stores", {"name": "mal legit", "topic": store})
+        legit.req("PUT", f"/stores/{store}/legit-key",
+                  {"value": b64("legit-value"),
+                   "content_type": "text/plain"})
+        # Rogue SELF-CLAIMS the same topic: creating it locally makes the
+        # rogue the owner of its replica, so its sync loop will publish a
+        # genuine OwnerAnnounce{owner: rogue} on <store>/state-sync.
+        rogue.req("POST", "/stores", {"name": "mal rogue", "topic": store})
+        rogue.req("PUT", f"/stores/{store}/rogue-key",
+                  {"value": b64("rogue-value"),
+                   "content_type": "text/plain"})
+        time.sleep(args.stagger_secs)
+        # Joiner anchors to the legit owner (expected_owner).
+        joiner = _spawn_isolated_node(
+            "mal-joiner", args.api_base + 22, args.quic_base + 22,
+            mv_dir, args.x0xd, args.log_level, [args.quic_base + 20])
+        nodes.append(joiner)
+        joiner.req("POST", f"/stores/{store}/join",
+                   ({"expected_owner": legit_aid} if legit_aid else {}))
+        # Wait for convergence: the joiner recovers the legit key with EXACT
+        # decoded bytes (legit delta merges; same store_id).
+        arrivals = sample_until(
+            {"legit_key": lambda: key_value_matches(
+                joiner, store, "legit-key", "legit-value")},
+            gate_secs=args.cold_gate, interval=args.poll_interval)
+        # POSITIVE ATTACK RECEIPT: poll for the conflict the rogue
+        # OwnerAnnounce{owner:rogue} produces against the legit anchor. PASS
+        # must PROVE the rogue identity was seen and rejected — not merely
+        # that the joiner stayed anchored (anchored-alone permits the false
+        # positive where the rogue announce never arrived).
+        conflict_observed = False
+        deadline = time.monotonic() + args.fork_window
+        while time.monotonic() < deadline:
+            jmc = store_meta(joiner, store)
+            if jmc["ownership_status"] == "conflict" and \
+                    (legit_aid is None or jmc["owner"] == legit_aid):
+                conflict_observed = True
+                break
+            time.sleep(args.poll_interval)
+        jm = store_meta(joiner, store)
+        # Stable legit owner: the anchor holds across the attack — owner is
+        # legit, NEVER the rogue.
+        owner_stable = (
+            (legit_aid is None or jm["owner"] == legit_aid)
+            and (rogue_aid is None or jm["owner"] != rogue_aid))
+        # The rogue's key (different store_id) must never appear on the
+        # joiner — exact bytes, not mere presence.
+        rogue_key_leaked = key_value_matches(joiner, store, "rogue-key",
+                                             "rogue-value")
+        # POST-ATTACK legit write: after the attack the legit owner can still
+        # write and the joiner recovers it — proving the anchor is not wedged
+        # by the rejected conflict.
+        legit.req("PUT", f"/stores/{store}/post-attack",
+                  {"value": b64("legit-after-attack"),
+                   "content_type": "text/plain"})
+        post_attack = sample_until(
+            {"key": lambda: key_value_matches(
+                joiner, store, "post-attack", "legit-after-attack")},
+            gate_secs=args.live_gate, interval=args.poll_interval)
+        post_attack_recovered = post_attack["key"] is not None
+        gate.update({
+            "status": ("pass" if conflict_observed and owner_stable
+                       and not rogue_key_leaked
+                       and arrivals["legit_key"] is not None
+                       and post_attack_recovered else "fail"),
+            "store": store,
+            "legit_agent_id": legit_aid,
+            "rogue_agent_id": rogue_aid,
+            "joiner_store_meta": jm,
+            "conflict_with_rogue_observed": conflict_observed,
+            "owner_stable_to_legit": owner_stable,
+            "legit_key_recovery_secs": arrivals["legit_key"],
+            "rogue_key_leaked_to_joiner": rogue_key_leaked,
+            "post_attack_key_recovery_secs": post_attack["key"],
+            "note": ("rogue self-claimed the same topic; its sync loop "
+                     "published a genuine OwnerAnnounce{owner:rogue}; PASS "
+                     "requires a POSITIVE conflict with the rogue identity, "
+                     "a stable legit owner, NO rogue content, and a legit "
+                     "post-attack write the joiner recovers"),
+        })
+        log(f"malicious_owner_announce: {gate['status']} "
+            f"conflict={conflict_observed} owner_stable={owner_stable} "
+            f"legit_key={arrivals['legit_key']}s "
+            f"rogue_leaked={rogue_key_leaked} "
+            f"post_attack={post_attack['key']}s")
+    except Exception as e:
+        gate["status"] = "fail"
+        gate["error"] = f"{type(e).__name__}: {e}"
+        log(f"malicious_owner_announce: EXCEPTION {e}")
+    finally:
+        for n in nodes:
+            try:
+                n.stop()
+            except Exception:
+                pass
+    return gate
+
+
+def run_forged_first_seen_gate(args, out_dir):
+    """First-seen forged/unattested TaskItem admission gate (in-repo injector).
+
+    A hostile gossip publisher ships a first-seen TaskItem carrying a
+    Claimed/Done element with NO matching attestation (or a malformed/
+    attacker-key/wrong-agent/wrong-scope attestation) over the live task-list
+    sync path (topic → decode_delta::<TaskListDelta> → merge_delta → admit()).
+    The fail-closed admission routine MUST purge it, leaving
+    current_state()==Empty: the forged task never appears, the list
+    version/fence does not churn, and a legitimate post-attack claim still
+    resolves. Driven by the in-repo `x0xd-forge-injector` binary (built by
+    `just convergence-release`), which crafts the unattested delta and
+    publishes it over REAL gossip via the daemon's /publish wire API — never
+    faked via REST. A missing injector is a hard setup failure (the recipe
+    builds it); UNSUPPORTED without it, FAIL under --expect-fixed.
+    """
+    gate = {"name": "forged_first_seen_task"}
+    inj = getattr(args, "forge_injector", None)
+    if not inj or not pathlib.Path(inj).is_file():
+        note = UNSUPPORTED_PREREQ_NOTES["forged_first_seen_task"]
+        log("forged_first_seen_task: UNSUPPORTED — in-repo injector absent "
+            f"at {inj}; build `cargo build --release --bin x0xd-forge-injector` "
+            "(the release recipe provisions it)")
+        gate.update({"status": "unsupported", "unsupported": note,
+                     "injector": str(inj) if inj else None})
+        return gate
+    inj = pathlib.Path(inj)
+    fg_dir = out_dir / "forged-first-seen"
+    fg_dir.mkdir(parents=True, exist_ok=True)
+    topic = f"x0x.convergence.forged.{int(time.time())}"
+    nodes = []
+
+    def list_ids(node):
+        r = node.req("GET", f"/task-lists/{topic}/tasks")
+        if r["status"] != 200 or not isinstance(r["body"], dict):
+            return set()
+        return {t.get("id") for t in r["body"].get("tasks", [])
+                if isinstance(t, dict)}
+
+    try:
+        creator = _spawn_isolated_node(
+            "forged-creator", args.api_base + 40, args.quic_base + 40,
+            fg_dir, args.x0xd, args.log_level, [])
+        nodes.append(creator)
+        time.sleep(args.stagger_secs)
+        receiver = _spawn_isolated_node(
+            "forged-receiver", args.api_base + 41, args.quic_base + 41,
+            fg_dir, args.x0xd, args.log_level, [args.quic_base + 40])
+        nodes.append(receiver)
+        creator.req("POST", "/task-lists",
+                    {"name": "forged admission", "topic": topic})
+        legit = creator.req("POST", f"/task-lists/{topic}/tasks",
+                            {"title": "legit-baseline",
+                             "description": "must survive the forged delta"})
+        legit_tid = legit["body"].get("task_id") if isinstance(
+            legit.get("body"), dict) else None
+        # Baseline convergence; snapshot receiver list state BEFORE attack.
+        sample_until({"t": lambda: task_visible(receiver, topic, legit_tid)},
+                     gate_secs=args.cold_gate, interval=args.poll_interval)
+        ids_before = list_ids(receiver)
+        ver_before = task_list_version(receiver, topic)
+        fence_before = task_list_fence(receiver, topic)
+        # Hostile injection: publish an unattested first-seen TaskItem over
+        # real gossip via the daemon's /publish wire API.
+        cmd = [str(inj), "--daemon", creator.base, "--token", creator.token,
+               "--topic", topic, "--variant", "missing_att"]
+        log(f"forged_first_seen_task: injector {cmd}")
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=60)
+        published = False
+        try:
+            outj = json.loads(proc.stdout) if proc.stdout.strip() else {}
+            published = bool(outj.get("published"))
+        except ValueError:
+            outj = {"raw": proc.stdout}
+        # Let the forged delta propagate. The security property is NO CLAIM
+        # HIJACK: the forged Claimed{victim,ts:1} must NOT make any task
+        # claimed-by the victim. admit() may either reject the whole forged
+        # task (absent) OR purge the element leaving an Empty task — both are
+        # acceptable; the FORBIDDEN outcome is claimed_by == victim.
+        forged_tid = outj.get("forged_task_id") if isinstance(outj, dict) else None
+        victim_hex = outj.get("victim_agent") if isinstance(outj, dict) else None
+        time.sleep(args.fork_window)
+        ft = get_task(receiver, topic, forged_tid) if forged_tid else None
+        ft_claimed_by = claimed_by_of(ft) if ft else None
+        claim_hijacked = (ft is not None and victim_hex is not None
+                          and ft_claimed_by == victim_hex)
+        # Forged task absent, OR present but unclaimed (Empty — element purged).
+        forged_absent_or_empty = (ft is None or ft_claimed_by is None)
+        ver_after = task_list_version(receiver, topic)
+        fence_after = task_list_fence(receiver, topic)
+        # Legit post-attack claim must still resolve (admission not wedged).
+        claim = creator.req("PATCH", f"/task-lists/{topic}/tasks/{legit_tid}",
+                            {"action": "claim",
+                             "fence_token": task_list_fence(creator, topic)})
+        claim_resolved = sample_until(
+            {"c": lambda: claimed_by_of(
+                get_task(receiver, topic, legit_tid)) is not None},
+            gate_secs=args.live_gate, interval=args.poll_interval)["c"] \
+            is not None
+        gate.update({
+            "status": ("pass" if published and not claim_hijacked
+                       and forged_absent_or_empty and claim_resolved
+                       else "fail"),
+            "store": topic,
+            "injector": str(inj),
+            "injector_sha256": sha256_file(inj),
+            "injector_version": binary_version(inj),
+            "injector_rc": proc.returncode,
+            "injector_output": outj,
+            "forged_task_id": forged_tid,
+            "victim_agent": victim_hex,
+            "forged_task_on_receiver": ft is not None,
+            "forged_task_claimed_by": ft_claimed_by,
+            "claim_hijacked": claim_hijacked,
+            "forged_absent_or_empty": forged_absent_or_empty,
+            "version_before": ver_before, "version_after": ver_after,
+            "fence_before": fence_before, "fence_after": fence_after,
+            "post_attack_claim_status": claim["status"],
+            "post_attack_claim_resolved": claim_resolved,
+            "scope": ("hostile injector published an unattested first-seen "
+                     "TaskItem over real gossip; admit() must purge the forged "
+                     "Claimed element so no task is claimed-by the victim "
+                     "(task absent OR Empty) and a legit post-attack claim "
+                     "still resolves"),
+        })
+        log(f"forged_first_seen_task: {gate['status']} "
+            f"published={published} hijacked={claim_hijacked} "
+            f"absent_or_empty={forged_absent_or_empty} "
+            f"claim_resolved={claim_resolved}")
+    except Exception as e:
+        gate["status"] = "fail"
+        gate["error"] = f"{type(e).__name__}: {e}"
+        log(f"forged_first_seen_task: EXCEPTION {e}")
+    finally:
+        for n in nodes:
+            try:
+                n.stop()
+            except Exception:
+                pass
+    return gate
+
+
+def run_owner_offline_checkpoint_gate(args, out_dir):
+    """Owner-offline checkpoint recovery + delete/tamper-integrity gate (P0).
+
+    Exercises the checkpoint-recovery contract end to end via REST:
+      1. owner multi-writes k1, k2; the anchored relay matches EXACT bytes;
+      2. owner updates k1; relay matches the EXACT new bytes (k2 unchanged);
+      3. owner deletes k2; relay drops it (delete recovery — replicas must
+         NOT retain deleted keys);
+      4. owner deletes k1 → EMPTY; relay shows both absent (the empty-
+         checkpoint early-return defect);
+      5. owner writes a final key; relay matches exact;
+      6. owner STOPPED; a fresh anchored joiner bootstraps ONLY to the relay
+         (not the owner) and recovers the EXACT final state — final key
+         exact, k1/k2 ABSENT (no resurrection). Owner-offline relay recovery
+         with content integrity.
+    All current-binary. FAIL ⇒ run fails (P0).
+    """
+    gate = {"name": "owner_offline_checkpoint_recovery"}
+    cp_dir = out_dir / "checkpoint-recovery"
+    cp_dir.mkdir(parents=True, exist_ok=True)
+    store = f"x0x-convergence-cp-{int(time.time())}"
+    nodes = []
+    try:
+        owner = _spawn_isolated_node(
+            "cp-owner", args.api_base + 30, args.quic_base + 30,
+            cp_dir, args.x0xd, args.log_level, [])
+        nodes.append(owner)
+        time.sleep(args.stagger_secs)
+        relay = _spawn_isolated_node(
+            "cp-relay", args.api_base + 31, args.quic_base + 31,
+            cp_dir, args.x0xd, args.log_level, [args.quic_base + 30])
+        nodes.append(relay)
+        owner_aid = node_agent_id(owner)
+        owner.req("POST", "/stores",
+                  {"name": "cp manifests", "topic": store})
+        relay.req("POST", f"/stores/{store}/join",
+                  ({"expected_owner": owner_aid} if owner_aid else {}))
+
+        def owner_put(key, plain):
+            owner.req("PUT", f"/stores/{store}/{key}",
+                      {"value": b64(plain), "content_type": "text/plain"})
+
+        def relay_exact(key, plain):
+            return sample_until(
+                {"k": lambda k=key, p=plain: key_value_matches(
+                    relay, store, k, p)},
+                gate_secs=args.cold_gate, interval=args.poll_interval)["k"]
+
+        # 1. multi-write
+        owner_put("k1", "alpha")
+        owner_put("k2", "beta")
+        m1 = relay_exact("k1", "alpha")
+        m2 = relay_exact("k2", "beta")
+        # 2. update k1 (mutate value); k2 must stay exact
+        owner_put("k1", "alpha-2")
+        m3 = relay_exact("k1", "alpha-2")
+        k2_still = key_value_matches(relay, store, "k2", "beta")
+        # 3. delete k2; relay must drop it (delete recovery). Wait for the
+        # delete delta to propagate — settling on k1 would NOT detect the
+        # removal (k1 is unchanged by deleting k2).
+        owner.req("DELETE", f"/stores/{store}/k2")
+        k2_gone = False
+        deadline = time.monotonic() + args.cold_gate
+        while time.monotonic() < deadline:
+            if key_value_bytes(relay, store, "k2") is None:
+                k2_gone = True
+                break
+            time.sleep(args.poll_interval)
+        # 4. delete k1 → empty (empty-checkpoint early-return case)
+        owner.req("DELETE", f"/stores/{store}/k1")
+        deadline = time.monotonic() + args.fork_window
+        empty_ok = False
+        while time.monotonic() < deadline:
+            if key_value_bytes(relay, store, "k1") is None and \
+                    key_value_bytes(relay, store, "k2") is None:
+                empty_ok = True
+                break
+            time.sleep(args.poll_interval)
+        # 5. final key
+        owner_put("k_final", "final")
+        mf = relay_exact("k_final", "final")
+        final_hash = key_content_hash(relay, store, "k_final")
+        # 6. owner OFFLINE; fresh anchored joiner via RELAY only
+        owner.stop()
+        time.sleep(2)
+        joiner = _spawn_isolated_node(
+            "cp-joiner", args.api_base + 32, args.quic_base + 32,
+            cp_dir, args.x0xd, args.log_level, [args.quic_base + 31])
+        nodes.append(joiner)
+        joiner.req("POST", f"/stores/{store}/join",
+                   ({"expected_owner": owner_aid} if owner_aid else {}))
+        jf = sample_until(
+            {"k": lambda: key_value_matches(
+                joiner, store, "k_final", "final")},
+            gate_secs=args.cold_gate, interval=args.poll_interval)["k"]
+        time.sleep(args.fork_window)  # window for any resurrection to show
+        j_final_exact = key_value_matches(joiner, store, "k_final", "final")
+        j_k1_absent = key_value_bytes(joiner, store, "k1") is None
+        j_k2_absent = key_value_bytes(joiner, store, "k2") is None
+        gate.update({
+            "status": ("pass" if all([
+                m1 is not None, m2 is not None, m3 is not None, k2_still,
+                k2_gone, empty_ok, mf is not None, jf is not None,
+                j_final_exact, j_k1_absent, j_k2_absent]) else "fail"),
+            "store": store,
+            "owner_agent_id": owner_aid,
+            "multi_write_k1_secs": m1, "multi_write_k2_secs": m2,
+            "update_k1_secs": m3, "k2_still_after_update": k2_still,
+            "delete_k2_propagated": k2_gone,
+            "delete_to_empty_propagated": empty_ok,
+            "final_key_secs": mf, "final_content_hash": final_hash,
+            "owner_offline_joiner_final_secs": jf,
+            "joiner_final_exact": j_final_exact,
+            "joiner_k1_absent_no_resurrection": j_k1_absent,
+            "joiner_k2_absent_no_resurrection": j_k2_absent,
+            "owner_binary": str(args.x0xd),
+            "scope": ("multi-write + update + delete + delete-to-empty with "
+                      "exact-byte replica match each step; owner OFFLINE, "
+                      "fresh anchored joiner via relay-only recovers exact "
+                      "final state with no key resurrection"),
+        })
+        log(f"owner_offline_checkpoint_recovery: {gate['status']} "
+            f"multi={m1}/{m2}s update={m3}s del_k2={k2_gone} "
+            f"empty={empty_ok} offline_joiner={jf}s "
+            f"final_exact={j_final_exact} "
+            f"no_resurrect={j_k1_absent and j_k2_absent}")
+    except Exception as e:
+        gate["status"] = "fail"
+        gate["error"] = f"{type(e).__name__}: {e}"
+        log(f"owner_offline_checkpoint_recovery: EXCEPTION {e}")
+    finally:
+        for n in nodes:
+            try:
+                n.stop()
+            except Exception:
+                pass
+    return gate
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -726,7 +2514,8 @@ def pctl(sorted_vals, q):
     return sorted_vals[k]
 
 
-def summarize(runs, args):
+def summarize(runs, args, prereq_gates=None, provenance=None,
+              release_env=None):
     lines = []
     total = len(runs)
     passed = sum(1 for r in runs if r["pass"])
@@ -738,16 +2527,16 @@ def summarize(runs, args):
     lines.append("=" * 72)
     lines.append(f"runs passed: {passed}/{total}")
 
-    # Gate pass rates
+    # Gate pass rates (pass / known-gap / unsupported / fail)
     lines.append("")
-    lines.append(f"{'phase':<42}{'pass':>6}{'gap':>6}{'fail':>6}")
+    lines.append(f"{'phase':<42}{'pass':>6}{'gap':>6}{'unsupp':>8}{'fail':>6}")
     phase_names = []
     for r in runs:
         for name in r["phases"]:
             if name not in phase_names:
                 phase_names.append(name)
     for name in phase_names:
-        n_pass = n_gap = n_fail = 0
+        n_pass = n_gap = n_unsupp = n_fail = 0
         for r in runs:
             e = r["phases"].get(name)
             if e is None:
@@ -755,11 +2544,14 @@ def summarize(runs, args):
             status = e.get("status")
             if status == "known-gap":
                 n_gap += 1
+            elif status == "unsupported":
+                n_unsupp += 1
             elif e.get("pass"):
                 n_pass += 1
             else:
                 n_fail += 1
-        lines.append(f"{name:<42}{n_pass:>6}{n_gap:>6}{n_fail:>6}")
+        lines.append(
+            f"{name:<42}{n_pass:>6}{n_gap:>6}{n_unsupp:>8}{n_fail:>6}")
 
     # Latency table
     series = latency_series(runs)
@@ -801,9 +2593,92 @@ def summarize(runs, args):
                      "gate on them):")
         for name, note in gaps.items():
             lines.append(f"  - {name}: {note}")
+    # Same-host topology (one run is representative): who-is-who for
+    # claim-winner / store-owner attribution.
+    topo = next((r.get("topology") for r in runs
+                 if r.get("topology")), {})
+    if topo:
+        lines.append("")
+        lines.append("same-host topology (agent_id[:8] / peer_id[:8]):")
+        for name, t in topo.items():
+            aid = (t.get("agent_id") or "?")[:8]
+            pid = (t.get("peer_id") or "?")[:8]
+            sib = ",".join((s.get("peer_id") or "?")[:8]
+                           for s in (t.get("bootstrap_siblings") or [])) or "-"
+            lines.append(f"  {name:<8} agent={aid} peer={pid} "
+                         f"quic={t.get('quic_addr')} siblings={sib}")
+        # mDNS mesh contamination (environmental): non-zero discovered_peers
+        # on an isolated cluster ⇒ stray x0xd daemons on the host.
+        mc = next((r.get("mesh_contamination") for r in runs
+                   if r.get("mesh_contamination")), {})
+        if mc:
+            tag = "CONTAMINATED" if mc.get("contaminated") else "clean"
+            lines.append(f"  mesh(mDNS): {tag} "
+                         f"(max_discovered_peers="
+                         f"{mc.get('max_mdns_discovered_peers')})")
+
+    # Release-oracle provenance: binary digests/versions + git source cutoff
+    # + release-environment gates (hard-error growth / mDNS contamination).
+    if provenance:
+        lines.append("")
+        lines.append("provenance (binary + source cutoff):")
+        cb = provenance.get("current_binary") or {}
+        lines.append(f"  current: v{cb.get('version')} "
+                     f"sha256={(cb.get('sha256') or '?')[:16]}… "
+                     f"mtime={cb.get('mtime_unix')}")
+        lb = provenance.get("legacy_binary")
+        if lb:
+            lines.append(f"  legacy:  v{lb.get('version')} "
+                         f"sha256={(lb.get('sha256') or '?')[:16]}… "
+                         f"(required v{provenance.get('legacy_required_version')})")
+        else:
+            lines.append("  legacy:  (none — mixed-version UNSUPPORTED)")
+        g = provenance.get("git") or {}
+        lines.append(f"  git:     head={(g.get('head') or '?')[:12]} "
+                     f"dirty={g.get('dirty')} "
+                     f"tree_hash={(g.get('dirty_tree_hash') or '-')[:16]}…")
+        if release_env:
+            he = "GROWTH" if release_env.get(
+                "dropped_critical_hard_error_growth") else "clean"
+            mc = "CONTAMINATED" if release_env.get(
+                "mdns_contaminated") else "clean"
+            lines.append(f"  env:     hard_error={he} mdns={mc}")
+
+    # Prerequisite-gated security/skew gates: pass / fail / UNSUPPORTED.
+    if prereq_gates:
+        lines.append("")
+        lines.append("prerequisite gates (mixed-version / malicious announce "
+                     "/ checkpoint-recovery / forged-first-seen):")
+        for g in prereq_gates:
+            st = g.get("status")
+            tag = {"unsupported": "UNSUPPORTED",
+                   "pass": "PASS", "fail": "FAIL"}.get(st, st)
+            lines.append(f"  {g.get('name'):<32}{tag}")
+            if st == "unsupported":
+                lines.append(f"    → {g.get('unsupported', '')}")
+                if args.expect_fixed:
+                    lines.append("      [expect-fixed] UNSUPPORTED required "
+                                 "prerequisite FAILS the run — supply the "
+                                 "named binary to exercise this gate")
+            elif st == "fail":
+                lines.append(f"    → error: {g.get('error', '(see report)')}")
 
     lines.append("")
-    lines.append(f"OVERALL: {'PASS' if passed == total else 'FAIL'}")
+    soak_pass = (passed == total)
+    if prereq_gates:
+        if args.expect_fixed:
+            prereq_pass = all(g.get("status") not in ("fail", "unsupported")
+                              for g in prereq_gates)
+        else:
+            prereq_pass = all(g.get("status") != "fail"
+                              for g in prereq_gates)
+    else:
+        prereq_pass = True
+    overall = soak_pass and prereq_pass
+    tag = "PASS" if overall else "FAIL"
+    if soak_pass and not prereq_pass:
+        tag += " (soak gates green; prerequisite gate(s) missing/failed)"
+    lines.append(f"OVERALL: {tag}")
     return "\n".join(lines)
 
 
@@ -846,6 +2721,17 @@ def parse_args():
                    help="output root for logs and reports")
     p.add_argument("--keep-data", action="store_true",
                    help="keep node data dirs after passing runs")
+    p.add_argument("--legacy-binary", default=None,
+                   help="path to a legacy (v0.30.1) x0xd binary for the "
+                        "mixed-version skew gate (or $X0XD_LEGACY_BINARY). "
+                        "If absent the gate reports UNSUPPORTED rather than "
+                        "faking the skew")
+    p.add_argument("--forge-injector", default=None,
+                   help="path to the in-repo x0xd-forge-injector binary for "
+                        "the forged-first-seen gate (default: "
+                        "target/release/x0xd-forge-injector, built by the "
+                        "release recipe). Optional $X0XD_FORGE_INJECTOR "
+                        "override; absent ⇒ the gate is UNSUPPORTED")
     args = p.parse_args()
     if args.nodes < 3:
         p.error("--nodes must be >= 3 (claims need two non-creator peers)")
@@ -853,6 +2739,15 @@ def parse_args():
         args.x0xd = os.environ.get(
             "X0XD_TEST_BINARY", str(REPO_ROOT / "target/release/x0xd"))
     args.x0xd = pathlib.Path(args.x0xd)
+    if args.legacy_binary is None:
+        args.legacy_binary = os.environ.get("X0XD_LEGACY_BINARY")
+    if args.legacy_binary:
+        args.legacy_binary = pathlib.Path(args.legacy_binary)
+    if args.forge_injector is None:
+        args.forge_injector = os.environ.get(
+            "X0XD_FORGE_INJECTOR",
+            str(REPO_ROOT / "target/release/x0xd-forge-injector"))
+    args.forge_injector = pathlib.Path(args.forge_injector)
     return args
 
 
@@ -867,12 +2762,39 @@ def main():
             log(f"ERROR: API port {args.api_base + i} already in use")
             return 2
 
+    # Release-oracle provenance: record binary SHA-256 + --version, Git HEAD
+    # + dirty-tree fingerprint + source cutoff, and REFUSE to attest a release
+    # from a stale binary or a non-v0.30.1 legacy. Under --expect-fixed a
+    # provenance refusal fails fast (release authority); without it the
+    # errors are warnings so the one-run smoke stays available.
+    provenance, prov_errors = record_and_verify_provenance(args)
+    for e in prov_errors:
+        log(f"PROVENANCE REFUSAL: {e}")
+    if prov_errors and args.expect_fixed:
+        refuse_root = pathlib.Path(args.out_dir) / time.strftime(
+            "%Y%m%d-%H%M%S")
+        refuse_root.mkdir(parents=True, exist_ok=True)
+        (refuse_root / "report.json").write_text(json.dumps({
+            "args": {k: str(v) if isinstance(v, pathlib.Path) else v
+                     for k, v in vars(args).items()},
+            "provenance": provenance, "provenance_errors": prov_errors,
+            "refused": True,
+        }, indent=2))
+        log("REFUSING release under --expect-fixed: rebuild "
+            "`cargo build --release --bin x0xd` and supply an authenticated "
+            "v0.30.1 legacy binary, then re-run.")
+        return 1
+
     out_root = pathlib.Path(args.out_dir) / time.strftime("%Y%m%d-%H%M%S")
     out_root.mkdir(parents=True, exist_ok=True)
     log(f"output: {out_root}")
     log(f"x0xd: {args.x0xd}")
 
     runs = []
+    prereq_gates = []
+    hard_error_growth = False
+    contaminated = False
+    release_env = {}
     try:
         for i in range(1, args.runs + 1):
             run_dir = out_root / f"run-{i}"
@@ -901,19 +2823,68 @@ def main():
                 for n in run.nodes:
                     shutil.rmtree(n.data_dir, ignore_errors=True)
             time.sleep(2)  # let UDP/TCP ports drain between runs
+
+        # Release-environment gates computed from the per-run diagnostics:
+        # any dropped_critical_hard_error growth, and mDNS mesh contamination.
+        hard_error_growth = any(
+            delta.get("dropped_critical_hard_error", 0)
+            for r in runs
+            for d in r.get("diagnostics_deltas", {}).values()
+            for delta in (d.get("admission_delta") or {}).values()
+            if isinstance(delta, dict))
+        contaminated = any(
+            r.get("mesh_contamination", {}).get("contaminated")
+            for r in runs)
+        release_env = {
+            "dropped_critical_hard_error_growth": hard_error_growth,
+            "mdns_contaminated": contaminated,
+        }
+
+        # Prerequisite-gated security/skew gates run ONCE per invocation
+        # (they do not depend on soak repetition and use isolated ports).
+        log("=== prerequisite gates (mixed-version / malicious announce) ===")
+        prereq_gates.extend(run_mixed_version_gate(args, out_root))
+        prereq_gates.append(run_malicious_owner_announce_gate(args, out_root))
+        prereq_gates.append(run_owner_offline_checkpoint_gate(args, out_root))
+        prereq_gates.append(run_forged_first_seen_gate(args, out_root))
     finally:
         report_path = out_root / "report.json"
         report_path.write_text(json.dumps({
             "args": {k: str(v) if isinstance(v, pathlib.Path) else v
                      for k, v in vars(args).items()},
+            "provenance": provenance,
+            "provenance_errors": prov_errors,
+            "release_environment": release_env,
             "runs": runs,
+            "prerequisite_gates": prereq_gates,
         }, indent=2))
-        summary = summarize(runs, args) if runs else "(no runs completed)"
+        summary = summarize(runs, args, prereq_gates, provenance,
+                            release_env) if runs \
+            else "(no runs completed)"
         (out_root / "summary.txt").write_text(summary + "\n")
         print(summary)
         log(f"report: {report_path}")
 
-    return 0 if runs and all(r["pass"] for r in runs) else 1
+    soak_ok = runs and all(r["pass"] for r in runs)
+    # A gate that ran and FAILED is always a failure. Under --expect-fixed an
+    # UNSUPPORTED gate (mixed-version without a legacy binary, or the
+    # forged-first-seen gossip-harness gap) is ALSO a failure: the release
+    # recipe demands every phase be exercised, never silently skipped. A
+    # provenance refusal (stale binary / wrong legacy version) already failed
+    # fast above under --expect-fixed.
+    if args.expect_fixed:
+        prereq_ok = all(g.get("status") not in ("fail", "unsupported")
+                        for g in prereq_gates)
+    else:
+        prereq_ok = all(g.get("status") != "fail" for g in prereq_gates)
+    # Release-environment gates: critical hard-error growth and mDNS mesh
+    # contamination are HARD gates under --expect-fixed (a release must run
+    # clean); reported but non-blocking in the one-run smoke.
+    if args.expect_fixed:
+        release_env_ok = (not hard_error_growth) and (not contaminated)
+    else:
+        release_env_ok = True
+    return 0 if (soak_ok and prereq_ok and release_env_ok) else 1
 
 
 if __name__ == "__main__":

--- a/tests/crdt_convergence_concurrent.rs
+++ b/tests/crdt_convergence_concurrent.rs
@@ -6,17 +6,39 @@
 //! from multiple agents. Tests OR-Set, LWW-Register, and RGA semantics.
 
 use saorsa_gossip_types::PeerId;
+use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::time::{sleep, Duration};
 use x0x::crdt::{TaskId, TaskItem, TaskList, TaskListId, TaskMetadata};
 use x0x::identity::AgentId;
 
+fn test_keys() -> &'static std::collections::HashMap<u8, (AgentId, x0x::gossip::SigningContext)> {
+    static KEYS: LazyLock<std::collections::HashMap<u8, (AgentId, x0x::gossip::SigningContext)>> =
+        LazyLock::new(|| {
+            (0u8..=64)
+                .map(|n| {
+                    let kp = x0x::identity::AgentKeypair::generate().expect("agent keygen");
+                    (
+                        n,
+                        (
+                            kp.agent_id(),
+                            x0x::gossip::SigningContext::from_keypair(&kp),
+                        ),
+                    )
+                })
+                .collect()
+        });
+    &KEYS
+}
+
 /// Helper to create unique agent ID
 fn agent_id(n: u8) -> AgentId {
-    let mut bytes = [0u8; 32];
-    bytes[0] = n;
-    bytes[1] = 0xFF; // Ensure uniqueness
-    AgentId(bytes)
+    test_keys().get(&n).expect("agent key").0
+}
+
+/// Helper to get the cached signing context matching `agent_id(n)` (self-signed).
+fn signing(n: u8) -> &'static x0x::gossip::SigningContext {
+    &test_keys().get(&n).expect("agent key").1
 }
 
 /// Helper to create unique peer ID
@@ -171,17 +193,17 @@ async fn test_concurrent_claim_same_task() {
 
     // Agent 1 claims
     replicas[0]
-        .claim_task(&tid, agent_id(1), peer_id(1), timestamp1)
+        .claim_task(&tid, agent_id(1), peer_id(1), timestamp1, signing(1))
         .expect("Agent 1 claim failed");
 
     // Agent 2 claims (same task, different agent)
     replicas[1]
-        .claim_task(&tid, agent_id(2), peer_id(2), timestamp2)
+        .claim_task(&tid, agent_id(2), peer_id(2), timestamp2, signing(2))
         .expect("Agent 2 claim failed");
 
     // Agent 3 claims (same task, different agent)
     replicas[2]
-        .claim_task(&tid, agent_id(3), peer_id(3), timestamp3)
+        .claim_task(&tid, agent_id(3), peer_id(3), timestamp3, signing(3))
         .expect("Agent 3 claim failed");
 
     // Merge all replicas
@@ -229,7 +251,7 @@ async fn test_same_task_claim_conflict_different_timestamps_converges() {
         .collect();
 
     replicas[0]
-        .claim_task(&tid, agent_id(1), peer_id(1), 1)
+        .claim_task(&tid, agent_id(1), peer_id(1), 1, signing(1))
         .expect("Agent 1 claim failed");
     let first_claim = replicas[0]
         .get_task(&tid)
@@ -241,7 +263,7 @@ async fn test_same_task_claim_conflict_different_timestamps_converges() {
 
     wait_until_clock_after(first_timestamp).await;
     replicas[1]
-        .claim_task(&tid, agent_id(2), peer_id(2), 1)
+        .claim_task(&tid, agent_id(2), peer_id(2), 1, signing(2))
         .expect("Agent 2 claim failed");
     let second_timestamp = replicas[1]
         .get_task(&tid)
@@ -253,7 +275,7 @@ async fn test_same_task_claim_conflict_different_timestamps_converges() {
 
     wait_until_clock_after(second_timestamp).await;
     replicas[2]
-        .claim_task(&tid, agent_id(3), peer_id(3), 1)
+        .claim_task(&tid, agent_id(3), peer_id(3), 1, signing(3))
         .expect("Agent 3 claim failed");
     let third_timestamp = replicas[2]
         .get_task(&tid)
@@ -440,7 +462,7 @@ async fn test_concurrent_complete_task() {
             let meta = metadata("Task to Complete", 1);
             let mut task = TaskItem::new(tid, meta, peer_id(1));
             // Pre-claim the task
-            task.claim(agent_id(1), peer_id(1), 100)
+            task.claim(task_list_id, agent_id(1), peer_id(1), 100, signing(1))
                 .expect("Failed to claim");
             list.add_task(task, peer_id(1), 1)
                 .expect("Failed to add task");
@@ -453,11 +475,11 @@ async fn test_concurrent_complete_task() {
     let timestamp2 = unix_timestamp_ms() + 50;
 
     replicas[0]
-        .complete_task(&tid, agent_id(1), peer_id(1), timestamp1)
+        .complete_task(&tid, agent_id(1), peer_id(1), timestamp1, signing(1))
         .expect("Agent 1 complete failed");
 
     replicas[1]
-        .complete_task(&tid, agent_id(2), peer_id(2), timestamp2)
+        .complete_task(&tid, agent_id(2), peer_id(2), timestamp2, signing(2))
         .expect("Agent 2 complete failed");
 
     // Merge
@@ -508,7 +530,13 @@ async fn test_mixed_concurrent_operations() {
         replicas[2].merge(&r0).expect("Failed to sync");
     }
     replicas[2]
-        .claim_task(&task_id(1), agent_id(3), peer_id(3), unix_timestamp_ms())
+        .claim_task(
+            &task_id(1),
+            agent_id(3),
+            peer_id(3),
+            unix_timestamp_ms(),
+            signing(3),
+        )
         .expect("Failed to claim task A");
 
     // Agent 4: Add task C
@@ -523,7 +551,13 @@ async fn test_mixed_concurrent_operations() {
         replicas[4].merge(&r1).expect("Failed to sync");
     }
     replicas[4]
-        .claim_task(&task_id(2), agent_id(5), peer_id(5), unix_timestamp_ms())
+        .claim_task(
+            &task_id(2),
+            agent_id(5),
+            peer_id(5),
+            unix_timestamp_ms(),
+            signing(5),
+        )
         .expect("Failed to claim task B");
 
     // Agent 6: Complete task A (need to sync first)
@@ -532,7 +566,13 @@ async fn test_mixed_concurrent_operations() {
         replicas[5].merge(&r2).expect("Failed to sync");
     }
     replicas[5]
-        .complete_task(&task_id(1), agent_id(6), peer_id(6), unix_timestamp_ms())
+        .complete_task(
+            &task_id(1),
+            agent_id(6),
+            peer_id(6),
+            unix_timestamp_ms(),
+            signing(6),
+        )
         .expect("Failed to complete task A");
 
     // Full mesh merge (simulates gossip convergence)

--- a/tests/crdt_integration.rs
+++ b/tests/crdt_integration.rs
@@ -5,12 +5,37 @@
 //! and synchronizing across multiple agents.
 
 use saorsa_gossip_types::PeerId;
+use std::sync::LazyLock;
 use x0x::crdt::{TaskId, TaskItem, TaskList, TaskListId, TaskMetadata};
 use x0x::identity::AgentId;
 
+fn test_keys() -> &'static std::collections::HashMap<u8, (AgentId, x0x::gossip::SigningContext)> {
+    static KEYS: LazyLock<std::collections::HashMap<u8, (AgentId, x0x::gossip::SigningContext)>> =
+        LazyLock::new(|| {
+            (0u8..=64)
+                .map(|n| {
+                    let kp = x0x::identity::AgentKeypair::generate().expect("agent keygen");
+                    (
+                        n,
+                        (
+                            kp.agent_id(),
+                            x0x::gossip::SigningContext::from_keypair(&kp),
+                        ),
+                    )
+                })
+                .collect()
+        });
+    &KEYS
+}
+
 /// Helper to create a test agent ID.
 fn test_agent_id(n: u8) -> AgentId {
-    AgentId([n; 32])
+    test_keys().get(&n).expect("agent key").0
+}
+
+/// Helper to get the cached signing context matching `test_agent_id(n)` (self-signed).
+fn signing(n: u8) -> &'static x0x::gossip::SigningContext {
+    &test_keys().get(&n).expect("agent key").1
 }
 
 /// Helper to create a test peer ID.
@@ -40,7 +65,7 @@ fn test_metadata(title: &str, creator: u8) -> TaskMetadata {
         title: title.to_string(),
         description: format!("Test task: {}", title),
         priority: 128,
-        created_by: test_agent_id(creator),
+        created_by: AgentId([creator; 32]),
         owner: None,
         created_at: 1000 + creator as u64,
         tags: vec!["test".to_string()],
@@ -85,6 +110,7 @@ fn test_task_list_claim_task() {
     let task_id = test_task_id(1);
     let peer_id = test_peer_id(1);
     let agent_id = test_agent_id(1);
+    let signing = signing(1);
 
     let mut task_list = TaskList::new(list_id, "Sprint".to_string(), peer_id);
     let metadata = test_metadata("Write code", agent_id.as_bytes()[0]);
@@ -93,7 +119,7 @@ fn test_task_list_claim_task() {
     task_list
         .add_task(task, peer_id, 1)
         .expect("Failed to add task");
-    let claim_result = task_list.claim_task(&task_id, agent_id, peer_id, 2);
+    let claim_result = task_list.claim_task(&task_id, agent_id, peer_id, 2, signing);
 
     assert!(claim_result.is_ok());
     let task = task_list.get_task(&task_id).expect("Task should exist");
@@ -107,6 +133,7 @@ fn test_task_list_complete_task() {
     let task_id = test_task_id(1);
     let peer_id = test_peer_id(1);
     let agent_id = test_agent_id(1);
+    let signing = signing(1);
 
     let mut task_list = TaskList::new(list_id, "Sprint".to_string(), peer_id);
     let metadata = test_metadata("Test code", agent_id.as_bytes()[0]);
@@ -116,9 +143,9 @@ fn test_task_list_complete_task() {
         .add_task(task, peer_id, 1)
         .expect("Failed to add task");
     task_list
-        .claim_task(&task_id, agent_id, peer_id, 2)
+        .claim_task(&task_id, agent_id, peer_id, 2, signing)
         .expect("Failed to claim task");
-    let complete_result = task_list.complete_task(&task_id, agent_id, peer_id, 3);
+    let complete_result = task_list.complete_task(&task_id, agent_id, peer_id, 3, signing);
 
     assert!(complete_result.is_ok());
     let task = task_list.get_task(&task_id).expect("Task should exist");
@@ -228,6 +255,8 @@ fn test_concurrent_claims() {
     let peer_id_b = test_peer_id(2);
     let agent_id_a = test_agent_id(1);
     let _agent_id_b = test_agent_id(2);
+    let signing_a = signing(1);
+    let signing_b = signing(2);
 
     let mut task_list = TaskList::new(list_id, "Sprint".to_string(), peer_id_a);
     let metadata = test_metadata("Claim test", agent_id_a.as_bytes()[0]);
@@ -239,12 +268,12 @@ fn test_concurrent_claims() {
 
     // Agent A claims the task
     task_list
-        .claim_task(&task_id, agent_id_a, peer_id_a, 2)
+        .claim_task(&task_id, agent_id_a, peer_id_a, 2, signing_a)
         .expect("A should claim");
 
     // Agent B also claims (concurrent)
     task_list
-        .claim_task(&task_id, _agent_id_b, peer_id_b, 2)
+        .claim_task(&task_id, _agent_id_b, peer_id_b, 2, signing_b)
         .expect("B should claim");
 
     // Both should be visible (OR-Set semantics)
@@ -301,6 +330,7 @@ fn test_version_tracking() {
     let list_id = test_task_list_id(1);
     let peer_id = test_peer_id(1);
     let agent_id = test_agent_id(1);
+    let signing = signing(1);
 
     let mut task_list = TaskList::new(list_id, "Sprint".to_string(), peer_id);
     let initial_version = task_list.version();
@@ -317,7 +347,7 @@ fn test_version_tracking() {
 
     // Claim the task
     task_list
-        .claim_task(&task_id, agent_id, peer_id, 2)
+        .claim_task(&task_id, agent_id, peer_id, 2, signing)
         .expect("Failed to claim");
 
     let version_after_claim = task_list.version();
@@ -351,6 +381,7 @@ fn test_invalid_state_transitions() {
     let task_id = test_task_id(1);
     let peer_id = test_peer_id(1);
     let agent_id = test_agent_id(1);
+    let signing = signing(1);
 
     let mut task_list = TaskList::new(list_id, "Sprint".to_string(), peer_id);
     let metadata = test_metadata("State test", agent_id.as_bytes()[0]);
@@ -359,7 +390,7 @@ fn test_invalid_state_transitions() {
     task_list.add_task(task, peer_id, 1).expect("Failed to add");
 
     // Try to complete without claiming first
-    let result = task_list.complete_task(&task_id, agent_id, peer_id, 2);
+    let result = task_list.complete_task(&task_id, agent_id, peer_id, 2, signing);
     assert!(result.is_err());
 }
 

--- a/tests/crdt_partition_tolerance.rs
+++ b/tests/crdt_partition_tolerance.rs
@@ -9,6 +9,7 @@ use saorsa_gossip_types::PeerId;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 use x0x::crdt::{TaskId, TaskItem, TaskList, TaskListDelta, TaskListId, TaskMetadata};
@@ -16,12 +17,33 @@ use x0x::identity::AgentId;
 
 type AntiEntropyFuture = Pin<Box<dyn Future<Output = Result<()>> + Send>>;
 
+fn test_keys() -> &'static std::collections::HashMap<u8, (AgentId, x0x::gossip::SigningContext)> {
+    static KEYS: LazyLock<std::collections::HashMap<u8, (AgentId, x0x::gossip::SigningContext)>> =
+        LazyLock::new(|| {
+            (0u8..=64)
+                .map(|n| {
+                    let kp = x0x::identity::AgentKeypair::generate().expect("agent keygen");
+                    (
+                        n,
+                        (
+                            kp.agent_id(),
+                            x0x::gossip::SigningContext::from_keypair(&kp),
+                        ),
+                    )
+                })
+                .collect()
+        });
+    &KEYS
+}
+
 /// Helper to create unique agent ID
 fn agent_id(n: u8) -> AgentId {
-    let mut bytes = [0u8; 32];
-    bytes[0] = n;
-    bytes[1] = 0xAA;
-    AgentId(bytes)
+    test_keys().get(&n).expect("agent key").0
+}
+
+/// Helper to get the cached signing context matching `agent_id(n)` (self-signed).
+fn signing(n: u8) -> &'static x0x::gossip::SigningContext {
+    &test_keys().get(&n).expect("agent key").1
 }
 
 /// Helper to create unique peer ID
@@ -341,7 +363,7 @@ fn test_partition_conflicting_claims() -> Result<()> {
 
     // Partition: Group A claims first. claim_task's fourth argument is the
     // OR-Set sequence tag; TaskItem::claim generates the conflict timestamp.
-    group_a[0].claim_task(&contested_task_id, agent_id(1), peer_id(1), 2)?;
+    group_a[0].claim_task(&contested_task_id, agent_id(1), peer_id(1), 2, signing(1))?;
     let group_a_claim_timestamp = group_a[0]
         .get_task(&contested_task_id)
         .and_then(|task| task.current_state().timestamp())
@@ -350,7 +372,7 @@ fn test_partition_conflicting_claims() -> Result<()> {
     wait_until_clock_after(group_a_claim_timestamp);
 
     // Partition: Group B claims after the clock advances, using its own sequence tag.
-    group_b[0].claim_task(&contested_task_id, agent_id(2), peer_id(3), 2)?;
+    group_b[0].claim_task(&contested_task_id, agent_id(2), peer_id(3), 2, signing(2))?;
     let group_b_claim_timestamp = group_b[0]
         .get_task(&contested_task_id)
         .and_then(|task| task.current_state().timestamp())
@@ -602,7 +624,13 @@ fn test_partition_state_transitions() {
     // Group A claims the task
     let timestamp_claim = unix_timestamp_ms();
     group_a[0]
-        .claim_task(&task_id_shared, agent_id(1), peer_id(1), timestamp_claim)
+        .claim_task(
+            &task_id_shared,
+            agent_id(1),
+            peer_id(1),
+            timestamp_claim,
+            signing(1),
+        )
         .expect("Claim failed");
 
     // Group B also claims and completes the task (later timestamps)
@@ -610,10 +638,22 @@ fn test_partition_state_transitions() {
     let timestamp_complete = timestamp_claim + 100;
 
     group_b[0]
-        .claim_task(&task_id_shared, agent_id(2), peer_id(2), timestamp_claim_b)
+        .claim_task(
+            &task_id_shared,
+            agent_id(2),
+            peer_id(2),
+            timestamp_claim_b,
+            signing(2),
+        )
         .expect("Claim B failed");
     group_b[0]
-        .complete_task(&task_id_shared, agent_id(2), peer_id(2), timestamp_complete)
+        .complete_task(
+            &task_id_shared,
+            agent_id(2),
+            peer_id(2),
+            timestamp_complete,
+            signing(2),
+        )
         .expect("Complete failed");
 
     // Heal

--- a/tests/crdt_subscription_persistence.rs
+++ b/tests/crdt_subscription_persistence.rs
@@ -1,0 +1,246 @@
+//! Regression tests for daemon-restart amnesia: task-list and kv-store
+//! registrations must survive an x0xd restart WITHOUT the application
+//! re-creating or re-joining them.
+//!
+//! Before the fix, `AppState.task_lists` / `AppState.kv_stores` were only
+//! populated by the REST create/join handlers, so a restarted daemon answered
+//! "task list not found" / "store not found" until an explicit re-create.
+//! The fix persists a subscription manifest (`crdt-subscriptions.json` in the
+//! instance data dir) and rehydrates it after `join_network` by driving the
+//! same Agent create/join paths — the empty-replica state-request bootstrap
+//! then recovers content (including offline mutations) from peer replicas.
+//!
+//! All tests are `#[ignore]` — they boot real x0xd daemons.
+//! Run with: cargo nextest run --test crdt_subscription_persistence --run-ignored all
+//! Before running: cargo build --bin x0xd (or set X0XD_TEST_BINARY)
+
+use base64::Engine;
+use std::time::Duration;
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+fn b64(s: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(s)
+}
+
+/// Poll `path` on `node` until `pred(json)` is true or the deadline passes.
+async fn poll_until(
+    node: &cluster::AgentInstance,
+    path: &str,
+    what: &str,
+    deadline_secs: u64,
+    pred: impl Fn(&serde_json::Value) -> bool,
+) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(deadline_secs);
+    let mut last = serde_json::Value::Null;
+    loop {
+        let resp = node.get(path).await;
+        if let Ok(json) = resp.json::<serde_json::Value>().await {
+            if pred(&json) {
+                return;
+            }
+            last = json;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!(
+                "{}: {what} not observed within {deadline_secs}s; last response: {last}",
+                node.name
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+fn tasks_contain(json: &serde_json::Value, title: &str) -> bool {
+    json["tasks"]
+        .as_array()
+        .is_some_and(|ts| ts.iter().any(|t| t["title"] == title))
+}
+
+/// WHY: this is the defect itself — after a restart, both a joined kv store
+/// and a created task list must be answerable via REST (registration AND
+/// content) without any re-create/re-join call. Bob is restarted because his
+/// config bootstraps to alice, so reconnection is deterministic; alice keeps
+/// the authoritative replicas that bob's rehydrated (empty) CRDTs pull state
+/// from via the state-request side channel.
+#[tokio::test]
+#[ignore]
+async fn task_list_and_kv_store_survive_daemon_restart() {
+    let mut pair = cluster::pair().await;
+    let suffix = rand::random::<u32>();
+    let list_topic = format!("restart-list-{suffix}");
+    let store_topic = format!("restart-store-{suffix}");
+
+    // Alice creates + populates both CRDTs.
+    let r = pair
+        .alice
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "restart-list", "topic": list_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates task list");
+    let r = pair
+        .alice
+        .post(
+            &format!("/task-lists/{list_topic}/tasks"),
+            serde_json::json!({ "title": "pre-restart-task" }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice adds task");
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "restart-store", "topic": store_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates store");
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{store_topic}/pre-key"),
+            serde_json::json!({ "value": b64(b"pre-restart-value") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice puts key");
+
+    // Bob replicates both: joins the store (role "joined") and creates the
+    // task list on the same topic (role "created" — the only REST path).
+    let r = pair
+        .bob
+        .post(
+            &format!("/stores/{store_topic}/join"),
+            serde_json::json!({}),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob joins store");
+    let r = pair
+        .bob
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "restart-list", "topic": list_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob creates task-list replica");
+
+    // Both registrations must be in bob's persisted manifest.
+    let manifest_path = pair.bob.data_dir().join("crdt-subscriptions.json");
+    assert!(
+        manifest_path.exists(),
+        "manifest not written at {}",
+        manifest_path.display()
+    );
+
+    // Bob converges before the restart (proves replication works at all).
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "pre-restart task replication",
+        120,
+        |json| tasks_contain(json, "pre-restart-task"),
+    )
+    .await;
+    poll_until(
+        &pair.bob,
+        &format!("/stores/{store_topic}/pre-key"),
+        "pre-restart key replication",
+        120,
+        |json| json["value"] == b64(b"pre-restart-value"),
+    )
+    .await;
+
+    // Restart bob. NO re-create/re-join calls after this point.
+    pair.bob.restart().await;
+
+    // Registration and content must come back on their own: the manifest
+    // rehydration re-subscribes, and the empty-replica state request pulls
+    // the full state from alice.
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "post-restart task list recovery (no re-create)",
+        120,
+        |json| tasks_contain(json, "pre-restart-task"),
+    )
+    .await;
+    poll_until(
+        &pair.bob,
+        &format!("/stores/{store_topic}/pre-key"),
+        "post-restart store key recovery (no re-join)",
+        120,
+        |json| json["value"] == b64(b"pre-restart-value"),
+    )
+    .await;
+}
+
+/// WHY: the point of persisting subscriptions is that mutations made while an
+/// instance is DOWN still arrive after it comes back — without the manifest,
+/// a restarted daemon has no handle, so the offline delta has nowhere to
+/// land and the app sees "task list not found" forever.
+#[tokio::test]
+#[ignore]
+async fn offline_mutation_arrives_after_restart_without_rejoin() {
+    let mut pair = cluster::pair().await;
+    let suffix = rand::random::<u32>();
+    let list_topic = format!("offline-list-{suffix}");
+
+    let r = pair
+        .alice
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "offline-list", "topic": list_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates task list");
+    let r = pair
+        .alice
+        .post(
+            &format!("/task-lists/{list_topic}/tasks"),
+            serde_json::json!({ "title": "task-before-outage" }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice adds first task");
+
+    // Bob replicates the list and converges.
+    let r = pair
+        .bob
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "offline-list", "topic": list_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob creates task-list replica");
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "pre-outage task replication",
+        120,
+        |json| tasks_contain(json, "task-before-outage"),
+    )
+    .await;
+
+    // Bob goes down; alice mutates while he is offline.
+    pair.bob.stop();
+    let r = pair
+        .alice
+        .post(
+            &format!("/task-lists/{list_topic}/tasks"),
+            serde_json::json!({ "title": "offline-task" }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice adds task while bob is down");
+
+    // Bob comes back. NO re-create call — the offline mutation must arrive
+    // via manifest rehydration + state-request recovery alone.
+    pair.bob.start().await;
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "offline mutation after restart (no rejoin)",
+        120,
+        |json| tasks_contain(json, "offline-task") && tasks_contain(json, "task-before-outage"),
+    )
+    .await;
+}

--- a/tests/crdt_subscription_persistence.rs
+++ b/tests/crdt_subscription_persistence.rs
@@ -106,16 +106,21 @@ async fn task_list_and_kv_store_survive_daemon_restart() {
         .await;
     assert!(r.status().is_success(), "alice puts key");
 
-    // Bob replicates both: joins the store (role "joined") and creates the
-    // task list on the same topic (role "created" — the only REST path).
+    // Bob replicates both: joins the store anchored on Alice's authoritative
+    // owner (role "joined") and creates the task list on the same topic
+    // (role "created" — the only REST path). Ownership is anchored ONLY at
+    // construction from the out-of-band expected_owner, so Bob's replica
+    // accepts Alice's deltas — a None anchor is permanently read-only and
+    // rejects them (silent merge_delta rejection), never converging.
+    let alice_id = pair.alice.agent_id().await;
     let r = pair
         .bob
         .post(
             &format!("/stores/{store_topic}/join"),
-            serde_json::json!({}),
+            serde_json::json!({ "expected_owner": alice_id }),
         )
         .await;
-    assert!(r.status().is_success(), "bob joins store");
+    assert!(r.status().is_success(), "bob joins store anchored on alice");
     let r = pair
         .bob
         .post(
@@ -125,12 +130,29 @@ async fn task_list_and_kv_store_survive_daemon_restart() {
         .await;
     assert!(r.status().is_success(), "bob creates task-list replica");
 
-    // Both registrations must be in bob's persisted manifest.
+    // Both registrations must be in bob's persisted manifest, and the store
+    // join must carry its expected_owner anchor so restart rehydration
+    // re-anchors on the same owner — a missing anchor rehydrates read-only
+    // and convergence is lost after restart.
     let manifest_path = pair.bob.data_dir().join("crdt-subscriptions.json");
     assert!(
         manifest_path.exists(),
         "manifest not written at {}",
         manifest_path.display()
+    );
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&manifest_path).expect("read manifest"))
+            .expect("manifest parses as json");
+    let store_entry = manifest["entries"]
+        .as_array()
+        .expect("manifest has entries array")
+        .iter()
+        .find(|e| e["kind"] == "kv_store" && e["id"] == store_topic)
+        .expect("store join persisted in manifest");
+    assert_eq!(
+        store_entry["expected_owner"].as_str(),
+        Some(alice_id.as_str()),
+        "manifest anchors store join on alice's owner id"
     );
 
     // Bob converges before the restart (proves replication works at all).
@@ -241,6 +263,565 @@ async fn offline_mutation_arrives_after_restart_without_rejoin() {
         "offline mutation after restart (no rejoin)",
         120,
         |json| tasks_contain(json, "offline-task") && tasks_contain(json, "task-before-outage"),
+    )
+    .await;
+}
+
+/// WHY (review test 22): at the route level the same store id may be joined and
+/// re-joined (the joiner's "re-create") concurrently. The persistence lock in
+/// `record()` serialises every durable write and `upsert` collapses same-id
+/// entries to one, so the manifest never holds duplicates or half-written
+/// state; a failed durable write rolls back the live handle so an un-persisted
+/// registration is never acknowledged. Startup rehydration must therefore
+/// reproduce a single, anchored, converging store — deterministically,
+/// independent of the interleaving that produced it. (The rollback-on-failure
+/// half of the invariant is pinned by the unit test
+/// `failed_durable_write_rolls_back_and_retries`.)
+#[tokio::test]
+#[ignore]
+async fn concurrent_same_id_join_recreate_rehydrates_deterministically() {
+    let mut pair = cluster::pair().await;
+    let suffix = rand::random::<u32>();
+    let topic = format!("determinism-{suffix}");
+    let owner = pair.alice.agent_id().await;
+
+    // Alice is the authoritative owner: she creates the store and seeds a
+    // value every joiner must converge on.
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "determinism", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates authoritative store");
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/seed"),
+            serde_json::json!({ "value": b64(b"anchor-value") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice seeds store");
+
+    // Fire a storm of concurrent same-id joins at bob (the joiner's create +
+    // re-create), all anchored on alice. The persistence lock serialises each
+    // `record()`; upsert must collapse them to a single manifest entry no
+    // matter how they interleave.
+    let join_path = format!("/stores/{topic}/join");
+    let join_body = serde_json::json!({ "expected_owner": owner });
+    let (r0, r1, r2, r3) = tokio::join!(
+        pair.bob.post(&join_path, join_body.clone()),
+        pair.bob.post(&join_path, join_body.clone()),
+        pair.bob.post(&join_path, join_body.clone()),
+        pair.bob.post(&join_path, join_body.clone()),
+    );
+    for (i, r) in [r0, r1, r2, r3].into_iter().enumerate() {
+        assert!(
+            r.status().is_success(),
+            "concurrent same-id join {i} succeeds"
+        );
+    }
+
+    // Determinism: exactly ONE kv_store entry for the topic survives in bob's
+    // manifest, anchored on alice. A lost update would leave zero or many; a
+    // missing dedup would leave duplicates.
+    let manifest_path = pair.bob.data_dir().join("crdt-subscriptions.json");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&manifest_path).expect("read manifest"))
+            .expect("manifest parses as json");
+    let same_id: Vec<&serde_json::Value> = manifest["entries"]
+        .as_array()
+        .expect("manifest has entries array")
+        .iter()
+        .filter(|e| e["kind"] == "kv_store" && e["id"] == topic)
+        .collect();
+    assert_eq!(same_id.len(), 1, "exactly one manifest entry for the topic");
+    assert_eq!(
+        same_id[0]["expected_owner"].as_str(),
+        Some(owner.as_str()),
+        "manifest entry anchored on alice"
+    );
+
+    // The anchored replica accepts alice's deltas and converges.
+    poll_until(
+        &pair.bob,
+        &format!("/stores/{topic}/seed"),
+        "concurrent-join seed convergence",
+        120,
+        |json| json["value"] == b64(b"anchor-value"),
+    )
+    .await;
+
+    // Restart bob. Rehydration replays the single manifest entry and must
+    // reproduce the same anchored, converging store — no re-join call.
+    pair.bob.restart().await;
+    poll_until(
+        &pair.bob,
+        &format!("/stores/{topic}/seed"),
+        "post-restart rehydrate convergence (no re-join)",
+        120,
+        |json| json["value"] == b64(b"anchor-value"),
+    )
+    .await;
+}
+
+/// WHY (P1 same-ID REST vs REST): two REST creates for the same task-list
+/// topic must not both win. The per-`(kind,id)` reservation serializes the
+/// whole create → insert-handle → persist transaction, so the first create
+/// returns 201 and installs exactly one handle (one sync listener), and every
+/// concurrent same-id create sees the handle present and returns 409 CONFLICT
+/// — never a duplicate listener, never one request's failure rolling back the
+/// other's handle. Asserts the API map (GET /task-lists), the disk manifest,
+/// and post-restart rehydrated state all agree on a single entry.
+#[tokio::test]
+#[ignore]
+async fn concurrent_same_id_rest_creates_install_a_single_handle() {
+    let mut pair = cluster::pair().await;
+    let suffix = rand::random::<u32>();
+    let topic = format!("same-id-rest-{suffix}");
+
+    // Alice seeds the list on the shared topic so convergence is observable.
+    let r = pair
+        .alice
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "same-id", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates seed list");
+    let r = pair
+        .alice
+        .post(
+            &format!("/task-lists/{topic}/tasks"),
+            serde_json::json!({ "title": "seed-task" }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice seeds task");
+
+    // Fire four concurrent same-id creates at bob. The reservation serializes
+    // them: the first installs the handle, the rest observe it and conflict.
+    let body = serde_json::json!({ "name": "same-id", "topic": topic });
+    let (r0, r1, r2, r3) = tokio::join!(
+        pair.bob.post("/task-lists", body.clone()),
+        pair.bob.post("/task-lists", body.clone()),
+        pair.bob.post("/task-lists", body.clone()),
+        pair.bob.post("/task-lists", body.clone()),
+    );
+    let statuses: Vec<u16> = [r0, r1, r2, r3]
+        .iter()
+        .map(|r| r.status().as_u16())
+        .collect();
+    let created = statuses.iter().filter(|&&s| s == 201).count();
+    let conflict = statuses.iter().filter(|&&s| s == 409).count();
+    assert_eq!(
+        created, 1,
+        "exactly one same-id create returns 201; got statuses {statuses:?}"
+    );
+    assert_eq!(
+        conflict, 3,
+        "the other three same-id creates return 409 CONFLICT"
+    );
+
+    // API map agrees: GET /task-lists lists the topic exactly once
+    // (one handle ⇒ one listener).
+    poll_until(
+        &pair.bob,
+        "/task-lists",
+        "bob lists the created task list exactly once",
+        60,
+        |json| {
+            json["task_lists"]
+                .as_array()
+                .is_some_and(|a| a.iter().filter(|t| t["id"] == topic).count() == 1)
+        },
+    )
+    .await;
+
+    // Disk manifest agrees: exactly one task_list entry for the topic.
+    let manifest_path = pair.bob.data_dir().join("crdt-subscriptions.json");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&manifest_path).expect("read manifest"))
+            .expect("manifest parses as json");
+    let n = manifest["entries"]
+        .as_array()
+        .expect("manifest has entries array")
+        .iter()
+        .filter(|e| e["kind"] == "task_list" && e["id"] == topic)
+        .count();
+    assert_eq!(n, 1, "exactly one manifest task_list entry for the topic");
+
+    // One listener ⇒ converges once.
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{topic}/tasks"),
+        "same-id seed convergence",
+        120,
+        |json| tasks_contain(json, "seed-task"),
+    )
+    .await;
+
+    // Post-restart state agrees: rehydration replays the single entry and
+    // reproduces a single converging handle — no re-create call.
+    pair.bob.restart().await;
+    poll_until(
+        &pair.bob,
+        "/task-lists",
+        "post-restart bob lists the task list exactly once",
+        60,
+        |json| {
+            json["task_lists"]
+                .as_array()
+                .is_some_and(|a| a.iter().filter(|t| t["id"] == topic).count() == 1)
+        },
+    )
+    .await;
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{topic}/tasks"),
+        "post-restart rehydrate convergence (no re-create)",
+        120,
+        |json| tasks_contain(json, "seed-task"),
+    )
+    .await;
+}
+
+/// WHY (P1 REST vs rehydrate): rehydration and a REST create for the same
+/// `(kind,id)` race on a check-then-create window. Without the shared
+/// per-`(kind,id)` reservation both could spawn a long-lived sync listener for
+/// the same topic (duplicate listeners) even though only one handle wins the
+/// map. With the reservation, one path installs the handle and the other sees
+/// it present (REST → 409, rehydrate → AlreadyPresent) — exactly one listener.
+/// This fires a REST create at bob the instant he restarts (rehydrate runs in
+/// a background task after `join_network`) and asserts the end state has a
+/// single manifest entry, a single API-map handle, and clean convergence,
+/// independent of which path won.
+#[tokio::test]
+#[ignore]
+async fn rest_create_racing_rehydrate_yields_single_handle() {
+    let mut pair = cluster::pair().await;
+    let suffix = rand::random::<u32>();
+    let topic = format!("rest-vs-rehydrate-{suffix}");
+
+    // Alice seeds the list; bob creates a replica, which is persisted so the
+    // restart rehydrates it.
+    let r = pair
+        .alice
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "rvrh", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates seed list");
+    let r = pair
+        .alice
+        .post(
+            &format!("/task-lists/{topic}/tasks"),
+            serde_json::json!({ "title": "rvrh-task" }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice seeds task");
+    let r = pair
+        .bob
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "rvrh", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob creates persisted replica");
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{topic}/tasks"),
+        "pre-restart convergence",
+        120,
+        |json| tasks_contain(json, "rvrh-task"),
+    )
+    .await;
+
+    // Restart bob. Rehydration runs after join_network in a background task;
+    // fire a REST create for the SAME topic immediately, racing rehydrate.
+    pair.bob.restart().await;
+    let race = pair
+        .bob
+        .post(
+            "/task-lists",
+            serde_json::json!({ "name": "rvrh", "topic": topic }),
+        )
+        .await;
+    // Whichever path won is fine: 201 (REST created before rehydrate ran) or
+    // 409 (rehydrate already installed the handle). Any other status is a bug.
+    let s = race.status().as_u16();
+    assert!(
+        s == 201 || s == 409,
+        "REST create racing rehydrate must be 201 or 409, got {s}"
+    );
+
+    // End state: exactly one manifest entry for the topic (no duplicate), and
+    // the API map lists it exactly once (one handle ⇒ one listener).
+    let manifest_path = pair.bob.data_dir().join("crdt-subscriptions.json");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&manifest_path).expect("read manifest"))
+            .expect("manifest parses as json");
+    let n = manifest["entries"]
+        .as_array()
+        .expect("manifest has entries array")
+        .iter()
+        .filter(|e| e["kind"] == "task_list" && e["id"] == topic)
+        .count();
+    assert_eq!(
+        n, 1,
+        "exactly one manifest entry — REST and rehydrate did not duplicate"
+    );
+    poll_until(
+        &pair.bob,
+        "/task-lists",
+        "bob lists the task list exactly once after the race",
+        60,
+        |json| {
+            json["task_lists"]
+                .as_array()
+                .is_some_and(|a| a.iter().filter(|t| t["id"] == topic).count() == 1)
+        },
+    )
+    .await;
+    // The single handle converges on alice's content.
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{topic}/tasks"),
+        "post-race convergence (single listener)",
+        120,
+        |json| tasks_contain(json, "rvrh-task"),
+    )
+    .await;
+}
+
+// ─── Reconnect-policy: named-node new-port proactive reconnect ──────────────
+
+/// Read a JSON field from `GET /diagnostics/connectivity` on `node`.
+async fn connectivity_json(node: &cluster::AgentInstance) -> serde_json::Value {
+    node.get("/diagnostics/connectivity")
+        .await
+        .json::<serde_json::Value>()
+        .await
+        .expect("connectivity json")
+}
+
+/// The node's own QUIC peer id (hex), from `/diagnostics/connectivity`.
+async fn node_peer_id(node: &cluster::AgentInstance) -> String {
+    connectivity_json(node).await["peer_id"]
+        .as_str()
+        .expect("peer_id field")
+        .to_string()
+}
+
+/// The UDP port the node's QUIC transport is bound to, parsed from
+/// `local_addr` (e.g. `[::]:53287` or `0.0.0.0:53287`).
+async fn local_quic_port(node: &cluster::AgentInstance) -> u16 {
+    let addr = connectivity_json(node).await;
+    let addr = addr["local_addr"].as_str().expect("local_addr field");
+    addr.rsplit_once(':')
+        .map(|(_, port)| port)
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or_else(|| panic!("could not parse port from local_addr {addr}"))
+}
+
+/// Whether the node is advertising itself via mDNS.
+async fn mdns_advertising(node: &cluster::AgentInstance) -> bool {
+    connectivity_json(node).await["mdns"]["advertising"]
+        .as_bool()
+        .unwrap_or(false)
+}
+
+/// Whether `alice` currently lists `peer_id_hex` (no 0x prefix) among its
+/// connected peers.
+async fn has_peer(alice: &cluster::AgentInstance, peer_id_hex: &str) -> bool {
+    let json = alice.get("/peers").await;
+    let peers = json.json::<serde_json::Value>().await.expect("peers json")["peers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    peers
+        .iter()
+        .any(|p| p["id"].as_str().is_some_and(|id| id == peer_id_hex))
+}
+
+/// WHY (review P1 — proactive reconnect): a killed named peer restarted with
+/// the SAME MachineId on a FORCED DIFFERENT QUIC port must be proactively
+/// re-dialed by the survivor — no manual trigger, no rejoin, no
+/// fixed-port/still-running-peer shortcut — with CRDT recovery and
+/// transport-path attribution.
+///
+/// Bob is restarted with NO bootstrap (and `--no-hard-coded-bootstrap`), so he
+/// cannot startup-dial alice. The only way the mesh reforms is alice's
+/// proactive reconnect, which — post-fix — refreshes bob's mDNS-announced new
+/// endpoint on every backoff attempt. Pre-fix the reconnect task snapshotted
+/// candidate addresses once and kept dialing bob's dead old port forever.
+#[tokio::test]
+#[ignore]
+async fn killed_named_peer_reconnects_on_new_port_via_proactive_path() {
+    let mut pair = cluster::pair().await;
+    let suffix = rand::random::<u32>();
+    let list_topic = format!("named-restart-{suffix}");
+
+    // Alice creates a task list and adds T1; bob creates a replica on the same
+    // topic so his handle is persisted to the manifest (rehydrated on restart).
+    assert!(
+        pair.alice
+            .post(
+                "/task-lists",
+                serde_json::json!({ "name": "named-restart", "topic": list_topic }),
+            )
+            .await
+            .status()
+            .is_success(),
+        "alice creates task list"
+    );
+    assert!(
+        pair.alice
+            .post(
+                &format!("/task-lists/{list_topic}/tasks"),
+                serde_json::json!({ "title": "T1-pre-kill" }),
+            )
+            .await
+            .status()
+            .is_success(),
+        "alice adds T1"
+    );
+    assert!(
+        pair.bob
+            .post(
+                "/task-lists",
+                serde_json::json!({ "name": "named-restart", "topic": list_topic }),
+            )
+            .await
+            .status()
+            .is_success(),
+        "bob creates task-list replica"
+    );
+    // Bob converges T1 before the kill (proves replication + bob's handle works).
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "bob sees T1 before kill",
+        120,
+        |json| tasks_contain(json, "T1-pre-kill"),
+    )
+    .await;
+
+    // Capture identity + transport endpoint before the kill.
+    let bob_agent_before = pair.bob.agent_id().await;
+    let bob_peer_before = node_peer_id(&pair.bob).await;
+    let bob_port_before = local_quic_port(&pair.bob).await;
+
+    // Kill bob hard (real transport drop). Alice will detect the dead QUIC
+    // connection and schedule a proactive (Transport) reconnect.
+    pair.bob.stop();
+
+    // Offline mutation: alice writes T2 while bob is DOWN. It must arrive at
+    // bob over the proactive reconnect path after he returns — no rejoin.
+    assert!(
+        pair.alice
+            .post(
+                &format!("/task-lists/{list_topic}/tasks"),
+                serde_json::json!({ "title": "T2-offline" }),
+            )
+            .await
+            .status()
+            .is_success(),
+        "alice adds T2 while bob offline"
+    );
+
+    // Restart bob on a FORCED NEW QUIC port, same data_dir (same MachineId),
+    // NO bootstrap (cannot startup-dial alice).
+    let bob_port_after = pair.bob.restart_on_new_quic_port_no_bootstrap().await;
+
+    // (1) Forced different port — no fixed-port shortcut.
+    assert_ne!(
+        bob_port_after, bob_port_before,
+        "bob must restart on a different QUIC port"
+    );
+    // (2) Same identity across restart (same data_dir ⇒ same machine.key ⇒
+    // same MachineId; agent.key persists identically).
+    let bob_agent_after = pair.bob.agent_id().await;
+    assert_eq!(
+        bob_agent_after, bob_agent_before,
+        "same agent/machine identity across restart (same MachineId)"
+    );
+    // (3) Bob actually bound the new port and is advertising via mDNS so alice
+    // can rediscover the new endpoint.
+    assert_eq!(
+        local_quic_port(&pair.bob).await,
+        bob_port_after,
+        "bob bound the new port"
+    );
+    assert!(
+        mdns_advertising(&pair.bob).await,
+        "bob must advertise via mDNS so alice can refresh the endpoint"
+    );
+
+    // (4) Transport-path attribution + endpoint refresh: with NO manual
+    // trigger or rejoin, alice proactively redials bob. bob had no bootstrap,
+    // so he CANNOT have initiated — the connection is alice's proactive
+    // reconnect picking up bob's new mDNS-announced port. Poll alice's peer
+    // list for bob's peer id (and bob's inbound count rising ≥1 confirms it).
+    let reconnect_deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        let bob_inbound = connectivity_json(&pair.bob).await["connections"]["connected_peers"]
+            .as_u64()
+            .unwrap_or(0);
+        if bob_inbound >= 1 {
+            // Bob accepted an inbound connection — alice redialed him.
+            break;
+        }
+        if tokio::time::Instant::now() > reconnect_deadline {
+            panic!(
+                "alice did not proactively reconnect to bob on the new port \
+                 within 120s (bob had no bootstrap, so this is the proactive path)"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    // Confirm from alice's side: she lists bob's peer id. peer_id is stable
+    // across restart (same machine.key), so the pre-kill id must reappear.
+    let mut alice_sees_bob = false;
+    let confirm_deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if has_peer(&pair.alice, &bob_peer_before).await {
+            alice_sees_bob = true;
+            break;
+        }
+        if tokio::time::Instant::now() > confirm_deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+    // peer_id stability is the expected behaviour; if ant-quic regenerated it,
+    // fall back to alice listing any peer (the isolated pair only has bob).
+    assert!(
+        alice_sees_bob
+            || connectivity_json(&pair.alice).await["connections"]["connected_peers"]
+                .as_u64()
+                .unwrap_or(0)
+                >= 1,
+        "alice must list bob after the proactive reconnect"
+    );
+
+    // (5) CRDT recovery: the offline mutation T2 arrives at bob over the
+    // proactive reconnect path — no rejoin call — and T1 is intact.
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "bob recovers offline mutation T2 over the proactive reconnect path",
+        120,
+        |json| tasks_contain(json, "T2-offline"),
+    )
+    .await;
+    poll_until(
+        &pair.bob,
+        &format!("/task-lists/{list_topic}/tasks"),
+        "bob still has T1 (state intact)",
+        60,
+        |json| tasks_contain(json, "T1-pre-kill"),
     )
     .await;
 }

--- a/tests/daemon_api_integration.rs
+++ b/tests/daemon_api_integration.rs
@@ -2012,6 +2012,26 @@ async fn daemon_api_claim_returns_version_and_structured_fields() -> Result<()> 
         body["committed"] == "local",
         "claim missing committed marker: {body:?}"
     );
+    // Advisory contract: claim is local + non-exclusive. The resolution
+    // block reports the local OR-Set snapshot; the caller is the sole
+    // candidate so locally_winning is true, yet exclusivity is disclaimed.
+    ensure!(
+        body["exclusive"] == false,
+        "claim must not claim exclusivity: {body:?}"
+    );
+    ensure!(
+        body["execution"]["authorization"] == "advisory",
+        "claim authorization is advisory: {body:?}"
+    );
+    ensure!(
+        body["resolution"]["locally_winning"] == true
+            && body["resolution"]["pending_convergence"] == true,
+        "claim resolution is local/provisional: {body:?}"
+    );
+    ensure!(
+        body["resolution"]["current_winner"]["agent_id"].is_string(),
+        "claim reports the current deterministic winner: {body:?}"
+    );
 
     // GET: structured ownership fields must be populated, legacy state kept.
     let listed = list_task_list_items(&d, &list_id).await?;
@@ -2082,35 +2102,62 @@ async fn daemon_api_claim_returns_version_and_structured_fields() -> Result<()> 
     Ok(())
 }
 
-// WHY: without a CAS signal two agents could both "successfully" claim and
-// neither could detect the race. expected_version turns a stale claim into
-// a visible 409 with the current version and NO mutation.
+// WHY: `fence_token` is a LOCAL, restart-safe fencing precondition, not a
+// distributed CAS. It is an OPAQUE `{epoch,revision}` token ("epoch:revision"
+// on the wire): the epoch changes on daemon restart, so a token captured
+// before a restart can never ABA-match a post-restart token even if the
+// revision counter reaches the same value. A stale revision OR a stale epoch
+// ⇒ 409 with no mutation. It still cannot stop two replicas at the same token
+// from both committing — cross-replica exclusion is intentionally not provided
+// (claims are advisory CRDT candidates).
 #[tokio::test]
 #[ignore]
-async fn daemon_api_claim_expected_version_cas() -> Result<()> {
+async fn daemon_api_claim_fence_token() -> Result<()> {
     let d = daemon().await;
-    let (list_id, task_id) = create_task_list_item(&d, "CAS claim").await?;
+    let (list_id, task_id) = create_task_list_item(&d, "fence claim").await?;
 
     let listed = list_task_list_items(&d, &list_id).await?;
     let version = listed["version"].as_u64().context("list version present")?;
+    let fence = listed["fence_token"]
+        .as_str()
+        .context("GET must return an opaque fence_token")?;
 
-    // Stale expected_version ⇒ 409 with current_version, task untouched.
+    // Build a stale fence token: same epoch, bumped revision (local snapshot
+    // moved). The token is opaque to clients; we fabricate a stale one to
+    // exercise the guard.
+    let (epoch, rev) = fence.split_once(':').context("fence token shape")?;
+    let stale_fence = format!("{}:{}", epoch, rev.parse::<u64>().unwrap() + 1000);
+
+    // Stale fence_token ⇒ 409 with current_version + current fence_token,
+    // task untouched, version unchanged.
     let (status, body) = patch_task_raw(
         &d,
         &list_id,
         &task_id,
-        serde_json::json!({"action":"claim","expected_version": version + 1000}),
+        serde_json::json!({"action":"claim","fence_token": stale_fence}),
     )
     .await?;
-    ensure!(status == StatusCode::CONFLICT, "stale CAS status: {status}");
-    ensure!(body["ok"] == false, "conflict response: {body:?}");
     ensure!(
-        body["error"] == "version conflict",
-        "conflict error: {body:?}"
+        status == StatusCode::CONFLICT,
+        "stale-fence status: {status}"
+    );
+    ensure!(body["ok"] == false, "conflict response: {body:?}");
+    // Honest wording: LOCAL staleness guard, not a distributed "version conflict".
+    ensure!(
+        body["error"] == "stale_local_version",
+        "conflict error wording: {body:?}"
+    );
+    ensure!(
+        body["cas"]["scope"] == "local_replica",
+        "fence scope must be localized: {body:?}"
     );
     ensure!(
         body["current_version"].as_u64() == Some(version),
-        "conflict must report current version: {body:?}"
+        "conflict must report current revision: {body:?}"
+    );
+    ensure!(
+        body["fence_token"].is_string(),
+        "conflict must echo the current fence token: {body:?}"
     );
     let listed = list_task_list_items(&d, &list_id).await?;
     let entry = task_entry(&listed, &task_id).context("task still listed")?;
@@ -2123,23 +2170,149 @@ async fn daemon_api_claim_expected_version_cas() -> Result<()> {
         "409 must not bump the version: {listed:?}"
     );
 
-    // Fresh expected_version ⇒ 200 committed with a bumped version.
+    // Fresh fence_token ⇒ 200 committed with a bumped version and a NEW token.
     let (status, body) = patch_task_raw(
         &d,
         &list_id,
         &task_id,
-        serde_json::json!({"action":"claim","expected_version": version}),
+        serde_json::json!({"action":"claim","fence_token": fence}),
     )
     .await?;
-    ensure!(status == StatusCode::OK, "fresh CAS status: {status}");
+    ensure!(status == StatusCode::OK, "fresh-fence status: {status}");
     ensure!(
         body["ok"] == true && body["committed"] == "local",
-        "fresh CAS response: {body:?}"
+        "fresh-fence response: {body:?}"
     );
     ensure!(
         body["version"].as_u64().is_some_and(|v| v > version),
-        "fresh CAS bumps version: {body:?}"
+        "fresh fence bumps version: {body:?}"
     );
+    ensure!(
+        body["fence_token"].is_string() && body["fence_token"] != fence,
+        "commit must return a new fence token: {body:?}"
+    );
+    // Advisory honesty: a fresh commit is local + advisory, NOT exclusive.
+    // The sole claimer is locally winning at commit time, but the response
+    // must still flag pending convergence and non-exclusivity.
+    ensure!(
+        body["resolution"]["pending_convergence"] == true,
+        "commit must be marked pending convergence: {body:?}"
+    );
+    ensure!(
+        body["exclusive"] == false,
+        "commit must never claim exclusivity: {body:?}"
+    );
+    ensure!(
+        body["execution"]["authorization"] == "advisory",
+        "execution authorization is advisory: {body:?}"
+    );
+    ensure!(
+        body["resolution"]["locally_winning"] == true,
+        "sole claimer is locally winning at commit: {body:?}"
+    );
+    Ok(())
+}
+// WHY (P1 fence bypass): the route parsed a provided `fence_token` with
+// `Option::and_then(FenceToken::from_wire)`, collapsing "present but
+// malformed/overflow" into `None` — and `None` means an *unfenced* advisory
+// commit. So a corrupt/legacy/garbage token silently downgraded to no fence
+// and the claim committed 200, exactly the opposite of the token contract.
+// A malformed or overflow token MUST be a hard client error (4xx) with NO
+// mutation of task, version, or fence — distinct from an ABSENT token (still
+// a valid unfenced advisory commit). This test pins that distinction.
+#[tokio::test]
+#[ignore]
+async fn daemon_api_claim_malformed_fence_token_is_rejected_non_mutating() -> Result<()> {
+    let d = daemon().await;
+    let (list_id, task_id) = create_task_list_item(&d, "malformed fence").await?;
+
+    let listed = list_task_list_items(&d, &list_id).await?;
+    let version_before = listed["version"]
+        .as_u64()
+        .context("list version present before attack")?;
+
+    // Every entry here is "present but invalid": a real client would never
+    // send these, but an attacker (or a corrupt/legacy cache) might. None of
+    // them may silently downgrade to an unfenced commit.
+    let malformed_tokens: &[&str] = &[
+        "",         // empty
+        "no-colon", // missing separator
+        ":5",       // missing epoch
+        "1:",       // missing revision
+        "1:2:3",    // too many parts
+        "abc:2",    // non-numeric epoch
+        "1:xyz",    // non-numeric revision
+        " 1:2 ",    // surrounding whitespace is not valid
+        // Overflow beyond u64 must be rejected, not wrapped/truncated.
+        "999999999999999999999999999999:1",
+        "1:999999999999999999999999999999",
+    ];
+
+    for bad in malformed_tokens {
+        let (status, body) = patch_task_raw(
+            &d,
+            &list_id,
+            &task_id,
+            serde_json::json!({"action":"claim","fence_token": bad}),
+        )
+        .await?;
+
+        // Contract: a present-but-malformed/overflow token is 400
+        // BAD_REQUEST with error "malformed_fence_token", never a silent 2xx
+        // commit. (Distinct from an ABSENT token, which is still a valid
+        // unfenced advisory commit.)
+        ensure!(
+            status == StatusCode::BAD_REQUEST,
+            "malformed fence_token {bad:?} must be 400, got {status}: {body:?}"
+        );
+        ensure!(
+            body["error"] == "malformed_fence_token",
+            "malformed fence_token {bad:?} must report malformed_fence_token: {body:?}"
+        );
+        ensure!(
+            body["ok"] == false,
+            "malformed fence_token must not report ok:true: {bad:?} -> {body:?}"
+        );
+    }
+
+    // After a storm of malformed attempts the task MUST be untouched: still
+    // empty, still unclaimed, and the list version unchanged (the rejection
+    // path neither claimed nor bumped the revision/fence).
+    let listed = list_task_list_items(&d, &list_id).await?;
+    let entry = task_entry(&listed, &task_id).context("task still present")?;
+    ensure!(
+        entry["state"] == "empty",
+        "malformed fence must not mutate task state: {entry:?}"
+    );
+    ensure!(
+        entry["claimed_by"].is_null(),
+        "malformed fence must not claim the task: {entry:?}"
+    );
+    ensure!(
+        listed["version"].as_u64() == Some(version_before),
+        "malformed fence rejection must not change the version: {:?} != {version_before}",
+        listed["version"]
+    );
+
+    // Teeth check: a VALID fence token (captured fresh from the current list
+    // state) still commits 200. This proves the gate rejects *malformed*
+    // tokens specifically, not all tokens — an over-rejection bug would fail
+    // here while passing every assertion above.
+    let fresh_fence = listed["fence_token"]
+        .as_str()
+        .context("GET must return an opaque fence_token")?;
+    let (status, body) = patch_task_raw(
+        &d,
+        &list_id,
+        &task_id,
+        serde_json::json!({"action":"claim","fence_token": fresh_fence}),
+    )
+    .await?;
+    ensure!(
+        status == StatusCode::OK,
+        "valid fence_token must still commit: {status} {body:?}"
+    );
+    ensure!(body["ok"] == true, "valid commit reports ok: {body:?}");
     Ok(())
 }
 

--- a/tests/daemon_api_integration.rs
+++ b/tests/daemon_api_integration.rs
@@ -1960,6 +1960,189 @@ async fn daemon_api_complete_task() -> Result<()> {
     Ok(())
 }
 
+/// PATCH a task with an arbitrary body, returning (status, body) for
+/// assertions on both success and conflict responses.
+async fn patch_task_raw(
+    d: &DaemonFixture,
+    list_id: &str,
+    task_id: &str,
+    body: Value,
+) -> Result<(StatusCode, Value)> {
+    let response = ca(d)
+        .patch(d.url(&format!("/task-lists/{list_id}/tasks/{task_id}")))
+        .json(&body)
+        .send()
+        .await?;
+    let status = response.status();
+    let body: Value = response.json().await?;
+    Ok((status, body))
+}
+
+fn task_entry<'a>(body: &'a Value, task_id: &str) -> Option<&'a Value> {
+    body["tasks"].as_array().and_then(|tasks| {
+        tasks
+            .iter()
+            .find(|task| task["id"].as_str() == Some(task_id))
+    })
+}
+
+// WHY: claiming used to return bare {"ok":true} with the task's assignee
+// null forever — ownership was only recoverable by parsing the Display
+// string "claimed:<hex>", and success gave no version or consistency
+// signal. This test pins the structured contract.
+#[tokio::test]
+#[ignore]
+async fn daemon_api_claim_returns_version_and_structured_fields() -> Result<()> {
+    let d = daemon().await;
+    let (list_id, task_id) = create_task_list_item(&d, "Structured claim").await?;
+
+    // Claim: response must carry the new list version and the explicit
+    // local-commit marker (success = local commit + publish, NOT replication).
+    let (status, body) = patch_task_raw(
+        &d,
+        &list_id,
+        &task_id,
+        serde_json::json!({"action":"claim"}),
+    )
+    .await?;
+    ensure!(status == StatusCode::OK, "claim status: {status}");
+    ensure!(body["ok"] == true, "claim response: {body:?}");
+    ensure!(body["version"].is_u64(), "claim missing version: {body:?}");
+    ensure!(
+        body["committed"] == "local",
+        "claim missing committed marker: {body:?}"
+    );
+
+    // GET: structured ownership fields must be populated, legacy state kept.
+    let listed = list_task_list_items(&d, &list_id).await?;
+    ensure!(
+        listed["version"].is_u64(),
+        "list missing version: {listed:?}"
+    );
+    let entry = task_entry(&listed, &task_id).context("task present in listing")?;
+    let claimed_by = entry["claimed_by"]
+        .as_str()
+        .context("claimed_by non-null")?;
+    ensure!(
+        claimed_by.len() == 64,
+        "claimed_by is hex AgentId: {entry:?}"
+    );
+    ensure!(
+        entry["claimed_at"]
+            .as_u64()
+            .is_some_and(|t| t > 1_000_000_000_000),
+        "claimed_at is Unix ms: {entry:?}"
+    );
+    ensure!(
+        entry["assignee"].as_str() == Some(claimed_by),
+        "assignee register populated by claim: {entry:?}"
+    );
+    ensure!(
+        entry["state"]
+            .as_str()
+            .is_some_and(|s| s.starts_with("claimed:")),
+        "legacy state string unchanged: {entry:?}"
+    );
+    ensure!(
+        entry["completed_by"].is_null() && entry["completed_at"].is_null(),
+        "completion fields null before done: {entry:?}"
+    );
+
+    // Complete: completion fields become non-null, claim record survives.
+    let (status, body) = patch_task_raw(
+        &d,
+        &list_id,
+        &task_id,
+        serde_json::json!({"action":"complete"}),
+    )
+    .await?;
+    ensure!(status == StatusCode::OK, "complete status: {status}");
+    ensure!(
+        body["version"].is_u64() && body["committed"] == "local",
+        "complete response: {body:?}"
+    );
+    let listed = list_task_list_items(&d, &list_id).await?;
+    let entry = task_entry(&listed, &task_id).context("task present after done")?;
+    ensure!(
+        entry["completed_by"]
+            .as_str()
+            .is_some_and(|s| s.len() == 64),
+        "completed_by non-null after done: {entry:?}"
+    );
+    ensure!(
+        entry["completed_at"]
+            .as_u64()
+            .is_some_and(|t| t > 1_000_000_000_000),
+        "completed_at is Unix ms: {entry:?}"
+    );
+    ensure!(
+        entry["claimed_by"].as_str() == Some(claimed_by),
+        "claim record survives completion: {entry:?}"
+    );
+    Ok(())
+}
+
+// WHY: without a CAS signal two agents could both "successfully" claim and
+// neither could detect the race. expected_version turns a stale claim into
+// a visible 409 with the current version and NO mutation.
+#[tokio::test]
+#[ignore]
+async fn daemon_api_claim_expected_version_cas() -> Result<()> {
+    let d = daemon().await;
+    let (list_id, task_id) = create_task_list_item(&d, "CAS claim").await?;
+
+    let listed = list_task_list_items(&d, &list_id).await?;
+    let version = listed["version"].as_u64().context("list version present")?;
+
+    // Stale expected_version ⇒ 409 with current_version, task untouched.
+    let (status, body) = patch_task_raw(
+        &d,
+        &list_id,
+        &task_id,
+        serde_json::json!({"action":"claim","expected_version": version + 1000}),
+    )
+    .await?;
+    ensure!(status == StatusCode::CONFLICT, "stale CAS status: {status}");
+    ensure!(body["ok"] == false, "conflict response: {body:?}");
+    ensure!(
+        body["error"] == "version conflict",
+        "conflict error: {body:?}"
+    );
+    ensure!(
+        body["current_version"].as_u64() == Some(version),
+        "conflict must report current version: {body:?}"
+    );
+    let listed = list_task_list_items(&d, &list_id).await?;
+    let entry = task_entry(&listed, &task_id).context("task still listed")?;
+    ensure!(
+        entry["state"] == "empty" && entry["claimed_by"].is_null(),
+        "409 must not mutate the task: {entry:?}"
+    );
+    ensure!(
+        listed["version"].as_u64() == Some(version),
+        "409 must not bump the version: {listed:?}"
+    );
+
+    // Fresh expected_version ⇒ 200 committed with a bumped version.
+    let (status, body) = patch_task_raw(
+        &d,
+        &list_id,
+        &task_id,
+        serde_json::json!({"action":"claim","expected_version": version}),
+    )
+    .await?;
+    ensure!(status == StatusCode::OK, "fresh CAS status: {status}");
+    ensure!(
+        body["ok"] == true && body["committed"] == "local",
+        "fresh CAS response: {body:?}"
+    );
+    ensure!(
+        body["version"].as_u64().is_some_and(|v| v > version),
+        "fresh CAS bumps version: {body:?}"
+    );
+    Ok(())
+}
+
 // ===========================================================================
 // Network (5)
 // ===========================================================================

--- a/tests/harness/src/cluster.rs
+++ b/tests/harness/src/cluster.rs
@@ -49,17 +49,83 @@ impl AgentInstance {
     }
 
     /// Start the daemon again after [`Self::stop`] and wait until healthy.
+    ///
+    /// Test-only: when `X0X_TEST_LOG_DIR` is set, the restarted daemon's
+    /// stdout/stderr are appended to `{dir}/{name}.restart.{out,err}.log`
+    /// (outside the per-node temp data_dir, so logs survive cleanup and are
+    /// preserved on test failure). When unset, I/O is discarded as before.
+    /// The daemon inherits `RUST_LOG` from this process — set it in the test
+    /// environment to raise verbosity for post-restart diagnostics.
     pub async fn start(&mut self) {
+        let (stdout, stderr) = match test_log_stdio(&self.name, "restart") {
+            Some(pair) => pair,
+            None => (Stdio::null(), Stdio::null()),
+        };
         self.process = Command::new(&self.binary)
             .arg("--config")
             .arg(&self.config_path)
             .arg("--name")
             .arg(&self.name)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stdout(stdout)
+            .stderr(stderr)
             .spawn()
             .unwrap_or_else(|e| panic!("Failed to restart x0xd {}: {e}", self.name));
         self.refresh_runtime_state().await;
+    }
+    /// Restart the daemon on a FORCED NEW QUIC (bind) port, keeping the same
+    /// data_dir (hence the same `machine.key`/`agent.key` → same MachineId and
+    /// QUIC peer_id), and with NO bootstrap peers configured.
+    ///
+    /// This is the named-node-restart primitive for the reconnect-policy
+    /// regression: the restarted peer cannot startup-dial anyone (no
+    /// bootstrap, `--no-hard-coded-bootstrap`), so the mesh can only reform
+    /// via the SURVIVOR's proactive reconnect refreshing the new mDNS-announced
+    /// endpoint. Returns the new QUIC bind port so the test can assert it
+    /// differs from the pre-kill port (no fixed-port shortcut).
+    pub async fn restart_on_new_quic_port_no_bootstrap(&mut self) -> u16 {
+        self.stop();
+        let new_bind = allocate_unused_udp_port();
+
+        // Rewrite the config in place: drop every `bootstrap_peers` line (so
+        // the restarted peer cannot initiate) and repoint `bind_address` at the
+        // new port. `data_dir` is preserved verbatim → identity is preserved.
+        let old_cfg = std::fs::read_to_string(&self.config_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", self.config_path.display()));
+        let mut rebuilt = String::new();
+        for line in old_cfg.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("bootstrap_peers") {
+                continue;
+            }
+            if trimmed.starts_with("bind_address") {
+                rebuilt.push_str(&format!("bind_address = \"0.0.0.0:{new_bind}\"\n"));
+                continue;
+            }
+            rebuilt.push_str(line);
+            rebuilt.push('\n');
+        }
+        std::fs::write(&self.config_path, &rebuilt)
+            .unwrap_or_else(|e| panic!("rewrite {}: {e}", self.config_path.display()));
+
+        let (stdout, stderr) = match test_log_stdio(&self.name, "restart-newport") {
+            Some(pair) => pair,
+            None => (Stdio::null(), Stdio::null()),
+        };
+        self.process = Command::new(&self.binary)
+            .arg("--config")
+            .arg(&self.config_path)
+            .arg("--name")
+            .arg(&self.name)
+            // No hard-coded internet bootstrap either: this peer must be
+            // unreachable by its own dialing so reconnection is attributable
+            // solely to the survivor's proactive path.
+            .arg("--no-hard-coded-bootstrap")
+            .stdout(stdout)
+            .stderr(stderr)
+            .spawn()
+            .unwrap_or_else(|e| panic!("Failed to restart x0xd {}: {e}", self.name));
+        self.refresh_runtime_state().await;
+        new_bind
     }
 
     async fn refresh_runtime_state(&mut self) {
@@ -529,6 +595,38 @@ fn allocate_unused_udp_port() -> u16 {
         .port()
 }
 
+/// Test-only daemon log capture.
+///
+/// When `X0X_TEST_LOG_DIR` is set, returns stdout/stderr `Stdio` handles that
+/// append to `{dir}/{name}.{suffix}.{out,err}.log`. That path lives outside the
+/// per-node temp data_dir, so the logs survive data-dir cleanup and are
+/// preserved on test failure. Returns `None` when the env var is unset so the
+/// caller's default sink (per-node data-dir files, or `Stdio::null()`) is used
+/// and other tests are unaffected.
+///
+/// The daemon inherits `RUST_LOG` from this process, so set `RUST_LOG` (e.g.
+/// `x0x::crdt=debug,x0x::server=debug`) in the test environment to raise
+/// verbosity; the directive is honoured by the daemon's `init_logging`.
+fn test_log_stdio(name: &str, suffix: &str) -> Option<(Stdio, Stdio)> {
+    let dir = std::env::var("X0X_TEST_LOG_DIR").ok()?;
+    let dir = dir.trim();
+    if dir.is_empty() {
+        return None;
+    }
+    let _ = std::fs::create_dir_all(dir);
+    let base = std::path::Path::new(dir).join(format!("{name}.{suffix}"));
+    let open = || {
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(format!("{}.log", base.display()))
+            .unwrap_or_else(|e| panic!("open test log {base:?}: {e}"))
+    };
+    // Two independent append handles to the same path; both file descriptions
+    // share O_APPEND, so interleaved stdout/stderr writes stay ordered.
+    Some((Stdio::from(open()), Stdio::from(open())))
+}
+
 async fn start_instance(
     binary: &PathBuf,
     name: &str,
@@ -563,12 +661,20 @@ async fn start_instance(
     );
     std::fs::write(&config_path, &config_content).expect("write config");
 
-    let stdout_path = config_dir.join("daemon.stdout.log");
-    let stderr_path = config_dir.join("daemon.stderr.log");
-    let stdout = std::fs::File::create(&stdout_path)
-        .unwrap_or_else(|e| panic!("Failed to create stdout log for {name}: {e}"));
-    let stderr = std::fs::File::create(&stderr_path)
-        .unwrap_or_else(|e| panic!("Failed to create stderr log for {name}: {e}"));
+    // Test-only capture (see `test_log_stdio`); fall back to per-node data-dir
+    // logs so the default behaviour is unchanged.
+    let (stdout, stderr) = match test_log_stdio(name, "start") {
+        Some(pair) => pair,
+        None => {
+            let stdout_path = config_dir.join("daemon.stdout.log");
+            let stderr_path = config_dir.join("daemon.stderr.log");
+            let out = std::fs::File::create(&stdout_path)
+                .unwrap_or_else(|e| panic!("Failed to create stdout log for {name}: {e}"));
+            let err = std::fs::File::create(&stderr_path)
+                .unwrap_or_else(|e| panic!("Failed to create stderr log for {name}: {e}"));
+            (Stdio::from(out), Stdio::from(err))
+        }
+    };
 
     let process = Command::new(binary)
         .arg("--config")
@@ -576,8 +682,8 @@ async fn start_instance(
         .arg("--name")
         .arg(name)
         .arg("--no-hard-coded-bootstrap")
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(stderr))
+        .stdout(stdout)
+        .stderr(stderr)
         .spawn()
         .unwrap_or_else(|e| panic!("Failed to start x0xd {name}: {e}"));
 

--- a/tests/harness/src/cluster.rs
+++ b/tests/harness/src/cluster.rs
@@ -36,8 +36,20 @@ impl AgentInstance {
     }
 
     pub async fn restart(&mut self) {
+        self.stop();
+        self.start().await;
+    }
+
+    /// Kill the daemon process without restarting it. Pair with
+    /// [`Self::start`] to create a downtime window during which other
+    /// instances can mutate shared state (offline-mutation tests).
+    pub fn stop(&mut self) {
         let _ = self.process.kill();
         let _ = self.process.wait();
+    }
+
+    /// Start the daemon again after [`Self::stop`] and wait until healthy.
+    pub async fn start(&mut self) {
         self.process = Command::new(&self.binary)
             .arg("--config")
             .arg(&self.config_path)

--- a/tests/kv_first_join_bootstrap.rs
+++ b/tests/kv_first_join_bootstrap.rs
@@ -69,9 +69,16 @@ async fn first_time_late_joiner_bootstraps_historical_keys() {
     // Only now does bob's daemon boot and connect.
     let bob = cluster::join_peer(&alice, alice_bind).await;
 
-    // Bob joins the store topic for the first time, after the write.
+    // Bob joins the store topic for the first time, after the write,
+    // anchoring on alice's authoritative owner. The expected_owner anchor is
+    // required out-of-band since the signed-store fork fix — an unanchored
+    // join is rejected fail-closed with 422 owner_required.
+    let alice_id = alice.agent_id().await;
     let r = bob
-        .post(&format!("/stores/{topic}/join"), serde_json::json!({}))
+        .post(
+            &format!("/stores/{topic}/join"),
+            serde_json::json!({ "expected_owner": alice_id }),
+        )
         .await;
     assert!(r.status().is_success(), "bob joins store");
     let pair = cluster::AgentPair { alice, bob };
@@ -127,9 +134,13 @@ async fn live_replication_still_works_after_bootstrap_change() {
         )
         .await;
     assert!(r.status().is_success(), "alice creates store");
+    let alice_id = pair.alice.agent_id().await;
     let r = pair
         .bob
-        .post(&format!("/stores/{topic}/join"), serde_json::json!({}))
+        .post(
+            &format!("/stores/{topic}/join"),
+            serde_json::json!({ "expected_owner": alice_id }),
+        )
         .await;
     assert!(r.status().is_success(), "bob joins before the write");
 

--- a/tests/kv_signed_store_auth.rs
+++ b/tests/kv_signed_store_auth.rs
@@ -1,0 +1,138 @@
+//! Security regression test — a non-owner joiner of a `Signed` KV store
+//! must NOT be able to mutate its local replica.
+//!
+//! Previously a joiner's replica claimed the joiner itself as owner with a
+//! permissive policy, so a local PUT via REST returned `200 {"ok":true}` and
+//! forked the joiner's replica away from the state authorized peers accept
+//! (the creator rejected the joiner's deltas, but the joiner kept its junk).
+//!
+//! The fix: a joined replica starts with no owner (fail closed, read-only),
+//! learns the authoritative owner + policy from an owner-signed announcement
+//! on the state-sync side topic, and enforces the same `is_authorized` rule
+//! on local writes as on inbound deltas. REST returns 403 for rejected
+//! writes.
+//!
+//! All tests are `#[ignore]` — they boot real x0xd daemons.
+//! Run with: cargo nextest run --test kv_signed_store_auth -- --ignored
+//! Before running: cargo build --release --bin x0xd
+
+use base64::Engine;
+use std::time::{Duration, Instant};
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+fn b64(s: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(s)
+}
+
+/// Poll until `key` is visible in bob's replica, panicking after `deadline`.
+async fn wait_for_key(bob: &cluster::AgentInstance, topic: &str, key: &str, secs: u64) {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    loop {
+        let r = bob.get(&format!("/stores/{topic}/{key}")).await;
+        if r.status().is_success() {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "key {key} never replicated to the joiner within {secs}s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn joiner_put_on_signed_store_is_403_and_does_not_mutate() {
+    let pair = cluster::pair().await;
+    let topic = format!("kv-auth-{}", rand::random::<u32>());
+
+    // Alice creates the store (Signed policy, owner = alice) and writes a
+    // seed key.
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "authz", "topic": topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates store");
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/seed"),
+            serde_json::json!({ "value": b64(b"owner-data") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice (owner) writes seed key");
+
+    // Bob joins. His replica must sync the seed key — which also proves he
+    // has adopted the authoritative owner, since a replica with an unknown
+    // owner rejects all inbound deltas (fail closed).
+    let r = pair
+        .bob
+        .post(&format!("/stores/{topic}/join"), serde_json::json!({}))
+        .await;
+    assert!(r.status().is_success(), "bob joins store");
+    wait_for_key(&pair.bob, &topic, "seed", 60).await;
+
+    // THE DEFECT: bob (non-owner) PUTs into the Signed store. This used to
+    // return 200 and mutate his local replica, creating a fork the creator
+    // rejects. It must now be a 403 with a distinct error body.
+    let r = pair
+        .bob
+        .put(
+            &format!("/stores/{topic}/intruder"),
+            serde_json::json!({ "value": b64(b"forked-junk") }),
+        )
+        .await;
+    assert_eq!(
+        r.status().as_u16(),
+        403,
+        "non-owner local PUT on a Signed store must be rejected with 403"
+    );
+    let body: serde_json::Value = r.json().await.expect("403 body is json");
+    assert_eq!(body["ok"], false, "error body must carry ok:false");
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("not authorized") && err.contains("owner is "),
+        "403 body must name the policy violation and the true owner; got: {err}"
+    );
+
+    // And the local replica must NOT have been mutated.
+    let r = pair.bob.get(&format!("/stores/{topic}/intruder")).await;
+    assert_eq!(
+        r.status().as_u16(),
+        404,
+        "rejected PUT must not mutate the joiner's local replica"
+    );
+
+    // Non-owner DELETE of an existing key must also be rejected without
+    // mutating the replica.
+    let r = pair.bob.delete(&format!("/stores/{topic}/seed")).await;
+    assert_eq!(
+        r.status().as_u16(),
+        403,
+        "non-owner local DELETE on a Signed store must be rejected with 403"
+    );
+    let r = pair.bob.get(&format!("/stores/{topic}/seed")).await;
+    assert!(
+        r.status().is_success(),
+        "rejected DELETE must not remove the key from the joiner's replica"
+    );
+
+    // Creator writes keep working and still replicate to the joiner.
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/post-join"),
+            serde_json::json!({ "value": b64(b"still-flows") }),
+        )
+        .await;
+    assert!(
+        r.status().is_success(),
+        "owner writes must keep working unchanged"
+    );
+    wait_for_key(&pair.bob, &topic, "post-join", 30).await;
+}

--- a/tests/kv_signed_store_auth.rs
+++ b/tests/kv_signed_store_auth.rs
@@ -6,11 +6,15 @@
 //! forked the joiner's replica away from the state authorized peers accept
 //! (the creator rejected the joiner's deltas, but the joiner kept its junk).
 //!
-//! The fix: a joined replica starts with no owner (fail closed, read-only),
-//! learns the authoritative owner + policy from an owner-signed announcement
-//! on the state-sync side topic, and enforces the same `is_authorized` rule
-//! on local writes as on inbound deltas. REST returns 403 for rejected
-//! writes.
+//! The fix: ownership is anchored ONLY at construction from trusted
+//! out-of-band input (an explicit `expected_owner` at join). It is NEVER
+//! adopted from an owner-signed announcement — `verified_sender == owner` is
+//! trivially satisfied by any self-claim, so learning ownership from an
+//! announce would let any agent that speaks first seize the topic
+//! (first-self-capture). A joiner anchored on the real owner accepts its
+//! deltas and enforces the same `is_authorized` rule on local writes as on
+//! inbound deltas; a no-anchor join is permanently read-only (no permissive
+//! fallback). REST returns 403 for rejected writes.
 //!
 //! All tests are `#[ignore]` — they boot real x0xd daemons.
 //! Run with: cargo nextest run --test kv_signed_store_auth -- --ignored
@@ -67,14 +71,19 @@ async fn joiner_put_on_signed_store_is_403_and_does_not_mutate() {
         .await;
     assert!(r.status().is_success(), "alice (owner) writes seed key");
 
-    // Bob joins. His replica must sync the seed key — which also proves he
-    // has adopted the authoritative owner, since a replica with an unknown
-    // owner rejects all inbound deltas (fail closed).
+    // Bob joins, anchoring on Alice's authoritative owner (out-of-band). His
+    // replica now accepts Alice's deltas and converges. Ownership is anchored
+    // at construction — never learned from an (attackable) announce — so a
+    // rogue that self-announces first cannot seize the topic.
+    let alice_id = pair.alice.agent_id().await;
     let r = pair
         .bob
-        .post(&format!("/stores/{topic}/join"), serde_json::json!({}))
+        .post(
+            &format!("/stores/{topic}/join"),
+            serde_json::json!({ "expected_owner": alice_id }),
+        )
         .await;
-    assert!(r.status().is_success(), "bob joins store");
+    assert!(r.status().is_success(), "bob joins store anchored on alice");
     wait_for_key(&pair.bob, &topic, "seed", 60).await;
 
     // THE DEFECT: bob (non-owner) PUTs into the Signed store. This used to

--- a/tests/proptest_crdt.rs
+++ b/tests/proptest_crdt.rs
@@ -8,7 +8,7 @@
 use proptest::prelude::*;
 use saorsa_gossip_types::PeerId;
 use x0x::crdt::{CheckboxState, TaskId, TaskItem, TaskList, TaskListId, TaskMetadata};
-use x0x::identity::AgentId;
+use x0x::identity::{AgentId, AgentKeypair};
 
 // ── Strategies ──────────────────────────────────────────────────────────
 
@@ -34,6 +34,25 @@ fn make_task_item(title: &str, agent_id: AgentId, peer_id: PeerId) -> TaskItem {
 fn make_task_list(name: &str, peer_id: PeerId) -> TaskList {
     let id = TaskListId::new([0u8; 32]);
     TaskList::new(id, name.to_string(), peer_id)
+}
+
+fn test_scope() -> TaskListId {
+    TaskListId::new([0u8; 32])
+}
+
+/// Deterministically derive a self-consistent signing context and its agent id
+/// from a 32-byte seed. `claim`/`complete` self-sign the attestation and reject
+/// any `agent_id` that does not match the signing key, so the actor's `AgentId`
+/// must be the one derived from this keypair's public key.
+fn signing_from_seed(seed: [u8; 32]) -> (x0x::gossip::SigningContext, AgentId) {
+    use fips204::traits::{KeyGen, SerDes};
+    let (public_key, secret_key) = fips204::ml_dsa_65::KG::keygen_from_seed(&seed);
+    let kp = AgentKeypair::from_bytes(&public_key.into_bytes(), &secret_key.into_bytes())
+        .expect("deterministic seed yields a valid ML-DSA-65 keypair");
+    (
+        x0x::gossip::SigningContext::from_keypair(&kp),
+        kp.agent_id(),
+    )
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -163,14 +182,14 @@ proptest! {
     /// Claiming an empty task succeeds.
     #[test]
     fn task_item_claim_empty_succeeds(
-        agent_bytes in prop::array::uniform32(any::<u8>()),
+        seed in prop::array::uniform32(any::<u8>()),
         peer_bytes in prop::array::uniform32(any::<u8>()),
     ) {
-        let agent = AgentId(agent_bytes);
+        let (signing, agent) = signing_from_seed(seed);
         let peer = make_peer_id(peer_bytes);
         let mut task = make_task_item("test", agent, peer);
 
-        let result = task.claim(agent, peer, 1);
+        let result = task.claim(test_scope(), agent, peer, 1, &signing);
         prop_assert!(result.is_ok(), "claim on empty should succeed");
 
         let state = task.current_state();
@@ -183,15 +202,15 @@ proptest! {
     /// Completing a claimed task succeeds.
     #[test]
     fn task_item_complete_claimed_succeeds(
-        agent_bytes in prop::array::uniform32(any::<u8>()),
+        seed in prop::array::uniform32(any::<u8>()),
         peer_bytes in prop::array::uniform32(any::<u8>()),
     ) {
-        let agent = AgentId(agent_bytes);
+        let (signing, agent) = signing_from_seed(seed);
         let peer = make_peer_id(peer_bytes);
         let mut task = make_task_item("test", agent, peer);
 
-        prop_assert!(task.claim(agent, peer, 1).is_ok(), "claim should succeed");
-        let result = task.complete(agent, peer, 2);
+        prop_assert!(task.claim(test_scope(), agent, peer, 1, &signing).is_ok(), "claim should succeed");
+        let result = task.complete(test_scope(), agent, peer, 2, &signing);
         prop_assert!(result.is_ok(), "complete on claimed should succeed");
 
         let state = task.current_state();
@@ -204,26 +223,25 @@ proptest! {
     /// TaskItem merge is idempotent: A.merge(B).merge(B) == A.merge(B).
     #[test]
     fn task_item_merge_idempotent(
-        agent_bytes in prop::array::uniform32(any::<u8>()),
+        seed in prop::array::uniform32(any::<u8>()),
         peer_bytes in prop::array::uniform32(any::<u8>()),
     ) {
-        let agent = AgentId(agent_bytes);
+        let (signing, agent) = signing_from_seed(seed);
         let peer = make_peer_id(peer_bytes);
-
         let mut a = make_task_item("test", agent, peer);
         let mut b = make_task_item("test", agent, peer);
-        prop_assert!(b.claim(agent, peer, 1).is_ok(), "claim should succeed");
+        prop_assert!(b.claim(test_scope(), agent, peer, 1, &signing).is_ok(), "claim should succeed");
         b.update_title("updated title".to_string(), peer);
         b.update_description("updated description".to_string(), peer);
         b.update_assignee(Some(agent), peer);
         b.update_priority(255, peer);
 
         // First merge
-        prop_assert!(a.merge(&b).is_ok(), "first merge should succeed");
+        prop_assert!(a.merge(test_scope(), &b).is_ok(), "first merge should succeed");
         let snapshot_after_one = task_snapshot(&a);
 
         // Second merge (same b)
-        prop_assert!(a.merge(&b).is_ok(), "second merge should succeed");
+        prop_assert!(a.merge(test_scope(), &b).is_ok(), "second merge should succeed");
         let snapshot_after_two = task_snapshot(&a);
 
         prop_assert_eq!(snapshot_after_one, snapshot_after_two, "merge should be idempotent");
@@ -309,7 +327,7 @@ proptest! {
     fn task_list_merge_commutative(
         peer_a_bytes in prop::array::uniform32(any::<u8>()),
         peer_b_bytes in prop::array::uniform32(any::<u8>()),
-        agent_bytes in prop::array::uniform32(any::<u8>()),
+        seed in prop::array::uniform32(any::<u8>()),
     ) {
         let peer_a = make_peer_id(peer_a_bytes);
         let peer_b = if peer_a_bytes == peer_b_bytes {
@@ -317,16 +335,15 @@ proptest! {
         } else {
             make_peer_id(peer_b_bytes)
         };
-        let agent = AgentId(agent_bytes);
+        let (signing, agent) = signing_from_seed(seed);
 
         let mut a = make_task_list("test", peer_a);
         let mut b = make_task_list("test", peer_b);
 
-        // Add the same task to each replica, then diverge observable state.
         let task_id = TaskId::new("shared-task", &agent, 1000);
         let metadata = TaskMetadata::new("shared-task", "desc", 128, agent, 1000);
         let mut task_a = TaskItem::new(task_id, metadata.clone(), peer_a);
-        prop_assert!(task_a.claim(agent, peer_a, 2).is_ok(), "claim should succeed");
+        prop_assert!(task_a.claim(test_scope(), agent, peer_a, 2, &signing).is_ok(), "claim should succeed");
         task_a.update_title("title from a".to_string(), peer_a);
         let seq_a = a.next_seq();
         prop_assert!(a.add_task(task_a, peer_a, seq_a).is_ok(), "add to a should succeed");

--- a/tests/provenance_crypto.rs
+++ b/tests/provenance_crypto.rs
@@ -1,0 +1,184 @@
+//! Integration-level verification of the task-claim provenance crypto core.
+//!
+//! Rationale: the in-crate `#[cfg(test)]` module in `src/crdt/provenance.rs`
+//! cannot execute until the lib *test* binary links, which is currently blocked
+//! by an in-flight `claim_task` signature migration elsewhere. This file is an
+//! *integration* test: it links against the non-test lib (which compiles
+//! warning-clean) and exercises the public provenance API against the REAL
+//! ML-DSA-65 implementation, independent of the lib-test modules.
+//!
+//! Covers the security-critical binding: a claim/complete attestation verifies
+//! only when signed by the ML-DSA-65 secret key whose public key hashes to the
+//! claimed `agent_id`. Impersonation, tampered signatures, malformed keys, and
+//! cross-task/cross-timestamp replay are all rejected.
+
+#![allow(clippy::unwrap_used)]
+
+use x0x::crdt::provenance::{
+    canonical_op_bytes, sign_attestation, verify_attestation, OpAttestation, OpKind,
+};
+use x0x::crdt::{TaskId, TaskListId};
+use x0x::gossip::SigningContext;
+use x0x::identity::{AgentId, AgentKeypair};
+
+/// Build a fresh signing context + its derived agent id.
+fn fresh_signing() -> (SigningContext, AgentId) {
+    let kp = AgentKeypair::generate().unwrap();
+    let aid = kp.agent_id();
+    (SigningContext::from_keypair(&kp), aid)
+}
+
+fn task_id_for(agent: &AgentId) -> TaskId {
+    TaskId::new("provenance-integration", agent, 1)
+}
+
+fn scope() -> TaskListId {
+    TaskListId::new([0xAA; 32])
+}
+
+// ── canonical_op_bytes: determinism & domain separation ─────────────────────
+
+#[test]
+fn canonical_bytes_are_deterministic_and_domain_separated() {
+    let (_, aid) = fresh_signing();
+    let tid = task_id_for(&aid);
+    let a = canonical_op_bytes(OpKind::Claim, &scope(), &tid, &aid, 1000);
+    let b = canonical_op_bytes(OpKind::Claim, &scope(), &tid, &aid, 1000);
+    assert_eq!(a, b, "identical inputs ⇒ identical bytes");
+
+    // Claim and complete domains must not collide (no cross-context replay).
+    let claim = canonical_op_bytes(OpKind::Claim, &scope(), &tid, &aid, 1000);
+    let complete = canonical_op_bytes(OpKind::Complete, &scope(), &tid, &aid, 1000);
+    assert_ne!(claim, complete);
+
+    // Every field is bound.
+    assert_ne!(
+        a,
+        canonical_op_bytes(OpKind::Claim, &scope(), &tid, &aid, 1001)
+    ); // ts
+    let other_task = TaskId::new("other", &aid, 9);
+    assert_ne!(
+        a,
+        canonical_op_bytes(OpKind::Claim, &scope(), &other_task, &aid, 1000)
+    ); // task
+    let (_, other_agent) = fresh_signing();
+    assert_ne!(
+        a,
+        canonical_op_bytes(OpKind::Claim, &scope(), &tid, &other_agent, 1000)
+    ); // agent
+}
+
+// ── sign / verify roundtrip ─────────────────────────────────────────────────
+
+#[test]
+fn validly_signed_attestation_verifies() {
+    let (signing, aid) = fresh_signing();
+    let tid = task_id_for(&aid);
+    let att = sign_attestation(&signing, OpKind::Claim, &scope(), &tid, &aid, 5000).unwrap();
+    assert!(
+        verify_attestation(&att, OpKind::Claim, &scope(), &tid, &aid, 5000),
+        "a validly-signed attestation must verify"
+    );
+    // Completion attestation verifies too.
+    let comp = sign_attestation(&signing, OpKind::Complete, &scope(), &tid, &aid, 6000).unwrap();
+    assert!(verify_attestation(
+        &comp,
+        OpKind::Complete,
+        &scope(),
+        &tid,
+        &aid,
+        6000,
+    ));
+}
+
+// ── impersonation: forged claimant agent_id ─────────────────────────────────
+
+#[test]
+fn attacker_key_cannot_attest_as_victim() {
+    // The attacker signs the victim's canonical bytes with the attacker's own
+    // key, then self-asserts the victim as the author. The derived agent
+    // (attacker) must not equal the claimed victim agent_id ⇒ rejected.
+    let (attacker_signing, attacker) = fresh_signing();
+    let (_, victim) = fresh_signing();
+    assert_ne!(attacker, victim, "fixtures must be distinct agents");
+    let tid = task_id_for(&victim);
+    let msg = canonical_op_bytes(OpKind::Claim, &scope(), &tid, &victim, 1);
+    let signature = attacker_signing.sign(&msg).unwrap();
+    let forged = OpAttestation {
+        author_agent_id: victim,
+        author_public_key: attacker_signing.public_key_bytes.clone(),
+        signature,
+    };
+    assert!(
+        !verify_attestation(&forged, OpKind::Claim, &scope(), &tid, &victim, 1),
+        "an attacker's key must not verify against a victim agent_id"
+    );
+}
+
+#[test]
+fn sign_attestation_refuses_to_attest_as_a_non_local_agent() {
+    let (signing, _) = fresh_signing();
+    let (_, other) = fresh_signing();
+    let tid = task_id_for(&other);
+    let res = sign_attestation(&signing, OpKind::Claim, &scope(), &tid, &other, 1);
+    assert!(
+        res.is_err(),
+        "sign_attestation must refuse to attest as a non-local agent"
+    );
+}
+
+// ── forged signature / malformed key ────────────────────────────────────────
+
+#[test]
+fn tampered_signature_is_rejected() {
+    let (signing, aid) = fresh_signing();
+    let tid = task_id_for(&aid);
+    let mut att = sign_attestation(&signing, OpKind::Claim, &scope(), &tid, &aid, 7).unwrap();
+    att.signature[0] ^= 0xff;
+    assert!(
+        !verify_attestation(&att, OpKind::Claim, &scope(), &tid, &aid, 7),
+        "a tampered signature must not verify"
+    );
+}
+
+#[test]
+fn malformed_public_key_is_rejected() {
+    let (signing, aid) = fresh_signing();
+    let tid = task_id_for(&aid);
+    let mut att = sign_attestation(&signing, OpKind::Complete, &scope(), &tid, &aid, 9).unwrap();
+    att.author_public_key = vec![0u8; 7]; // garbage
+    assert!(
+        !verify_attestation(&att, OpKind::Complete, &scope(), &tid, &aid, 9),
+        "a malformed public key must not verify"
+    );
+}
+
+// ── no cross-task / cross-timestamp replay ───────────────────────────────────
+
+#[test]
+fn attestation_does_not_transfer_across_task_or_timestamp() {
+    let (signing, aid) = fresh_signing();
+    let tid_a = TaskId::new("task-a", &aid, 1);
+    let tid_b = TaskId::new("task-b", &aid, 1);
+    let att = sign_attestation(&signing, OpKind::Claim, &scope(), &tid_a, &aid, 100).unwrap();
+    assert!(verify_attestation(
+        &att,
+        OpKind::Claim,
+        &scope(),
+        &tid_a,
+        &aid,
+        100
+    ));
+    assert!(
+        !verify_attestation(&att, OpKind::Claim, &scope(), &tid_b, &aid, 100),
+        "attestation must not transfer to a different task"
+    );
+    assert!(
+        !verify_attestation(&att, OpKind::Claim, &scope(), &tid_a, &aid, 999),
+        "attestation must not transfer to a different timestamp"
+    );
+    assert!(
+        !verify_attestation(&att, OpKind::Complete, &scope(), &tid_a, &aid, 100),
+        "a claim attestation must not verify as a completion"
+    );
+}


### PR DESCRIPTION
Supersedes #223 (which was the earlier `rc/v0.31.0-convergence` branch — WP1-6 only; this branch contains all of it plus the omp security wave and the remediation of it).

## What's here (on top of v0.30.1)

**Convergence fixes (WP1-6):** KV Signed-store ownership enforcement, task-list/store subscription persistence + startup rehydrate, structured claim fields + versioned CAS, the in-repo convergence soak harness, and WebSocket session-token doc/example fixes.

**omp security wave:** checkpoint integrity (P0 forgery + multi-write/delete recovery), task provenance admission (fail-closed attestation gate), manifest durability (cancellation-safe stage-then-commit), reconnect suppression (revoked peers not auto-reconnected) + backoff jitter.

**Remediation of the wave:**
- `fix(crdt): derive TaskListId from topic alone` — the headline: create/join derived different list ids (name+agent vs topic+agent), so scope-bound claim attestations never verified cross-node and concurrent claims never converged. Now derived from the shared topic alone.
- `fix(crdt): move TaskItem.attestations to trailing field with tolerant decode` + `fix(kv): make KvStore wave-added fields trailing + EOF-tolerant` — the wave added fields mid-struct with `#[serde(default)]`, a no-op for bincode; moved trailing with tolerant deserializers.
- `fix(kv): authoritative full-replace checkpoint adoption` — closes the removed-injection MEDIUM and makes checkpoint adoption authoritative full-state.
- `fix(network): cooldown after failed reconnect to stop NAT-storm memory leak` — see below.

## Verification

- **Real-WAN testnet soak (NYC/Singapore/Helsinki):** all 5 functional fixes GO, durable across restarts (claim convergence proven: identical list id all nodes, single deterministic winner byte-identical across nodes).
- **Local convergence soak:** 10/10 core runs green across 15 phases; mixed-version (vs a real v0.30.1 binary), malicious-announce, forged-first-seen security oracles pass.
- Full suite green (one known `cancel_before_rename` timing flake, passes in isolation).

## ⚠️ Not yet ready to merge — one gate remaining

The testnet soak found a **memory leak** (v0.31 grew ~1MB/s → OOM; v0.30.1 flat). Root-caused as a remediation regression: the reconnect wave's lifecycle-`Closed` → `schedule_reconnect` path creates a tight NAT-traversal loop to genuinely dead peers. Fixed with a 60s failure cooldown (`f8470d5`), **validated locally** (plateaus vs unbounded climb; all reconnect tests pass). **Pending: a controlled testnet memory re-validation on a box with swap before merge.**

Two deferred checkpoint-recovery follow-ups (both outside the online-agent use case) are documented: intermittent `owner_offline` cold-recovery resurrection, and a secondary auto-connect-retry leak suspect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds convergence and security fixes across CRDT task lists, KV stores, reconnects, and app auth examples. The main changes are:

- Owner-signed KV checkpoints and signed-store write enforcement.
- Task claim attestations, advisory claim resolution, and local fence tokens.
- Durable CRDT subscription manifests with startup rehydration.
- Reconnect backoff/cooldown handling for dead peers.
- Session-token based WebSocket docs and browser examples.
- Convergence soak tooling and related regression tests.

<h3>Confidence Score: 4/5</h3>

The task attestation decode path needs a fix before merging.

- Present but malformed attestation data can be treated as absent.
- Task claim and completion state now depends on that decoded map.
- The KV checkpoint and reconnect paths have clear guards in the changed code.

src/crdt/task_item.rs

<details open><summary><h3>Security Review</h3></summary>

Malformed present task attestation bytes can be treated as missing attestations, which can suppress claimed or completed task state from untrusted gossip or corrupted persisted data.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/crdt/task_item.rs | Adds task operation attestations and changes task state resolution to use the attestation map. |
| src/kv/store.rs | Adds owner checkpoint verification, full-state adoption, and signed-store write authorization. |
| src/network.rs | Adds bounded reconnect retry behavior and cooldown suppression for failed reconnects. |
| src/server/crdt_subscriptions.rs | Adds durable CRDT subscription manifests and restart rehydration. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[TaskItem bytes from gossip or disk] --> B[Deserialize TaskItem]
  B --> C{Trailing attestations decode?}
  C -->|Valid| D[Use attestation map]
  C -->|Missing or malformed| E[Default to empty map]
  D --> F[Resolve task state]
  E --> F
  F --> G[Claim or completion may disappear]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[TaskItem bytes from gossip or disk] --> B[Deserialize TaskItem]
  B --> C{Trailing attestations decode?}
  C -->|Valid| D[Use attestation map]
  C -->|Missing or malformed| E[Default to empty map]
  D --> F[Resolve task state]
  E --> F
  F --> G[Claim or completion may disappear]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/crdt/task_item.rs:124-132
**Malformed Attestations Erase State**

When a current-format `TaskItem` has present but malformed trailing attestation bytes, this decoder returns an empty map instead of rejecting the payload. Since claim and completion state now resolve from `attestations.keys()`, a corrupted or hostile gossip/disk payload can turn an attested claimed or done task into `Empty`, silently dropping task state instead of failing the message.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(network): cooldown after failed reco..."](https://github.com/saorsa-labs/x0x/commit/f8470d59e936bd0f7d3a69d85ea68dab7804452b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43754147)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->