### PR TITLE
fix(tests): Phase-D smoke waits for authority-committed join before peer posts (#226)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -442,6 +442,10 @@ curl -X POST "http://$API/groups/<group_id>/invite" -H "Authorization: Bearer $T
 # Join via that invite link (on the other agent)
 curl -X POST "http://$API/groups/join" -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" -d '{"invite": "x0x://invite/<...>"}'
+# Membership is committed by the group authority: after joining, poll
+# GET /groups/<group_id>/members until your own agent_id appears with
+# state "active" (typically <1 s while the inviter is online) — posting
+# before that returns 403 "members-only write policy".
 ```
 
 ### Presence & Discovery

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -62,7 +62,7 @@ Bash + Python test harnesses in `tests/` for end-to-end validation:
 | `e2e_vps_groups.py` | Phase B — 6 VPS groups + contacts dogfood | up to 49 | Anchor creates a `public_open` group, DMs invites to all runners, each posts a group message, contacts add/Trust/Block/remove cycle per node. See §7c. |
 | `e2e_local_mesh.sh` | Local 3-node Phase A smoke | 6 directed pairs | Boots alice/bob/charlie + a runner each, runs `e2e_vps_mesh.py --no-tunnel` against alice. Proves the protocol without SSH. |
 | `e2e_dogfood_groups.sh` | Phase B — local 3-instance groups + contacts | 29 | Same dogfood as §7c but local. ~5 s wall-clock. |
-| `e2e_dogfood_local.sh` | Phase D — fast 2-instance pre-commit smoke | 19 | Identity + contacts + DM round-trip + group lifecycle, all via DMs. ~5 s wall-clock; targets every-commit cadence. See §7e. |
+| `e2e_dogfood_local.sh` | Phase D — fast 2-instance pre-commit smoke | 20 | Identity + contacts + DM round-trip + group lifecycle (incl. authority-committed join), all via DMs. ~5 s wall-clock; targets every-commit cadence. See §7e. |
 | `e2e_deploy.sh` | Build + deploy to VPS (with optional mesh verification) | ~24 | Cross-compile, upload `x0xd` **and** the mesh test runner (`x0x-test-runner.service`) to 6 nodes, verify health/version/mesh, collect API tokens. **`--mesh-verify` flag** chains Phase A + Phase B verification onto the deploy via 1 SSH tunnel. See §7d. |
 
 ## Running E2E Tests

--- a/tests/e2e_dogfood_local.py
+++ b/tests/e2e_dogfood_local.py
@@ -19,6 +19,7 @@ What gets exercised:
         bob's runner echoes a `received_dm` result back to the anchor
     Named groups (public_open)
         anchor creates → invite → bob joins
+        bob's join is committed by the authority (MemberAdded applied)
         each member posts; each member sees own message in local cache
         bob leaves → bob's /groups list no longer contains the group
 
@@ -541,6 +542,40 @@ class Phase_D_Harness:
             "peer joins via invite", join.get("outcome") == "ok",
         )
         peer_gid = (join.get("details") or {}).get("group_id") or gid
+
+        # Membership is authority-committed: the joiner seeds the invite's
+        # roster snapshot (which predates them) and only becomes an active
+        # member once the inviter's signed MemberAdded commit arrives
+        # (docs/design/groups-join-roster-propagation.md). Posting before
+        # that commit is rejected with 403 members-only write policy, so
+        # wait for the commit — itself a real end-to-end gate on the
+        # MemberJoined → MemberAdded round trip.
+        commit_deadline = time.time() + 15
+        peer_is_member = False
+        commit_err = ""
+        while time.time() < commit_deadline and not peer_is_member:
+            try:
+                view = self.call_remote(
+                    "group_members", {"group_id": peer_gid},
+                )
+            except Exception as exc:
+                commit_err = str(exc)
+                break
+            members = (view.get("details") or {}).get("members") or []
+            peer_is_member = any(
+                (m.get("agent_id") or "").lower()
+                == self.peer.agent_id.lower()
+                and m.get("state", "active") == "active"
+                for m in members
+            )
+            if not peer_is_member:
+                time.sleep(0.5)
+        if not self.assert_pass(
+            "peer join committed by authority (MemberAdded applied)",
+            peer_is_member,
+            commit_err,
+        ):
+            return
 
         # Each member posts in the group and sees their own message.
         anchor_msg = self.call_local(

--- a/tests/e2e_dogfood_local.sh
+++ b/tests/e2e_dogfood_local.sh
@@ -60,6 +60,12 @@ instance_name = "$node"
 data_dir = "${DATA_DIRS[$node]}"
 api_address = "127.0.0.1:${API_PORTS[$node]}"
 log_level = "warn"
+
+# Fully disable self-update: --skip-update-check only suppresses the
+# startup GitHub check, not gossip-delivered auto-apply — an older
+# binary under test would otherwise replace itself and exit mid-run.
+[update]
+enabled = false
 TOML
     "$X0XD" \
         --config "${CONFIGS[$node]}" \


### PR DESCRIPTION
## Root cause — stale test, not a product regression

x0x#226 reported the Phase-D dogfood smoke failing 2/19 deterministically: the joiner's group post returned an error and its own message never reached its local cache.

Diagnosis (minimal 2-daemon repro with raw HTTP capture):

- The joiner's `POST /groups/:id/send` immediately after `/groups/join` returns **403 `members-only write policy`**.
- This is the **intended** post-remediation contract: the joiner seeds the invite's authority roster snapshot (which predates them) and only becomes an active member when the inviter's signed `MemberAdded` commit is applied (`docs/design/groups-join-roster-propagation.md`).
- With connectivity, the commit lands in **~0.5 s** and the same send then succeeds.
- **v0.30.1 behaves identically** (verified against the released 0.30.1 binary) — the issue's "last known-green on v0.30.x" assumption was wrong. The smoke landed 2026-05-01, when joiners still self-added to their own roster; the join-roster remediation made membership authority-committed and this manual (non-CI) smoke silently went stale.

## Changes

- **Orchestrator**: new hard assertion `peer join committed by authority (MemberAdded applied)` — polls the peer's own roster (≤15 s) between join and post. This converts the race into a genuine end-to-end gate on the MemberJoined → MemberAdded round trip.
- **Smoke daemon config**: `[update] enabled = false`. `--skip-update-check` only suppresses the startup GitHub check; an older binary under test otherwise self-updates and exits mid-run (bit this session when comparing against v0.30.1; independently reported in the external v0.31.1 retest).
- **SKILL.md**: document that after `/groups/join` an agent must poll `GET /groups/:id/members` until its own agent_id is `active` before posting.
- **tests/CLAUDE.md**: Phase-D assertion count 19 → 20.

## Verification

`bash tests/e2e_dogfood_local.sh` → **pass=20 fail=0**, twice, ~1.6 s (budget 60 s). Commit-wait resolves after a single 0.5 s poll.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Phase-D local dogfood smoke around authority-committed group joins. The main changes are:

- Adds a wait for the joiner to appear as an active member before group posts.
- Disables daemon self-update in the local smoke config.
- Documents the join-before-post polling requirement.
- Updates Phase-D smoke documentation for the new join gate.

<h3>Confidence Score: 5/5</h3>

The changed flow looks safe to merge after a small documentation cleanup.

- The join wait matches the authority-committed membership flow.
- The update config uses an existing disabled-update shape.
- The remaining issue is an incorrect documented assertion count.

tests/CLAUDE.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/e2e_dogfood_local.py | Adds a bounded active-member poll after group join and before group sends. |
| tests/e2e_dogfood_local.sh | Adds `[update] enabled = false` to the generated daemon config for the smoke run. |
| SKILL.md | Documents polling group members until the joiner is active before posting. |
| tests/CLAUDE.md | Updates the Phase-D row, but the documented assertion count does not match the harness. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/CLAUDE.md:65
**Assertion Count Drift**

This row now says the Phase-D smoke has 20 assertions, but the updated harness has 19 `assert_pass` checkpoints. Any agent or tooling that checks the documented pass count against the script output can look for a non-existent assertion even when the smoke succeeds.

```suggestion
| `e2e_dogfood_local.sh` | Phase D — fast 2-instance pre-commit smoke | 19 | Identity + contacts + DM round-trip + group lifecycle (incl. authority-committed join), all via DMs. ~5 s wall-clock; targets every-commit cadence. See §7e. |
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): Phase-D smoke waits for auth..."](https://github.com/saorsa-labs/x0x/commit/ac7181e24692beaae4ab48a344bb5c09fc8e7379) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44053299)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->