### PR TITLE
fix(recovery): #238 — rehydration wedge, zombie subscription, policy misreport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 profile-heap = ["dep:dhat"]
 
 [dev-dependencies]
+# `start_paused` virtual-clock tests for the state-request bootstrap tail
+# (issue #238) — multi-minute retry schedules run in milliseconds.
+tokio = { version = "1", features = ["full", "test-util"] }
 tokio-tungstenite = "0.24"
 futures-util = "0.3"
 criterion = "0.5"

--- a/justfile
+++ b/justfile
@@ -47,6 +47,13 @@ test-kv-e2e:
     cargo build --release --bin x0xd
     cargo nextest run --all-features --test kv_append_only_rest -- --ignored
 
+# CRDT-subscription restart-recovery suite (#[ignore] — boots real x0xd
+# daemons; covers the issue #238 rehydration-wedge and zombie-subscription
+# regressions plus the original restart-amnesia tests).
+test-recovery-e2e:
+    cargo build --bin x0xd
+    cargo nextest run --all-features --test crdt_subscription_persistence --run-ignored all
+
 # ── Test coverage (line/region) ───────────────────────────────────────────
 #
 # Uses cargo-llvm-cov + nextest. Install once with:

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -117,11 +117,19 @@ pub struct TaskListSync {
     /// requests on the wire.
     local_peer_id: PeerId,
 
-    /// Set by [`stop`](Self::stop). The bootstrap requester checks it every
-    /// iteration: its schedule is infinite (issue #238), and the sibling
-    /// loops hold strong `Arc`s to the list, so without this flag an
-    /// explicitly stopped sync would keep publishing state requests forever.
+    /// Set by [`silence_bootstrap`](Self::silence_bootstrap). The bootstrap
+    /// requester checks it every iteration: its schedule is infinite (issue
+    /// #238), so a sync that should stop generating traffic — but keep
+    /// serving — arms this without ending the listener/responder loops.
     stopped: Arc<std::sync::atomic::AtomicBool>,
+
+    /// Cancelled by [`cancel_sync`](Self::cancel_sync) / [`stop`](Self::stop).
+    /// ALL background loops (delta listener, responder, requester) select on
+    /// it, so a discarded sync tears down completely without the topic-wide
+    /// `unsubscribe` that would kill unrelated subscribers sharing the topic
+    /// string (round-4 review: flag-only teardown left ghost listeners and a
+    /// live responder until daemon shutdown).
+    cancel: tokio_util::sync::CancellationToken,
 }
 
 impl TaskListSync {
@@ -168,6 +176,7 @@ impl TaskListSync {
             topic,
             local_peer_id,
             stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            cancel: tokio_util::sync::CancellationToken::new(),
         })
     }
 
@@ -218,9 +227,18 @@ impl TaskListSync {
         // Subscribe to topic — received messages will contain serialized deltas.
         let mut sub = self.pubsub.subscribe(self.topic.clone()).await;
         let task_list = Arc::clone(&self.task_list);
+        let listener_cancel = self.cancel.clone();
 
         spawn(Box::pin(async move {
-            while let Some(msg) = sub.recv().await {
+            loop {
+                let msg = tokio::select! {
+                    // cancel_sync tears down every loop (round-4 review) —
+                    // recv alone would keep this listener alive until
+                    // daemon shutdown.
+                    () = listener_cancel.cancelled() => return,
+                    msg = sub.recv() => msg,
+                };
+                let Some(msg) = msg else { return };
                 match decode_delta::<TaskListDelta>(&msg.payload) {
                     Ok((peer_id, delta)) => {
                         let mut list = task_list.write().await;
@@ -250,6 +268,7 @@ impl TaskListSync {
         // decide convergence.
         let served_evidence = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let responder_served = Arc::clone(&served_evidence);
+        let responder_cancel = self.cancel.clone();
         let local_peer_id = self.local_peer_id;
         spawn(Box::pin(async move {
             // Response-storm damping (issue #238 review): one full-state
@@ -259,7 +278,13 @@ impl TaskListSync {
             // (tiny) StateServed marker, so its convergence check runs
             // against state served moments ago.
             let mut last_full_response: Option<tokio::time::Instant> = None;
-            while let Some(msg) = sync_sub.recv().await {
+            loop {
+                let msg = tokio::select! {
+                    // cancel_sync tears down every loop (round-4 review).
+                    () = responder_cancel.cancelled() => return,
+                    msg = sync_sub.recv() => msg,
+                };
+                let Some(msg) = msg else { return };
                 let Ok(sync_msg) = bincode::deserialize::<TaskListSyncMessage>(&msg.payload) else {
                     continue;
                 };
@@ -362,12 +387,18 @@ impl TaskListSync {
             let requester_list = Arc::downgrade(&self.task_list);
             let sync_topic = self.state_sync_topic();
             let stopped = Arc::clone(&self.stopped);
+            let requester_cancel = self.cancel.clone();
             let requester_served = Arc::clone(&served_evidence);
             spawn(Box::pin(async move {
                 for (attempt, delay_secs) in state_request_delays().enumerate() {
-                    tokio::time::sleep(jittered_secs(delay_secs)).await;
+                    tokio::select! {
+                        // cancel_sync tears down every loop promptly, even
+                        // mid-sleep (round-4 review).
+                        () = requester_cancel.cancelled() => return,
+                        () = tokio::time::sleep(jittered_secs(delay_secs)) => {}
+                    }
                     if stopped.load(std::sync::atomic::Ordering::Relaxed) {
-                        return; // stop() called — never chatter for a dead sync
+                        return; // silenced — never chatter for a dead sync
                     }
                     // Tail attempts stop on convergence; front attempts
                     // always run (see above). Convergence requires BOTH a
@@ -416,29 +447,36 @@ impl TaskListSync {
     ///
     /// Returns an error if operations fail.
     pub async fn stop(&self) -> Result<()> {
-        // Arm the requester kill flag FIRST: the bootstrap requester's
-        // schedule is infinite while the list is empty (issue #238), and
-        // unsubscribing does not end that loop (it holds no subscription).
-        self.silence_bootstrap();
+        // End the loops FIRST: the bootstrap requester's schedule is
+        // infinite while the list is empty (issue #238), and unsubscribing
+        // does not end that loop (it holds no subscription).
+        self.cancel_sync();
         self.pubsub.unsubscribe(&self.topic).await;
         self.pubsub.unsubscribe(&self.state_sync_topic()).await;
         Ok(())
     }
 
-    /// Silence this sync's bootstrap requester (its schedule is infinite
-    /// while unconverged — issue #238) WITHOUT touching topic
+    /// Silence ONLY this sync's bootstrap requester (its schedule is
+    /// infinite while unconverged — issue #238), leaving the listener and
+    /// responder loops serving. Discarded handles want
+    /// [`cancel_sync`](Self::cancel_sync).
+    pub fn silence_bootstrap(&self) {
+        self.stopped
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Tear down ALL of this sync's background loops (delta listener,
+    /// state-request responder, bootstrap requester) WITHOUT touching topic
     /// subscriptions.
     ///
     /// This is the correct teardown for a discarded handle inside a daemon:
     /// `PubSubManager::unsubscribe` (what [`stop`](Self::stop) does) removes
     /// the ENTIRE topic — including subscriptions owned by other components
-    /// that legally share the topic string — so a registration-rollback
-    /// must never unsubscribe, only stop generating traffic. The passive
-    /// listener loops end at `Agent::shutdown()` like every other tracked
-    /// task.
-    pub fn silence_bootstrap(&self) {
-        self.stopped
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+    /// that legally share the topic string. Ending the loops drops their
+    /// `Subscription` receivers, so the pub/sub layer prunes the closed
+    /// senders on its next delivery.
+    pub fn cancel_sync(&self) {
+        self.cancel.cancel();
     }
 
     /// Apply a delta received from a remote peer.
@@ -860,22 +898,31 @@ mod tests {
         sync.stop().await.expect("second stop (idempotent)");
     }
 
-    /// WHY (round-1 review): the requester's schedule is now INFINITE while
+    /// WHY (rounds 1+4 review): the requester's schedule is INFINITE while
     /// the list is empty, and the sibling loops hold strong `Arc`s to the
-    /// list — so `stop()` arming this flag is the only thing that prevents
-    /// a stopped sync from publishing state requests forever. The requester
-    /// checks the flag on every iteration.
+    /// list — so the cancellation token (all loops) and the
+    /// silence_bootstrap flag (requester only) are the only things that end
+    /// a discarded sync's background work before daemon shutdown.
     #[tokio::test]
-    async fn stop_arms_the_requester_kill_flag() {
+    async fn stop_and_silence_arm_their_kill_switches() {
         let sync = make_sync("tasks/stopflag").await;
         assert!(
-            !sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
-            "flag must start disarmed"
+            !sync.cancel.is_cancelled() && !sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
+            "both switches must start disarmed"
+        );
+        sync.silence_bootstrap();
+        assert!(
+            sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
+            "silence_bootstrap() arms the requester-only flag"
+        );
+        assert!(
+            !sync.cancel.is_cancelled(),
+            "silence_bootstrap() must NOT cancel the listener/responder loops"
         );
         sync.stop().await.expect("stop");
         assert!(
-            sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
-            "stop() must arm the requester kill flag"
+            sync.cancel.is_cancelled(),
+            "stop() must cancel ALL background loops via the token"
         );
     }
 

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -33,18 +33,29 @@ const STATE_SYNC_TOPIC_SUFFIX: &str = "/state-sync";
 /// flooding.
 const STATE_REQUEST_RETRY_SECS: [u64; 4] = [1, 5, 15, 30];
 
-/// Persistent tail interval for the state-request bootstrap. After the
-/// aggressive front-loaded schedule exhausts (~51s), a first-time joiner
-/// whose list is STILL empty keeps asking at this interval so a slow mesh
-/// reformation — e.g. a post-restart rejoin while sibling CRDTs also recover
-/// — still converges. The loop self-terminates the moment the local list
-/// becomes non-empty.
-const STATE_REQUEST_TAIL_SECS: u64 = 30;
+/// First persistent-tail delay after the front-loaded schedule exhausts.
+const STATE_REQUEST_TAIL_START_SECS: u64 = 30;
 
-/// Hard cap on persistent-tail state requests so a genuinely-new (forever-
-/// empty) list stops after a bounded window instead of chattering
-/// indefinitely. 20 × 30s ≈ 10 min, ample for any realistic reformation.
-const STATE_REQUEST_MAX_TAIL_ATTEMPTS: usize = 20;
+/// Ceiling for the persistent tail's exponential backoff. While a list is
+/// still empty it keeps requesting at most this often — the steady-state
+/// cost is one ~50-byte side-topic message per list per 5 minutes.
+const STATE_REQUEST_TAIL_CAP_SECS: u64 = 300;
+
+/// The complete state-request delay schedule: the front-loaded burst, then
+/// an infinite exponential tail (30s doubling to a 300s ceiling).
+///
+/// Infinite BY DESIGN (issue #238): holders answer state requests only
+/// reactively and never volunteer state to late subscribers, so a bounded
+/// schedule (the previous 20 × 30s ≈ 10 min hard cap) left a replica that
+/// rehydrated while every holder was offline permanently un-synced once the
+/// cap expired. Convergence — the list turning non-empty — is the only
+/// legitimate stop condition, and the requester loop owns that check.
+fn state_request_delays() -> impl Iterator<Item = u64> {
+    let tail = std::iter::successors(Some(STATE_REQUEST_TAIL_START_SECS), |d| {
+        Some(d.saturating_mul(2).min(STATE_REQUEST_TAIL_CAP_SECS))
+    });
+    STATE_REQUEST_RETRY_SECS.into_iter().chain(tail)
+}
 
 /// Message exchanged on the state-sync side topic.
 #[derive(Debug, Serialize, Deserialize)]
@@ -226,46 +237,30 @@ impl TaskListSync {
         // and has no other way to learn tasks written before it subscribed
         // (the gossip message cache only replays recent deltas). Ask holders
         // to republish. The schedule is front-loaded for a fast mesh, then
-        // runs a persistent tail so a SLOW mesh reformation still converges —
-        // e.g. a post-restart rejoin while sibling CRDTs also recover may not
-        // finish within the aggressive window. The loop self-terminates the
-        // moment the local list becomes non-empty (converged) and is hard-
-        // capped, so a genuinely-new list (no holder answers) stops after a
-        // bounded window instead of chattering forever. Requests and the
-        // full-delta responses they trigger are idempotent CRDT merges, so the
-        // extra chatter is harmless.
+        // runs an INFINITE backoff tail (issue #238): holders answer only
+        // reactively, so a hard-capped tail left a list that rehydrated
+        // while every holder was offline permanently un-synced once the cap
+        // expired. The loop self-terminates the moment the local list
+        // becomes non-empty (converged); until then a genuinely-new list
+        // costs one tiny side-topic message per backoff interval. Requests
+        // and the full-delta responses they trigger are idempotent CRDT
+        // merges, so the extra chatter is harmless.
         if self.task_list.read().await.task_count() == 0 {
             let requester_pubsub = Arc::clone(&self.pubsub);
-            let requester_list = Arc::clone(&self.task_list);
+            // Weak: the requester must not keep the list alive on its own —
+            // if every other holder of the list is gone, the tail exits.
+            let requester_list = Arc::downgrade(&self.task_list);
             let sync_topic = self.state_sync_topic();
             spawn(Box::pin(async move {
-                // Aggressive front-loaded schedule for a fast mesh.
-                for delay_secs in STATE_REQUEST_RETRY_SECS {
+                for delay_secs in state_request_delays() {
                     tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
-                    if requester_list.read().await.task_count() > 0 {
+                    let Some(list) = requester_list.upgrade() else {
+                        return; // sync torn down — nothing left to bootstrap
+                    };
+                    if list.read().await.task_count() > 0 {
                         return; // converged — stop asking
                     }
-                    let request = TaskListSyncMessage::StateRequest {
-                        requester: local_peer_id,
-                    };
-                    let Ok(serialized) = bincode::serialize(&request) else {
-                        return;
-                    };
-                    if let Err(e) = requester_pubsub
-                        .publish(sync_topic.clone(), bytes::Bytes::from(serialized))
-                        .await
-                    {
-                        tracing::debug!("TaskList state-request publish failed: {e}");
-                    }
-                }
-                // Persistent tail: keep asking until convergence or the cap,
-                // so a slow mesh reformation still recovers state.
-                for _ in 0..STATE_REQUEST_MAX_TAIL_ATTEMPTS {
-                    tokio::time::sleep(std::time::Duration::from_secs(STATE_REQUEST_TAIL_SECS))
-                        .await;
-                    if requester_list.read().await.task_count() > 0 {
-                        return; // converged — stop asking
-                    }
+                    drop(list);
                     let request = TaskListSyncMessage::StateRequest {
                         requester: local_peer_id,
                     };
@@ -719,5 +714,88 @@ mod tests {
         // unsubscribe is infallible and tolerant of already-removed topics,
         // so a second stop() must remain Ok.
         sync.stop().await.expect("second stop (idempotent)");
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #238: the bootstrap requester must never give up while empty
+    // ------------------------------------------------------------------
+
+    /// WHY: holders answer state requests reactively and never volunteer
+    /// state to a late subscriber, so the request schedule is the only
+    /// recovery trigger. The previous hard cap (20 × 30s ≈ 10 min) left a
+    /// list that rehydrated while every holder was offline permanently
+    /// empty once the cap expired. The schedule must be front-loaded, then
+    /// an infinite capped tail — convergence is the only stop condition.
+    #[test]
+    fn state_request_schedule_never_terminates_while_unconverged() {
+        let front: Vec<u64> = state_request_delays().take(4).collect();
+        assert_eq!(front, STATE_REQUEST_RETRY_SECS, "front burst unchanged");
+        let tail: Vec<u64> = state_request_delays().skip(4).take(8).collect();
+        assert_eq!(
+            tail,
+            [30, 60, 120, 240, 300, 300, 300, 300],
+            "tail doubles to the cap, then holds it"
+        );
+        assert_eq!(
+            state_request_delays().nth(10_000),
+            Some(STATE_REQUEST_TAIL_CAP_SECS),
+            "the schedule is infinite — convergence, not the schedule, \
+             is what ends the requester"
+        );
+    }
+
+    /// WHY (issue #238 — zombie subscription): a joiner whose every request
+    /// fired while all holders were offline must still converge when a
+    /// holder returns — even long after the OLD hard cap (front ~51s +
+    /// 20 × 30s ≈ 651s) would have silenced the requester forever. Paused
+    /// time drives the virtual clock, so the >10-minute scenario runs in
+    /// moments.
+    #[tokio::test(start_paused = true)]
+    async fn requester_recovers_when_holder_returns_after_old_hard_cap() {
+        let node = make_node().await;
+        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        let topic = "tasks-238-zombie";
+
+        // Empty joiner: subscribes and starts requesting into the void.
+        let joiner_list = TaskList::new(list_id(1), "Test List".to_string(), peer(2));
+        let joiner =
+            TaskListSync::new(joiner_list, Arc::clone(&pubsub), topic.to_string(), peer(2))
+                .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+
+        // Sail PAST the old hard cap with no holder online. The old code is
+        // permanently silent from here on — this is the zombie window.
+        tokio::time::sleep(Duration::from_secs(700)).await;
+        assert_eq!(
+            joiner.read().await.task_count(),
+            0,
+            "nobody was online to answer"
+        );
+
+        // A holder with state appears. It only answers when ASKED, so the
+        // joiner's tail must still be alive to ask.
+        let mut holder_list = TaskList::new(list_id(1), "Test List".to_string(), peer(1));
+        holder_list
+            .add_task(make_task(1, peer(1)), peer(1), 1)
+            .expect("add task");
+        let holder =
+            TaskListSync::new(holder_list, Arc::clone(&pubsub), topic.to_string(), peer(1))
+                .expect("holder sync");
+        holder.start().await.expect("start holder");
+
+        // The next tail request is at most STATE_REQUEST_TAIL_CAP_SECS away.
+        let mut converged = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if joiner.read().await.task_count() > 0 {
+                converged = true;
+                break;
+            }
+        }
+        assert!(
+            converged,
+            "the infinite tail must recover state from a holder that \
+             returns after the old hard cap (zombie subscription, issue #238)"
+        );
     }
 }

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -277,25 +277,31 @@ impl TaskListSync {
                             }
                             list.full_delta()
                         };
+                        // The StateServed marker is published ONLY alongside
+                        // an actual full-delta publish: a marker must
+                        // witness a real broadcast — one sent for a
+                        // cooldown-suppressed response could convince a
+                        // requester that never received the state to stop
+                        // asking (round-3 review). A requester inside the
+                        // window is served by its next scheduled attempt.
                         let cooled_down = last_full_response.is_some_and(|t| {
                             t.elapsed()
                                 < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
                         });
-                        if !cooled_down {
-                            if let Ok(serialized) = encode_delta(local_peer_id, &full) {
-                                if let Err(e) = responder_pubsub
-                                    .publish(
-                                        responder_topic.clone(),
-                                        bytes::Bytes::from(serialized),
-                                    )
-                                    .await
-                                {
-                                    tracing::warn!("TaskList state-response publish failed: {e}");
-                                } else {
-                                    last_full_response = Some(tokio::time::Instant::now());
-                                }
-                            }
+                        if cooled_down {
+                            continue;
                         }
+                        let Ok(serialized) = encode_delta(local_peer_id, &full) else {
+                            continue;
+                        };
+                        if let Err(e) = responder_pubsub
+                            .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
+                            .await
+                        {
+                            tracing::warn!("TaskList state-response publish failed: {e}");
+                            continue;
+                        }
+                        last_full_response = Some(tokio::time::Instant::now());
                         let marker = TaskListSyncMessage::StateServed {
                             responder: local_peer_id,
                         };
@@ -413,11 +419,26 @@ impl TaskListSync {
         // Arm the requester kill flag FIRST: the bootstrap requester's
         // schedule is infinite while the list is empty (issue #238), and
         // unsubscribing does not end that loop (it holds no subscription).
-        self.stopped
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.silence_bootstrap();
         self.pubsub.unsubscribe(&self.topic).await;
         self.pubsub.unsubscribe(&self.state_sync_topic()).await;
         Ok(())
+    }
+
+    /// Silence this sync's bootstrap requester (its schedule is infinite
+    /// while unconverged — issue #238) WITHOUT touching topic
+    /// subscriptions.
+    ///
+    /// This is the correct teardown for a discarded handle inside a daemon:
+    /// `PubSubManager::unsubscribe` (what [`stop`](Self::stop) does) removes
+    /// the ENTIRE topic — including subscriptions owned by other components
+    /// that legally share the topic string — so a registration-rollback
+    /// must never unsubscribe, only stop generating traffic. The passive
+    /// listener loops end at `Agent::shutdown()` like every other tracked
+    /// task.
+    pub fn silence_bootstrap(&self) {
+        self.stopped
+            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Apply a delta received from a remote peer.

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -57,6 +57,21 @@ fn state_request_delays() -> impl Iterator<Item = u64> {
     STATE_REQUEST_RETRY_SECS.into_iter().chain(tail)
 }
 
+/// Minimum spacing between full-state responses from ONE holder for ONE
+/// list — the same response-storm damping as `KvStoreSync` (issue #238
+/// review): the response is a broadcast on the main topic, so one response
+/// per window serves every concurrently-bootstrapping replica.
+const STATE_RESPONSE_COOLDOWN_SECS: u64 = 15;
+
+/// Sleep duration for a scheduled delay with ±20% jitter, so a fleet of
+/// replicas restarted together does not phase-lock its request (and thus
+/// full-state response) schedule. Mirrors the reconnect-backoff jitter in
+/// `lib.rs`.
+fn jittered_secs(secs: u64) -> std::time::Duration {
+    let factor = 0.8 + rand::random::<f64>() * 0.4;
+    std::time::Duration::from_secs_f64(secs as f64 * factor)
+}
+
 /// Message exchanged on the state-sync side topic.
 #[derive(Debug, Serialize, Deserialize)]
 enum TaskListSyncMessage {
@@ -82,6 +97,12 @@ pub struct TaskListSync {
     /// This node's gossip peer id — identifies our deltas and state
     /// requests on the wire.
     local_peer_id: PeerId,
+
+    /// Set by [`stop`](Self::stop). The bootstrap requester checks it every
+    /// iteration: its schedule is infinite (issue #238), and the sibling
+    /// loops hold strong `Arc`s to the list, so without this flag an
+    /// explicitly stopped sync would keep publishing state requests forever.
+    stopped: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl TaskListSync {
@@ -127,6 +148,7 @@ impl TaskListSync {
             pubsub,
             topic,
             local_peer_id,
+            stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 
@@ -205,6 +227,12 @@ impl TaskListSync {
         let responder_topic = self.topic.clone();
         let local_peer_id = self.local_peer_id;
         spawn(Box::pin(async move {
+            // Response-storm damping (issue #238 review): one full-state
+            // response per cooldown window — the response is a broadcast,
+            // so it serves every concurrently-bootstrapping replica; a
+            // requester that lands inside the window is served by its next
+            // scheduled request.
+            let mut last_full_response: Option<tokio::time::Instant> = None;
             while let Some(msg) = sync_sub.recv().await {
                 let Ok(TaskListSyncMessage::StateRequest { requester }) =
                     bincode::deserialize::<TaskListSyncMessage>(&msg.payload)
@@ -212,6 +240,11 @@ impl TaskListSync {
                     continue;
                 };
                 if requester == local_peer_id {
+                    continue;
+                }
+                if last_full_response.is_some_and(|t| {
+                    t.elapsed() < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
+                }) {
                     continue;
                 }
                 let full = {
@@ -229,6 +262,8 @@ impl TaskListSync {
                     .await
                 {
                     tracing::warn!("TaskList state-response publish failed: {e}");
+                } else {
+                    last_full_response = Some(tokio::time::Instant::now());
                 }
             }
         }));
@@ -240,27 +275,39 @@ impl TaskListSync {
         // runs an INFINITE backoff tail (issue #238): holders answer only
         // reactively, so a hard-capped tail left a list that rehydrated
         // while every holder was offline permanently un-synced once the cap
-        // expired. The loop self-terminates the moment the local list
-        // becomes non-empty (converged); until then a genuinely-new list
-        // costs one tiny side-topic message per backoff interval. Requests
-        // and the full-delta responses they trigger are idempotent CRDT
-        // merges, so the extra chatter is harmless.
+        // expired. The FULL front burst always runs (aligned with
+        // `KvStoreSync`, round-1 review): a single incremental task arriving
+        // via live gossip before the first request must not cancel the
+        // request for the complete historical state. The tail then
+        // self-terminates the moment the local list is non-empty; until
+        // then a genuinely-new list costs one tiny side-topic message per
+        // backoff interval. Requests and the full-delta responses they
+        // trigger are idempotent CRDT merges, so the extra chatter is
+        // harmless.
         if self.task_list.read().await.task_count() == 0 {
             let requester_pubsub = Arc::clone(&self.pubsub);
-            // Weak: the requester must not keep the list alive on its own —
-            // if every other holder of the list is gone, the tail exits.
+            // Weak: the requester must not keep the list alive on its own.
+            // (Belt-and-braces — the sibling loops hold strong Arcs, so the
+            // authoritative kill switch is the `stopped` flag below.)
             let requester_list = Arc::downgrade(&self.task_list);
             let sync_topic = self.state_sync_topic();
+            let stopped = Arc::clone(&self.stopped);
             spawn(Box::pin(async move {
-                for delay_secs in state_request_delays() {
-                    tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
-                    let Some(list) = requester_list.upgrade() else {
-                        return; // sync torn down — nothing left to bootstrap
-                    };
-                    if list.read().await.task_count() > 0 {
-                        return; // converged — stop asking
+                for (attempt, delay_secs) in state_request_delays().enumerate() {
+                    tokio::time::sleep(jittered_secs(delay_secs)).await;
+                    if stopped.load(std::sync::atomic::Ordering::Relaxed) {
+                        return; // stop() called — never chatter for a dead sync
                     }
-                    drop(list);
+                    // Tail attempts stop on convergence; front attempts
+                    // always run (see above).
+                    if attempt >= STATE_REQUEST_RETRY_SECS.len() {
+                        let Some(list) = requester_list.upgrade() else {
+                            return; // sync torn down — nothing left to bootstrap
+                        };
+                        if list.read().await.task_count() > 0 {
+                            return; // converged — stop asking
+                        }
+                    }
                     let request = TaskListSyncMessage::StateRequest {
                         requester: local_peer_id,
                     };
@@ -292,6 +339,11 @@ impl TaskListSync {
     ///
     /// Returns an error if operations fail.
     pub async fn stop(&self) -> Result<()> {
+        // Arm the requester kill flag FIRST: the bootstrap requester's
+        // schedule is infinite while the list is empty (issue #238), and
+        // unsubscribing does not end that loop (it holds no subscription).
+        self.stopped
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         self.pubsub.unsubscribe(&self.topic).await;
         self.pubsub.unsubscribe(&self.state_sync_topic()).await;
         Ok(())
@@ -714,6 +766,25 @@ mod tests {
         // unsubscribe is infallible and tolerant of already-removed topics,
         // so a second stop() must remain Ok.
         sync.stop().await.expect("second stop (idempotent)");
+    }
+
+    /// WHY (round-1 review): the requester's schedule is now INFINITE while
+    /// the list is empty, and the sibling loops hold strong `Arc`s to the
+    /// list — so `stop()` arming this flag is the only thing that prevents
+    /// a stopped sync from publishing state requests forever. The requester
+    /// checks the flag on every iteration.
+    #[tokio::test]
+    async fn stop_arms_the_requester_kill_flag() {
+        let sync = make_sync("tasks/stopflag").await;
+        assert!(
+            !sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
+            "flag must start disarmed"
+        );
+        sync.stop().await.expect("stop");
+        assert!(
+            sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
+            "stop() must arm the requester kill flag"
+        );
     }
 
     // ------------------------------------------------------------------

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -132,6 +132,18 @@ pub struct TaskListSync {
     cancel: tokio_util::sync::CancellationToken,
 }
 
+/// Structural teardown (parallel-review finding): the background loops hold
+/// clones of the token, the list, and the pubsub — never the sync itself —
+/// so when the last `TaskListSync` reference drops, every loop (including
+/// the INFINITE bootstrap requester, issue #238) is cancelled without any
+/// caller having to remember `cancel_sync()`. The explicit rollback calls
+/// remain as belt-and-braces.
+impl Drop for TaskListSync {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
 impl TaskListSync {
     /// Create a new TaskList synchronization manager.
     ///
@@ -238,7 +250,16 @@ impl TaskListSync {
                     () = listener_cancel.cancelled() => return,
                     msg = sub.recv() => msg,
                 };
-                let Some(msg) = msg else { return };
+                let Some(msg) = msg else {
+                    // The main-topic subscription is gone: this sync can no
+                    // longer replicate, so it is half-dead — self-cancel so
+                    // the sibling loops (in particular the INFINITE
+                    // bootstrap requester) never outlive it (parallel-review
+                    // finding: a dead sibling must not leave the requester
+                    // chattering at capped cadence forever).
+                    listener_cancel.cancel();
+                    return;
+                };
                 match decode_delta::<TaskListDelta>(&msg.payload) {
                     Ok((peer_id, delta)) => {
                         let mut list = task_list.write().await;
@@ -273,10 +294,11 @@ impl TaskListSync {
         spawn(Box::pin(async move {
             // Response-storm damping (issue #238 review): one full-state
             // response per cooldown window — the response is a broadcast,
-            // so it serves every concurrently-bootstrapping replica; a
-            // requester that lands inside the window still receives the
-            // (tiny) StateServed marker, so its convergence check runs
-            // against state served moments ago.
+            // so it serves every concurrently-bootstrapping replica. A
+            // request landing inside the window gets NOTHING (no response,
+            // no marker — markers must witness a real broadcast, round-3
+            // review); the requester is served by its next scheduled
+            // attempt.
             let mut last_full_response: Option<tokio::time::Instant> = None;
             loop {
                 let msg = tokio::select! {
@@ -284,13 +306,36 @@ impl TaskListSync {
                     () = responder_cancel.cancelled() => return,
                     msg = sync_sub.recv() => msg,
                 };
-                let Some(msg) = msg else { return };
+                let Some(msg) = msg else {
+                    // The side-topic subscription is gone: this sync can no
+                    // longer receive StateServed evidence, so the requester
+                    // could never legitimately stop — self-cancel so it
+                    // (and the sibling loops) never outlive the responder.
+                    responder_cancel.cancel();
+                    return;
+                };
                 let Ok(sync_msg) = bincode::deserialize::<TaskListSyncMessage>(&msg.payload) else {
                     continue;
                 };
                 match sync_msg {
                     TaskListSyncMessage::StateRequest { requester } => {
                         if requester == local_peer_id {
+                            continue;
+                        }
+                        // The StateServed marker is published ONLY alongside
+                        // an actual full-delta publish: a marker must
+                        // witness a real broadcast — one sent for a
+                        // cooldown-suppressed response could convince a
+                        // requester that never received the state to stop
+                        // asking (round-3 review). A requester inside the
+                        // window is served by its next scheduled attempt.
+                        // Checked BEFORE building the full delta — no point
+                        // cloning the whole list for a suppressed response.
+                        let cooled_down = last_full_response.is_some_and(|t| {
+                            t.elapsed()
+                                < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
+                        });
+                        if cooled_down {
                             continue;
                         }
                         // Empty holders stay entirely silent — no response,
@@ -302,20 +347,6 @@ impl TaskListSync {
                             }
                             list.full_delta()
                         };
-                        // The StateServed marker is published ONLY alongside
-                        // an actual full-delta publish: a marker must
-                        // witness a real broadcast — one sent for a
-                        // cooldown-suppressed response could convince a
-                        // requester that never received the state to stop
-                        // asking (round-3 review). A requester inside the
-                        // window is served by its next scheduled attempt.
-                        let cooled_down = last_full_response.is_some_and(|t| {
-                            t.elapsed()
-                                < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
-                        });
-                        if cooled_down {
-                            continue;
-                        }
                         let Ok(serialized) = encode_delta(local_peer_id, &full) else {
                             continue;
                         };
@@ -923,6 +954,22 @@ mod tests {
         assert!(
             sync.cancel.is_cancelled(),
             "stop() must cancel ALL background loops via the token"
+        );
+    }
+
+    /// WHY (parallel-review finding): teardown must be STRUCTURAL — a
+    /// caller that discards its last reference without remembering
+    /// cancel_sync() must still end all background loops (the requester is
+    /// infinite while unconverged), so Drop cancels the token.
+    #[tokio::test]
+    async fn dropping_the_sync_cancels_all_loops() {
+        let sync = make_sync("tasks/dropcancel").await;
+        let token = sync.cancel.clone();
+        assert!(!token.is_cancelled());
+        drop(sync);
+        assert!(
+            token.is_cancelled(),
+            "dropping the last sync reference must cancel every loop"
         );
     }
 

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -48,8 +48,9 @@ const STATE_REQUEST_TAIL_CAP_SECS: u64 = 300;
 /// reactively and never volunteer state to late subscribers, so a bounded
 /// schedule (the previous 20 × 30s ≈ 10 min hard cap) left a replica that
 /// rehydrated while every holder was offline permanently un-synced once the
-/// cap expired. Convergence — the list turning non-empty — is the only
-/// legitimate stop condition, and the requester loop owns that check.
+/// cap expired. Convergence — a `StateServed` marker plus local state — is
+/// the only legitimate stop condition, and the requester loop owns that
+/// check.
 fn state_request_delays() -> impl Iterator<Item = u64> {
     let tail = std::iter::successors(Some(STATE_REQUEST_TAIL_START_SECS), |d| {
         Some(d.saturating_mul(2).min(STATE_REQUEST_TAIL_CAP_SECS))
@@ -78,6 +79,24 @@ enum TaskListSyncMessage {
     /// A peer with no local state for the list asks holders to republish
     /// their full state (as a regular delta) on the main topic.
     StateRequest { requester: PeerId },
+    /// A NON-EMPTY holder's declaration that it has answered a
+    /// `StateRequest` (its full state was republished on the main topic,
+    /// possibly earlier within the response cooldown). Requesters exit their
+    /// bootstrap tail only after seeing a marker AND holding local state —
+    /// mere non-emptiness is not convergence evidence (a single incremental
+    /// delta must not silence recovery, round-2 review). Task lists have no
+    /// authoritative owner, so an empty holder NEVER declares (two empty
+    /// bootstrapping replicas must not talk each other into a false
+    /// "converged empty"); a genuinely-empty list keeps its capped-cadence
+    /// tail (~one tiny message per 5 minutes) until state exists.
+    ///
+    /// Wire compatibility: additive variant — older peers fail to
+    /// deserialize it and skip the message (same precedent as the kv-store
+    /// side channel).
+    StateServed {
+        /// The declaring holder (receivers skip their own echo).
+        responder: PeerId,
+    },
 }
 
 /// Synchronization wrapper for a TaskList.
@@ -225,45 +244,90 @@ impl TaskListSync {
         let responder_list = Arc::clone(&self.task_list);
         let responder_pubsub = Arc::clone(&self.pubsub);
         let responder_topic = self.topic.clone();
+        let sync_topic = self.state_sync_topic();
+        // StateServed evidence: written by the responder loop (which owns
+        // the side-topic subscription), read by the bootstrap requester to
+        // decide convergence.
+        let served_evidence = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let responder_served = Arc::clone(&served_evidence);
         let local_peer_id = self.local_peer_id;
         spawn(Box::pin(async move {
             // Response-storm damping (issue #238 review): one full-state
             // response per cooldown window — the response is a broadcast,
             // so it serves every concurrently-bootstrapping replica; a
-            // requester that lands inside the window is served by its next
-            // scheduled request.
+            // requester that lands inside the window still receives the
+            // (tiny) StateServed marker, so its convergence check runs
+            // against state served moments ago.
             let mut last_full_response: Option<tokio::time::Instant> = None;
             while let Some(msg) = sync_sub.recv().await {
-                let Ok(TaskListSyncMessage::StateRequest { requester }) =
-                    bincode::deserialize::<TaskListSyncMessage>(&msg.payload)
-                else {
+                let Ok(sync_msg) = bincode::deserialize::<TaskListSyncMessage>(&msg.payload) else {
                     continue;
                 };
-                if requester == local_peer_id {
-                    continue;
-                }
-                if last_full_response.is_some_and(|t| {
-                    t.elapsed() < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
-                }) {
-                    continue;
-                }
-                let full = {
-                    let list = responder_list.read().await;
-                    if list.task_count() == 0 {
-                        continue;
+                match sync_msg {
+                    TaskListSyncMessage::StateRequest { requester } => {
+                        if requester == local_peer_id {
+                            continue;
+                        }
+                        // Empty holders stay entirely silent — no response,
+                        // no marker (see StateServed docs).
+                        let full = {
+                            let list = responder_list.read().await;
+                            if list.task_count() == 0 {
+                                continue;
+                            }
+                            list.full_delta()
+                        };
+                        let cooled_down = last_full_response.is_some_and(|t| {
+                            t.elapsed()
+                                < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
+                        });
+                        if !cooled_down {
+                            if let Ok(serialized) = encode_delta(local_peer_id, &full) {
+                                if let Err(e) = responder_pubsub
+                                    .publish(
+                                        responder_topic.clone(),
+                                        bytes::Bytes::from(serialized),
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!("TaskList state-response publish failed: {e}");
+                                } else {
+                                    last_full_response = Some(tokio::time::Instant::now());
+                                }
+                            }
+                        }
+                        let marker = TaskListSyncMessage::StateServed {
+                            responder: local_peer_id,
+                        };
+                        match bincode::serialize(&marker) {
+                            Ok(serialized) => {
+                                if let Err(e) = responder_pubsub
+                                    .publish(sync_topic.clone(), bytes::Bytes::from(serialized))
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        "TaskList state-served marker publish failed: {e}"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "TaskList state-served marker serialize failed: {e}"
+                                );
+                            }
+                        }
                     }
-                    list.full_delta()
-                };
-                let Ok(serialized) = encode_delta(local_peer_id, &full) else {
-                    continue;
-                };
-                if let Err(e) = responder_pubsub
-                    .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
-                    .await
-                {
-                    tracing::warn!("TaskList state-response publish failed: {e}");
-                } else {
-                    last_full_response = Some(tokio::time::Instant::now());
+                    TaskListSyncMessage::StateServed { responder } => {
+                        if responder == local_peer_id {
+                            continue; // our own marker echoed back
+                        }
+                        // Trust note: the marker steers only WHEN the
+                        // requester stops asking, never list content, and
+                        // the requester still requires local non-emptiness
+                        // — a forged marker cannot inject state and stops
+                        // recovery no earlier than a real holder could.
+                        responder_served.store(true, std::sync::atomic::Ordering::Relaxed);
+                    }
                 }
             }
         }));
@@ -292,6 +356,7 @@ impl TaskListSync {
             let requester_list = Arc::downgrade(&self.task_list);
             let sync_topic = self.state_sync_topic();
             let stopped = Arc::clone(&self.stopped);
+            let requester_served = Arc::clone(&served_evidence);
             spawn(Box::pin(async move {
                 for (attempt, delay_secs) in state_request_delays().enumerate() {
                     tokio::time::sleep(jittered_secs(delay_secs)).await;
@@ -299,13 +364,19 @@ impl TaskListSync {
                         return; // stop() called — never chatter for a dead sync
                     }
                     // Tail attempts stop on convergence; front attempts
-                    // always run (see above).
+                    // always run (see above). Convergence requires BOTH a
+                    // StateServed marker (a holder actually answered) AND
+                    // local state — mere non-emptiness can be faked by one
+                    // incremental delta while full history is still missing
+                    // (round-2 review).
                     if attempt >= STATE_REQUEST_RETRY_SECS.len() {
                         let Some(list) = requester_list.upgrade() else {
                             return; // sync torn down — nothing left to bootstrap
                         };
-                        if list.read().await.task_count() > 0 {
-                            return; // converged — stop asking
+                        if requester_served.load(std::sync::atomic::Ordering::Relaxed)
+                            && list.read().await.task_count() > 0
+                        {
+                            return; // a holder served us and we hold state
                         }
                     }
                     let request = TaskListSyncMessage::StateRequest {
@@ -812,6 +883,76 @@ mod tests {
             Some(STATE_REQUEST_TAIL_CAP_SECS),
             "the schedule is infinite — convergence, not the schedule, \
              is what ends the requester"
+        );
+    }
+
+    /// WHY (round-2 review — P1: one incremental delta must not silence
+    /// recovery): a live task arriving before any holder has actually
+    /// SERVED full state makes the list non-empty, and the round-1 tail
+    /// exited on non-emptiness alone — permanently missing all older
+    /// tasks. Convergence now additionally requires a StateServed marker,
+    /// so the bait delta leaves the requester alive and a late full holder
+    /// still gets asked.
+    #[tokio::test(start_paused = true)]
+    async fn single_incremental_delta_does_not_stop_recovery() {
+        let node = make_node().await;
+        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        let topic = "tasks-238-bait";
+
+        let joiner_list = TaskList::new(list_id(1), "Test List".to_string(), peer(2));
+        let joiner =
+            TaskListSync::new(joiner_list, Arc::clone(&pubsub), topic.to_string(), peer(2))
+                .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+
+        // Past the front burst with nobody online.
+        tokio::time::sleep(Duration::from_secs(70)).await;
+
+        // The bait: ONE live incremental delta (task 2) — no full response,
+        // no StateServed marker. The list becomes non-empty.
+        let bait_task = make_task(2, peer(3));
+        let bait_id = *bait_task.id();
+        let mut bait = TaskListDelta::new(1);
+        bait.added_tasks.insert(bait_id, (bait_task, (peer(3), 1)));
+        let encoded = encode_delta(peer(3), &bait).expect("encode bait");
+        pubsub
+            .publish(topic.to_string(), bytes::Bytes::from(encoded))
+            .await
+            .expect("publish bait");
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        assert_eq!(
+            joiner.read().await.task_count(),
+            1,
+            "bait delta merged — the false-convergence precondition holds"
+        );
+
+        // A holder with the FULL history (task 1 and task 2) appears long
+        // after the bait. Only a still-alive requester can reach it.
+        let mut holder_list = TaskList::new(list_id(1), "Test List".to_string(), peer(1));
+        holder_list
+            .add_task(make_task(1, peer(1)), peer(1), 1)
+            .expect("holder task 1");
+        holder_list
+            .add_task(make_task(2, peer(1)), peer(1), 2)
+            .expect("holder task 2");
+        let holder =
+            TaskListSync::new(holder_list, Arc::clone(&pubsub), topic.to_string(), peer(1))
+                .expect("holder sync");
+        holder.start().await.expect("start holder");
+
+        let historical = TaskId::from_bytes([1; 32]);
+        let mut converged = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if joiner.read().await.get_task(&historical).is_some() {
+                converged = true;
+                break;
+            }
+        }
+        assert!(
+            converged,
+            "the requester must survive the bait delta and recover the \
+             historical task from the late holder"
         );
     }
 

--- a/src/gossip/pubsub.rs
+++ b/src/gossip/pubsub.rs
@@ -452,7 +452,32 @@ impl PubSubManager {
         let sub_topic = topic.clone();
         let stats = Arc::clone(&self.stats);
         tokio::spawn(async move {
-            while let Some((_peer, encoded_payload)) = plumtree_rx.recv().await {
+            loop {
+                let received = tokio::select! {
+                    // The subscriber dropping its receiver must end this
+                    // forwarding task PROMPTLY, even on a forever-quiet
+                    // topic — parking on recv() alone only notices the
+                    // closed downstream when the next message arrives, so
+                    // every discarded subscription would pin a task and its
+                    // PlumTree registration indefinitely (issue #238
+                    // round-5 review: registration rollbacks on unique
+                    // topics leaked these unboundedly). Both arms are
+                    // cancel-safe.
+                    () = tx.closed() => {
+                        stats
+                            .subscriber_channel_closed
+                            .fetch_add(1, Ordering::Relaxed);
+                        tracing::debug!(
+                            topic = %sub_topic,
+                            "[4/6 pubsub] subscriber receiver dropped — ending forwarding task"
+                        );
+                        return;
+                    }
+                    received = plumtree_rx.recv() => received,
+                };
+                let Some((_peer, encoded_payload)) = received else {
+                    return;
+                };
                 stats.incoming_total.fetch_add(1, Ordering::Relaxed);
                 tracing::debug!(
                     topic = %sub_topic,
@@ -1766,6 +1791,43 @@ mod tests {
         let manager = PubSubManager::new(node, None).expect("manager");
         let sub = manager.subscribe("test-topic".to_string()).await;
         assert_eq!(sub.topic(), "test-topic");
+    }
+
+    /// WHY (issue #238 round-5 review): dropping a `Subscription` must end
+    /// its forwarding task PROMPTLY — on a forever-QUIET topic, with no
+    /// message ever arriving to surface the closed downstream channel.
+    /// Before the fix the task parked on `plumtree_rx.recv()` indefinitely,
+    /// so every discarded subscription (e.g. a daemon registration
+    /// rollback on a unique topic) pinned a ghost task and its PlumTree
+    /// registration until process exit. The `subscriber_channel_closed`
+    /// counter is the task's exit breadcrumb — it must tick WITHOUT any
+    /// publish.
+    #[tokio::test]
+    async fn dropping_subscription_ends_forwarding_task_on_quiet_topic() {
+        let node = test_node().await;
+        let manager = PubSubManager::new(node, None).expect("manager");
+        let before = manager.stats().subscriber_channel_closed;
+
+        let sub = manager
+            .subscribe("quiet-topic-238-teardown".to_string())
+            .await;
+        drop(sub);
+
+        // No publish ever happens on the topic; the forwarding task must
+        // still notice the dropped receiver via tx.closed() and exit.
+        let mut ended = false;
+        for _ in 0..200 {
+            if manager.stats().subscriber_channel_closed > before {
+                ended = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            ended,
+            "forwarding task must exit promptly when its subscriber is \
+             dropped on a quiet topic (ghost-task leak)"
+        );
     }
 
     #[tokio::test]

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -215,6 +215,18 @@ pub struct KvStoreSync {
     cancel: tokio_util::sync::CancellationToken,
 }
 
+/// Structural teardown (parallel-review finding): the background loops hold
+/// clones of the token, the store, and the pubsub — never the sync itself —
+/// so when the last `KvStoreSync` reference drops, every loop (including the
+/// INFINITE bootstrap requester, issue #238) is cancelled without any caller
+/// having to remember `cancel_sync()`. The explicit rollback calls remain as
+/// belt-and-braces.
+impl Drop for KvStoreSync {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
 /// Shared persistence context for one store's snapshot file.
 struct PersistCtx {
     /// Snapshot file path.
@@ -410,7 +422,16 @@ impl KvStoreSync {
                     () = listener_cancel.cancelled() => return,
                     msg = sub.recv() => msg,
                 };
-                let Some(msg) = msg else { return };
+                let Some(msg) = msg else {
+                    // The main-topic subscription is gone: this sync can no
+                    // longer replicate, so it is half-dead — self-cancel so
+                    // the sibling loops (in particular the INFINITE
+                    // bootstrap requester) never outlive it (parallel-review
+                    // finding: a dead sibling must not leave the requester
+                    // chattering at capped cadence forever).
+                    listener_cancel.cancel();
+                    return;
+                };
                 if msg.topic != main_topic {
                     // Cross-topic replay defense: ignore envelopes not on our
                     // subscribed topic (see start_with_spawner).
@@ -489,7 +510,14 @@ impl KvStoreSync {
                     () = responder_cancel.cancelled() => return,
                     msg = sync_sub.recv() => msg,
                 };
-                let Some(msg) = msg else { return };
+                let Some(msg) = msg else {
+                    // The side-topic subscription is gone: this sync can no
+                    // longer receive StateServed evidence, so the requester
+                    // could never legitimately stop — self-cancel so it
+                    // (and the sibling loops) never outlive the responder.
+                    responder_cancel.cancel();
+                    return;
+                };
                 if msg.topic != sync_topic {
                     // Cross-topic replay defense (see start_with_spawner).
                     continue;
@@ -536,6 +564,20 @@ impl KvStoreSync {
                                 }
                             }
                         }
+                        // Cooldown gates the full-state broadcast. The
+                        // StateServed marker is published ONLY alongside an
+                        // actual full-delta publish (or for an owner's
+                        // checkpoint-less empty store, which has no payload
+                        // at all): a marker must witness a real broadcast —
+                        // a marker for a cooldown-suppressed response could
+                        // convince a requester that never received the state
+                        // to stop asking (round-3 review). Checked BEFORE
+                        // building the full delta — no point cloning the
+                        // whole store for a suppressed response.
+                        let cooled_down = last_full_response.is_some_and(|t| {
+                            t.elapsed()
+                                < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
+                        });
                         // Snapshot state once for the full-delta and the
                         // StateServed marker below. A full response is
                         // served when the store is non-empty, OR when it is
@@ -547,53 +589,37 @@ impl KvStoreSync {
                         // replica (round-3 review — an empty owner must not
                         // be silent while stale holders keep advertising
                         // obsolete state).
-                        let (full, is_empty, is_owner, checkpoint_seq) = {
+                        let (full, is_empty, is_owner, checkpoint_seq, has_payload) = {
                             let s = responder_store.read().await;
                             let is_owner =
                                 local_agent_id.is_some() && s.owner() == local_agent_id.as_ref();
                             let cp =
                                 (s.highest_checkpoint_seq > 0).then_some(s.highest_checkpoint_seq);
-                            let full = (!s.is_empty() || s.latest_checkpoint.is_some())
-                                .then(|| s.full_delta());
-                            (full, s.is_empty(), is_owner, cp)
+                            let has_payload = !s.is_empty() || s.latest_checkpoint.is_some();
+                            let full = (has_payload && !cooled_down).then(|| s.full_delta());
+                            (full, s.is_empty(), is_owner, cp, has_payload)
                         };
-                        // Cooldown gates the full-state broadcast. The
-                        // StateServed marker is published ONLY alongside an
-                        // actual full-delta publish (or for an owner's
-                        // checkpoint-less empty store, which has no payload
-                        // at all): a marker must witness a real broadcast —
-                        // a marker for a cooldown-suppressed response could
-                        // convince a requester that never received the state
-                        // to stop asking (round-3 review).
-                        let cooled_down = last_full_response.is_some_and(|t| {
-                            t.elapsed()
-                                < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
-                        });
                         let mut marker = None;
                         if let Some(full) = full {
-                            if !cooled_down {
-                                if let Ok(serialized) = encode_delta(local_peer_id, &full) {
-                                    if let Err(e) = responder_pubsub
-                                        .publish(
-                                            responder_topic.clone(),
-                                            bytes::Bytes::from(serialized),
-                                        )
-                                        .await
-                                    {
-                                        tracing::warn!(
-                                            "KvStore state-response publish failed: {e}"
-                                        );
-                                    } else {
-                                        last_full_response = Some(tokio::time::Instant::now());
-                                        marker = Some(KvSyncMessage::StateServed {
-                                            responder: local_peer_id,
-                                            empty: is_empty,
-                                            checkpoint_seq,
-                                        });
-                                    }
+                            if let Ok(serialized) = encode_delta(local_peer_id, &full) {
+                                if let Err(e) = responder_pubsub
+                                    .publish(
+                                        responder_topic.clone(),
+                                        bytes::Bytes::from(serialized),
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!("KvStore state-response publish failed: {e}");
+                                } else {
+                                    last_full_response = Some(tokio::time::Instant::now());
+                                    marker = Some(KvSyncMessage::StateServed {
+                                        responder: local_peer_id,
+                                        empty: is_empty,
+                                        checkpoint_seq,
+                                    });
                                 }
                             }
-                        } else if is_owner {
+                        } else if !has_payload && is_owner {
                             // Checkpoint-less empty owner: nothing to serve,
                             // and only the OWNER may declare emptiness — an
                             // empty non-owner replica stays silent so
@@ -842,7 +868,8 @@ impl KvStoreSync {
     /// WHOLE process (every subscriber of those topic strings), which is
     /// only appropriate when this sync is the topics' sole consumer.
     /// In-process daemons discarding one handle should use
-    /// [`cancel_sync`](Self::cancel_sync) instead.
+    /// [`cancel_sync`](Self::cancel_sync) — or simply drop every handle
+    /// clone: the [`Drop`] impl cancels structurally.
     pub async fn stop(&self) -> Result<()> {
         // End the loops FIRST: the bootstrap requester's schedule is
         // infinite while the store is empty (issue #238), and unsubscribing
@@ -1454,6 +1481,22 @@ mod tests {
         assert!(
             sync.cancel.is_cancelled(),
             "stop() must cancel ALL background loops via the token"
+        );
+    }
+
+    /// WHY (parallel-review finding): teardown must be STRUCTURAL — a
+    /// caller that discards its last reference without remembering
+    /// cancel_sync() must still end all background loops (the requester is
+    /// infinite while unconverged), so Drop cancels the token.
+    #[tokio::test]
+    async fn dropping_the_sync_cancels_all_loops() {
+        let sync = make_sync("store/dropcancel", AccessPolicy::Signed).await;
+        let token = sync.cancel.clone();
+        assert!(!token.is_cancelled());
+        drop(sync);
+        assert!(
+            token.is_cancelled(),
+            "dropping the last sync reference must cancel every loop"
         );
     }
 

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -26,6 +26,31 @@ const STATE_SYNC_TOPIC_SUFFIX: &str = "/state-sync";
 /// subscription propagation) still converges without flooding.
 const STATE_REQUEST_RETRY_SECS: [u64; 4] = [1, 5, 15, 30];
 
+/// First persistent-tail delay after the front-loaded schedule exhausts.
+const STATE_REQUEST_TAIL_START_SECS: u64 = 30;
+
+/// Ceiling for the persistent tail's exponential backoff. While a replica
+/// is still empty it keeps requesting at most this often — the steady-state
+/// cost is one ~50-byte side-topic message per store per 5 minutes.
+const STATE_REQUEST_TAIL_CAP_SECS: u64 = 300;
+
+/// The complete state-request delay schedule: the front-loaded burst, then
+/// an infinite exponential tail (30s doubling to a 300s ceiling).
+///
+/// Infinite BY DESIGN (issue #238): the owner answers state requests only
+/// reactively and never volunteers state to late subscribers, so a finite
+/// schedule left a replica that rehydrated while the owner was offline
+/// permanently un-synced (a "zombie subscription" — even the owner
+/// returning did not revive it; only a full daemon restart did, by minting
+/// a fresh schedule). Convergence — the store turning non-empty — is the
+/// only legitimate stop condition, and the requester loop owns that check.
+fn state_request_delays() -> impl Iterator<Item = u64> {
+    let tail = std::iter::successors(Some(STATE_REQUEST_TAIL_START_SECS), |d| {
+        Some(d.saturating_mul(2).min(STATE_REQUEST_TAIL_CAP_SECS))
+    });
+    STATE_REQUEST_RETRY_SECS.into_iter().chain(tail)
+}
+
 /// Message exchanged on the state-sync side topic.
 ///
 /// Wire compatibility: `StateRequest` keeps its variant index and shape, so
@@ -456,19 +481,39 @@ impl KvStoreSync {
         // store and has no other way to learn keys written before it
         // subscribed (the gossip message cache only replays ~60s, and
         // pruning on busy topics removes older deltas entirely). Ask
-        // holders to republish over a short retry schedule. The full
-        // schedule always runs — a partial state arriving early (for
-        // example fresh keys via cache replay) must not stop the
-        // request for the complete historical state. Requests and the
-        // full-delta responses they trigger are idempotent CRDT merges,
-        // so the extra chatter is bounded and harmless. A creator of a
-        // genuinely new store also sends these — nobody answers.
+        // holders to republish. The full FRONT schedule always runs — a
+        // partial state arriving early (for example fresh keys via cache
+        // replay) must not stop the request for the complete historical
+        // state. After the front schedule, an infinite backoff tail keeps
+        // asking while the store is STILL EMPTY (issue #238): holders
+        // answer only reactively, so a replica whose requests all fired
+        // while the owner was offline would otherwise stay a zombie
+        // forever. The tail self-terminates the moment any state merges
+        // (the owner's full-delta response also carries its checkpoint,
+        // so policy converges with the data). Requests and the full-delta
+        // responses they trigger are idempotent CRDT merges, so the
+        // chatter is harmless; a genuinely-new empty store costs one tiny
+        // side-topic message per backoff interval until its first write.
         if bootstrap_needed {
             let requester_pubsub = Arc::clone(&self.pubsub);
             let sync_topic = self.state_sync_topic();
+            // Weak: the requester must not keep the store alive on its own —
+            // if every other holder of the store is gone, the tail exits.
+            let requester_store = Arc::downgrade(&self.store);
             spawn(Box::pin(async move {
-                for delay_secs in STATE_REQUEST_RETRY_SECS {
+                for (attempt, delay_secs) in state_request_delays().enumerate() {
                     tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                    // Tail attempts stop on convergence; front attempts
+                    // always run (see above — partial early state must not
+                    // cancel the request for full history).
+                    if attempt >= STATE_REQUEST_RETRY_SECS.len() {
+                        let Some(store) = requester_store.upgrade() else {
+                            return; // sync torn down — nothing left to bootstrap
+                        };
+                        if !store.read().await.is_empty() {
+                            return; // converged — stop asking
+                        }
+                    }
                     let request = KvSyncMessage::StateRequest {
                         requester: local_peer_id,
                     };
@@ -1069,5 +1114,149 @@ mod tests {
         // unsubscribe is infallible and tolerant of already-removed topics,
         // so a second stop() must remain Ok.
         sync.stop().await.expect("second stop (idempotent)");
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #238: the bootstrap requester must never give up while empty
+    // ------------------------------------------------------------------
+
+    /// WHY: the request schedule is the ONLY trigger for state recovery —
+    /// holders answer reactively and never volunteer state to a late
+    /// subscriber. A finite schedule therefore turned "owner offline while
+    /// the schedule ran" into a permanent zombie: the replica stayed empty
+    /// forever, even after the owner returned. The schedule must be
+    /// front-loaded (a fast mesh converges in seconds) and then an
+    /// infinite capped tail (bounded chatter, unbounded patience).
+    #[test]
+    fn state_request_schedule_never_terminates_while_unconverged() {
+        let front: Vec<u64> = state_request_delays().take(4).collect();
+        assert_eq!(front, STATE_REQUEST_RETRY_SECS, "front burst unchanged");
+        let tail: Vec<u64> = state_request_delays().skip(4).take(8).collect();
+        assert_eq!(
+            tail,
+            [30, 60, 120, 240, 300, 300, 300, 300],
+            "tail doubles to the cap, then holds it"
+        );
+        assert_eq!(
+            state_request_delays().nth(10_000),
+            Some(STATE_REQUEST_TAIL_CAP_SECS),
+            "the schedule is infinite — convergence, not the schedule, \
+             is what ends the requester"
+        );
+    }
+
+    /// WHY (issue #238 — zombie subscription + transient policy misreport):
+    /// a replica that joins while the store owner is offline must still
+    /// converge when the owner returns AFTER the front-loaded request
+    /// schedule has exhausted. Before the fix the requester died at ~51s
+    /// and nothing ever asked again; the replica stayed permanently empty
+    /// (and permanently reported the `signed` replica-default policy) until
+    /// a full daemon restart minted a fresh schedule. Paused time drives
+    /// the virtual clock, so the multi-minute scenario runs in moments.
+    #[tokio::test(start_paused = true)]
+    async fn requester_tail_recovers_when_owner_returns_after_front_schedule() {
+        let node = make_node().await;
+        // Sign as the owner so the OwnerAnnounce path (policy refresh) is
+        // exercised: v2 delivery exposes the verified sender AgentId, which
+        // learn_ownership requires to equal the claimed owner.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-238-zombie";
+
+        // Empty replica anchored on the (offline) owner — exactly what the
+        // daemon's rehydration path builds for a joined store.
+        let replica = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner_id),
+            crate::kv::store::AnchorChannel::RestParam,
+        );
+        let joiner = KvStoreSync::new(
+            replica,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+
+        // The entire front schedule (~51s) fires into the void.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        assert!(
+            joiner.read().await.is_empty(),
+            "nobody was online to answer the front schedule"
+        );
+        assert_eq!(
+            *joiner.read().await.policy(),
+            AccessPolicy::Signed,
+            "replica still reports its construction-default policy while \
+             the owner is away (the transient misreport under test)"
+        );
+
+        // The owner comes online only AFTER the front schedule exhausted —
+        // the window in which the old requester was already dead.
+        let mut owned = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner_id,
+            AccessPolicy::AppendOnly,
+        );
+        owned
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner put");
+        let owner_sync = KvStoreSync::new(
+            owned,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(owner_id),
+        )
+        .expect("owner sync");
+        owner_sync.start().await.expect("start owner");
+
+        // The persistent tail must ask again and converge the data.
+        let mut converged = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if !joiner.read().await.is_empty() {
+                converged = true;
+                break;
+            }
+        }
+        assert!(
+            converged,
+            "the tail requester must recover the store once the owner \
+             returns (zombie subscription, issue #238)"
+        );
+        assert_eq!(
+            joiner.read().await.get("k1").map(|e| e.value.clone()),
+            Some(b"v1".to_vec()),
+            "the owner's key must arrive via the state response"
+        );
+
+        // Defect 3: the owner's announce rides the same recovery, so the
+        // policy misreport heals with the data (poll — the announce and the
+        // full-delta response are separate messages).
+        let mut policy_ok = false;
+        for _ in 0..60 {
+            if *joiner.read().await.policy() == AccessPolicy::AppendOnly {
+                policy_ok = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+        assert!(
+            policy_ok,
+            "the owner announce must refresh the replica policy \
+             (transient `signed` misreport, issue #238)"
+        );
     }
 }

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -199,11 +199,20 @@ pub struct KvStoreSync {
     /// rewrites of keys it no longer remembers holding.
     persist: std::sync::Mutex<Option<Arc<PersistCtx>>>,
 
-    /// Set by [`stop`](Self::stop). The bootstrap requester checks it every
-    /// iteration: its schedule is infinite (issue #238), and the sibling
-    /// loops hold strong `Arc`s to the store, so without this flag an
-    /// explicitly stopped sync would keep publishing state requests forever.
+    /// Set by [`silence_bootstrap`](Self::silence_bootstrap). The bootstrap
+    /// requester checks it every iteration: its schedule is infinite (issue
+    /// #238), so a sync that should stop generating traffic — but keep
+    /// serving (e.g. the deletion-test harness) — arms this without ending
+    /// the listener/responder loops.
     stopped: Arc<std::sync::atomic::AtomicBool>,
+
+    /// Cancelled by [`cancel_sync`](Self::cancel_sync) / [`stop`](Self::stop).
+    /// ALL background loops (delta listener, responder, requester) select on
+    /// it, so a discarded sync tears down completely without the topic-wide
+    /// `unsubscribe` that would kill unrelated subscribers sharing the topic
+    /// string (round-4 review: flag-only teardown left ghost listeners and a
+    /// live responder until daemon shutdown).
+    cancel: tokio_util::sync::CancellationToken,
 }
 
 /// Shared persistence context for one store's snapshot file.
@@ -251,6 +260,7 @@ impl KvStoreSync {
             local_agent_id,
             persist: std::sync::Mutex::new(None),
             stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            cancel: tokio_util::sync::CancellationToken::new(),
         })
     }
 
@@ -390,8 +400,17 @@ impl KvStoreSync {
         let persist_ctx = self.persist_ctx();
 
         let loop_persist_ctx = persist_ctx.clone();
+        let listener_cancel = self.cancel.clone();
         spawn(Box::pin(async move {
-            while let Some(msg) = sub.recv().await {
+            loop {
+                let msg = tokio::select! {
+                    // cancel_sync tears down every loop (round-4 review) —
+                    // recv alone would keep this listener alive until
+                    // daemon shutdown.
+                    () = listener_cancel.cancelled() => return,
+                    msg = sub.recv() => msg,
+                };
+                let Some(msg) = msg else { return };
                 if msg.topic != main_topic {
                     // Cross-topic replay defense: ignore envelopes not on our
                     // subscribed topic (see start_with_spawner).
@@ -457,13 +476,20 @@ impl KvStoreSync {
         // decide convergence.
         let served_evidence = Arc::new(std::sync::Mutex::new(ServedEvidence::default()));
         let responder_served = Arc::clone(&served_evidence);
+        let responder_cancel = self.cancel.clone();
         spawn(Box::pin(async move {
             // Response-storm damping (issue #238 review): one full-state
             // response per cooldown window, regardless of how many replicas
             // are requesting — the response is a broadcast, so it serves
             // them all.
             let mut last_full_response: Option<tokio::time::Instant> = None;
-            while let Some(msg) = sync_sub.recv().await {
+            loop {
+                let msg = tokio::select! {
+                    // cancel_sync tears down every loop (round-4 review).
+                    () = responder_cancel.cancelled() => return,
+                    msg = sync_sub.recv() => msg,
+                };
+                let Some(msg) = msg else { return };
                 if msg.topic != sync_topic {
                     // Cross-topic replay defense (see start_with_spawner).
                     continue;
@@ -729,12 +755,18 @@ impl KvStoreSync {
             // authoritative kill switch is the `stopped` flag below.)
             let requester_store = Arc::downgrade(&self.store);
             let stopped = Arc::clone(&self.stopped);
+            let requester_cancel = self.cancel.clone();
             let requester_served = Arc::clone(&served_evidence);
             spawn(Box::pin(async move {
                 for (attempt, delay_secs) in state_request_delays().enumerate() {
-                    tokio::time::sleep(jittered_secs(delay_secs)).await;
+                    tokio::select! {
+                        // cancel_sync tears down every loop promptly, even
+                        // mid-sleep (round-4 review).
+                        () = requester_cancel.cancelled() => return,
+                        () = tokio::time::sleep(jittered_secs(delay_secs)) => {}
+                    }
                     if stopped.load(std::sync::atomic::Ordering::Relaxed) {
-                        return; // stop() called — never chatter for a dead sync
+                        return; // silenced — never chatter for a dead sync
                     }
                     // Tail attempts stop on convergence; front attempts
                     // always run (see above — partial early state must not
@@ -778,20 +810,30 @@ impl KvStoreSync {
         Ok(())
     }
 
-    /// Silence this sync's bootstrap requester (its schedule is infinite
-    /// while unconverged — issue #238) WITHOUT touching topic
+    /// Silence ONLY this sync's bootstrap requester (its schedule is
+    /// infinite while unconverged — issue #238), leaving the listener and
+    /// responder loops serving.
+    ///
+    /// Use when the replica should keep replicating but never generate
+    /// bootstrap chatter (e.g. an authoritative holder in a single-identity
+    /// test harness). Discarded handles want [`cancel_sync`](Self::cancel_sync).
+    pub fn silence_bootstrap(&self) {
+        self.stopped
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Tear down ALL of this sync's background loops (delta listener,
+    /// state-request responder, bootstrap requester) WITHOUT touching topic
     /// subscriptions.
     ///
     /// This is the correct teardown for a discarded handle inside a daemon:
     /// `PubSubManager::unsubscribe` (what [`stop`](Self::stop) does) removes
     /// the ENTIRE topic — including subscriptions owned by other components
-    /// that legally share the topic string — so a registration-rollback
-    /// must never unsubscribe, only stop generating traffic. The passive
-    /// listener loops end at `Agent::shutdown()` like every other tracked
-    /// task.
-    pub fn silence_bootstrap(&self) {
-        self.stopped
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+    /// that legally share the topic string. Ending the loops drops their
+    /// `Subscription` receivers, so the pub/sub layer prunes the closed
+    /// senders on its next delivery.
+    pub fn cancel_sync(&self) {
+        self.cancel.cancel();
     }
 
     /// Stop background synchronization.
@@ -800,12 +842,12 @@ impl KvStoreSync {
     /// WHOLE process (every subscriber of those topic strings), which is
     /// only appropriate when this sync is the topics' sole consumer.
     /// In-process daemons discarding one handle should use
-    /// [`silence_bootstrap`](Self::silence_bootstrap) instead.
+    /// [`cancel_sync`](Self::cancel_sync) instead.
     pub async fn stop(&self) -> Result<()> {
-        // Arm the requester kill flag FIRST: the bootstrap requester's
-        // schedule is infinite while the store is empty (issue #238), and
-        // unsubscribing does not end that loop (it holds no subscription).
-        self.silence_bootstrap();
+        // End the loops FIRST: the bootstrap requester's schedule is
+        // infinite while the store is empty (issue #238), and unsubscribing
+        // does not end that loop (it holds no subscription).
+        self.cancel_sync();
         self.pubsub.unsubscribe(&self.topic).await;
         self.pubsub.unsubscribe(&self.state_sync_topic()).await;
         Ok(())
@@ -1387,22 +1429,31 @@ mod tests {
         sync.stop().await.expect("second stop (idempotent)");
     }
 
-    /// WHY (round-1 review): the requester's schedule is now INFINITE while
+    /// WHY (rounds 1+4 review): the requester's schedule is INFINITE while
     /// the store is empty, and the sibling loops hold strong `Arc`s to the
-    /// store — so `stop()` arming this flag is the only thing that prevents
-    /// a stopped sync from publishing state requests forever. The requester
-    /// checks the flag on every iteration.
+    /// store — so the cancellation token (all loops) and the
+    /// silence_bootstrap flag (requester only) are the only things that end
+    /// a discarded sync's background work before daemon shutdown.
     #[tokio::test]
-    async fn stop_arms_the_requester_kill_flag() {
+    async fn stop_and_silence_arm_their_kill_switches() {
         let sync = make_sync("store/stopflag", AccessPolicy::Signed).await;
         assert!(
-            !sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
-            "flag must start disarmed"
+            !sync.cancel.is_cancelled() && !sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
+            "both switches must start disarmed"
+        );
+        sync.silence_bootstrap();
+        assert!(
+            sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
+            "silence_bootstrap() arms the requester-only flag"
+        );
+        assert!(
+            !sync.cancel.is_cancelled(),
+            "silence_bootstrap() must NOT cancel the listener/responder loops"
         );
         sync.stop().await.expect("stop");
         assert!(
-            sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
-            "stop() must arm the requester kill flag"
+            sync.cancel.is_cancelled(),
+            "stop() must cancel ALL background loops via the token"
         );
     }
 

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -42,8 +42,9 @@ const STATE_REQUEST_TAIL_CAP_SECS: u64 = 300;
 /// schedule left a replica that rehydrated while the owner was offline
 /// permanently un-synced (a "zombie subscription" — even the owner
 /// returning did not revive it; only a full daemon restart did, by minting
-/// a fresh schedule). Convergence — the store turning non-empty — is the
-/// only legitimate stop condition, and the requester loop owns that check.
+/// a fresh schedule). Convergence — `StateServed` evidence matched against
+/// local state, see [`bootstrap_converged`] — is the only legitimate stop
+/// condition, and the requester loop owns that check.
 fn state_request_delays() -> impl Iterator<Item = u64> {
     let tail = std::iter::successors(Some(STATE_REQUEST_TAIL_START_SECS), |d| {
         Some(d.saturating_mul(2).min(STATE_REQUEST_TAIL_CAP_SECS))
@@ -104,6 +105,64 @@ enum KvSyncMessage {
         /// strictly greater than the receiver's current `policy_version`.
         policy_version: u64,
     },
+    /// A holder's declaration that it has answered a `StateRequest`: its
+    /// full state either was republished on the main topic (possibly
+    /// earlier, within the response cooldown) or there is nothing to serve.
+    /// Requesters match this against their OWN state to decide whether the
+    /// bootstrap tail may stop — mere non-emptiness is not convergence
+    /// evidence (a single incremental delta must not silence recovery).
+    ///
+    /// Wire compatibility: additive variant, same precedent as
+    /// `OwnerAnnounce` — v0.33.0 peers fail to deserialize it and skip the
+    /// message. Against a fleet of only-older responders no markers arrive
+    /// and the requester keeps its capped-cadence tail (bounded chatter,
+    /// never a zombie).
+    StateServed {
+        /// The declaring holder (receivers skip their own echo).
+        responder: PeerId,
+        /// True when the holder's store is empty. Only the OWNER ever
+        /// declares emptiness (an empty non-owner replica stays silent) —
+        /// otherwise two empty bootstrapping replicas would convince each
+        /// other the store is legitimately empty and re-create the zombie.
+        empty: bool,
+        /// The holder's owner-signed checkpoint high-water mark, when it
+        /// holds one. A requester whose own mark has reached this value has
+        /// provably absorbed at least this much owner history — the exact
+        /// convergence gate for checkpoint-bearing stores.
+        checkpoint_seq: Option<u64>,
+    },
+}
+
+/// Aggregated `StateServed` evidence observed by one replica's responder
+/// loop, consumed by its bootstrap requester to decide convergence.
+#[derive(Debug, Default, Clone, Copy)]
+struct ServedEvidence {
+    /// A holder declared non-empty state.
+    saw_nonempty: bool,
+    /// The OWNER declared the store legitimately empty.
+    saw_owner_empty: bool,
+    /// Highest checkpoint sequence any holder declared.
+    max_checkpoint_seq: u64,
+}
+
+/// Convergence rule for the bootstrap tail (pure for unit-testing).
+///
+/// Strongest available evidence wins:
+/// - a declared checkpoint sequence must be matched by this replica's own
+///   high-water mark (exact, survives partial/lost responses);
+/// - otherwise a declared non-empty holder requires local non-emptiness
+///   (best-effort — documented limit for checkpoint-less state);
+/// - otherwise only an owner-declared-empty store counts as converged.
+///
+/// No evidence at all (`ServedEvidence::default()`) is NEVER convergence.
+fn bootstrap_converged(ev: ServedEvidence, is_empty: bool, highest_checkpoint_seq: u64) -> bool {
+    if ev.max_checkpoint_seq > 0 {
+        highest_checkpoint_seq >= ev.max_checkpoint_seq
+    } else if ev.saw_nonempty {
+        !is_empty
+    } else {
+        ev.saw_owner_empty
+    }
 }
 
 /// Synchronization wrapper for a KvStore.
@@ -393,6 +452,11 @@ impl KvStoreSync {
         let sync_topic = self.state_sync_topic();
         let local_peer_id = self.local_peer_id;
         let local_agent_id = self.local_agent_id;
+        // StateServed evidence: written by the responder loop (which owns
+        // the side-topic subscription), read by the bootstrap requester to
+        // decide convergence.
+        let served_evidence = Arc::new(std::sync::Mutex::new(ServedEvidence::default()));
+        let responder_served = Arc::clone(&served_evidence);
         spawn(Box::pin(async move {
             // Response-storm damping (issue #238 review): one full-state
             // response per cooldown window, regardless of how many replicas
@@ -446,43 +510,117 @@ impl KvStoreSync {
                                 }
                             }
                         }
+                        // Snapshot state once for the full-delta and the
+                        // StateServed marker below.
+                        let (full, is_empty, is_owner, checkpoint_seq) = {
+                            let s = responder_store.read().await;
+                            let is_owner =
+                                local_agent_id.is_some() && s.owner() == local_agent_id.as_ref();
+                            let cp =
+                                (s.highest_checkpoint_seq > 0).then_some(s.highest_checkpoint_seq);
+                            let full = (!s.is_empty()).then(|| s.full_delta());
+                            (full, s.is_empty(), is_owner, cp)
+                        };
                         // Cooldown gates only the (potentially large)
-                        // full-state broadcast — the OwnerAnnounce above is
-                        // tiny and always answered. A requester that lands
-                        // inside the window is served by its next scheduled
-                        // request (the requester schedule is infinite while
-                        // unconverged, so nothing is starved).
-                        if last_full_response.is_some_and(|t| {
+                        // full-state broadcast — the OwnerAnnounce above and
+                        // the StateServed marker below are tiny and always
+                        // answered. A requester that lands inside the window
+                        // still receives the marker, so its convergence
+                        // check runs against state served moments ago.
+                        let cooled_down = last_full_response.is_some_and(|t| {
                             t.elapsed()
                                 < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
-                        }) {
-                            continue;
-                        }
-                        // Known residual (documented in issue #238 review):
-                        // an owner whose CURRENT state is legitimately empty
-                        // (all keys deleted) sends only the announce, so a
-                        // stale non-empty holder can win the response race.
-                        // Deletion-aware cold recovery needs checkpoint-
-                        // frontier convergence — tracked as follow-up work;
-                        // AppendOnly stores (the integrity-critical case)
-                        // cannot delete.
-                        let full = {
-                            let s = responder_store.read().await;
-                            if s.is_empty() {
-                                continue;
+                        });
+                        if let Some(full) = full.filter(|_| !cooled_down) {
+                            if let Ok(serialized) = encode_delta(local_peer_id, &full) {
+                                if let Err(e) = responder_pubsub
+                                    .publish(
+                                        responder_topic.clone(),
+                                        bytes::Bytes::from(serialized),
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!("KvStore state-response publish failed: {e}");
+                                } else {
+                                    last_full_response = Some(tokio::time::Instant::now());
+                                }
                             }
-                            s.full_delta()
+                        }
+                        // StateServed marker: non-empty holders always
+                        // declare; an EMPTY store is declared only by its
+                        // owner (authoritative emptiness) — an empty
+                        // non-owner replica stays silent so bootstrapping
+                        // replicas can never talk each other into a false
+                        // "converged empty".
+                        //
+                        // Known residual (issue #238 review, follow-up
+                        // filed): full responses carry only live entries —
+                        // no tombstones — so deletions cannot cold-sync to
+                        // a stale replica; deletion-aware recovery needs
+                        // checkpoint-frontier state transfer. AppendOnly
+                        // stores (the integrity-critical case) cannot
+                        // delete.
+                        if !is_empty || is_owner {
+                            let marker = KvSyncMessage::StateServed {
+                                responder: local_peer_id,
+                                empty: is_empty,
+                                checkpoint_seq,
+                            };
+                            match bincode::serialize(&marker) {
+                                Ok(serialized) => {
+                                    if let Err(e) = responder_pubsub
+                                        .publish(sync_topic.clone(), bytes::Bytes::from(serialized))
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "KvStore state-served marker publish failed: {e}"
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "KvStore state-served marker serialize failed: {e}"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    KvSyncMessage::StateServed {
+                        responder,
+                        empty,
+                        checkpoint_seq,
+                    } => {
+                        if responder == local_peer_id {
+                            continue; // our own marker echoed back
+                        }
+                        // Trust note: markers steer only WHEN the bootstrap
+                        // requester stops asking — never store content, and
+                        // convergence is re-checked against local state
+                        // (`bootstrap_converged`), so a forged marker cannot
+                        // inject state. A forged non-empty/checkpoint marker
+                        // at worst prolongs the capped-cadence tail or stops
+                        // it no earlier than a real holder could (the
+                        // any-holder-answers trust the protocol already
+                        // has). A forged EMPTY marker, however, would stop
+                        // an empty replica's recovery outright — so
+                        // emptiness is trusted only from the pub/sub-
+                        // verified anchored owner.
+                        let owner_verified_empty = empty && {
+                            let anchored = responder_store.read().await.owner().copied();
+                            anchored.is_some() && msg.sender.as_ref() == anchored.as_ref()
                         };
-                        let Ok(serialized) = encode_delta(local_peer_id, &full) else {
-                            continue;
-                        };
-                        if let Err(e) = responder_pubsub
-                            .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
-                            .await
-                        {
-                            tracing::warn!("KvStore state-response publish failed: {e}");
+                        let mut ev = responder_served
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        if empty {
+                            if owner_verified_empty {
+                                ev.saw_owner_empty = true;
+                            }
                         } else {
-                            last_full_response = Some(tokio::time::Instant::now());
+                            ev.saw_nonempty = true;
+                        }
+                        if let Some(seq) = checkpoint_seq {
+                            ev.max_checkpoint_seq = ev.max_checkpoint_seq.max(seq);
                         }
                     }
                     KvSyncMessage::OwnerAnnounce {
@@ -568,6 +706,7 @@ impl KvStoreSync {
             // authoritative kill switch is the `stopped` flag below.)
             let requester_store = Arc::downgrade(&self.store);
             let stopped = Arc::clone(&self.stopped);
+            let requester_served = Arc::clone(&served_evidence);
             spawn(Box::pin(async move {
                 for (attempt, delay_secs) in state_request_delays().enumerate() {
                     tokio::time::sleep(jittered_secs(delay_secs)).await;
@@ -576,13 +715,25 @@ impl KvStoreSync {
                     }
                     // Tail attempts stop on convergence; front attempts
                     // always run (see above — partial early state must not
-                    // cancel the request for full history).
+                    // cancel the request for full history). Convergence is
+                    // judged against StateServed evidence matched to local
+                    // state (`bootstrap_converged`) — NOT mere non-emptiness,
+                    // which a single incremental delta can fake while the
+                    // full historical state is still missing (round-2
+                    // review).
                     if attempt >= STATE_REQUEST_RETRY_SECS.len() {
                         let Some(store) = requester_store.upgrade() else {
                             return; // sync torn down — nothing left to bootstrap
                         };
-                        if !store.read().await.is_empty() {
-                            return; // converged — stop asking
+                        let ev = *requester_served
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        let (is_empty, cp_hwm) = {
+                            let s = store.read().await;
+                            (s.is_empty(), s.highest_checkpoint_seq)
+                        };
+                        if bootstrap_converged(ev, is_empty, cp_hwm) {
+                            return; // a holder served us and local state matches
                         }
                     }
                     let request = KvSyncMessage::StateRequest {
@@ -1237,6 +1388,149 @@ mod tests {
             Some(STATE_REQUEST_TAIL_CAP_SECS),
             "the schedule is infinite — convergence, not the schedule, \
              is what ends the requester"
+        );
+    }
+
+    /// WHY (round-2 review): the convergence rule must weigh evidence
+    /// correctly — checkpoint match is exact; declared-non-empty requires
+    /// local state; emptiness counts only when the owner declared it; and
+    /// NO evidence is NEVER convergence (a replica that heard nothing keeps
+    /// asking, whatever its local state looks like).
+    #[test]
+    fn bootstrap_convergence_rule() {
+        let none = ServedEvidence::default();
+        // No evidence: never converged, empty or not.
+        assert!(!bootstrap_converged(none, true, 0));
+        assert!(!bootstrap_converged(none, false, 9));
+
+        // Checkpoint evidence is exact: local HWM must reach it.
+        let cp = ServedEvidence {
+            saw_nonempty: true,
+            saw_owner_empty: false,
+            max_checkpoint_seq: 5,
+        };
+        assert!(!bootstrap_converged(cp, false, 4), "behind the served HWM");
+        assert!(bootstrap_converged(cp, false, 5));
+        assert!(bootstrap_converged(cp, false, 7));
+
+        // Non-empty holder, no checkpoint: local non-emptiness required.
+        let nonempty = ServedEvidence {
+            saw_nonempty: true,
+            saw_owner_empty: false,
+            max_checkpoint_seq: 0,
+        };
+        assert!(!bootstrap_converged(nonempty, true, 0));
+        assert!(bootstrap_converged(nonempty, false, 0));
+
+        // Owner-declared empty (and nothing stronger): converged even empty.
+        let owner_empty = ServedEvidence {
+            saw_nonempty: false,
+            saw_owner_empty: true,
+            max_checkpoint_seq: 0,
+        };
+        assert!(bootstrap_converged(owner_empty, true, 0));
+        // A non-empty holder claim outranks owner-empty when both were seen.
+        let mixed = ServedEvidence {
+            saw_nonempty: true,
+            saw_owner_empty: true,
+            max_checkpoint_seq: 0,
+        };
+        assert!(
+            !bootstrap_converged(mixed, true, 0),
+            "divergent holders: the data-bearing claim must win, keep asking"
+        );
+    }
+
+    /// WHY (round-2 review — P1: restored non-empty replicas still became
+    /// zombies): round 1 made non-owner replicas run the front burst, but
+    /// the tail still exited on mere non-emptiness — a restored replica
+    /// whose owner stayed offline through the burst exited on its first
+    /// tail check and never asked again. Convergence now requires
+    /// StateServed evidence: the replica must keep asking until a holder
+    /// actually answers, however long the owner is away.
+    #[tokio::test(start_paused = true)]
+    async fn restored_replica_keeps_asking_until_a_holder_serves() {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-238-restored-late-owner";
+
+        // Snapshot-restored replica: non-empty, owner OFFLINE.
+        let mut replica = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner_id),
+            crate::kv::store::AnchorChannel::Persistence,
+        );
+        replica
+            .put(
+                "k_old".to_string(),
+                b"v_old".to_vec(),
+                "text/plain".to_string(),
+                peer(2),
+            )
+            .expect("seed restored key");
+        let joiner = KvStoreSync::new(
+            replica,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+
+        // The entire front burst fires with the owner away. The round-1
+        // code exited the tail right here (non-empty ⇒ "converged").
+        tokio::time::sleep(Duration::from_secs(90)).await;
+
+        // Owner returns much later, holding a key the replica missed.
+        let mut owned = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner_id,
+            AccessPolicy::Signed,
+        );
+        owned
+            .put(
+                "k_old".to_string(),
+                b"v_old".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner k_old");
+        owned
+            .put(
+                "k_new".to_string(),
+                b"v_new".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner k_new");
+        let owner_sync = KvStoreSync::new(
+            owned,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(owner_id),
+        )
+        .expect("owner sync");
+        owner_sync.start().await.expect("start owner");
+
+        let mut recovered = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if joiner.read().await.get("k_new").is_some() {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(
+            recovered,
+            "a restored non-empty replica must keep requesting until a \
+             holder serves it — non-emptiness alone is not convergence"
         );
     }
 

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -51,6 +51,25 @@ fn state_request_delays() -> impl Iterator<Item = u64> {
     STATE_REQUEST_RETRY_SECS.into_iter().chain(tail)
 }
 
+/// Minimum spacing between full-state responses from ONE holder for ONE
+/// store. Every empty replica's request would otherwise make every holder
+/// republish its complete state — after a fleet restart N replicas × M
+/// holders align on the same schedule and the amplification is N×M full
+/// publications per cadence. One response per window per holder serves all
+/// concurrently-bootstrapping replicas (the response is a broadcast on the
+/// main topic); a request that lands inside the window is served by the
+/// requester's next scheduled attempt.
+const STATE_RESPONSE_COOLDOWN_SECS: u64 = 15;
+
+/// Sleep duration for a scheduled delay with ±20% jitter, so a fleet of
+/// replicas restarted together does not phase-lock its request (and thus
+/// full-state response) schedule. Mirrors the reconnect-backoff jitter in
+/// `lib.rs`.
+fn jittered_secs(secs: u64) -> std::time::Duration {
+    let factor = 0.8 + rand::random::<f64>() * 0.4;
+    std::time::Duration::from_secs_f64(secs as f64 * factor)
+}
+
 /// Message exchanged on the state-sync side topic.
 ///
 /// Wire compatibility: `StateRequest` keeps its variant index and shape, so
@@ -120,6 +139,12 @@ pub struct KvStoreSync {
     /// restart: an owner (or replica) with amnesia would otherwise accept
     /// rewrites of keys it no longer remembers holding.
     persist: std::sync::Mutex<Option<Arc<PersistCtx>>>,
+
+    /// Set by [`stop`](Self::stop). The bootstrap requester checks it every
+    /// iteration: its schedule is infinite (issue #238), and the sibling
+    /// loops hold strong `Arc`s to the store, so without this flag an
+    /// explicitly stopped sync would keep publishing state requests forever.
+    stopped: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Shared persistence context for one store's snapshot file.
@@ -166,6 +191,7 @@ impl KvStoreSync {
             local_peer_id,
             local_agent_id,
             persist: std::sync::Mutex::new(None),
+            stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 
@@ -275,11 +301,24 @@ impl KvStoreSync {
     {
         let mut sub = self.pubsub.subscribe(self.topic.clone()).await;
         let store = Arc::clone(&self.store);
-        // Capture emptiness BEFORE any listener can merge a cached delta.
-        // Otherwise a partial cache replay landing between subscribe and this
-        // check would make the store non-empty and skip the bootstrap
-        // state-request schedule — aged/pruned keys would never arrive.
-        let bootstrap_needed = store.read().await.is_empty();
+        // Capture the bootstrap decision BEFORE any listener can merge a
+        // cached delta. Otherwise a partial cache replay landing between
+        // subscribe and this check could make the store non-empty and skip
+        // the bootstrap state-request schedule — aged/pruned keys would
+        // never arrive.
+        //
+        // Non-owner replicas ALWAYS bootstrap: a snapshot-restored replica
+        // may have missed deltas while it was offline, and emptiness cannot
+        // distinguish "fresh join" from "restored but stale" (the gossip
+        // cache only replays ~60s of history). Owners are authoritative and
+        // request only when EMPTY — that is snapshot-loss recovery from
+        // their replicas.
+        let bootstrap_needed = {
+            let s = store.read().await;
+            let local_is_owner =
+                self.local_agent_id.is_some() && s.owner() == self.local_agent_id.as_ref();
+            !local_is_owner || s.is_empty()
+        };
         // Defense in depth against cross-topic replay: the v2 signature covers
         // the embedded topic, but pub/sub delivery does not re-check it against
         // this subscription, so a raw-mesh participant could place a valid
@@ -355,6 +394,11 @@ impl KvStoreSync {
         let local_peer_id = self.local_peer_id;
         let local_agent_id = self.local_agent_id;
         spawn(Box::pin(async move {
+            // Response-storm damping (issue #238 review): one full-state
+            // response per cooldown window, regardless of how many replicas
+            // are requesting — the response is a broadcast, so it serves
+            // them all.
+            let mut last_full_response: Option<tokio::time::Instant> = None;
             while let Some(msg) = sync_sub.recv().await {
                 if msg.topic != sync_topic {
                     // Cross-topic replay defense (see start_with_spawner).
@@ -402,6 +446,26 @@ impl KvStoreSync {
                                 }
                             }
                         }
+                        // Cooldown gates only the (potentially large)
+                        // full-state broadcast — the OwnerAnnounce above is
+                        // tiny and always answered. A requester that lands
+                        // inside the window is served by its next scheduled
+                        // request (the requester schedule is infinite while
+                        // unconverged, so nothing is starved).
+                        if last_full_response.is_some_and(|t| {
+                            t.elapsed()
+                                < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
+                        }) {
+                            continue;
+                        }
+                        // Known residual (documented in issue #238 review):
+                        // an owner whose CURRENT state is legitimately empty
+                        // (all keys deleted) sends only the announce, so a
+                        // stale non-empty holder can win the response race.
+                        // Deletion-aware cold recovery needs checkpoint-
+                        // frontier convergence — tracked as follow-up work;
+                        // AppendOnly stores (the integrity-critical case)
+                        // cannot delete.
                         let full = {
                             let s = responder_store.read().await;
                             if s.is_empty() {
@@ -417,6 +481,8 @@ impl KvStoreSync {
                             .await
                         {
                             tracing::warn!("KvStore state-response publish failed: {e}");
+                        } else {
+                            last_full_response = Some(tokio::time::Instant::now());
                         }
                     }
                     KvSyncMessage::OwnerAnnounce {
@@ -497,12 +563,17 @@ impl KvStoreSync {
         if bootstrap_needed {
             let requester_pubsub = Arc::clone(&self.pubsub);
             let sync_topic = self.state_sync_topic();
-            // Weak: the requester must not keep the store alive on its own —
-            // if every other holder of the store is gone, the tail exits.
+            // Weak: the requester must not keep the store alive on its own.
+            // (Belt-and-braces — the sibling loops hold strong Arcs, so the
+            // authoritative kill switch is the `stopped` flag below.)
             let requester_store = Arc::downgrade(&self.store);
+            let stopped = Arc::clone(&self.stopped);
             spawn(Box::pin(async move {
                 for (attempt, delay_secs) in state_request_delays().enumerate() {
-                    tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                    tokio::time::sleep(jittered_secs(delay_secs)).await;
+                    if stopped.load(std::sync::atomic::Ordering::Relaxed) {
+                        return; // stop() called — never chatter for a dead sync
+                    }
                     // Tail attempts stop on convergence; front attempts
                     // always run (see above — partial early state must not
                     // cancel the request for full history).
@@ -535,6 +606,11 @@ impl KvStoreSync {
 
     /// Stop background synchronization.
     pub async fn stop(&self) -> Result<()> {
+        // Arm the requester kill flag FIRST: the bootstrap requester's
+        // schedule is infinite while the store is empty (issue #238), and
+        // unsubscribing does not end that loop (it holds no subscription).
+        self.stopped
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         self.pubsub.unsubscribe(&self.topic).await;
         self.pubsub.unsubscribe(&self.state_sync_topic()).await;
         Ok(())
@@ -1116,6 +1192,25 @@ mod tests {
         sync.stop().await.expect("second stop (idempotent)");
     }
 
+    /// WHY (round-1 review): the requester's schedule is now INFINITE while
+    /// the store is empty, and the sibling loops hold strong `Arc`s to the
+    /// store — so `stop()` arming this flag is the only thing that prevents
+    /// a stopped sync from publishing state requests forever. The requester
+    /// checks the flag on every iteration.
+    #[tokio::test]
+    async fn stop_arms_the_requester_kill_flag() {
+        let sync = make_sync("store/stopflag", AccessPolicy::Signed).await;
+        assert!(
+            !sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
+            "flag must start disarmed"
+        );
+        sync.stop().await.expect("stop");
+        assert!(
+            sync.stopped.load(std::sync::atomic::Ordering::Relaxed),
+            "stop() must arm the requester kill flag"
+        );
+    }
+
     // ------------------------------------------------------------------
     // Issue #238: the bootstrap requester must never give up while empty
     // ------------------------------------------------------------------
@@ -1142,6 +1237,99 @@ mod tests {
             Some(STATE_REQUEST_TAIL_CAP_SECS),
             "the schedule is infinite — convergence, not the schedule, \
              is what ends the requester"
+        );
+    }
+
+    /// WHY (round-1 review — missed-delta recovery): a snapshot-restored
+    /// NON-OWNER replica is non-empty, but may have missed deltas written
+    /// while it was offline, and the gossip cache only replays ~60s. The
+    /// old `is_empty()` bootstrap gate meant such a replica NEVER requested
+    /// state — the missed keys were unrecoverable without another restart
+    /// race. Non-owner replicas must always run the front burst.
+    #[tokio::test(start_paused = true)]
+    async fn restored_non_empty_replica_still_requests_missed_state() {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-238-missed-delta";
+
+        // Owner holds k_old AND k_new (k_new written while the replica was
+        // "offline" — i.e. absent from the replica's restored snapshot).
+        let mut owned = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner_id,
+            AccessPolicy::Signed,
+        );
+        owned
+            .put(
+                "k_old".to_string(),
+                b"v_old".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner put k_old");
+        owned
+            .put(
+                "k_new".to_string(),
+                b"v_new".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner put k_new");
+        let owner_sync = KvStoreSync::new(
+            owned,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(owner_id),
+        )
+        .expect("owner sync");
+        owner_sync.start().await.expect("start owner");
+
+        // Snapshot-restored replica: NON-empty (has k_old), anchored on the
+        // owner, local agent is NOT the owner. Under the old gate this
+        // replica never requested anything.
+        let mut replica = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner_id),
+            crate::kv::store::AnchorChannel::Persistence,
+        );
+        replica
+            .put(
+                "k_old".to_string(),
+                b"v_old".to_vec(),
+                "text/plain".to_string(),
+                peer(2),
+            )
+            .expect("seed restored key");
+        let joiner = KvStoreSync::new(
+            replica,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+
+        // The front burst must fire despite the replica being non-empty,
+        // and the owner's full-state response must deliver the missed key.
+        let mut recovered = false;
+        for _ in 0..30 {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            if joiner.read().await.get("k_new").is_some() {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(
+            recovered,
+            "a restored non-empty non-owner replica must still request \
+             state and recover deltas it missed while offline"
         );
     }
 

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -511,61 +511,75 @@ impl KvStoreSync {
                             }
                         }
                         // Snapshot state once for the full-delta and the
-                        // StateServed marker below.
+                        // StateServed marker below. A full response is
+                        // served when the store is non-empty, OR when it is
+                        // empty but holds an owner checkpoint: the
+                        // checkpoint-adopt merge path is a full REPLACE
+                        // (keys absent from the signed set are removed), so
+                        // a checkpoint-bearing empty delta is exactly how a
+                        // deleted-to-empty store cold-syncs to a stale
+                        // replica (round-3 review — an empty owner must not
+                        // be silent while stale holders keep advertising
+                        // obsolete state).
                         let (full, is_empty, is_owner, checkpoint_seq) = {
                             let s = responder_store.read().await;
                             let is_owner =
                                 local_agent_id.is_some() && s.owner() == local_agent_id.as_ref();
                             let cp =
                                 (s.highest_checkpoint_seq > 0).then_some(s.highest_checkpoint_seq);
-                            let full = (!s.is_empty()).then(|| s.full_delta());
+                            let full = (!s.is_empty() || s.latest_checkpoint.is_some())
+                                .then(|| s.full_delta());
                             (full, s.is_empty(), is_owner, cp)
                         };
-                        // Cooldown gates only the (potentially large)
-                        // full-state broadcast — the OwnerAnnounce above and
-                        // the StateServed marker below are tiny and always
-                        // answered. A requester that lands inside the window
-                        // still receives the marker, so its convergence
-                        // check runs against state served moments ago.
+                        // Cooldown gates the full-state broadcast. The
+                        // StateServed marker is published ONLY alongside an
+                        // actual full-delta publish (or for an owner's
+                        // checkpoint-less empty store, which has no payload
+                        // at all): a marker must witness a real broadcast —
+                        // a marker for a cooldown-suppressed response could
+                        // convince a requester that never received the state
+                        // to stop asking (round-3 review).
                         let cooled_down = last_full_response.is_some_and(|t| {
                             t.elapsed()
                                 < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
                         });
-                        if let Some(full) = full.filter(|_| !cooled_down) {
-                            if let Ok(serialized) = encode_delta(local_peer_id, &full) {
-                                if let Err(e) = responder_pubsub
-                                    .publish(
-                                        responder_topic.clone(),
-                                        bytes::Bytes::from(serialized),
-                                    )
-                                    .await
-                                {
-                                    tracing::warn!("KvStore state-response publish failed: {e}");
-                                } else {
-                                    last_full_response = Some(tokio::time::Instant::now());
+                        let mut marker = None;
+                        if let Some(full) = full {
+                            if !cooled_down {
+                                if let Ok(serialized) = encode_delta(local_peer_id, &full) {
+                                    if let Err(e) = responder_pubsub
+                                        .publish(
+                                            responder_topic.clone(),
+                                            bytes::Bytes::from(serialized),
+                                        )
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "KvStore state-response publish failed: {e}"
+                                        );
+                                    } else {
+                                        last_full_response = Some(tokio::time::Instant::now());
+                                        marker = Some(KvSyncMessage::StateServed {
+                                            responder: local_peer_id,
+                                            empty: is_empty,
+                                            checkpoint_seq,
+                                        });
+                                    }
                                 }
                             }
-                        }
-                        // StateServed marker: non-empty holders always
-                        // declare; an EMPTY store is declared only by its
-                        // owner (authoritative emptiness) — an empty
-                        // non-owner replica stays silent so bootstrapping
-                        // replicas can never talk each other into a false
-                        // "converged empty".
-                        //
-                        // Known residual (issue #238 review, follow-up
-                        // filed): full responses carry only live entries —
-                        // no tombstones — so deletions cannot cold-sync to
-                        // a stale replica; deletion-aware recovery needs
-                        // checkpoint-frontier state transfer. AppendOnly
-                        // stores (the integrity-critical case) cannot
-                        // delete.
-                        if !is_empty || is_owner {
-                            let marker = KvSyncMessage::StateServed {
+                        } else if is_owner {
+                            // Checkpoint-less empty owner: nothing to serve,
+                            // and only the OWNER may declare emptiness — an
+                            // empty non-owner replica stays silent so
+                            // bootstrapping replicas can never talk each
+                            // other into a false "converged empty".
+                            marker = Some(KvSyncMessage::StateServed {
                                 responder: local_peer_id,
-                                empty: is_empty,
-                                checkpoint_seq,
-                            };
+                                empty: true,
+                                checkpoint_seq: None,
+                            });
+                        }
+                        if let Some(marker) = marker {
                             match bincode::serialize(&marker) {
                                 Ok(serialized) => {
                                     if let Err(e) = responder_pubsub
@@ -597,15 +611,24 @@ impl KvStoreSync {
                         // requester stops asking — never store content, and
                         // convergence is re-checked against local state
                         // (`bootstrap_converged`), so a forged marker cannot
-                        // inject state. A forged non-empty/checkpoint marker
-                        // at worst prolongs the capped-cadence tail or stops
-                        // it no earlier than a real holder could (the
-                        // any-holder-answers trust the protocol already
-                        // has). A forged EMPTY marker, however, would stop
-                        // an empty replica's recovery outright — so
-                        // emptiness is trusted only from the pub/sub-
-                        // verified anchored owner.
-                        let owner_verified_empty = empty && {
+                        // inject state. A forged NON-EMPTY marker at worst
+                        // stops the tail no earlier than a real holder could
+                        // (the any-holder-answers trust the protocol already
+                        // has). The two evidence classes that could do real
+                        // damage are trusted only from the pub/sub-verified
+                        // anchored owner:
+                        // - EMPTY would stop an empty replica's recovery
+                        //   outright;
+                        // - CHECKPOINT_SEQ is the exact convergence gate,
+                        //   and a forged u64::MAX would pin the requester
+                        //   at capped cadence forever while a forged low
+                        //   value could retire a stale replica early
+                        //   (round-3 review).
+                        // Owner-marker checkpoints also self-correlate: the
+                        // local high-water mark only rises by MERGING the
+                        // checkpoint-bearing full delta, so satisfying the
+                        // gate proves the state actually arrived.
+                        let owner_verified = {
                             let anchored = responder_store.read().await.owner().copied();
                             anchored.is_some() && msg.sender.as_ref() == anchored.as_ref()
                         };
@@ -613,13 +636,13 @@ impl KvStoreSync {
                             .lock()
                             .unwrap_or_else(std::sync::PoisonError::into_inner);
                         if empty {
-                            if owner_verified_empty {
+                            if owner_verified {
                                 ev.saw_owner_empty = true;
                             }
                         } else {
                             ev.saw_nonempty = true;
                         }
-                        if let Some(seq) = checkpoint_seq {
+                        if let Some(seq) = checkpoint_seq.filter(|_| owner_verified) {
                             ev.max_checkpoint_seq = ev.max_checkpoint_seq.max(seq);
                         }
                     }
@@ -755,13 +778,34 @@ impl KvStoreSync {
         Ok(())
     }
 
+    /// Silence this sync's bootstrap requester (its schedule is infinite
+    /// while unconverged — issue #238) WITHOUT touching topic
+    /// subscriptions.
+    ///
+    /// This is the correct teardown for a discarded handle inside a daemon:
+    /// `PubSubManager::unsubscribe` (what [`stop`](Self::stop) does) removes
+    /// the ENTIRE topic — including subscriptions owned by other components
+    /// that legally share the topic string — so a registration-rollback
+    /// must never unsubscribe, only stop generating traffic. The passive
+    /// listener loops end at `Agent::shutdown()` like every other tracked
+    /// task.
+    pub fn silence_bootstrap(&self) {
+        self.stopped
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
     /// Stop background synchronization.
+    ///
+    /// Topic-wide: unsubscribes the main and state-sync topics for the
+    /// WHOLE process (every subscriber of those topic strings), which is
+    /// only appropriate when this sync is the topics' sole consumer.
+    /// In-process daemons discarding one handle should use
+    /// [`silence_bootstrap`](Self::silence_bootstrap) instead.
     pub async fn stop(&self) -> Result<()> {
         // Arm the requester kill flag FIRST: the bootstrap requester's
         // schedule is infinite while the store is empty (issue #238), and
         // unsubscribing does not end that loop (it holds no subscription).
-        self.stopped
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.silence_bootstrap();
         self.pubsub.unsubscribe(&self.topic).await;
         self.pubsub.unsubscribe(&self.state_sync_topic()).await;
         Ok(())
@@ -1531,6 +1575,129 @@ mod tests {
             recovered,
             "a restored non-empty replica must keep requesting until a \
              holder serves it — non-emptiness alone is not convergence"
+        );
+    }
+
+    /// WHY (round-3 review — deleted-to-empty must cold-sync): an owner
+    /// whose store is legitimately empty but checkpointed (everything
+    /// deleted) must still serve state requests: the checkpoint-adopt merge
+    /// path is a full REPLACE, so its checkpoint-bearing EMPTY full delta
+    /// is exactly what removes a stale replica's obsolete keys. Before this
+    /// fix the empty owner was silent while stale holders kept advertising
+    /// old state; convergence was also unreachable (the marker declared a
+    /// checkpoint the replica could never adopt).
+    #[tokio::test(start_paused = true)]
+    async fn checkpointed_empty_owner_deletes_stale_replica_state() {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-238-deleted-to-empty";
+
+        // Owner: EMPTY store carrying an owner-signed checkpoint over the
+        // empty set (the state after deleting everything).
+        let mut owned = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner_id,
+            AccessPolicy::Signed,
+        );
+        let (pub_bytes, sec_bytes) = kp.to_bytes();
+        let public_key =
+            ant_quic::MlDsaPublicKey::from_bytes(&pub_bytes).expect("public key bytes");
+        let secret_key =
+            ant_quic::MlDsaSecretKey::from_bytes(&sec_bytes).expect("secret key bytes");
+        let pairs = owned.checkpoint_pairs();
+        let root = crate::kv::store::content_root(owned.id(), owned.name(), &pairs);
+        let cp = crate::kv::store::make_owner_checkpoint(crate::kv::store::OwnerCheckpointParams {
+            topic,
+            store_id: &store_id(1),
+            secret_key: &secret_key,
+            public_key: &public_key,
+            policy: &AccessPolicy::Signed,
+            policy_version: owned.policy_version(),
+            checkpoint_seq: 3,
+            content_root: root,
+            timestamp: 1,
+        })
+        .expect("sign empty checkpoint");
+        owned.latest_checkpoint = Some(cp);
+        owned.highest_checkpoint_seq = 3;
+        // Stale replica: still holds a key the owner deleted (hwm 0).
+        // Started FIRST so its subscriptions are fully registered before
+        // any response can be published (in-process paused-time harness:
+        // a response racing the main-topic registration is silently
+        // missed; production requesters simply retry, but the poll loop
+        // below burns virtual time much faster than real deliveries).
+        let mut replica = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner_id),
+            crate::kv::store::AnchorChannel::Persistence,
+        );
+        replica
+            .put(
+                "k_stale".to_string(),
+                b"obsolete".to_vec(),
+                "text/plain".to_string(),
+                peer(2),
+            )
+            .expect("seed stale key");
+        let joiner = KvStoreSync::new(
+            replica,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+
+        let owner_sync = KvStoreSync::new(
+            owned,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(owner_id),
+        )
+        .expect("owner sync");
+        // Harness artifact: both syncs share ONE signing identity (the
+        // pubsub ctx), so the stale joiner's responses arrive signed AS THE
+        // OWNER — the empty owner's own bootstrap requester (empty ⇒
+        // snapshot-loss recovery) would adopt the stale key back and its
+        // checkpoint root would never match again. Production daemons have
+        // distinct identities (a stale replica's response is not
+        // owner-authorized), so silence the owner's requester: it is not
+        // the machinery under test.
+        owner_sync.silence_bootstrap();
+        owner_sync.start().await.expect("start owner");
+
+        // The replica's request must be answered with the checkpoint-bearing
+        // empty full delta; adopting it removes the stale key and raises the
+        // high-water mark to the served checkpoint (convergence reachable).
+        // Poll generously: virtual time advances the requester schedule, but
+        // the signing/delivery pipeline runs in REAL time (blocking-pool
+        // ML-DSA ops) — each iteration donates a real scheduling window, so
+        // under CPU contention more iterations are needed, not more virtual
+        // seconds.
+        let mut cleaned = false;
+        for _ in 0..400 {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            let s = joiner.read().await;
+            if s.get("k_stale").is_none() && s.highest_checkpoint_seq == 3 {
+                cleaned = true;
+                break;
+            }
+        }
+        assert!(
+            cleaned,
+            "the checkpointed empty owner's response must full-replace the \
+             stale replica (key removed, checkpoint HWM adopted)"
+        );
+        assert!(
+            joiner.read().await.is_empty(),
+            "replica converges to the owner's (empty) state"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10240,18 +10240,19 @@ impl std::fmt::Debug for TaskListHandle {
 }
 
 impl TaskListHandle {
-    /// Tear down this replica's background synchronization: unsubscribes
-    /// the main and state-sync topics and arms the bootstrap requester's
-    /// kill flag (its schedule is infinite while unconverged — issue #238 —
-    /// so a discarded handle must silence it explicitly).
+    /// Silence this replica's bootstrap requester — its schedule is
+    /// infinite while unconverged (issue #238), so a discarded handle must
+    /// silence it explicitly or it publishes state requests until
+    /// `Agent::shutdown()`.
     ///
-    /// Callers that remove a handle without keeping any other clone (e.g.
-    /// the daemon's registration-rollback paths) MUST call this, or the
-    /// sync loops keep running until `Agent::shutdown()`.
-    pub async fn stop_sync(&self) {
-        // TaskListSync::stop only unsubscribes (infallible today); a failure
-        // would mean the pubsub layer is gone, which is strictly "stopped".
-        let _ = self.sync.stop().await;
+    /// Deliberately does NOT unsubscribe: `PubSubManager::unsubscribe` is
+    /// topic-wide and would tear down every other subscriber sharing the
+    /// topic string (round-3 review). The passive listener loops end at
+    /// shutdown like every other tracked task. Callers that remove a handle
+    /// without keeping any other clone (e.g. the daemon's
+    /// registration-rollback paths) MUST call this.
+    pub fn silence_bootstrap(&self) {
+        self.sync.silence_bootstrap();
     }
 
     /// Generate a fresh per-replica epoch at handle construction.
@@ -10992,18 +10993,19 @@ impl KvStoreHandle {
         self.peer_id
     }
 
-    /// Tear down this replica's background synchronization: unsubscribes
-    /// the main and state-sync topics and arms the bootstrap requester's
-    /// kill flag (its schedule is infinite while unconverged — issue #238 —
-    /// so a discarded handle must silence it explicitly).
+    /// Silence this replica's bootstrap requester — its schedule is
+    /// infinite while unconverged (issue #238), so a discarded handle must
+    /// silence it explicitly or it publishes state requests until
+    /// `Agent::shutdown()`.
     ///
-    /// Callers that remove a handle without keeping any other clone (e.g.
-    /// the daemon's registration-rollback paths) MUST call this, or the
-    /// sync loops keep running until `Agent::shutdown()`.
-    pub async fn stop_sync(&self) {
-        // KvStoreSync::stop only unsubscribes (infallible today); a failure
-        // would mean the pubsub layer is gone, which is strictly "stopped".
-        let _ = self.sync.stop().await;
+    /// Deliberately does NOT unsubscribe: `PubSubManager::unsubscribe` is
+    /// topic-wide and would tear down every other subscriber sharing the
+    /// topic string (round-3 review). The passive listener loops end at
+    /// shutdown like every other tracked task. Callers that remove a handle
+    /// without keeping any other clone (e.g. the daemon's
+    /// registration-rollback paths) MUST call this.
+    pub fn silence_bootstrap(&self) {
+        self.sync.silence_bootstrap();
     }
 
     /// Return the store's ownership/policy/version metadata for auditability.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10240,19 +10240,19 @@ impl std::fmt::Debug for TaskListHandle {
 }
 
 impl TaskListHandle {
-    /// Silence this replica's bootstrap requester — its schedule is
-    /// infinite while unconverged (issue #238), so a discarded handle must
-    /// silence it explicitly or it publishes state requests until
-    /// `Agent::shutdown()`.
+    /// Tear down this replica's background sync loops (delta listener,
+    /// responder, and the bootstrap requester — whose schedule is infinite
+    /// while unconverged, issue #238). A discarded handle must call this or
+    /// its loops run until `Agent::shutdown()`.
     ///
     /// Deliberately does NOT unsubscribe: `PubSubManager::unsubscribe` is
     /// topic-wide and would tear down every other subscriber sharing the
-    /// topic string (round-3 review). The passive listener loops end at
-    /// shutdown like every other tracked task. Callers that remove a handle
-    /// without keeping any other clone (e.g. the daemon's
-    /// registration-rollback paths) MUST call this.
-    pub fn silence_bootstrap(&self) {
-        self.sync.silence_bootstrap();
+    /// topic string (round-3 review); ending the loops instead drops their
+    /// receivers, which the pub/sub layer prunes on its next delivery.
+    /// Callers that remove a handle without keeping any other clone (e.g.
+    /// the daemon's registration-rollback paths) MUST call this.
+    pub fn cancel_sync(&self) {
+        self.sync.cancel_sync();
     }
 
     /// Generate a fresh per-replica epoch at handle construction.
@@ -10993,19 +10993,19 @@ impl KvStoreHandle {
         self.peer_id
     }
 
-    /// Silence this replica's bootstrap requester — its schedule is
-    /// infinite while unconverged (issue #238), so a discarded handle must
-    /// silence it explicitly or it publishes state requests until
-    /// `Agent::shutdown()`.
+    /// Tear down this replica's background sync loops (delta listener,
+    /// responder, and the bootstrap requester — whose schedule is infinite
+    /// while unconverged, issue #238). A discarded handle must call this or
+    /// its loops run until `Agent::shutdown()`.
     ///
     /// Deliberately does NOT unsubscribe: `PubSubManager::unsubscribe` is
     /// topic-wide and would tear down every other subscriber sharing the
-    /// topic string (round-3 review). The passive listener loops end at
-    /// shutdown like every other tracked task. Callers that remove a handle
-    /// without keeping any other clone (e.g. the daemon's
-    /// registration-rollback paths) MUST call this.
-    pub fn silence_bootstrap(&self) {
-        self.sync.silence_bootstrap();
+    /// topic string (round-3 review); ending the loops instead drops their
+    /// receivers, which the pub/sub layer prunes on its next delivery.
+    /// Callers that remove a handle without keeping any other clone (e.g.
+    /// the daemon's registration-rollback paths) MUST call this.
+    pub fn cancel_sync(&self) {
+        self.sync.cancel_sync();
     }
 
     /// Return the store's ownership/policy/version metadata for auditability.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10240,6 +10240,20 @@ impl std::fmt::Debug for TaskListHandle {
 }
 
 impl TaskListHandle {
+    /// Tear down this replica's background synchronization: unsubscribes
+    /// the main and state-sync topics and arms the bootstrap requester's
+    /// kill flag (its schedule is infinite while unconverged — issue #238 —
+    /// so a discarded handle must silence it explicitly).
+    ///
+    /// Callers that remove a handle without keeping any other clone (e.g.
+    /// the daemon's registration-rollback paths) MUST call this, or the
+    /// sync loops keep running until `Agent::shutdown()`.
+    pub async fn stop_sync(&self) {
+        // TaskListSync::stop only unsubscribes (infallible today); a failure
+        // would mean the pubsub layer is gone, which is strictly "stopped".
+        let _ = self.sync.stop().await;
+    }
+
     /// Generate a fresh per-replica epoch at handle construction.
     ///
     /// Uses a CSPRNG incarnation nonce (64-bit random from `OsRng`) so a
@@ -10976,6 +10990,20 @@ impl KvStoreHandle {
     #[must_use]
     pub fn peer_id(&self) -> saorsa_gossip_types::PeerId {
         self.peer_id
+    }
+
+    /// Tear down this replica's background synchronization: unsubscribes
+    /// the main and state-sync topics and arms the bootstrap requester's
+    /// kill flag (its schedule is infinite while unconverged — issue #238 —
+    /// so a discarded handle must silence it explicitly).
+    ///
+    /// Callers that remove a handle without keeping any other clone (e.g.
+    /// the daemon's registration-rollback paths) MUST call this, or the
+    /// sync loops keep running until `Agent::shutdown()`.
+    pub async fn stop_sync(&self) {
+        // KvStoreSync::stop only unsubscribes (infallible today); a failure
+        // would mean the pubsub layer is gone, which is strictly "stopped".
+        let _ = self.sync.stop().await;
     }
 
     /// Return the store's ownership/policy/version metadata for auditability.

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -472,10 +472,13 @@ fn parse_owner_hex(hex_str: &str) -> Option<crate::identity::AgentId> {
 /// Rehydrate every persisted subscription by driving the same `Agent`
 /// create/join paths the REST handlers use.
 ///
-/// Runs after `join_network` returns so the gossip mesh is (re)forming; the
-/// per-CRDT empty-replica state-request retry schedule then recovers state —
-/// including mutations made while this daemon was offline — from peer
-/// replicas. A failed entry is logged (warn) and skipped, never fatal, and
+/// Runs concurrently with `join_network` (issue #238) — it must NOT wait for
+/// bootstrap: a daemon's own stores restore from local snapshots and joined
+/// stores only register subscriptions, so an unreachable bootstrap peer must
+/// never delay them. The per-CRDT state-request schedule (front burst plus a
+/// persistent while-empty tail) recovers state — including mutations made
+/// while this daemon was offline — from peer replicas whenever they become
+/// reachable. A failed entry is logged (warn) and skipped, never fatal, and
 /// stays in the manifest so the next restart retries it.
 ///
 /// Entries are rehydrated CONCURRENTLY (not sequentially) so that a slow or

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -195,11 +195,21 @@ async fn write_manifest_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()>
     let mut temp = TempFile::new(temp_path.clone());
 
     let result = async {
-        let mut file = tokio::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temp_path)
-            .await?;
+        // Create the temp file SYNCHRONOUSLY (one fast syscall, same pattern
+        // as `sync_parent_dir`), not via tokio::fs: the async open dispatches
+        // to the blocking pool, and if this future is cancelled while the
+        // open is in flight, the file can be created AFTER the TempFile
+        // guard's drop already ran its cleanup — orphaned `.tmp` debris.
+        // Creating before the first await point means the guard always sees
+        // the file; a blocking write still in flight at cancellation goes to
+        // the unlinked inode and is freed on close.
+        let mut file = {
+            let std_file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)?;
+            tokio::fs::File::from_std(std_file)
+        };
         file.write_all(bytes).await?;
         file.sync_all().await?;
         drop(file);
@@ -1290,15 +1300,27 @@ mod tests {
             );
         };
 
-        // After cancellation: live memory and disk must both be clean. The OLD
-        // code left the entry in live memory here (mutated before the write).
+        // After cancellation: live memory must be clean — the invariant the
+        // fix guarantees unconditionally (memory is only ever committed AFTER
+        // a durable write). The OLD code left the entry in memory here.
         assert!(
             manifest.read().await.entries.is_empty(),
             "cancellation mid-write must not leave an un-persisted entry in memory"
         );
+        // Disk may land in either honest state: usually empty (cancelled
+        // before the rename), but the rename op runs on the blocking pool
+        // and is not revoked by dropping the future — if it was already in
+        // flight, the fully-written, fsync'd manifest lands even though the
+        // caller saw cancellation. That is NOT a durability lie (nothing was
+        // acknowledged; memory is behind disk, and the identical retry
+        // converges them). A PARTIAL manifest is impossible either way — the
+        // rename only ever installs a complete synced file.
+        let disk = read_manifest(&path).await;
         assert!(
-            read_manifest(&path).await.entries.is_empty(),
-            "cancellation mid-write must not leave a partial manifest on disk"
+            disk.entries.is_empty()
+                || (disk.entries.len() == 1 && disk.entries[0].id == "cancel-store"),
+            "post-cancellation disk must be empty or the complete staged \
+             manifest, never a blend: {disk:?}"
         );
         // No temp-file debris from the aborted rename (TempFile guard).
         let debris = std::fs::read_dir(dir.path())

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -425,6 +425,13 @@ async fn persist_recorded(
 pub(super) async fn handle_reservation(state: &AppState, kind: &str, id: &str) -> Arc<Mutex<()>> {
     let key = format!("{kind}:{id}");
     let mut locks = state.crdt_handle_locks.write().await;
+    // Opportunistic pruning (issue #238 round-2 review): without it every
+    // distinct (kind,id) ever requested pins an Arc<Mutex> forever — an
+    // unbounded-growth vector for authenticated callers minting unique ids.
+    // An entry with strong count 1 is held ONLY by this map: a live guard
+    // implies a cloned Arc, and clones are only ever minted under this same
+    // write lock, so removal cannot race a concurrent acquisition.
+    locks.retain(|k, v| *k == key || Arc::strong_count(v) > 1);
     locks
         .entry(key)
         .or_insert_with(|| Arc::new(Mutex::new(())))
@@ -1229,41 +1236,59 @@ mod tests {
     /// the disk write) leaves memory == disk == pre-call state and an identical
     /// retry re-stages and re-writes.
     ///
-    /// Deterministic — no sleeps, no timing: `biased` select! polls
+    /// No sleeps, no wall-clock timing: `biased` select! polls
     /// `persist_recorded` first. It advances synchronously through the
     /// uncontended locks and the in-memory stage until its FIRST blocking
-    /// await (the `tokio::fs` disk op, which dispatches to the blocking pool
-    /// and returns `Pending`). At that suspension point the OLD code had
-    /// already mutated live memory; the fixed code has not. `yield_now` then
-    /// wins the select and drops the future mid-write — exactly the
+    /// await (the `tokio::fs` disk op, which dispatches to the blocking
+    /// pool). At that suspension point the OLD code had already mutated
+    /// live memory; the fixed code has not. `yield_now` then wins the
+    /// select and drops the future mid-write — exactly the
     /// cancellation-before-rename window.
+    ///
+    /// One scheduling hazard remains: `tokio::fs` is `spawn_blocking`
+    /// underneath, so on a loaded machine the blocking thread can finish
+    /// the op BEFORE this task's first poll — persist then completes
+    /// without ever suspending and no cancellation happens. Such attempts
+    /// prove nothing (not a pass, not a failure), so the scenario retries
+    /// with fresh state until a genuine mid-write cancellation is observed,
+    /// bounded so a real change in suspension behaviour still fails loudly.
     #[tokio::test]
     async fn cancel_before_rename_leaves_memory_clean_and_retry_writes() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("crdt-subscriptions.json");
-        let manifest = Arc::new(RwLock::new(CrdtSubscriptionManifest::default()));
-        let lock = Arc::new(Mutex::new(()));
         let make_entry = || entry(KIND_KV_STORE, "cancel-store", ROLE_CREATED);
 
         // Drive persist_recorded until it suspends at its first disk await,
         // then cancel (drop) it — the cancellation-before-rename hole.
-        let cancelled = tokio::select! {
-            biased;
-            // Polled first: runs through the locks + in-memory stage and
-            // suspends at the blocking `tokio::fs` write.
-            res = persist_recorded(&manifest, &lock, &path, make_entry()) => {
-                // A genuine completion is not the scenario under test; assert
-                // it at least succeeded so the assertions below stay coherent.
-                assert!(res.is_ok(), "if persist completed it must succeed");
-                false
+        let mut observed = None;
+        for _ in 0..64 {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("crdt-subscriptions.json");
+            let manifest = Arc::new(RwLock::new(CrdtSubscriptionManifest::default()));
+            let lock = Arc::new(Mutex::new(()));
+            let cancelled = tokio::select! {
+                biased;
+                // Polled first: runs through the locks + in-memory stage and
+                // suspends at the blocking `tokio::fs` write.
+                res = persist_recorded(&manifest, &lock, &path, make_entry()) => {
+                    // A genuine completion is not the scenario under test;
+                    // assert it at least succeeded so the retry stays sound.
+                    assert!(res.is_ok(), "if persist completed it must succeed");
+                    false
+                }
+                _ = tokio::task::yield_now() => true,
+            };
+            if cancelled {
+                observed = Some((dir, path, manifest, lock));
+                break;
             }
-            _ = tokio::task::yield_now() => true,
+        }
+        let Some((dir, path, manifest, lock)) = observed else {
+            panic!(
+                "no attempt out of 64 was still suspended in its disk write \
+                 when cancelled — persist_recorded's first blocking await \
+                 has changed and this test no longer exercises the \
+                 cancellation-before-rename hole"
+            );
         };
-        assert!(
-            cancelled,
-            "persist_recorded must still be suspended in its disk write when \
-             cancelled; if it completed, the cancellation hole was not exercised"
-        );
 
         // After cancellation: live memory and disk must both be clean. The OLD
         // code left the entry in live memory here (mutated before the write).

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1139,7 +1139,23 @@ pub async fn serve_with_options(
         dm_inbox_kv_store_delta_route_tx,
     )));
 
+    // Restart-amnesia fix: re-register every persisted task-list/kv-store
+    // subscription via the same Agent create/join paths the REST handlers
+    // use, so the topic subscription + empty-replica state-request happen
+    // and offline mutations arrive from peers.
+    //
+    // Runs CONCURRENTLY with join_network (issue #238): rehydration needs
+    // only the local gossip runtime, which exists at Agent build time —
+    // subscriptions register locally and the per-CRDT state-request tail
+    // keeps re-requesting until peers appear, so nothing here depends on
+    // the mesh being formed. Sequencing rehydration AFTER join_network
+    // wedged the daemon's OWN stores (restored from local snapshots, no
+    // network needed) behind an unreachable bootstrap peer's full dial
+    // schedule (~70s of "store not found").
     let crdt_rehydrate_state = Arc::clone(&state);
+    bg_tasks.push(tokio::spawn(async move {
+        crdt_subscriptions::rehydrate(crdt_rehydrate_state).await;
+    }));
     bg_tasks.push(tokio::spawn(async move {
         match join_agent.join_network().await {
             Ok(()) => {
@@ -1156,13 +1172,6 @@ pub async fn serve_with_options(
                 tracing::error!("Failed to join network: {e}");
             }
         }
-        // Restart-amnesia fix: re-register every persisted task-list/kv-store
-        // subscription via the same Agent create/join paths the REST handlers
-        // use, so the topic subscription + empty-replica state-request happen
-        // and offline mutations arrive from peers. Runs on BOTH join arms:
-        // even when join_network errors, the local gossip runtime exists and
-        // the subscription is what lets state recover once peers appear.
-        crdt_subscriptions::rehydrate(crdt_rehydrate_state).await;
     }));
 
     let self_published_release_manifests =

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15954,7 +15954,7 @@ async fn create_kv_store(
                 // chatter until daemon shutdown.
                 tracing::error!("failed to persist kv store registration {id}: {e}");
                 if let Some(h) = state.kv_stores.write().await.remove(&id) {
-                    h.stop_sync().await;
+                    h.silence_bootstrap();
                 }
                 return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -16049,7 +16049,7 @@ async fn join_kv_store(
                 // chatter until daemon shutdown.
                 tracing::error!("failed to persist kv store join {id}: {e}");
                 if let Some(h) = state.kv_stores.write().await.remove(&id) {
-                    h.stop_sync().await;
+                    h.silence_bootstrap();
                 }
                 return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15954,7 +15954,7 @@ async fn create_kv_store(
                 // chatter until daemon shutdown.
                 tracing::error!("failed to persist kv store registration {id}: {e}");
                 if let Some(h) = state.kv_stores.write().await.remove(&id) {
-                    h.silence_bootstrap();
+                    h.cancel_sync();
                 }
                 return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -16049,7 +16049,7 @@ async fn join_kv_store(
                 // chatter until daemon shutdown.
                 tracing::error!("failed to persist kv store join {id}: {e}");
                 if let Some(h) = state.kv_stores.write().await.remove(&id) {
-                    h.silence_bootstrap();
+                    h.cancel_sync();
                 }
                 return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15948,9 +15948,14 @@ async fn create_kv_store(
             .await
             {
                 // Durable write failed: roll back the live handle so success is
-                // not acknowledged for an un-persisted registration.
+                // not acknowledged for an un-persisted registration, and STOP
+                // its sync — the discarded handle's bootstrap requester is
+                // infinite while unconverged (issue #238) and would otherwise
+                // chatter until daemon shutdown.
                 tracing::error!("failed to persist kv store registration {id}: {e}");
-                state.kv_stores.write().await.remove(&id);
+                if let Some(h) = state.kv_stores.write().await.remove(&id) {
+                    h.stop_sync().await;
+                }
                 return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("failed to persist subscription registration: {e}"),
@@ -16038,9 +16043,14 @@ async fn join_kv_store(
             .await
             {
                 // Durable write failed: roll back the live handle so success is
-                // not acknowledged for an un-persisted registration.
+                // not acknowledged for an un-persisted registration, and STOP
+                // its sync — the discarded handle's bootstrap requester is
+                // infinite while unconverged (issue #238) and would otherwise
+                // chatter until daemon shutdown.
                 tracing::error!("failed to persist kv store join {id}: {e}");
-                state.kv_stores.write().await.remove(&id);
+                if let Some(h) = state.kv_stores.write().await.remove(&id) {
+                    h.stop_sync().await;
+                }
                 return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("failed to persist subscription registration: {e}"),

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -316,7 +316,12 @@ pub(in crate::server) async fn create_task_list(
                     topic = %req.topic,
                     "failed to persist task-list subscription registration: {e}"
                 );
-                state.task_lists.write().await.remove(&id);
+                // Roll back AND stop the discarded handle's sync — its
+                // bootstrap requester is infinite while unconverged
+                // (issue #238) and would otherwise chatter until shutdown.
+                if let Some(h) = state.task_lists.write().await.remove(&id) {
+                    h.stop_sync().await;
+                }
                 return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "failed to persist subscription registration",

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -320,7 +320,7 @@ pub(in crate::server) async fn create_task_list(
                 // bootstrap requester is infinite while unconverged
                 // (issue #238) and would otherwise chatter until shutdown.
                 if let Some(h) = state.task_lists.write().await.remove(&id) {
-                    h.silence_bootstrap();
+                    h.cancel_sync();
                 }
                 return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/server/routes/tasks.rs
+++ b/src/server/routes/tasks.rs
@@ -320,7 +320,7 @@ pub(in crate::server) async fn create_task_list(
                 // bootstrap requester is infinite while unconverged
                 // (issue #238) and would otherwise chatter until shutdown.
                 if let Some(h) = state.task_lists.write().await.remove(&id) {
-                    h.stop_sync().await;
+                    h.silence_bootstrap();
                 }
                 return api_error(
                     StatusCode::INTERNAL_SERVER_ERROR,

--- a/tests/crdt_subscription_persistence.rs
+++ b/tests/crdt_subscription_persistence.rs
@@ -979,12 +979,16 @@ async fn joined_store_syncs_after_owner_returns_late() {
 
     // The owner returns. Bob's persistent tail must ask again (next request
     // ≤ the backoff ceiling away) and recover k1 — no re-join, no restart.
+    // Deadline covers the worst jittered envelope: a request missed during
+    // reconnection pushes recovery to the following tail attempt, and tail
+    // delays carry ±20% jitter (a 201s pass was observed against the old
+    // 240s bound — round-4 review).
     pair.alice.start().await;
     poll_until(
         &pair.bob,
         &format!("/stores/{store_topic}/k1"),
         "bob recovers k1 after the owner returns late (no re-join/restart)",
-        240,
+        360,
         |json| json["value"] == b64(b"offline-write"),
     )
     .await;

--- a/tests/crdt_subscription_persistence.rs
+++ b/tests/crdt_subscription_persistence.rs
@@ -825,3 +825,156 @@ async fn killed_named_peer_reconnects_on_new_port_via_proactive_path() {
     )
     .await;
 }
+
+/// WHY (issue #238 — rehydration wedge): rehydration must NOT wait for
+/// `join_network`'s bootstrap dial schedule. With bob's only bootstrap peer
+/// (alice) down, the old daemon sequenced `rehydrate()` AFTER the full ~70s
+/// dial schedule (3 rounds × 15s connect timeout + inter-round sleeps), so
+/// `GET /stores` stayed empty for 30s+ — including bob's OWN created store,
+/// which needs no network at all (it restores from the local snapshot).
+/// Rehydration now runs concurrently with join_network: both registrations
+/// must be listed — and the own store's key readable — within seconds of the
+/// API coming up, while alice is still down.
+#[tokio::test]
+#[ignore]
+async fn own_and_joined_stores_surface_while_bootstrap_peer_is_down() {
+    let mut pair = cluster::pair().await;
+    let suffix = rand::random::<u32>();
+    let own_topic = format!("wedge-own-{suffix}");
+    let joined_topic = format!("wedge-joined-{suffix}");
+
+    // Alice creates a store; bob joins it anchored on alice's owner id.
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "wedge-joined", "topic": joined_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates store");
+    let alice_id = pair.alice.agent_id().await;
+    let r = pair
+        .bob
+        .post(
+            &format!("/stores/{joined_topic}/join"),
+            serde_json::json!({ "expected_owner": alice_id }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob joins alice's store");
+
+    // Bob creates his OWN store and writes a key (snapshot on bob's disk).
+    let r = pair
+        .bob
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "wedge-own", "topic": own_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob creates own store");
+    let r = pair
+        .bob
+        .put(
+            &format!("/stores/{own_topic}/mykey"),
+            serde_json::json!({ "value": b64(b"mine") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob writes own key");
+
+    // Kill BOTH; restart bob only. His sole bootstrap peer (alice) is down,
+    // so join_network's dial schedule runs its full ~70s course — which must
+    // no longer gate rehydration.
+    pair.bob.stop();
+    pair.alice.stop();
+    pair.bob.start().await;
+
+    // Both stores surface long before the dial schedule could complete.
+    // 20s is generous for snapshot restore + subscribe, and far below the
+    // ~70s wedge this test regresses against.
+    poll_until(
+        &pair.bob,
+        "/stores",
+        "both stores listed with alice down",
+        20,
+        |json| {
+            json["stores"].as_array().is_some_and(|stores| {
+                let has = |t: &str| stores.iter().any(|s| s["topic"] == t || s["id"] == t);
+                has(&own_topic) && has(&joined_topic)
+            })
+        },
+    )
+    .await;
+
+    // Own-store content is local: readable without any peer.
+    poll_until(
+        &pair.bob,
+        &format!("/stores/{own_topic}/mykey"),
+        "own key readable from local snapshot with alice down",
+        10,
+        |json| json["value"] == b64(b"mine"),
+    )
+    .await;
+}
+
+/// WHY (issue #238 — zombie subscription): a joined store that rehydrates
+/// while its owner is offline must still converge when the owner returns
+/// AFTER the front-loaded state-request schedule (~51s) has exhausted.
+/// Before the fix, the requester fired its last request into the void and
+/// nothing ever asked again — the owner answers only reactively — so bob's
+/// replica stayed permanently empty (>300s observed) and even an explicit
+/// re-join (409) could not revive it; only another full restart did.
+#[tokio::test]
+#[ignore]
+async fn joined_store_syncs_after_owner_returns_late() {
+    let mut pair = cluster::pair().await;
+    let suffix = rand::random::<u32>();
+    let store_topic = format!("zombie-{suffix}");
+
+    // Alice creates the store (no keys yet); bob joins anchored on alice.
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "zombie-store", "topic": store_topic }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice creates store");
+    let alice_id = pair.alice.agent_id().await;
+    let r = pair
+        .bob
+        .post(
+            &format!("/stores/{store_topic}/join"),
+            serde_json::json!({ "expected_owner": alice_id }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob joins alice's store");
+
+    // Bob goes down; alice writes k1 while bob is offline; alice goes down.
+    pair.bob.stop();
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{store_topic}/k1"),
+            serde_json::json!({ "value": b64(b"offline-write") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice writes k1 while bob is down");
+    pair.alice.stop();
+
+    // Bob restarts with the owner offline and rehydrates an EMPTY replica;
+    // let the entire front-loaded request schedule (~51s) fire into the
+    // void — the window in which the old requester died permanently.
+    pair.bob.start().await;
+    tokio::time::sleep(Duration::from_secs(60)).await;
+
+    // The owner returns. Bob's persistent tail must ask again (next request
+    // ≤ the backoff ceiling away) and recover k1 — no re-join, no restart.
+    pair.alice.start().await;
+    poll_until(
+        &pair.bob,
+        &format!("/stores/{store_topic}/k1"),
+        "bob recovers k1 after the owner returns late (no re-join/restart)",
+        240,
+        |json| json["value"] == b64(b"offline-write"),
+    )
+    .await;
+}

--- a/tests/crdt_subscription_persistence.rs
+++ b/tests/crdt_subscription_persistence.rs
@@ -316,12 +316,23 @@ async fn concurrent_same_id_join_recreate_rehydrates_deterministically() {
         pair.bob.post(&join_path, join_body.clone()),
         pair.bob.post(&join_path, join_body.clone()),
     );
-    for (i, r) in [r0, r1, r2, r3].into_iter().enumerate() {
-        assert!(
-            r.status().is_success(),
-            "concurrent same-id join {i} succeeds"
-        );
-    }
+    // The per-(kind,id) reservation serialises the storm: exactly ONE join
+    // wins and installs the handle; every other request sees the handle
+    // present and gets 409 CONFLICT — same contract the sibling create test
+    // pins. (This assert originally required all four to succeed, which the
+    // 409 duplicate-join guard introduced in the same commit made
+    // impossible — the #[ignore] suite hid the contradiction.)
+    let statuses: Vec<_> = [r0, r1, r2, r3].into_iter().map(|r| r.status()).collect();
+    let winners = statuses.iter().filter(|s| s.is_success()).count();
+    let conflicts = statuses
+        .iter()
+        .filter(|s| **s == reqwest::StatusCode::CONFLICT)
+        .count();
+    assert_eq!(
+        (winners, conflicts),
+        (1, 3),
+        "exactly one concurrent join wins and the rest 409: {statuses:?}"
+    );
 
     // Determinism: exactly ONE kv_store entry for the topic survives in bob's
     // manifest, anchored on alice. A lost update would leave zero or many; a

--- a/tests/kv_first_join_bootstrap.rs
+++ b/tests/kv_first_join_bootstrap.rs
@@ -84,9 +84,11 @@ async fn first_time_late_joiner_bootstraps_historical_keys() {
     let pair = cluster::AgentPair { alice, bob };
 
     // The historical key must arrive via the state-sync bootstrap. The
-    // requester retries at 1/5/15/30s; allow the full schedule plus
+    // requester's front burst is 1/5/15/30s with ±20% jitter (issue #238:
+    // worst-case cumulative ~61s), and if the mesh forms slowly the first
+    // TAIL attempt lands at up to ~97s jittered — allow that envelope plus
     // propagation slack.
-    let deadline = Instant::now() + Duration::from_secs(60);
+    let deadline = Instant::now() + Duration::from_secs(150);
     loop {
         let r = pair.bob.get(&format!("/stores/{topic}/keys")).await;
         let body: serde_json::Value = r.json().await.expect("keys response is json");

--- a/tests/tasklist_first_join_bootstrap.rs
+++ b/tests/tasklist_first_join_bootstrap.rs
@@ -87,8 +87,11 @@ async fn first_time_late_joiner_bootstraps_historical_tasks() {
     assert!(r.status().is_success(), "bob subscribes to the task list");
 
     // The historical task must arrive via the state-sync bootstrap. The
-    // requester retries at 1/5/15/30s; allow the full schedule plus slack.
-    let deadline = Instant::now() + Duration::from_secs(60);
+    // requester's front burst is 1/5/15/30s with ±20% jitter (issue #238:
+    // worst-case cumulative ~61s), and if the mesh forms slowly the first
+    // TAIL attempt lands at up to ~97s jittered — allow that envelope plus
+    // propagation slack.
+    let deadline = Instant::now() + Duration::from_secs(150);
     loop {
         let titles = task_titles(&bob, &topic).await;
         if titles.iter().any(|t| t == "written-before-bob-existed") {


### PR DESCRIPTION
Fixes the three v0.33.0 restart-recovery defects found by the tracker-integrity-v2 two-daemon harness (#238), hardened through five Codex adversarial review rounds (findings converging 6 → 5 → 6 → 2 → 1 → 0-blocking) plus a three-reviewer parallel review (all SOUND).

## The three defects

1. **Rehydration wedge** — `crdt_subscriptions::rehydrate()` was sequenced after `join_network().await`, so an unreachable bootstrap peer's full dial schedule (~70s: 3 rounds × 15s connect timeout + inter-round sleeps) held ALL store rehydration hostage, including the daemon's own stores (which restore from local snapshots and need no network). **Fix:** rehydration runs in its own task, concurrent with join_network. *E2E: both stores listed <24s with the bootstrap peer down.*
2. **Zombie subscription** — the state-request bootstrap requester fired exactly 4 requests (t≈1,6,21,51s) then exited forever; holders answer only reactively, so a replica that rehydrated while the store owner was offline stayed permanently empty even after the owner returned (>300s observed; re-join 409'd without reviving). Task lists had the same defect past their 10-min hard cap. **Fix:** infinite front-burst + exponential-backoff tail (30s→300s cap, ±20% jitter), stopping only on served evidence. *E2E: the exact issue-repro sequence recovers ~25s after the owner returns.*
3. **Transient policy misreport** — a fresh joined replica hardcodes `signed` until an OwnerAnnounce or checkpoint-bearing delta arrives; with the dead schedule that window was unbounded. **Fix:** the announce rides the same now-unbounded recovery. *Module test asserts policy convergence.*

## Review-round hardening (each round's findings fixed and committed separately)

- **StateServed convergence evidence** (additive wire variant — v0.33.0 peers skip it): requesters stop only when a holder actually served them, matched against local state. Exact checkpoint-HWM gating where checkpoints exist (self-correlating: the HWM only rises by merging the delta that carried it); owner-verified emptiness; marker+non-emptiness as documented best-effort for checkpoint-less state. Emptiness and checkpoint evidence are trusted ONLY from the pub/sub-verified anchored owner (forged-marker poisoning neutralized).
- **Empty checkpointed owners serve deletion-to-empty**: the checkpoint-adopt merge path is a full replace, so the owner's checkpoint-bearing empty full delta removes a stale replica's obsolete keys (test proves stale-key removal + HWM adoption).
- **Response-storm damping**: ±20% request jitter + 15s per-holder full-response cooldown; markers only witness real broadcasts (no cooldown-suppression correlation hole).
- **Missed-delta bootstrap**: non-owner replicas always run the front burst — a snapshot-restored replica may have missed deltas offline, and emptiness cannot distinguish fresh-join from restored-but-stale.
- **Teardown correctness**: per-sync `CancellationToken` selected on by all three loops; `Drop` on both syncs cancels structurally; registration rollbacks call `cancel_sync()` (never the topic-wide `unsubscribe`, which would kill unrelated subscribers sharing the topic string); loops self-cancel the sync if their subscription dies; the pub/sub forwarding task exits promptly via `tx.closed()` on quiet topics (was an unbounded ghost-task leak).
- **Reservation-lock map pruning** (strong-count sweep under the write lock, race-free) and a repaired e2e test that had been broken since its introduction in 8fa7c15 (asserted all concurrent joins succeed while the same commit added the 409 duplicate-join guard — verified failing on v0.33.0 main).

## Documented accepted residuals (follow-up issue)

- Cross-topic loss window for checkpoint-less state (marker survives, full delta lost, replica already non-empty) — full fix needs a digest/frontier protocol.
- Deletion cold-sync for checkpoint-less deltas (full responses carry no tombstones).
- Genuinely-empty stores keep a ≤1-msg-per-5-min side-topic cadence until first write.

## Validation

- `just check` green (fmt, clippy `-D warnings`, build, 2,338 tests, doc) — full suite 2338/2338 on an idle machine.
- `just test-recovery-e2e` (new recipe): 8/8 real-daemon tests including both new #238 regressions.
- Pre-existing load-flaky tests observed during the program (pass in isolation, untouched by this branch, fail only under CPU contention): `proactive_reconnect_recovers_dropped_same_host_peer`, `proactive_reconnect_default_global_bootstrap_same_host`, `test_receive_message_with_timeout_context`. The similarly-flaky `cancel_before_rename_leaves_memory_clean_and_retry_writes` was root-caused (spawn_blocking races) and fixed here, including a real production cancellation leak (temp file created after guard cleanup).

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens CRDT restart recovery and subscription cleanup. The main changes are:

- Concurrent persisted-store rehydration and network joining.
- Infinite, jittered state-request retries with served-state evidence.
- Checkpoint-aware KV recovery and full-state response cooldowns.
- Structural cancellation for synchronization loops and pub/sub forwarding tasks.
- Reservation-based registration and cancellation-safe manifest persistence.

<h3>Confidence Score: 4/5</h3>

The KV recovery marker check needs a fix before merging.

- Non-empty recovery evidence is accepted from an arbitrary mesh sender.
- Existing stale data can then satisfy the convergence gate and stop all later requests.
- The cancellation, reservation, persistence, and forwarding-task changes have consistent ownership and serialization.

src/kv/sync.rs

<details open><summary><h3>Security Review</h3></summary>

KV recovery accepts non-empty served-state markers from any mesh peer. A peer can use such a marker to stop recovery when a restored replica already contains stale data.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/kv/sync.rs | Adds persistent recovery, served-state evidence, checkpoint convergence, response cooldowns, and structural cancellation; non-empty evidence lacks sender verification. |
| src/crdt/sync.rs | Adds persistent task-list recovery, served markers, response cooldowns, and cancellable background loops. |
| src/server/crdt_subscriptions.rs | Adds reservation-aware rehydration and cancellation-safe, stage-then-commit manifest persistence. |
| src/gossip/pubsub.rs | Ends forwarding tasks when their downstream subscription receiver is dropped. |
| src/server/mod.rs | Runs rehydration concurrently with network joining and rolls back failed registrations safely. |
| src/server/routes/tasks.rs | Serializes task-list registration with rehydration and cancels synchronization after persistence failure. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant R as Restored replica
    participant P as Mesh peer
    participant O as Store owner
    R->>R: Start with stale non-empty snapshot
    P->>R: "StateServed(empty=false, checkpoint=None)"
    R->>R: Record saw_nonempty
    R->>R: Treat existing data as converged
    R--xO: Stop sending StateRequest
    Note over R: Missing owner state remains unrecovered
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant R as Restored replica
    participant P as Mesh peer
    participant O as Store owner
    R->>R: Start with stale non-empty snapshot
    P->>R: "StateServed(empty=false, checkpoint=None)"
    R->>R: Record saw_nonempty
    R->>R: Treat existing data as converged
    R--xO: Stop sending StateRequest
    Note over R: Missing owner state remains unrecovered
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/kv/sync.rs:687-692
**Unauthenticated Marker Ends Recovery**

A restored non-owner can already contain stale, non-empty data when any mesh peer sends `StateServed` with `empty: false` and no checkpoint. This branch accepts that marker without owner verification, so `bootstrap_converged` treats the stale local data as sufficient and permanently stops requesting the missing state.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(recovery): #238 parallel-review — se..."](https://github.com/saorsa-labs/x0x/commit/2bd144a71fd670ff3c5d384ed0bcae293c3cfbc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44931861)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->