### PR TITLE
fix(kv): drop stale owner deltas at or below the adopted checkpoint high-water mark

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -398,8 +398,15 @@ curl -H "Authorization: Bearer $TOKEN" "http://$API/stores/team-config-store/key
 curl -H "Authorization: Bearer $TOKEN" "http://$API/stores/team-config-store/greeting" # get (value is base64)
 curl -X DELETE "http://$API/stores/team-config-store/greeting" -H "Authorization: Bearer $TOKEN"
 
-# Join a store another agent created (replicate it locally)
-curl -X POST "http://$API/stores/team-config-store/join" -H "Authorization: Bearer $TOKEN"
+# Join a store another agent created (replicate it locally).
+# expected_owner anchors the join: pass the owner's agent_id, learned
+# OUT-OF-BAND (from the owner's message, agent card, or your contacts) —
+# never from the store itself. A replica only trusts owner-signed state
+# for the anchored owner; unanchored Signed-store joins are rejected
+# (422 owner_required) so a malicious replica cannot claim ownership.
+curl -X POST "http://$API/stores/team-config-store/join" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"expected_owner": "<owner agent_id, 64-hex>"}'
 ```
 
 ### Named Groups

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -29,6 +29,22 @@ To exercise it locally, push a scratch tag on a commit with intentionally-red
 CI (e.g. a draft/prerelease) and confirm `require-green-ci` fails before any
 artifact is built; delete the tag/release afterward.
 
+## Convergence Release Gate (manual, pre-tag)
+
+`just convergence-release` is the authoritative multi-daemon convergence gate
+(10/10 clean runs of `tests/convergence/convergence_soak.py --expect-fixed`,
+including the owner-offline checkpoint-recovery and mixed-version skew gates).
+It is **not** wired into `release.yml`: it takes on the order of an hour and
+requires an authenticated v0.30.1 legacy binary (`X0XD_LEGACY_BINARY`) that
+cannot be built from this tree, so it runs manually on the release engineer's
+machine **before tagging**. The v0.31.1 external retest flagged that this gate
+had not been exercised for that release — treat it as a required pre-tag step
+for any release touching the KV/store, CRDT, or gossip planes.
+
+```bash
+X0XD_LEGACY_BINARY=/path/to/authentic/x0xd-0.30.1 just convergence-release
+```
+
 ## Coverage Gate
 
 The CI coverage job runs on Linux with `cargo-llvm-cov` and `cargo-nextest`.

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -978,6 +978,24 @@ impl KvStore {
             if self.try_adopt_full_snapshot(delta, peer_id, cp) {
                 return Ok(());
             }
+            // Stale-delta gate: a delta carrying a genuine owner checkpoint
+            // at or below the adopted high-water mark was published at or
+            // before the adopted checkpoint's state, so its mutations are
+            // already reflected in (or superseded by) that full snapshot.
+            // Without this gate the gossip replay/cache window re-delivers
+            // old owner-signed incremental deltas after a cold-recovery
+            // checkpoint adoption, and the sender-auth path below re-adds
+            // owner-DELETED keys on a fresh joiner (which holds no OR-Set
+            // tombstones for them) — resurrecting deleted state.
+            if self.is_subsumed_by_adopted_checkpoint(cp) {
+                tracing::debug!(
+                    "dropped stale owner delta (checkpoint_seq {} <= adopted {}) for store {}",
+                    cp.checkpoint_seq,
+                    self.highest_checkpoint_seq,
+                    self.id
+                );
+                return Ok(());
+            }
         }
         // Access control: reject unauthorized writes
         if let Some(writer_id) = writer {
@@ -1206,6 +1224,28 @@ impl KvStore {
         self.highest_checkpoint_seq = cp.checkpoint_seq;
         self.version += 1;
         true
+    }
+
+    /// True when `cp` is a genuine checkpoint for this store's anchored owner
+    /// whose sequence is at or below the adopted high-water mark.
+    ///
+    /// Only a verified owner checkpoint bound to this store may trigger the
+    /// stale-delta drop: an unverifiable or cross-store checkpoint falls
+    /// through to the sender-auth path unchanged, so a forged checkpoint
+    /// cannot be used to suppress legitimate writes. The writer's wire
+    /// signature covers the whole delta (checkpoint included), so a relay
+    /// cannot graft a stale checkpoint onto a fresh owner delta either.
+    fn is_subsumed_by_adopted_checkpoint(&self, cp: &OwnerCheckpoint) -> bool {
+        if cp.checkpoint_seq > self.highest_checkpoint_seq {
+            return false;
+        }
+        let Some(expected_owner) = self.owner else {
+            return false;
+        };
+        if cp.verify(&expected_owner).is_err() {
+            return false;
+        }
+        cp.store_id == self.id
     }
 
     /// After applying an incremental mutation via the sender-auth path, cache
@@ -2224,6 +2264,71 @@ mod tests {
             "injected removed must not truncate the owner-signed set"
         );
         assert_eq!(joiner.highest_checkpoint_seq, 1, "checkpoint adopted");
+    }
+
+    #[test]
+    fn stale_owner_delta_below_adopted_checkpoint_cannot_resurrect_deleted_keys() {
+        // v0.31.1 retest defect: owner writes k1 (checkpoint 1), later
+        // deletes it and writes k_final (checkpoint 2). A fresh anchored
+        // joiner cold-recovers checkpoint 2 ({k_final} only) from a relay,
+        // then the gossip replay/cache window re-delivers the owner's OLD
+        // k1 delta (still genuinely owner-signed, checkpoint 1 attached).
+        // The joiner holds no OR-Set tombstone for k1 — it never observed
+        // that add — so without the stale-delta gate the sender-auth path
+        // re-adds it, resurrecting an owner-deleted key.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/resurrect";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        // Owner at time 1: state {k1}; the broadcast delta carries cp seq 1.
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        owner_store
+            .put(
+                "k1".to_string(),
+                b"alpha".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put k1");
+        let cp1 = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut stale_delta = owner_store.full_delta();
+        stale_delta.owner_checkpoint = Some(cp1);
+
+        // Owner at time 2: k1 deleted, k_final written; checkpoint seq 2.
+        owner_store.remove("k1").expect("remove k1");
+        owner_store
+            .put(
+                "k_final".to_string(),
+                b"final".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put k_final");
+        let cp2 = checkpoint_for(&owner_store, topic, &kp, 2);
+        let mut snapshot = owner_store.full_delta();
+        snapshot.owner_checkpoint = Some(cp2);
+
+        // Fresh anchored joiner cold-recovers checkpoint 2 via a relay.
+        let mut joiner =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner
+            .merge_delta(&snapshot, peer(9), Some(&agent(9)))
+            .expect("adopt checkpoint 2");
+        assert!(joiner.get("k_final").is_some(), "recovered final state");
+        assert!(joiner.get("k1").is_none(), "k1 deleted in checkpoint 2");
+        assert_eq!(joiner.highest_checkpoint_seq, 2);
+
+        // Replay the stale owner delta (writer == owner, so the sender-auth
+        // path WOULD authorize it). The stale-delta gate must drop it.
+        joiner
+            .merge_delta(&stale_delta, peer(1), Some(&owner))
+            .expect("stale replay merge");
+        assert!(
+            joiner.get("k1").is_none(),
+            "owner-deleted key must not resurrect from a stale owner-signed delta"
+        );
+        assert_eq!(joiner.highest_checkpoint_seq, 2, "high-water unchanged");
     }
 
     #[test]

--- a/tests/convergence/convergence_soak.py
+++ b/tests/convergence/convergence_soak.py
@@ -232,6 +232,13 @@ class Node:
             # bootstrap network, keeping the cluster fully isolated. Do NOT
             # pass --no-hard-coded-bootstrap: it clears config peers too.
             f'bootstrap_peers = [{peers}]\n'
+            # Fully disable self-update. --skip-update-check (passed at
+            # start) only suppresses the startup GitHub check — it does NOT
+            # stop gossip-delivered auto-apply, which replaced a v0.30.1
+            # legacy participant with the latest release mid-run and
+            # invalidated the mixed-version skew gate (v0.31.1 retest).
+            '[update]\n'
+            'enabled = false\n'
         )
 
     def reconfigure_port(self, new_quic_port, bootstrap_quic_ports):


### PR DESCRIPTION
## Defect (v0.31.1 external retest — owner-offline checkpoint recovery)

A fresh relay-only anchored joiner recovered `k_final` exactly but **resurrected owner-deleted keys**. Reproduced locally on the released 0.31.1 binary: 2 of 5 convergence-gate runs failed (`k1` in one, `k2` in the other — nondeterministic, depends on the gossip replay window).

### Mechanism

1. The joiner adopts the authoritative full-snapshot checkpoint (seq N) → state is exactly the owner-signed set; deleted keys are dropped **without OR-Set tombstones** (the joiner never observed those adds).
2. The gossip replay/cache window re-delivers **older, genuinely owner-signed incremental deltas** (checkpoint seq ≤ N).
3. Those fail full-snapshot adoption on the monotonic-seq gate and fell through to the sender-auth path — where writer == owner is authorized — so the replayed `added` entries re-introduced deleted keys with brand-new tags.

### Fix

`merge_delta` now drops any delta carrying a **verified** owner checkpoint (signature + owner binding + store binding) whose `checkpoint_seq` is at or below the adopted high-water mark: such a delta was published at or before the adopted snapshot's state, so its mutations are already reflected in or superseded by it.

Not a suppression vector: a forged or cross-store checkpoint fails verification and falls through unchanged, and the writer's wire signature covers the whole delta (checkpoint included), so a relay cannot graft a stale checkpoint onto a fresh owner delta.

## Verification

- New unit test `stale_owner_delta_below_adopted_checkpoint_cannot_resurrect_deleted_keys` — **fails with the gate disabled, passes with it**.
- Convergence harness `owner_offline_checkpoint_recovery` gate: released 0.31.1 binary **2/5 fail**; this branch's binary **6/6 pass** (1 initial + 5 looped).
- Full workspace suite green (2285/2285). Note: `server::crdt_subscriptions::tests::cancel_before_rename_leaves_memory_clean_and_retry_writes` flakes intermittently under full-suite load on this machine — unrelated (nextest per-test process isolation; the test never touches `kv::`); being triaged separately.

## Also from the retest

- **Convergence harness**: daemon configs now set `[update] enabled = false` — `--skip-update-check` does not stop gossip-delivered auto-apply, which replaced the v0.30.1 legacy participant mid-run and invalidated the mixed-version skew gate.
- **SKILL.md**: store-join example now includes the required out-of-band `expected_owner` anchor with a provenance note.
- **docs/cicd.md**: documents `just convergence-release` as a required manual pre-tag gate (not wired into release.yml: ~1h runtime + needs an authenticated legacy binary CI cannot build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes stale KV owner-delta replay after checkpoint adoption. The main changes are:

- Drops verified owner deltas at or below the adopted checkpoint high-water mark.
- Adds a regression test for deleted-key resurrection after checkpoint recovery.
- Disables daemon self-update in the convergence harness config.
- Updates store-join and release-gate documentation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after checking the legacy convergence config path.

- No blocking issues found in the changed KV merge path.
- The only follow-up is confirming that the legacy binary accepts the new `[update]` config section.

tests/convergence/convergence_soak.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/kv/store.rs | Adds the stale owner-checkpoint drop gate and regression coverage for deleted-key resurrection. |
| tests/convergence/convergence_soak.py | Adds `[update] enabled = false` to generated daemon configs, with a legacy-version compatibility point to confirm. |
| SKILL.md | Updates the store-join example to include the required `expected_owner` request body. |
| docs/cicd.md | Documents the manual convergence release gate and why it runs outside CI. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/convergence/convergence_soak.py:238-239
**Legacy Config Compatibility**

When the mixed-version gate starts the v0.30.1 binary, this same generated config now includes an `[update]` table. If that older binary rejects unknown config sections, the legacy node can fail during startup and the convergence gate will fail before exercising the mixed-version skew scenario.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(cicd): document just convergence-re..."](https://github.com/saorsa-labs/x0x/commit/58c0ddf5f7bae6a1b3bfccf1a062a0a14477165c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44058193)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->