### PR TITLE
chore: close local code nits — NodeStatus comment, rendezvous test wiring, LWW tie-break docs

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -1736,7 +1736,12 @@ impl NetworkNode {
             total_connections: status.direct_connections + status.relayed_connections,
             active_connections: status.active_connections as u32,
             bytes_sent: status.relay_bytes_forwarded,
-            bytes_received: 0, // TODO: Track in future
+            // `ant_quic::NodeStatus` (ant-quic 0.27.33) exposes only
+            // `relay_bytes_forwarded` — bytes this node forwarded as a relay
+            // for other peers. There is no inbound/received byte counter on
+            // the status struct, so bytes_received stays zero until upstream
+            // adds one. Wiring a fake value here would silently misreport.
+            bytes_received: 0,
             peer_count: status.connected_peers,
         }
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1736,10 +1736,10 @@ impl NetworkNode {
             total_connections: status.direct_connections + status.relayed_connections,
             active_connections: status.active_connections as u32,
             bytes_sent: status.relay_bytes_forwarded,
-            // `ant_quic::NodeStatus` (ant-quic 0.27.33) exposes only
-            // `relay_bytes_forwarded` — bytes this node forwarded as a relay
-            // for other peers. There is no inbound/received byte counter on
-            // the status struct, so bytes_received stays zero until upstream
+            // `ant_quic::NodeStatus` (ant-quic 0.27.33) exposes no
+            // inbound byte counter — its only byte-related field is
+            // `relay_bytes_forwarded` (bytes this node forwarded as a relay
+            // for other peers). bytes_received stays zero until upstream
             // adds one. Wiring a fake value here would silently misreport.
             bytes_received: 0,
             peer_count: status.connected_peers,

--- a/tests/crdt_convergence_concurrent.rs
+++ b/tests/crdt_convergence_concurrent.rs
@@ -164,8 +164,15 @@ async fn test_concurrent_add_task() {
 /// Scenario: 3 agents try to claim the same task simultaneously.
 /// Expected: OR-Set semantics - all claims recorded, convergence resolves to single owner.
 ///
-/// TODO: Fix LWW-Register tie-breaking in saorsa-gossip-crdt-sync
-/// When timestamps are equal, need deterministic tie-breaking via AgentId comparison
+/// Still failing on the pinned saorsa-gossip-crdt-sync 0.5.67 (Cargo.toml).
+/// That crate's `LwwRegister::merge` resolves concurrent (vector-clock-
+/// incomparable) writes with a `hash_clock` tiebreaker — `DefaultHasher`
+/// over the sorted vector-clock entries, smaller hash wins — not the
+/// AgentId comparison this test expected. Confirmed failing when run
+/// with `cargo test -- --ignored` on 0.5.67. Un-ignoring needs an
+/// upstream change (AgentId-based deterministic tiebreak, or a
+/// documented earliest/latest-wins resolver this test is aligned with)
+/// plus a test-expectation review.
 #[ignore = "Flaky: needs LWW tie-breaking fix in saorsa-gossip"]
 #[tokio::test]
 async fn test_concurrent_claim_same_task() {
@@ -307,8 +314,15 @@ async fn test_same_task_claim_conflict_different_timestamps_converges() {
 /// Scenario: 5 agents update task title concurrently.
 /// Expected: LWW-Register semantics - latest timestamp wins.
 ///
-/// TODO: Fix LWW-Register tie-breaking in saorsa-gossip-crdt-sync
-/// When timestamps are equal, need deterministic tie-breaking via AgentId comparison
+/// Still failing on the pinned saorsa-gossip-crdt-sync 0.5.67 (Cargo.toml).
+/// That crate's `LwwRegister::merge` resolves concurrent (vector-clock-
+/// incomparable) writes with a `hash_clock` tiebreaker — `DefaultHasher`
+/// over the sorted vector-clock entries, smaller hash wins — not the
+/// AgentId comparison this test expected. Confirmed failing when run
+/// with `cargo test -- --ignored` on 0.5.67. Un-ignoring needs an
+/// upstream change (AgentId-based deterministic tiebreak, or a
+/// documented earliest/latest-wins resolver this test is aligned with)
+/// plus a test-expectation review.
 #[ignore = "Flaky: needs LWW tie-breaking fix in saorsa-gossip"]
 #[tokio::test]
 async fn test_concurrent_metadata_updates() {

--- a/tests/crdt_convergence_concurrent.rs
+++ b/tests/crdt_convergence_concurrent.rs
@@ -167,12 +167,12 @@ async fn test_concurrent_add_task() {
 /// Still failing on the pinned saorsa-gossip-crdt-sync 0.5.67 (Cargo.toml).
 /// That crate's `LwwRegister::merge` resolves concurrent (vector-clock-
 /// incomparable) writes with a `hash_clock` tiebreaker — `DefaultHasher`
-/// over the sorted vector-clock entries, smaller hash wins — not the
-/// AgentId comparison this test expected. Confirmed failing when run
-/// with `cargo test -- --ignored` on 0.5.67. Un-ignoring needs an
-/// upstream change (AgentId-based deterministic tiebreak, or a
-/// documented earliest/latest-wins resolver this test is aligned with)
-/// plus a test-expectation review.
+/// over the sorted vector-clock entries, smaller hash wins — ignoring
+/// wall-clock timestamps entirely, so this test's latest-timestamp-wins
+/// expectation cannot hold for concurrent writes. Confirmed failing when
+/// run with `cargo test -- --ignored` on 0.5.67. Un-ignoring needs an
+/// upstream change (deterministic tiebreak aligned with the test's
+/// documented expectation) plus a test-expectation review.
 #[ignore = "Flaky: needs LWW tie-breaking fix in saorsa-gossip"]
 #[tokio::test]
 async fn test_concurrent_claim_same_task() {
@@ -317,12 +317,12 @@ async fn test_same_task_claim_conflict_different_timestamps_converges() {
 /// Still failing on the pinned saorsa-gossip-crdt-sync 0.5.67 (Cargo.toml).
 /// That crate's `LwwRegister::merge` resolves concurrent (vector-clock-
 /// incomparable) writes with a `hash_clock` tiebreaker — `DefaultHasher`
-/// over the sorted vector-clock entries, smaller hash wins — not the
-/// AgentId comparison this test expected. Confirmed failing when run
-/// with `cargo test -- --ignored` on 0.5.67. Un-ignoring needs an
-/// upstream change (AgentId-based deterministic tiebreak, or a
-/// documented earliest/latest-wins resolver this test is aligned with)
-/// plus a test-expectation review.
+/// over the sorted vector-clock entries, smaller hash wins — ignoring
+/// wall-clock timestamps entirely, so this test's latest-timestamp-wins
+/// expectation cannot hold for concurrent writes. Confirmed failing when
+/// run with `cargo test -- --ignored` on 0.5.67. Un-ignoring needs an
+/// upstream change (deterministic tiebreak aligned with the test's
+/// documented expectation) plus a test-expectation review.
 #[ignore = "Flaky: needs LWW tie-breaking fix in saorsa-gossip"]
 #[tokio::test]
 async fn test_concurrent_metadata_updates() {

--- a/tests/rendezvous_integration.rs
+++ b/tests/rendezvous_integration.rs
@@ -149,43 +149,105 @@ async fn test_agent_registers_to_shard() -> TestResult {
     agent.join_network().await?;
     sleep(Duration::from_secs(5)).await;
 
-    // TODO: Verify agent registered to correct shard coordinator
-    // let shard_id = compute_shard_id(&agent.agent_id());
-    // let coordinator = agent.get_shard_coordinator(shard_id).await?;
-    // assert!(coordinator.has_agent(&agent.agent_id()));
+    // No x0x API exposes "which shard coordinator holds my registration".
+    // `Agent::get_shard_coordinator` / `coordinator.has_agent` do not exist:
+    // rendezvous in x0x is publish-only. The agent pushes a signed
+    // `ProviderSummary` to its shard topic via `advertise_identity`; seekers
+    // consume it via `find_agent` / `find_agent_rendezvous` (see
+    // `test_agent_lookup_via_shard`). Successful `join_network` plus the
+    // settle window above is the strongest registration signal x0x surfaces.
     Ok(())
 }
 
 /// Test 4: Agent lookup via shard query
 #[tokio::test]
 #[ignore = "requires Phase 1.3 and VPS testnet"]
-async fn test_agent_lookup_via_shard() {
-    // TODO: Create 2 agents
-    // TODO: Agent A queries shard for Agent B
-    // Expected: Query returns Agent B's network address
-    // Expected: Query latency < 1 second
+async fn test_agent_lookup_via_shard() -> TestResult {
+    // Advertiser joins the mesh and publishes a rendezvous `ProviderSummary`
+    // to its shard topic; the seeker subscribes to that shard topic via
+    // `find_agent_rendezvous` and expects to observe the advertiser's
+    // ProviderSummary-encoded addresses within the lookup window.
+    let bootstrap_addrs: Vec<_> = VPS_NODES.iter().filter_map(|s| s.parse().ok()).collect();
+
+    let advertiser_dir = TempDir::new()?;
+    let advertiser = Agent::builder()
+        .with_machine_key(advertiser_dir.path().join("machine.key"))
+        .with_network_config(NetworkConfig {
+            bind_addr: Some("0.0.0.0:0".parse()?),
+            bootstrap_nodes: bootstrap_addrs.clone(),
+            ..Default::default()
+        })
+        .build()
+        .await?;
+    advertiser.join_network().await?;
+
+    let seeker_dir = TempDir::new()?;
+    let seeker = Agent::builder()
+        .with_machine_key(seeker_dir.path().join("machine.key"))
+        .with_network_config(NetworkConfig {
+            bind_addr: Some("0.0.0.0:0".parse()?),
+            bootstrap_nodes: bootstrap_addrs,
+            ..Default::default()
+        })
+        .build()
+        .await?;
+    seeker.join_network().await?;
+
+    // Let both agents settle on the mesh before the lookup.
+    sleep(Duration::from_secs(3)).await;
+
+    let target = advertiser.agent_id();
+    // Run the seeker's shard lookup concurrently with a fresh re-publish by
+    // the advertiser so the subscriber catches a ProviderSummary even if the
+    // first advertisement raced ahead of the subscription. 24h validity
+    // matches the daemon's rendezvous re-advertise cadence.
+    let lookup = tokio::time::timeout(
+        Duration::from_secs(15),
+        seeker.find_agent_rendezvous(target, 10),
+    );
+    let republish = async {
+        for _ in 0..4 {
+            let _ = advertiser.advertise_identity(86_400_000).await;
+            sleep(Duration::from_secs(2)).await;
+        }
+    };
+    let (lookup_outcome, _) = tokio::join!(lookup, republish);
+    let found = lookup_outcome
+        .expect("seeker find_agent_rendezvous did not return within 15s")?;
+    assert!(
+        found.is_some(),
+        "find_agent_rendezvous should return the advertiser's addresses from its shard topic"
+    );
+    Ok(())
 }
 
 /// Test 5: Coordinator advert propagation
 #[tokio::test]
 #[ignore = "requires Phase 1.3 and VPS testnet"]
 async fn test_coordinator_advert_propagation() {
-    // TODO: VPS nodes should advertise as coordinators
-    // TODO: Verify ML-DSA signed adverts propagate globally
-    // Expected: All 6 VPS nodes advertise as coordinators
-    // Expected: Adverts have 24h TTL
-    // Expected: Adverts propagate within 10 seconds
+    // Not wired in x0x. The daemon never publishes the ML-DSA-signed
+    // `saorsa_gossip_coordinator::CoordinatorAdvert` (0.5.67): that type
+    // exists in the dependency and `GossipCacheAdapter` consumes it on
+    // ingest, but no x0x code path produces or broadcasts one. The only
+    // signed adverts x0x emits are `CapabilityAdvert` (DM caps,
+    // `x0x/caps/v1`; 5-min republish / 15-min cache TTL) and the rendezvous
+    // `ProviderSummary`. The "24h-TTL coordinator advert with 10s global
+    // propagation" this test described is a feature the application does
+    // not exercise.
 }
 
 /// Test 6: Coordinator failover
 #[tokio::test]
 #[ignore = "requires Phase 1.3 and VPS testnet with coordinator shutdown"]
 async fn test_coordinator_failover() {
-    // TODO: Identify primary coordinator for a shard
-    // TODO: Simulate coordinator going offline
-    // TODO: Verify backup coordinator takes over
-    // Expected: Failover within 30 seconds
-    // Expected: No data loss during failover
+    // No failover API exists. Neither x0x nor saorsa-gossip-coordinator
+    // 0.5.67 exposes a primary/backup coordinator role, leader election, or
+    // takeover hook for a shard: `CoordinatorAdvert` is a capability
+    // advertisement with a validity window, and
+    // `GossipCacheAdapter::select_coordinators` ranks candidates by score
+    // but does not elect or fail over. The "identify primary, kill it,
+    // verify backup takes over within 30s" flow this test described would
+    // require a coordination/election layer that is absent upstream.
 }
 
 /// Test 7: Shard load balancing
@@ -231,10 +293,55 @@ fn test_shard_load_balancing() -> TestResult {
 /// Test 8: Concurrent shard queries
 #[tokio::test]
 #[ignore = "requires Phase 1.3 and VPS testnet"]
-async fn test_concurrent_shard_queries() {
-    // TODO: Launch 100 concurrent shard queries
-    // TODO: Verify all queries succeed
-    // Expected: No query timeouts
-    // Expected: Mean latency < 500ms
-    // Expected: p99 latency < 2s
+async fn test_concurrent_shard_queries() -> TestResult {
+    // Fire 100 concurrent lookups via the real `find_agent` API and verify
+    // the query path stays responsive under fan-out: every query completes
+    // within its budget, none hang or error. Targets are deterministic agent
+    // ids; on a live testnet some may resolve and some may not, so success
+    // here is "every query returns an Ok outcome within the per-query
+    // budget", not "every query finds an agent". (The mean/p99 latency
+    // bounds originally listed assumed a warm, populated testnet and cannot
+    // be asserted without 100 known-live advertisers, so they are replaced
+    // by the honest completion/no-hang assertion.)
+    let bootstrap_addrs: Vec<_> = VPS_NODES.iter().filter_map(|s| s.parse().ok()).collect();
+    let seeker_dir = TempDir::new()?;
+    let seeker = Agent::builder()
+        .with_machine_key(seeker_dir.path().join("machine.key"))
+        .with_network_config(NetworkConfig {
+            bind_addr: Some("0.0.0.0:0".parse()?),
+            bootstrap_nodes: bootstrap_addrs,
+            ..Default::default()
+        })
+        .build()
+        .await?;
+    seeker.join_network().await?;
+    // Settle before fanning out so the gossip runtime is ready.
+    sleep(Duration::from_secs(3)).await;
+
+    const QUERY_COUNT: usize = 100;
+    // find_agent's internal budget is ~10s (5s shard + 5s rendezvous); add margin.
+    const PER_QUERY_BUDGET: Duration = Duration::from_secs(15);
+    let seeker = std::sync::Arc::new(seeker);
+
+    let mut handles = Vec::with_capacity(QUERY_COUNT);
+    for seed in 0..QUERY_COUNT as u32 {
+        let seeker = std::sync::Arc::clone(&seeker);
+        handles.push(tokio::spawn(async move {
+            tokio::time::timeout(
+                PER_QUERY_BUDGET,
+                seeker.find_agent(deterministic_agent_id(seed)),
+            )
+            .await
+        }));
+    }
+
+    for handle in handles {
+        let outcome = handle.await.expect("query task must join");
+        let resolved = outcome.expect("query exceeded per-query budget; query path hung under fan-out");
+        // find_agent returns Result<Option<Vec<SocketAddr>>, x0x::Error>; propagate any
+        // error as a test failure. Ok(None) is acceptable (target not present
+        // on the testnet) — only the no-hang + no-error contract is asserted.
+        let _ = resolved?;
+    }
+    Ok(())
 }

--- a/tests/rendezvous_integration.rs
+++ b/tests/rendezvous_integration.rs
@@ -212,8 +212,7 @@ async fn test_agent_lookup_via_shard() -> TestResult {
         }
     };
     let (lookup_outcome, _) = tokio::join!(lookup, republish);
-    let found = lookup_outcome
-        .expect("seeker find_agent_rendezvous did not return within 15s")?;
+    let found = lookup_outcome.expect("seeker find_agent_rendezvous did not return within 15s")?;
     assert!(
         found.is_some(),
         "find_agent_rendezvous should return the advertiser's addresses from its shard topic"
@@ -337,7 +336,8 @@ async fn test_concurrent_shard_queries() -> TestResult {
 
     for handle in handles {
         let outcome = handle.await.expect("query task must join");
-        let resolved = outcome.expect("query exceeded per-query budget; query path hung under fan-out");
+        let resolved =
+            outcome.expect("query exceeded per-query budget; query path hung under fan-out");
         // find_agent returns Result<Option<Vec<SocketAddr>>, x0x::Error>; propagate any
         // error as a test failure. Ok(None) is acceptable (target not present
         // on the testnet) — only the no-hang + no-error contract is asserted.


### PR DESCRIPTION
Three small honest-resolution items (no TODO markers left behind):

- **network.rs**: bytes_received TODO replaced with an accurate comment — ant-quic 0.27.33 NodeStatus has no inbound byte counter (only relay_bytes_forwarded); no fake plumbing wired.
- **rendezvous_integration.rs**: two shard-lookup tests implemented against the REAL Agent::advertise_identity / find_agent_rendezvous APIs (kept #[ignore]d behind the VPS testnet gate); three TODO blocks condensed to comments naming the missing upstream features (CoordinatorAdvert publish, coordinator failover/election).
- **crdt_convergence_concurrent.rs**: LWW tie-break TODOs replaced with precise comments — saorsa-gossip-crdt-sync 0.5.67's LwwRegister::merge uses a hash_clock tiebreaker (DefaultHasher over sorted vector clocks), ignoring wall-clock timestamps, so the tests' latest-timestamp-wins expectation cannot hold; both stay #[ignore]d pending an upstream resolver change.

Gates: fmt/clippy/check clean. Adversarial review: SOUND (comment accuracy verified against dependency sources, two wording nits fixed in the follow-up commit).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves several local TODOs with accurate documentation and real integration-test wiring. The main changes are:

- Documents why inbound byte statistics remain unavailable.
- Explains the current LWW concurrent-write tie-break behavior.
- Adds ignored rendezvous lookup and concurrent-query tests.
- Documents unsupported coordinator advertisement and failover flows.

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after a small cleanup to its test diagnostics.

- Production behavior is unchanged.
- The new tests remain explicitly gated behind the VPS testnet requirement.
- The rendezvous lookup test can mask publication errors as discovery failures.

tests/rendezvous_integration.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Clarifies why the current NodeStatus API cannot populate inbound byte statistics without changing runtime behavior. |
| tests/crdt_convergence_concurrent.rs | Documents the dependency's current concurrent LWW tie-break behavior for two ignored tests. |
| tests/rendezvous_integration.rs | Adds real ignored-test coverage and coordinator limitations, but the lookup test discards advertisement errors. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/rendezvous_integration.rs:210
**Publish Errors Become Lookup Failures**

When the advertiser cannot publish, such as after joining without a usable peer, every error is discarded and the seeker eventually reports `Ok(None)`. The test then fails with a misleading discovery assertion instead of the publication error that caused it.

```suggestion
            advertiser.advertise_identity(86_400_000).await?;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style: cargo fmt"](https://github.com/saorsa-labs/x0x/commit/f88e3eae4e74c6737fbe141429b0940cc0b4067b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45223212)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->