### PR TITLE
chore(release): v0.31.3 — ant-quic 0.27.32 security (GHSA-4w2j-m93h-cj5j) + lazy stream alloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v0.31.3] - 2026-07-14
+
+Includes the previously-unreleased v0.31.2 changes (below); v0.31.2 was prepared
+but never tagged, so its content ships here.
 
 ### Security
 
@@ -11,8 +14,9 @@ All notable changes to this project will be documented in this file.
   out-of-order reassembly buffer without bound via gapped fragments with a withheld
   prefix) and lazy remote stream-state allocation (removes ~1.58 MB/connection of
   eager per-stream preallocation, the dominant per-failed-dial retention behind the
-  fleet OOM churn tracked in ant-quic #210). Both are ant-quic-internal; no x0x API
-  change.
+  fleet OOM churn tracked in ant-quic #210, verified eliminated: 0 leaks and ~1 KB
+  retained per failed dial vs the prior ~2.3 MB). Both are ant-quic-internal; no
+  x0x API change.
 
 ## [v0.31.2] - 2026-07-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.31.2"
+version = "0.31.3"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.31.2
+version: 0.31.3
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Release v0.31.3. Ships the ant-quic 0.27.32 dependency (already merged via #233) and formally versions the previously-unreleased 0.31.2 content.

## What ships
- **Security — ant-quic GHSA-4w2j-m93h-cj5j (CVSS 7.5, CWE-770):** unbounded out-of-order reassembly buffering, now capped.
- **Lazy remote stream-state allocation:** removes ~1.58 MB/connection eager prealloc — the dominant per-failed-dial retention behind fleet OOM churn. Verified eliminated on a fixed build: `0 leaks` and ~1 KB retained per failed dial (vs prior ~2.3 MB), whole-process 8.4 MB after 60 failed dials (ant-quic #210, now closed).
- Previously-unreleased v0.31.2 content (Signed-store stale-delta gate #230, dogfood join-commit assertion #226).

## Release gate
`just convergence-release` (authoritative): **10/10 runs PASS**, all phases clean (0 gaps/failures/unsupported), all prerequisite security gates green (mixed-version skew, malicious-owner-announce, owner-offline checkpoint recovery, forged-first-seen), against an authenticated v0.30.1 legacy binary. Zero dropped-critical-hard-error growth; mDNS clean.

Tag `v0.31.3` after merge triggers release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the v0.31.3 release. The main changes are:

- `Cargo.toml` version bumped from `0.31.2` to `0.31.3`.
- Changelog promoted from Unreleased to `v0.31.3`.
- Release notes expanded for the ant-quic security and memory-retention fixes.

<h3>Confidence Score: 4/5</h3>

The release path can fail before publishing the intended security release.

- `Cargo.toml` now declares `0.31.3`.
- `SKILL.md` still declares `0.31.2`.
- The release metadata check compares those versions and can stop the tag workflow before artifacts are published.

Cargo.toml and SKILL.md

<details open><summary><h3>Security Review</h3></summary>

The release is intended to ship a security fix, but the stale release metadata can block the tag workflow from publishing it.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the crate version to `0.31.3`, but companion release metadata remains stale. |
| CHANGELOG.md | Adds the `v0.31.3` release section and clarifies the included security and memory-retention changes. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Cargo.toml:3
**Release Metadata Version Mismatch**

When this commit is validated or tagged as `v0.31.3`, the blocking release metadata check compares `Cargo.toml` with `SKILL.md`. This line now says `0.31.3`, but `SKILL.md` still says `0.31.2`, so the release workflow fails before publishing the security release.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): sync SKILL.md to 0.31.3 ..."](https://github.com/saorsa-labs/x0x/commit/7575472efffc465f382cb5c5f1042cc37c76bf68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44136321)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->