### PR TITLE
feat(kv): AccessPolicy::AppendOnly — owner-signed stores with immutable existing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,54 @@ All notable changes to this project will be documented in this file.
 
 - `AccessPolicy::AppendOnly` for KV stores (tracker-integrity-v2 WP-X,
   x0x-symphony #10): owner-signed like `Signed`, but existing keys are
-  IMMUTABLE — no update to different content, no delete, even by the owner.
-  Enforced at every path: local put/remove (`KvError::ImmutableKey`),
-  remote deltas (violating entries/removals are skipped and logged, the
-  rest of the delta still applies), and owner-signed checkpoint adoption
-  (a checkpoint that shrinks the keyset or rewrites an existing key is
-  rejected outright; fresh-joiner cold-start adoption is unaffected).
-  Byte-identical re-puts are accepted as idempotent no-ops (retry-friendly).
-  REST: `POST /stores` accepts `"policy": "append_only"`; `PUT`/`DELETE` on
-  an existing key of an append-only store return 409 Conflict. CLI:
-  `x0x store create --policy append_only`. The policy is persisted in the
-  subscription manifest so a restarted creator rehydrates append-only.
+  IMMUTABLE — frozen in full (value, content type, metadata, timestamps),
+  no update, no delete, even by the owner. Enforced at every path: local
+  put/remove (`KvError::ImmutableKey`), remote deltas (violating
+  entries/removals are skipped and logged, the rest of the delta still
+  applies), full-state `KvStore::merge` (transactional reject), and
+  owner-signed checkpoint adoption (a checkpoint that shrinks the keyset,
+  rewrites an existing key, or downgrades the policy is rejected outright;
+  fresh-joiner cold-start adoption is unaffected). The policy is TERMINAL:
+  no announce, checkpoint, or manifest entry can transition a replica away
+  from append_only once known. Checkpoint adoption also rejects any delta
+  carrying the same key in both `added` and `updated` (ambiguous-multiset
+  tamper), for all policies. Byte-identical re-puts are accepted as true
+  idempotent no-ops (no version bump, no checkpoint-sequence advance, no
+  publish). REST: `POST /stores` accepts `"policy": "append_only"`;
+  `PUT`/`DELETE` on an existing key of an append-only store return 409
+  Conflict. CLI: `x0x store create --policy append_only`.
+  **Guarantee scope**: keys are immutable after first observation by a
+  continuously-persistent replica; a fresh joiner with no prior state
+  necessarily trusts the owner's current signed snapshot. Fresh-joiner
+  rewrite detection requires content chaining above the store
+  (x0x-symphony tracker-integrity-v2, saorsa-labs/x0x-symphony#10).
   Wire/storage compat: the variant is appended at the END of the
   bincode-positional `AccessPolicy` enum, so existing stores, deltas, and
   checkpoints are unaffected.
+- KV store state snapshots: the daemon now persists every KV store's full
+  state (policy, keyset, entries, latest adopted checkpoint, checkpoint
+  high-water mark) to `<data_dir>/kv-stores/<store-id-hex>.bin` (bincode,
+  atomic temp-file + fsync + rename) after every local mutation, merged
+  remote delta, and policy refresh — and restores it on restart BEFORE any
+  write is accepted (`Agent::create_kv_store_persistent` /
+  `Agent::join_kv_store_persistent`). This closes the restart-amnesia hole
+  where an append-only owner or replica came back empty and would have
+  re-accepted (and, for an owner, re-signed) rewrites of keys it no longer
+  remembered. Corrupt snapshots, store-id/owner mismatches, policy
+  conflicts, and malformed manifest policy strings all FAIL CLOSED (loud
+  skip/startup error, never a silent Signed downgrade). Legacy manifest
+  entries without a policy field remain Signed (documented compatibility
+  default).
+
+### Compatibility caveats
+
+- Binaries older than this release cannot decode an `AccessPolicy` value of
+  `append_only` (bincode positional variant 3): they skip checkpoints and
+  announces carrying it. Rolling BACK to an older x0xd after creating an
+  append-only store leaves that store's snapshot and manifest entry
+  undecodable/unenforced on the old binary — do not roll back daemons that
+  host append-only stores (the immutability guarantee does not exist on
+  pre-AppendOnly binaries).
 
 ## [v0.32.1] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `AccessPolicy::AppendOnly` for KV stores (tracker-integrity-v2 WP-X,
+  x0x-symphony #10): owner-signed like `Signed`, but existing keys are
+  IMMUTABLE — no update to different content, no delete, even by the owner.
+  Enforced at every path: local put/remove (`KvError::ImmutableKey`),
+  remote deltas (violating entries/removals are skipped and logged, the
+  rest of the delta still applies), and owner-signed checkpoint adoption
+  (a checkpoint that shrinks the keyset or rewrites an existing key is
+  rejected outright; fresh-joiner cold-start adoption is unaffected).
+  Byte-identical re-puts are accepted as idempotent no-ops (retry-friendly).
+  REST: `POST /stores` accepts `"policy": "append_only"`; `PUT`/`DELETE` on
+  an existing key of an append-only store return 409 Conflict. CLI:
+  `x0x store create --policy append_only`. The policy is persisted in the
+  subscription manifest so a restarted creator rehydrates append-only.
+  Wire/storage compat: the variant is appended at the END of the
+  bincode-positional `AccessPolicy` enum, so existing stores, deltas, and
+  checkpoints are unaffected.
+
 ## [v0.32.1] - 2026-07-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,18 +34,33 @@ All notable changes to this project will be documented in this file.
   checkpoints are unaffected.
 - KV store state snapshots: the daemon now persists every KV store's full
   state (policy, keyset, entries, latest adopted checkpoint, checkpoint
-  high-water mark) to `<data_dir>/kv-stores/<store-id-hex>.bin` (bincode,
-  atomic temp-file + fsync + rename) after every local mutation, merged
-  remote delta, and policy refresh — and restores it on restart BEFORE any
-  write is accepted (`Agent::create_kv_store_persistent` /
-  `Agent::join_kv_store_persistent`). This closes the restart-amnesia hole
-  where an append-only owner or replica came back empty and would have
-  re-accepted (and, for an owner, re-signed) rewrites of keys it no longer
-  remembered. Corrupt snapshots, store-id/owner mismatches, policy
-  conflicts, and malformed manifest policy strings all FAIL CLOSED (loud
-  skip/startup error, never a silent Signed downgrade). Legacy manifest
-  entries without a policy field remain Signed (documented compatibility
-  default).
+  high-water mark, and the OR-Set sequence-counter ceiling) to
+  `<data_dir>/kv-stores/<store-id-hex>.bin` after every local mutation,
+  merged remote delta — gossip AND the direct-delivery side channel — and
+  policy refresh, restoring it on restart BEFORE any write is accepted
+  (`Agent::create_kv_store_persistent` / `Agent::join_kv_store_persistent`).
+  This closes the restart-amnesia hole where an append-only owner or replica
+  came back empty and would have re-accepted (and, for an owner, re-signed)
+  rewrites of keys it no longer remembered. Corrupt snapshots,
+  store-id/owner mismatches, policy conflicts, and malformed manifest policy
+  strings all FAIL CLOSED (loud skip/startup error, never a silent Signed
+  downgrade). Legacy manifest entries without a policy field remain Signed
+  (documented compatibility default).
+  Durability contract: snapshot format v1 (`X0XKVS1` magic + bincode body;
+  introduced unreleased, no compat read path — unrecognized files fail
+  closed); writes are atomic (unique temp file + fsync + rename + parent
+  directory fsync on Unix; on non-Unix the parent fsync is skipped — the
+  rename stays atomic but its power-loss durability is not guaranteed
+  there); commits are serialized per store and version-gated so a
+  concurrent persist burst can never rename an older snapshot over a newer
+  one; a FAILED snapshot write on the local write path errors the write
+  (REST 500), does NOT publish the delta (durability before announcement —
+  the in-memory mutation stays applied and is recovered by the next
+  successful persist), flags the store `durability_degraded` (surfaced in
+  `GET /stores` and store create/join responses), and refuses further LOCAL
+  writes until a persist succeeds; remote-delta persist failures degrade
+  but never wedge replication. SIGKILL/power loss beyond the parent-dir
+  fsync (e.g. hardware write caches) is out of scope.
 
 ### Compatibility caveats
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -762,10 +762,25 @@ to the owner**. `PUT` on an existing key with different content and `DELETE`
 on any existing key return **409 Conflict** with
 `{"ok":false,"error":"immutable key: <key> — append-only store; ..."}`.
 Re-putting byte-identical content (same value and content type) is accepted
-as an idempotent no-op, so retries are safe. Replicas enforce the same rule
-against remote deltas and owner-signed checkpoints, so an owner cannot
-rewrite or truncate the log retroactively — this is what makes append-only
-event logs tamper-evident against their own author.
+as an idempotent no-op, so retries are safe (and no new owner checkpoint is
+produced). The policy is terminal: once a replica knows a store is
+append-only, no owner announce or checkpoint can transition it back to
+`signed`. The daemon snapshots every store's full state to
+`<data_dir>/kv-stores/<store-id-hex>.bin` after each mutation, so
+immutability knowledge survives restarts; a corrupt or conflicting snapshot
+fails closed at startup rather than silently starting empty.
+
+**Exact guarantee**: keys are immutable *after first observation by a
+continuously-persistent replica*. Such a replica rejects every rewrite or
+removal — including owner-signed deltas and owner-signed checkpoints. A
+**fresh joiner with no prior state necessarily trusts the owner's current
+signed snapshot**: signatures alone cannot prove that snapshot is the
+original history rather than a rewrite, and two fresh joiners fed different
+owner-signed snapshots will diverge (detectable by comparing adopted
+checkpoint content roots). Applications that need fresh-joiner rewrite
+detection must layer content chaining above the store (per-author sequence
+numbers + previous-entry hashes) — x0x-symphony's tracker-integrity-v2 does
+exactly this (saorsa-labs/x0x-symphony#10).
 
 ## File transfers
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -766,9 +766,14 @@ as an idempotent no-op, so retries are safe (and no new owner checkpoint is
 produced). The policy is terminal: once a replica knows a store is
 append-only, no owner announce or checkpoint can transition it back to
 `signed`. The daemon snapshots every store's full state to
-`<data_dir>/kv-stores/<store-id-hex>.bin` after each mutation, so
-immutability knowledge survives restarts; a corrupt or conflicting snapshot
-fails closed at startup rather than silently starting empty.
+`<data_dir>/kv-stores/<store-id-hex>.bin` after each mutation (local
+writes, gossip deltas, and direct-delivery deltas alike), so immutability
+knowledge survives restarts; a corrupt or conflicting snapshot fails closed
+at startup rather than silently starting empty. If a snapshot write FAILS,
+the local write returns **500**, the delta is NOT published (durability
+before announcement), the store reports `"durability_degraded": true` in
+`GET /stores` and create/join responses, and further local writes are
+refused until a snapshot succeeds; remote replication continues.
 
 **Exact guarantee**: keys are immutable *after first observation by a
 continuously-persistent replica*. Such a replica rejects every rewrite or

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -721,6 +721,20 @@ unconditional (still advisory).
 | GET | `/stores/:id/:key` | `x0x store get <store_id> <key>` | Get a value |
 | DELETE | `/stores/:id/:key` | `x0x store rm <store_id> <key>` | Remove a value |
 
+### Store create request body
+
+```json
+{
+  "name": "events",
+  "topic": "my-app/events",
+  "policy": "append_only"
+}
+```
+
+`policy` is optional: `"signed"` (default) or `"append_only"`. Any other
+value is a **400**. CLI: `x0x store create <name> <topic> --policy append_only`.
+`GET /stores` and the create/join responses report the store's policy string.
+
 ### Store put request body
 
 ```json
@@ -739,6 +753,19 @@ when this daemon's agent is not authorized — including on a joined replica
 that has not yet learned the store's authoritative owner from the
 owner-signed announcement (`"not authorized: store owner unknown: ..."`).
 Reads are always allowed.
+
+### Append-only stores
+
+A store created with `"policy": "append_only"` behaves like `Signed`
+(owner-only writes) with one addition: **existing keys are immutable, even
+to the owner**. `PUT` on an existing key with different content and `DELETE`
+on any existing key return **409 Conflict** with
+`{"ok":false,"error":"immutable key: <key> — append-only store; ..."}`.
+Re-putting byte-identical content (same value and content type) is accepted
+as an idempotent no-op, so retries are safe. Replicas enforce the same rule
+against remote deltas and owner-signed checkpoints, so an owner cannot
+rewrite or truncate the log retroactively — this is what makes append-only
+event logs tamper-evident against their own author.
 
 ## File transfers
 

--- a/justfile
+++ b/justfile
@@ -41,6 +41,12 @@ quick-check: fmt-check lint test
 
 check: fmt-check lint build test doc
 
+# KV append-only REST/e2e suite (#[ignore] — boots real x0xd daemons, so it
+# needs a built binary and cannot run hermetically under plain `just test`).
+test-kv-e2e:
+    cargo build --release --bin x0xd
+    cargo nextest run --all-features --test kv_append_only_rest -- --ignored
+
 # ── Test coverage (line/region) ───────────────────────────────────────────
 #
 # Uses cargo-llvm-cov + nextest. Install once with:

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -1100,6 +1100,10 @@ enum StoreSub {
         name: String,
         /// Gossip topic for sync.
         topic: String,
+        /// Access policy: "signed" (default) or "append_only" (existing keys
+        /// are immutable — no update, no delete, even by the owner).
+        #[arg(long)]
+        policy: Option<String>,
     },
     /// Join an existing store by topic.
     ///
@@ -1770,9 +1774,11 @@ async fn run(
         Commands::Store { sub } => match sub {
             None => commands::store::list(&client).await,
             Some(StoreSub::List) => commands::store::list(&client).await,
-            Some(StoreSub::Create { name, topic }) => {
-                commands::store::create(&client, &name, &topic).await
-            }
+            Some(StoreSub::Create {
+                name,
+                topic,
+                policy,
+            }) => commands::store::create(&client, &name, &topic, policy.as_deref()).await,
             Some(StoreSub::Join { topic, owner }) => {
                 commands::store::join(&client, &topic, &owner).await
             }

--- a/src/cli/commands/store.rs
+++ b/src/cli/commands/store.rs
@@ -9,9 +9,20 @@ pub async fn list(client: &DaemonClient) -> Result<()> {
 }
 
 /// `x0x store create` — POST /stores.
-pub async fn create(client: &DaemonClient, name: &str, topic: &str) -> Result<()> {
+///
+/// `policy` is the optional access policy: `"signed"` (default) or
+/// `"append_only"` (existing keys immutable, even to the owner).
+pub async fn create(
+    client: &DaemonClient,
+    name: &str,
+    topic: &str,
+    policy: Option<&str>,
+) -> Result<()> {
     client.ensure_running().await?;
-    let body = serde_json::json!({ "name": name, "topic": topic });
+    let mut body = serde_json::json!({ "name": name, "topic": topic });
+    if let Some(p) = policy {
+        body["policy"] = serde_json::Value::String(p.to_string());
+    }
     let resp = client.post("/stores", &body).await?;
     print_value(client.format(), &resp);
     Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,6 +74,13 @@ pub enum IdentityError {
     /// maps this to HTTP 403.
     #[error("not authorized: {0}")]
     Unauthorized(String),
+
+    /// A local write was rejected because the store's `AppendOnly` policy
+    /// makes existing keys immutable (no update to different content, no
+    /// delete), even for the owner. The API layer maps this to HTTP 409
+    /// Conflict.
+    #[error("immutable key: {0} — append-only store; existing keys cannot be updated or deleted")]
+    ImmutableKey(String),
 }
 
 /// Standard Result type for x0x identity operations.

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -79,6 +79,15 @@ pub enum KvError {
     /// stale/replayed policy refresh. The store state is unchanged.
     #[error("invalid ownership token: {0}")]
     OwnerTokenInvalid(String),
+
+    /// Write rejected by the `AppendOnly` policy: the key already exists and
+    /// existing keys are immutable — no update to different content, no
+    /// delete — even for the store owner. This is what makes append-only
+    /// event logs tamper-evident against their own author retroactively
+    /// rewriting history. (A re-put of byte-identical content is accepted as
+    /// an idempotent no-op and never raises this error.)
+    #[error("immutable key: {0} — append-only store; existing keys cannot be updated or deleted")]
+    ImmutableKey(String),
 }
 
 #[cfg(test)]
@@ -113,6 +122,15 @@ mod tests {
     fn test_error_display_gossip() {
         let error = KvError::Gossip("timeout".to_string());
         assert!(format!("{error}").contains("gossip error"));
+    }
+
+    #[test]
+    fn test_error_display_immutable_key() {
+        let error = KvError::ImmutableKey("evt-0001".to_string());
+        let display = format!("{error}");
+        assert!(display.contains("immutable key"));
+        assert!(display.contains("evt-0001"));
+        assert!(display.contains("append-only"));
     }
 
     #[test]

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -649,16 +649,26 @@ impl KvStore {
         self.seq_counter.fetch_add(1, Ordering::Relaxed) + 1
     }
 
-    /// Floor the in-memory sequence counter to the persisted `version`.
+    /// Current value of the in-memory sequence counter (highest seq minted).
     ///
-    /// `seq_counter` is `serde(skip)`, so a snapshot-restored store would
-    /// otherwise mint OR-Set tags starting from 0 again — potentially
-    /// colliding with tags issued before the restart. `version` increments on
-    /// every mutation, so it is always >= the number of locally minted tags.
-    pub(crate) fn floor_seq_counter_to_version(&self) {
-        let v = self.version;
-        if self.seq_counter.load(Ordering::Relaxed) < v {
-            self.seq_counter.store(v, Ordering::Relaxed);
+    /// Snapshot persistence stores this alongside the store state so a
+    /// restart can restore the exact tag ceiling — `seq_counter` itself is
+    /// `serde(skip)` for wire/legacy-layout reasons.
+    pub(crate) fn seq_counter_value(&self) -> u64 {
+        self.seq_counter.load(Ordering::Relaxed)
+    }
+
+    /// Restore the in-memory sequence counter to at least `floor`.
+    ///
+    /// Called on snapshot restore with the persisted counter value so a
+    /// restarted node can never re-mint an OR-Set `(peer, seq)` tag it used
+    /// before the restart. (`KvStoreHandle::put_with_delta` mints a second
+    /// seq per put for the published delta tag, so the counter deliberately
+    /// runs ahead of `version` — persisting the real counter, not a
+    /// version-derived floor, is what makes this bound exact.)
+    pub(crate) fn restore_seq_counter(&self, floor: u64) {
+        if self.seq_counter.load(Ordering::Relaxed) < floor {
+            self.seq_counter.store(floor, Ordering::Relaxed);
         }
     }
 
@@ -1133,6 +1143,24 @@ impl KvStore {
                     );
                     return Ok(());
                 }
+            }
+        }
+
+        // Canonical-map gate, ALL policies: a delta carrying the same key in
+        // both `added` and `updated` is ambiguous by construction (two values
+        // for one key in one message) — no legitimate producer emits it
+        // (`for_put` is added-only, removals are removed-only, `full_delta`
+        // is added-only). Drop the whole delta rather than letting map
+        // iteration/LWW order decide which copy wins. Mirrors the adoption
+        // path's 5b gate; only the authorized writer can reach this point,
+        // so rejection cannot be used by third parties to censor writes.
+        for key in delta.updated.keys() {
+            if delta.added.contains_key(key) {
+                tracing::warn!(
+                    "rejected ambiguous delta for store {}: key {key:?} appears in both added and updated",
+                    self.id
+                );
+                return Ok(());
             }
         }
 
@@ -3423,21 +3451,15 @@ mod tests {
                 (peer(2), 42),
             ),
         );
-        // New keys in the same delta must still append fine.
+        // New keys in the same delta must still append fine. (k1 must NOT
+        // also appear in `updated` here — the global canonical-map gate
+        // drops any delta carrying one key in both maps; that shape has its
+        // own tests.)
         delta.added.insert(
             "k2".to_string(),
             (
                 KvEntry::new("k2".to_string(), b"v2".to_vec(), "text/plain".to_string()),
                 (peer(2), 43),
-            ),
-        );
-        // The `updated` path must be gated identically.
-        delta.updated.insert(
-            "k1".to_string(),
-            KvEntry::new(
-                "k1".to_string(),
-                b"REWRITTEN-2".to_vec(),
-                "text/plain".to_string(),
             ),
         );
         store
@@ -3452,6 +3474,26 @@ mod tests {
             store.get("k2").map(|e| e.value.clone()),
             Some(b"v2".to_vec()),
             "appends in the same delta still apply"
+        );
+
+        // The `updated` path is gated identically (separate delta so the
+        // canonical-map gate does not trigger).
+        let mut delta2 = KvStoreDelta::new(100);
+        delta2.updated.insert(
+            "k1".to_string(),
+            KvEntry::new(
+                "k1".to_string(),
+                b"REWRITTEN-2".to_vec(),
+                "text/plain".to_string(),
+            ),
+        );
+        store
+            .merge_delta(&delta2, peer(2), Some(&owner))
+            .expect("updated-path violation skipped");
+        assert_eq!(
+            store.get("k1").map(|e| e.value.clone()),
+            Some(b"v1".to_vec()),
+            "updated-path rewrite skipped too"
         );
     }
 
@@ -4096,6 +4138,65 @@ mod tests {
             root_before,
             "latest_checkpoint unchanged after a skip-only delta"
         );
+    }
+
+    #[test]
+    fn signed_store_ambiguous_added_updated_delta_dropped() {
+        // WHY: the canonical-map rule is global, not AppendOnly-only. A delta
+        // carrying one key in both `added` and `updated` holds two values for
+        // one key in one message — which copy wins would be decided by map
+        // iteration/LWW ordering, not by anything the producer expressed. No
+        // legitimate producer emits this shape, so merge_delta drops the
+        // whole delta for EVERY policy.
+        let owner = agent(1);
+        let mut store = KvStore::new(
+            store_id(9),
+            "plain".to_string(),
+            owner,
+            AccessPolicy::Signed,
+        );
+        store
+            .put(
+                "k".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+        let v_before = store.current_version();
+
+        let mut dup = KvStoreDelta::new(99);
+        dup.added.insert(
+            "k".to_string(),
+            (
+                KvEntry::new("k".to_string(), b"v2".to_vec(), "text/plain".to_string()),
+                (peer(2), 7),
+            ),
+        );
+        dup.updated.insert(
+            "k".to_string(),
+            KvEntry::new("k".to_string(), b"v3".to_vec(), "text/plain".to_string()),
+        );
+        // An innocent sibling key must not survive either: the ambiguity
+        // poisons the whole delta.
+        dup.added.insert(
+            "other".to_string(),
+            (
+                KvEntry::new("other".to_string(), b"x".to_vec(), "text/plain".to_string()),
+                (peer(2), 8),
+            ),
+        );
+
+        store
+            .merge_delta(&dup, peer(2), Some(&owner))
+            .expect("dropped, not an error");
+        assert_eq!(
+            store.get("k").map(|e| e.value.clone()),
+            Some(b"v1".to_vec()),
+            "ambiguous delta must not change the key on a Signed store"
+        );
+        assert!(store.get("other").is_none(), "whole delta dropped");
+        assert_eq!(store.current_version(), v_before, "no state change");
     }
 
     #[test]

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -4141,6 +4141,39 @@ mod tests {
     }
 
     #[test]
+    fn append_only_ambiguous_delta_dropped_without_checkpoint() {
+        // Standalone global-gate case: no checkpoint attached, so the
+        // adoption path is never entered — this exercises merge_delta's own
+        // canonical-map gate on an AppendOnly store. Even a NEW key (no
+        // immutability conflict at all) carried in both maps drops the
+        // whole delta.
+        let owner = agent(1);
+        let mut store = append_only_owner_store(owner);
+        let v_before = store.current_version();
+
+        let mut dup = KvStoreDelta::new(77);
+        dup.added.insert(
+            "fresh".to_string(),
+            (
+                KvEntry::new("fresh".to_string(), b"a".to_vec(), "text/plain".to_string()),
+                (peer(2), 11),
+            ),
+        );
+        dup.updated.insert(
+            "fresh".to_string(),
+            KvEntry::new("fresh".to_string(), b"b".to_vec(), "text/plain".to_string()),
+        );
+        store
+            .merge_delta(&dup, peer(2), Some(&owner))
+            .expect("dropped, not an error");
+        assert!(
+            store.get("fresh").is_none(),
+            "ambiguous delta dropped whole — neither copy of the new key applies"
+        );
+        assert_eq!(store.current_version(), v_before, "no state change");
+    }
+
+    #[test]
     fn signed_store_ambiguous_added_updated_delta_dropped() {
         // WHY: the canonical-map rule is global, not AppendOnly-only. A delta
         // carrying one key in both `added` and `updated` holds two values for

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -3657,4 +3657,473 @@ mod tests {
             .expect("Signed store delete must still work");
         assert!(store.get("k").is_none());
     }
+
+    // ── AppendOnly hardening (adversarial-review wave) ──────────────────
+
+    #[test]
+    fn append_only_downgrade_announce_rejected() {
+        // WHY: if an owner-signed announce could flip append_only back to
+        // signed, the owner could downgrade, delete freely, and re-upgrade —
+        // the policy would be decorative. AppendOnly must be terminal for
+        // ANY policy_version (forward or equal).
+        let owner = agent(1);
+        let mut store = append_only_owner_store(owner);
+        let v = store.policy_version();
+
+        // Forward-version downgrade: rejected.
+        let err = store
+            .learn_ownership(owner, AccessPolicy::Signed, v + 10, &owner)
+            .expect_err("forward-version downgrade must be rejected");
+        assert!(matches!(err, KvError::OwnerTokenInvalid(_)));
+        assert_eq!(*store.policy(), AccessPolicy::AppendOnly);
+
+        // Equal-version downgrade: rejected.
+        let err = store
+            .learn_ownership(owner, AccessPolicy::Signed, v, &owner)
+            .expect_err("equal-version downgrade must be rejected");
+        assert!(matches!(err, KvError::OwnerTokenInvalid(_)));
+        assert_eq!(*store.policy(), AccessPolicy::AppendOnly);
+
+        // A refresh that KEEPS append_only is still fine.
+        store
+            .learn_ownership(owner, AccessPolicy::AppendOnly, v + 1, &owner)
+            .expect("append_only-preserving refresh is allowed");
+        assert_eq!(*store.policy(), AccessPolicy::AppendOnly);
+    }
+
+    #[test]
+    fn append_only_checkpoint_policy_downgrade_rejected() {
+        // WHY: the checkpoint adoption path refreshes policy from cp.policy
+        // (step 10). A content-identical checkpoint whose only change is
+        // policy=Signed would otherwise downgrade the replica, unfreezing
+        // the log. Content equality means the immutability gate alone
+        // cannot catch this — the terminal-policy gate must.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/ao-downgrade";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        owner_store
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner append");
+        let cp1 = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut snap1 = owner_store.full_delta();
+        snap1.owner_checkpoint = Some(cp1.clone());
+
+        let mut replica =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        replica
+            .merge_delta(&snap1, peer(9), Some(&agent(9)))
+            .expect("initial adoption");
+        assert_eq!(*replica.policy(), AccessPolicy::AppendOnly);
+
+        // Forge: identical content, policy flipped to Signed, newer seq +
+        // newer policy_version.
+        let mut forged = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        forged
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("forge put");
+        let cp2 = checkpoint_for(&forged, topic, &kp, 2);
+        let mut snap2 = forged.full_delta();
+        snap2.owner_checkpoint = Some(cp2);
+
+        replica
+            .merge_delta(&snap2, peer(9), Some(&owner))
+            .expect("rejection is loud in logs but not an error");
+        assert_eq!(
+            *replica.policy(),
+            AccessPolicy::AppendOnly,
+            "append_only is terminal: a policy-downgrading checkpoint must not apply"
+        );
+        assert_eq!(replica.highest_checkpoint_seq, 1);
+    }
+
+    #[test]
+    fn adoption_rejects_key_in_both_added_and_updated() {
+        // WHY: adoption validates one merged view of (added ∪ updated) but
+        // applies both maps in sequence — a crafted delta carrying the same
+        // key twice with different values could rewrite what was validated.
+        // The canonical-map gate must reject the ambiguity outright.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/ao-dup";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        owner_store
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner append");
+        let cp1 = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut snap1 = owner_store.full_delta();
+        snap1.owner_checkpoint = Some(cp1.clone());
+
+        let mut replica =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        replica
+            .merge_delta(&snap1, peer(9), Some(&agent(9)))
+            .expect("initial adoption");
+
+        // Craft the REAL attack: k1 in `added` with EVIL bytes and a maxed
+        // LWW timestamp (so adoption's entry merge would keep it), k1 in
+        // `updated` with the benign local entry (so a last-wins validation
+        // map sees only the benign copy), and a checkpoint the "owner"
+        // signed over the DUPLICATED relayed multiset — which is exactly
+        // what step 6's root computation hashes, so without the
+        // canonical-map gate the root check passes while adoption ends on
+        // the evil bytes.
+        let benign = replica.get("k1").expect("local k1").clone();
+        let mut evil = KvEntry::new(
+            "k1".to_string(),
+            b"REWRITTEN".to_vec(),
+            "text/plain".to_string(),
+        );
+        evil.updated_at = u64::MAX;
+        let multiset_root = content_root(&id, "S", &[("k1", &evil), ("k1", &benign)]);
+        let cp2 = make_owner_checkpoint(OwnerCheckpointParams {
+            topic,
+            store_id: &id,
+            secret_key: kp.secret_key(),
+            public_key: kp.public_key(),
+            policy: &AccessPolicy::AppendOnly,
+            policy_version: 0,
+            checkpoint_seq: 2,
+            content_root: multiset_root,
+            timestamp: 0,
+        })
+        .expect("sign forged multiset checkpoint");
+
+        let mut dup = KvStoreDelta::new(99);
+        dup.added.insert("k1".to_string(), (evil, (peer(2), 42)));
+        dup.updated.insert("k1".to_string(), benign);
+        dup.name_update = Some(owner_store.name_register().clone());
+        dup.owner_checkpoint = Some(cp2);
+
+        replica
+            .merge_delta(&dup, peer(9), Some(&owner))
+            .expect("rejected adoption falls through safely");
+        assert_eq!(
+            replica.get("k1").map(|e| e.value.clone()),
+            Some(b"v1".to_vec()),
+            "duplicate-key delta must not rewrite the validated value"
+        );
+        assert_eq!(
+            replica.highest_checkpoint_seq, 1,
+            "forged multiset checkpoint must not advance the high-water mark"
+        );
+    }
+
+    #[test]
+    fn append_only_public_merge_rejected_transactionally() {
+        // WHY: KvStore::merge is public API that bypasses every merge_delta
+        // gate. It must enforce the same freeze — and atomically, so a
+        // violating merge cannot leave partial state behind.
+        let owner = agent(1);
+        let mut store = append_only_owner_store(owner);
+        let v_before = store.current_version();
+
+        // Hostile full-state replica: k1 rewritten (newer LWW timestamp so
+        // the entry merge would pick it), plus an innocent new key k9 that
+        // must NOT survive the rejected transaction.
+        let mut hostile = KvStore::new(
+            *store.id(),
+            "log".to_string(),
+            owner,
+            AccessPolicy::AppendOnly,
+        );
+        hostile
+            .put(
+                "k1".to_string(),
+                b"REWRITTEN".to_vec(),
+                "text/plain".to_string(),
+                peer(2),
+            )
+            .expect("hostile put");
+        hostile
+            .put(
+                "k9".to_string(),
+                b"new".to_vec(),
+                "text/plain".to_string(),
+                peer(2),
+            )
+            .expect("hostile put");
+        if let Some(e) = hostile.entries.get_mut("k1") {
+            e.updated_at = u64::MAX; // guarantee LWW would pick the rewrite
+        }
+
+        let err = store
+            .merge(&hostile)
+            .expect_err("public merge must reject an append-only rewrite");
+        assert!(matches!(err, KvError::ImmutableKey(_)));
+        assert_eq!(
+            store.get("k1").map(|e| e.value.clone()),
+            Some(b"v1".to_vec()),
+            "value retained"
+        );
+        assert!(
+            store.get("k9").is_none(),
+            "rejected merge must be transactional — no partial application"
+        );
+        assert_eq!(store.current_version(), v_before, "no state change at all");
+
+        // A purely-additive merge still works.
+        let mut additive = KvStore::new(
+            *store.id(),
+            "log".to_string(),
+            owner,
+            AccessPolicy::AppendOnly,
+        );
+        additive
+            .put(
+                "k2".to_string(),
+                b"v2".to_vec(),
+                "text/plain".to_string(),
+                peer(2),
+            )
+            .expect("additive put");
+        store.merge(&additive).expect("additive merge is allowed");
+        assert!(store.get("k1").is_some() && store.get("k2").is_some());
+    }
+
+    #[test]
+    fn append_only_delta_metadata_mutation_with_identical_bytes_skipped() {
+        // WHY: entries are frozen in FULL. KvEntry::merge is LWW on
+        // updated_at and replaces metadata wholesale — a same-value entry
+        // with a newer timestamp could otherwise mutate metadata/updated_at
+        // while the bytes "look" unchanged.
+        let owner = agent(1);
+        let mut store = append_only_owner_store(owner);
+        let (meta_before, updated_before) = {
+            let e = store.get("k1").expect("k1");
+            (e.metadata.clone(), e.updated_at)
+        };
+
+        let mut sneaky = KvEntry::new("k1".to_string(), b"v1".to_vec(), "text/plain".to_string());
+        sneaky
+            .metadata
+            .insert("injected".to_string(), "gotcha".to_string());
+        sneaky.updated_at = u64::MAX; // LWW would pick this entry
+
+        let mut delta = KvStoreDelta::new(99);
+        delta.added.insert("k1".to_string(), (sneaky, (peer(2), 7)));
+        store
+            .merge_delta(&delta, peer(2), Some(&owner))
+            .expect("skipped, not an error");
+
+        let e = store.get("k1").expect("k1 retained");
+        assert_eq!(e.metadata, meta_before, "metadata frozen");
+        assert_eq!(e.updated_at, updated_before, "updated_at frozen");
+    }
+
+    #[test]
+    fn two_fresh_joiners_conflicting_snapshots_diverge_detectably() {
+        // WHY (documented limitation, P0-D): a fresh joiner has no prior
+        // state, so it MUST trust the owner's current signed snapshot —
+        // signatures cannot distinguish original history from a rewrite.
+        // Two fresh joiners fed different owner-signed snapshots therefore
+        // diverge. The detection surface is the adopted checkpoint content
+        // root: they differ, and neither replica auto-reconciles (later
+        // cross-delivered snapshots hit the immutability gate).
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/ao-fork";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let snap_x = forged_snapshot(id, owner, &kp, topic, &[("k", b"x")], 1);
+        let snap_y = forged_snapshot(id, owner, &kp, topic, &[("k", b"y")], 1);
+
+        let mut a = KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        let mut b = KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        a.merge_delta(&snap_x, peer(9), Some(&agent(9)))
+            .expect("A adopts X");
+        b.merge_delta(&snap_y, peer(9), Some(&agent(9)))
+            .expect("B adopts Y");
+
+        assert_eq!(a.get("k").map(|e| e.value.clone()), Some(b"x".to_vec()));
+        assert_eq!(b.get("k").map(|e| e.value.clone()), Some(b"y".to_vec()));
+        assert_eq!(a.highest_checkpoint_seq, 1);
+        assert_eq!(b.highest_checkpoint_seq, 1);
+        let root_a = a.latest_checkpoint.as_ref().expect("A cp").content_root;
+        let root_b = b.latest_checkpoint.as_ref().expect("B cp").content_root;
+        assert_ne!(
+            root_a, root_b,
+            "divergence is detectable by comparing adopted checkpoint roots"
+        );
+
+        // Cross-feed: A now DROPS the other snapshot (same seq → the
+        // stale-delta gate; a newer-seq rewrite would hit the immutability
+        // gate instead) — the fork is sticky and visible, never silently
+        // reconciled.
+        a.merge_delta(&snap_y, peer(9), Some(&owner))
+            .expect("skip, not error");
+        assert_eq!(
+            a.get("k").map(|e| e.value.clone()),
+            Some(b"x".to_vec()),
+            "A keeps its observed history"
+        );
+    }
+
+    #[test]
+    fn rejected_truncated_checkpoint_does_not_poison_later_legit_flow() {
+        // WHY: interaction with the PR #230 stale-delta gate. A rejected
+        // forged checkpoint must not advance the high-water mark (else it
+        // would stale-drop legitimate owner deltas), and a later LEGITIMATE
+        // superset checkpoint must still adopt normally, while replays of
+        // old snapshots stay stale-dropped.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/ao-truncate";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        for (k, v) in [("k1", b"v1".as_slice()), ("k2", b"v2".as_slice())] {
+            owner_store
+                .put(k.to_string(), v.to_vec(), "text/plain".to_string(), peer(1))
+                .expect("owner append");
+        }
+        let cp1 = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut snap1 = owner_store.full_delta();
+        snap1.owner_checkpoint = Some(cp1);
+
+        let mut replica =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        replica
+            .merge_delta(&snap1, peer(9), Some(&agent(9)))
+            .expect("initial adoption");
+        assert_eq!(replica.highest_checkpoint_seq, 1);
+
+        // Forged truncation at seq 2: rejected, HWM must NOT move.
+        let forged = forged_snapshot(id, owner, &kp, topic, &[("k1", b"v1")], 2);
+        replica
+            .merge_delta(&forged, peer(9), Some(&owner))
+            .expect("skip, not error");
+        assert!(replica.get("k2").is_some(), "truncation rejected");
+        assert_eq!(
+            replica.highest_checkpoint_seq, 1,
+            "rejected forge must not advance HWM (would stale-drop legit deltas)"
+        );
+
+        // Legit superset at seq 3 still adopts.
+        owner_store
+            .put(
+                "k3".to_string(),
+                b"v3".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner append k3");
+        let cp3 = checkpoint_for(&owner_store, topic, &kp, 3);
+        let mut snap3 = owner_store.full_delta();
+        snap3.owner_checkpoint = Some(cp3);
+        replica
+            .merge_delta(&snap3, peer(9), Some(&agent(9)))
+            .expect("legit superset adopts");
+        assert_eq!(replica.highest_checkpoint_seq, 3);
+        assert!(replica.get("k3").is_some());
+
+        // Replay of the old seq-1 snapshot: stale-dropped, no mutation.
+        let v_before = replica.current_version();
+        replica
+            .merge_delta(&snap1, peer(9), Some(&agent(9)))
+            .expect("stale replay is a no-op");
+        assert_eq!(replica.current_version(), v_before);
+        assert_eq!(replica.highest_checkpoint_seq, 3);
+    }
+
+    #[test]
+    fn skip_only_delta_does_not_advance_hwm_or_replace_checkpoint() {
+        // WHY: when every mutation in a hostile delta is skipped, the
+        // attached (genuine, newer-seq) checkpoint must not be cached either
+        // — the post-merge state root does not match it. HWM and
+        // latest_checkpoint must be exactly what they were.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/ao-skiponly";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        owner_store
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner append");
+        let cp1 = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut snap1 = owner_store.full_delta();
+        snap1.owner_checkpoint = Some(cp1.clone());
+
+        let mut replica =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        replica
+            .merge_delta(&snap1, peer(9), Some(&agent(9)))
+            .expect("initial adoption");
+        let root_before = replica
+            .latest_checkpoint
+            .as_ref()
+            .expect("cp cached")
+            .content_root;
+
+        // Hostile: rewrite-only delta with a genuine seq-2 checkpoint over
+        // the forged state.
+        let hostile = forged_snapshot(id, owner, &kp, topic, &[("k1", b"REWRITTEN")], 2);
+        replica
+            .merge_delta(&hostile, peer(9), Some(&owner))
+            .expect("skip, not error");
+
+        assert_eq!(replica.highest_checkpoint_seq, 1, "HWM unchanged");
+        assert_eq!(
+            replica
+                .latest_checkpoint
+                .as_ref()
+                .expect("cp still cached")
+                .content_root,
+            root_before,
+            "latest_checkpoint unchanged after a skip-only delta"
+        );
+    }
+
+    #[test]
+    fn access_policy_bincode_discriminants_are_pinned() {
+        // WHY: AccessPolicy is bincode-encoded positionally in persisted
+        // stores, checkpoints (wire + signing bytes), and deltas. If anyone
+        // reorders or inserts a variant mid-enum, every existing store
+        // corrupts. This test pins the exact on-wire indices 0..=3.
+        let cases: [(AccessPolicy, u32); 4] = [
+            (AccessPolicy::Signed, 0),
+            (AccessPolicy::Allowlisted, 1),
+            (
+                AccessPolicy::Encrypted {
+                    group_id: Vec::new(),
+                },
+                2,
+            ),
+            (AccessPolicy::AppendOnly, 3),
+        ];
+        for (policy, index) in cases {
+            let bytes = bincode::serialize(&policy).expect("serialize");
+            assert!(bytes.len() >= 4, "bincode enum tag is a u32");
+            let tag = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            assert_eq!(
+                tag, index,
+                "bincode discriminant for {policy} moved — this BREAKS every existing store/checkpoint"
+            );
+        }
+    }
 }

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -1453,10 +1453,9 @@ impl KvStore {
         //     Belt-and-braces: AppendOnly is terminal — the 6b gate already
         //     rejected any checkpoint that would downgrade it, so this branch
         //     can only keep or adopt AppendOnly, never leave it.
-        if cp.policy_version >= self.policy_version
-            && !(matches!(self.policy, AccessPolicy::AppendOnly)
-                && !matches!(cp.policy, AccessPolicy::AppendOnly))
-        {
+        let downgrades_terminal_policy = matches!(self.policy, AccessPolicy::AppendOnly)
+            && !matches!(cp.policy, AccessPolicy::AppendOnly);
+        if cp.policy_version >= self.policy_version && !downgrades_terminal_policy {
             self.policy = cp.policy.clone();
             self.policy_version = cp.policy_version;
         }

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -12,6 +12,10 @@
 //! - **Encrypted**: Reserved for group-scoped encrypted stores. The current
 //!   KvStore sync path does not encrypt deltas; do not rely on this policy for
 //!   confidentiality until encrypted sync is wired.
+//! - **AppendOnly**: Like `Signed` (owner-only writes), but existing keys are
+//!   immutable — no update, no delete, even by the owner. Use for
+//!   tamper-evident event logs where the author must not be able to rewrite
+//!   history retroactively.
 
 use crate::identity::AgentId;
 use crate::kv::{KvEntry, KvError, KvStoreDelta, Result};
@@ -42,6 +46,23 @@ pub enum AccessPolicy {
         /// MLS group ID for this store.
         group_id: Vec<u8>,
     },
+
+    /// Owner-signed append-only store: like [`Signed`](Self::Signed), only the
+    /// owner can write — but existing keys are IMMUTABLE. A key, once written,
+    /// can never be updated to different content or deleted, **even by the
+    /// owner**. Re-putting byte-identical content is accepted as an idempotent
+    /// no-op (retry-friendly).
+    ///
+    /// This makes append-only event logs tamper-evident against their own
+    /// author: an owner retroactively rewriting or truncating history is
+    /// rejected at every enforcement point (local writes, remote deltas, and
+    /// owner-signed checkpoint adoption).
+    ///
+    /// NOTE: this variant MUST stay last — bincode encodes enum variants
+    /// positionally, and stores/checkpoints/deltas carrying `AccessPolicy`
+    /// are bincode-serialized on disk and on the wire. Inserting a variant
+    /// mid-enum would corrupt every existing store.
+    AppendOnly,
 }
 
 impl std::fmt::Display for AccessPolicy {
@@ -50,6 +71,7 @@ impl std::fmt::Display for AccessPolicy {
             Self::Signed => write!(f, "signed"),
             Self::Allowlisted => write!(f, "allowlisted"),
             Self::Encrypted { .. } => write!(f, "encrypted"),
+            Self::AppendOnly => write!(f, "append_only"),
         }
     }
 }
@@ -702,6 +724,12 @@ impl KvStore {
                 // the secure sync path once wired.
                 true
             }
+            AccessPolicy::AppendOnly => {
+                // Owner-only writes, exactly like Signed. Immutability of
+                // existing keys is enforced separately at each mutation site
+                // (put/remove/merge_delta/checkpoint adoption).
+                self.owner.as_ref().is_some_and(|o| o == agent_id)
+            }
         }
     }
 
@@ -858,7 +886,11 @@ impl KvStore {
 
     /// Put a key-value entry.
     ///
-    /// If the key already exists, the value is updated using LWW semantics.
+    /// If the key already exists, the value is updated using LWW semantics —
+    /// except under [`AccessPolicy::AppendOnly`], where an existing key is
+    /// immutable: a re-put of byte-identical content (same value AND
+    /// content type) is accepted as an idempotent no-op so retries are safe,
+    /// and anything else returns [`KvError::ImmutableKey`].
     pub fn put(
         &mut self,
         key: String,
@@ -871,6 +903,16 @@ impl KvStore {
                 size: value.len(),
                 max: crate::kv::entry::MAX_INLINE_SIZE,
             });
+        }
+
+        // AppendOnly: existing keys are immutable, even for the owner.
+        if matches!(self.policy, AccessPolicy::AppendOnly) {
+            if let Some(existing) = self.get(&key) {
+                if existing.value == value && existing.content_type == content_type {
+                    return Ok(()); // idempotent re-put of identical content
+                }
+                return Err(KvError::ImmutableKey(key));
+            }
         }
 
         let seq = self.next_seq();
@@ -910,9 +952,18 @@ impl KvStore {
     }
 
     /// Remove a key from the store.
+    ///
+    /// # Errors
+    ///
+    /// - [`KvError::KeyNotFound`] if the key does not exist.
+    /// - [`KvError::ImmutableKey`] under [`AccessPolicy::AppendOnly`]: keys
+    ///   can never be deleted, even by the owner.
     pub fn remove(&mut self, key: &str) -> Result<()> {
         if !self.entries.contains_key(key) {
             return Err(KvError::KeyNotFound(key.to_string()));
+        }
+        if matches!(self.policy, AccessPolicy::AppendOnly) {
+            return Err(KvError::ImmutableKey(key.to_string()));
         }
 
         self.keys
@@ -1041,6 +1092,9 @@ impl KvStore {
 
         // Apply added entries
         for (key, (entry, tag)) in &delta.added {
+            if self.append_only_rejects_entry(key, entry) {
+                continue; // skip this entry; the rest of the delta still applies
+            }
             self.keys
                 .add(key.clone(), *tag)
                 .map_err(|e| KvError::Merge(format!("OR-Set add failed: {e}")))?;
@@ -1052,14 +1106,30 @@ impl KvStore {
             }
         }
 
-        // Apply removed keys
-        for key in delta.removed.keys() {
-            let _ = self.keys.remove(&key.to_string());
-            self.entries.remove(key.as_str());
+        // Apply removed keys — never for AppendOnly stores: keys are immutable
+        // and cannot be removed, even by an owner-signed delta (an owner
+        // retroactively deleting records is exactly the attack AppendOnly
+        // exists to stop).
+        if matches!(self.policy, AccessPolicy::AppendOnly) {
+            if !delta.removed.is_empty() {
+                tracing::warn!(
+                    "append-only violation: skipped {} remote key removal(s) for store {}",
+                    delta.removed.len(),
+                    self.id
+                );
+            }
+        } else {
+            for key in delta.removed.keys() {
+                let _ = self.keys.remove(&key.to_string());
+                self.entries.remove(key.as_str());
+            }
         }
 
         // Apply updated entries (upsert)
         for (key, entry) in &delta.updated {
+            if self.append_only_rejects_entry(key, entry) {
+                continue; // skip this entry; the rest of the delta still applies
+            }
             if let Some(existing) = self.entries.get_mut(key) {
                 existing.merge(entry);
             } else {
@@ -1086,6 +1156,32 @@ impl KvStore {
 
         self.version += 1;
         Ok(())
+    }
+
+    /// AppendOnly guard for one incoming delta entry.
+    ///
+    /// `true` when this store is [`AccessPolicy::AppendOnly`] and `key` is
+    /// already active locally with different content — the mutation must be
+    /// skipped and the local value retained. Owner-signed deltas are NOT
+    /// exempt: an owner retroactively rewriting records is exactly the attack
+    /// this policy exists to stop. A byte-identical re-delivery is allowed
+    /// through (idempotent; the LWW entry merge is a no-op on content).
+    fn append_only_rejects_entry(&self, key: &str, entry: &KvEntry) -> bool {
+        if !matches!(self.policy, AccessPolicy::AppendOnly) {
+            return false;
+        }
+        match self.get(key) {
+            Some(local)
+                if local.value != entry.value || local.content_type != entry.content_type =>
+            {
+                tracing::warn!(
+                    "append-only violation: skipped remote update of existing key {key:?} for store {}",
+                    self.id
+                );
+                true
+            }
+            _ => false,
+        }
     }
 
     /// Try to adopt an owner-signed checkpoint as an authoritative full
@@ -1166,6 +1262,48 @@ impl KvStore {
             .unwrap_or("");
         if content_root(&self.id, relayed_name, &relayed) != cp.content_root {
             return false; // tamper / truncation / subset / incremental — fall through
+        }
+        // 6b. AppendOnly immutability gate: a checkpoint may only EXTEND the
+        //     keyset. If adopting it would drop a locally-present key or
+        //     change its bytes, reject the whole checkpoint and keep local
+        //     state (fail loud) — an owner signing a rewritten/truncated
+        //     history is exactly the attack AppendOnly exists to stop. A
+        //     fresh joiner holds no local keys, so cold-start adoption is
+        //     unaffected. Checked against BOTH the local policy and the
+        //     checkpoint's claimed policy, so a hostile checkpoint cannot
+        //     dodge the gate by flipping its own policy field.
+        if matches!(self.policy, AccessPolicy::AppendOnly)
+            || matches!(cp.policy, AccessPolicy::AppendOnly)
+        {
+            let signed_entries: HashMap<&str, &KvEntry> =
+                relayed.iter().map(|(k, e)| (*k, *e)).collect();
+            for key in self.keys.elements() {
+                let Some(local) = self.entries.get(key) else {
+                    continue;
+                };
+                match signed_entries.get(key.as_str()) {
+                    None => {
+                        tracing::warn!(
+                            "append-only violation: rejected owner checkpoint seq {} for store {} — it drops existing key {key:?}",
+                            cp.checkpoint_seq,
+                            self.id
+                        );
+                        return false;
+                    }
+                    Some(remote)
+                        if remote.value != local.value
+                            || remote.content_type != local.content_type =>
+                    {
+                        tracing::warn!(
+                            "append-only violation: rejected owner checkpoint seq {} for store {} — it rewrites existing key {key:?}",
+                            cp.checkpoint_seq,
+                            self.id
+                        );
+                        return false;
+                    }
+                    _ => {}
+                }
+            }
         }
         // 7. Adopt: merge the entries as owner-authorized (bypass sender-auth).
         for (key, (entry, tag)) in &delta.added {
@@ -3026,5 +3164,352 @@ mod tests {
             "newer checkpoint advances"
         );
         assert!(restarted.get("k2").is_some());
+    }
+
+    // ── AppendOnly policy ───────────────────────────────────────────────
+    //
+    // WHY these tests exist: AppendOnly makes an owner-signed store
+    // tamper-evident against its OWN author. Every path an owner (or anyone)
+    // could use to rewrite or truncate history — local put/remove, remote
+    // deltas, owner-signed checkpoint adoption — must refuse to touch an
+    // existing key. If any of these tests can pass while an existing key's
+    // bytes change or disappear, the policy's entire guarantee is void.
+
+    fn append_only_owner_store(owner: AgentId) -> KvStore {
+        let mut store = KvStore::new(
+            store_id(7),
+            "log".to_string(),
+            owner,
+            AccessPolicy::AppendOnly,
+        );
+        store
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("initial append");
+        store
+    }
+
+    #[test]
+    fn append_only_put_existing_key_different_content_rejected() {
+        let owner = agent(1);
+        let mut store = append_only_owner_store(owner);
+        let err = store
+            .put(
+                "k1".to_string(),
+                b"REWRITTEN".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect_err("owner must not be able to rewrite an existing key");
+        assert!(matches!(err, KvError::ImmutableKey(ref k) if k == "k1"));
+        assert_eq!(
+            store.get("k1").map(|e| e.value.clone()),
+            Some(b"v1".to_vec()),
+            "original bytes retained"
+        );
+    }
+
+    #[test]
+    fn append_only_put_identical_content_is_idempotent_noop() {
+        let owner = agent(1);
+        let mut store = append_only_owner_store(owner);
+        let v_before = store.current_version();
+        store
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("byte-identical re-put is accepted (retry-friendly)");
+        assert_eq!(
+            store.current_version(),
+            v_before,
+            "idempotent re-put is a no-op: no version bump, no state change"
+        );
+        // Same bytes but a different content type is a mutation — rejected.
+        let err = store
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "application/json".to_string(),
+                peer(1),
+            )
+            .expect_err("content-type change on an existing key is a mutation");
+        assert!(matches!(err, KvError::ImmutableKey(_)));
+    }
+
+    #[test]
+    fn append_only_remove_rejected() {
+        let owner = agent(1);
+        let mut store = append_only_owner_store(owner);
+        let err = store
+            .remove("k1")
+            .expect_err("owner must not be able to delete an existing key");
+        assert!(matches!(err, KvError::ImmutableKey(ref k) if k == "k1"));
+        assert!(store.get("k1").is_some(), "key retained after rejected delete");
+        // A key that never existed still reports KeyNotFound (unchanged).
+        assert!(matches!(
+            store.remove("ghost"),
+            Err(KvError::KeyNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn append_only_owner_delta_rewrite_skipped_value_retained() {
+        // A hostile delta authored by the OWNER updating an existing key must
+        // be skipped: owner-signed is not exempt from immutability.
+        let owner = agent(1);
+        let mut store = append_only_owner_store(owner);
+
+        let mut delta = KvStoreDelta::new(99);
+        delta.added.insert(
+            "k1".to_string(),
+            (
+                KvEntry::new(
+                    "k1".to_string(),
+                    b"REWRITTEN".to_vec(),
+                    "text/plain".to_string(),
+                ),
+                (peer(2), 42),
+            ),
+        );
+        // New keys in the same delta must still append fine.
+        delta.added.insert(
+            "k2".to_string(),
+            (
+                KvEntry::new("k2".to_string(), b"v2".to_vec(), "text/plain".to_string()),
+                (peer(2), 43),
+            ),
+        );
+        // The `updated` path must be gated identically.
+        delta.updated.insert(
+            "k1".to_string(),
+            KvEntry::new(
+                "k1".to_string(),
+                b"REWRITTEN-2".to_vec(),
+                "text/plain".to_string(),
+            ),
+        );
+        store
+            .merge_delta(&delta, peer(2), Some(&owner))
+            .expect("violations are skipped, not errors — delta not poisoned");
+        assert_eq!(
+            store.get("k1").map(|e| e.value.clone()),
+            Some(b"v1".to_vec()),
+            "existing key retained its original bytes"
+        );
+        assert_eq!(
+            store.get("k2").map(|e| e.value.clone()),
+            Some(b"v2".to_vec()),
+            "appends in the same delta still apply"
+        );
+    }
+
+    #[test]
+    fn append_only_owner_delta_removal_skipped_key_retained() {
+        let owner = agent(1);
+        let mut store = append_only_owner_store(owner);
+
+        let mut delta = KvStoreDelta::new(99);
+        delta.removed.insert("k1".to_string(), HashSet::new());
+        store
+            .merge_delta(&delta, peer(2), Some(&owner))
+            .expect("removal is skipped, not an error");
+        assert!(
+            store.get("k1").is_some(),
+            "owner-signed removal must not delete an append-only key"
+        );
+    }
+
+    #[test]
+    fn append_only_fresh_joiner_adopts_first_checkpoint() {
+        // Cold start: a fresh anchored joiner has no local keys, so the
+        // immutability gate is trivially satisfied and adoption proceeds.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/ao-cold";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        owner_store
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner append");
+        let cp = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut snap = owner_store.full_delta();
+        snap.owner_checkpoint = Some(cp);
+
+        let mut joiner =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        joiner
+            .merge_delta(&snap, peer(9), Some(&agent(9)))
+            .expect("fresh joiner adopts");
+        assert_eq!(joiner.highest_checkpoint_seq, 1);
+        assert_eq!(
+            joiner.get("k1").map(|e| e.value.clone()),
+            Some(b"v1".to_vec())
+        );
+        assert_eq!(
+            *joiner.policy(),
+            AccessPolicy::AppendOnly,
+            "joiner learns the append-only policy from the checkpoint"
+        );
+    }
+
+    /// Build an owner-signed "rewritten history" snapshot: a fresh store with
+    /// the given entries, checkpointed at `seq`. Models an owner forging a
+    /// past-state replacement offline.
+    fn forged_snapshot(
+        id: KvStoreId,
+        owner: AgentId,
+        kp: &crate::identity::AgentKeypair,
+        topic: &str,
+        entries: &[(&str, &[u8])],
+        seq: u64,
+    ) -> KvStoreDelta {
+        let mut forged = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        for (k, v) in entries {
+            forged
+                .put(
+                    (*k).to_string(),
+                    v.to_vec(),
+                    "text/plain".to_string(),
+                    peer(1),
+                )
+                .expect("forge put");
+        }
+        let cp = checkpoint_for(&forged, topic, kp, seq);
+        let mut snap = forged.full_delta();
+        snap.owner_checkpoint = Some(cp);
+        snap
+    }
+
+    #[test]
+    fn append_only_checkpoint_shrinking_keyset_rejected() {
+        // An owner-signed checkpoint that DROPS an existing key must be
+        // rejected on a non-fresh replica: local state intact, high-water
+        // mark not advanced. An owner truncating its own log is exactly the
+        // attack this policy exists to stop.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/ao-shrink";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        for (k, v) in [("k1", b"v1".as_slice()), ("k2", b"v2".as_slice())] {
+            owner_store
+                .put(k.to_string(), v.to_vec(), "text/plain".to_string(), peer(1))
+                .expect("owner append");
+        }
+        let cp1 = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut snap1 = owner_store.full_delta();
+        snap1.owner_checkpoint = Some(cp1);
+
+        let mut replica =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        replica
+            .merge_delta(&snap1, peer(9), Some(&agent(9)))
+            .expect("initial adoption");
+        assert_eq!(replica.highest_checkpoint_seq, 1);
+
+        // Owner forges history without k2.
+        let snap2 = forged_snapshot(id, owner, &kp, topic, &[("k1", b"v1")], 2);
+        replica
+            .merge_delta(&snap2, peer(9), Some(&owner))
+            .expect("rejection is loud in logs but not an error");
+        assert!(
+            replica.get("k2").is_some(),
+            "checkpoint that shrinks the keyset must not delete k2"
+        );
+        assert_eq!(
+            replica.highest_checkpoint_seq, 1,
+            "forged checkpoint must not advance the high-water mark"
+        );
+    }
+
+    #[test]
+    fn append_only_checkpoint_rewriting_value_rejected() {
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/ao-rewrite";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        owner_store
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner append");
+        let cp1 = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut snap1 = owner_store.full_delta();
+        snap1.owner_checkpoint = Some(cp1);
+
+        let mut replica =
+            KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
+        replica
+            .merge_delta(&snap1, peer(9), Some(&agent(9)))
+            .expect("initial adoption");
+
+        // Owner forges history with k1 rewritten (same keyset, new bytes).
+        let snap2 = forged_snapshot(id, owner, &kp, topic, &[("k1", b"REWRITTEN")], 2);
+        replica
+            .merge_delta(&snap2, peer(9), Some(&owner))
+            .expect("rejection is loud in logs but not an error");
+        assert_eq!(
+            replica.get("k1").map(|e| e.value.clone()),
+            Some(b"v1".to_vec()),
+            "checkpoint rewriting an existing key must not change its bytes"
+        );
+        assert_eq!(replica.highest_checkpoint_seq, 1);
+    }
+
+    #[test]
+    fn signed_store_owner_update_and_delete_still_allowed() {
+        // Regression guard: AppendOnly enforcement must not leak into Signed
+        // stores — the owner's normal update/delete cycle is unchanged.
+        let owner = agent(1);
+        let mut store = KvStore::new(
+            store_id(8),
+            "plain".to_string(),
+            owner,
+            AccessPolicy::Signed,
+        );
+        store
+            .put(
+                "k".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+        store
+            .put(
+                "k".to_string(),
+                b"v2".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("Signed store update must still work");
+        assert_eq!(
+            store.get("k").map(|e| e.value.clone()),
+            Some(b"v2".to_vec())
+        );
+        store.remove("k").expect("Signed store delete must still work");
+        assert!(store.get("k").is_none());
     }
 }

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -3251,7 +3251,10 @@ mod tests {
             .remove("k1")
             .expect_err("owner must not be able to delete an existing key");
         assert!(matches!(err, KvError::ImmutableKey(ref k) if k == "k1"));
-        assert!(store.get("k1").is_some(), "key retained after rejected delete");
+        assert!(
+            store.get("k1").is_some(),
+            "key retained after rejected delete"
+        );
         // A key that never existed still reports KeyNotFound (unchanged).
         assert!(matches!(
             store.remove("ghost"),
@@ -3335,8 +3338,7 @@ mod tests {
         let topic = "store/ao-cold";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store =
-            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
         owner_store
             .put(
                 "k1".to_string(),
@@ -3405,8 +3407,7 @@ mod tests {
         let topic = "store/ao-shrink";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store =
-            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
         for (k, v) in [("k1", b"v1".as_slice()), ("k2", b"v2".as_slice())] {
             owner_store
                 .put(k.to_string(), v.to_vec(), "text/plain".to_string(), peer(1))
@@ -3445,8 +3446,7 @@ mod tests {
         let topic = "store/ao-rewrite";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store =
-            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
         owner_store
             .put(
                 "k1".to_string(),
@@ -3509,7 +3509,9 @@ mod tests {
             store.get("k").map(|e| e.value.clone()),
             Some(b"v2".to_vec())
         );
-        store.remove("k").expect("Signed store delete must still work");
+        store
+            .remove("k")
+            .expect("Signed store delete must still work");
         assert!(store.get("k").is_none());
     }
 }

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -49,14 +49,32 @@ pub enum AccessPolicy {
 
     /// Owner-signed append-only store: like [`Signed`](Self::Signed), only the
     /// owner can write — but existing keys are IMMUTABLE. A key, once written,
-    /// can never be updated to different content or deleted, **even by the
-    /// owner**. Re-putting byte-identical content is accepted as an idempotent
-    /// no-op (retry-friendly).
+    /// can never be updated or deleted, **even by the owner**, and the entry
+    /// is frozen in FULL (value, content type, metadata, timestamps).
+    /// Re-putting byte-identical content is accepted as an idempotent no-op
+    /// (retry-friendly, and it does not advance the checkpoint sequence).
+    /// The policy itself is TERMINAL: once a replica knows a store is
+    /// append-only, every policy transition away from it is rejected —
+    /// announces, checkpoints, and manifests included, regardless of
+    /// `policy_version`.
     ///
-    /// This makes append-only event logs tamper-evident against their own
-    /// author: an owner retroactively rewriting or truncating history is
-    /// rejected at every enforcement point (local writes, remote deltas, and
-    /// owner-signed checkpoint adoption).
+    /// ## Exact guarantee (read carefully)
+    ///
+    /// Keys are immutable **after first observation by a
+    /// continuously-persistent replica**. A replica that has seen key `k`
+    /// (and has not lost its state) rejects every rewrite or removal of `k`
+    /// at all enforcement points: local writes, remote deltas — owner-signed
+    /// included — and owner-signed checkpoint adoption. A **fresh joiner
+    /// with no prior state necessarily trusts the owner's current signed
+    /// snapshot**: signatures alone cannot tell it whether that snapshot is
+    /// the original history or a rewrite, so two fresh joiners fed different
+    /// owner-signed snapshots will adopt divergent states (detectable after
+    /// the fact by comparing adopted checkpoint content roots, never
+    /// auto-reconciled). Applications that need fresh-joiner rewrite
+    /// detection must layer content chaining on top (per-author sequence
+    /// numbers + previous-entry hashes, as x0x-symphony's tracker-integrity-v2
+    /// does — see saorsa-labs/x0x-symphony#10); witnesses/transparency logs
+    /// are out of scope here.
     ///
     /// NOTE: this variant MUST stay last — bincode encodes enum variants
     /// positionally, and stores/checkpoints/deltas carrying `AccessPolicy`
@@ -348,6 +366,23 @@ fn lp_bytes(buf: &mut Vec<u8>, data: &[u8]) {
     buf.extend_from_slice(data);
 }
 
+/// Full-field entry equality for the AppendOnly freeze.
+///
+/// Under [`AccessPolicy::AppendOnly`] an existing entry is frozen in FULL —
+/// value, content hash, content type, metadata, and both timestamps — not
+/// just its value bytes. This matches exactly the fields the owner-signed
+/// checkpoint root commits to (see [`entry_commitment_bytes`]), so "equal
+/// here" and "same commitment" are the same statement.
+fn entry_frozen_fields_equal(a: &KvEntry, b: &KvEntry) -> bool {
+    a.key == b.key
+        && a.value == b.value
+        && a.content_hash == b.content_hash
+        && a.content_type == b.content_type
+        && a.metadata == b.metadata
+        && a.created_at == b.created_at
+        && a.updated_at == b.updated_at
+}
+
 /// Validate that a relayed entry is internally consistent before adoption.
 ///
 /// Independently enforces:
@@ -614,6 +649,19 @@ impl KvStore {
         self.seq_counter.fetch_add(1, Ordering::Relaxed) + 1
     }
 
+    /// Floor the in-memory sequence counter to the persisted `version`.
+    ///
+    /// `seq_counter` is `serde(skip)`, so a snapshot-restored store would
+    /// otherwise mint OR-Set tags starting from 0 again — potentially
+    /// colliding with tags issued before the restart. `version` increments on
+    /// every mutation, so it is always >= the number of locally minted tags.
+    pub(crate) fn floor_seq_counter_to_version(&self) {
+        let v = self.version;
+        if self.seq_counter.load(Ordering::Relaxed) < v {
+            self.seq_counter.store(v, Ordering::Relaxed);
+        }
+    }
+
     /// Get the current version.
     #[must_use]
     pub fn current_version(&self) -> u64 {
@@ -839,6 +887,20 @@ impl KvStore {
         // different policy at the same version cannot be signed by the owner.
         // An older replay (version < current) is still dropped, preventing a
         // downgrade. A matching forward refresh clears a recorded conflict.
+        //
+        // AppendOnly is TERMINAL: once this replica knows the store is
+        // append-only, no announce — however fresh, however genuinely
+        // owner-signed — may transition the policy away from it. Allowing
+        // that would let the owner downgrade to Signed, delete/rewrite keys,
+        // and (optionally) upgrade back: exactly the retroactive-rewrite
+        // attack AppendOnly exists to stop.
+        if matches!(self.policy, AccessPolicy::AppendOnly)
+            && !matches!(policy, AccessPolicy::AppendOnly)
+        {
+            return Err(KvError::OwnerTokenInvalid(
+                "append-only policy is terminal; policy downgrade rejected".to_string(),
+            ));
+        }
         if policy_version >= self.policy_version {
             self.policy = policy;
             self.policy_version = policy_version;
@@ -1161,27 +1223,29 @@ impl KvStore {
     /// AppendOnly guard for one incoming delta entry.
     ///
     /// `true` when this store is [`AccessPolicy::AppendOnly`] and `key` is
-    /// already active locally with different content — the mutation must be
-    /// skipped and the local value retained. Owner-signed deltas are NOT
-    /// exempt: an owner retroactively rewriting records is exactly the attack
-    /// this policy exists to stop. A byte-identical re-delivery is allowed
-    /// through (idempotent; the LWW entry merge is a no-op on content).
+    /// already active locally — the incoming entry must be skipped WHOLESALE.
+    /// Existing entries are frozen in full (value, content type, metadata,
+    /// timestamps, content hash): even a byte-identical redelivery is not
+    /// merged, because [`KvEntry::merge`] resolves by LWW timestamp and could
+    /// otherwise mutate `metadata`/`updated_at` while the value stays equal.
+    /// Owner-signed deltas are NOT exempt: an owner retroactively rewriting
+    /// records is exactly the attack this policy exists to stop. Only a
+    /// content-differing skip is warn-logged; an identical redelivery is a
+    /// silent idempotent no-op.
     fn append_only_rejects_entry(&self, key: &str, entry: &KvEntry) -> bool {
         if !matches!(self.policy, AccessPolicy::AppendOnly) {
             return false;
         }
-        match self.get(key) {
-            Some(local)
-                if local.value != entry.value || local.content_type != entry.content_type =>
-            {
-                tracing::warn!(
-                    "append-only violation: skipped remote update of existing key {key:?} for store {}",
-                    self.id
-                );
-                true
-            }
-            _ => false,
+        let Some(local) = self.get(key) else {
+            return false; // new key — a legitimate append
+        };
+        if !entry_frozen_fields_equal(local, entry) {
+            tracing::warn!(
+                "append-only violation: skipped remote update of existing key {key:?} for store {}",
+                self.id
+            );
         }
+        true
     }
 
     /// Try to adopt an owner-signed checkpoint as an authoritative full
@@ -1245,6 +1309,26 @@ impl KvStore {
                 return false;
             }
         }
+        // 5b. Canonical-map gate: `added` and `updated` must be DISJOINT on
+        //     the adoption path. No legitimate producer emits the same key in
+        //     both maps of a full-state relay (`full_delta` populates only
+        //     `added`; incremental owner deltas are single-map), but a crafted
+        //     delta could carry key K in both with different values — the
+        //     validation/root pass would see one set while adoption applies
+        //     both maps in sequence, letting the second silently rewrite what
+        //     was validated. Reject for ALL policies: adoption is a
+        //     security-critical full-replace and an ambiguous multiset is
+        //     tamper by construction. Fall-through to sender-auth is safe —
+        //     its loops re-check state sequentially per entry.
+        for key in delta.updated.keys() {
+            if delta.added.contains_key(key) {
+                tracing::warn!(
+                    "rejected owner checkpoint for store {}: key {key:?} appears in both added and updated",
+                    self.id
+                );
+                return false;
+            }
+        }
         // 6. Content integrity: the canonical root over the relayed entry set
         //    must match. This only holds for a full-state relay; an incremental
         //    delta's single entry set won't match a full-state checkpoint root,
@@ -1272,6 +1356,21 @@ impl KvStore {
         //     unaffected. Checked against BOTH the local policy and the
         //     checkpoint's claimed policy, so a hostile checkpoint cannot
         //     dodge the gate by flipping its own policy field.
+        // AppendOnly is TERMINAL: a checkpoint claiming the store is no
+        // longer append-only, presented to a replica that knows it is, is
+        // hostile by definition (adopting it would downgrade the policy in
+        // step 10 and unfreeze the log). Reject the whole checkpoint.
+        if matches!(self.policy, AccessPolicy::AppendOnly)
+            && !matches!(cp.policy, AccessPolicy::AppendOnly)
+        {
+            tracing::warn!(
+                "append-only violation: rejected owner checkpoint seq {} for store {} — it downgrades the terminal append_only policy to {}",
+                cp.checkpoint_seq,
+                self.id,
+                cp.policy
+            );
+            return false;
+        }
         if matches!(self.policy, AccessPolicy::AppendOnly)
             || matches!(cp.policy, AccessPolicy::AppendOnly)
         {
@@ -1290,10 +1389,7 @@ impl KvStore {
                         );
                         return false;
                     }
-                    Some(remote)
-                        if remote.value != local.value
-                            || remote.content_type != local.content_type =>
-                    {
+                    Some(remote) if !entry_frozen_fields_equal(remote, local) => {
                         tracing::warn!(
                             "append-only violation: rejected owner checkpoint seq {} for store {} — it rewrites existing key {key:?}",
                             cp.checkpoint_seq,
@@ -1354,7 +1450,13 @@ impl KvStore {
             self.name.merge(name_register);
         }
         // 10. Refresh policy (forward only) and cache the checkpoint.
-        if cp.policy_version >= self.policy_version {
+        //     Belt-and-braces: AppendOnly is terminal — the 6b gate already
+        //     rejected any checkpoint that would downgrade it, so this branch
+        //     can only keep or adopt AppendOnly, never leave it.
+        if cp.policy_version >= self.policy_version
+            && !(matches!(self.policy, AccessPolicy::AppendOnly)
+                && !matches!(cp.policy, AccessPolicy::AppendOnly))
+        {
             self.policy = cp.policy.clone();
             self.policy_version = cp.policy_version;
         }
@@ -1426,11 +1528,52 @@ impl KvStore {
     }
 
     /// Merge another store into this one.
+    ///
+    /// # Errors
+    ///
+    /// - [`KvError::StoreIdMismatch`] if the ids differ.
+    /// - [`KvError::ImmutableKey`] under [`AccessPolicy::AppendOnly`] if the
+    ///   merge would remove any locally-active key or change any of its
+    ///   frozen fields. The merge is applied transactionally: on violation
+    ///   NOTHING is applied (no partial merge). This closes the bypass where
+    ///   a full-state merge (which skips every `merge_delta` gate) could
+    ///   rewrite or tombstone append-only history. Currently this method has
+    ///   no non-test callers — the live sync path is
+    ///   [`merge_delta`](Self::merge_delta) — but it is public API, so the
+    ///   invariant is enforced here too rather than removed (removal would be
+    ///   a semver break; flagged for v0.33.0).
     pub fn merge(&mut self, other: &KvStore) -> Result<()> {
         if self.id != other.id {
             return Err(KvError::StoreIdMismatch);
         }
 
+        // AppendOnly: run the merge on a trial clone and verify the freeze
+        // invariant before committing, so a violating merge cannot leave
+        // partial state behind.
+        if matches!(self.policy, AccessPolicy::AppendOnly) {
+            let mut trial = self.clone();
+            trial.merge_unchecked(other)?;
+            for key in self.keys.elements() {
+                let Some(local) = self.get(key) else { continue };
+                match trial.get(key) {
+                    None => {
+                        return Err(KvError::ImmutableKey(key.clone()));
+                    }
+                    Some(merged) if !entry_frozen_fields_equal(merged, local) => {
+                        return Err(KvError::ImmutableKey(key.clone()));
+                    }
+                    _ => {}
+                }
+            }
+            *self = trial;
+            return Ok(());
+        }
+
+        self.merge_unchecked(other)
+    }
+
+    /// The raw CRDT merge, without the AppendOnly freeze check.
+    fn merge_unchecked(&mut self, other: &KvStore) -> Result<()> {
         self.keys
             .merge_state(&other.keys)
             .map_err(|e| KvError::Merge(format!("OR-Set merge failed: {e}")))?;

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -133,7 +133,7 @@ impl KvStoreSync {
     /// Call before [`start`](Self::start) so no merged delta can land
     /// unpersisted. The caller is responsible for loading any existing
     /// snapshot BEFORE constructing this sync (see
-    /// [`load_snapshot`](load_snapshot)); this method only arms writes.
+    /// [`load_snapshot`]); this method only arms writes.
     pub fn set_persist_path(&self, path: PathBuf) {
         if let Ok(mut guard) = self.persist_path.lock() {
             *guard = Some(path);

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -563,6 +563,59 @@ mod tests {
         KvStoreId::new([n; 32])
     }
 
+    #[test]
+    fn snapshot_roundtrip_missing_and_corrupt() {
+        // WHY: snapshot restore is what makes AppendOnly immutability
+        // survive a restart. Missing file = clean first run (Ok(None));
+        // a valid snapshot must round-trip policy, entries, and the
+        // checkpoint high-water mark; a corrupt file must be an Err so
+        // callers FAIL CLOSED instead of silently starting empty (amnesia).
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("kv").join("snap.bin");
+
+        assert!(
+            matches!(load_snapshot(&path), Ok(None)),
+            "missing snapshot is a clean first run"
+        );
+
+        let mut store = KvStore::new(
+            store_id(7),
+            "log".to_string(),
+            agent(1),
+            AccessPolicy::AppendOnly,
+        );
+        store
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+        store.highest_checkpoint_seq = 5;
+        let bytes = bincode::serialize(&store).expect("serialize");
+        write_snapshot_atomic(&path, &bytes).expect("atomic write");
+
+        let restored = load_snapshot(&path)
+            .expect("load ok")
+            .expect("snapshot present");
+        assert_eq!(*restored.policy(), AccessPolicy::AppendOnly);
+        assert_eq!(
+            restored.get("k1").map(|e| e.value.clone()),
+            Some(b"v1".to_vec())
+        );
+        assert_eq!(restored.highest_checkpoint_seq, 5);
+        // seq_counter floored to version: freshly minted tags cannot collide
+        // with pre-restart tags.
+        assert!(restored.next_seq() > restored.current_version());
+
+        std::fs::write(&path, b"not a snapshot").expect("corrupt");
+        assert!(
+            load_snapshot(&path).is_err(),
+            "corrupt snapshot must be an error (fail closed), not a silent fresh start"
+        );
+    }
+
     /// Construct an isolated network node (mirrors the helper in
     /// `src/gossip/pubsub.rs` tests). `PubSubManager` is fully constructable
     /// in tests, so `KvStoreSync` is testable end-to-end without a live mesh.

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -85,16 +85,32 @@ pub struct KvStoreSync {
     /// [`KvSyncMessage::OwnerAnnounce`]) and to ignore its own announces.
     local_agent_id: Option<AgentId>,
 
-    /// Optional on-disk snapshot path. When set (see
+    /// Optional persistence context. When armed (see
     /// [`set_persist_path`](Self::set_persist_path)), the full store state is
-    /// bincode-snapshotted atomically after every local mutation and every
-    /// merged remote delta, so a restart restores policy, keyset, entry
-    /// contents, the latest adopted checkpoint, and the checkpoint high-water
-    /// mark instead of coming back as an empty replica. This is what makes
-    /// `AppendOnly` immutability survive a restart: an owner (or replica)
-    /// with amnesia would otherwise accept rewrites of keys it no longer
-    /// remembers holding.
-    persist_path: std::sync::Mutex<Option<PathBuf>>,
+    /// snapshotted atomically after every local mutation and every merged
+    /// remote delta, so a restart restores policy, keyset, entry contents,
+    /// the latest adopted checkpoint, the checkpoint high-water mark, and the
+    /// OR-Set sequence-counter ceiling instead of coming back as an empty
+    /// replica. This is what makes `AppendOnly` immutability survive a
+    /// restart: an owner (or replica) with amnesia would otherwise accept
+    /// rewrites of keys it no longer remembers holding.
+    persist: std::sync::Mutex<Option<Arc<PersistCtx>>>,
+}
+
+/// Shared persistence context for one store's snapshot file.
+struct PersistCtx {
+    /// Snapshot file path.
+    path: PathBuf,
+    /// Serializes snapshot commits AND records the last durably-persisted
+    /// store version. `(version, bytes)` are captured under this lock, so
+    /// commit order equals capture order — a concurrent persist burst can
+    /// never rename an older snapshot over a newer one — and the version
+    /// gate skips writes that would not advance durable state.
+    gate: tokio::sync::Mutex<Option<u64>>,
+    /// True after a failed snapshot write; cleared by the next success.
+    /// While set, LOCAL writes are refused (fail-closed for what this node
+    /// controls); remote-delta merges continue (replication is not wedged).
+    degraded: std::sync::atomic::AtomicBool,
 }
 
 impl KvStoreSync {
@@ -124,7 +140,7 @@ impl KvStoreSync {
             topic,
             local_peer_id,
             local_agent_id,
-            persist_path: std::sync::Mutex::new(None),
+            persist: std::sync::Mutex::new(None),
         })
     }
 
@@ -135,23 +151,65 @@ impl KvStoreSync {
     /// snapshot BEFORE constructing this sync (see
     /// [`load_snapshot`]); this method only arms writes.
     pub fn set_persist_path(&self, path: PathBuf) {
-        if let Ok(mut guard) = self.persist_path.lock() {
-            *guard = Some(path);
+        if let Ok(mut guard) = self.persist.lock() {
+            *guard = Some(Arc::new(PersistCtx {
+                path,
+                gate: tokio::sync::Mutex::new(None),
+                degraded: std::sync::atomic::AtomicBool::new(false),
+            }));
         }
     }
 
-    /// Snapshot the store to the configured persist path (no-op when
-    /// persistence is not armed). Failures are error-logged, never silent —
-    /// the in-memory state is already committed and published, so the write
-    /// path does not unwind, but a failing disk must be loud (it reopens the
-    /// restart-amnesia window this exists to close).
-    pub async fn persist(&self) {
-        let path = match self.persist_path.lock() {
-            Ok(guard) => guard.clone(),
-            Err(_) => None,
-        };
-        if let Some(path) = path {
-            persist_snapshot(&self.store, &path).await;
+    /// Clone the armed persistence context, if any.
+    fn persist_ctx(&self) -> Option<Arc<PersistCtx>> {
+        self.persist.lock().ok().and_then(|g| g.clone())
+    }
+
+    /// Snapshot the store to the configured persist path (`Ok` no-op when
+    /// persistence is not armed).
+    ///
+    /// Durability contract:
+    /// - Commits are serialized per store and version-gated, so concurrent
+    ///   persists can never regress durable state.
+    /// - On failure the store is flagged **durability-degraded**
+    ///   ([`durability_degraded`](Self::durability_degraded)): callers on the
+    ///   LOCAL write path must propagate the error to the writer and MUST NOT
+    ///   publish the mutation (durability before announcement); callers on
+    ///   the REMOTE merge path log and continue (replication is not wedged —
+    ///   peers hold the data; only this node's disk is behind).
+    /// - The next successful persist (including via
+    ///   [`ensure_durable`](Self::ensure_durable)) clears the flag.
+    ///
+    /// # Errors
+    ///
+    /// I/O or serialization failure writing the snapshot.
+    pub async fn persist(&self) -> Result<()> {
+        match self.persist_ctx() {
+            Some(ctx) => persist_snapshot(&self.store, &ctx).await,
+            None => Ok(()),
+        }
+    }
+
+    /// True while the last snapshot attempt failed and no retry has
+    /// succeeded. Local writes are refused in this state (fail-closed).
+    pub fn durability_degraded(&self) -> bool {
+        self.persist_ctx()
+            .is_some_and(|c| c.degraded.load(std::sync::atomic::Ordering::Relaxed))
+    }
+
+    /// If the store is durability-degraded, retry persisting the CURRENT
+    /// state before any new mutation is accepted. `Ok` when not degraded,
+    /// not persistent, or the retry succeeded.
+    ///
+    /// # Errors
+    ///
+    /// The retry failed — the caller must refuse the local write.
+    pub async fn ensure_durable(&self) -> Result<()> {
+        match self.persist_ctx() {
+            Some(ctx) if ctx.degraded.load(std::sync::atomic::Ordering::Relaxed) => {
+                persist_snapshot(&self.store, &ctx).await
+            }
+            _ => Ok(()),
         }
     }
 
@@ -203,12 +261,12 @@ impl KvStoreSync {
         // owner-signed envelope from store A under topic B. Each listener binds
         // to the exact topic it subscribed to.
         let main_topic = self.topic.clone();
-        // Snapshot the persist path once: it is armed before start() by
+        // Snapshot the persist context once: it is armed before start() by
         // construction (set_persist_path docs), so the loops never observe a
         // late change.
-        let persist_path = self.persist_path.lock().ok().and_then(|g| g.clone());
+        let persist_ctx = self.persist_ctx();
 
-        let loop_persist_path = persist_path.clone();
+        let loop_persist_ctx = persist_ctx.clone();
         spawn(Box::pin(async move {
             while let Some(msg) = sub.recv().await {
                 if msg.topic != main_topic {
@@ -233,10 +291,13 @@ impl KvStoreSync {
                             }
                         };
                         // Persist OUTSIDE the write guard so disk latency
-                        // never blocks other writers.
+                        // never blocks other writers. A failure flags the
+                        // store durability-degraded (persist_snapshot logs);
+                        // remote merges continue — replication must not
+                        // wedge on this node's disk.
                         if merged {
-                            if let Some(path) = loop_persist_path.as_ref() {
-                                persist_snapshot(&store, path).await;
+                            if let Some(ctx) = loop_persist_ctx.as_ref() {
+                                let _ = persist_snapshot(&store, ctx).await;
                             }
                         }
                     }
@@ -262,7 +323,7 @@ impl KvStoreSync {
         // sender is the claimed owner itself (see KvSyncMessage docs).
         let mut sync_sub = self.pubsub.subscribe(self.state_sync_topic()).await;
         let responder_store = Arc::clone(&self.store);
-        let responder_persist_path = persist_path.clone();
+        let responder_persist_ctx = persist_ctx.clone();
         let responder_pubsub = Arc::clone(&self.pubsub);
         let responder_topic = self.topic.clone();
         let sync_topic = self.state_sync_topic();
@@ -382,8 +443,8 @@ impl KvStoreSync {
                         // A policy refresh mutates durable state — persist it
                         // (outside the write guard).
                         if learned {
-                            if let Some(path) = responder_persist_path.as_ref() {
-                                persist_snapshot(&responder_store, path).await;
+                            if let Some(ctx) = responder_persist_ctx.as_ref() {
+                                let _ = persist_snapshot(&responder_store, ctx).await;
                             }
                         }
                     }
@@ -469,29 +530,92 @@ impl KvStoreSync {
 /// temp file mid-rename.
 static SNAPSHOT_TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-/// Snapshot the store to `path` (bincode, atomic temp-file + fsync + rename).
+/// Magic prefix of the v1 snapshot file format.
 ///
-/// Failures are error-logged and never unwind the caller: the in-memory
-/// mutation is already committed and published, so the correct response to a
-/// failing disk is a loud log, not a poisoned store.
-async fn persist_snapshot(store: &Arc<RwLock<KvStore>>, path: &Path) {
-    let bytes = {
-        let s = store.read().await;
-        match bincode::serialize(&*s) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::error!("kv snapshot serialize failed for {}: {e}", path.display());
-                return;
-            }
-        }
+/// Format: `MAGIC(8) || bincode(SnapshotBody { store, seq_counter })`.
+/// The envelope exists so the OR-Set sequence-counter ceiling (which is
+/// `serde(skip)` on `KvStore` for wire/legacy-layout reasons) survives a
+/// restart exactly. The format is introduced unreleased — no shipped binary
+/// ever wrote a bare-`KvStore` snapshot — so there is no compat read path:
+/// a file without the magic is rejected (fail closed) rather than guessed at.
+const SNAPSHOT_MAGIC: &[u8; 8] = b"X0XKVS1\0";
+
+/// Owned snapshot body (decode side).
+#[derive(Deserialize)]
+struct SnapshotBody {
+    store: KvStore,
+    seq_counter: u64,
+}
+
+/// Borrowing snapshot body (encode side — avoids cloning the store).
+#[derive(Serialize)]
+struct SnapshotBodyRef<'a> {
+    store: &'a KvStore,
+    seq_counter: u64,
+}
+
+/// Encode a store into v1 snapshot bytes (magic + body).
+fn encode_snapshot(store: &KvStore) -> Result<Vec<u8>> {
+    let body = SnapshotBodyRef {
+        store,
+        seq_counter: store.seq_counter_value(),
     };
-    if let Err(e) = write_snapshot_atomic(path, &bytes) {
-        tracing::error!("kv snapshot write failed for {}: {e}", path.display());
+    let mut out = Vec::with_capacity(256);
+    out.extend_from_slice(SNAPSHOT_MAGIC);
+    out.extend_from_slice(&bincode::serialize(&body)?);
+    Ok(out)
+}
+
+/// Snapshot the store to the persistence context's path.
+///
+/// Serialized per store via `ctx.gate`: `(version, bytes)` are captured
+/// under the gate, so commit order equals capture order and a slow persist
+/// can never rename an older snapshot over a newer one; the recorded
+/// last-persisted version additionally skips writes that would not advance
+/// durable state. Success clears the degraded flag; failure sets it and is
+/// error-logged here (callers decide whether to propagate — local writes
+/// must, remote merges must not).
+///
+/// # Errors
+///
+/// Serialization or I/O failure writing the snapshot.
+async fn persist_snapshot(store: &Arc<RwLock<KvStore>>, ctx: &PersistCtx) -> Result<()> {
+    let result = async {
+        let mut last = ctx.gate.lock().await;
+        let (version, bytes) = {
+            let s = store.read().await;
+            (s.current_version(), encode_snapshot(&s)?)
+        };
+        if last.is_some_and(|l| l >= version) {
+            // Durable state already at (or beyond) this version.
+            return Ok(());
+        }
+        write_snapshot_atomic(&ctx.path, &bytes)?;
+        *last = Some(version);
+        Ok(())
     }
+    .await;
+    ctx.degraded
+        .store(result.is_err(), std::sync::atomic::Ordering::Relaxed);
+    if let Err(e) = &result {
+        tracing::error!(
+            "kv snapshot persist failed for {}: {e} — store is durability-degraded; \
+             local writes are refused until a snapshot succeeds",
+            ctx.path.display()
+        );
+    }
+    result
 }
 
 /// Durable atomic file write: unique temp file in the same directory,
-/// fsync, then rename over the destination.
+/// fsync, rename over the destination, then (Unix) fsync the parent
+/// directory so the rename itself survives power loss.
+///
+/// Platform note: on non-Unix targets the parent-directory fsync is skipped
+/// (std cannot fsync a directory handle there); the rename is still atomic,
+/// but its durability across power loss is not guaranteed. SIGKILL/power
+/// loss beyond the parent fsync (e.g. hardware write caches) is out of
+/// scope.
 fn write_snapshot_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -504,13 +628,15 @@ fn write_snapshot_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
         f.write_all(bytes)?;
         f.sync_all()?;
     }
-    match std::fs::rename(&tmp, path) {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            let _ = std::fs::remove_file(&tmp);
-            Err(e)
-        }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
     }
+    #[cfg(unix)]
+    if let Some(parent) = path.parent() {
+        std::fs::File::open(parent)?.sync_all()?;
+    }
+    Ok(())
 }
 
 /// Load a previously persisted store snapshot from `path`.
@@ -518,15 +644,17 @@ fn write_snapshot_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 /// Returns:
 /// - `Ok(Some(store))` — snapshot present and valid.
 /// - `Ok(None)` — no snapshot at `path` (first run).
-/// - `Err(_)` — snapshot present but unreadable/undecodable. Callers MUST
-///   fail closed on this (refuse to start an empty replica over a corrupt
-///   snapshot): silently discarding it would reopen the restart-amnesia
-///   window (an `AppendOnly` owner that forgets its keys will re-accept
-///   rewrites of them).
+/// - `Err(_)` — snapshot present but unreadable, undecodable, or not in the
+///   v1 format. Callers MUST fail closed on this (refuse to start an empty
+///   replica over a corrupt snapshot): silently discarding it would reopen
+///   the restart-amnesia window (an `AppendOnly` owner that forgets its keys
+///   will re-accept rewrites of them).
 ///
-/// The restored store's in-memory `seq_counter` (not serialized) is floored
-/// to `version` so freshly minted OR-Set tags can never collide with tags
-/// issued before the restart.
+/// The restored store's in-memory `seq_counter` is set to the persisted
+/// counter (floored by `version` as defense in depth), so freshly minted
+/// OR-Set `(peer, seq)` tags can never collide with tags issued before the
+/// restart — including the extra per-put delta tag minted by
+/// `KvStoreHandle::put_with_delta`.
 ///
 /// # Errors
 ///
@@ -537,8 +665,16 @@ pub fn load_snapshot(path: &Path) -> Result<Option<KvStore>> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => return Err(e.into()),
     };
-    let store: KvStore = bincode::deserialize(&bytes)?;
-    store.floor_seq_counter_to_version();
+    let Some(body_bytes) = bytes.strip_prefix(SNAPSHOT_MAGIC.as_slice()) else {
+        return Err(std::io::Error::other(
+            "unrecognized kv snapshot format (missing v1 magic) — corrupt or foreign file; \
+             refusing to start with amnesia",
+        )
+        .into());
+    };
+    let body: SnapshotBody = bincode::deserialize(body_bytes)?;
+    let store = body.store;
+    store.restore_seq_counter(body.seq_counter.max(store.current_version()));
     Ok(Some(store))
 }
 
@@ -593,7 +729,13 @@ mod tests {
             )
             .expect("put");
         store.highest_checkpoint_seq = 5;
-        let bytes = bincode::serialize(&store).expect("serialize");
+        // Simulate the handle-layer double seq mint: the counter can run
+        // ahead of `version`. The persisted counter — not a version-derived
+        // floor — must be the restore ceiling.
+        let _ = store.next_seq();
+        let _ = store.next_seq();
+        let counter_before = store.seq_counter_value();
+        let bytes = encode_snapshot(&store).expect("encode");
         write_snapshot_atomic(&path, &bytes).expect("atomic write");
 
         let restored = load_snapshot(&path)
@@ -605,14 +747,34 @@ mod tests {
             Some(b"v1".to_vec())
         );
         assert_eq!(restored.highest_checkpoint_seq, 5);
-        // seq_counter floored to version: freshly minted tags cannot collide
-        // with pre-restart tags.
-        assert!(restored.next_seq() > restored.current_version());
+        // Exact tag ceiling restored: the next minted seq is strictly above
+        // every pre-restart seq (no OR-Set (peer, seq) tag reuse).
+        assert!(
+            restored.next_seq() > counter_before,
+            "restored seq counter must exceed every pre-restart seq"
+        );
+
+        // A file without the v1 magic (e.g. a bare-bincode or foreign file)
+        // fails closed.
+        std::fs::write(&path, bincode::serialize(&store).expect("serialize")).expect("write bare");
+        assert!(
+            load_snapshot(&path).is_err(),
+            "missing-magic snapshot must be an error (fail closed)"
+        );
 
         std::fs::write(&path, b"not a snapshot").expect("corrupt");
         assert!(
             load_snapshot(&path).is_err(),
             "corrupt snapshot must be an error (fail closed), not a silent fresh start"
+        );
+
+        // Truncated/garbage body AFTER a valid magic also fails closed.
+        let mut evil = SNAPSHOT_MAGIC.to_vec();
+        evil.extend_from_slice(b"\x01\x02\x03");
+        std::fs::write(&path, evil).expect("write garbage body");
+        assert!(
+            load_snapshot(&path).is_err(),
+            "garbage body must be an error (fail closed)"
         );
     }
 

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -10,6 +10,7 @@ use crate::kv::store::AccessPolicy;
 use crate::kv::{KvStore, KvStoreDelta, Result};
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -83,6 +84,17 @@ pub struct KvStoreSync {
     /// is the store owner (and should answer state requests with an
     /// [`KvSyncMessage::OwnerAnnounce`]) and to ignore its own announces.
     local_agent_id: Option<AgentId>,
+
+    /// Optional on-disk snapshot path. When set (see
+    /// [`set_persist_path`](Self::set_persist_path)), the full store state is
+    /// bincode-snapshotted atomically after every local mutation and every
+    /// merged remote delta, so a restart restores policy, keyset, entry
+    /// contents, the latest adopted checkpoint, and the checkpoint high-water
+    /// mark instead of coming back as an empty replica. This is what makes
+    /// `AppendOnly` immutability survive a restart: an owner (or replica)
+    /// with amnesia would otherwise accept rewrites of keys it no longer
+    /// remembers holding.
+    persist_path: std::sync::Mutex<Option<PathBuf>>,
 }
 
 impl KvStoreSync {
@@ -112,7 +124,35 @@ impl KvStoreSync {
             topic,
             local_peer_id,
             local_agent_id,
+            persist_path: std::sync::Mutex::new(None),
         })
+    }
+
+    /// Enable on-disk snapshot persistence at `path`.
+    ///
+    /// Call before [`start`](Self::start) so no merged delta can land
+    /// unpersisted. The caller is responsible for loading any existing
+    /// snapshot BEFORE constructing this sync (see
+    /// [`load_snapshot`](load_snapshot)); this method only arms writes.
+    pub fn set_persist_path(&self, path: PathBuf) {
+        if let Ok(mut guard) = self.persist_path.lock() {
+            *guard = Some(path);
+        }
+    }
+
+    /// Snapshot the store to the configured persist path (no-op when
+    /// persistence is not armed). Failures are error-logged, never silent —
+    /// the in-memory state is already committed and published, so the write
+    /// path does not unwind, but a failing disk must be loud (it reopens the
+    /// restart-amnesia window this exists to close).
+    pub async fn persist(&self) {
+        let path = match self.persist_path.lock() {
+            Ok(guard) => guard.clone(),
+            Err(_) => None,
+        };
+        if let Some(path) = path {
+            persist_snapshot(&self.store, &path).await;
+        }
     }
 
     /// The state-sync side topic for this store.
@@ -163,7 +203,12 @@ impl KvStoreSync {
         // owner-signed envelope from store A under topic B. Each listener binds
         // to the exact topic it subscribed to.
         let main_topic = self.topic.clone();
+        // Snapshot the persist path once: it is armed before start() by
+        // construction (set_persist_path docs), so the loops never observe a
+        // late change.
+        let persist_path = self.persist_path.lock().ok().and_then(|g| g.clone());
 
+        let loop_persist_path = persist_path.clone();
         spawn(Box::pin(async move {
             while let Some(msg) = sub.recv().await {
                 if msg.topic != main_topic {
@@ -174,12 +219,25 @@ impl KvStoreSync {
                 let decoded = decode_delta::<KvStoreDelta>(&msg.payload);
                 match decoded {
                     Ok((peer_id, delta)) => {
-                        let mut s = store.write().await;
-                        // Pass sender identity for access control enforcement.
-                        // The gossip V2 wire format includes a verified AgentId.
-                        let writer = msg.sender.as_ref();
-                        if let Err(e) = s.merge_delta(&delta, peer_id, writer) {
-                            tracing::warn!("Failed to merge KvStore delta: {e}");
+                        let merged = {
+                            let mut s = store.write().await;
+                            // Pass sender identity for access control enforcement.
+                            // The gossip V2 wire format includes a verified AgentId.
+                            let writer = msg.sender.as_ref();
+                            match s.merge_delta(&delta, peer_id, writer) {
+                                Ok(()) => true,
+                                Err(e) => {
+                                    tracing::warn!("Failed to merge KvStore delta: {e}");
+                                    false
+                                }
+                            }
+                        };
+                        // Persist OUTSIDE the write guard so disk latency
+                        // never blocks other writers.
+                        if merged {
+                            if let Some(path) = loop_persist_path.as_ref() {
+                                persist_snapshot(&store, path).await;
+                            }
                         }
                     }
                     Err(e) => {
@@ -204,6 +262,7 @@ impl KvStoreSync {
         // sender is the claimed owner itself (see KvSyncMessage docs).
         let mut sync_sub = self.pubsub.subscribe(self.state_sync_topic()).await;
         let responder_store = Arc::clone(&self.store);
+        let responder_persist_path = persist_path.clone();
         let responder_pubsub = Arc::clone(&self.pubsub);
         let responder_topic = self.topic.clone();
         let sync_topic = self.state_sync_topic();
@@ -292,25 +351,39 @@ impl KvStoreSync {
                         if local_agent_id.is_some_and(|me| me == sender) {
                             continue; // our own announce echoed back
                         }
-                        let mut s = responder_store.write().await;
-                        // learn_ownership can only refresh policy (when the
-                        // owner matches and policy_version is forward) or
-                        // record a conflict; it never establishes ownership.
-                        match s.learn_ownership(owner, policy, policy_version, &sender) {
-                            Ok(()) => {
-                                tracing::info!(
-                                    "KvStore {} processed owner announce from {} (policy {}, version {})",
-                                    s.id(),
-                                    hex::encode(owner.as_bytes()),
-                                    s.policy(),
-                                    s.policy_version()
-                                );
+                        let learned = {
+                            let mut s = responder_store.write().await;
+                            // learn_ownership can only refresh policy (when the
+                            // owner matches and policy_version is forward) or
+                            // record a conflict; it never establishes ownership.
+                            // AppendOnly is terminal: a downgrade announce is
+                            // rejected inside learn_ownership regardless of
+                            // policy_version.
+                            match s.learn_ownership(owner, policy, policy_version, &sender) {
+                                Ok(()) => {
+                                    tracing::info!(
+                                        "KvStore {} processed owner announce from {} (policy {}, version {})",
+                                        s.id(),
+                                        hex::encode(owner.as_bytes()),
+                                        s.policy(),
+                                        s.policy_version()
+                                    );
+                                    true
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "rejected KvStore ownership announcement from {}: {e}",
+                                        hex::encode(sender.as_bytes())
+                                    );
+                                    false
+                                }
                             }
-                            Err(e) => {
-                                tracing::warn!(
-                                    "rejected KvStore ownership announcement from {}: {e}",
-                                    hex::encode(sender.as_bytes())
-                                );
+                        };
+                        // A policy refresh mutates durable state — persist it
+                        // (outside the write guard).
+                        if learned {
+                            if let Some(path) = responder_persist_path.as_ref() {
+                                persist_snapshot(&responder_store, path).await;
                             }
                         }
                     }
@@ -389,6 +462,84 @@ impl KvStoreSync {
     pub fn topic(&self) -> &str {
         &self.topic
     }
+}
+
+/// Monotonic counter for unique snapshot temp-file names — concurrent
+/// persists (receive loop vs. local write) must never clobber each other's
+/// temp file mid-rename.
+static SNAPSHOT_TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Snapshot the store to `path` (bincode, atomic temp-file + fsync + rename).
+///
+/// Failures are error-logged and never unwind the caller: the in-memory
+/// mutation is already committed and published, so the correct response to a
+/// failing disk is a loud log, not a poisoned store.
+async fn persist_snapshot(store: &Arc<RwLock<KvStore>>, path: &Path) {
+    let bytes = {
+        let s = store.read().await;
+        match bincode::serialize(&*s) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!("kv snapshot serialize failed for {}: {e}", path.display());
+                return;
+            }
+        }
+    };
+    if let Err(e) = write_snapshot_atomic(path, &bytes) {
+        tracing::error!("kv snapshot write failed for {}: {e}", path.display());
+    }
+}
+
+/// Durable atomic file write: unique temp file in the same directory,
+/// fsync, then rename over the destination.
+fn write_snapshot_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let n = SNAPSHOT_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("tmp.{}.{n}", std::process::id()));
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    match std::fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
+/// Load a previously persisted store snapshot from `path`.
+///
+/// Returns:
+/// - `Ok(Some(store))` — snapshot present and valid.
+/// - `Ok(None)` — no snapshot at `path` (first run).
+/// - `Err(_)` — snapshot present but unreadable/undecodable. Callers MUST
+///   fail closed on this (refuse to start an empty replica over a corrupt
+///   snapshot): silently discarding it would reopen the restart-amnesia
+///   window (an `AppendOnly` owner that forgets its keys will re-accept
+///   rewrites of them).
+///
+/// The restored store's in-memory `seq_counter` (not serialized) is floored
+/// to `version` so freshly minted OR-Set tags can never collide with tags
+/// issued before the restart.
+///
+/// # Errors
+///
+/// [`crate::kv::KvError::Io`]/[`crate::kv::KvError::Serialization`] as above.
+pub fn load_snapshot(path: &Path) -> Result<Option<KvStore>> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    let store: KvStore = bincode::deserialize(&bytes)?;
+    store.floor_seq_counter_to_version();
+    Ok(Some(store))
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10808,7 +10808,14 @@ impl Agent {
         }
         let sync = std::sync::Arc::new(sync);
         if persistent {
-            sync.persist().await;
+            // Fail closed at registration: refuse to run a "persistent"
+            // store whose snapshot cannot even be written once.
+            sync.persist().await.map_err(|e| {
+                kv_storage_err(format!(
+                    "kv store snapshot dir is not writable ({e}); refusing to start a \
+                     persistent store without durability"
+                ))
+            })?;
         }
         sync.start_with_spawner(|fut| self.spawn_tracked(fut))
             .await
@@ -10998,6 +11005,7 @@ impl KvStoreHandle {
             policy_version: s.policy_version(),
             ownership_status: status,
             announced_owner: announced,
+            durability_degraded: self.sync.durability_degraded(),
         }
     }
 
@@ -11092,6 +11100,16 @@ impl KvStoreHandle {
         value: Vec<u8>,
         content_type: String,
     ) -> error::Result<kv::KvStoreDelta> {
+        // Durability gate: while the store is durability-degraded (a prior
+        // snapshot write failed), refuse NEW local mutations until a retry
+        // persist of the current state succeeds — otherwise unpersisted
+        // writes pile up behind a dead disk.
+        self.sync.ensure_durable().await.map_err(|e| {
+            error::IdentityError::Storage(std::io::Error::other(format!(
+                "kv store durability degraded: snapshot persistence failing ({e}); \
+                 local writes refused until a snapshot succeeds"
+            )))
+        })?;
         let delta = {
             let mut store = self.sync.write().await;
             Self::check_local_write(&store, &self.agent_id)?;
@@ -11122,6 +11140,16 @@ impl KvStoreHandle {
             let version = store.current_version();
             let mut delta = match entry {
                 Some(e) => {
+                    // NOTE: this next_seq() is the SECOND seq minted for this
+                    // put (KvStore::put minted one for the local OR-Set tag),
+                    // so the published delta tag differs from the local tag.
+                    // That divergence is benign — removals are key-scoped
+                    // (tag sets are not consulted) and tags only need to be
+                    // unique per peer — and the snapshot persists the real
+                    // counter, so neither tag can ever be re-minted after a
+                    // restart. Deliberately not "fixed": returning the tag
+                    // from KvStore::put would change its public signature
+                    // for no behavioral gain.
                     kv::KvStoreDelta::for_put(key, e, (self.peer_id, store.next_seq()), version)
                 }
                 None => {
@@ -11140,10 +11168,20 @@ impl KvStoreHandle {
             }
             delta
         };
-        // Persist the committed mutation before announcing it (crash between
-        // the two re-publishes on next write; the reverse order could sign a
-        // checkpoint the disk never saw).
-        self.sync.persist().await;
+        // Durability before announcement: persist the committed mutation and
+        // DO NOT publish if the snapshot fails — announcing state the disk
+        // never saw is how an owner ends up re-signing rewritten history
+        // after a crash. The in-memory mutation stays applied (CRDT state
+        // cannot be safely unwound); the caller sees the error, the store is
+        // flagged degraded, and further local writes are refused until a
+        // persist succeeds. Anti-entropy re-publishes the state later once
+        // durable.
+        self.sync.persist().await.map_err(|e| {
+            error::IdentityError::Storage(std::io::Error::other(format!(
+                "kv write applied locally but snapshot persistence FAILED ({e}); \
+                 delta not published; store is durability-degraded"
+            )))
+        })?;
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta.clone()).await {
             tracing::warn!("failed to publish kv put delta: {e}");
         }
@@ -11188,6 +11226,13 @@ impl KvStoreHandle {
     /// [`error::IdentityError::Unauthorized`] if this agent is not permitted
     /// to write under the store's access policy.
     pub async fn remove_with_delta(&self, key: &str) -> error::Result<kv::KvStoreDelta> {
+        // Durability gate — see put_with_delta.
+        self.sync.ensure_durable().await.map_err(|e| {
+            error::IdentityError::Storage(std::io::Error::other(format!(
+                "kv store durability degraded: snapshot persistence failing ({e}); \
+                 local writes refused until a snapshot succeeds"
+            )))
+        })?;
         let delta = {
             let mut store = self.sync.write().await;
             Self::check_local_write(&store, &self.agent_id)?;
@@ -11211,9 +11256,13 @@ impl KvStoreHandle {
             }
             d
         };
-        // Persist the committed mutation before announcing it (see
-        // put_with_delta).
-        self.sync.persist().await;
+        // Durability before announcement — see put_with_delta.
+        self.sync.persist().await.map_err(|e| {
+            error::IdentityError::Storage(std::io::Error::other(format!(
+                "kv remove applied locally but snapshot persistence FAILED ({e}); \
+                 delta not published; store is durability-degraded"
+            )))
+        })?;
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta.clone()).await {
             tracing::warn!("failed to publish kv remove delta: {e}");
         }
@@ -11231,14 +11280,23 @@ impl KvStoreHandle {
         delta: &kv::KvStoreDelta,
         writer: Option<identity::AgentId>,
     ) -> error::Result<()> {
-        let mut store = self.sync.write().await;
-        store
-            .merge_delta(delta, peer_id, writer.as_ref())
-            .map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "kv direct delta merge failed: {e}",
-                )))
-            })
+        {
+            let mut store = self.sync.write().await;
+            store
+                .merge_delta(delta, peer_id, writer.as_ref())
+                .map_err(|e| {
+                    error::IdentityError::Storage(std::io::Error::other(format!(
+                        "kv direct delta merge failed: {e}",
+                    )))
+                })?;
+        }
+        // Direct-delivery deltas mutate state just like the gossip receive
+        // loop — persist with the same semantics (an attacker who can steer
+        // deltas onto this side channel must not gain an unpersisted-merge
+        // window). Remote-path failure degrades durability (persist logs and
+        // flags it) but does not wedge replication.
+        let _ = self.sync.persist().await;
+        Ok(())
     }
 
     /// List all active keys in the store.
@@ -11314,6 +11372,11 @@ pub struct KvStoreOwnershipInfo {
     pub ownership_status: kv::OwnershipStatus,
     /// Hex-encoded owner claimed by a rejected announce (`conflict` only).
     pub announced_owner: Option<String>,
+    /// True while the last state-snapshot write failed and no retry has
+    /// succeeded. Local writes are refused in this state (fail-closed);
+    /// remote replication continues. Always `false` for non-persistent
+    /// stores.
+    pub durability_degraded: bool,
 }
 
 /// Read-only snapshot of a task's current state.
@@ -12349,6 +12412,21 @@ mod tests {
             );
             assert_eq!(s.highest_checkpoint_seq, 2, "HWM survives restart");
             assert!(s.get("k").is_some() && s.get("k2").is_some());
+            // OR-Set tag ceiling: each handle put mints TWO seqs (local tag +
+            // published delta tag) while version moves by one, so after two
+            // puts the counter is 4 with version 2. The snapshot must restore
+            // the REAL counter — the old version-derived floor (2) would let
+            // the restarted owner re-mint the already-published tags 3 and 4.
+            assert!(
+                s.seq_counter_value() >= 4,
+                "persisted seq-counter ceiling restored exactly (got {}, need >= 4)",
+                s.seq_counter_value()
+            );
+            assert!(
+                s.seq_counter_value() > s.current_version(),
+                "counter must exceed version (double mint per put) — a \
+                 version floor would reuse tags"
+            );
         }
         // The restarted owner still cannot rewrite its own history.
         let err = restored
@@ -12407,6 +12485,202 @@ mod tests {
             "append_only requested over a Signed snapshot must fail closed"
         );
         agent3.shutdown().await;
+    }
+
+    /// Durability blockers (round-3 review): (1) the direct-delivery path
+    /// (`apply_remote_delta`, used by the daemon's delta side channel) must
+    /// persist like the gossip receive loop — otherwise an attacker who
+    /// suppresses gossip and feeds direct deltas gets an unpersisted-merge
+    /// window that a crash rolls back; (2) a concurrent mutation burst must
+    /// never leave the snapshot behind the store (commit order == capture
+    /// order under the persist gate).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn kv_snapshot_covers_direct_delivery_and_concurrent_bursts() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let state_dir = dir.path().join("kv-stores");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("agent");
+
+        // Source store produces an authorized (owner-signed identity) delta.
+        let src = agent
+            .create_kv_store_persistent(
+                "src",
+                "dd-src-topic",
+                kv::AccessPolicy::AppendOnly,
+                &state_dir,
+            )
+            .await
+            .expect("create src");
+        let mut delta = src
+            .put_with_delta("k".to_string(), b"v".to_vec(), "text/plain".to_string())
+            .await
+            .expect("owner put");
+        // Strip the checkpoint (it is bound to the src store id) so the
+        // replica takes the plain sender-auth path.
+        delta.owner_checkpoint = None;
+
+        // Replica on a DIFFERENT topic + state dir, fed ONLY via the
+        // direct-delivery path — the gossip loop never sees this delta, so
+        // if the snapshot contains the key, apply_remote_delta persisted it.
+        let replica_dir = dir.path().join("kv-stores-replica");
+        let replica = agent
+            .join_kv_store_persistent(
+                "dd-replica-topic",
+                agent.agent_id(),
+                kv::store::AnchorChannel::RestParam,
+                &replica_dir,
+            )
+            .await
+            .expect("join replica");
+        replica
+            .apply_remote_delta(replica.peer_id(), &delta, Some(agent.agent_id()))
+            .await
+            .expect("direct delivery merge");
+        let replica_path = kv_snapshot_path(
+            &replica_dir,
+            &kv::KvStoreId::for_topic_owner("dd-replica-topic", &agent.agent_id()),
+        );
+        let snap = kv::sync::load_snapshot(&replica_path)
+            .expect("load replica snapshot")
+            .expect("replica snapshot present");
+        assert_eq!(
+            snap.get("k").map(|e| e.value.clone()),
+            Some(b"v".to_vec()),
+            "direct-delivery mutation must be persisted (no unpersisted-merge window)"
+        );
+
+        // Concurrent bursts: after every round the snapshot version must
+        // equal the store version — the serialized persist gate makes a
+        // regression (older snapshot renamed over newer) impossible.
+        let src_path = kv_snapshot_path(
+            &state_dir,
+            &kv::KvStoreId::for_topic_owner("dd-src-topic", &agent.agent_id()),
+        );
+        for round in 0..3u8 {
+            let mut tasks = Vec::new();
+            for i in 0..20u8 {
+                let s = src.clone();
+                tasks.push(tokio::spawn(async move {
+                    s.put(
+                        format!("burst-{round}-{i}"),
+                        vec![round, i],
+                        "application/octet-stream".to_string(),
+                    )
+                    .await
+                }));
+            }
+            for t in tasks {
+                t.await.expect("join").expect("burst put");
+            }
+            let store_version = src.sync.read().await.current_version();
+            let snap = kv::sync::load_snapshot(&src_path)
+                .expect("load src snapshot")
+                .expect("src snapshot present");
+            assert_eq!(
+                snap.current_version(),
+                store_version,
+                "round {round}: snapshot must not lag or regress the store version"
+            );
+        }
+        agent.shutdown().await;
+    }
+
+    /// Durability blocker (round-3 review): a failing snapshot write must
+    /// FAIL CLOSED on the local write path — error to the caller, no delta
+    /// published, store flagged durability-degraded, further local writes
+    /// refused BEFORE mutating — and recover cleanly once the disk heals.
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn kv_persist_failure_fails_closed_and_recovers() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let state_dir = dir.path().join("kv-stores");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("agent");
+        let store = agent
+            .create_kv_store_persistent(
+                "degrade",
+                "degrade-topic",
+                kv::AccessPolicy::AppendOnly,
+                &state_dir,
+            )
+            .await
+            .expect("create");
+        store
+            .put("k1".to_string(), b"v1".to_vec(), "text/plain".to_string())
+            .await
+            .expect("healthy put");
+        assert!(!store.ownership_info().await.durability_degraded);
+
+        // Break the disk: the snapshot dir becomes unwritable.
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o555))
+            .expect("chmod ro");
+
+        let err = store
+            .put("k2".to_string(), b"v2".to_vec(), "text/plain".to_string())
+            .await
+            .expect_err("persist failure must fail the local write");
+        assert!(
+            format!("{err}").contains("durability-degraded"),
+            "error names the durability failure; got: {err}"
+        );
+        assert!(
+            store.ownership_info().await.durability_degraded,
+            "degraded flag surfaced in store info"
+        );
+        // While degraded, the NEXT local write is refused before mutating.
+        let err = store
+            .put("k3".to_string(), b"v3".to_vec(), "text/plain".to_string())
+            .await
+            .expect_err("degraded store refuses further local writes");
+        assert!(
+            format!("{err}").contains("durability degraded"),
+            "gate error names degradation; got: {err}"
+        );
+        assert!(
+            store.get("k3").await.expect("read").is_none(),
+            "fail-closed BEFORE mutation: k3 must not exist even in memory"
+        );
+
+        // Heal the disk: the retry persists the full pending state (k2
+        // included), clears the flag, and writes flow again.
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod rw");
+        store
+            .put("k4".to_string(), b"v4".to_vec(), "text/plain".to_string())
+            .await
+            .expect("recovered put");
+        assert!(!store.ownership_info().await.durability_degraded);
+        let snap_path = kv_snapshot_path(
+            &state_dir,
+            &kv::KvStoreId::for_topic_owner("degrade-topic", &agent.agent_id()),
+        );
+        let snap = kv::sync::load_snapshot(&snap_path)
+            .expect("load")
+            .expect("present");
+        for k in ["k1", "k2", "k4"] {
+            assert!(
+                snap.get(k).is_some(),
+                "recovered snapshot must contain {k} (k2 was applied in memory \
+                 before its persist failed and is captured by the recovery persist)"
+            );
+        }
+        assert!(snap.get("k3").is_none(), "refused write never existed");
+        agent.shutdown().await;
     }
 
     /// P1 fence (restart-ABA): a fence token captured before an incarnation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11143,13 +11143,21 @@ impl KvStoreHandle {
                     // NOTE: this next_seq() is the SECOND seq minted for this
                     // put (KvStore::put minted one for the local OR-Set tag),
                     // so the published delta tag differs from the local tag.
-                    // That divergence is benign — removals are key-scoped
-                    // (tag sets are not consulted) and tags only need to be
-                    // unique per peer — and the snapshot persists the real
-                    // counter, so neither tag can ever be re-minted after a
-                    // restart. Deliberately not "fixed": returning the tag
-                    // from KvStore::put would change its public signature
-                    // for no behavioral gain.
+                    // That divergence is benign, precisely because of how the
+                    // two remove paths treat tags: a LOCAL remove
+                    // (KvStore::remove) calls OrSet::remove, which tombstones
+                    // every tag the local set has OBSERVED for the key
+                    // (observed-remove — tags ARE consulted there, but only
+                    // locally-observed ones, which always include the local
+                    // tag); the WIRE remove path (merge_delta's `removed`
+                    // loop) is key-scoped — receivers remove by key and never
+                    // consult the delta's tag sets — so a receiver drops its
+                    // divergent tag too. Neither side can strand or resurrect
+                    // a key on account of the mismatch. The snapshot persists
+                    // the real counter, so neither tag can ever be re-minted
+                    // after a restart. Deliberately not "fixed": returning
+                    // the tag from KvStore::put would change its public
+                    // signature for no behavioral gain.
                     kv::KvStoreDelta::for_put(key, e, (self.peer_id, store.next_seq()), version)
                 }
                 None => {
@@ -12626,6 +12634,15 @@ mod tests {
             .expect("healthy put");
         assert!(!store.ownership_info().await.durability_degraded);
 
+        // Observe the store's main topic directly so publish suppression can
+        // be asserted, not merely inferred. (k1's delta was published before
+        // this subscription; the state-request/announce chatter uses the
+        // /state-sync side topic and cannot land here.)
+        let mut topic_sub = agent
+            .subscribe("degrade-topic")
+            .await
+            .expect("subscribe main topic");
+
         // Break the disk: the snapshot dir becomes unwritable.
         std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o555))
             .expect("chmod ro");
@@ -12656,8 +12673,46 @@ mod tests {
             "fail-closed BEFORE mutation: k3 must not exist even in memory"
         );
 
-        // Heal the disk: the retry persists the full pending state (k2
-        // included), clears the flag, and writes flow again.
+        // Publish suppression, asserted DIRECTLY: neither the failed k2 put
+        // nor the refused k3 put may have announced anything on the topic.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(800), topic_sub.recv())
+                .await
+                .is_err(),
+            "failed-persist local writes must not publish a delta (durability before announcement)"
+        );
+
+        // Degrade-not-wedge: REMOTE merges continue while degraded. The
+        // owner-authored delta applies (state converges) even though its
+        // persist attempt fails; the store stays degraded but replication is
+        // never refused.
+        let mut remote = kv::KvStoreDelta::new(50);
+        remote.added.insert(
+            "remote-k".to_string(),
+            (
+                kv::KvEntry::new(
+                    "remote-k".to_string(),
+                    b"rv".to_vec(),
+                    "text/plain".to_string(),
+                ),
+                (store.peer_id(), 999),
+            ),
+        );
+        store
+            .apply_remote_delta(store.peer_id(), &remote, Some(agent.agent_id()))
+            .await
+            .expect("remote merge must CONTINUE while durability-degraded");
+        assert!(
+            store.get("remote-k").await.expect("read").is_some(),
+            "remote delta applied while degraded"
+        );
+        assert!(
+            store.ownership_info().await.durability_degraded,
+            "still degraded after the remote merge (its persist also failed) — degraded, not wedged"
+        );
+
+        // Heal the disk: the retry persists the full pending state (k2 and
+        // remote-k included), clears the flag, and writes flow again.
         std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755))
             .expect("chmod rw");
         store
@@ -12665,6 +12720,17 @@ mod tests {
             .await
             .expect("recovered put");
         assert!(!store.ownership_info().await.durability_degraded);
+
+        // Positive control for the suppression assert above: the recovered
+        // put DOES publish, proving the subscription observes this topic.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(15), topic_sub.recv())
+                .await
+                .ok()
+                .flatten()
+                .is_some(),
+            "recovered put must publish its delta (subscription sees the topic)"
+        );
         let snap_path = kv_snapshot_path(
             &state_dir,
             &kv::KvStoreId::for_topic_owner("degrade-topic", &agent.agent_id()),
@@ -12672,14 +12738,103 @@ mod tests {
         let snap = kv::sync::load_snapshot(&snap_path)
             .expect("load")
             .expect("present");
-        for k in ["k1", "k2", "k4"] {
+        for k in ["k1", "k2", "k4", "remote-k"] {
             assert!(
                 snap.get(k).is_some(),
-                "recovered snapshot must contain {k} (k2 was applied in memory \
-                 before its persist failed and is captured by the recovery persist)"
+                "recovered snapshot must contain {k} (k2/remote-k were applied in \
+                 memory while degraded and are captured by the recovery persist)"
             );
         }
         assert!(snap.get("k3").is_none(), "refused write never existed");
+        agent.shutdown().await;
+    }
+
+    /// Nit-1 (round-3 review): the remove path has the identical durability
+    /// contract as put — a failed snapshot errors the remove (mutation stays
+    /// in memory), the NEXT remove is refused BEFORE mutating, and healing
+    /// the disk recovers the pending tombstone and clears the flag. Uses a
+    /// Signed store because AppendOnly rejects removes outright.
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn kv_remove_persist_failure_fails_closed_and_recovers() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let state_dir = dir.path().join("kv-stores");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("agent");
+        let store = agent
+            .create_kv_store_persistent(
+                "rm-degrade",
+                "rm-degrade-topic",
+                kv::AccessPolicy::Signed,
+                &state_dir,
+            )
+            .await
+            .expect("create");
+        for k in ["k1", "k2", "k3"] {
+            store
+                .put(k.to_string(), b"v".to_vec(), "text/plain".to_string())
+                .await
+                .expect("seed put");
+        }
+
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o555))
+            .expect("chmod ro");
+
+        // Failing persist errors the remove; the tombstone is already in
+        // memory (mutation precedes persist, same as put).
+        let err = store
+            .remove("k1")
+            .await
+            .expect_err("persist failure must fail the local remove");
+        assert!(
+            format!("{err}").contains("durability-degraded"),
+            "error names the durability failure; got: {err}"
+        );
+        assert!(store.ownership_info().await.durability_degraded);
+        assert!(
+            store.get("k1").await.expect("read").is_none(),
+            "k1 tombstone applied in memory before the failed persist"
+        );
+
+        // While degraded, the NEXT remove is refused BEFORE mutating.
+        let err = store
+            .remove("k2")
+            .await
+            .expect_err("degraded store refuses further local removes");
+        assert!(
+            format!("{err}").contains("durability degraded"),
+            "gate error names degradation; got: {err}"
+        );
+        assert!(
+            store.get("k2").await.expect("read").is_some(),
+            "fail-closed BEFORE mutation: k2 still present"
+        );
+
+        // Heal: the retry persists the pending k1 tombstone, then the remove
+        // of k2 proceeds and the flag clears.
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod rw");
+        store.remove("k2").await.expect("recovered remove");
+        assert!(!store.ownership_info().await.durability_degraded);
+
+        let snap_path = kv_snapshot_path(
+            &state_dir,
+            &kv::KvStoreId::for_topic_owner("rm-degrade-topic", &agent.agent_id()),
+        );
+        let snap = kv::sync::load_snapshot(&snap_path)
+            .expect("load")
+            .expect("present");
+        assert!(snap.get("k1").is_none(), "pending tombstone recovered");
+        assert!(snap.get("k2").is_none(), "post-recovery remove persisted");
+        assert!(snap.get("k3").is_some(), "untouched key retained");
         agent.shutdown().await;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10656,6 +10656,26 @@ impl Agent {
     ///
     /// Returns an error if the gossip runtime is not initialized.
     pub async fn create_kv_store(&self, name: &str, topic: &str) -> error::Result<KvStoreHandle> {
+        self.create_kv_store_with_policy(name, topic, kv::AccessPolicy::Signed)
+            .await
+    }
+
+    /// Create a new key-value store with an explicit access policy.
+    ///
+    /// Like [`create_kv_store`](Self::create_kv_store) (which uses
+    /// [`kv::AccessPolicy::Signed`]), but lets the creator choose the policy —
+    /// e.g. [`kv::AccessPolicy::AppendOnly`] for tamper-evident event logs
+    /// whose existing keys are immutable even to the owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gossip runtime is not initialized.
+    pub async fn create_kv_store_with_policy(
+        &self,
+        name: &str,
+        topic: &str,
+        policy: kv::AccessPolicy,
+    ) -> error::Result<KvStoreHandle> {
         let runtime = self.gossip_runtime.as_ref().ok_or_else(|| {
             error::IdentityError::Storage(std::io::Error::other(
                 "gossip runtime not initialized - configure agent with network first",
@@ -10664,12 +10684,7 @@ impl Agent {
 
         let peer_id = runtime.peer_id();
         let store_id = kv::KvStoreId::for_topic_owner(topic, &self.agent_id());
-        let store = kv::KvStore::new(
-            store_id,
-            name.to_string(),
-            self.agent_id(),
-            kv::AccessPolicy::Signed,
-        );
+        let store = kv::KvStore::new(store_id, name.to_string(), self.agent_id(), policy);
 
         let sync = kv::KvStoreSync::new(
             store,
@@ -10949,10 +10964,13 @@ impl KvStoreHandle {
                     content_type.clone(),
                     self.peer_id,
                 )
-                .map_err(|e| {
-                    error::IdentityError::Storage(std::io::Error::other(format!(
-                        "kv put failed: {e}",
-                    )))
+                .map_err(|e| match e {
+                    // AppendOnly immutability violation — surfaced distinctly
+                    // so the API layer can map it to HTTP 409 Conflict.
+                    kv::KvError::ImmutableKey(k) => error::IdentityError::ImmutableKey(k),
+                    other => error::IdentityError::Storage(std::io::Error::other(format!(
+                        "kv put failed: {other}",
+                    ))),
                 })?;
             let entry = store.get(&key).cloned();
             let version = store.current_version();
@@ -11023,10 +11041,13 @@ impl KvStoreHandle {
         let delta = {
             let mut store = self.sync.write().await;
             Self::check_local_write(&store, &self.agent_id)?;
-            store.remove(key).map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "kv remove failed: {e}",
-                )))
+            store.remove(key).map_err(|e| match e {
+                // AppendOnly immutability violation — surfaced distinctly
+                // so the API layer can map it to HTTP 409 Conflict.
+                kv::KvError::ImmutableKey(k) => error::IdentityError::ImmutableKey(k),
+                other => error::IdentityError::Storage(std::io::Error::other(format!(
+                    "kv remove failed: {other}",
+                ))),
             })?;
             let mut d = kv::KvStoreDelta::new(store.current_version());
             d.removed
@@ -11128,7 +11149,8 @@ pub struct KvStoreOwnershipInfo {
     /// Hex-encoded anchored owner, or `None` when no owner is anchored
     /// (read-only by design).
     pub owner: Option<String>,
-    /// Access policy (`"signed"` / `"allowlisted"` / `"encrypted"`).
+    /// Access policy (`"signed"` / `"allowlisted"` / `"encrypted"` /
+    /// `"append_only"`).
     pub policy: String,
     /// Store version (monotonic, bumped on every mutation).
     pub version: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12263,6 +12263,152 @@ mod tests {
         }
     }
 
+    /// AppendOnly end-to-end at the handle layer: an idempotent re-put must
+    /// be a TRUE no-op (no checkpoint-sequence advance — a non-mutation must
+    /// not consume owner-signature freshness), and an owner restart restored
+    /// from the state snapshot must retain entries, the terminal append_only
+    /// policy, and the checkpoint high-water mark — otherwise the owner
+    /// forgets its keys and re-signs rewrites of them (the P0-C amnesia
+    /// attack).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn append_only_idempotent_seq_and_owner_restart_persistence() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let state_dir = dir.path().join("kv-stores");
+        let build_agent = || async {
+            Agent::builder()
+                .with_machine_key(dir.path().join("machine.key"))
+                .with_agent_key_path(dir.path().join("agent.key"))
+                .with_contact_store_path(dir.path().join("contacts.json"))
+                .with_peer_cache_disabled()
+                .with_network_config(loopback_network_config())
+                .build()
+                .await
+                .expect("agent")
+        };
+
+        let agent = build_agent().await;
+        let store = agent
+            .create_kv_store_persistent(
+                "log",
+                "ao-persist-topic",
+                kv::AccessPolicy::AppendOnly,
+                &state_dir,
+            )
+            .await
+            .expect("create persistent append_only store");
+
+        store
+            .put("k".to_string(), b"v1".to_vec(), "text/plain".to_string())
+            .await
+            .expect("first append");
+        assert_eq!(store.sync.read().await.highest_checkpoint_seq, 1);
+
+        // Idempotent re-put: checkpoint sequence must NOT advance.
+        store
+            .put("k".to_string(), b"v1".to_vec(), "text/plain".to_string())
+            .await
+            .expect("idempotent re-put accepted");
+        assert_eq!(
+            store.sync.read().await.highest_checkpoint_seq,
+            1,
+            "idempotent re-put must not advance the checkpoint sequence"
+        );
+
+        // Rewrite rejected with the distinct error the API maps to 409.
+        let err = store
+            .put("k".to_string(), b"v2".to_vec(), "text/plain".to_string())
+            .await
+            .expect_err("rewrite rejected");
+        assert!(matches!(err, error::IdentityError::ImmutableKey(_)));
+
+        store
+            .put("k2".to_string(), b"v2".to_vec(), "text/plain".to_string())
+            .await
+            .expect("second append");
+        assert_eq!(store.sync.read().await.highest_checkpoint_seq, 2);
+        agent.shutdown().await;
+
+        // Restart (same identity, same state dir). Request Signed on purpose:
+        // the snapshot's terminal append_only must win.
+        let agent2 = build_agent().await;
+        let restored = agent2
+            .create_kv_store_persistent(
+                "log",
+                "ao-persist-topic",
+                kv::AccessPolicy::Signed,
+                &state_dir,
+            )
+            .await
+            .expect("restore from snapshot");
+        {
+            let s = restored.sync.read().await;
+            assert_eq!(
+                *s.policy(),
+                kv::AccessPolicy::AppendOnly,
+                "snapshot's terminal append_only policy wins over the request"
+            );
+            assert_eq!(s.highest_checkpoint_seq, 2, "HWM survives restart");
+            assert!(s.get("k").is_some() && s.get("k2").is_some());
+        }
+        // The restarted owner still cannot rewrite its own history.
+        let err = restored
+            .put(
+                "k".to_string(),
+                b"REWRITE".to_vec(),
+                "text/plain".to_string(),
+            )
+            .await
+            .expect_err("post-restart rewrite rejected");
+        assert!(matches!(err, error::IdentityError::ImmutableKey(_)));
+        agent2.shutdown().await;
+
+        // Fail-closed checks: corrupt snapshot and policy-conflict requests
+        // must refuse to start, never silently start empty.
+        let agent3 = build_agent().await;
+        let store_id = kv::KvStoreId::for_topic_owner("ao-persist-topic", &agent3.agent_id());
+        let snap_path = kv_snapshot_path(&state_dir, &store_id);
+        let good_bytes = std::fs::read(&snap_path).expect("snapshot exists");
+        std::fs::write(&snap_path, b"garbage").expect("corrupt");
+        assert!(
+            agent3
+                .create_kv_store_persistent(
+                    "log",
+                    "ao-persist-topic",
+                    kv::AccessPolicy::AppendOnly,
+                    &state_dir,
+                )
+                .await
+                .is_err(),
+            "corrupt snapshot must fail closed, not start empty"
+        );
+        std::fs::write(&snap_path, good_bytes).expect("restore snapshot");
+
+        // Requesting append_only over a Signed snapshot fails closed.
+        let signed_store = agent3
+            .create_kv_store_persistent(
+                "plain",
+                "signed-persist-topic",
+                kv::AccessPolicy::Signed,
+                &state_dir,
+            )
+            .await
+            .expect("create signed persistent store");
+        drop(signed_store);
+        assert!(
+            agent3
+                .create_kv_store_persistent(
+                    "plain",
+                    "signed-persist-topic",
+                    kv::AccessPolicy::AppendOnly,
+                    &state_dir,
+                )
+                .await
+                .is_err(),
+            "append_only requested over a Signed snapshot must fail closed"
+        );
+        agent3.shutdown().await;
+    }
+
     /// P1 fence (restart-ABA): a fence token captured before an incarnation
     /// change (daemon restart) must be rejected even when submitted at the
     /// SAME revision afterwards — the per-replica epoch component differs, so

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10676,37 +10676,93 @@ impl Agent {
         topic: &str,
         policy: kv::AccessPolicy,
     ) -> error::Result<KvStoreHandle> {
-        let runtime = self.gossip_runtime.as_ref().ok_or_else(|| {
-            error::IdentityError::Storage(std::io::Error::other(
-                "gossip runtime not initialized - configure agent with network first",
-            ))
-        })?;
+        self.create_kv_store_inner(name, topic, policy, None).await
+    }
 
-        let peer_id = runtime.peer_id();
-        let store_id = kv::KvStoreId::for_topic_owner(topic, &self.agent_id());
-        let store = kv::KvStore::new(store_id, name.to_string(), self.agent_id(), policy);
-
-        let sync = kv::KvStoreSync::new(
-            store,
-            std::sync::Arc::clone(runtime.pubsub()),
-            topic.to_string(),
-            peer_id,
-            Some(self.agent_id()),
-        )
-        .map_err(|e| {
-            error::IdentityError::Storage(std::io::Error::other(format!(
-                "kv store sync creation failed: {e}",
-            )))
-        })?;
-
-        let sync = std::sync::Arc::new(sync);
-        sync.start_with_spawner(|fut| self.spawn_tracked(fut))
+    /// Create (or restore) a key-value store with an on-disk state snapshot.
+    ///
+    /// Like [`create_kv_store_with_policy`](Self::create_kv_store_with_policy)
+    /// but the full store state (policy, keyset, entry contents, latest
+    /// adopted checkpoint, and the checkpoint high-water mark) is snapshotted
+    /// to `state_dir/<store-id-hex>.bin` after every mutation and restored
+    /// here on restart — BEFORE any network or local write is accepted. This
+    /// closes the restart-amnesia hole for [`kv::AccessPolicy::AppendOnly`]:
+    /// an owner that forgot its keys would otherwise re-accept (and re-sign)
+    /// rewrites of them.
+    ///
+    /// # Errors
+    ///
+    /// - Gossip runtime not initialized.
+    /// - A snapshot exists but is corrupt/undecodable, belongs to a different
+    ///   store, is owned by a different agent, or its policy conflicts with
+    ///   `policy` (requesting `AppendOnly` over a non-`AppendOnly` snapshot).
+    ///   All of these FAIL CLOSED — silently starting empty would reopen the
+    ///   amnesia window.
+    pub async fn create_kv_store_persistent(
+        &self,
+        name: &str,
+        topic: &str,
+        policy: kv::AccessPolicy,
+        state_dir: &std::path::Path,
+    ) -> error::Result<KvStoreHandle> {
+        self.create_kv_store_inner(name, topic, policy, Some(state_dir))
             .await
-            .map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "kv store sync start failed: {e}",
-                )))
-            })?;
+    }
+
+    async fn create_kv_store_inner(
+        &self,
+        name: &str,
+        topic: &str,
+        policy: kv::AccessPolicy,
+        state_dir: Option<&std::path::Path>,
+    ) -> error::Result<KvStoreHandle> {
+        let store_id = kv::KvStoreId::for_topic_owner(topic, &self.agent_id());
+        let persist_path = state_dir.map(|d| kv_snapshot_path(d, &store_id));
+        let store = match persist_path.as_deref().map(kv::sync::load_snapshot) {
+            Some(Ok(Some(snap))) => {
+                if snap.id() != &store_id {
+                    return Err(kv_storage_err(format!(
+                        "kv snapshot store-id mismatch for topic {topic}"
+                    )));
+                }
+                if snap.owner() != Some(&self.agent_id()) {
+                    return Err(kv_storage_err(format!(
+                        "kv snapshot for topic {topic} is owned by a different agent"
+                    )));
+                }
+                if matches!(policy, kv::AccessPolicy::AppendOnly)
+                    && !matches!(snap.policy(), kv::AccessPolicy::AppendOnly)
+                {
+                    // The registration says append-only but the snapshot says
+                    // otherwise: tamper or corruption. Fail closed rather
+                    // than silently downgrading immutability.
+                    return Err(kv_storage_err(format!(
+                        "kv snapshot for topic {topic} is not append_only but the store was registered append_only; refusing to downgrade"
+                    )));
+                }
+                if matches!(snap.policy(), kv::AccessPolicy::AppendOnly)
+                    && !matches!(policy, kv::AccessPolicy::AppendOnly)
+                {
+                    // AppendOnly is terminal: the snapshot's knowledge wins.
+                    tracing::warn!(
+                        "kv store {topic}: snapshot policy is terminal append_only; ignoring requested policy {policy}"
+                    );
+                }
+                snap
+            }
+            Some(Ok(None)) | None => {
+                kv::KvStore::new(store_id, name.to_string(), self.agent_id(), policy)
+            }
+            Some(Err(e)) => {
+                // Corrupt snapshot: fail closed, loudly. Starting an empty
+                // replica here would silently discard append-only history.
+                return Err(kv_storage_err(format!(
+                    "kv snapshot for topic {topic} is unreadable ({e}); refusing to start with amnesia — repair or remove the snapshot file explicitly"
+                )));
+            }
+        };
+
+        let (sync, peer_id) = self.spawn_kv_sync(store, topic, persist_path).await?;
 
         // The creator is the owner: capture signing material so each write
         // produces an owner-signed content checkpoint (cold-recovery provenance).
@@ -10720,6 +10776,44 @@ impl Agent {
                 secret_key_bytes: sk_bytes,
             })),
         })
+    }
+
+    /// Construct, arm persistence for, and start a `KvStoreSync`.
+    async fn spawn_kv_sync(
+        &self,
+        store: kv::KvStore,
+        topic: &str,
+        persist_path: Option<std::path::PathBuf>,
+    ) -> error::Result<(std::sync::Arc<kv::KvStoreSync>, saorsa_gossip_types::PeerId)> {
+        let runtime = self.gossip_runtime.as_ref().ok_or_else(|| {
+            error::IdentityError::Storage(std::io::Error::other(
+                "gossip runtime not initialized - configure agent with network first",
+            ))
+        })?;
+        let peer_id = runtime.peer_id();
+        let sync = kv::KvStoreSync::new(
+            store,
+            std::sync::Arc::clone(runtime.pubsub()),
+            topic.to_string(),
+            peer_id,
+            Some(self.agent_id()),
+        )
+        .map_err(|e| kv_storage_err(format!("kv store sync creation failed: {e}")))?;
+        // Arm persistence BEFORE start so no merged delta can land
+        // unpersisted, and write an initial snapshot so the file exists from
+        // the first moment the store does.
+        let persistent = persist_path.is_some();
+        if let Some(path) = persist_path {
+            sync.set_persist_path(path);
+        }
+        let sync = std::sync::Arc::new(sync);
+        if persistent {
+            sync.persist().await;
+        }
+        sync.start_with_spawner(|fut| self.spawn_tracked(fut))
+            .await
+            .map_err(|e| kv_storage_err(format!("kv store sync start failed: {e}")))?;
+        Ok((sync, peer_id))
     }
 
     /// Join an existing key-value store by topic, anchoring ownership on the
@@ -10747,39 +10841,73 @@ impl Agent {
         owner: identity::AgentId,
         channel: kv::store::AnchorChannel,
     ) -> error::Result<KvStoreHandle> {
-        let runtime = self.gossip_runtime.as_ref().ok_or_else(|| {
-            error::IdentityError::Storage(std::io::Error::other(
-                "gossip runtime not initialized - configure agent with network first",
-            ))
-        })?;
+        self.join_kv_store_inner(topic, owner, channel, None).await
+    }
 
-        let peer_id = runtime.peer_id();
+    /// Join (or restore) a key-value store replica with an on-disk snapshot.
+    ///
+    /// Like [`join_kv_store`](Self::join_kv_store) but the replica's full
+    /// state — including a learned `AppendOnly` policy, the keyset, entry
+    /// contents, and the checkpoint high-water mark — is snapshotted to
+    /// `state_dir/<store-id-hex>.bin` and restored here on restart, BEFORE
+    /// any delta is merged. Without this, a restarted joiner comes back as an
+    /// empty `Signed` replica and cannot detect an owner rewriting keys it
+    /// used to hold.
+    ///
+    /// # Errors
+    ///
+    /// As [`join_kv_store`](Self::join_kv_store), plus fail-closed snapshot
+    /// errors (corrupt file, store-id mismatch, or an anchored owner in the
+    /// snapshot that differs from `owner`).
+    pub async fn join_kv_store_persistent(
+        &self,
+        topic: &str,
+        owner: identity::AgentId,
+        channel: kv::store::AnchorChannel,
+        state_dir: &std::path::Path,
+    ) -> error::Result<KvStoreHandle> {
+        self.join_kv_store_inner(topic, owner, channel, Some(state_dir))
+            .await
+    }
+
+    async fn join_kv_store_inner(
+        &self,
+        topic: &str,
+        owner: identity::AgentId,
+        channel: kv::store::AnchorChannel,
+        state_dir: Option<&std::path::Path>,
+    ) -> error::Result<KvStoreHandle> {
         // The store id is the verifiable topic→owner binding; it agrees with
         // the creator's id (both derive for_topic_owner(topic, owner)).
         let store_id = kv::KvStoreId::for_topic_owner(topic, &owner);
-        let store = kv::KvStore::new_replica(store_id, String::new(), Some(owner), channel);
+        let persist_path = state_dir.map(|d| kv_snapshot_path(d, &store_id));
+        let store = match persist_path.as_deref().map(kv::sync::load_snapshot) {
+            Some(Ok(Some(snap))) => {
+                if snap.id() != &store_id {
+                    return Err(kv_storage_err(format!(
+                        "kv snapshot store-id mismatch for topic {topic}"
+                    )));
+                }
+                if snap.owner() != Some(&owner) {
+                    // The snapshot is anchored on a different owner than the
+                    // caller supplied: identity confusion. Fail closed.
+                    return Err(kv_storage_err(format!(
+                        "kv snapshot for topic {topic} is anchored on a different owner"
+                    )));
+                }
+                snap
+            }
+            Some(Ok(None)) | None => {
+                kv::KvStore::new_replica(store_id, String::new(), Some(owner), channel)
+            }
+            Some(Err(e)) => {
+                return Err(kv_storage_err(format!(
+                    "kv snapshot for topic {topic} is unreadable ({e}); refusing to start with amnesia — repair or remove the snapshot file explicitly"
+                )));
+            }
+        };
 
-        let sync = kv::KvStoreSync::new(
-            store,
-            std::sync::Arc::clone(runtime.pubsub()),
-            topic.to_string(),
-            peer_id,
-            Some(self.agent_id()),
-        )
-        .map_err(|e| {
-            error::IdentityError::Storage(std::io::Error::other(format!(
-                "kv store sync creation failed: {e}",
-            )))
-        })?;
-
-        let sync = std::sync::Arc::new(sync);
-        sync.start_with_spawner(|fut| self.spawn_tracked(fut))
-            .await
-            .map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "kv store sync start failed: {e}",
-                )))
-            })?;
+        let (sync, peer_id) = self.spawn_kv_sync(store, topic, persist_path).await?;
 
         Ok(KvStoreHandle {
             sync,
@@ -10790,6 +10918,16 @@ impl Agent {
             owner_signing: None,
         })
     }
+}
+
+/// Snapshot file path for a store: `<dir>/<store-id-hex>.bin`.
+fn kv_snapshot_path(dir: &std::path::Path, id: &kv::KvStoreId) -> std::path::PathBuf {
+    dir.join(format!("{}.bin", hex::encode(id.as_bytes())))
+}
+
+/// Shorthand for the storage-flavoured [`error::IdentityError`].
+fn kv_storage_err(msg: String) -> error::IdentityError {
+    error::IdentityError::Storage(std::io::Error::other(msg))
 }
 
 /// Handle for interacting with a replicated key-value store.
@@ -10957,6 +11095,7 @@ impl KvStoreHandle {
         let delta = {
             let mut store = self.sync.write().await;
             Self::check_local_write(&store, &self.agent_id)?;
+            let version_before = store.current_version();
             store
                 .put(
                     key.clone(),
@@ -10972,6 +11111,13 @@ impl KvStoreHandle {
                         "kv put failed: {other}",
                     ))),
                 })?;
+            // An AppendOnly idempotent re-put is a TRUE no-op: the store
+            // version did not move, so produce no checkpoint (the sequence
+            // must not advance for a non-mutation), publish nothing, and
+            // persist nothing. Retries stay observationally silent.
+            if store.current_version() == version_before {
+                return Ok(kv::KvStoreDelta::new(version_before));
+            }
             let entry = store.get(&key).cloned();
             let version = store.current_version();
             let mut delta = match entry {
@@ -10994,6 +11140,10 @@ impl KvStoreHandle {
             }
             delta
         };
+        // Persist the committed mutation before announcing it (crash between
+        // the two re-publishes on next write; the reverse order could sign a
+        // checkpoint the disk never saw).
+        self.sync.persist().await;
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta.clone()).await {
             tracing::warn!("failed to publish kv put delta: {e}");
         }
@@ -11061,6 +11211,9 @@ impl KvStoreHandle {
             }
             d
         };
+        // Persist the committed mutation before announcing it (see
+        // put_with_delta).
+        self.sync.persist().await;
         if let Err(e) = self.sync.publish_delta(self.peer_id, delta.clone()).await {
             tracing::warn!("failed to publish kv remove delta: {e}");
         }

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -443,7 +443,9 @@ pub(super) async fn handle_reservation(state: &AppState, kind: &str, id: &str) -
 /// - Present but unrecognized → `None`: the caller must FAIL CLOSED (skip the
 ///   rehydration loudly). Mapping garbage to `Signed` would silently strip a
 ///   possibly-append-only store of its immutability.
-fn manifest_policy(extra: &serde_json::Map<String, serde_json::Value>) -> Option<crate::kv::AccessPolicy> {
+fn manifest_policy(
+    extra: &serde_json::Map<String, serde_json::Value>,
+) -> Option<crate::kv::AccessPolicy> {
     match extra.get("policy") {
         None => Some(crate::kv::AccessPolicy::Signed),
         Some(serde_json::Value::String(s)) if s == "signed" => {
@@ -693,6 +695,40 @@ async fn rehydrate_one(state: Arc<AppState>, entry: CrdtSubscriptionEntry) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn manifest_policy_parses_and_fails_closed() {
+        // WHY: a malformed policy string must NEVER silently become Signed —
+        // that would strip a possibly-append-only store of its immutability
+        // on restart. Absent = legacy Signed (compat default); garbage =
+        // None (caller skips loudly).
+        let mut extra = serde_json::Map::new();
+        assert_eq!(
+            manifest_policy(&extra),
+            Some(crate::kv::AccessPolicy::Signed),
+            "legacy entry without a policy field is Signed"
+        );
+        extra.insert("policy".into(), serde_json::Value::String("signed".into()));
+        assert_eq!(
+            manifest_policy(&extra),
+            Some(crate::kv::AccessPolicy::Signed)
+        );
+        extra.insert(
+            "policy".into(),
+            serde_json::Value::String("append_only".into()),
+        );
+        assert_eq!(
+            manifest_policy(&extra),
+            Some(crate::kv::AccessPolicy::AppendOnly)
+        );
+        extra.insert(
+            "policy".into(),
+            serde_json::Value::String("immutable".into()),
+        );
+        assert_eq!(manifest_policy(&extra), None, "garbage fails closed");
+        extra.insert("policy".into(), serde_json::Value::Bool(true));
+        assert_eq!(manifest_policy(&extra), None, "non-string fails closed");
+    }
 
     fn entry(kind: &str, id: &str, role: &str) -> CrdtSubscriptionEntry {
         CrdtSubscriptionEntry {

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -599,7 +599,20 @@ async fn rehydrate_one(state: Arc<AppState>, entry: CrdtSubscriptionEntry) -> Re
                         )
                         .await
                 }
-                ROLE_CREATED => state.agent.create_kv_store(&entry.name, &entry.topic).await,
+                ROLE_CREATED => {
+                    // Restore the persisted policy: an append-only store must
+                    // never rehydrate as plain Signed (that would silently
+                    // drop its immutability guarantees). Legacy entries with
+                    // no stored policy predate AppendOnly and were Signed.
+                    let policy = match entry.extra.get("policy").and_then(|v| v.as_str()) {
+                        Some("append_only") => crate::kv::AccessPolicy::AppendOnly,
+                        _ => crate::kv::AccessPolicy::Signed,
+                    };
+                    state
+                        .agent
+                        .create_kv_store_with_policy(&entry.name, &entry.topic, policy)
+                        .await
+                }
                 other => {
                     tracing::warn!(
                         id = %entry.id,

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -434,6 +434,28 @@ pub(super) async fn handle_reservation(state: &AppState, kind: &str, id: &str) -
 /// Parse a hex-encoded `AgentId` (64 hex chars → 32 bytes) from a manifest
 /// `expected_owner` field. Returns `None` if the value is not valid hex or not
 /// exactly 32 bytes — the caller treats that as migration-required.
+/// Resolve the persisted access policy from a manifest entry's `extra` map.
+///
+/// - `"append_only"` → `AppendOnly`; `"signed"` → `Signed`.
+/// - Absent key → `Signed` (legacy entries predate the policy field and were
+///   all created Signed — this is a documented compatibility default, not a
+///   downgrade).
+/// - Present but unrecognized → `None`: the caller must FAIL CLOSED (skip the
+///   rehydration loudly). Mapping garbage to `Signed` would silently strip a
+///   possibly-append-only store of its immutability.
+fn manifest_policy(extra: &serde_json::Map<String, serde_json::Value>) -> Option<crate::kv::AccessPolicy> {
+    match extra.get("policy") {
+        None => Some(crate::kv::AccessPolicy::Signed),
+        Some(serde_json::Value::String(s)) if s == "signed" => {
+            Some(crate::kv::AccessPolicy::Signed)
+        }
+        Some(serde_json::Value::String(s)) if s == "append_only" => {
+            Some(crate::kv::AccessPolicy::AppendOnly)
+        }
+        Some(_) => None,
+    }
+}
+
 fn parse_owner_hex(hex_str: &str) -> Option<crate::identity::AgentId> {
     let bytes = hex::decode(hex_str).ok()?;
     if bytes.len() == crate::identity::PEER_ID_LENGTH {
@@ -592,25 +614,41 @@ async fn rehydrate_one(state: Arc<AppState>, entry: CrdtSubscriptionEntry) -> Re
                     };
                     state
                         .agent
-                        .join_kv_store(
+                        .join_kv_store_persistent(
                             &entry.topic,
                             owner,
                             crate::kv::store::AnchorChannel::Persistence,
+                            &state.kv_store_state_dir,
                         )
                         .await
                 }
                 ROLE_CREATED => {
                     // Restore the persisted policy: an append-only store must
                     // never rehydrate as plain Signed (that would silently
-                    // drop its immutability guarantees). Legacy entries with
-                    // no stored policy predate AppendOnly and were Signed.
-                    let policy = match entry.extra.get("policy").and_then(|v| v.as_str()) {
-                        Some("append_only") => crate::kv::AccessPolicy::AppendOnly,
-                        _ => crate::kv::AccessPolicy::Signed,
+                    // drop its immutability guarantees). A malformed policy
+                    // string FAILS CLOSED (skip loudly) — defaulting it to
+                    // Signed would be a silent downgrade. The state snapshot
+                    // (restored inside create_kv_store_persistent) is the
+                    // final authority and itself fails closed on conflicts.
+                    let policy = match manifest_policy(&entry.extra) {
+                        Some(policy) => policy,
+                        None => {
+                            tracing::warn!(
+                                id = %entry.id,
+                                "stored kv-store policy is malformed; \
+                                 skipping rehydration (migration_required)"
+                            );
+                            return RehydrateOutcome::Skipped;
+                        }
                     };
                     state
                         .agent
-                        .create_kv_store_with_policy(&entry.name, &entry.topic, policy)
+                        .create_kv_store_persistent(
+                            &entry.name,
+                            &entry.topic,
+                            policy,
+                            &state.kv_store_state_dir,
+                        )
                         .await
                 }
                 other => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -955,6 +955,7 @@ pub async fn serve_with_options(
         kv_stores: RwLock::new(HashMap::new()),
         crdt_subscriptions: RwLock::new(crdt_subscriptions::CrdtSubscriptionManifest::default()),
         crdt_subscriptions_path: config.data_dir.join("crdt-subscriptions.json"),
+        kv_store_state_dir: config.data_dir.join("kv-stores"),
         crdt_subscriptions_persistence_lock: Mutex::new(()),
         crdt_handle_locks: RwLock::new(HashMap::new()),
         named_groups: RwLock::new(named_groups),
@@ -15902,7 +15903,7 @@ async fn create_kv_store(
     let policy_str = policy.to_string();
     match state
         .agent
-        .create_kv_store_with_policy(&req.name, &req.topic, policy)
+        .create_kv_store_persistent(&req.name, &req.topic, policy, &state.kv_store_state_dir)
         .await
     {
         Ok(handle) => {
@@ -15990,7 +15991,12 @@ async fn join_kv_store(
     }
     match state
         .agent
-        .join_kv_store(&id, owner, x0x::kv::store::AnchorChannel::RestParam)
+        .join_kv_store_persistent(
+            &id,
+            owner,
+            x0x::kv::store::AnchorChannel::RestParam,
+            &state.kv_store_state_dir,
+        )
         .await
     {
         Ok(handle) => {
@@ -21308,6 +21314,7 @@ mod tests {
             kv_stores: RwLock::new(HashMap::new()),
             crdt_subscriptions: RwLock::new(crdt_subscriptions::CrdtSubscriptionManifest::default()),
             crdt_subscriptions_path: data_dir.join("crdt-subscriptions.json"),
+            kv_store_state_dir: data_dir.join("kv-stores"),
             crdt_subscriptions_persistence_lock: Mutex::new(()),
             crdt_handle_locks: RwLock::new(HashMap::new()),
             named_groups: RwLock::new(named_groups),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15798,10 +15798,15 @@ async fn apply_direct_kv_store_delta(
 }
 
 /// Request body for POST /stores.
+///
+/// `policy` selects the access policy: `"signed"` (default — owner-only
+/// writes) or `"append_only"` (owner-only writes AND existing keys are
+/// immutable, even to the owner).
 #[derive(Debug, Deserialize)]
 struct CreateStoreRequest {
     name: String,
     topic: String,
+    policy: Option<String>,
 }
 
 /// Request body for PUT /stores/:id/:key.
@@ -15871,6 +15876,16 @@ async fn create_kv_store(
     Json(req): Json<CreateStoreRequest>,
 ) -> impl IntoResponse {
     let id = req.topic.clone();
+    // Resolve the requested access policy before any state is reserved.
+    let policy = match req.policy.as_deref() {
+        None | Some("signed") => x0x::kv::AccessPolicy::Signed,
+        Some("append_only") => x0x::kv::AccessPolicy::AppendOnly,
+        Some(other) => {
+            return bad_request(format!(
+                "unsupported policy {other:?}: expected \"signed\" or \"append_only\""
+            ))
+        }
+    };
     // Reserve the entire handle+manifest transaction for this (kind,id) so
     // a concurrent create/rehydrate for the same id cannot interleave handle
     // insertion with failure rollback, or spawn a duplicate listener.
@@ -15884,7 +15899,12 @@ async fn create_kv_store(
     if state.kv_stores.read().await.contains_key(&id) {
         return api_error(StatusCode::CONFLICT, "store already exists");
     }
-    match state.agent.create_kv_store(&req.name, &req.topic).await {
+    let policy_str = policy.to_string();
+    match state
+        .agent
+        .create_kv_store_with_policy(&req.name, &req.topic, policy)
+        .await
+    {
         Ok(handle) => {
             let info = handle.ownership_info().await;
             state.kv_stores.write().await.insert(id.clone(), handle);
@@ -15896,6 +15916,12 @@ async fn create_kv_store(
             extra.insert(
                 "expected_owner".to_string(),
                 serde_json::Value::String(owner_hex),
+            );
+            // Persist the policy so a restarted creator rehydrates with the
+            // same policy (an append-only store must never come back Signed).
+            extra.insert(
+                "policy".to_string(),
+                serde_json::Value::String(policy_str),
             );
             if let Err(e) = crdt_subscriptions::record(
                 &state,
@@ -16081,7 +16107,11 @@ async fn put_kv_value(
             (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
         }
         Err(e) => {
-            let status = if matches!(e, x0x::error::IdentityError::Unauthorized(_)) {
+            let status = if matches!(e, x0x::error::IdentityError::ImmutableKey(_)) {
+                // AppendOnly store: the key already exists and existing keys
+                // are immutable, even to the owner.
+                StatusCode::CONFLICT
+            } else if matches!(e, x0x::error::IdentityError::Unauthorized(_)) {
                 // Local write rejected by the store's access policy — the
                 // caller is not the owner (or an allowlisted writer), or the
                 // joined replica has not yet learned the authoritative owner.
@@ -16150,6 +16180,10 @@ async fn delete_kv_value(
             let recipients = kv_store_delta_direct_recipients(&state).await;
             spawn_kv_store_delta_delivery(&state, recipients, &id, handle.peer_id(), &delta);
             (StatusCode::OK, Json(serde_json::json!({ "ok": true })))
+        }
+        Err(e) if matches!(e, x0x::error::IdentityError::ImmutableKey(_)) => {
+            // AppendOnly store: keys can never be deleted, even by the owner.
+            api_error(StatusCode::CONFLICT, format!("{e}"))
         }
         Err(e) if matches!(e, x0x::error::IdentityError::Unauthorized(_)) => {
             api_error(StatusCode::FORBIDDEN, format!("{e}"))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15842,6 +15842,9 @@ struct StoreListEntry {
     policy_version: u64,
     /// Strongly-typed ownership discriminant.
     ownership_status: x0x::kv::OwnershipStatus,
+    /// True while snapshot persistence is failing (local writes refused
+    /// until a snapshot succeeds).
+    durability_degraded: bool,
 }
 
 /// GET /stores
@@ -15866,6 +15869,7 @@ async fn list_kv_stores(State(state): State<Arc<AppState>>) -> impl IntoResponse
             version: info.version,
             policy_version: info.policy_version,
             ownership_status: info.ownership_status,
+            durability_degraded: info.durability_degraded,
         });
     }
     Json(serde_json::json!({ "ok": true, "stores": entries }))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15919,10 +15919,7 @@ async fn create_kv_store(
             );
             // Persist the policy so a restarted creator rehydrates with the
             // same policy (an append-only store must never come back Signed).
-            extra.insert(
-                "policy".to_string(),
-                serde_json::Value::String(policy_str),
-            );
+            extra.insert("policy".to_string(), serde_json::Value::String(policy_str));
             if let Err(e) = crdt_subscriptions::record(
                 &state,
                 crdt_subscriptions::CrdtSubscriptionEntry {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -539,6 +539,11 @@ pub(super) struct AppState {
     /// Disk location for the CRDT subscription manifest (instance data dir,
     /// alongside `directory-subscriptions.json`).
     pub(super) crdt_subscriptions_path: PathBuf,
+    /// Directory holding per-store KV state snapshots
+    /// (`kv-stores/<store-id-hex>.bin`). Restored on create/join/rehydrate so
+    /// store contents — and in particular `AppendOnly` immutability knowledge
+    /// — survive a daemon restart instead of coming back as empty replicas.
+    pub(super) kv_store_state_dir: PathBuf,
     /// Serializes snapshot-and-write of `crdt-subscriptions.json` so an older
     /// in-memory snapshot cannot rename over a newer one after a concurrent
     /// `crdt_subscriptions::record` (the snapshot-after-unlock lost update).

--- a/tests/kv_append_only_rest.rs
+++ b/tests/kv_append_only_rest.rs
@@ -11,12 +11,43 @@
 //! Before running: cargo build --release --bin x0xd
 
 use base64::Engine;
+use std::time::{Duration, Instant};
 
 #[path = "harness/src/cluster.rs"]
 mod cluster;
 
 fn b64(s: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(s)
+}
+
+/// Poll until `key` reads back successfully on `node`, panicking after `secs`.
+async fn wait_for_key(node: &cluster::AgentInstance, topic: &str, key: &str, secs: u64) {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    loop {
+        let r = node.get(&format!("/stores/{topic}/{key}")).await;
+        if r.status().is_success() {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "key {key} not visible on {topic} within {secs}s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Fetch the policy string GET /stores reports for `topic`.
+async fn store_policy(node: &cluster::AgentInstance, topic: &str) -> Option<String> {
+    let r = node.get("/stores").await;
+    if !r.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = r.json().await.ok()?;
+    body["stores"]
+        .as_array()?
+        .iter()
+        .find(|s| s["topic"] == topic)
+        .and_then(|s| s["policy"].as_str().map(str::to_string))
 }
 
 #[tokio::test]
@@ -131,4 +162,114 @@ async fn append_only_store_rest_put_conflict_and_delete_conflict() {
     }
     let r = node.delete(&format!("/stores/{signed_topic}/k")).await;
     assert!(r.status().is_success(), "Signed store delete still works");
+}
+
+/// WHY (P0-C restart amnesia): an append-only owner or replica must come
+/// back from a daemon restart with its state — otherwise the owner forgets
+/// key k, accepts its own k=v2 as a fresh append, and signs a rewritten
+/// history. State snapshots (`<data_dir>/kv-stores/<id>.bin`) are the fix;
+/// this proves them end-to-end through real daemon restarts, including a
+/// joiner restarting while the owner is OFFLINE (the data can only come
+/// from disk).
+#[tokio::test]
+#[ignore]
+async fn append_only_state_survives_daemon_restart() {
+    let mut pair = cluster::pair().await;
+    let topic = format!("kv-ao-restart-{}", rand::random::<u32>());
+
+    // Alice creates the append-only store and appends a key.
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "events", "topic": topic, "policy": "append_only" }),
+        )
+        .await;
+    assert_eq!(r.status().as_u16(), 201, "alice creates append_only store");
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/evt-1"),
+            serde_json::json!({ "value": b64(b"created") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice appends evt-1");
+
+    // Bob joins anchored on alice and syncs the key (his replica learns the
+    // append_only policy from alice's owner-signed checkpoint).
+    let alice_id = pair.alice.agent_id().await;
+    let r = pair
+        .bob
+        .post(
+            &format!("/stores/{topic}/join"),
+            serde_json::json!({ "expected_owner": alice_id }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob joins");
+    wait_for_key(&pair.bob, &topic, "evt-1", 60).await;
+
+    // OWNER RESTART: alice must rehydrate with entries + policy from disk,
+    // and still refuse to rewrite her own history.
+    pair.alice.restart().await;
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        if store_policy(&pair.alice, &topic).await.as_deref() == Some("append_only") {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "alice did not rehydrate the append_only store within 60s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    wait_for_key(&pair.alice, &topic, "evt-1", 30).await;
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/evt-1"),
+            serde_json::json!({ "value": b64(b"REWRITTEN") }),
+        )
+        .await;
+    assert_eq!(
+        r.status().as_u16(),
+        409,
+        "restarted owner must STILL refuse to rewrite (state restored from snapshot)"
+    );
+    let r = pair.alice.get(&format!("/stores/{topic}/evt-1")).await;
+    let body: serde_json::Value = r.json().await.expect("json");
+    assert_eq!(body["value"], b64(b"created"), "original bytes retained");
+
+    // JOINER RESTART WITH OWNER OFFLINE: bob's data + learned append_only
+    // policy can only come from his snapshot.
+    pair.alice.stop();
+    pair.bob.restart().await;
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        if store_policy(&pair.bob, &topic).await.as_deref() == Some("append_only") {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "bob did not rehydrate the append_only replica (owner offline) within 60s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    wait_for_key(&pair.bob, &topic, "evt-1", 30).await;
+    let r = pair.bob.get(&format!("/stores/{topic}/evt-1")).await;
+    let body: serde_json::Value = r.json().await.expect("json");
+    assert_eq!(
+        body["value"],
+        b64(b"created"),
+        "joiner restored entry from disk while owner offline"
+    );
+    // Bob is not the owner: local writes stay 403 (authorization precedes
+    // immutability).
+    let r = pair
+        .bob
+        .put(
+            &format!("/stores/{topic}/evt-1"),
+            serde_json::json!({ "value": b64(b"junk") }),
+        )
+        .await;
+    assert_eq!(r.status().as_u16(), 403, "non-owner writes still 403");
 }

--- a/tests/kv_append_only_rest.rs
+++ b/tests/kv_append_only_rest.rs
@@ -1,0 +1,134 @@
+//! REST surface of `AccessPolicy::AppendOnly` (tracker-integrity-v2 WP-X).
+//!
+//! WHY: append-only event logs must be tamper-evident against their own
+//! author. The owner can append new keys, but an existing key can never be
+//! updated to different content or deleted — even by the owner. The API must
+//! surface that as 409 Conflict (not 403: the caller IS authorized to write,
+//! the specific mutation is what conflicts with the store's immutability).
+//!
+//! All tests are `#[ignore]` — they boot a real x0xd daemon.
+//! Run with: cargo nextest run --test kv_append_only_rest -- --ignored
+//! Before running: cargo build --release --bin x0xd
+
+use base64::Engine;
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+fn b64(s: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(s)
+}
+
+#[tokio::test]
+#[ignore]
+async fn append_only_store_rest_put_conflict_and_delete_conflict() {
+    let (node, _bind) = cluster::solo().await;
+    let topic = format!("kv-ao-{}", rand::random::<u32>());
+
+    // Create with the append_only policy; the response must reflect it.
+    let r = node
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "events", "topic": topic, "policy": "append_only" }),
+        )
+        .await;
+    assert_eq!(r.status().as_u16(), 201, "create append_only store");
+    let body: serde_json::Value = r.json().await.expect("create body json");
+    assert_eq!(
+        body["policy"], "append_only",
+        "create response must report the append_only policy"
+    );
+
+    // An unsupported policy string must be a 400, not a silent Signed store.
+    let r = node
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "x", "topic": format!("{topic}-bad"), "policy": "immutable" }),
+        )
+        .await;
+    assert_eq!(r.status().as_u16(), 400, "unknown policy is rejected");
+
+    // First append succeeds.
+    let r = node
+        .put(
+            &format!("/stores/{topic}/evt-1"),
+            serde_json::json!({ "value": b64(b"created") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "owner appends a new key");
+
+    // Re-put with DIFFERENT content: 409 Conflict, value untouched.
+    let r = node
+        .put(
+            &format!("/stores/{topic}/evt-1"),
+            serde_json::json!({ "value": b64(b"REWRITTEN") }),
+        )
+        .await;
+    assert_eq!(
+        r.status().as_u16(),
+        409,
+        "owner rewriting an existing key must be 409 Conflict"
+    );
+    let body: serde_json::Value = r.json().await.expect("409 body json");
+    assert_eq!(body["ok"], false);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("immutable key"),
+        "409 body names the immutability violation; got: {body}"
+    );
+
+    // Re-put with IDENTICAL content: idempotent no-op, accepted (retry-safe).
+    let r = node
+        .put(
+            &format!("/stores/{topic}/evt-1"),
+            serde_json::json!({ "value": b64(b"created"), "content_type": "application/octet-stream" }),
+        )
+        .await;
+    assert!(
+        r.status().is_success(),
+        "byte-identical re-put is an accepted idempotent no-op"
+    );
+
+    // DELETE an existing key: 409 Conflict, key retained.
+    let r = node.delete(&format!("/stores/{topic}/evt-1")).await;
+    assert_eq!(
+        r.status().as_u16(),
+        409,
+        "owner deleting an existing key must be 409 Conflict"
+    );
+
+    // The original bytes are still there.
+    let r = node.get(&format!("/stores/{topic}/evt-1")).await;
+    assert!(r.status().is_success(), "key survives rejected mutations");
+    let body: serde_json::Value = r.json().await.expect("get body json");
+    assert_eq!(
+        body["value"],
+        b64(b"created"),
+        "original append is retained verbatim"
+    );
+
+    // Regression: a default (Signed) store still allows owner update+delete.
+    let signed_topic = format!("{topic}-signed");
+    let r = node
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "plain", "topic": signed_topic }),
+        )
+        .await;
+    assert_eq!(r.status().as_u16(), 201, "create default Signed store");
+    let body: serde_json::Value = r.json().await.expect("create body json");
+    assert_eq!(body["policy"], "signed", "default policy is still signed");
+    for v in [b"v1".as_slice(), b"v2".as_slice()] {
+        let r = node
+            .put(
+                &format!("/stores/{signed_topic}/k"),
+                serde_json::json!({ "value": b64(v) }),
+            )
+            .await;
+        assert!(r.status().is_success(), "Signed store update still works");
+    }
+    let r = node.delete(&format!("/stores/{signed_topic}/k")).await;
+    assert!(r.status().is_success(), "Signed store delete still works");
+}

--- a/tests/kv_append_only_rest.rs
+++ b/tests/kv_append_only_rest.rs
@@ -211,18 +211,18 @@ async fn append_only_state_survives_daemon_restart() {
     // OWNER RESTART: alice must rehydrate with entries + policy from disk,
     // and still refuse to rewrite her own history.
     pair.alice.restart().await;
-    let deadline = Instant::now() + Duration::from_secs(60);
+    let deadline = Instant::now() + Duration::from_secs(120);
     loop {
         if store_policy(&pair.alice, &topic).await.as_deref() == Some("append_only") {
             break;
         }
         assert!(
             Instant::now() < deadline,
-            "alice did not rehydrate the append_only store within 60s"
+            "alice did not rehydrate the append_only store within 120s"
         );
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
-    wait_for_key(&pair.alice, &topic, "evt-1", 30).await;
+    wait_for_key(&pair.alice, &topic, "evt-1", 60).await;
     let r = pair
         .alice
         .put(
@@ -243,18 +243,18 @@ async fn append_only_state_survives_daemon_restart() {
     // policy can only come from his snapshot.
     pair.alice.stop();
     pair.bob.restart().await;
-    let deadline = Instant::now() + Duration::from_secs(60);
+    let deadline = Instant::now() + Duration::from_secs(120);
     loop {
         if store_policy(&pair.bob, &topic).await.as_deref() == Some("append_only") {
             break;
         }
         assert!(
             Instant::now() < deadline,
-            "bob did not rehydrate the append_only replica (owner offline) within 60s"
+            "bob did not rehydrate the append_only replica (owner offline) within 120s"
         );
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
-    wait_for_key(&pair.bob, &topic, "evt-1", 30).await;
+    wait_for_key(&pair.bob, &topic, "evt-1", 60).await;
     let r = pair.bob.get(&format!("/stores/{topic}/evt-1")).await;
     let body: serde_json::Value = r.json().await.expect("json");
     assert_eq!(


### PR DESCRIPTION
## Summary

Tracker-integrity-v2 **WP-X** (x0x-symphony #10): new KV store access policy `AccessPolicy::AppendOnly` — semantics of `Signed` (owner-only writes, owner anchoring, owner-signed checkpoints) PLUS **existing keys are immutable, even to the owner**, with entries frozen in FULL (value, content type, metadata, timestamps). Includes the full hardening wave from the Codex adversarial review (terminal policy, canonical adoption map, restart persistence, narrowed guarantee).

## Exact guarantee (deliberately narrowed)

**Keys are immutable after first observation by a continuously-persistent replica.** Such a replica rejects every rewrite or removal — local writes, remote deltas (owner-signed included), and owner-signed checkpoint adoption. A **fresh joiner with no prior state necessarily trusts the owner's current signed snapshot**: signatures alone cannot distinguish original history from a rewrite, and two fresh joiners fed different owner-signed snapshots diverge (detectable by comparing adopted checkpoint content roots; the fork is sticky and visible, never silently reconciled). Applications needing fresh-joiner rewrite detection must layer content chaining above the store (per-author seq + prev-hash) — x0x-symphony's tracker-integrity-v2 does exactly this (saorsa-labs/x0x-symphony#10). Witnesses/transparency logs are explicitly out of scope.

## Enforcement points

| Path | Behavior |
|---|---|
| Local `put` existing key, different content OR content type | `KvError::ImmutableKey` → REST **409** |
| Local `put`, byte-identical | TRUE idempotent no-op: no version bump, **no checkpoint-seq advance**, no publish |
| Local `remove` existing key | `ImmutableKey` → **409** (no bulk/clear path exists) |
| Remote delta touching an existing key | Skipped wholesale (full-entry freeze: metadata/`updated_at` cannot mutate under identical bytes); rest of delta applies |
| Remote delta `removed` | All removals skipped + warn-logged |
| Owner-signed checkpoint adoption | Rejected if it shrinks the keyset, rewrites any frozen field of an existing key, or downgrades the policy; fresh-joiner cold-start adoption unaffected |
| `added` ∩ `updated` duplicate key in an adoption delta | Rejected for ALL policies (ambiguous multiset = tamper; the root check hashes the duplicated vec, so a signed multiset forge otherwise validates one copy and applies the other) |
| Policy transitions | **AppendOnly is TERMINAL**: `learn_ownership` rejects any transition away regardless of `policy_version` (forward AND equal); checkpoint downgrades rejected; manifest/snapshot conflicts fail closed |
| Public `KvStore::merge` | Enforces the freeze transactionally (trial clone; `ImmutableKey`, zero partial application). Kept public — zero non-test callers verified repo-wide; removal is a semver break, flagged for v0.33.0 |

## Restart persistence + durability (P0-C, round-3 hardened)

The task-list "survives restart" mechanism is manifest-only + recover-from-peers — insufficient here (an owner with amnesia re-signs rewrites of keys it forgot). This PR adds **full-value KV state snapshots** (simplest correct option): each store's complete state (policy, keyset, entries, latest adopted checkpoint, checkpoint HWM, **and the OR-Set seq-counter ceiling**) is persisted to `<data_dir>/kv-stores/<store-id-hex>.bin` and restored on create/join/rehydrate BEFORE any write is accepted (`Agent::create_kv_store_persistent` / `join_kv_store_persistent`, `kv::sync::load_snapshot`).

**Durability contract (round-3 blockers):**
- **Every mutation entry point persists**: local put/remove, gossip receive loop, owner-announce policy refresh, and the daemon's **direct-delivery side channel** (`apply_remote_delta`) — no unpersisted-merge window remains (audited; `KvStoreSync::write()` is the one documented library escape hatch, no non-test callers).
- **Atomic + power-loss durable**: unique temp file + fsync + rename + **parent-directory fsync** (Unix). Non-Unix: rename stays atomic, parent fsync unavailable — documented limitation. SIGKILL/power loss beyond the parent fsync (hardware write caches) is out of scope.
- **Ordered commits**: persists are serialized per store; `(version, bytes)` are captured under the commit gate so commit order == capture order, plus a last-persisted-version gate — a concurrent burst can never rename an older snapshot over a newer one (test loops 3×20 concurrent puts and asserts snapshot version == store version).
- **Fail-closed local writes**: a failed snapshot write errors the local write (REST **500**), does **not** publish the delta (durability before announcement; the in-memory CRDT mutation stays applied and is captured by the next successful persist), sets a `durability_degraded` flag (in `GET /stores` + create/join responses), and further local writes are refused BEFORE mutating until a persist succeeds. Remote-delta persist failures degrade but never wedge replication. Initial persist failure fails store creation/join outright.
- **Exact tag ceiling**: the snapshot's v1 envelope (`X0XKVS1` magic + body) carries the real `seq_counter` — the handle mints two seqs per put (local OR-Set tag + published delta tag; divergence documented as benign since removals are key-scoped), so the previous version-derived floor would have re-minted published tags after a restart. The format is introduced unreleased, so there is no compat read path: files without the magic fail closed.

Fail-closed on load: corrupt snapshot, store-id mismatch, owner mismatch, `append_only` registration over a non-append-only snapshot, malformed manifest policy strings. Snapshot's terminal `append_only` wins over a `signed` request. Legacy manifest entries without a policy field remain Signed (documented compat default).

**P0-B remainder closed**: the added∩updated dup-key rejection is now global — `merge_delta` drops the whole ambiguous delta for ALL policies (tested on a Signed store), in addition to the checkpoint-adoption gate.

## Wire/storage compatibility

`AccessPolicy` is bincode-positional in persisted stores, `OwnerCheckpoint` (wire + signing bytes), and deltas. `AppendOnly` is appended as variant **3**; indices 0–2 unchanged — all existing stores/checkpoints/deltas decode identically (pinned by a discriminant test). **Rollback caveat** (CHANGELOG): pre-AppendOnly binaries cannot decode the new variant — do not roll back daemons hosting append-only stores.

## REST / CLI

`POST /stores` accepts `"policy": "signed" | "append_only"` (unknown → 400); PUT/DELETE immutability violations → **409** via `IdentityError::ImmutableKey`; policy persisted in the subscription manifest; CLI `x0x store create --policy append_only`; docs in `docs/api-reference.md` (incl. the narrowed guarantee), CHANGELOG under Unreleased.

## Tests

**Unit (src/kv/store.rs)**: put-different rejected · identical re-put idempotent no-op (content-type change rejected) · remove rejected · owner-delta rewrite/removal skipped · fresh-joiner adoption works + learns policy · checkpoint shrink/rewrite/policy-downgrade rejected · forged added∩updated multiset checkpoint rejected · public merge transactional reject · metadata mutation under identical bytes frozen · two fresh joiners diverge detectably (documented P0-D limitation) · truncated forge × PR#230 replay doesn't poison later legit checkpoints · skip-only delta leaves HWM+latest_checkpoint untouched · bincode discriminants pinned 0..=3 · Signed-store regression guard · announce downgrade (fwd+equal) rejected.
**sync.rs**: snapshot round-trip (missing/valid/corrupt-fail-closed). **crdt_subscriptions**: manifest policy parse fail-closed. **lib.rs (runtime)**: idempotent re-put checkpoint-seq stability + owner-restart snapshot restore + fail-closed corrupt/conflict paths.
**e2e (`tests/kv_append_only_rest.rs`, `#[ignore]`, real daemons — `just test-kv-e2e`)**: create/put/delete 409 surface + owner restart keeps 409-on-rewrite + joiner restart with owner OFFLINE restores entry+policy from disk. The suite stays `#[ignore]` because it needs a built x0xd binary (not hermetic); the new `just test-kv-e2e` recipe builds and runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
