### PR TITLE
fix(forward): #216 — attestation denial observability + codec round-trip tamper suite

### DIFF
--- a/src/forward.rs
+++ b/src/forward.rs
@@ -500,13 +500,27 @@ async fn decide_inbound_attested(
 
     // ── Replay: recipient scope binding ──────────────────────────────
     // The header must name THIS machine as the recipient — a header captured
-    // on machine A cannot be replayed to machine B.
+    // on machine A cannot be replayed to machine B. NOTE: the comparison is
+    // against the LOCAL machine id, never `peer_machine` — comparing against
+    // the opener's machine denied every cross-node forward (#216).
     if header.recipient_machine_id != ctx.own_machine_id {
+        tracing::warn!(
+            target: "x0x::forward",
+            reason = "recipient_mismatch",
+            stamped_recipient = %hex::encode(header.recipient_machine_id.as_bytes()),
+            own_machine = %hex::encode(ctx.own_machine_id.as_bytes()),
+            "forward v2 attestation denied: recipient binding is not this machine"
+        );
         return Err(ConnectDenialReason::AttestationFailed);
     }
 
     // ── Replay: freshness / TTL ──────────────────────────────────────
     if header.issued_at_ms == 0 {
+        tracing::warn!(
+            target: "x0x::forward",
+            reason = "missing_issued_at",
+            "forward v2 attestation denied: header carries no issue timestamp"
+        );
         return Err(ConnectDenialReason::AttestationFailed);
     }
     // Stale: older than the TTL window.
@@ -515,6 +529,14 @@ async fn decide_inbound_attested(
             .issued_at_ms
             .saturating_add(FORWARD_V2_ATTESTATION_TTL_MS)
     {
+        tracing::warn!(
+            target: "x0x::forward",
+            reason = "stale_attestation",
+            issued_at_ms = header.issued_at_ms,
+            now_ms = ctx.now_ms,
+            ttl_ms = FORWARD_V2_ATTESTATION_TTL_MS,
+            "forward v2 attestation denied: attestation older than TTL"
+        );
         return Err(ConnectDenialReason::AttestationFailed);
     }
     // Future: more than the skew allowance ahead of our clock.
@@ -523,6 +545,14 @@ async fn decide_inbound_attested(
             .now_ms
             .saturating_add(FORWARD_V2_ATTESTATION_FUTURE_SKEW_MS)
     {
+        tracing::warn!(
+            target: "x0x::forward",
+            reason = "future_attestation",
+            issued_at_ms = header.issued_at_ms,
+            now_ms = ctx.now_ms,
+            skew_ms = FORWARD_V2_ATTESTATION_FUTURE_SKEW_MS,
+            "forward v2 attestation denied: attestation dated beyond clock-skew allowance"
+        );
         return Err(ConnectDenialReason::AttestationFailed);
     }
 
@@ -535,10 +565,26 @@ async fn decide_inbound_attested(
         let cache = ctx.discovery_cache.read().await;
         cache.get(&header.opener_agent_id).cloned()
     };
-    let agent = cached.ok_or(ConnectDenialReason::AttestationFailed)?;
+    let agent = cached.ok_or_else(|| {
+        tracing::warn!(
+            target: "x0x::forward",
+            reason = "agent_not_in_discovery_cache",
+            agent = %hex::encode(header.opener_agent_id.as_bytes()),
+            "forward v2 attestation denied: opener absent from discovery cache"
+        );
+        ConnectDenialReason::AttestationFailed
+    })?;
 
     // Confirm the agent is on the transport-authenticated machine.
     if agent.machine_id != *peer_machine {
+        tracing::warn!(
+            target: "x0x::forward",
+            reason = "agent_not_on_machine",
+            agent = %hex::encode(header.opener_agent_id.as_bytes()),
+            cached_machine = %hex::encode(agent.machine_id.as_bytes()),
+            peer_machine = %hex::encode(peer_machine.as_bytes()),
+            "forward v2 attestation denied: cached machine differs from transport peer"
+        );
         return Err(ConnectDenialReason::AgentNotOnMachine);
     }
 
@@ -547,9 +593,21 @@ async fn decide_inbound_attested(
     // (binding) and the ML-DSA-65 signature. This eliminates the dependency
     // on the discovery cache having a non-empty `agent_public_key` — the soak
     // NO-GO root cause.
+    // #216: log the inner ForwardError (missing / key-binding / signature)
+    // BEFORE collapsing to `AttestationFailed` — the silent collapse made the
+    // cross-node happy-path failure undiagnosable at the default WARN level.
     header
         .verify_attestation(&header.opener_agent_public_key)
-        .map_err(|_| ConnectDenialReason::AttestationFailed)?;
+        .map_err(|e| {
+            tracing::warn!(
+                target: "x0x::forward",
+                reason = "attestation_verify_failed",
+                error = %e,
+                agent = %hex::encode(header.opener_agent_id.as_bytes()),
+                "forward v2 attestation denied: cryptographic verification failed"
+            );
+            ConnectDenialReason::AttestationFailed
+        })?;
 
     // Opportunistically upgrade the cache entry with the header's key so
     // subsequent forwards (and other subsystems) benefit.
@@ -761,7 +819,7 @@ pub(crate) async fn handle_inbound(mut stream: PeerStream, ctx: &InboundCtx) {
                         .send_mut()
                         .write_all(&encode_response_denied(reason))
                         .await;
-                    tracing::info!(
+                    tracing::warn!(
                         target: "x0x::forward",
                         peer = %hex::encode(peer.as_bytes()),
                         ?reason,
@@ -782,10 +840,11 @@ pub(crate) async fn handle_inbound(mut stream: PeerStream, ctx: &InboundCtx) {
             if ctx.require_attestation {
                 ctx.connect_diag
                     .record_denied(ConnectDenialReason::AttestationFailed);
-                tracing::info!(
+                tracing::warn!(
                     target: "x0x::forward",
                     peer = %hex::encode(peer.as_bytes()),
-                    "inbound forward v1 denied: attestation required (ctx.require_attestation=true)"
+                    reason = "attestation_required",
+                    "inbound forward v1 denied: attestation required (require_attestation=true)"
                 );
                 return;
             }
@@ -1981,6 +2040,319 @@ mod tests {
         let verification = decoded.verify_attestation(&decoded.opener_agent_public_key);
         eprintln!("wire-round-trip verify_attestation result: {verification:?}");
         assert_eq!(verification, Ok(()));
+    }
+
+    /// Shared sink that captures fmt-layer tracing output so tests can assert
+    /// the distinct `reason` identity emitted with each attestation denial
+    /// (#216). Cloneable; the fmt layer writes through the shared buffer.
+    #[derive(Clone, Default)]
+    struct LogCapture(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for LogCapture {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            if let Ok(mut v) = self.0.lock() {
+                v.extend_from_slice(buf);
+            }
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl LogCapture {
+        /// Captured output as text (lossy).
+        fn text(&self) -> String {
+            self.0
+                .lock()
+                .map(|v| String::from_utf8_lossy(&v).into_owned())
+                .unwrap_or_default()
+        }
+        /// Reset the buffer between tamper cases.
+        fn clear(&self) {
+            if let Ok(mut v) = self.0.lock() {
+                v.clear();
+            }
+        }
+    }
+
+    /// Install a thread-local WARN-level fmt subscriber writing into a
+    /// [`LogCapture`]. The guard is thread-scoped and `#[tokio::test]` runs
+    /// the body on the current-thread runtime, so every event the gate emits
+    /// lands in the buffer without cross-test interference.
+    fn capture_warn_logs() -> (LogCapture, tracing::subscriber::DefaultGuard) {
+        let capture = LogCapture::default();
+        let writer = capture.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .with_writer(move || writer.clone())
+            .finish();
+        let guard = tracing::subscriber::set_default(subscriber);
+        (capture, guard)
+    }
+
+    /// Frame a header through the real async codec pair the QUIC stream uses
+    /// (`write_header_v2` → `read_header_v2`).
+    async fn v2_wire_round_trip(header: &ForwardV2Header) -> ForwardV2Header {
+        let mut wire = Vec::new();
+        write_header_v2(&mut wire, header)
+            .await
+            .expect("write v2 header");
+        let mut cursor: &[u8] = &wire;
+        read_header_v2(&mut cursor).await.expect("read v2 header")
+    }
+
+    #[tokio::test]
+    async fn v2_two_agent_cross_node_attestation_verifies_end_to_end() {
+        // #216: the exact cross-node path the live testnet exercised —
+        // construct as the opener does, sign, frame through the REAL async
+        // stream codec (write_header_v2 → read_header_v2), then verify as
+        // the recipient does. Two agents on two distinct machines; asserts
+        // the happy path SUCCEEDS and pins key-binding vs signature vs
+        // recipient-machine if any inner check fails (the inner ForwardError
+        // is inspected here, before any map_err collapse).
+        let opener_kp = AgentKeypair::generate().unwrap();
+        let opener_machine = MachineId([2u8; 32]);
+        let recipient_machine = MachineId([3u8; 32]);
+        let target: SocketAddr = "127.0.0.1:22".parse().unwrap();
+
+        // ── Opener: construct exactly as try_outbound_v2 does — the header
+        // names the RECIPIENT machine (stream.peer() on the dial side).
+        let mut header = ForwardV2Header::new(
+            "127.0.0.1".to_string(),
+            22,
+            opener_kp.agent_id(),
+            opener_kp.public_key().as_bytes().to_vec(),
+            recipient_machine,
+        );
+        header.sign(&opener_kp).expect("sign");
+
+        // ── Wire: the real async codec pair used on the QUIC stream (the
+        // encode/decode-only tests never exercised these).
+        let decoded = v2_wire_round_trip(&header).await;
+        assert_eq!(decoded, header);
+
+        // ── Recipient: pin the key↔id binding check separately from the
+        // ML-DSA signature check, then run the full attestation verify.
+        let pubkey =
+            MlDsaPublicKey::from_bytes(&decoded.opener_agent_public_key).expect("pubkey parses");
+        assert_eq!(
+            AgentId::from_public_key(&pubkey),
+            decoded.opener_agent_id,
+            "key↔id binding: header key must derive the claimed agent id"
+        );
+        let verification = decoded.verify_attestation(&decoded.opener_agent_public_key);
+        assert_eq!(
+            verification,
+            Ok(()),
+            "cross-node wire-round-trip attestation must verify"
+        );
+
+        // ── Full recipient gate: opener announced on `opener_machine`, the
+        // local machine is `recipient_machine`, ACL permits the pair.
+        let cache = cache_with_agent(&opener_kp, opener_machine);
+        let contacts = trusted_store(opener_kp.agent_id());
+        let policy = policy_with_allow(opener_kp.agent_id(), opener_machine, target);
+        assert_eq!(
+            decide_inbound_attested(
+                &decoded,
+                &policy,
+                &opener_machine,
+                &AttestationVerifyCtx {
+                    discovery_cache: cache,
+                    contact_store: contacts,
+                    own_machine_id: recipient_machine,
+                    now_ms: now_ms(),
+                },
+            )
+            .await,
+            Ok(target),
+            "cross-node attested gate must allow the verified opener"
+        );
+    }
+
+    #[tokio::test]
+    async fn v2_wire_codec_tamper_suite_denies_with_distinct_reasons() {
+        // #216: codec/round-trip tamper suite. Each case frames the header
+        // through the real async codec, tampers exactly one input, and asserts
+        // (a) the gate denies with the expected ConnectDenialReason AND
+        // (b) the denial carries its DISTINCT structured `reason` at warn! —
+        // the identity previously collapsed silently into `attestation_failed`.
+        let (logs, _guard) = capture_warn_logs();
+        let opener_kp = AgentKeypair::generate().unwrap();
+        let opener = opener_kp.agent_id();
+        let opener_machine = MachineId([2u8; 32]);
+        let recipient_machine = MachineId([3u8; 32]);
+        let target: SocketAddr = "127.0.0.1:22".parse().unwrap();
+
+        // ── Control: the untampered wire header is allowed and logs no
+        // denial reason.
+        let header = signed_v2_header("127.0.0.1", 22, &opener_kp, recipient_machine);
+        let decoded = v2_wire_round_trip(&header).await;
+        assert_eq!(
+            decide_inbound_attested(
+                &decoded,
+                &policy_with_allow(opener, opener_machine, target),
+                &opener_machine,
+                &AttestationVerifyCtx {
+                    discovery_cache: cache_with_agent(&opener_kp, opener_machine),
+                    contact_store: trusted_store(opener),
+                    own_machine_id: recipient_machine,
+                    now_ms: now_ms(),
+                },
+            )
+            .await,
+            Ok(target),
+            "control: untampered wire header must be allowed"
+        );
+        assert!(
+            !logs.text().contains("attestation denied"),
+            "control: no denial reason may be logged for the happy path"
+        );
+        logs.clear();
+
+        // ── Tamper: header signed for a DIFFERENT recipient machine. The
+        // recipient scope-binding check fires before any crypto verify.
+        let other_recipient = MachineId([9u8; 32]);
+        let header = signed_v2_header("127.0.0.1", 22, &opener_kp, other_recipient);
+        let decoded = v2_wire_round_trip(&header).await;
+        assert_eq!(
+            decide_inbound_attested(
+                &decoded,
+                &policy_with_allow(opener, opener_machine, target),
+                &opener_machine,
+                &AttestationVerifyCtx {
+                    discovery_cache: cache_with_agent(&opener_kp, opener_machine),
+                    contact_store: trusted_store(opener),
+                    own_machine_id: recipient_machine,
+                    now_ms: now_ms(),
+                },
+            )
+            .await,
+            Err(ConnectDenialReason::AttestationFailed),
+            "wrong recipient must deny"
+        );
+        assert!(
+            logs.text().contains("recipient_mismatch"),
+            "wrong recipient must log its distinct reason"
+        );
+        logs.clear();
+
+        // ── Tamper: stale timestamp (post-codec). The freshness check fires
+        // BEFORE signature verification, so the logged reason must be the
+        // timestamp — not the (also-invalidated) signature.
+        let header = signed_v2_header("127.0.0.1", 22, &opener_kp, recipient_machine);
+        let mut decoded = v2_wire_round_trip(&header).await;
+        decoded.issued_at_ms = now_ms().saturating_sub(FORWARD_V2_ATTESTATION_TTL_MS + 1000);
+        assert_eq!(
+            decide_inbound_attested(
+                &decoded,
+                &policy_with_allow(opener, opener_machine, target),
+                &opener_machine,
+                &AttestationVerifyCtx {
+                    discovery_cache: cache_with_agent(&opener_kp, opener_machine),
+                    contact_store: trusted_store(opener),
+                    own_machine_id: recipient_machine,
+                    now_ms: now_ms(),
+                },
+            )
+            .await,
+            Err(ConnectDenialReason::AttestationFailed),
+            "stale timestamp must deny"
+        );
+        assert!(
+            logs.text().contains("stale_attestation"),
+            "stale timestamp must log its distinct reason"
+        );
+        logs.clear();
+
+        // ── Tamper: timestamp beyond the future-skew allowance (post-codec).
+        let header = signed_v2_header("127.0.0.1", 22, &opener_kp, recipient_machine);
+        let mut decoded = v2_wire_round_trip(&header).await;
+        decoded.issued_at_ms = now_ms() + FORWARD_V2_ATTESTATION_FUTURE_SKEW_MS + 1000;
+        assert_eq!(
+            decide_inbound_attested(
+                &decoded,
+                &policy_with_allow(opener, opener_machine, target),
+                &opener_machine,
+                &AttestationVerifyCtx {
+                    discovery_cache: cache_with_agent(&opener_kp, opener_machine),
+                    contact_store: trusted_store(opener),
+                    own_machine_id: recipient_machine,
+                    now_ms: now_ms(),
+                },
+            )
+            .await,
+            Err(ConnectDenialReason::AttestationFailed),
+            "future timestamp must deny"
+        );
+        assert!(
+            logs.text().contains("future_attestation"),
+            "future timestamp must log its distinct reason"
+        );
+        logs.clear();
+
+        // ── Tamper: discovery cache binds the opener to a DIFFERENT machine
+        // than the transport-authenticated peer. The signature, recipient,
+        // and timestamps are all valid — only the machine binding fails.
+        let stranger_machine = MachineId([7u8; 32]);
+        let header = signed_v2_header("127.0.0.1", 22, &opener_kp, recipient_machine);
+        let decoded = v2_wire_round_trip(&header).await;
+        assert_eq!(
+            decide_inbound_attested(
+                &decoded,
+                &policy_with_allow(opener, opener_machine, target),
+                &opener_machine,
+                &AttestationVerifyCtx {
+                    discovery_cache: cache_with_agent(&opener_kp, stranger_machine),
+                    contact_store: trusted_store(opener),
+                    own_machine_id: recipient_machine,
+                    now_ms: now_ms(),
+                },
+            )
+            .await,
+            Err(ConnectDenialReason::AgentNotOnMachine),
+            "wrong cached machine must deny"
+        );
+        assert!(
+            logs.text().contains("agent_not_on_machine"),
+            "wrong cached machine must log its distinct reason"
+        );
+        logs.clear();
+
+        // ── Tamper: signature byte flipped post-codec. Every check before
+        // the cryptographic verify passes, so the logged reason must be the
+        // verify failure with the inner AttestationInvalid Display.
+        let header = signed_v2_header("127.0.0.1", 22, &opener_kp, recipient_machine);
+        let mut decoded = v2_wire_round_trip(&header).await;
+        let mid = decoded.signature.len() / 2;
+        decoded.signature[mid] ^= 0xFF;
+        assert_eq!(
+            decide_inbound_attested(
+                &decoded,
+                &policy_with_allow(opener, opener_machine, target),
+                &opener_machine,
+                &AttestationVerifyCtx {
+                    discovery_cache: cache_with_agent(&opener_kp, opener_machine),
+                    contact_store: trusted_store(opener),
+                    own_machine_id: recipient_machine,
+                    now_ms: now_ms(),
+                },
+            )
+            .await,
+            Err(ConnectDenialReason::AttestationFailed),
+            "bad signature must deny"
+        );
+        let text = logs.text();
+        assert!(
+            text.contains("attestation_verify_failed"),
+            "bad signature must log its distinct reason"
+        );
+        assert!(
+            text.contains("attestation invalid"),
+            "bad signature must surface the inner ForwardError"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Addresses #216.

**Key finding:** #216's deterministic cross-node denial was root-caused to the pre-9885c69 recipient-machine comparison. That behavioral fix (`9885c69 fix(forward): validate attestation recipient locally`, 2026-07-11) already ships on main — the issue's evidence came from RC build a72d925d which predates it. main also carries a passing distinct-machine cross-node happy-path test.

**This branch** closes the diagnosability gap the issue called out (denial log was info! while the daemon runs at WARN, and every failure collapsed into `attestation_failed`):
- every attestation denial path now logs at warn! with its distinct inner cause (stale/future timestamp, recipient mismatch, cache miss, signature verify)
- new codec round-trip tamper suite: wrong recipient, wrong machine, stale, future, bad signature — each asserting the denial and its distinct reason

**Remaining live validation (out of scope here):** re-run the testnet attested-forward proof (nyc→helsinki, require_attestation=true) on v0.33.1 — with these warn! logs, any residual denial now names its cause.

Gates: fmt/clippy clean, 57/57 attestation+forward tests. Adversarial review caught the original mislabeled commit; this amended version has no decision-logic changes and claims none.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves attestation-denial diagnostics and adds codec round-trip coverage. The main changes are:

- Distinct WARN-level reasons for attestation failures.
- WARN-level summaries for rejected inbound forwards.
- Cross-node success and tampered-header codec tests.

<h3>Confidence Score: 4/5</h3>

The attestation decisions remain intact, but the new diagnostics expose stable identities and the log tests can fail when execution changes worker threads.

- Default-WARN paths bypass the existing salted identity wrappers.
- Verification errors can include additional raw identity data.
- Async log capture depends on a thread-local subscriber.

src/forward.rs

<details open><summary><h3>Security Review</h3></summary>

The new default-WARN diagnostics expose raw machine and agent identifiers. Some fields are attacker-controlled, while the verification error can also contain a derived identity; these should use the existing salted logging representations.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/forward.rs | Adds granular denial warnings and codec tests, but exposes raw identities in logs and uses a thread-local subscriber in async tests. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/forward.rs:510-511
**Raw Machine IDs Enter Logs**

A transport-authenticated peer can send a mismatched recipient and make this default-WARN path record the raw stamped and local machine IDs. The repository provides salted logging wrappers for these identifiers, so bypassing them exposes stable machine identities to production log storage.

### Issue 2 of 3
src/forward.rs:605-606
**Verification Errors Expose Identities**

When a peer supplies a public key that does not derive the claimed agent ID, the displayed key-mismatch error contains both raw IDs and the separate `agent` field repeats one of them. This sends attacker-controlled and derived identity material to default-WARN logs instead of using the repository's salted agent-ID representation.

### Issue 3 of 3
src/forward.rs:2086-2091
**Thread-Local Subscriber Loses Events**

`set_default` installs the capture only on the current thread, but these tests use `#[tokio::test]` without forcing a current-thread runtime. If the async test future resumes on another worker after an await, the denial warning uses that worker's subscriber and the expected reason is absent from `LogCapture`, causing nondeterministic CI failures.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(forward): #216 — attestation denial ..."](https://github.com/saorsa-labs/x0x/commit/c6492be83f1e3b9174282faf92fbfd3726bcce7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45223226)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->