### PR TITLE
fix(network): single bootstrap cache shared with the transport + SSE/cache doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **Single bootstrap cache shared with the transport (requires ant-quic >= 0.27.33).**
+  x0x previously opened its own bootstrap cache at `<data_dir>/peers/` while the
+  ant-quic endpoint silently opened a *second* cache in a **host-shared** default
+  directory (`$TMPDIR/ant-quic-cache` or `~/.cache/ant-quic`). The two never shared
+  data: the endpoint's reconnection quality data never reached x0x's cache-first
+  join phases, x0x's presence-beacon enrichment never reached the endpoint's
+  reconnection, and multiple daemons on one host (e.g. prod + testnet on a VPS)
+  could commingle peer planes in the shared directory. x0x now plumbs its
+  per-instance cache config through `NodeConfig::bootstrap_cache` and borrows the
+  endpoint's single instance (`Node::bootstrap_cache()`). The endpoint owns cache
+  maintenance and flushes the cache on shutdown.
+- **`--disable-peer-cache` is now truly hermetic.** It previously only stopped
+  x0x's own cache, while the endpoint kept using (and could persist to) the
+  host-shared default directory. The flag now yields a session-only in-memory
+  cache: nothing is loaded from previous runs, nothing is written to disk, and no
+  cache directory is created.
+- Removed the dead `NetworkConfig.peer_cache_path` field - it was written by the
+  daemon but never read anywhere.
+- SKILL.md/api-reference doc fixes: the peer cache file is
+  `<data_dir>/peers/bootstrap_cache.json` (not `peers.cache`); documented the SSE
+  `/events` envelope shape (fields nested under `data`, unlike the flat WebSocket
+  frame) and the flat `/direct/events` shape.
+
 ## [v0.31.4] - 2026-07-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v0.32.0] - 2026-07-15
+
+Breaking (library API): `NetworkNode::new` now takes an
+`Option<ant_quic::BootstrapCacheConfig>` instead of a pre-opened cache, and
+the dead `NetworkConfig.peer_cache_path` field was removed.
 
 ### Fixed
 
@@ -24,6 +28,10 @@ All notable changes to this project will be documented in this file.
   cache directory is created.
 - Removed the dead `NetworkConfig.peer_cache_path` field - it was written by the
   daemon but never read anywhere.
+- **x0xd now handles SIGTERM like Ctrl-C** (what systemd/launchd send on
+  stop/restart): the graceful shutdown path closes connections and flushes the
+  bootstrap peer cache, so learned peers survive a service restart without
+  waiting for the next periodic save tick.
 - SKILL.md/api-reference doc fixes: the peer cache file is
   `<data_dir>/peers/bootstrap_cache.json` (not `peers.cache`); documented the SSE
   `/events` envelope shape (fields nested under `data`, unlike the flat WebSocket

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.31.4"
+version = "0.32.0"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.32"
+ant-quic = "0.27.33"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"

--- a/SKILL.md
+++ b/SKILL.md
@@ -208,6 +208,13 @@ curl -X POST "http://$API/publish" \
 curl -H "Authorization: Bearer $TOKEN" "http://$API/events"
 ```
 
+`/events` (SSE) wraps each gossip message in an envelope — the fields live
+under `data`, unlike the flat WebSocket shape shown later:
+
+```json
+{"type": "message", "data": {"subscription_id": "…", "topic": "…", "payload": "base64…", "sender": "hex…", "verified": true, "trust_level": "known"}}
+```
+
 ### Direct Messaging
 
 ```bash
@@ -225,6 +232,12 @@ curl -X POST "http://$API/direct/send" \
 
 # Stream direct messages (SSE)
 curl -H "Authorization: Bearer $TOKEN" "http://$API/direct/events"
+```
+
+`/direct/events` (SSE) delivers each message flat (no `data` envelope):
+
+```json
+{"sender": "hex…", "machine_id": "hex…", "payload": "base64…", "received_at": 1774860000, "verified": true, "trust_decision": "Accept"}
 ```
 
 ### MLS Group Encryption
@@ -334,7 +347,7 @@ rendezvous_enabled = true             # Global agent findability
 <data_dir>/api-token         # Bearer token for CLI/apps/scripts
 <data_dir>/contacts.json     # Trust/contact store
 <data_dir>/mls_groups.bin    # MLS group state
-<data_dir>/peers/peers.cache   # Bootstrap peer cache
+<data_dir>/peers/bootstrap_cache.json   # Bootstrap peer cache
 ```
 
 **Default identity_dir:** `~/.x0x/` | named instances: `~/.x0x-<name>/`

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.31.4
+version: 0.32.0
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -222,6 +222,25 @@ Notes:
 }
 ```
 
+### `/events` SSE message shape
+
+Each gossip message arrives as an envelope with the fields nested under
+`data` (unlike the flat WebSocket `message` frame):
+
+```json
+{
+  "type": "message",
+  "data": {
+    "subscription_id": "8daec1f568bc0a54",
+    "topic": "updates",
+    "payload": "aGVsbG8=",
+    "sender": "8a3f...",
+    "verified": true,
+    "trust_level": "known"
+  }
+}
+```
+
 ### `local:` topics (same-daemon IPC)
 
 Topics whose name starts with `local:` (e.g. `local:my-app/events`) are
@@ -310,6 +329,21 @@ Identity types: `anonymous`, `known`, `trusted`, `pinned`
 {
   "agent_id": "8a3f...",
   "payload": "aGVsbG8="
+}
+```
+
+### `/direct/events` SSE message shape
+
+Direct messages arrive flat — no `data` envelope:
+
+```json
+{
+  "sender": "8a3f...",
+  "machine_id": "b2c4...",
+  "payload": "aGVsbG8=",
+  "received_at": 1774860000,
+  "verified": true,
+  "trust_decision": "Accept"
 }
 ```
 

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -327,6 +327,23 @@ async fn main() -> anyhow::Result<()> {
             cancel.cancel();
         }
     });
+    // SIGTERM (what systemd/launchd send on stop/restart) must drive the same
+    // graceful exit as Ctrl-C: the shutdown path closes connections and
+    // flushes the bootstrap peer cache so learned peers survive restart.
+    #[cfg(unix)]
+    {
+        let cancel = handle.cancellation_token();
+        tokio::spawn(async move {
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut sigterm) => {
+                    if sigterm.recv().await.is_some() {
+                        cancel.cancel();
+                    }
+                }
+                Err(e) => tracing::warn!("failed to install SIGTERM handler: {e}"),
+            }
+        });
+    }
     handle.wait().await
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9643,11 +9643,14 @@ impl AgentBuilder {
         self
     }
 
-    /// Disable the bootstrap peer cache entirely.
+    /// Disable bootstrap peer cache persistence.
     ///
-    /// When set, the agent will not open or load any cached peers on
-    /// startup. This ensures complete network isolation from previously
-    /// seen peers for embedders and dedicated test harnesses.
+    /// When set, the cache is in-memory only for this session: no cached
+    /// peers are loaded on startup and nothing is written to disk (no
+    /// cache directory is created). This ensures complete network
+    /// isolation from previously seen peers for embedders and dedicated
+    /// test harnesses, while the transport keeps its normal in-session
+    /// reconnection behaviour.
     ///
     /// Note: the x0xd daemon's `--no-hard-coded-bootstrap` flag does
     /// not call this; it clears only the embedded global bootstrap
@@ -9918,30 +9921,27 @@ impl AgentBuilder {
             identity::Identity::new(machine_keypair, agent_keypair)
         };
 
-        // Open bootstrap peer cache if network will be configured
-        // and the cache is not explicitly disabled by the caller.
-        let bootstrap_cache = if self.network_config.is_some() && !self.disable_peer_cache {
+        // Configure the bootstrap peer cache. The cache *instance* is owned
+        // by the ant-quic endpoint (one cache per node, shared by transport
+        // reconnection, x0x join phases and presence enrichment) — x0x only
+        // chooses where it lives and whether it persists, then borrows the
+        // endpoint's instance after node creation. `disable_peer_cache`
+        // yields a session-only in-memory cache: nothing is loaded from
+        // previous runs and nothing is written to disk.
+        let bootstrap_cache_config = if self.network_config.is_some() {
             let cache_dir = self.peer_cache_dir.unwrap_or_else(|| {
                 dirs::home_dir()
                     .unwrap_or_else(|| std::path::PathBuf::from("."))
                     .join(".x0x")
                     .join("peers")
             });
-            let config = ant_quic::BootstrapCacheConfig::builder()
-                .cache_dir(cache_dir)
-                .min_peers_to_save(1)
-                .build();
-            match ant_quic::BootstrapCache::open(config).await {
-                Ok(cache) => {
-                    let cache = std::sync::Arc::new(cache);
-                    std::sync::Arc::clone(&cache).start_maintenance();
-                    Some(cache)
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to open bootstrap cache: {e}");
-                    None
-                }
-            }
+            Some(
+                ant_quic::BootstrapCacheConfig::builder()
+                    .cache_dir(cache_dir)
+                    .min_peers_to_save(1)
+                    .persist(!self.disable_peer_cache)
+                    .build(),
+            )
         } else {
             None
         };
@@ -10008,7 +10008,7 @@ impl AgentBuilder {
         > = std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
 
         let network = if let Some(config) = self.network_config {
-            let node = network::NetworkNode::new(config, bootstrap_cache.clone(), machine_keypair)
+            let node = network::NetworkNode::new(config, bootstrap_cache_config, machine_keypair)
                 .await
                 .map_err(|e| {
                     error::IdentityError::Storage(std::io::Error::other(format!(
@@ -10028,6 +10028,12 @@ impl AgentBuilder {
         } else {
             None
         };
+
+        // Borrow the endpoint-owned cache so every layer (transport
+        // reconnection, join phases, presence enrichment, gossip adapter)
+        // reads and writes one instance. The endpoint runs maintenance —
+        // do not start it again here.
+        let bootstrap_cache = network.as_ref().and_then(|n| n.bootstrap_cache());
 
         // Load the local revocation set now (shared Arc) so the relay-DM
         // listener can enforce revocation on inbound relayed envelopes. The

--- a/src/network.rs
+++ b/src/network.rs
@@ -29,7 +29,6 @@ use saorsa_gossip_transport::GossipStreamType;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::net::SocketAddr;
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, TryLockError};
 use std::time::{Duration, Instant};
@@ -213,10 +212,6 @@ pub struct NetworkConfig {
     /// Interval for collecting and reporting stats.
     #[serde(default = "default_stats_interval")]
     pub stats_interval: Duration,
-
-    /// Path to persist peer cache.
-    #[serde(default)]
-    pub peer_cache_path: Option<PathBuf>,
 
     /// Pinned bootstrap peer IDs. When non-empty, `dial_bootstrap()` rejects
     /// peers whose ID is not in this set. Prevents spoofed bootstrap nodes.
@@ -459,7 +454,6 @@ impl Default for NetworkConfig {
             max_connections: DEFAULT_MAX_CONNECTIONS,
             connection_timeout: DEFAULT_CONNECTION_TIMEOUT,
             stats_interval: DEFAULT_STATS_INTERVAL,
-            peer_cache_path: None,
             pinned_bootstrap_peers: std::collections::HashSet::new(),
             inbound_allowlist: std::collections::HashSet::new(),
             max_peers_per_ip: 3,
@@ -1399,7 +1393,13 @@ impl NetworkNode {
     /// # Arguments
     ///
     /// * `config` - Network configuration options.
-    /// * `bootstrap_cache` - Optional bootstrap peer cache for quality-scored reconnection.
+    /// * `bootstrap_cache_config` - Optional bootstrap peer cache configuration.
+    ///   The cache instance itself is owned by the ant-quic endpoint (one cache
+    ///   per node, shared by transport reconnection and x0x enrichment); this
+    ///   parameter only chooses where it lives and whether it persists. When
+    ///   `None`, ant-quic's default applies — a **host-shared** cache directory,
+    ///   so callers running multiple nodes per host should pass an explicit
+    ///   per-instance config.
     /// * `keypair` - Optional ML-DSA-65 keypair for identity unification. When provided,
     ///   the ant-quic `Node` uses this keypair for QUIC TLS, making the transport PeerId
     ///   equal to the x0x MachineId derived from the same key.
@@ -1413,7 +1413,7 @@ impl NetworkNode {
     /// Returns `NetworkError` if node creation fails.
     pub async fn new(
         config: NetworkConfig,
-        bootstrap_cache: Option<Arc<ant_quic::BootstrapCache>>,
+        bootstrap_cache_config: Option<ant_quic::BootstrapCacheConfig>,
         keypair: Option<(ant_quic::MlDsaPublicKey, ant_quic::MlDsaSecretKey)>,
     ) -> NetworkResult<Self> {
         let mut builder = NodeConfig::builder()
@@ -1471,11 +1471,21 @@ impl NetworkNode {
         // (and downstream via the daemon's config TOML / CLI flag).
         builder = builder.port_mapping_enabled(config.port_mapping_enabled);
 
+        // Single-cache architecture: the endpoint owns the bootstrap cache;
+        // x0x borrows the same instance below instead of opening a second
+        // cache on the same directory.
+        if let Some(cache_config) = bootstrap_cache_config {
+            builder = builder.bootstrap_cache(cache_config);
+        }
+
         let node = Node::with_config(builder.build()).await.map_err(|e| {
             NetworkError::NodeCreation(format!("Failed to create ant-quic node: {}", e))
         })?;
 
         let peer_id = node.peer_id();
+        // Share the endpoint's cache instance (never a second handle on the
+        // same file). The endpoint runs cache maintenance itself.
+        let bootstrap_cache = Some(node.bootstrap_cache());
         let (event_sender, _event_receiver) = broadcast::channel(32);
         // Inbound gossip buffers are split by stream type so PubSub back-pressure
         // cannot block Bulk presence beacons or Membership/SWIM control traffic.
@@ -1549,6 +1559,16 @@ impl NetworkNode {
     /// A reference to the network configuration.
     pub fn config(&self) -> &NetworkConfig {
         &self.config
+    }
+
+    /// The bootstrap peer cache shared with the ant-quic endpoint.
+    ///
+    /// This is the endpoint's own cache instance (see
+    /// [`ant_quic::Node::bootstrap_cache`]) — enrich and query it freely,
+    /// but do not call `start_maintenance` on it: the endpoint already
+    /// runs maintenance.
+    pub fn bootstrap_cache(&self) -> Option<Arc<ant_quic::BootstrapCache>> {
+        self.bootstrap_cache.clone()
     }
 
     /// Get the configured bind address (may contain port 0 before binding).
@@ -3944,6 +3964,85 @@ async fn test_network_node_multiple_subscribers() {
     assert!(rx2.recv().await.is_ok());
 }
 
+/// The endpoint must own exactly one bootstrap cache and honor the
+/// per-instance directory plumbed through the cache config. Before this,
+/// the endpoint silently opened a *second* cache in a host-shared
+/// directory (`$TMPDIR/ant-quic-cache`), so instances on one host (e.g.
+/// prod and testnet daemons on a VPS) could pollute each other's peer
+/// planes and the endpoint's reconnection data diverged from x0x's.
+#[tokio::test]
+async fn network_node_uses_plumbed_per_instance_cache() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_dir = dir.path().join("peers");
+    let cache_config = ant_quic::BootstrapCacheConfig::builder()
+        .cache_dir(&cache_dir)
+        .min_peers_to_save(1)
+        .build();
+    let config = NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().unwrap()),
+        bootstrap_nodes: Vec::new(),
+        ..NetworkConfig::default()
+    };
+    let node = NetworkNode::new(config, Some(cache_config), None)
+        .await
+        .unwrap();
+
+    let cache = node
+        .bootstrap_cache()
+        .expect("endpoint cache must be shared with x0x");
+    cache
+        .add_seed(
+            ant_quic::PeerId([9u8; 32]),
+            vec!["127.0.0.1:9000".parse().unwrap()],
+        )
+        .await;
+    cache.save().await.unwrap();
+
+    assert!(
+        cache_dir.join("bootstrap_cache.json").exists(),
+        "endpoint cache must persist to the per-instance dir x0x configured"
+    );
+}
+
+/// `persist(false)` (the daemon's `--disable-peer-cache`) must leave zero
+/// disk state: nothing loaded from previous runs, nothing written — this
+/// is what guarantees hermetic test harnesses and local-only setups.
+#[tokio::test]
+async fn network_node_in_memory_cache_writes_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_dir = dir.path().join("peers");
+    let cache_config = ant_quic::BootstrapCacheConfig::builder()
+        .cache_dir(&cache_dir)
+        .min_peers_to_save(1)
+        .persist(false)
+        .build();
+    let config = NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().unwrap()),
+        bootstrap_nodes: Vec::new(),
+        ..NetworkConfig::default()
+    };
+    let node = NetworkNode::new(config, Some(cache_config), None)
+        .await
+        .unwrap();
+
+    let cache = node
+        .bootstrap_cache()
+        .expect("in-memory cache still usable");
+    cache
+        .add_seed(
+            ant_quic::PeerId([9u8; 32]),
+            vec!["127.0.0.1:9000".parse().unwrap()],
+        )
+        .await;
+    cache.save().await.unwrap();
+
+    assert!(
+        !cache_dir.exists(),
+        "in-memory cache must not create any disk state"
+    );
+    assert_eq!(cache.peer_count().await, 1, "runtime behaviour unchanged");
+}
+
 /// Test that connections between local nodes are bidirectionally visible.
 ///
 /// This reproduces the "phantom connection" bug where `connect_addr()` succeeds
@@ -3972,7 +4071,6 @@ async fn test_mesh_connections_are_bidirectional() {
             max_connections: 100,
             connection_timeout: CONNECT_TIMEOUT,
             stats_interval: std::time::Duration::from_secs(60),
-            peer_cache_path: None,
             pinned_bootstrap_peers: std::collections::HashSet::new(),
             inbound_allowlist: std::collections::HashSet::new(),
             max_peers_per_ip: 3,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -761,7 +761,6 @@ pub async fn serve_with_options(
         max_connections: 50,
         connection_timeout: std::time::Duration::from_secs(30),
         stats_interval: std::time::Duration::from_secs(60),
-        peer_cache_path: (!cli_disable_peer_cache).then(|| cache_dir.join("peers.cache")),
         pinned_bootstrap_peers: std::collections::HashSet::new(),
         inbound_allowlist: std::collections::HashSet::new(),
         max_peers_per_ip: 3,


### PR DESCRIPTION
## Problem

x0x opened its own bootstrap cache at `<data_dir>/peers/` while the ant-quic endpoint silently opened a **second** cache in a host-shared default directory (`$TMPDIR/ant-quic-cache` / `~/.cache/ant-quic`). The two never shared data:

- the endpoint's transport-level reconnection quality never reached x0x's cache-first join phases
- x0x's presence-beacon enrichment never reached the endpoint's reconnection
- prod + testnet daemons on one VPS could commingle peer planes in the shared dir
- `--disable-peer-cache` only disabled x0x's cache — the endpoint kept using the shared default

## Changes

- Plumb the per-instance `BootstrapCacheConfig` through `NodeConfig::bootstrap_cache` (ant-quic 0.27.33) and borrow the endpoint's single instance via `Node::bootstrap_cache()` — every existing use-site (join phases, presence enrichment, gossip adapter) now reads/writes one cache
- `--disable-peer-cache` → session-only in-memory cache (`persist=false`): nothing loaded, nothing written, no cache dir created
- Remove dead `NetworkConfig.peer_cache_path` (written by the daemon, never read anywhere)
- x0xd: handle **SIGTERM** like Ctrl-C so systemd stop/restart drives graceful shutdown, which now flushes the cache
- SKILL.md/api-reference doc fixes: peer-cache filename is `peers/bootstrap_cache.json` (not `peers.cache`); documented the SSE `/events` envelope shape (fields nested under `data`) vs the flat `/direct/events` shape

## Validation (live, prod bootstraps)

- fresh daemon → endpoint persists to the per-instance dir x0x configured
- `kill -TERM` after 38 s → 32 KB `bootstrap_cache.json` flushed; `$TMPDIR/ant-quic-cache` stays empty
- restart → `Phase 0: Trying 10 addresses from 6 cached coordinators` → `Phase 1: 4/12 cached peers connected` → hardcoded Phase 2 never needed
- 1715/1716 lib tests pass (the one failure is the pre-existing `crdt_subscriptions` parallel-load flake, passes in isolation, untouched code); fmt/clippy/doc gates clean
- New tests: `network_node_uses_plumbed_per_instance_cache`, `network_node_in_memory_cache_writes_nothing`

## ⚠️ Merge order

**Blocked on ant-quic 0.27.33 being published to crates.io** (companion PR: saorsa-labs/ant-quic `fix/node-bootstrap-cache-plumbing`). CI will fail resolution until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves bootstrap caching into the ant-quic endpoint and updates related shutdown and documentation behavior. The main changes are:

- Shares one per-instance bootstrap cache across transport and x0x layers.
- Adds session-only cache mode for `--disable-peer-cache`.
- Handles SIGTERM through graceful daemon shutdown.
- Removes the unused network cache-path field.
- Corrects cache filenames and SSE response shapes in the docs.

<h3>Confidence Score: 4/5</h3>

The disabled-cache filesystem path and public configuration compatibility need fixes before merging.

- Disabled caching still creates the custom peers directory.
- Removing `peer_cache_path` can break downstream Rust builds.
- The shared endpoint cache and SIGTERM shutdown flow otherwise fit the existing lifecycle.

src/lib.rs, src/server/mod.rs, src/network.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib.rs | Passes bootstrap cache configuration to the endpoint and reuses its cache instance across x0x layers. |
| src/network.rs | Adds endpoint cache plumbing and persistence tests, while removing a public configuration field. |
| src/server/mod.rs | Selects the per-instance cache directory but still creates it when caching is disabled. |
| src/bin/x0xd.rs | Routes Unix SIGTERM into the existing graceful shutdown flow. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/network.rs`, line 263-265 ([link](https://github.com/saorsa-labs/x0x/blob/0fa5de046a7a3525e9380a4822f15b006b497ed3/src/network.rs#L263-L265)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Public Config Field Removal Breaks Callers**

   Removing `NetworkConfig::peer_cache_path` breaks downstream Rust callers that construct this public struct or access the field, even though x0x no longer reads it internally. Upgrading to this patch release can therefore cause compile failures; retain a deprecated ignored field or remove it in a breaking release.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/network.rs
   Line: 263-265

   Comment:
   **Public Config Field Removal Breaks Callers**

   Removing `NetworkConfig::peer_cache_path` breaks downstream Rust callers that construct this public struct or access the field, even though x0x no longer reads it internally. Upgrading to this patch release can therefore cause compile failures; retain a deprecated ignored field or remove it in a breaking release.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib.rs:9942
**Disabled Cache Still Creates Directory**

When `--disable-peer-cache` is used with a custom data directory, `serve_with_options` creates `<data_dir>/peers` before this in-memory configuration is applied. The flag therefore still leaves cache filesystem state, contrary to the new no-directory contract; directory creation should be skipped or deferred until persistent caching opens the cache.

### Issue 2 of 2
src/network.rs:263-265
**Public Config Field Removal Breaks Callers**

Removing `NetworkConfig::peer_cache_path` breaks downstream Rust callers that construct this public struct or access the field, even though x0x no longer reads it internally. Upgrading to this patch release can therefore cause compile failures; retain a deprecated ignored field or remove it in a breaking release.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(network): single bootstrap cache sha..."](https://github.com/saorsa-labs/x0x/commit/0fa5de046a7a3525e9380a4822f15b006b497ed3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44431579)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->