### PR TITLE
test(net): #241 — load-independent invariants for reconnect + timeout tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12240,6 +12240,64 @@ mod tests {
         }
     }
 
+    /// Scaling factor for wall-clock deadlines in scheduling-dependent tests
+    /// (issue #241).
+    ///
+    /// These deadlines are panic-on-never guards: the asserted invariant is
+    /// EVENTUAL behaviour (a reconnect fires, a completed dial registers),
+    /// never the wall-clock bound itself. Under full-suite CPU contention
+    /// every timer, lock acquisition, and event hop stretches, so a deadline
+    /// sized for an idle machine flakes even when the behaviour is correct.
+    /// Set `X0X_TEST_TIME_MULTIPLIER=3..5` on loaded CI runners to scale the
+    /// guard with the environment; defaults to 1 (unloaded local runs).
+    fn test_time_multiplier() -> u32 {
+        std::env::var("X0X_TEST_TIME_MULTIPLIER")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .filter(|&m| m >= 1)
+            .unwrap_or(1)
+    }
+
+    /// Wait until `peer` has been CONTINUOUSLY connected for `window` — i.e.
+    /// the connection has quiesced — before returning (issue #241).
+    ///
+    /// WHY: the initial dial can leave duplicate/zombie connection legs
+    /// (mutual-dial rendezvous) whose PeerConnected event is emitted by the
+    /// connection-watcher task with a load-dependent DELAY. If the test
+    /// disconnects while such an event is still in flight, it arrives after
+    /// the disconnect, the event listener reads it as "connection recovered"
+    /// and ABORTS the just-scheduled proactive reconnect — and when the
+    /// zombie leg dies (silently: duplicate/locally-initiated closes are
+    /// invisible to both event streams) no reconnect remains and none is
+    /// re-triggered. That is the #241 flake mechanism, verified with
+    /// instrumentation: the tests were racing setup churn, not measuring
+    /// transport-drop recovery. Disconnecting only from a settled connection
+    /// guarantees any post-disconnect PeerConnected is a GENUINE recovery.
+    async fn await_quiesced_connection(
+        network: &network::NetworkNode,
+        peer: &ant_quic::PeerId,
+        window: std::time::Duration,
+    ) {
+        let deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(10) * test_time_multiplier();
+        let mut stable_since: Option<tokio::time::Instant> = None;
+        loop {
+            if network.is_connected(peer).await {
+                let since = stable_since.get_or_insert_with(tokio::time::Instant::now);
+                if since.elapsed() >= window {
+                    return;
+                }
+            } else {
+                stable_since = None;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "connection never quiesced"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    }
+
     fn normalize_loopback_addr(addr: std::net::SocketAddr) -> std::net::SocketAddr {
         if addr.ip().is_unspecified() {
             std::net::SocketAddr::new(
@@ -13258,8 +13316,11 @@ mod tests {
             .expect("alice connects to bob");
         assert_eq!(connected_peer.0, bob.machine_id().0);
 
-        // Wait for the connection to register on both sides.
-        let connected_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        // Wait for the connection to register on both sides. The dial
+        // already completed above; this deadline is a panic-on-never guard,
+        // scaled for loaded runners (issue #241).
+        let connected_deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(5) * test_time_multiplier();
         while tokio::time::Instant::now() < connected_deadline {
             if alice_network.is_connected(&bob_peer).await {
                 break;
@@ -13271,6 +13332,16 @@ mod tests {
             "alice should be connected to bob after initial dial"
         );
 
+        // Let the connection quiesce before the explicit drop (issue #241):
+        // a delayed PeerConnected from a duplicate dial leg would otherwise
+        // arrive after the disconnect and abort the just-scheduled reconnect.
+        await_quiesced_connection(
+            &alice_network,
+            &bob_peer,
+            std::time::Duration::from_secs(1) * test_time_multiplier(),
+        )
+        .await;
+
         // Phase 2: force a disconnect (simulates the QUIC transport drop
         // that occurs when the remote daemon restarts or the idle timeout
         // fires). This emits PeerDisconnected, which triggers
@@ -13280,17 +13351,36 @@ mod tests {
             .await
             .expect("disconnect bob");
 
-        // Give the disconnect time to propagate.
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        assert!(
-            !alice_network.is_connected(&bob_peer).await,
-            "alice should be disconnected after explicit disconnect"
-        );
+        // The disconnect must register in alice's connection view. Poll
+        // rather than sleep-then-assert: `disconnect()` awaits the transport
+        // close, but the registry reflects it on its own schedule, and a
+        // fixed sleep is load-racy in BOTH directions — too short and the
+        // registry lags; task-starved past the first 1s reconnect backoff
+        // and the successful recovery reads as a false failure (issue #241).
+        // Polling exits the moment the drop lands; our 25ms wakeups are
+        // timer-ordered ahead of the reconnect task's >=1s backoff expiry,
+        // so the drop is always observed before any redial can complete.
+        let drop_deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(5) * test_time_multiplier();
+        while alice_network.is_connected(&bob_peer).await {
+            assert!(
+                tokio::time::Instant::now() < drop_deadline,
+                "alice should observe the disconnect promptly"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
 
         // Phase 3: wait for the proactive reconnect to recover the
-        // connection. The first backoff delay is 1 s; allow generous
-        // headroom for CI scheduling jitter.
-        let reconnect_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+        // connection. The invariant is EVENTUAL recovery via the backoff
+        // machinery, not the wall-clock bound — the deadline is a
+        // panic-on-never guard sized to the full reconnect envelope:
+        // RECONNECT_BACKOFF_DELAYS cumulative 31s (±20% jitter → ~37s) plus
+        // up to 5 × 5s per-attempt connect timeouts (~62s total), plus
+        // headroom, scaled by X0X_TEST_TIME_MULTIPLIER for loaded CI
+        // runners. (Issue #241: 20s sat INSIDE the envelope and flaked
+        // under full-suite CPU contention.)
+        let reconnect_deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(90) * test_time_multiplier();
         while tokio::time::Instant::now() < reconnect_deadline {
             if alice_network.is_connected(&bob_peer).await {
                 break;
@@ -13384,8 +13474,11 @@ mod tests {
             .expect("alice connects to bob");
         assert_eq!(connected.0, bob.machine_id().0);
 
-        // Wait for connection to register.
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        // Wait for connection to register. The dial already completed
+        // above; this deadline is a panic-on-never guard, scaled for loaded
+        // runners (issue #241).
+        let deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(5) * test_time_multiplier();
         while tokio::time::Instant::now() < deadline {
             if alice_network.is_connected(&bob_peer).await {
                 break;
@@ -13426,19 +13519,44 @@ mod tests {
              confirms bootstrap cache does not scope-filter (got {cached_addr})"
         );
 
+        // Let the connection quiesce before the explicit drop (issue #241,
+        // see await_quiesced_connection): a delayed PeerConnected from a
+        // duplicate dial leg would otherwise abort the scheduled reconnect.
+        await_quiesced_connection(
+            &alice_network,
+            &bob_peer,
+            std::time::Duration::from_secs(1) * test_time_multiplier(),
+        )
+        .await;
+
         // Force disconnect (simulates transport drop / restart).
         alice_network
             .disconnect(&bob_peer)
             .await
             .expect("disconnect bob");
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        assert!(
-            !alice_network.is_connected(&bob_peer).await,
-            "alice should be disconnected"
-        );
+        // Poll for the drop to register rather than sleep-then-assert — a
+        // fixed sleep is load-racy in both directions (registry lag vs.
+        // task starvation past the first 1s reconnect backoff letting the
+        // successful recovery read as a false failure; issue #241). See the
+        // sibling test above for the full rationale.
+        let drop_deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(5) * test_time_multiplier();
+        while alice_network.is_connected(&bob_peer).await {
+            assert!(
+                tokio::time::Instant::now() < drop_deadline,
+                "alice should observe the disconnect promptly"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
 
         // Wait for proactive reconnect via Phase 2 (bootstrap cache).
-        let reconnect_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+        // EVENTUAL recovery is the invariant; the deadline is a
+        // panic-on-never guard sized to the full reconnect envelope
+        // (~62s worst case: 31s cumulative backoff ±20% jitter, plus 5 ×
+        // 5s per-attempt connect timeouts) with headroom, scaled by
+        // X0X_TEST_TIME_MULTIPLIER (issue #241: 20s flaked under load).
+        let reconnect_deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(90) * test_time_multiplier();
         while tokio::time::Instant::now() < reconnect_deadline {
             if alice_network.is_connected(&bob_peer).await {
                 break;
@@ -13522,7 +13640,8 @@ mod tests {
             .await
             .expect("alice connects to bob");
         assert_eq!(connected.0, bob.machine_id().0);
-        let reg = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        let reg = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(5) * test_time_multiplier();
         while tokio::time::Instant::now() < reg {
             if alice_network.is_connected(&bob_peer).await {
                 break;
@@ -13539,6 +13658,16 @@ mod tests {
             "Transport is the only reconnect-eligible reason"
         );
 
+        // Let the connection quiesce before the explicit drop (issue #241,
+        // see await_quiesced_connection): a delayed PeerConnected from a
+        // duplicate dial leg would otherwise abort the scheduled reconnect.
+        await_quiesced_connection(
+            &alice_network,
+            &bob_peer,
+            std::time::Duration::from_secs(1) * test_time_multiplier(),
+        )
+        .await;
+
         alice_network
             .disconnect_with_reason(&bob_peer, network::DisconnectReason::Transport)
             .await
@@ -13552,8 +13681,11 @@ mod tests {
             "bob disconnected after transport disconnect"
         );
 
-        // Proactive reconnect must recover bob within the backoff window.
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+        // Proactive reconnect must recover bob EVENTUALLY — the deadline is
+        // a panic-on-never guard sized to the full backoff envelope (~62s
+        // worst case) with headroom, scaled for loaded runners (issue #241).
+        let deadline = tokio::time::Instant::now()
+            + std::time::Duration::from_secs(90) * test_time_multiplier();
         while tokio::time::Instant::now() < deadline {
             if alice_network.is_connected(&bob_peer).await {
                 break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13336,7 +13336,7 @@ mod tests {
         // a delayed PeerConnected from a duplicate dial leg would otherwise
         // arrive after the disconnect and abort the just-scheduled reconnect.
         await_quiesced_connection(
-            &alice_network,
+            alice_network,
             &bob_peer,
             std::time::Duration::from_secs(1) * test_time_multiplier(),
         )
@@ -13523,7 +13523,7 @@ mod tests {
         // see await_quiesced_connection): a delayed PeerConnected from a
         // duplicate dial leg would otherwise abort the scheduled reconnect.
         await_quiesced_connection(
-            &alice_network,
+            alice_network,
             &bob_peer,
             std::time::Duration::from_secs(1) * test_time_multiplier(),
         )
@@ -13662,7 +13662,7 @@ mod tests {
         // see await_quiesced_connection): a delayed PeerConnected from a
         // duplicate dial leg would otherwise abort the scheduled reconnect.
         await_quiesced_connection(
-            &alice_network,
+            alice_network,
             &bob_peer,
             std::time::Duration::from_secs(1) * test_time_multiplier(),
         )

--- a/tests/network_timeout.rs
+++ b/tests/network_timeout.rs
@@ -6,36 +6,56 @@ use saorsa_gossip_transport::GossipTransport;
 use std::time::Duration;
 use x0x::network::{NetworkConfig, NetworkNode};
 
+/// Hermetic node config: loopback bind, no bootstrap peers. "No messages
+/// arrive" is then load- AND environment-independent — `NetworkConfig::
+/// default()` lists the real WAN bootstrap seeds, so a gossip message
+/// landing inside the short timeout window completes `receive_message()`
+/// and races the timeout assertion (issue #241).
+fn isolated_config() -> NetworkConfig {
+    NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr")),
+        bootstrap_nodes: Vec::new(),
+        ..NetworkConfig::default()
+    }
+}
+
 #[tokio::test]
 async fn test_receive_message_blocks_until_message() {
     // Create a network node
-    let network = NetworkNode::new(NetworkConfig::default(), None, None)
+    let network = NetworkNode::new(isolated_config(), None, None)
         .await
         .expect("Failed to create network node");
 
     // Verify receive_message() correctly blocks when no messages available
     let result = tokio::time::timeout(Duration::from_millis(100), network.receive_message()).await;
 
-    // Should timeout since no peers are connected and no messages sent
-    assert!(
-        result.is_err(),
-        "receive_message() should timeout when no messages available"
-    );
+    // The timeout ERROR CONTEXT is the assertion, not the wall-clock bound:
+    // on an isolated node the receive can only end via the caller's
+    // deadline (Elapsed) — never via an arriving message or a closed
+    // channel — however long a loaded runtime takes to fire the timer.
+    let Err(_elapsed) = result else {
+        panic!("receive_message() completed on an isolated node; expected Elapsed");
+    };
 }
 
 #[tokio::test]
 async fn test_receive_message_with_timeout_context() {
     // This test verifies that receive_message() doesn't panic or leak resources
     // when timing out
-    let network = NetworkNode::new(NetworkConfig::default(), None, None)
+    let network = NetworkNode::new(isolated_config(), None, None)
         .await
         .expect("Failed to create network node");
 
-    // Multiple timeout attempts should be safe
+    // Multiple timeout attempts should be safe. Each must end in the
+    // caller's timeout context (Elapsed): on an isolated node no message
+    // can arrive, so the outcome no longer depends on when a loaded
+    // runtime fires the timer (issue #241).
     for _ in 0..3 {
         let result: Result<_, tokio::time::error::Elapsed> =
             tokio::time::timeout(Duration::from_millis(50), network.receive_message()).await;
-        assert!(result.is_err());
+        let Err(_elapsed) = result else {
+            panic!("receive_message() completed on an isolated node; expected Elapsed");
+        };
     }
 
     // Network should still be functional


### PR DESCRIPTION
Closes #241.

Three tests flaked under full-suite CPU contention on wall-clock deadlines. Root cause: they raced setup churn (a delayed spurious PeerConnected post-disconnect aborts the just-scheduled reconnect) and pinned tight deadlines (20s) below the genuine reconnect envelope (~62s worst case: 31s backoff + 20% jitter + 5×5s dial timeouts).

- Reconnect tests now assert the load-independent invariant (reconnect EVENTUALLY fires) with a panic-on-never guard of 90s × X0X_TEST_TIME_MULTIPLIER (~1.45× the genuine envelope — a broken reconnect still fails); a quiesce window absorbs delayed setup events before the disconnect
- Fixed 200ms sleep-then-assert replaced with poll-until-observed (strictly stronger)
- network_timeout: node config now isolates from the 24 real WAN bootstrap seeds so receive_message can only end via the caller's Elapsed; asserts the error variant, not wall-clock bounds
- Production code untouched (all changes in #[cfg(test)] + tests/)

Stability evidence: 10× back-to-back passes under induced CPU contention (concurrent cargo check). Gates: fmt/clippy clean, 4/4 targeted tests. Adversarial review: SOUND (5/5 criteria).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes reconnect and timeout tests less dependent on wall-clock timing. The main changes are:

- Adds scaled deadlines and a connection-quiescence helper.
- Polls for disconnect and eventual reconnect state.
- Isolates timeout tests from default WAN bootstrap peers.
- Asserts the timeout result variant directly.

<h3>Confidence Score: 4/5</h3>

The reconnect tests can still fail under delayed event handling or executor starvation.

- Stable connection state does not prove that queued connection events were consumed.
- A completed reconnect can hide the disconnected state before the polling task runs.
- The isolated timeout-test changes appear safe.

src/lib.rs reconnect-test synchronization.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib.rs | Adds reconnect-test timing and synchronization, but two scheduler and event-order races remain. |
| tests/network_timeout.rs | Makes timeout tests hermetic and checks for the expected elapsed result. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib.rs:12289-12291
**Stable State Does Not Drain Events**

When the event-listener task is delayed for longer than the quiesce window, `is_connected()` can stay true while an earlier `PeerConnected` remains unprocessed. The helper then returns, the test disconnects, and the stale event can abort the new reconnect task, reproducing the original timeout flake.

### Issue 2 of 2
src/lib.rs:13363-13371
**Reconnect Can Hide The Drop**

Under executor starvation, both the 25 ms poll timer and the reconnect task's backoff can expire before either task runs; Tokio does not guarantee that this polling task runs first. If reconnect completes first, `is_connected()` stays true until `drop_deadline`, so the test fails despite a successful disconnect and recovery; the mirrored polling loop has the same race.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style: #241 — clippy needless\_borrow on ..."](https://github.com/saorsa-labs/x0x/commit/dca097b928eb4dc90f104576bdc94b27fb6e1ac8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45223261)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->