### PR TITLE
feat(dm): #120 — opt-in coarsened observed-prefix origin token on DM surfaces

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -347,6 +347,16 @@ Direct messages arrive flat — no `data` envelope:
 }
 ```
 
+Opt-in (issue #120): when the daemon sets `observed_prefix_enabled = true`
+and the message arrived over the live point-to-point transport connection,
+an `observed_origin` field is added — a coarse, masked origin token such as
+`{"observed_prefix": "203.0.113.0/24", "direct": true, "cgnat": false}`
+(`/24` IPv4, `/48` IPv6; `direct=false` marks a relayed observation; `cgnat`
+marks RFC 6598 space). When the option is off (the default) the field is
+entirely absent. The same optional field appears on `/ws` and `/ws/direct`
+`direct_message` frames and on per-peer rows of `GET /diagnostics/dm`;
+it is never gossiped, never announced, and never on `/peers`.
+
 ## MLS encrypted groups
 
 Operational invariant (maintainer follow-up): legacy/raw `/mls/groups` helpers

--- a/docs/trust-and-connectivity.md
+++ b/docs/trust-and-connectivity.md
@@ -101,3 +101,41 @@ revoke that agent.
 (`relay_refused_not_a_contact`, `relay_refused_blocked`, `relay_refused_rate_limited`,
 `relay_refused_bandwidth_exceeded`) plus `relay_forward_bytes` (total bytes
 committed to forward) so operators can see and alert on refusals.
+
+## Observed-Origin Token (issue #120, `connectivity.rs`, opt-in)
+
+The transport already observes every connected peer's remote address (the same
+live connection-table data `connected_peer_snapshot()` reads and
+`add_from_connection()` enriches the bootstrap cache from). Issue #120 surfaces
+that observation as a coarse, masked *origin token* on **point-to-point DM
+surfaces only**:
+
+```json
+{ "observed_prefix": "203.0.113.0/24", "direct": true, "cgnat": false }
+```
+
+- `observed_prefix` — the observed IP with host bits zeroed at a fixed mask
+  (`/24` IPv4, `/48` IPv6). Never a raw IP; no GeoIP; no new dependencies.
+  Loopback/unspecified observations yield no token at all.
+- `direct` — `false` marks a relayed observation (the connection is via a
+  relay, per the transport's `TraversalMethod`).
+- `cgnat` — the observed address is in the RFC 6598 range (100.64.0.0/10),
+  reusing the existing `connectivity.rs` check.
+
+**Default-off.** Set `observed_prefix_enabled = true` in the daemon TOML to
+opt in (no CLI flag — same pattern as `[peer_relay]`). When disabled the
+token is never computed and every surface is byte-identical to before.
+
+**Surfaces** (each carries the token as an optional field, entirely absent —
+not `null` — when disabled or unobserved):
+
+- DM-receive WS (`/ws`, `/ws/direct`) and SSE (`/direct/events`)
+  `direct_message` events, as `observed_origin` — populated only for
+  messages that arrived over the live point-to-point transport connection
+  (gossip-inbox, relay-injected, and loopback deliveries never carry it).
+- Per-peer rows of `GET /diagnostics/dm`, as `observed_origin` (latest
+  captured token per sender agent).
+
+The token is **never gossiped, never announced, and never on `/peers`**: it
+is populated only in the raw-QUIC DM receive path and serialized only on the
+DM surfaces above.

--- a/src/connectivity.rs
+++ b/src/connectivity.rs
@@ -824,11 +824,7 @@ mod tests {
         );
         // All-ones host portion still masks to the network.
         assert_eq!(
-            mask_observed_prefix(
-                "2001:db8:ffff:ffff:ffff:ffff:ffff:ffff"
-                    .parse()
-                    .unwrap()
-            ),
+            mask_observed_prefix("2001:db8:ffff:ffff:ffff:ffff:ffff:ffff".parse().unwrap()),
             Some("2001:db8:ffff::/48".to_string())
         );
     }
@@ -876,8 +872,8 @@ mod tests {
         assert!(!below.cgnat);
 
         // CGNAT is a v4 concept; v6 observations never carry the flag.
-        let v6 = ObservedOrigin::from_observed("2001:db8::1".parse().unwrap(), false)
-            .expect("v6 masks");
+        let v6 =
+            ObservedOrigin::from_observed("2001:db8::1".parse().unwrap(), false).expect("v6 masks");
         assert!(!v6.cgnat);
         assert_eq!(v6.observed_prefix, "2001:db8::/48");
     }

--- a/src/connectivity.rs
+++ b/src/connectivity.rs
@@ -207,13 +207,96 @@ fn is_vpn_egress(ip: IpAddr) -> bool {
 }
 
 /// Whether `ip` is in the RFC 6598 CGNAT range.
-fn is_cgnat(ip: IpAddr) -> bool {
+pub(crate) fn is_cgnat(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => {
             let (net, prefix) = CGNAT_V4_RANGE;
             v4_in_cidr(v4, net, prefix)
         }
         IpAddr::V6(_) => false,
+    }
+}
+
+/// Fixed coarsening mask applied to observed IPv4 peer addresses for the
+/// opt-in observed-origin token (issue #120). Host bits below /24 are zeroed.
+pub const OBSERVED_PREFIX_V4_MASK: u8 = 24;
+
+/// Fixed coarsening mask applied to observed IPv6 peer addresses for the
+/// opt-in observed-origin token (issue #120). Host bits below /48 are zeroed.
+pub const OBSERVED_PREFIX_V6_MASK: u8 = 48;
+
+/// Coarsen an observed peer IP into a fixed-width prefix string
+/// (`"203.0.113.0/24"` / `"2001:db8::/48"`) for the issue #120 origin token.
+///
+/// Never returns a raw IP: the host bits are zeroed before formatting.
+/// Returns `None` for loopback and unspecified addresses — those carry no
+/// origin information and must surface as *absence of the token*, not as a
+/// prefix.
+#[must_use]
+pub fn mask_observed_prefix(ip: IpAddr) -> Option<String> {
+    match ip {
+        IpAddr::V4(v4) => {
+            if v4.is_loopback() || v4.is_unspecified() {
+                return None;
+            }
+            let masked = u32::from(v4) & (u32::MAX << (32 - OBSERVED_PREFIX_V4_MASK));
+            Some(format!(
+                "{}/{}",
+                Ipv4Addr::from(masked),
+                OBSERVED_PREFIX_V4_MASK
+            ))
+        }
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() || v6.is_unspecified() {
+                return None;
+            }
+            let masked = u128::from(v6) & (u128::MAX << (128 - OBSERVED_PREFIX_V6_MASK));
+            Some(format!(
+                "{}/{}",
+                Ipv6Addr::from(masked),
+                OBSERVED_PREFIX_V6_MASK
+            ))
+        }
+    }
+}
+
+/// Opt-in, coarse origin token surfaced on point-to-point DM surfaces only
+/// (issue #120): the transport-observed peer address, coarsened to a fixed
+/// prefix, plus directness and CGNAT markers.
+///
+/// Hard constraints (all enforced structurally):
+/// - Populated only from the live transport connection table — never from
+///   gossip, announcements, or address hints, and never serialized onto
+///   `/peers`.
+/// - Default OFF (`observed_prefix_enabled` in the daemon TOML); surfaces
+///   wrap it in `Option` with `skip_serializing_if`, so when disabled the
+///   field is entirely absent and wire output is byte-identical.
+/// - `observed_prefix` is always masked ([`mask_observed_prefix`]) — never a
+///   raw IP, no GeoIP, no new dependencies.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ObservedOrigin {
+    /// Coarsened observed address prefix (`"203.0.113.0/24"` /
+    /// `"2001:db8::/48"`). Never a raw IP.
+    pub observed_prefix: String,
+    /// `false` marks a relayed observation (the connection to the peer is
+    /// via a relay, so the address is the relay-observed one).
+    pub direct: bool,
+    /// The observed address is in the RFC 6598 CGNAT range (100.64.0.0/10).
+    pub cgnat: bool,
+}
+
+impl ObservedOrigin {
+    /// Build the token from a transport-observed IP and whether the
+    /// connection carrying it is relayed. Returns `None` when the IP yields
+    /// no maskable prefix (loopback / unspecified) — surfaces then omit the
+    /// token entirely.
+    #[must_use]
+    pub fn from_observed(ip: IpAddr, relayed: bool) -> Option<Self> {
+        Some(Self {
+            observed_prefix: mask_observed_prefix(ip)?,
+            direct: !relayed,
+            cgnat: is_cgnat(ip),
+        })
     }
 }
 
@@ -700,5 +783,108 @@ mod tests {
         assert!(env.degraded);
         assert!(!env.vpn_suspected && !env.cgnat_suspected);
         assert!(env.guidance.unwrap().contains("UDP/443"));
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #120 — observed-origin token masking
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn mask_observed_prefix_v4_zeroes_host_bits_below_24() {
+        // Boundary: the last octet is always zeroed, including 0 and 255.
+        assert_eq!(
+            mask_observed_prefix("203.0.113.129".parse().unwrap()),
+            Some("203.0.113.0/24".to_string())
+        );
+        assert_eq!(
+            mask_observed_prefix("203.0.113.0".parse().unwrap()),
+            Some("203.0.113.0/24".to_string())
+        );
+        assert_eq!(
+            mask_observed_prefix("203.0.113.255".parse().unwrap()),
+            Some("203.0.113.0/24".to_string())
+        );
+        // Bits above /24 survive untouched.
+        assert_eq!(
+            mask_observed_prefix("8.8.8.8".parse().unwrap()),
+            Some("8.8.8.0/24".to_string())
+        );
+    }
+
+    #[test]
+    fn mask_observed_prefix_v6_zeroes_host_bits_below_48() {
+        assert_eq!(
+            mask_observed_prefix("2001:db8::1".parse().unwrap()),
+            Some("2001:db8::/48".to_string())
+        );
+        // Segments past the third are zeroed; the /48 network survives.
+        assert_eq!(
+            mask_observed_prefix("2001:db8:abcd:1234:5678:9abc:def0:1234".parse().unwrap()),
+            Some("2001:db8:abcd::/48".to_string())
+        );
+        // All-ones host portion still masks to the network.
+        assert_eq!(
+            mask_observed_prefix(
+                "2001:db8:ffff:ffff:ffff:ffff:ffff:ffff"
+                    .parse()
+                    .unwrap()
+            ),
+            Some("2001:db8:ffff::/48".to_string())
+        );
+    }
+
+    #[test]
+    fn mask_observed_prefix_loopback_and_unspecified_are_absent() {
+        // Loopback/unspecified carry no origin information: absence, not a
+        // prefix (a "127.0.0.0/24" token would be noise, not signal).
+        assert_eq!(mask_observed_prefix("127.0.0.1".parse().unwrap()), None);
+        assert_eq!(mask_observed_prefix("127.0.0.53".parse().unwrap()), None);
+        assert_eq!(mask_observed_prefix("::1".parse().unwrap()), None);
+        assert_eq!(mask_observed_prefix("0.0.0.0".parse().unwrap()), None);
+        assert_eq!(mask_observed_prefix("::".parse().unwrap()), None);
+    }
+
+    #[test]
+    fn observed_origin_direct_flag_marks_relayed_observation() {
+        let direct = ObservedOrigin::from_observed("203.0.113.9".parse().unwrap(), false)
+            .expect("public v4 masks");
+        assert!(direct.direct);
+        assert!(!direct.cgnat);
+        assert_eq!(direct.observed_prefix, "203.0.113.0/24");
+
+        // A relayed observation must report direct=false (issue #120).
+        let relayed = ObservedOrigin::from_observed("203.0.113.9".parse().unwrap(), true)
+            .expect("public v4 masks");
+        assert!(!relayed.direct);
+    }
+
+    #[test]
+    fn observed_origin_cgnat_flag_uses_rfc6598_range() {
+        // 100.64.0.0/10 membership is delegated to the existing is_cgnat
+        // check — cover both range boundaries here.
+        let cgnat = ObservedOrigin::from_observed("100.64.0.1".parse().unwrap(), false)
+            .expect("CGNAT v4 still masks");
+        assert!(cgnat.cgnat);
+        assert_eq!(cgnat.observed_prefix, "100.64.0.0/24");
+
+        let top = ObservedOrigin::from_observed("100.127.255.255".parse().unwrap(), false)
+            .expect("top of CGNAT range masks");
+        assert!(top.cgnat);
+
+        let below = ObservedOrigin::from_observed("100.63.255.255".parse().unwrap(), false)
+            .expect("just below CGNAT range masks");
+        assert!(!below.cgnat);
+
+        // CGNAT is a v4 concept; v6 observations never carry the flag.
+        let v6 = ObservedOrigin::from_observed("2001:db8::1".parse().unwrap(), false)
+            .expect("v6 masks");
+        assert!(!v6.cgnat);
+        assert_eq!(v6.observed_prefix, "2001:db8::/48");
+    }
+
+    #[test]
+    fn observed_origin_none_for_loopback() {
+        assert!(ObservedOrigin::from_observed("127.0.0.1".parse().unwrap(), false).is_none());
+        assert!(ObservedOrigin::from_observed("::1".parse().unwrap(), true).is_none());
     }
 }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -66,6 +66,7 @@
 //! assert_eq!(msg.payload, b"hello");
 //! ```
 
+use crate::connectivity::ObservedOrigin;
 use crate::dm::DmPath;
 use crate::error::{NetworkError, NetworkResult};
 use crate::identity::{AgentId, MachineId};
@@ -226,6 +227,17 @@ pub struct DirectMessage {
     /// When present, reflects the full trust evaluation including contact
     /// store trust level and machine pinning.
     pub trust_decision: Option<TrustDecision>,
+    /// Issue #120: opt-in coarsened origin token — the transport-observed
+    /// peer address masked to a fixed prefix, with directness and CGNAT
+    /// markers.
+    ///
+    /// Populated ONLY when (a) the daemon opted in via
+    /// `observed_prefix_enabled`, (b) the message arrived over the live
+    /// point-to-point transport connection (gossip-inbox, relay-injected,
+    /// and loopback deliveries always carry `None`), and (c) the observed
+    /// IP yields a maskable prefix (loopback/unspecified do not). Never
+    /// gossiped, never announced, never on `/peers`.
+    pub observed_origin: Option<ObservedOrigin>,
 }
 
 impl DirectMessage {
@@ -256,6 +268,7 @@ impl DirectMessage {
             received_at,
             verified,
             trust_decision,
+            observed_origin: None,
         }
     }
 
@@ -500,6 +513,11 @@ struct DirectPeerDiagnosticsState {
     send_failed: u64,
     recv_count: u64,
     preferred_path: Option<&'static str>,
+    /// Issue #120: latest observed-origin token captured at receive time.
+    /// `None` unless the daemon opted in and a point-to-point delivery
+    /// carried a maskable observation; gossip/loopback deliveries never
+    /// overwrite an existing token.
+    observed_origin: Option<ObservedOrigin>,
 }
 
 impl DirectPeerDiagnosticsState {
@@ -562,6 +580,11 @@ pub struct DmPeerDiagnostics {
     pub send_failed: u64,
     pub recv_count: u64,
     pub preferred_path: String,
+    /// Issue #120: opt-in coarsened origin token. Entirely absent unless the
+    /// daemon opted in (`observed_prefix_enabled`) AND a point-to-point
+    /// delivery from this peer carried a maskable observation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_origin: Option<ObservedOrigin>,
 }
 
 /// Snapshot of the direct-message diagnostics surface.
@@ -1044,6 +1067,7 @@ impl DirectMessaging {
                             send_failed: peer.send_failed,
                             recv_count: peer.recv_count,
                             preferred_path: peer.preferred_path.unwrap_or("unknown").to_string(),
+                            observed_origin: peer.observed_origin.clone(),
                         },
                     )
                 })
@@ -1079,6 +1103,8 @@ impl DirectMessaging {
             payload,
             true,
             Some(TrustDecision::Accept),
+            // Loopback never carries a transport observation (issue #120).
+            None,
         )
         .await
     }
@@ -1088,6 +1114,12 @@ impl DirectMessaging {
     /// Called by the network layer when a direct message is received.
     /// The `verified` and `trust_decision` fields are populated by the
     /// caller based on the identity discovery cache and contact store.
+    ///
+    /// `observed_origin` (issue #120) is the opt-in coarsened origin token
+    /// captured by the point-to-point raw-QUIC listener when the daemon has
+    /// enabled `observed_prefix_enabled`; every other delivery path
+    /// (gossip-inbox, relay-injected, loopback) passes `None`, and a `None`
+    /// never erases a previously captured token in the per-peer diagnostics.
     ///
     /// Returns the number of subscribers that successfully received the
     /// message. Slow subscribers keep their streams open, but when a queue
@@ -1100,6 +1132,7 @@ impl DirectMessaging {
         payload: Vec<u8>,
         verified: bool,
         trust_decision: Option<TrustDecision>,
+        observed_origin: Option<ObservedOrigin>,
     ) -> u64 {
         self.diagnostics
             .incoming_envelopes_total
@@ -1108,15 +1141,19 @@ impl DirectMessaging {
         self.with_peer_diagnostics(sender_agent_id, |peer| {
             peer.last_recv_at_ms = Some(now_ms);
             peer.recv_count = peer.recv_count.saturating_add(1);
+            if observed_origin.is_some() {
+                peer.observed_origin = observed_origin.clone();
+            }
         });
 
-        let msg = DirectMessage::new_verified(
+        let mut msg = DirectMessage::new_verified(
             sender_agent_id,
             machine_id,
             payload,
             verified,
             trust_decision,
         );
+        msg.observed_origin = observed_origin;
 
         let subscribers = self.subscriber_snapshot();
         let mut delivered = 0_u64;
@@ -1527,7 +1564,7 @@ mod tests {
         let machine_id = MachineId([2u8; 32]);
         let payload = b"test message".to_vec();
 
-        dm.handle_incoming(machine_id, sender, payload.clone(), true, None)
+        dm.handle_incoming(machine_id, sender, payload.clone(), true, None, None)
             .await;
 
         let msg = rx.recv().await.unwrap();
@@ -1553,7 +1590,7 @@ mod tests {
         let machine_id = MachineId([4u8; 32]);
         let payload = b"fanout".to_vec();
 
-        dm.handle_incoming(machine_id, sender, payload.clone(), true, None)
+        dm.handle_incoming(machine_id, sender, payload.clone(), true, None, None)
             .await;
 
         assert_eq!(rx1.recv().await.unwrap().payload, payload);
@@ -1569,7 +1606,7 @@ mod tests {
         let machine_id = MachineId([6u8; 32]);
 
         for idx in 0_u64..=2 {
-            dm.handle_incoming(machine_id, sender, idx.to_be_bytes().to_vec(), true, None)
+            dm.handle_incoming(machine_id, sender, idx.to_be_bytes().to_vec(), true, None, None)
                 .await;
         }
 
@@ -1689,5 +1726,113 @@ mod tests {
         let binary_msg =
             DirectMessage::new(AgentId([1u8; 32]), MachineId([2u8; 32]), vec![0xff, 0xfe]);
         assert!(binary_msg.payload_str().is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #120 — opt-in observed-origin token plumbing
+    // ------------------------------------------------------------------
+
+    fn test_observed_origin() -> ObservedOrigin {
+        ObservedOrigin {
+            observed_prefix: "203.0.113.0/24".to_string(),
+            direct: true,
+            cgnat: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_incoming_observed_origin_reaches_subscriber_and_diagnostics() {
+        let dm = DirectMessaging::new();
+        let mut rx = dm.subscribe();
+        let sender = AgentId([7u8; 32]);
+        let machine_id = MachineId([8u8; 32]);
+        let origin = test_observed_origin();
+
+        dm.handle_incoming(
+            machine_id,
+            sender,
+            b"hello".to_vec(),
+            true,
+            None,
+            Some(origin.clone()),
+        )
+        .await;
+
+        // The fan-out message carries the token …
+        let msg = rx.recv().await.unwrap();
+        assert_eq!(msg.observed_origin, Some(origin.clone()));
+
+        // … and the per-peer diagnostics row exposes it for /diagnostics/dm.
+        let snap = dm.diagnostics_snapshot();
+        let row = snap
+            .per_peer
+            .get(&hex::encode(sender.as_bytes()))
+            .expect("sender diagnostics row");
+        assert_eq!(row.observed_origin, Some(origin));
+    }
+
+    #[tokio::test]
+    async fn handle_incoming_none_origin_never_clobbers_existing_token() {
+        // WHY: gossip-inbox and loopback deliveries always pass None; a later
+        // gossip-path DM from the same agent must not erase the token a
+        // point-to-point delivery captured.
+        let dm = DirectMessaging::new();
+        let sender = AgentId([9u8; 32]);
+        let machine_id = MachineId([10u8; 32]);
+        let origin = test_observed_origin();
+
+        dm.handle_incoming(
+            machine_id,
+            sender,
+            b"p2p".to_vec(),
+            true,
+            None,
+            Some(origin.clone()),
+        )
+        .await;
+        dm.handle_incoming(machine_id, sender, b"gossip".to_vec(), true, None, None)
+            .await;
+
+        let snap = dm.diagnostics_snapshot();
+        let row = snap
+            .per_peer
+            .get(&hex::encode(sender.as_bytes()))
+            .expect("sender diagnostics row");
+        assert_eq!(row.observed_origin, Some(origin));
+    }
+
+    #[tokio::test]
+    async fn dm_peer_diagnostics_omits_observed_origin_key_when_absent() {
+        // WHY (issue #120 acceptance): with the token absent the serialized
+        // per-peer row must be byte-identical to before the field existed —
+        // no `"observed_origin": null`.
+        let dm = DirectMessaging::new();
+        let sender = AgentId([11u8; 32]);
+        let machine_id = MachineId([12u8; 32]);
+        dm.handle_incoming(machine_id, sender, b"x".to_vec(), true, None, None)
+            .await;
+
+        let snap = dm.diagnostics_snapshot();
+        let json = serde_json::to_string(&snap.per_peer).expect("serialize per_peer");
+        assert!(
+            !json.contains("observed_origin"),
+            "absent token must not serialize: {json}"
+        );
+
+        // And when present, the row carries the masked token.
+        let origin = test_observed_origin();
+        dm.handle_incoming(
+            machine_id,
+            sender,
+            b"y".to_vec(),
+            true,
+            None,
+            Some(origin),
+        )
+        .await;
+        let snap = dm.diagnostics_snapshot();
+        let json = serde_json::to_string(&snap.per_peer).expect("serialize per_peer");
+        let needle = "\"observed_origin\":{\"observed_prefix\":\"203.0.113.0/24\",\"direct\":true,\"cgnat\":false}";
+        assert!(json.contains(needle), "present token serializes masked: {json}");
     }
 }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -1606,8 +1606,15 @@ mod tests {
         let machine_id = MachineId([6u8; 32]);
 
         for idx in 0_u64..=2 {
-            dm.handle_incoming(machine_id, sender, idx.to_be_bytes().to_vec(), true, None, None)
-                .await;
+            dm.handle_incoming(
+                machine_id,
+                sender,
+                idx.to_be_bytes().to_vec(),
+                true,
+                None,
+                None,
+            )
+            .await;
         }
 
         let snap = dm.diagnostics_snapshot();
@@ -1821,18 +1828,14 @@ mod tests {
 
         // And when present, the row carries the masked token.
         let origin = test_observed_origin();
-        dm.handle_incoming(
-            machine_id,
-            sender,
-            b"y".to_vec(),
-            true,
-            None,
-            Some(origin),
-        )
-        .await;
+        dm.handle_incoming(machine_id, sender, b"y".to_vec(), true, None, Some(origin))
+            .await;
         let snap = dm.diagnostics_snapshot();
         let json = serde_json::to_string(&snap.per_peer).expect("serialize per_peer");
         let needle = "\"observed_origin\":{\"observed_prefix\":\"203.0.113.0/24\",\"direct\":true,\"cgnat\":false}";
-        assert!(json.contains(needle), "present token serializes masked: {json}");
+        assert!(
+            json.contains(needle),
+            "present token serializes masked: {json}"
+        );
     }
 }

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -585,6 +585,9 @@ impl InboxPipeline {
                     plaintext.payload,
                     true,
                     Some(decision),
+                    // Gossip-inbox deliveries carry no point-to-point
+                    // transport observation (issue #120).
+                    None,
                 )
                 .await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,13 @@ pub struct Agent {
     network_event_listener_started: std::sync::atomic::AtomicBool,
     /// Ensures direct message listener is spawned once.
     direct_listener_started: std::sync::atomic::AtomicBool,
+    /// Issue #120: opt-in gate for surfacing the transport-observed peer
+    /// address as a coarsened origin token on point-to-point DM surfaces.
+    /// Sourced from `NetworkConfig::observed_prefix_enabled` (daemon TOML
+    /// `observed_prefix_enabled`, default `false`). When `false` the raw
+    /// DM listener never computes the token and every surface stays
+    /// byte-identical to before the feature existed.
+    observed_prefix_enabled: bool,
     /// Presence system wrapper for beacons, FOAF discovery, and events.
     presence: Option<std::sync::Arc<presence::PresenceWrapper>>,
     /// Whether the user has consented to disclosing their identity in
@@ -8274,6 +8281,7 @@ impl Agent {
         let contact_store = std::sync::Arc::clone(&self.contact_store);
         let revocation_set = std::sync::Arc::clone(&self.revocation_set);
         let token = self.shutdown_token.clone();
+        let observed_prefix_enabled = self.observed_prefix_enabled;
 
         self.spawn_tracked(async move {
             tracing::info!(target: "x0x::direct", stage = "listener", "direct message listener started");
@@ -8419,9 +8427,28 @@ impl Agent {
                 // Register and mark the sender as connected for future reverse direct sends.
                 dm.mark_connected(sender, machine_id).await;
 
+                // Issue #120: opt-in coarsened origin token from the live
+                // connection table (the same source add_from_connection()
+                // enriches the bootstrap cache from). Computed after the
+                // drop gates so revoked/expired senders never trigger a
+                // table scan; entirely skipped when the daemon has not
+                // opted in, keeping default wire output byte-identical.
+                let observed_origin = if observed_prefix_enabled {
+                    network.observed_peer_origin(&ant_peer_id).await
+                } else {
+                    None
+                };
+
                 // Fan out to all subscribe_direct() receivers with verification info.
                 let delivered = dm
-                    .handle_incoming(machine_id, sender, data, verified, trust_decision)
+                    .handle_incoming(
+                        machine_id,
+                        sender,
+                        data,
+                        verified,
+                        trust_decision,
+                        observed_origin,
+                    )
                     .await;
 
                 tracing::debug!(
@@ -9999,6 +10026,16 @@ impl AgentBuilder {
         let relay_candidates =
             std::sync::Arc::new(tokio::sync::RwLock::new(parsed_relay_candidates));
 
+        // Issue #120: extract the opt-in observed-prefix gate before
+        // `self.network_config` is moved into `NetworkNode::new` (same
+        // pattern as `peer_relay_config` above). With no network config the
+        // feature is off.
+        let observed_prefix_enabled = self
+            .network_config
+            .as_ref()
+            .map(|cfg| cfg.observed_prefix_enabled)
+            .unwrap_or(false);
+
         // X0X-0070b: discovery cache is hoisted out of the `Agent` literal so
         // the relay-DM listener (spawned below) can hold an `Arc` clone of it
         // without going through `&self` - the listener is a sibling task to
@@ -10176,6 +10213,7 @@ impl AgentBuilder {
             direct_messaging,
             network_event_listener_started: std::sync::atomic::AtomicBool::new(false),
             direct_listener_started: std::sync::atomic::AtomicBool::new(false),
+            observed_prefix_enabled,
             presence,
             user_identity_consented: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             capability_store: std::sync::Arc::new(dm_capability::CapabilityStore::new()),
@@ -12238,6 +12276,48 @@ mod tests {
             bootstrap_nodes: Vec::new(),
             ..network::NetworkConfig::default()
         }
+    }
+
+    #[tokio::test]
+    async fn observed_prefix_gate_defaults_off_and_follows_network_config() {
+        // Issue #120: the Agent-side gate must track the NetworkConfig flag —
+        // off with no network config, off by default, on when opted in.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let identity_only = Agent::builder()
+            .with_machine_key(dir.path().join("m1.key"))
+            .with_agent_key_path(dir.path().join("a1.key"))
+            .with_contact_store_path(dir.path().join("c1.json"))
+            .build()
+            .await
+            .expect("identity-only agent");
+        assert!(!identity_only.observed_prefix_enabled);
+        identity_only.shutdown().await;
+
+        let defaulted = Agent::builder()
+            .with_machine_key(dir.path().join("m2.key"))
+            .with_agent_key_path(dir.path().join("a2.key"))
+            .with_contact_store_path(dir.path().join("c2.json"))
+            .with_peer_cache_dir(dir.path().join("p2"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("defaulted-network agent");
+        assert!(!defaulted.observed_prefix_enabled);
+        defaulted.shutdown().await;
+
+        let mut opted_in_cfg = loopback_network_config();
+        opted_in_cfg.observed_prefix_enabled = true;
+        let opted_in = Agent::builder()
+            .with_machine_key(dir.path().join("m3.key"))
+            .with_agent_key_path(dir.path().join("a3.key"))
+            .with_contact_store_path(dir.path().join("c3.json"))
+            .with_peer_cache_dir(dir.path().join("p3"))
+            .with_network_config(opted_in_cfg)
+            .build()
+            .await
+            .expect("opted-in agent");
+        assert!(opted_in.observed_prefix_enabled);
+        opted_in.shutdown().await;
     }
 
     fn normalize_loopback_addr(addr: std::net::SocketAddr) -> std::net::SocketAddr {

--- a/src/network.rs
+++ b/src/network.rs
@@ -1844,7 +1844,7 @@ impl NetworkNode {
     }
 
     /// Issue #120: transport-observed origin token for a connected peer —
-    /// the same live connection-table data [`Self::connected_peer_snapshot`]
+    /// the same live connection-table data `Self::connected_peer_snapshot`
     /// reads (and `add_from_connection` enriches the bootstrap cache from),
     /// coarsened via [`crate::connectivity::ObservedOrigin`].
     ///

--- a/src/network.rs
+++ b/src/network.rs
@@ -245,6 +245,16 @@ pub struct NetworkConfig {
     /// `[peer_relay] enabled = true` in TOML.
     #[serde(default)]
     pub peer_relay: PeerRelayConfig,
+
+    /// Issue #120: opt-in surfacing of the transport-observed peer address
+    /// as a coarse, masked origin token (`/24` v4, `/48` v6) on
+    /// point-to-point DM surfaces only (DM-receive WS/SSE event + per-peer
+    /// `GET /diagnostics/dm`). Default `false`: when disabled the fields are
+    /// entirely absent and wire behaviour is byte-identical to before. The
+    /// token is never gossiped, never announced, and never appears on
+    /// `/peers`.
+    #[serde(default)]
+    pub observed_prefix_enabled: bool,
 }
 
 /// X0X-0070b: TOML-shaped configuration for the peer-relay fallback
@@ -459,6 +469,7 @@ impl Default for NetworkConfig {
             max_peers_per_ip: 3,
             port_mapping_enabled: true,
             peer_relay: PeerRelayConfig::default(),
+            observed_prefix_enabled: false,
         }
     }
 }
@@ -1829,6 +1840,37 @@ impl NetworkNode {
                     _ => None,
                 };
                 (addr, now.saturating_duration_since(conn.last_activity))
+            })
+    }
+
+    /// Issue #120: transport-observed origin token for a connected peer —
+    /// the same live connection-table data [`Self::connected_peer_snapshot`]
+    /// reads (and `add_from_connection` enriches the bootstrap cache from),
+    /// coarsened via [`crate::connectivity::ObservedOrigin`].
+    ///
+    /// Returns `None` when the peer is not in the live table, when the
+    /// connection is not UDP, or when the observed IP carries no origin
+    /// information (loopback / unspecified). Callers MUST gate on
+    /// `observed_prefix_enabled` before invoking; the token is surfaced only
+    /// on point-to-point DM surfaces, never on gossip/announce/`/peers`.
+    pub async fn observed_peer_origin(
+        &self,
+        peer_id: &AntPeerId,
+    ) -> Option<crate::connectivity::ObservedOrigin> {
+        let node = self.require_node().await.ok()?;
+        node.connected_peers()
+            .await
+            .into_iter()
+            .find(|conn| conn.peer_id == *peer_id)
+            .and_then(|conn| {
+                let addr = match conn.remote_addr {
+                    TransportAddr::Udp(addr) => addr,
+                    _ => return None,
+                };
+                crate::connectivity::ObservedOrigin::from_observed(
+                    addr.ip(),
+                    matches!(conn.traversal_method, ant_quic::TraversalMethod::Relay),
+                )
             })
     }
 
@@ -4076,6 +4118,7 @@ async fn test_mesh_connections_are_bidirectional() {
             max_peers_per_ip: 3,
             port_mapping_enabled: true,
             peer_relay: PeerRelayConfig::default(),
+            observed_prefix_enabled: false,
         };
 
         let node = NetworkNode::new(config, None, None).await.unwrap();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -768,6 +768,7 @@ pub async fn serve_with_options(
         // single invocation without editing the config file.
         port_mapping_enabled: config.port_mapping_enabled && !cli_no_port_mapping,
         peer_relay: config.peer_relay.clone(),
+        observed_prefix_enabled: config.observed_prefix_enabled,
     };
 
     let contacts_path = config.data_dir.join("contacts.json");

--- a/src/server/sse.rs
+++ b/src/server/sse.rs
@@ -132,6 +132,30 @@ pub(super) async fn presence_events(
     Sse::new(stream)
 }
 
+/// Serialize a received [`crate::direct::DirectMessage`] into the JSON
+/// payload carried by the `/direct/events` SSE `direct_message` event.
+///
+/// Issue #120: `observed_origin` is inserted only when the message carries
+/// the opt-in coarsened origin token — when the token is absent the output
+/// is byte-identical to the pre-#120 shape (the key never appears, not even
+/// as `null`). The token never reaches gossip, announcements, or `/peers`.
+fn direct_message_event_data(msg: &crate::direct::DirectMessage) -> serde_json::Value {
+    let mut data = serde_json::json!({
+        "sender": hex::encode(msg.sender.as_bytes()),
+        "machine_id": hex::encode(msg.machine_id.as_bytes()),
+        "payload": BASE64.encode(&msg.payload),
+        "received_at": msg.received_at,
+        "verified": msg.verified,
+        "trust_decision": msg.trust_decision.as_ref().map(|d| d.to_string())
+    });
+    if let Some(origin) = &msg.observed_origin {
+        if let (Some(obj), Ok(value)) = (data.as_object_mut(), serde_json::to_value(origin)) {
+            obj.insert("observed_origin".to_string(), value);
+        }
+    }
+    data
+}
+
 /// GET /direct/events — SSE stream of incoming direct messages.
 pub(super) async fn direct_events_sse(
     State(state): State<Arc<AppState>>,
@@ -158,14 +182,7 @@ pub(super) async fn direct_events_sse(
                         machine_id = %hex::encode(msg.machine_id.as_bytes()),
                         bytes = msg.payload.len(),
                     );
-                    let data = serde_json::json!({
-                        "sender": hex::encode(msg.sender.as_bytes()),
-                        "machine_id": hex::encode(msg.machine_id.as_bytes()),
-                        "payload": BASE64.encode(&msg.payload),
-                        "received_at": msg.received_at,
-                        "verified": msg.verified,
-                        "trust_decision": msg.trust_decision.map(|d| d.to_string())
-                    });
+                    let data = direct_message_event_data(&msg);
                     let event = Event::default()
                         .event("direct_message")
                         .data(data.to_string());
@@ -227,4 +244,70 @@ pub(super) async fn peer_events_handler(
         }
     };
     Sse::new(stream).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connectivity::ObservedOrigin;
+    use crate::direct::DirectMessage;
+    use crate::identity::{AgentId, MachineId};
+
+    fn dm_with_origin(origin: Option<ObservedOrigin>) -> DirectMessage {
+        let mut msg = DirectMessage::new(
+            AgentId([0x8a; 32]),
+            MachineId([0xb2; 32]),
+            b"hello".to_vec(),
+        );
+        msg.received_at = 1_774_860_000;
+        msg.verified = true;
+        msg.observed_origin = origin;
+        msg
+    }
+
+    #[test]
+    fn direct_message_event_data_is_byte_identical_without_origin() {
+        // Issue #120 acceptance: with the token absent (the default — the
+        // daemon has not opted in) the serialized event is byte-identical to
+        // the pre-#120 shape. No `observed_origin` key, not even as null.
+        let data = direct_message_event_data(&dm_with_origin(None));
+        let s = data.to_string();
+        assert!(
+            !s.contains("observed_origin"),
+            "absent token must not serialize: {s}"
+        );
+        assert_eq!(
+            s,
+            format!(
+                "{{\"machine_id\":\"{}\",\"payload\":\"aGVsbG8=\",\"received_at\":1774860000,\"sender\":\"{}\",\"trust_decision\":null,\"verified\":true}}",
+                hex::encode([0xb2; 32]),
+                hex::encode([0x8a; 32]),
+            )
+        );
+    }
+
+    #[test]
+    fn direct_message_event_data_inserts_masked_origin_when_present() {
+        // Opted-in nodes emit the masked token on the DM-receive event;
+        // relayed observation => direct=false, CGNAT => cgnat=true.
+        let origin = ObservedOrigin {
+            observed_prefix: "203.0.113.0/24".to_string(),
+            direct: false,
+            cgnat: true,
+        };
+        let data = direct_message_event_data(&dm_with_origin(Some(origin)));
+        assert_eq!(
+            data["observed_origin"],
+            serde_json::json!({
+                "observed_prefix": "203.0.113.0/24",
+                "direct": false,
+                "cgnat": true
+            })
+        );
+        // The pre-existing fields are untouched by the insertion.
+        assert_eq!(data["payload"], "aGVsbG8=");
+        assert_eq!(data["verified"], true);
+        assert_eq!(data["received_at"], 1_774_860_000);
+        assert!(data["trust_decision"].is_null());
+    }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -248,6 +248,16 @@ pub struct DaemonConfig {
     #[serde(default)]
     pub(super) peer_relay: x0x::network::PeerRelayConfig,
 
+    /// Issue #120: opt-in surfacing of the transport-observed peer address
+    /// as a coarse, masked origin token (`/24` IPv4, `/48` IPv6) on
+    /// point-to-point DM surfaces only — the DM-receive WS/SSE event and
+    /// per-peer `GET /diagnostics/dm`. Default `false`; when disabled the
+    /// fields are entirely absent and wire behaviour is byte-identical. The
+    /// token is never gossiped, never announced, and never on `/peers`.
+    /// Like `[peer_relay]` (opt-in), there is intentionally no CLI flag.
+    #[serde(default)]
+    pub(super) observed_prefix_enabled: bool,
+
     /// Update configuration.
     #[serde(default)]
     pub(super) update: DaemonUpdateConfig,
@@ -506,6 +516,7 @@ impl Default for DaemonConfig {
             bootstrap_peers: None,
             port_mapping_enabled: default_port_mapping_enabled(),
             peer_relay: x0x::network::PeerRelayConfig::default(),
+            observed_prefix_enabled: false,
             update: DaemonUpdateConfig::default(),
             gossip: x0x::gossip::GossipConfig::default(),
             heartbeat_interval_secs: default_heartbeat_interval(),
@@ -954,5 +965,20 @@ mod tests {
             .filter_map(|s| s.parse().ok())
             .collect();
         assert_eq!(config.resolved_bootstrap_peers(), embedded);
+    }
+
+    #[test]
+    fn observed_prefix_enabled_defaults_off_and_parses_opt_in() {
+        // Issue #120: the gate is default-OFF in every construction path —
+        // absent TOML key, empty TOML, and `DaemonConfig::default()` — so
+        // unconfigured daemons keep byte-identical DM wire output.
+        let config: DaemonConfig = toml::from_str("").expect("empty config parses");
+        assert!(!config.observed_prefix_enabled);
+        assert!(!DaemonConfig::default().observed_prefix_enabled);
+
+        // Explicit opt-in parses through.
+        let config: DaemonConfig =
+            toml::from_str("observed_prefix_enabled = true").expect("opt-in parses");
+        assert!(config.observed_prefix_enabled);
     }
 }

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -94,6 +94,13 @@ enum WsOutbound {
         received_at: u64,
         verified: bool,
         trust_decision: Option<String>,
+        /// Issue #120: opt-in coarsened origin token. Entirely absent
+        /// (never `null`) unless the daemon opted in via
+        /// `observed_prefix_enabled` AND the message arrived over the live
+        /// point-to-point transport connection with a maskable observed
+        /// address. Never gossiped, never announced, never on `/peers`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        observed_origin: Option<crate::connectivity::ObservedOrigin>,
     },
     #[serde(rename = "subscribed")]
     Subscribed { topics: Vec<String> },
@@ -427,6 +434,7 @@ async fn handle_ws_connection(
                     received_at: msg.received_at,
                     verified: msg.verified,
                     trust_decision: msg.trust_decision.map(|d| d.to_string()),
+                    observed_origin: msg.observed_origin,
                 };
                 // DMs are fire-and-forget (DirectSubscriberQueue, drop-oldest,
                 // 8192 deep — no retaining inbox behind subscribe_direct), so a
@@ -853,6 +861,64 @@ mod tests {
             1,
             "the dropped frame must be counted"
         );
+    }
+
+    // ========================================================================
+    // Issue #120 — WS `direct_message` observed-origin serialization.
+    // ========================================================================
+
+    fn ws_dm_frame(observed_origin: Option<crate::connectivity::ObservedOrigin>) -> WsOutbound {
+        WsOutbound::DirectMessage {
+            sender: hex::encode([0x8a; 32]),
+            machine_id: hex::encode([0xb2; 32]),
+            payload: "aGVsbG8=".to_string(),
+            received_at: 1_774_860_000,
+            verified: true,
+            trust_decision: None,
+            observed_origin,
+        }
+    }
+
+    #[test]
+    fn ws_direct_message_frame_is_byte_identical_without_origin() {
+        // Issue #120 acceptance: default-off (no token) wire bytes are
+        // identical to the pre-#120 frame — no `observed_origin` key, not
+        // even as null.
+        let s = serde_json::to_string(&ws_dm_frame(None)).expect("serialize frame");
+        assert!(
+            !s.contains("observed_origin"),
+            "absent token must not serialize: {s}"
+        );
+        assert_eq!(
+            s,
+            format!(
+                "{{\"type\":\"direct_message\",\"sender\":\"{}\",\"machine_id\":\"{}\",\"payload\":\"aGVsbG8=\",\"received_at\":1774860000,\"verified\":true,\"trust_decision\":null}}",
+                hex::encode([0x8a; 32]),
+                hex::encode([0xb2; 32]),
+            )
+        );
+    }
+
+    #[test]
+    fn ws_direct_message_frame_carries_masked_origin_when_present() {
+        // Opted-in nodes emit the masked token; relayed => direct=false,
+        // CGNAT => cgnat=true.
+        let origin = crate::connectivity::ObservedOrigin {
+            observed_prefix: "2001:db8::/48".to_string(),
+            direct: false,
+            cgnat: true,
+        };
+        let v = serde_json::to_value(ws_dm_frame(Some(origin))).expect("serialize frame");
+        assert_eq!(
+            v["observed_origin"],
+            serde_json::json!({
+                "observed_prefix": "2001:db8::/48",
+                "direct": false,
+                "cgnat": true
+            })
+        );
+        assert_eq!(v["type"], "direct_message");
+        assert_eq!(v["payload"], "aGVsbG8=");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #120.

- Config: observed_prefix_enabled (default FALSE at every layer — DaemonConfig, NetworkConfig, AgentBuilder). Off = fields entirely absent; SSE+WS byte-identity proven by full byte-equality tests.
- Token: { observed_prefix, direct, cgnat } — v4 masked to /24, v6 to /48, host bits zeroed BEFORE formatting with no unmasked fallback; loopback/unspecified → absent; cgnat reuses the canonical RFC 6598 check; direct reflects actual transport directness.
- Surfaces: DM-receive WS + SSE events and per-peer /diagnostics/dm ONLY. DirectMessage has no Serialize derive (cannot leak by accident); ObservedOrigin is referenced by exactly those three serializations. Never gossiped, never on /peers.
- No new dependencies.

Review (privacy-focused, SOUND): no raw-IP path, no always-on path, no gossip leakage. INFO notes for follow-up: v4-mapped-v6 observations collapse to ::/48 (uninformative, not a leak — ant-quic reports v4 peers as V4); link-local/multicast are masked but not excluded (per the issue spec); DmPeerDiagnostics byte test could be tightened to full byte-equality (structural serde attribute carries the guarantee today).

Gates: fmt/clippy clean, 9/9 targeted tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an opt-in coarse origin token to direct-message surfaces. The main changes are:

- Masks observed IPv4 and IPv6 addresses to fixed prefixes.
- Adds default-off daemon and network configuration.
- Exposes the token through DM WebSocket, SSE, and diagnostics output.
- Keeps the field absent when the feature is disabled or no origin is available.

<h3>Confidence Score: 4/5</h3>

The connection attribution and stale diagnostics paths need fixes before merging.

- A peer-ID snapshot can read a replacement connection instead of the one that carried the DM.
- A point-to-point delivery without a current observation can leave an earlier prefix in diagnostics.
- Masking, default-off configuration, and output omission are otherwise consistent.

src/network.rs and src/direct.rs

<details open><summary><h3>Security Review</h3></summary>

The token is default-off and limited to the intended DM surfaces. Connection replacement can still attach another connection's origin to a message, and missing observations can leave an old prefix visible in diagnostics.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/connectivity.rs | Adds fixed IPv4 and IPv6 masking plus the serializable origin token. |
| src/network.rs | Adds origin lookup from the live connection table, but the result is not tied to the connection that delivered the message. |
| src/lib.rs | Propagates the option into the agent and computes origin metadata in the direct-message listener. |
| src/direct.rs | Adds message and diagnostics propagation, but preserves cached origins when a newer point-to-point delivery has no observation. |
| src/server/sse.rs | Conditionally adds the token to direct-message SSE events. |
| src/server/ws.rs | Conditionally adds the token to direct-message WebSocket frames. |
| src/server/state.rs | Adds default-off daemon configuration parsing. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Peer
    participant Receive as DM receive path
    participant Connections as Live connection table
    participant Output as DM surfaces
    Peer->>Receive: Message arrives on connection C1
    Receive->>Receive: Validate and authorize
    Note over Connections: C1 may be replaced by C2
    Receive->>Connections: Find current entry by peer ID
    Connections-->>Receive: C2 address and traversal method
    Receive->>Output: Emit message with C2 origin
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Peer
    participant Receive as DM receive path
    participant Connections as Live connection table
    participant Output as DM surfaces
    Peer->>Receive: Message arrives on connection C1
    Receive->>Receive: Validate and authorize
    Note over Connections: C1 may be replaced by C2
    Receive->>Connections: Find current entry by peer ID
    Connections-->>Receive: C2 address and traversal method
    Receive->>Output: Emit message with C2 origin
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/network.rs:1868-1869
**Origin Uses A Different Connection**

When a connection is replaced after `recv_direct()` returns but before this snapshot runs, `find` can select the replacement connection for the same peer ID. The DM then exposes that connection's prefix and traversal method, so a message received on a direct connection can be labeled with a relay origin, or vice versa; the receive path needs metadata from the exact connection that carried the message.

### Issue 2 of 2
src/direct.rs:1143-1145
**Unobserved Delivery Preserves Stale Origin**

After a peer reconnects from another address, a valid point-to-point DM can have no token when the live-table lookup misses the connection or the address is unmaskable. This guard then keeps the previous connection's prefix in `/diagnostics/dm`, so the row no longer represents the latest observed delivery; only non-observed paths such as gossip and loopback should preserve the cached value.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/saorsa-labs/x0x/commit/f75e88e13fd2e34edcdc68f921710cb09fc74b04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45236268)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->