### PR TITLE
docs(groups): #107 — delegated-admin authority docs + admin-ban convergence e2e

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10835,7 +10835,18 @@ async fn spawn_public_message_listener(state: Arc<AppState>, group_id: String) {
         .insert(group_id, handle);
 }
 
-/// POST /groups/:id/invite — generate an invite link (body optional).
+/// POST /groups/:id/invite — generate an invite link (admin+; body optional).
+///
+/// Authority follows ADR-0016: any active Admin-or-higher member may mint
+/// invites (issue #107 — invite minting is an admission/routing act, not a
+/// creator-cryptographic one). The route checks the caller's role against
+/// its daemon's LOCAL roster view, which may lag convergence (a just-demoted
+/// admin can still mint until the demotion applies locally). That is safe,
+/// not a bypass: the joiner's `MemberJoined` routes to the minting admin,
+/// which authors the authority-signed `MemberAdded` commit, and every
+/// receiver's `validate_apply` enforces `AdminOrHigher` against ITS
+/// converged roster — a commit signed by a no-longer-admin fails group-wide,
+/// so a stale invite never produces unauthorized membership.
 async fn create_group_invite(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -13461,7 +13472,12 @@ async fn update_group_policy(
     )
 }
 
-/// PATCH /groups/:id/members/:agent_id/role — change a member's role.
+/// PATCH /groups/:id/members/:agent_id/role — change a member's role (admin+).
+///
+/// Only the flat ADR-0016 vocabulary (`admin`, `member`) is assignable.
+/// Ownership transfer is deliberately unsupported: ADR-0016 §4 dissolved
+/// the distinct Owner role, so `role=owner` returns a 400 naming the legacy
+/// role rather than a partial-transfer stub (issue #107 item (d)).
 async fn update_member_role(
     State(state): State<Arc<AppState>>,
     Path((id, agent_id_hex)): Path<(String, String)>,

--- a/tests/named_group_d4_apply.rs
+++ b/tests/named_group_d4_apply.rs
@@ -704,9 +704,13 @@ async fn d4_non_creator_admin_ban_commit_advances_binding_and_converges() {
     let charlie = &cluster.charlie; // ban target
     bootstrap_agent_cards(&[alice, bob, charlie]).await;
 
-    let group_id =
-        create_group_preset(alice, "D4 Admin Ban", "non-creator admin ban", "private_secure")
-            .await;
+    let group_id = create_group_preset(
+        alice,
+        "D4 Admin Ban",
+        "non-creator admin ban",
+        "private_secure",
+    )
+    .await;
 
     // Bob (future admin) and charlie (target) join via creator invites.
     let bob_invite = create_invite(alice, &group_id).await;

--- a/tests/named_group_d4_apply.rs
+++ b/tests/named_group_d4_apply.rs
@@ -677,6 +677,190 @@ async fn d4_mls_ban_commit_advances_binding_and_converges() {
         .await;
 }
 
+/// Issue #107: a promoted, NON-creator Admin bans a member on a
+/// `private_secure` (TreeKEM) group. The signed state-commit chain's
+/// `AdminOrHigher` authority is the contract, so the admin-authored ban must
+/// (a) pass the route's role gate on the admin's own daemon, (b) produce a
+/// verified TreeKEM removal commit that advances the epoch on every
+/// remaining member INCLUDING the acting admin (actor-side convergence), and
+/// (c) converge the target to `banned` in all remaining rosters.
+///
+/// The ban route resolves the target's TreeKEM KeyPackage from the local
+/// roster, falling back to the issue-#205 member-keyed catch-up with a
+/// retryable 424; in a fully converged trio the acting admin already holds
+/// the target's package from the join-time delivery, so the ban succeeds
+/// without a retry storm. The loop below still honors the documented
+/// `retry: true` contract so a transient catch-up window cannot flake the
+/// proof — a persistent 424 fails the test.
+#[tokio::test]
+#[ignore = "daemon-trio admin-ban convergence (gossip wait window) flakes the always-on Test Suite under CI load; runs in the integration tier"]
+async fn d4_non_creator_admin_ban_commit_advances_binding_and_converges() {
+    let _guard = suite_lock().await;
+    // Owned trio, not the shared singleton — same loopback-contention
+    // reasoning as `d4_mls_ban_commit_advances_binding_and_converges`.
+    let cluster = cluster::trio_with_extra_config("").await;
+    let alice = &cluster.alice; // creator
+    let bob = &cluster.bob; // promoted admin (ban actor)
+    let charlie = &cluster.charlie; // ban target
+    bootstrap_agent_cards(&[alice, bob, charlie]).await;
+
+    let group_id =
+        create_group_preset(alice, "D4 Admin Ban", "non-creator admin ban", "private_secure")
+            .await;
+
+    // Bob (future admin) and charlie (target) join via creator invites.
+    let bob_invite = create_invite(alice, &group_id).await;
+    let bob_join = join_via_invite(bob, &bob_invite, "bob-admin-actor").await;
+    assert_eq!(bob_join["ok"], true, "bob join response: {bob_join:?}");
+    let bob_group_id = bob_join["group_id"]
+        .as_str()
+        .unwrap_or(&group_id)
+        .to_string();
+    let _ = wait_state_available(bob, &bob_group_id).await;
+
+    let charlie_invite = create_invite(alice, &group_id).await;
+    let charlie_join = join_via_invite(charlie, &charlie_invite, "charlie-ban-target").await;
+    assert_eq!(
+        charlie_join["ok"], true,
+        "charlie join response: {charlie_join:?}"
+    );
+    let charlie_group_id = charlie_join["group_id"]
+        .as_str()
+        .unwrap_or(&group_id)
+        .to_string();
+    let _ = wait_state_available(charlie, &charlie_group_id).await;
+
+    let bob_agent_id = bob.agent_id().await;
+    let charlie_agent_id = charlie.agent_id().await;
+    assert_ne!(bob_agent_id, charlie_agent_id, "distinct ban actor/target");
+
+    // Converge: both members Active in every roster before the promotion.
+    let active = wait_until(Duration::from_secs(90), || async {
+        let alice_members = get_members(alice, &group_id).await;
+        let bob_members = get_members(bob, &bob_group_id).await;
+        member_state(&alice_members, &bob_agent_id).as_deref() == Some("active")
+            && member_state(&alice_members, &charlie_agent_id).as_deref() == Some("active")
+            && member_state(&bob_members, &bob_agent_id).as_deref() == Some("active")
+            && member_state(&bob_members, &charlie_agent_id).as_deref() == Some("active")
+    })
+    .await;
+    assert!(active, "bob and charlie did not converge to active rosters");
+
+    // The creator promotes bob to Admin; the promotion commit must converge
+    // so bob's OWN daemon observes bob as Admin at the same state hash — the
+    // ban route gates on the converged roster, not on creator identity.
+    let role_resp = authed_client(alice)
+        .patch(alice.url(&format!("/groups/{group_id}/members/{bob_agent_id}/role")))
+        .json(&serde_json::json!({ "role": "admin" }))
+        .send()
+        .await
+        .expect("promote bob");
+    assert_eq!(role_resp.status(), StatusCode::OK, "promote status");
+    let promoted = wait_until(Duration::from_secs(90), || async {
+        let alice_members = get_members(alice, &group_id).await;
+        let bob_members = get_members(bob, &bob_group_id).await;
+        let alice_hash = get_state(alice, &group_id).await;
+        let bob_hash = get_state(bob, &bob_group_id).await;
+        member_role(&alice_members, &bob_agent_id).as_deref() == Some("admin")
+            && member_role(&bob_members, &bob_agent_id).as_deref() == Some("admin")
+            && state_commit_keys(&alice_hash).is_some()
+            && state_commit_keys(&alice_hash) == state_commit_keys(&bob_hash)
+    })
+    .await;
+    assert!(promoted, "bob's admin promotion did not converge to bob");
+
+    // The TreeKEM plane is live on creator and admin before the ban.
+    let alice_pre = get_state(alice, &group_id).await;
+    let alice_pre_binding = alice_pre["security_binding"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        alice_pre_binding.starts_with("treekem:epoch="),
+        "pre-ban alice binding should be on the treekem plane, got {alice_pre_binding:?}"
+    );
+    let bob_pre = get_state(bob, &bob_group_id).await;
+    let bob_pre_binding = bob_pre["security_binding"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        bob_pre_binding.starts_with("treekem:epoch="),
+        "pre-ban bob binding should be on the treekem plane, got {bob_pre_binding:?}"
+    );
+
+    // Bob (non-creator Admin) bans charlie. Honor the route's documented
+    // retry contract (`424 member_key_package_pending` with `retry: true`)
+    // for the on-demand KeyPackage catch-up window; any other failure, or a
+    // window that never closes, fails the proof.
+    let ban_deadline = tokio::time::Instant::now() + Duration::from_secs(90);
+    let ban_body: Value = loop {
+        let resp = authed_client(bob)
+            .post(bob.url(&format!("/groups/{bob_group_id}/ban/{charlie_agent_id}")))
+            .send()
+            .await
+            .expect("admin ban request");
+        let status = resp.status();
+        let body: Value = resp.json().await.expect("admin ban json");
+        if status == StatusCode::OK {
+            assert_eq!(body["ok"], true, "admin ban body: {body:?}");
+            break body;
+        }
+        let retryable = status == StatusCode::FAILED_DEPENDENCY && body["retry"] == true;
+        assert!(
+            retryable,
+            "admin ban must succeed or ask for a documented retry, got {status}: {body:?}"
+        );
+        assert!(
+            tokio::time::Instant::now() < ban_deadline,
+            "admin ban KeyPackage catch-up never closed; last response: {body:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    };
+    let ban_revision = ban_body["revision"].as_u64().expect("ban revision");
+
+    // Actor-side convergence: the acting admin's own epoch binding advances.
+    let actor_advanced = wait_until(Duration::from_secs(90), || async {
+        let bob_state = get_state(bob, &bob_group_id).await;
+        let binding = bob_state["security_binding"].as_str().unwrap_or_default();
+        binding.starts_with("treekem:epoch=") && binding != bob_pre_binding
+    })
+    .await;
+    assert!(
+        actor_advanced,
+        "admin-authored ban should advance the ACTOR's treekem epoch binding from {bob_pre_binding:?}"
+    );
+
+    // Cross-daemon convergence: the creator observes the same advanced epoch
+    // and the same state chain head as the acting admin, and charlie is
+    // `banned` in both remaining rosters.
+    let converged = wait_until(Duration::from_secs(90), || async {
+        let alice_state = get_state(alice, &group_id).await;
+        let bob_state = get_state(bob, &bob_group_id).await;
+        let alice_binding = alice_state["security_binding"].as_str().unwrap_or_default();
+        let bob_binding = bob_state["security_binding"].as_str().unwrap_or_default();
+        let alice_members = get_members(alice, &group_id).await;
+        let bob_members = get_members(bob, &bob_group_id).await;
+        alice_binding.starts_with("treekem:epoch=")
+            && alice_binding != alice_pre_binding
+            && alice_binding == bob_binding
+            && state_commit_keys(&alice_state).is_some()
+            && state_commit_keys(&alice_state) == state_commit_keys(&bob_state)
+            && member_state(&alice_members, &charlie_agent_id).as_deref() == Some("banned")
+            && member_state(&bob_members, &charlie_agent_id).as_deref() == Some("banned")
+    })
+    .await;
+    assert!(
+        converged,
+        "admin-authored ban (rev {ban_revision}) did not converge coherently across creator and acting admin"
+    );
+
+    let _ = authed_client(alice)
+        .delete(alice.url(&format!("/groups/{group_id}")))
+        .send()
+        .await;
+}
+
 /// issue #111: the retained state-commit history endpoint serves applied
 /// commits paired with independently-verifiable roster projections, ordered by
 /// revision, with working pagination. Members-only (the local owner is a


### PR DESCRIPTION
Addresses #107.

**Findings (verified against main):**
1. Admin-delegated INVITE already shipped — `require_admin_or_above` on the invite route landed 2026-06-20 (ADR-0016 Phase 1, ten days after this issue was filed against v0.22.0). The '403 only the creator' repro predates it.
2. Authority is enforced in three layers with no bypass: route pre-check on local roster → inviter-side re-check at MemberJoined apply → the chain's validate_apply enforcing AdminOrHigher on every receiver's converged roster. A just-demoted admin can mint an invite while their daemon's local view is stale, but the commit they author is rejected group-wide — stale invites never produce unauthorized membership (documented precisely at the route).
3. Admin-delegated BAN works: new convergence e2e proves a non-creator admin's ban commit advances the binding and converges across a daemon trio (integration tier; the gossip wait window makes it load-flaky in the always-on tier, noted in the test's ignore comment). The 424 'missing TreeKEM KeyPackage' from the issue is the honest transient — the admin's daemon authors the removal once it holds the material.
4. Ownership transfer remains deliberately unsupported (400).

**Changes:** doc comments pinning the exact authority semantics (invite route + ban path), one new integration-tier e2e test.

Gates: fmt/clippy clean, 35/35 route/unit tests, new e2e passes (77s). Adversarial review: no bypass found; doc overstatement fixed; commit message corrected to reflect that this is docs+test, not a route-code change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR documents delegated-admin group authority and adds convergence coverage. The main changes are:

- Documents admin invite authority and stale-roster validation.
- Documents assignable roles and unsupported ownership transfer.
- Adds an ignored integration test for non-creator admin bans and TreeKEM convergence.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after confirming the integration tier runs the ignored test.

- The documentation matches the inspected authorization and role parsing behavior.
- The new test checks promotion, retry handling, epoch advancement, and cross-daemon convergence.
- The test provides no coverage unless its integration command explicitly includes ignored tests.

tests/named_group_d4_apply.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/mod.rs | Adds API documentation consistent with the existing invite authorization and role-assignment behavior. |
| tests/named_group_d4_apply.rs | Adds comprehensive admin-ban convergence coverage, but the test only runs when the integration tier explicitly includes ignored tests. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/named_group_d4_apply.rs:696
**Integration Test Can Stay Disabled**

This test is ignored by every normal test run, while the attribute only states that an integration tier runs it. Unless that tier explicitly uses `--ignored` or `--include-ignored` for this test, the new admin-ban coverage never executes and future regressions pass CI unnoticed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style: cargo fmt"](https://github.com/saorsa-labs/x0x/commit/0b9d9a5e647b6a2d1e6ada200ddb93a15782845e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45223281)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->