### PR TITLE
fix(net): #228 — gate inbound accept loop on reconnect suppression

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13897,6 +13897,116 @@ mod tests {
         }
     }
 
+    /// Issue #228: a reconnect-suppressed peer must not re-enter through the
+    /// INBOUND accept path. ant-quic's symmetric transport can reverse-open a
+    /// connection back to alice immediately after she closes hers (the CI
+    /// flake: the tombstoned peer reappeared inside the backoff window), and
+    /// a revoked/rejected peer can equally just dial back in. The accept loop
+    /// is the last x0x-controlled gate: it must close the suppressed inbound
+    /// connection immediately — no `PeerConnected`, no cache success, no pool
+    /// admission — and leave the tombstone intact.
+    ///
+    /// Deterministic version of the CI race: instead of relying on ant-quic's
+    /// reverse-open timing, bob dials alice back explicitly after she
+    /// policy-rejects him — the exact accept-loop decision the flake
+    /// exercised.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn suppressed_peer_inbound_redial_is_rejected() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("alice");
+        let alice_network = alice.network().expect("alice network");
+        let alice_addr = normalize_loopback_addr(
+            alice_network
+                .bound_addr()
+                .await
+                .expect("alice bound"),
+        );
+
+        let bob = Agent::builder()
+            .with_machine_key(dir.path().join("bob-machine.key"))
+            .with_agent_key_path(dir.path().join("bob-agent.key"))
+            .with_contact_store_path(dir.path().join("bob-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("bob-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("bob");
+        let bob_network = bob.network().expect("bob network");
+        let bob_addr = normalize_loopback_addr(bob_network.bound_addr().await.expect("bob bound"));
+        let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+        let bob_id = bob.machine_id().0;
+
+        let connected = alice_network
+            .connect_addr(bob_addr)
+            .await
+            .expect("alice connects bob");
+        assert_eq!(connected.0, bob.machine_id().0);
+        let reg = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < reg {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await,
+            "bob connected before rejection"
+        );
+
+        alice_network
+            .disconnect_with_reason(&bob_peer, network::DisconnectReason::PolicyRejection)
+            .await
+            .expect("policy reject");
+        assert!(
+            alice_network.is_reconnect_suppressed(bob_id),
+            "PolicyRejection sets a permanent tombstone"
+        );
+
+        // Watch for any `PeerConnected` for bob: the gate must suppress it.
+        let mut events = alice_network.subscribe();
+
+        // bob dials alice back — the deterministic stand-in for ant-quic's
+        // reverse-open (and for a revoked peer simply dialing back in). The
+        // handshake completes on bob's side (loopback is fast and alice's
+        // accept loop must be scheduled before her close lands); alice's
+        // accept loop must then close it immediately and never surface it.
+        // Asserting the dial reached alice keeps the test non-vacuous.
+        let dialed = bob_network
+            .connect_addr(alice_addr)
+            .await
+            .expect("bob redials alice after rejection");
+        assert_eq!(dialed.0, alice.machine_id().0, "bob dialed alice");
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while tokio::time::Instant::now() < deadline {
+            assert!(
+                !alice_network.is_connected(&bob_peer).await,
+                "suppressed bob must not re-enter via the inbound accept path"
+            );
+            while let Ok(event) = events.try_recv() {
+                if let network::NetworkEvent::PeerConnected { peer_id, .. } = event {
+                    assert_ne!(
+                        peer_id, bob_id,
+                        "suppressed bob must not surface a PeerConnected event"
+                    );
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            alice_network.is_reconnect_suppressed(bob_id),
+            "rejecting the inbound redial must not clear the tombstone"
+        );
+    }
+
     /// A connection-pool eviction (LRU over `max_connections`) must not
     /// trigger a redial that immediately reconnects the evicted peer — the
     /// evict/redial churn loop flagged in the final review. This exercises the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13923,12 +13923,8 @@ mod tests {
             .await
             .expect("alice");
         let alice_network = alice.network().expect("alice network");
-        let alice_addr = normalize_loopback_addr(
-            alice_network
-                .bound_addr()
-                .await
-                .expect("alice bound"),
-        );
+        let alice_addr =
+            normalize_loopback_addr(alice_network.bound_addr().await.expect("alice bound"));
 
         let bob = Agent::builder()
             .with_machine_key(dir.path().join("bob-machine.key"))

--- a/src/network.rs
+++ b/src/network.rs
@@ -1370,10 +1370,10 @@ pub struct NetworkNode {
     /// Reconnect-suppression tombstones, keyed by peer id. Set when a peer is
     /// disconnected for a non-transport reason (policy rejection, pool
     /// eviction, admin, revocation, shutdown) so neither the proactive
-    /// reconnect scheduler nor the ant-quic lifecycle `Closed` watcher redials
-    /// it — undoing a security rejection, churning an LRU eviction, or
-    /// ignoring an operator teardown. See [`DisconnectReason`] and
-    /// [`NetworkNode::is_reconnect_suppressed`].
+    /// reconnect scheduler, nor the ant-quic lifecycle `Closed` watcher, nor
+    /// the inbound accept loop (re)admits it — undoing a security rejection,
+    /// churning an LRU eviction, or ignoring an operator teardown. See
+    /// [`DisconnectReason`] and [`NetworkNode::is_reconnect_suppressed`].
     reconnect_suppressions: Arc<Mutex<HashMap<[u8; 32], ReconnectSuppression>>>,
     /// Handles to the background tasks spawned at construction (receiver, accept
     /// loop, connection-pool eviction).
@@ -2489,16 +2489,7 @@ impl NetworkNode {
     /// revocation, shutdown) never expire.
     #[must_use]
     pub fn is_reconnect_suppressed(&self, peer_id: [u8; 32]) -> bool {
-        let mut map = match self.reconnect_suppressions.lock() {
-            Ok(m) => m,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        let now = Instant::now();
-        let live = map.get(&peer_id).is_some_and(|s| s.is_live(now));
-        if !live {
-            map.remove(&peer_id);
-        }
-        live
+        reconnect_suppression_is_live(self.reconnect_suppressions.as_ref(), peer_id)
     }
 
     /// Get list of connected peer IDs.
@@ -3168,6 +3159,37 @@ impl NetworkNode {
                             continue;
                         }
 
+                        // Reject peers carrying a live reconnect-suppression
+                        // tombstone. ant-quic's symmetric transport can
+                        // reverse-open a connection back to us immediately
+                        // after we closed ours (observed as the #228 CI
+                        // flake: a policy-rejected peer reappearing inside
+                        // the backoff window), and a revoked/evicted peer can
+                        // simply dial back in. ant-quic registers the inbound
+                        // connection inside `accept()` before x0x can gate,
+                        // so the last x0x-controlled point is right here:
+                        // close it immediately — without recording cache
+                        // success, emitting `PeerConnected`, touching the
+                        // connection pool, or touching the tombstone itself
+                        // (`Node::disconnect` maps to a plain transport close
+                        // and never mutates x0x suppressions).
+                        if reconnect_suppression_is_live(
+                            reconnect_suppressions.as_ref(),
+                            peer_conn.peer_id.0,
+                        ) {
+                            tracing::warn!(
+                                "SECURITY: Rejecting inbound connection from reconnect-suppressed peer {:?}",
+                                peer_conn.peer_id
+                            );
+                            if let Err(e) = node_ref.disconnect(&peer_conn.peer_id).await {
+                                debug!(
+                                    "disconnect of suppressed inbound peer {:?} failed: {}",
+                                    peer_conn.peer_id, e
+                                );
+                            }
+                            continue;
+                        }
+
                         tracing::info!(
                             "Accepted inbound connection from peer {:?} at {:?}",
                             peer_conn.peer_id,
@@ -3538,6 +3560,28 @@ impl ReconnectSuppression {
             Some(ttl) => now.duration_since(self.set_at) < ttl,
         }
     }
+}
+
+/// Returns `true` iff a live suppression tombstone for `peer_id` exists in
+/// `map`, pruning an expired bounded tombstone as observed.
+///
+/// Shared by [`NetworkNode::is_reconnect_suppressed`] and the inbound accept
+/// loop: both must observe the exact same liveness semantics or a tombstoned
+/// peer could re-enter through whichever path checked the stale copy (#228).
+fn reconnect_suppression_is_live(
+    map: &Mutex<HashMap<[u8; 32], ReconnectSuppression>>,
+    peer_id: [u8; 32],
+) -> bool {
+    let mut map = match map.lock() {
+        Ok(m) => m,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let now = Instant::now();
+    let live = map.get(&peer_id).is_some_and(|s| s.is_live(now));
+    if !live {
+        map.remove(&peer_id);
+    }
+    live
 }
 
 /// Events emitted by the network node.


### PR DESCRIPTION
Closes #228.

Root cause: the inbound accept loop admitted any completed handshake after only the allowlist check — it never consulted the reconnect-suppression tombstone. A tombstoned imposter still listening (deliberately, in the test) could redial inbound during the backoff window and get readmitted to cache/pool/event stream. The outbound paths all consulted suppression; inbound accept was the gap, and on slow CI runners the imposter's redial won the race.

- Extracted the suppression liveness check into one shared helper (reconnect_suppression_is_live) used by BOTH the outbound query API and the new inbound gate — byte-identical semantics (poison recovery, expiry prune), no second convention
- Inbound gate: suppressed peer's accepted connection is disconnected immediately at the accept loop, before cache/pool/event admission; bounded tombstones still expire (time-bounded gate), permanent reasons (PolicyRejection/Revocation/Shutdown) stay permanent, matching outbound
- Regression test: tombstoned peer stays transport-level disconnected for the full backoff window (event-independent assertion, proven non-vacuous by negative control with the gate disabled)

Gates: fmt/clippy clean, 18/18 suppression-family tests incl. the 34s backoff-window test. Adversarial review: SOUND (5/5 claims).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies reconnect suppression to inbound peer connections. The main changes are:

- Extracts tombstone liveness and expiry pruning into a shared helper.
- Rejects suppressed peers before cache, pool, and event admission.
- Adds a test for inbound redial after permanent policy rejection.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The helper preserves the existing poison recovery and expiry behavior.
- The inbound check runs before application-level peer admission and leaves live tombstones intact.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Shares suppression semantics across outbound queries and inbound admission, closing suppressed connections before cache, pool, or event updates. |
| src/lib.rs | Adds coverage showing that a policy-rejected peer cannot re-enter through an inbound redial. |

</details>

<sub>Reviews (1): Last reviewed commit: ["style: cargo fmt"](https://github.com/saorsa-labs/x0x/commit/7536b95f264b8603ba352b8bbf560036cfd4c558) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45223243)</sub>

<!-- /greptile_comment -->