### PR TITLE
chore(deps): bump ant-quic to 0.27.32 (security GHSA-4w2j-m93h-cj5j + lazy stream alloc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Security
+
+- **Bump `ant-quic` to 0.27.32** — pulls in the reassembly-buffer memory-exhaustion
+  fix (GHSA-4w2j-m93h-cj5j, CVSS 7.5, CWE-770: a peer could grow the receiver's
+  out-of-order reassembly buffer without bound via gapped fragments with a withheld
+  prefix) and lazy remote stream-state allocation (removes ~1.58 MB/connection of
+  eager per-stream preallocation, the dominant per-failed-dial retention behind the
+  fleet OOM churn tracked in ant-quic #210). Both are ant-quic-internal; no x0x API
+  change.
+
 ## [v0.31.2] - 2026-07-14
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.31"
+ant-quic = "0.27.32"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
Bumps the `ant-quic` dependency floor `0.27.31` → `0.27.32` (published to crates.io today).

## Why
ant-quic 0.27.32 ships two per-connection memory fixes relevant to the x0x fleet:
- **Security — GHSA-4w2j-m93h-cj5j (CVSS 7.5, CWE-770):** unbounded out-of-order reassembly buffering (gapped fragments + withheld prefix). Now capped at 1024 chunks.
- **Lazy remote stream-state allocation:** removes ~1.58 MB/connection eager preallocation — the dominant per-failed-dial retention behind the fleet OOM churn tracked in ant-quic #210. x0x nodes redial unreachable NAT'd peers frequently, so this is the highest-impact half for us.

Both are ant-quic-internal; no x0x API change. `cargo check --all-features` green locally.

## Not included / left to the release owner
- **No x0x version bump or tag.** v0.31.2 is already on `main` but untagged and awaiting the required `just convergence-release` manual gate (per `docs/cicd.md`). This PR only bumps the dependency and files the change under `[Unreleased]`, so you can fold it into the 0.31.2 release (retag) or a 0.31.3 as you prefer — and run the convergence gate — without this PR presuming either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the project to the next `ant-quic` patch release. The main changes are:

- `Cargo.toml` raises the direct `ant-quic` dependency floor from `0.27.31` to `0.27.32`.
- `CHANGELOG.md` adds an `[Unreleased]` security note for the dependency bump.
- The changelog documents the reassembly-buffer cap and lazy remote stream-state allocation fixes.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The dependency bump matches the repository's existing pattern for `ant-quic` patch updates.
- The new changelog section follows the existing unreleased-change flow.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Raises the direct `ant-quic` dependency requirement from `0.27.31` to `0.27.32`. |
| CHANGELOG.md | Adds an `[Unreleased]` security entry describing the `ant-quic` bump and its expected fixes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump ant-quic to 0.27.32 (s..."](https://github.com/saorsa-labs/x0x/commit/18923372dc6ba080eb0b22342c9caede15381197) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44122083)</sub>

<!-- /greptile_comment -->