### PR TITLE
chore(release): v0.31.1 — uni-stream memory fix + ant-quic 0.27.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.31.1] - 2026-07-13
+
+### Fixed
+
+- **Per-connection memory cut ~12× (ant-quic#210 follow-through).** The daemon advertised 50,000 concurrent uni streams per connection; ant-quic materializes a streams-table slot for every advertised stream at `Connection` construction, so every connection — live or failed dial — carried ~1.6 MB of preallocated stream state. This was the dominant term in the v0.31 memory investigation: ~2.3 MB retained per failed dial to an unreachable (NATed/dead) announcing peer. The advertisement is now 4,096 (>4× headroom over the concurrency the X0X-0063 soak actually measured; `data_channel_capacity` keeps its justified 50,000). Measured on identical loopback repros: announcement-replay storm +35 MB → +8–12 MB per 300 s; per-dead-peer residual ~25 MB → ~3 MB; idle 3-node baseline 38 MB → 33 MB.
+
+- **ant-quic 0.27.30 → 0.27.31.** Terminally-failed NAT-traversal sessions are now closed, released, and reaped instead of pinning their connection state indefinitely (ant-quic#210/#211).
+
 ## [v0.31.0] - 2026-07-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.30"
+ant-quic = "0.27.31"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.31.0
+version: 0.31.1
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Release for the ant-quic#210 follow-through: #225's 4,096-stream advertisement + ant-quic 0.27.31 (failed-session release). Changelog + SKILL.md version included. See #225 for measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the v0.31.1 release. The main changes are:

- Cargo package version bumped to 0.31.1.
- `ant-quic` dependency bumped to 0.27.31.
- Changelog and skill metadata updated for the release.

<h3>Confidence Score: 4/5</h3>

The release dependency path needs a fix or confirmation before merging.

- The changed manifest can make normal Cargo resolution fail before compilation if `ant-quic` 0.27.31 is unavailable in the build registry.
- The changelog and skill metadata changes are consistent with the release version.

Cargo.toml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the crate version and bumps `ant-quic`; the dependency resolution path needs confirmation before release. |
| CHANGELOG.md | Adds the v0.31.1 release notes for the memory fix and `ant-quic` update. |
| SKILL.md | Updates the skill metadata version to 0.31.1. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Cargo.toml:22
**Unlocked Dependency Resolution**

This manifest now requires `ant-quic = "0.27.31"` without a committed lockfile. When CI, `cargo publish`, or downstream installs resolve dependencies, the release will fail before compilation if that exact crate version is not available in the registry used by the build.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.31.1 — 4,096 uni-stre..."](https://github.com/saorsa-labs/x0x/commit/299d7e0475168c98aeb211681077712e126cec88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43930007)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->