### PR TITLE
fix(server): #188 — retryable status + idempotent join for cmd-DM group join

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -230,6 +230,15 @@ pub enum DmError {
     #[error("recipient key material unavailable: {0}")]
     RecipientKeyUnavailable(String),
 
+    /// The locally cached capability advert / contact card carries a KEM
+    /// public key that does not decode under the active KEM variant — the
+    /// sender's view of the recipient has not converged (or is corrupt).
+    /// Transient: a fresh advert/contact sync replaces the entry, so callers
+    /// should retry rather than treat this as a malformed request (issue
+    /// #188 — this used to surface as an opaque `envelope_construction` 400).
+    #[error("recipient key material invalid: {0}")]
+    RecipientKeyInvalid(String),
+
     /// No application-layer ACK received within the retry budget. The DM
     /// MAY or may not have been delivered; the sender cannot distinguish.
     /// Safe to retry (recipient dedupes on `request_id`).
@@ -726,6 +735,20 @@ fn build_aead_aad(
     aad
 }
 
+/// Validate that cached recipient KEM public-key bytes decode under the
+/// active [`KEM_VARIANT`].
+///
+/// Senders call this before committing to the gossip-inbox path so a
+/// stale/corrupt capability entry surfaces as the retryable
+/// [`DmError::RecipientKeyInvalid`] instead of an opaque
+/// [`DmError::EnvelopeConstruction`] deep inside envelope building (issue
+/// #188). Cheap: a length/format check only, no crypto.
+pub fn validate_recipient_kem_key(recipient_kem_pubkey_bytes: &[u8]) -> std::result::Result<(), String> {
+    MlKemPublicKey::from_bytes(KEM_VARIANT, recipient_kem_pubkey_bytes)
+        .map(|_| ())
+        .map_err(|e| format!("recipient KEM pubkey decode: {e}"))
+}
+
 /// Encrypt an inner `DmPlaintext` into a `DmPayload` using the recipient's
 /// ML-KEM-768 public key.
 pub fn encrypt_payload(
@@ -915,9 +938,10 @@ impl EnvelopeBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`DmError::EnvelopeConstruction`] if KEM encapsulation,
-    /// AEAD encryption, signing-bytes serialisation, or the `sign`
-    /// closure fail.
+    /// Returns [`DmError::PayloadTooLarge`] if `payload` exceeds
+    /// [`MAX_PAYLOAD_BYTES`], or [`DmError::EnvelopeConstruction`] if KEM
+    /// encapsulation, AEAD encryption, signing-bytes serialisation, or the
+    /// `sign` closure fail.
     #[allow(clippy::too_many_arguments)]
     pub fn build_payload_envelope<F>(
         request_id: [u8; 16],
@@ -933,6 +957,16 @@ impl EnvelopeBuilder {
     where
         F: FnOnce(&[u8]) -> std::result::Result<Vec<u8>, String>,
     {
+        // Classify the size cap with its dedicated variant so API layers can
+        // answer 413 instead of the opaque `envelope_construction` 400
+        // (issue #188). Covers the relay-fallback path, which has no earlier
+        // size gate.
+        if payload.len() > MAX_PAYLOAD_BYTES {
+            return Err(DmError::PayloadTooLarge {
+                len: payload.len(),
+                max: MAX_PAYLOAD_BYTES,
+            });
+        }
         let body = Self::build_payload_body(
             &request_id,
             self_agent_id.as_bytes(),
@@ -1137,6 +1171,44 @@ mod tests {
         cache.insert(k, DmAckOutcome::Accepted);
         std::thread::sleep(Duration::from_millis(100));
         assert!(cache.lookup(&k).is_none());
+    }
+
+    #[test]
+    fn build_payload_envelope_oversized_payload_is_payload_too_large() {
+        // Issue #188: the size cap must be classified with its dedicated
+        // variant (API answers 413), never `EnvelopeConstruction` (400).
+        // Covers the relay-fallback path, which has no earlier size gate.
+        let result = EnvelopeBuilder::build_payload_envelope(
+            [1u8; 16],
+            &AgentId([1u8; 32]),
+            &MachineId([2u8; 32]),
+            &AgentId([3u8; 32]),
+            // KEM key deliberately empty — the size check must fire first.
+            &[],
+            0,
+            0,
+            vec![0u8; MAX_PAYLOAD_BYTES + 1],
+            |bytes| Ok(bytes.to_vec()),
+        );
+        assert!(
+            matches!(
+                result,
+                Err(DmError::PayloadTooLarge { len, max })
+                    if len == MAX_PAYLOAD_BYTES + 1 && max == MAX_PAYLOAD_BYTES
+            ),
+            "oversized payload must be PayloadTooLarge, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn validate_recipient_kem_key_rejects_garbage_accepts_real_key() {
+        // Issue #188: empty / wrong-length cached keys are the transient
+        // not-converged case the sender must classify as retryable
+        // `RecipientKeyInvalid`, not `EnvelopeConstruction`.
+        assert!(validate_recipient_kem_key(&[]).is_err());
+        assert!(validate_recipient_kem_key(&[0xAAu8; 32]).is_err());
+        let keypair = AgentKemKeypair::generate().expect("kem keypair");
+        assert!(validate_recipient_kem_key(&keypair.public_bytes).is_ok());
     }
 
     #[test]

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -743,7 +743,9 @@ fn build_aead_aad(
 /// [`DmError::RecipientKeyInvalid`] instead of an opaque
 /// [`DmError::EnvelopeConstruction`] deep inside envelope building (issue
 /// #188). Cheap: a length/format check only, no crypto.
-pub fn validate_recipient_kem_key(recipient_kem_pubkey_bytes: &[u8]) -> std::result::Result<(), String> {
+pub fn validate_recipient_kem_key(
+    recipient_kem_pubkey_bytes: &[u8],
+) -> std::result::Result<(), String> {
     MlKemPublicKey::from_bytes(KEM_VARIANT, recipient_kem_pubkey_bytes)
         .map(|_| ())
         .map_err(|e| format!("recipient KEM pubkey decode: {e}"))

--- a/src/dm_send.rs
+++ b/src/dm_send.rs
@@ -70,11 +70,13 @@ pub async fn send_via_gossip(
         inflight,
     } = ctx;
     if payload.len() > MAX_PAYLOAD_BYTES {
-        return Err(DmError::EnvelopeConstruction(format!(
-            "payload exceeds MAX_PAYLOAD_BYTES ({} > {})",
-            payload.len(),
-            MAX_PAYLOAD_BYTES
-        )));
+        // 413-class rejection, not `EnvelopeConstruction`: the API layer must
+        // be able to distinguish an oversized payload from a crypto/build
+        // failure (issue #188).
+        return Err(DmError::PayloadTooLarge {
+            len: payload.len(),
+            max: MAX_PAYLOAD_BYTES,
+        });
     }
     if recipient_kem_public_key.is_empty() {
         return Err(DmError::RecipientKeyUnavailable(

--- a/src/groups/invite.rs
+++ b/src/groups/invite.rs
@@ -22,11 +22,11 @@ pub const DEFAULT_EXPIRY_SECS: u64 = 7 * 24 * 60 * 60;
 ///
 /// The gossip-inbox DM path caps user payloads at
 /// [`crate::dm::MAX_PAYLOAD_BYTES`] (49 152). Invite links travel as the bulk
-/// of the `group_join` cmd-DM, so a link near that cap guarantees the DM is
-/// rejected at the sender with `envelope_construction` (issue #188). 40 KiB
-/// leaves room for the cmd-DM envelope wrapper while flagging roster growth at
-/// the mint site instead of as a mysterious cross-node 400. See issues #188 /
-/// #205.
+/// of the `group_join` cmd-DM, so a link near that cap used to be rejected at
+/// the sender with an opaque `envelope_construction` 400 (issue #188; now a
+/// truthful `payload_too_large` 413). 40 KiB leaves room for the cmd-DM
+/// envelope wrapper while flagging roster growth at the mint site instead of
+/// as a mysterious cross-node rejection. See issues #188 / #205.
 pub const INVITE_LINK_MAX_BYTES: usize = 40 * 1024;
 
 /// A signed invite token for joining a group.
@@ -99,8 +99,9 @@ pub struct SignedInvite {
 /// Error returned when an encoded invite link exceeds the safe DM budget.
 ///
 /// Carries the measured and limit sizes so callers can surface a structured
-/// error at the mint site (issue #205) instead of letting the link 400 later
-/// at `/direct/send` with an opaque `envelope_construction`.
+/// error at the mint site (issue #205) instead of letting the link fail later
+/// at `/direct/send` with `payload_too_large` (issue #188 — formerly an
+/// opaque `envelope_construction` 400).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InviteLinkTooLarge {
     /// Measured encoded link length in bytes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4188,6 +4188,20 @@ impl Agent {
             });
         }
 
+        // Issue #188: a non-empty but undecodable cached KEM key means our
+        // view of the recipient's capability state has not converged (or is
+        // corrupt). Fail with a retryable, distinctly-named error here rather
+        // than letting envelope construction surface it downstream as an
+        // opaque 400-class `EnvelopeConstruction`.
+        if gossip_ok {
+            if let Some(caps) = &cap {
+                if let Err(reason) = dm::validate_recipient_kem_key(&caps.kem_public_key) {
+                    self.direct_messaging.record_outgoing_failed(*to);
+                    return Err(dm::DmError::RecipientKeyInvalid(reason));
+                }
+            }
+        }
+
         let mut preferred_raw_err = None;
         let prefer_newest_grace = std::time::Duration::from_millis(config.prefer_newest_grace_ms);
         let preferred_raw_receipt = if config.prefer_raw_quic_if_connected && !config.require_gossip

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10891,7 +10891,8 @@ async fn create_group_invite(
 
         // Issue #205: enforce the DM-safe budget at mint so a roster that
         // would blow the gossip-DM cap fails loudly here, not as an opaque
-        // `envelope_construction` 400 at /direct/send later (issue #188).
+        // `envelope_construction` rejection at /direct/send later (issue
+        // #188; that path now reports `payload_too_large` 413).
         let link = match invite.encode_link() {
             Ok(link) => link,
             Err(e) => {
@@ -11064,7 +11065,30 @@ async fn join_group_via_invite(
                 .values()
                 .any(|info| info.mls_group_id == group_id_hex)
         {
-            return api_error(StatusCode::CONFLICT, "group already joined");
+            // Issue #188: a duplicate/replayed join (retried cmd-DM,
+            // redelivered invite) for a group this node already joined — or
+            // is mid-join on, since the local stub lands in `named_groups`
+            // before TreeKEM convergence completes — is an idempotent
+            // success, not an error. No state is mutated and no MemberJoined
+            // is re-published; the membership lock above serializes the
+            // first-join/replay race.
+            let info = groups.get(&group_id_hex).or_else(|| {
+                groups
+                    .values()
+                    .find(|info| info.mls_group_id == group_id_hex)
+            });
+            if let Some(info) = info {
+                return (
+                    StatusCode::OK,
+                    Json(serde_json::json!({
+                        "ok": true,
+                        "already_joined": true,
+                        "group_id": group_id_hex,
+                        "group_name": info.name,
+                        "chat_topic": info.general_chat_topic(),
+                    })),
+                );
+            }
         }
     }
     let inviter = match parse_agent_id_hex(&invite.inviter) {
@@ -16745,6 +16769,12 @@ async fn direct_send(
                 x0x::dm::DmError::RecipientKeyUnavailable(_) => {
                     (StatusCode::NOT_FOUND, "recipient_key_unavailable")
                 }
+                // Issue #188: the cached capability advert / contact card is
+                // not converged (or corrupt) — transient, safe to retry. 409,
+                // NOT 400: the request itself was well-formed.
+                x0x::dm::DmError::RecipientKeyInvalid(_) => {
+                    (StatusCode::CONFLICT, "recipient_key_invalid")
+                }
                 x0x::dm::DmError::Timeout { .. } => (StatusCode::GATEWAY_TIMEOUT, "timeout"),
                 x0x::dm::DmError::PeerLikelyOffline { .. } => {
                     (StatusCode::BAD_GATEWAY, "peer_likely_offline")
@@ -16758,8 +16788,11 @@ async fn direct_send(
                 x0x::dm::DmError::LocalGossipUnavailable(_) => {
                     (StatusCode::SERVICE_UNAVAILABLE, "local_gossip_unavailable")
                 }
+                // Local envelope build/crypto failure (signing, AEAD, KEM
+                // encap, serialization). A well-formed client request cannot
+                // cause this — it is a server fault, never a 400 (issue #188).
                 x0x::dm::DmError::EnvelopeConstruction(_) => {
-                    (StatusCode::BAD_REQUEST, "envelope_construction")
+                    (StatusCode::INTERNAL_SERVER_ERROR, "envelope_construction")
                 }
                 x0x::dm::DmError::PayloadTooLarge { .. } => {
                     (StatusCode::PAYLOAD_TOO_LARGE, "payload_too_large")
@@ -27114,11 +27147,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn second_join_group_via_invite_for_present_group_returns_conflict_preserving_state(
+    async fn second_join_group_via_invite_for_present_group_returns_ok_idempotent_preserving_state(
     ) -> Result<()> {
-        // Codex blocker 2: a second join_group_via_invite for an already-present
-        // group must short-circuit with CONFLICT before mutating any GroupInfo or
-        // TreeKEM state.
+        // Issue #188: a duplicate/replayed join cmd (retried cmd-DM,
+        // redelivered invite) for an already-present group is an idempotent
+        // 200 no-op — it must not mutate GroupInfo / TreeKEM state and must
+        // not re-publish the MemberJoined event. Previously this returned
+        // 409, which the dogfood runner surfaced as a join failure.
         let fixture = member_joined_treekem_fixture(0xd1, 0xd2).await?;
         let state = Arc::clone(&fixture.state);
         let (pre_hash, pre_epoch) = {
@@ -27129,13 +27164,17 @@ mod tests {
         };
         let invite = x0x::groups::invite::SignedInvite::new(
             fixture.group_id.clone(),
-            "conflict-guard".to_string(),
+            "idempotent-replay".to_string(),
             &state.agent.agent_id(),
             3600,
         );
         let invite_link = invite
             .encode_link()
             .expect("minimal invite encodes under budget");
+        NAMED_GROUP_METADATA_PUBLISH_ATTEMPTS_FOR_TEST
+            .lock()
+            .expect("publish-attempt recorder poisoned")
+            .clear();
         let response = join_group_via_invite(
             State(Arc::clone(&state)),
             Json(JoinGroupRequest {
@@ -27148,8 +27187,25 @@ mod tests {
         let (status, body) = response_json(response).await?;
         assert_eq!(
             status,
-            StatusCode::CONFLICT,
-            "second join for present group returns CONFLICT, body: {body}"
+            StatusCode::OK,
+            "duplicate join for present group is an idempotent 200, body: {body}"
+        );
+        assert_eq!(body["ok"], true);
+        assert_eq!(
+            body["already_joined"], true,
+            "duplicate join is flagged as an idempotent no-op, body: {body}"
+        );
+        assert_eq!(body["group_id"], fixture.group_id);
+        assert!(
+            body["chat_topic"].as_str().is_some_and(|t| !t.is_empty()),
+            "idempotent response keeps the success shape, body: {body}"
+        );
+        assert!(
+            NAMED_GROUP_METADATA_PUBLISH_ATTEMPTS_FOR_TEST
+                .lock()
+                .expect("publish-attempt recorder poisoned")
+                .is_empty(),
+            "duplicate join must not re-publish MemberJoined"
         );
         let (post_hash, post_epoch) = {
             let groups = state.named_groups.read().await;
@@ -27159,6 +27215,129 @@ mod tests {
         };
         assert_eq!(post_hash, pre_hash, "GroupInfo state hash preserved");
         assert_eq!(post_epoch, pre_epoch, "TreeKEM epoch preserved");
+        Ok(())
+    }
+
+    fn direct_send_test_request(agent_id: String, payload: String) -> DirectSendRequest {
+        DirectSendRequest {
+            agent_id,
+            payload,
+            prefer_raw_quic_if_connected: false,
+            raw_quic_receive_ack_ms: None,
+            stop_fallback_on_raw_error: false,
+            require_gossip: false,
+            require_gossip_ack: None,
+            require_ack_ms: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn direct_send_malformed_request_fields_stay_bad_request() -> Result<()> {
+        // Issue #188 acceptance: genuinely malformed payloads remain 400.
+        let (state, _dir) = secure_endpoint_test_state().await?;
+
+        // Non-hex agent_id.
+        let response = direct_send(
+            State(Arc::clone(&state)),
+            Json(direct_send_test_request(
+                "not-hex".to_string(),
+                BASE64.encode(b"hello"),
+            )),
+        )
+        .await
+        .into_response();
+        let (status, body) = response_json(response).await?;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "garbage agent_id stays 400, body: {body}"
+        );
+        assert_eq!(body["ok"], false);
+
+        // Well-formed agent_id, invalid base64 payload.
+        let response = direct_send(
+            State(state),
+            Json(direct_send_test_request(
+                "ab".repeat(32),
+                "!!!not-base64!!!".to_string(),
+            )),
+        )
+        .await
+        .into_response();
+        let (status, body) = response_json(response).await?;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "garbage base64 payload stays 400, body: {body}"
+        );
+        assert_eq!(body["ok"], false);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn direct_send_undecodable_recipient_key_is_retryable_conflict_not_bad_request(
+    ) -> Result<()> {
+        // Issue #188: a cached capability advert whose KEM key does not
+        // decode (the sender's not-yet-converged / corrupt view of the
+        // recipient) is a transient — 409 with a distinct error string,
+        // never the opaque `envelope_construction` 400 the dogfood hit.
+        let (state, _dir) = secure_endpoint_test_state().await?;
+        let recipient = AgentId([7u8; 32]);
+        state.agent.capability_store().insert(
+            recipient,
+            x0x::identity::MachineId([9u8; 32]),
+            x0x::dm::DmCapabilities::v1_gossip_ready(vec![0xAAu8; 32]),
+            x0x::dm::now_unix_ms(),
+        );
+        let response = direct_send(
+            State(state),
+            Json(direct_send_test_request(
+                hex::encode(recipient.as_bytes()),
+                BASE64.encode(b"hello"),
+            )),
+        )
+        .await
+        .into_response();
+        let (status, body) = response_json(response).await?;
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "undecodable cached key must be a retryable 409, body: {body}"
+        );
+        assert_eq!(body["error"], "recipient_key_invalid");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn direct_send_unready_gossip_runtime_is_retryable_503_not_bad_request() -> Result<()> {
+        // Issue #188: the recipient's capability is valid but the local
+        // gossip runtime is not up yet — a not-ready transient surfaced as
+        // 503, never 400.
+        let (state, _dir) = secure_endpoint_test_state().await?;
+        let recipient = AgentId([7u8; 32]);
+        let kem = x0x::groups::kem_envelope::AgentKemKeypair::generate()?;
+        state.agent.capability_store().insert(
+            recipient,
+            x0x::identity::MachineId([9u8; 32]),
+            x0x::dm::DmCapabilities::v1_gossip_ready(kem.public_bytes.clone()),
+            x0x::dm::now_unix_ms(),
+        );
+        let response = direct_send(
+            State(state),
+            Json(direct_send_test_request(
+                hex::encode(recipient.as_bytes()),
+                BASE64.encode(b"hello"),
+            )),
+        )
+        .await
+        .into_response();
+        let (status, body) = response_json(response).await?;
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "not-ready gossip runtime must be a retryable 503, body: {body}"
+        );
+        assert_eq!(body["error"], "local_gossip_unavailable");
         Ok(())
     }
 


### PR DESCRIPTION
Closes #188.

Root cause: the join cmd-DM's HTTP 400 came from DmError::EnvelopeConstruction being a catch-all mapped to 400 — three distinct causes (oversized payload, undecodable cached recipient KEM key, crypto/serialize faults) all surfaced as 'malformed request'. The oversized-payload leg was already eliminated upstream by #205 key-package stripping; this closes the residual misclassification and adds idempotency.

- Transient conditions now return retryable statuses: 409 recipient_key_invalid (capability not yet converged), 413 payload_too_large, 503 gossip_unavailable/backpressured/no_connectivity, 502 peer_likely_offline, 504 timeout; EnvelopeConstruction residuals are 500 (server fault, never 400)
- Genuinely malformed requests (bad agent_id hex, bad base64) stay 400
- join_group_via_invite is idempotent: replaying a join for an already-joined group returns 200 {already_joined:true} read-only before any mutation — no TreeKEM key-schedule double-advance, no duplicate MemberJoined publish (serialized by group_membership_lock)
- Dogfood client (tests/e2e_vps_groups.py) retries any non-2xx, so all new statuses are honored with no client change
- Route-level regression tests: malformed→400, transient→retryable, duplicate join→200 idempotent with unchanged state hash/epoch

Gates: fmt/clippy clean, 374/374 targeted tests. Adversarial review: SOUND (6/6 contract points).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes direct-message failures more specific and makes repeated group joins idempotent. The main changes are:

- Adds retryable recipient-key and transport error responses.
- Reports oversized payloads as HTTP 413.
- Reports envelope construction faults as HTTP 500.
- Returns a read-only success for duplicate group joins.
- Adds tests for malformed requests, transient failures, and join replay.

<h3>Confidence Score: 4/5</h3>

Raw delivery can be skipped by an unrelated gossip-key error, and interrupted group joins can become permanently stuck.

- A stale gossip key can reject a send before a usable raw-QUIC transport is tried.
- A failed or timed-out join can leave a stub that causes every retry to return success without restoring TreeKEM state.
- The payload-size and HTTP error mappings otherwise follow the intended behavior.

src/lib.rs and src/server/mod.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dm.rs | Adds recipient-key validation and classifies oversized envelope payloads separately. |
| src/dm_send.rs | Returns `PayloadTooLarge` for oversized gossip payloads. |
| src/groups/invite.rs | Updates invite-size documentation for the new HTTP classification. |
| src/lib.rs | Validates cached KEM keys before transport selection, which can block an independent raw-QUIC path. |
| src/server/mod.rs | Updates HTTP error mappings and adds duplicate-join success handling that can misclassify incomplete joins. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Direct send] --> B{Cached gossip key decodes?}
    B -- No --> C[Return recipient_key_invalid]
    C -. skips .-> D[Usable raw QUIC]
    B -- Yes --> E[Select transport]

    J[Join invite] --> K[Insert local group stub]
    K --> L{TreeKEM converges?}
    L -- Yes --> M[Completed membership]
    L -- No --> N[Stub remains]
    N --> O[Retry returns already_joined]
    O -. skips .-> P[Restart join]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Direct send] --> B{Cached gossip key decodes?}
    B -- No --> C[Return recipient_key_invalid]
    C -. skips .-> D[Usable raw QUIC]
    B -- Yes --> E[Select transport]

    J[Join invite] --> K[Insert local group stub]
    K --> L{TreeKEM converges?}
    L -- Yes --> M[Completed membership]
    L -- No --> N[Stub remains]
    N --> O[Retry returns already_joined]
    O -. skips .-> P[Restart join]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib.rs:4233-4240
**Invalid Gossip Key Blocks Raw QUIC**

When gossip is optional and raw QUIC is preferred, a connected recipient can still have a stale, undecodable KEM key in the capability cache. This branch returns `RecipientKeyInvalid` before transport selection, so the send fails even though raw QUIC does not use the KEM key and could succeed.

### Issue 2 of 2
src/server/mod.rs:11076-11082
**Incomplete Join Becomes Permanent Membership**

`named_groups` can contain the stub inserted before `MemberJoined` publication and TreeKEM convergence finish. If signing, publication, or convergence fails, a retry now returns `200 already_joined` from this branch without restarting the join, leaving the group visible locally but without usable TreeKEM state.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/saorsa-labs/x0x/commit/6c1de5fd788e92446129e5671271fe20218d0bdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45236249)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->