### PR TITLE
docs(identity): #215 — document pubsub sender-auth invariant + saorsa-gossip audit

### DIFF
--- a/docs/audit-wp-g-sender-auth.md
+++ b/docs/audit-wp-g-sender-auth.md
@@ -54,7 +54,7 @@
   `handle_eager`.
 - **IHAVE / IWANT**: verified before processing (dep lib.rs:6559-6561,
   6586-6588); they carry no subscriber payload. IWANT responses re-send cached
-  (previously verified) messages as EAGER (dep lib.rs:5563-5569).
+  (previously verified) messages as EAGER (dep lib.rs:5534-5560).
 - **publish_local** self-delivers the node's own freshly signed payload to its
   own subscribers without a verification step (dep lib.rs:5197-5198): local
   origin by construction, benign.
@@ -115,10 +115,12 @@ its inner v2 signature, so a relay cannot spoof `msg.sender` past
 
 ## Tripwire — what breaks if the invariant is violated
 
-If a future dependency bump (or a change to `decode_v2` /
-`decode_for_delivery`) lets a relay-injected payload reach consumers with a
-spoofed sender and `verified == true`, these tests fail first — the pair issue
-#215 refers to as tests 8–9:
+The guard tests issue #215 refers to as tests 8–9 construct a `PubSubMessage`
+by hand (verified sender fields, no decode) and call the binding function
+directly. They therefore trip ONLY on regressions of the guard itself
+(`identity_announcement_has_direct_agent_origin` /
+`record_authenticated_machine_binding_from_message`) — NOT on a
+saorsa-gossip-pubsub bump or a `decode_v2` change, which they never exercise:
 - `wrong_origin_machine_announcement_cannot_populate_or_overwrite_binding`
   (src/lib.rs:15399) — attacker's verified envelope carrying the victim's
   announcement must not populate/overwrite the victim's binding.
@@ -126,10 +128,16 @@ spoofed sender and `verified == true`, these tests fail first — the pair issue
   (src/lib.rs:15440) — a relay's verified rebroadcast of the origin's
   announcement must not populate/overwrite the retained binding.
 
+The decode-layer tripwire — the test that fails if `decode_v2` ever accepts a
+forged or tampered signature — is `test_v2_tampered_payload_fails_verification`
+(src/gossip/pubsub.rs:1523). No unit test cited here covers a dependency bump:
+`saorsa-gossip-pubsub` upgrades need an integration-level check (a live
+relay/forward scenario) before merge; the pair above must not be read as
+covering that case.
+
 Supporting guards: `direct_origin_identity_ingest_populates_authenticated_binding`
 (src/lib.rs:15377, positive control),
 `missing_or_invalid_sender_key_cannot_populate_authenticated_binding`
-(src/lib.rs:15478), and at the decode layer
-`test_v2_tampered_payload_fails_verification` (src/gossip/pubsub.rs:1523).
+(src/lib.rs:15478).
 Run on any `saorsa-gossip-pubsub` bump:
 `cargo nextest run -E 'test(wrong_origin_machine_announcement_cannot_populate_or_overwrite_binding) or test(verified_rebroadcast_cannot_populate_or_overwrite_authenticated_binding)'`

--- a/docs/audit-wp-g-sender-auth.md
+++ b/docs/audit-wp-g-sender-auth.md
@@ -1,0 +1,135 @@
+# Audit WP-G: saorsa-gossip pubsub sender authentication
+
+- **Issue:** #215 (follow-up to PR #214, gossip-DM machine-revocation origin authentication)
+- **Date:** 2026-07-17
+- **Question:** can any receive path in the gossip stack deliver a message whose
+  application-visible `sender` is self-declared / unsigned, with
+  `verified == true`? `identity_announcement_has_direct_agent_origin`
+  (src/lib.rs:1015) relies on the answer being "no".
+
+## Dependency under audit
+
+- Crate: `saorsa-gossip-pubsub` **0.5.67** (version requirement `0.5.67` in
+  Cargo.toml:48; resolved to exactly 0.5.67 via `cargo metadata` — Cargo.lock
+  is gitignored, .gitignore:3).
+- Source audited: the extracted registry copy
+  `~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/saorsa-gossip-pubsub-0.5.67/src/lib.rs`
+  (cited below as "dep lib.rs:N").
+
+## What the dependency actually delivers to x0x
+
+- Local subscribers receive `(PeerId, Bytes)` tuples — dep lib.rs:2466
+  (`subscribers: Vec<mpsc::UnboundedSender<(PeerId, Bytes)>>`), registered by
+  `subscribe` (dep lib.rs:6482-6496). On inbound EAGER the tuple sent is
+  `(from, payload.clone())` (dep lib.rs:5337, 5346), where `from` is the
+  **immediate transport peer that forwarded the frame**, not an application
+  origin.
+- x0x discards that peer ID: `let Some((_peer, encoded_payload)) = received`
+  (src/gossip/pubsub.rs:478). The dependency therefore has **no
+  application-visible sender field at all** — x0x's `PubSubMessage.sender`
+  (src/gossip/pubsub.rs:164-176) is computed entirely inside x0x's own
+  `decode_v2`.
+
+## Receive-path signature enforcement in the dependency
+
+- `handle_message` (dep lib.rs:6530) postcard-decodes the `GossipMessage`
+  (dep lib.rs:6533) and dispatches on `header.kind` (dep lib.rs:6556).
+- `GossipMessage` carries a sender-supplied `signature` and `public_key`
+  alongside the header and optional payload (dep lib.rs:1889-1898). The
+  signature is ML-DSA-65 over the postcard-serialized `MessageHeader`:
+  `sign_message` (dep lib.rs:5063-5083, "Per SPEC2 §2, all gossip messages
+  MUST be signed"), verified by `verify_signature` via
+  `saorsa_gossip_identity::MlDsaKeyPair::verify(public_key, header_bytes,
+  signature)` (dep lib.rs:5092-5118, verify call at 5109), wrapped by
+  `verify_message_signature` (dep lib.rs:4108-4114).
+- **EAGER** (the only inbound kind that delivers payload to subscribers):
+  `handle_eager` (dep lib.rs:5205) verifies the signature **first**
+  (dep lib.rs:5213); on failure it logs, records an invalid-message penalty
+  against the forwarding peer, and returns `Err` **without caching or
+  delivering** (dep lib.rs:5214-5218). Subscriber delivery happens only after
+  verification, dedupe, and replay checks (dep lib.rs:5334-5346).
+- **Anti-entropy**: verified before any processing (dep lib.rs:5581-5583); it
+  serves only messages already in the local cache (i.e. verified on original
+  ingest), re-sent as EAGER, which recipients re-verify through
+  `handle_eager`.
+- **IHAVE / IWANT**: verified before processing (dep lib.rs:6559-6561,
+  6586-6588); they carry no subscriber payload. IWANT responses re-send cached
+  (previously verified) messages as EAGER (dep lib.rs:5563-5569).
+- **publish_local** self-delivers the node's own freshly signed payload to its
+  own subscribers without a verification step (dep lib.rs:5197-5198): local
+  origin by construction, benign.
+
+## How x0x populates `sender` / `verified` (for completeness)
+
+- `decode_v2` (src/gossip/pubsub.rs:1080) parses the v2 wire format
+  (`0x02 || agent_id(32) || lp(public_key) || lp(signature) || lp(topic) ||
+  payload`), computes `verified = verify_signature(...)`
+  (src/gossip/pubsub.rs:1114-1120), then sets `sender: Some(agent_id)` and
+  `verified` from that result (src/gossip/pubsub.rs:1129-1136).
+- `verify_signature` (src/gossip/pubsub.rs:1171) binds the wire `agent_id` to
+  the embedded public key (`AgentId::from_public_key(&public_key) ==
+  agent_id`, src/gossip/pubsub.rs:1184-1188) and verifies the ML-DSA-65
+  signature over `b"x0x-msg-v2" || agent_id(32) || topic_bytes || payload`
+  (`build_signing_payload`, src/gossip/pubsub.rs:1161-1167; prefix constant at
+  src/gossip/pubsub.rs:104; verify call at src/gossip/pubsub.rs:1198-1202).
+- Legacy v1 decode yields `sender: None`, `verified: false`
+  (src/gossip/pubsub.rs:996-1003). `publish_local` yields the local agent with
+  `verified: true` — local origin by construction (src/gossip/pubsub.rs:620-633).
+- Delivery-time backstop: `decode_for_delivery` drops any signed message with
+  `verified == false` (src/gossip/pubsub.rs:781-789).
+
+## Findings
+
+1. **No receive path in saorsa-gossip-pubsub 0.5.67 delivers an unverified
+   remote payload to local subscribers.** Every payload-delivering inbound
+   path verifies the envelope ML-DSA-65 signature first and drops on failure
+   (evidence above). There is also no code path by which a remote peer could
+   choose an application-level sender identity: the only sender-ish value the
+   dependency propagates is the transport `PeerId` of the immediate forwarder,
+   which x0x discards (src/gossip/pubsub.rs:478).
+2. **The dependency's envelope signature covers only the serialized
+   `MessageHeader`** (dep lib.rs:1896-1897). Payload binding is indirect:
+   `msg_id` embeds `blake3(payload)` at publish time (dep lib.rs:5053-5056),
+   but `handle_eager` trusts `header.msg_id` (dep lib.rs:5210) without
+   recomputing it from the received payload. A relay could therefore in
+   principle attach a different payload to a captured, validly signed header.
+   This does **not** weaken x0x's sender-auth invariant: the substituted
+   payload fails x0x's inner v2 ML-DSA-65 verification, which covers the exact
+   payload bytes (src/gossip/pubsub.rs:1161-1167, 1198-1202), so
+   `verified == false` and the message is dropped (src/gossip/pubsub.rs:781-789).
+   Worth re-checking on any dependency bump, since x0x's defense here is
+   single-layer by design (the inner signature), not double-layer.
+3. x0x's `sender` is self-declared wire data, but it can only carry
+   `verified == true` when (a) the declared agent ID equals
+   `AgentId::from_public_key(embedded_key)` and (b) the ML-DSA-65 signature
+   over the domain-separated payload verifies under that key. A relay without
+   the origin's private key cannot satisfy both.
+
+## Conclusion
+
+In saorsa-gossip-pubsub 0.5.67, no receive path can populate an
+application-visible sender with `verified == true` absent a valid ML-DSA-65
+signature from the claimed origin's key; x0x derives `msg.sender` solely from
+its inner v2 signature, so a relay cannot spoof `msg.sender` past
+`identity_announcement_has_direct_agent_origin`.
+
+## Tripwire — what breaks if the invariant is violated
+
+If a future dependency bump (or a change to `decode_v2` /
+`decode_for_delivery`) lets a relay-injected payload reach consumers with a
+spoofed sender and `verified == true`, these tests fail first — the pair issue
+#215 refers to as tests 8–9:
+- `wrong_origin_machine_announcement_cannot_populate_or_overwrite_binding`
+  (src/lib.rs:15399) — attacker's verified envelope carrying the victim's
+  announcement must not populate/overwrite the victim's binding.
+- `verified_rebroadcast_cannot_populate_or_overwrite_authenticated_binding`
+  (src/lib.rs:15440) — a relay's verified rebroadcast of the origin's
+  announcement must not populate/overwrite the retained binding.
+
+Supporting guards: `direct_origin_identity_ingest_populates_authenticated_binding`
+(src/lib.rs:15377, positive control),
+`missing_or_invalid_sender_key_cannot_populate_authenticated_binding`
+(src/lib.rs:15478), and at the decode layer
+`test_v2_tampered_payload_fails_verification` (src/gossip/pubsub.rs:1523).
+Run on any `saorsa-gossip-pubsub` bump:
+`cargo nextest run -E 'test(wrong_origin_machine_announcement_cannot_populate_or_overwrite_binding) or test(verified_rebroadcast_cannot_populate_or_overwrite_authenticated_binding)'`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -975,6 +975,43 @@ fn identity_announcement_timestamp_is_acceptable(announced_at: u64, now: u64) ->
     announced_at <= now.saturating_add(IDENTITY_ANNOUNCEMENT_CLOCK_SKEW_SECS)
 }
 
+/// True only when the pubsub envelope proves the announcement arrived directly
+/// from its origin agent: the message is signature-verified, its sender is the
+/// announcement's agent, and the sender's ML-DSA-65 public key derives that
+/// same agent ID.
+///
+/// # Invariant this depends on (issue #215)
+///
+/// This check is sound only because pubsub `msg.sender` / `msg.verified` are
+/// cryptographically origin-authenticated end to end — a relay cannot set
+/// `sender` to a foreign agent with `verified == true`:
+///
+/// - `decode_v2` (src/gossip/pubsub.rs:1080) parses the sender's 32-byte agent
+///   ID, ML-DSA-65 public key, and signature out of the v2 wire bytes and sets
+///   `verified` to the result of `verify_signature`
+///   (src/gossip/pubsub.rs:1114-1120), which requires
+///   `AgentId::from_public_key(sender_public_key) == agent_id`
+///   (src/gossip/pubsub.rs:1184-1188) and verifies the ML-DSA-65 signature
+///   over `b"x0x-msg-v2" || agent_id(32) || topic_bytes || payload`
+///   (`build_signing_payload`, src/gossip/pubsub.rs:1161-1167; prefix constant
+///   at src/gossip/pubsub.rs:104; verify call at src/gossip/pubsub.rs:1198-1202).
+///   `sender` is then set to `Some(agent_id)` and `verified` to that check's
+///   result (src/gossip/pubsub.rs:1129-1136).
+/// - Excluded spoof: a relay re-publishing the origin's announcement under its
+///   own v2 envelope yields `msg.sender == <relay agent>` !=
+///   `announcement.agent_id`, so this function returns false. A relay forging
+///   the origin's agent ID in the envelope must produce an ML-DSA-65 signature
+///   over the payload with a key that derives that agent ID — impossible
+///   without the origin's private key — so `verify_signature` fails,
+///   `verified == false`, the payload is dropped in `decode_for_delivery`
+///   (src/gossip/pubsub.rs:781-789), and even a hand-constructed message with
+///   `verified == false` fails this check: the binding is not retained.
+/// - The transport hop is never consulted for `sender`: saorsa-gossip-pubsub
+///   delivers `(transport_peer, payload)` and x0x discards the peer
+///   (src/gossip/pubsub.rs:478).
+///
+/// Audit of the dependency's sender-authentication path:
+/// docs/audit-wp-g-sender-auth.md.
 fn identity_announcement_has_direct_agent_origin(
     msg: &gossip::PubSubMessage,
     announcement: &IdentityAnnouncement,


### PR DESCRIPTION
Closes #215.

- Doc comment on identity_announcement_has_direct_agent_origin states the invariant precisely: msg.sender/msg.verified derive solely from the end-to-end ML-DSA-65 v2 signature; a relay forging the origin's agent id needs the origin's private key, so spoof ⇒ verified=false ⇒ binding not retained. Transport hop is never consulted for sender.
- docs/audit-wp-g-sender-auth.md: full receive-path audit of saorsa-gossip-pubsub 0.5.67 with file:line citations into the registry source — EAGER, anti-entropy, IHAVE/IWANT, publish_local — concluding no receive path can populate a verified sender absent a valid origin signature.
- Tripwire section is precise about coverage: the binding guard tests (lib.rs:15399, 15440) trip only on regressions of the guard itself; test_v2_tampered_payload_fails_verification (pubsub.rs:1523) is the decode-layer tripwire; dependency bumps need an integration-level check (called out explicitly).

Gates: fmt/clippy/check clean. Accuracy review: all citations opened and verified; two defects (tripwire scope, one citation range) fixed in the follow-up commit.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR documents the sender-authentication invariant used by identity-announcement binding. The main changes are:

- Adds an audit of pubsub receive and signature-verification paths.
- Explains how application-visible sender identity is derived.
- Clarifies the scope of guard, decode-layer, and dependency-level tests.
- Adds the invariant and audit reference to the binding guard documentation.

<h3>Confidence Score: 4/5</h3>

The version-specific security audit needs a reproducible dependency version before merging.

- The local sender and signature checks match the documented guard behavior.
- Cargo can resolve a later `0.5.x` dependency that the audit does not cover.
- The updated tripwire section accurately states that its unit tests do not validate dependency behavior.

docs/audit-wp-g-sender-auth.md

<details open><summary><h3>Security Review</h3></summary>

The documented sender-authentication argument is consistent for saorsa-gossip-pubsub 0.5.67, but the manifest does not pin that version. Without a tracked lockfile, builds may use a later unaudited 0.5.x release.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/audit-wp-g-sender-auth.md | Adds the sender-auth audit and tripwire guidance, but describes a semver-ranged dependency as resolving reproducibly to the audited version. |
| src/lib.rs | Adds documentation for the existing direct-origin guard without changing runtime behavior. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/audit-wp-g-sender-auth.md:12-14
**Audited Version Is Not Pinned**

Cargo interprets `"0.5.67"` as a caret requirement, so a fresh checkout without a tracked lockfile may compile a later `0.5.x` release. The audit can then claim 0.5.67 while its line citations and sender-auth conclusions do not cover the dependency actually running.

```suggestion
- Crate audited: `saorsa-gossip-pubsub` **0.5.67**. Cargo.toml:48 uses
  the caret-compatible requirement `0.5.67`, and Cargo.lock is gitignored
  (.gitignore:3), so fresh resolution may select a later `0.5.x` release.
  Confirm with `cargo metadata` that exactly 0.5.67 is resolved before relying
  on this audit.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(identity): #215 review — precise tr..."](https://github.com/saorsa-labs/x0x/commit/f7219383014de5ff6320d9d8adc5a62af05806c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45214253)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->