### PR TITLE
fix(network): advertise 4,096 concurrent uni streams, not 50,000 (memory)

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -1437,7 +1437,20 @@ impl NetworkNode {
             // backpressure earlier in the pubsub flush_ihave_batches loop is
             // the proper fix.
             .data_channel_capacity(50_000)
-            .max_concurrent_uni_streams(50_000);
+            // Deliberately NOT 50_000 like data_channel_capacity above: this
+            // is the per-connection QUIC uni-stream credit we ADVERTISE to
+            // the remote, and ant-quic materializes a streams-table slot for
+            // every advertised stream at Connection construction — 50_000
+            // slots ≈ 1.6 MB per connection (live OR failed dial), the
+            // dominant term in the v0.31 memory investigation (ant-quic#210:
+            // ~2.3 MB retained per failed dial to an unreachable peer).
+            // The X0X-0063 soak that justified 50_000 measured data_tx slot
+            // saturation (~67 events/s × ≤2.5 s hold ≈ hundreds concurrent),
+            // which bounds *our outbound* sends against the PEER's limit —
+            // not what we must advertise inbound. 4_096 keeps >4× headroom
+            // over that observed concurrency at 1/12 the per-connection
+            // memory (~130 KB).
+            .max_concurrent_uni_streams(4_096);
 
         if let Some(bind_addr) = config.bind_addr {
             builder = builder.bind_addr(bind_addr);


### PR DESCRIPTION
## Why

ant-quic materializes a streams-table slot for **every advertised remote uni stream at `Connection` construction**: 50,000 slots ≈ 1.6 MB **per connection** — live or failed dial. This was the dominant term in the v0.31 memory investigation (saorsa-labs/ant-quic#210: ~2.3 MB retained per failed dial to an unreachable peer).

The X0X-0063 soak that justified 50,000 measured **data_tx slot saturation** (~67 events/s × ≤2.5 s hold ≈ hundreds concurrent) — that bounds our *outbound* sends against the *peer's* limit, not what we must advertise inbound. `data_channel_capacity` keeps its justified 50,000; only the advertised QUIC stream credit drops. 4,096 keeps >4× headroom over observed concurrency at 1/12 the per-connection memory (~130 KB).

## Measured (loopback repros, identical pressure)

| Scenario | 50,000 | 4,096 |
|---|---|---|
| Announcement-replay storm, 300 s | +35 MB | **+8–12 MB** |
| Dead-peer residual (per dead peer) | ~25 MB | **~3 MB** |
| Idle 3-node baseline | 38 MB | **33 MB** |

## Gates

fmt, clippy `-D warnings`, full `nextest` 2284/2284 green. Phase-D dogfood smoke: 17 pass / 2 fail — the 2 failures ("peer posts group message", "peer sees own message in local cache") reproduce identically on **main with unpatched ant-quic**, i.e. pre-existing and unrelated (issue to follow).

Complements saorsa-labs/ant-quic#211 (session-lifecycle release on failed dials); neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lowers the advertised inbound QUIC stream credit to reduce per-connection memory use. The main changes are:

- Keeps `data_channel_capacity` at 50,000.
- Changes `max_concurrent_uni_streams` from 50,000 to 4,096.
- Adds comments explaining why inbound stream credit is separate from outbound buffering.

<h3>Confidence Score: 4/5</h3>

The changed flow looks mergeable after confirming the new per-peer stream credit is high enough for bursty inbound gossip.

- The memory reduction is localized to the QUIC builder setting.
- A single peer that opens more than 4,096 streams before earlier streams are released can hit transport backpressure while the application queue still has capacity.
- No security concern was identified.

src/network.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Lowers the advertised inbound unidirectional stream limit while preserving the larger application data channel capacity. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/network.rs:1453
**Transport Credit Caps Inbound Bursts**

When one peer opens more than 4,096 unidirectional streams before this node drains and releases earlier streams, the new advertised limit can block or fail the peer's later `send()` calls even though this node still has room for 50,000 queued data messages. This makes the transport limit, not `data_channel_capacity`, the first backpressure point for large per-peer inbound bursts and can stall or drop gossip delivery under that state.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(network): advertise 4\_096 concurrent..."](https://github.com/saorsa-labs/x0x/commit/a5f751583efbd3b103c90973944f9c013ea83d3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43891253)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->