### PR TITLE
feat(dm): #213 — machine-key attestation binding for gossip DMs

### DIFF
--- a/docs/adr/0021-dm-origin-machine-attestation.md
+++ b/docs/adr/0021-dm-origin-machine-attestation.md
@@ -1,0 +1,236 @@
+# ADR 0021: DM origin-machine attestation for gossip DMs
+
+- **Status:** Proposed
+- **Date:** 2026-07-17
+- **Decision owners:** x0x maintainers
+- **Reviewers:** (pending)
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** issue #213; issue #184 (retained-binding mitigation); #204 ForwardV2 attestation (`src/forward.rs`); ADR 0018 (key lifecycle / revocation)
+
+## Context
+
+Gossip DM envelopes (`DmEnvelope`) are signed by the sender's portable
+**agent** key and carry a sender-controlled `sender_machine_id` claim. The
+#184 mitigation retains the latest authenticated AgentId→MachineId binding
+from verified `IdentityAnnouncement`s and rejects envelope claims that
+disagree with it — but only when a binding exists. Three states leave the
+receiver with nothing but the sender's claim:
+
+1. **Never observed** — the sender is a Trusted contact whose announcement
+   never propagated to this receiver.
+2. **Restart** — the retained-binding LRU is intentionally in-memory; a
+   process restart empties it before announcements repopulate it.
+3. **Bounded-LRU eviction** — capacity pressure evicts the binding.
+
+In all three, a holder of a stolen agent key operating on a **revoked**
+machine A can place an unrevoked machine B in `sender_machine_id` and bypass
+revocation of the true origin machine (the EP3 gate checks only the claim).
+The receiver cannot authenticate the physical origin machine from its own
+state because no per-message proof from the origin machine exists.
+
+## Decision Drivers
+
+- Origin authentication MUST work with **zero prior discovery-cache state**
+  (cold receiver, restart, LRU eviction, offline-then-online delivery).
+- A revoked origin machine MUST fail verification even when the envelope
+  claims an unrevoked machine.
+- Portable agents (same agent key, new machine) MUST keep working under an
+  explicit, testable policy.
+- Wire changes MUST be additive: old receivers skip the new field; new
+  receivers tolerate its absence.
+- Reuse the established attestation pattern (ForwardV2 #204, CRDT
+  provenance): self-certifying public key + `from_public_key` hash binding +
+  domain-separated ML-DSA-65 signature. No new cryptography.
+
+## Considered Options
+
+1. **Per-DM machine-key attestation embedded in the envelope (chosen).**
+   The origin machine signs a small struct riding inside every DM envelope;
+   the machine public key travels with it and is self-certifying via
+   `MachineId::from_public_key == sender_machine_id`.
+2. **Rely on identity announcements + persistent binding cache.** Rejected:
+   propagation timing and restart amnesia are exactly the gap; persisting
+   bindings helps restarts but not the never-observed case, and adds disk
+   state to a security boundary that can instead be stateless.
+3. **Sign the envelope with the machine key instead of the agent key.**
+   Rejected: breaks the portable-agent model (the agent identity is the DM
+   principal) and every existing verifier; also machine keys are not
+   portable so contact trust (keyed by agent) could not be evaluated.
+4. **Hard-require attestations immediately (reject all unattested DMs).**
+   Rejected for this release: no capability negotiation exists on the DM
+   wire path, so every pre-#213 peer — including mid-rolling-upgrade
+   daemons and the legacy DM bus — would be silently cut off. See
+   Downgrade policy below.
+
+## Decision
+
+We will bind a fresh **machine-key attestation** into every gossip DM
+envelope, verified by receivers with zero prior cache state.
+
+### Signed material
+
+`DmOriginAttestation` (new struct in `src/dm.rs`):
+
+| field | purpose |
+|---|---|
+| `attestation_version: u16` | format version (1); unknown versions fail closed |
+| `protocol_version: u16` | mirrors the envelope's DM protocol version |
+| `sender_agent_id: [u8; 32]` | the DM principal |
+| `sender_machine_id: [u8; 32]` | claimed origin machine |
+| `machine_public_key: Vec<u8>` | self-certifying ML-DSA-65 machine key |
+| `recipient_agent_id: [u8; 32]` | replay scope |
+| `request_id: [u8; 16]` | binds the attestation to one logical DM (retries reuse it) |
+| `created_at_unix_ms / expires_at_unix_ms: u64` | freshness/expiry window (mirrors envelope) |
+| `signature: Vec<u8>` | ML-DSA-65 over the bytes below, by the machine secret key |
+
+Signed bytes (deterministic, domain-separated — mirrors
+`ForwardV2Header::signable_bytes`):
+
+```
+"x0x-dm-origin-attestation.v1"
+|| attestation_version.be || protocol_version.be
+|| request_id || sender_agent_id || sender_machine_id
+|| len32be(machine_public_key) || machine_public_key
+|| recipient_agent_id
+|| created_at_unix_ms.be || expires_at_unix_ms.be
+```
+
+### Envelope placement and codec tolerance
+
+The attestation rides as a **trailing optional field** on `DmEnvelope`:
+
+```rust
+#[serde(default, deserialize_with = "deserialize_origin_attestation")]
+pub origin_attestation: Option<DmOriginAttestation>,
+```
+
+postcard is positional: old receivers stop after `signature` and ignore
+trailing bytes (verified by a mixed-version test decoding new bytes with the
+old struct shape); new receivers tolerate EOF via the `deserialize_with`
+fallback (`None`). The agent signature scope (`build_signed_bytes`) is
+**unchanged**, so old receivers verify new envelopes and vice versa.
+
+### Verification (receiver, zero prior state)
+
+In `InboxPipeline::handle_incoming`, after the existing envelope-signature
+and sender-match checks:
+
+1. **Attestation present and valid** → the attested `MachineId` wins.
+   Verification is self-contained: `machine_public_key` parses;
+   `MachineId::from_public_key(key) == sender_machine_id` (hash binding);
+   every mirrored field equals the envelope's; the ML-DSA-65 signature
+   verifies. The retained #184 binding is **refreshed** with the attested
+   machine (`created_at_unix_ms / 1000`, keeping the cache's
+   seconds-granularity ordering coherent with announcement-sourced
+   bindings).
+2. **Attestation present but invalid** (any check fails, including unknown
+   `attestation_version`) → **hard drop**. No fallback: a present-but-bad
+   attestation is an attack or corruption signal, never a legacy peer.
+3. **Attestation absent** (legacy peer) → the existing #184 path:
+   retained-binding match enforced when a binding exists; claimed-machine
+   fallback otherwise.
+
+The EP3 revocation gate then runs against the **resolved** machine id, so a
+revoked origin A fails even when the envelope claims unrevoked B: claiming B
+requires B's machine signature (unforgeable), and carrying A's valid
+attestation names A, which EP3 rejects.
+
+### Portable-agent move policy (A → B)
+
+A move is legitimate when the agent keyholder starts sending from machine B.
+
+- **Per-DM authentication.** Each DM authenticates its own origin machine;
+  there is no session or registration step. B's first attested DM is
+  accepted immediately, even with zero receiver state and even while the
+  retained binding still says A — the valid fresh attestation supersedes
+  (and refreshes) the stale binding.
+- **Freshness and order.** The attestation mirrors the envelope's
+  `created_at/expires_at`, already window-validated (30 s future skew;
+  ≤ 10 min lifetime). The retained-binding cache orders updates by
+  timestamp (seconds): a later announcement or attestation may move the
+  binding; an older one cannot roll it back.
+- **Overlap.** During a move, DMs may briefly arrive from both A and B.
+  Both verify independently; delivery is per-DM, so overlap is benign.
+- **Revocation interaction.** Revoking A after a valid move does not affect
+  B-attested DMs (EP3 checks the resolved machine, B). A-attested DMs in
+  flight when A is revoked are dropped by EP3 — intended fail-closed.
+
+### Replay, relay substitution, downgrade, offline receivers
+
+- **Replay.** The attestation binds `request_id` + `recipient` + expiry.
+  Re-presenting it inside a re-signed envelope with a different
+  `request_id` fails the field-match check; re-presenting the identical
+  envelope is absorbed by the existing dedupe cache (keyed on
+  `(sender, request_id)`, 630 s TTL ≥ 600 s max envelope lifetime + 30 s
+  accepted skew); past-expiry
+  replays die at the timestamp window.
+- **Relay substitution.** A relay (X0X-0070b) forwards the sealed envelope
+  verbatim; it cannot retarget the attestation (recipient + request_id are
+  signed) nor swap it for another DM's (field match fails).
+- **Downgrade / mixed-version (transition window).** Receivers
+  **accept-with-binding-fallback** for unattested DMs (option 4 rejected
+  above). Justification: there is no capability negotiation on the DM path,
+  so hard-require would silently sever every pre-#213 peer; the transition
+  policy is strictly monotonic — every #213+ sender is authenticated
+  per-message, and unattested senders keep exactly the #184 guarantees, no
+  worse. Residual (documented, pre-existing): an agent-key holder can
+  *strip* the attestation and fall back to the claim path when the receiver
+  has no retained binding — the same exposure #213 sets out to close,
+  narrowed to unattested senders only. End-state: once attestation support
+  is ubiquitous (advertised via `DmCapabilities` in a follow-up), receivers
+  hard-require attestations and the residual closes.
+- **Offline receivers.** Verification needs only envelope-carried material
+  (self-certifying machine key + hash binding + signature). A receiver that
+  was offline through every announcement and cache window authenticates the
+  origin identically to a warm receiver.
+
+## Consequences
+
+### Positive
+
+- Acceptance criteria: cold-cache origin authentication; revoked origin
+  cannot hide behind an unrevoked claim; explicit move policy; restart and
+  eviction do not degrade attested senders; old receivers skip the field.
+- Stateless verification — no new disk state on the security boundary.
+- Pattern reuse: hash binding + domain-separated ML-DSA-65, as in #204 and
+  CRDT provenance; `saorsa-pqc` wrappers only.
+
+### Negative / Trade-offs
+
+- ~5.3 KB per envelope (ML-DSA-65 machine pubkey 1952 B + signature 3293 B
+  plus struct overhead) added to every DM and ACK; under `MAX_ENVELOPE_BYTES` (64 KiB) but real
+  gossip bandwidth. Accepted: security property requires the key travel
+  with the message (zero-state requirement).
+- Transition-window strip residual (above) until hard-require lands.
+- Scope: the attestation does NOT cover the DM body — body integrity is
+  the agent signature's job (`build_signed_bytes` covers `postcard(body)`).
+  Post-TTL body substitution requires a stolen agent key, and even then the
+  swapped body fails AEAD decryption (AAD + KEM-sealed content key).
+
+### Neutral / Operational
+
+- `EnvelopeBuilder::build_payload_envelope` now requires the sender's
+  `MachineKeypair`; ACK envelopes are attested too (fake `Accepted` ACKs
+  from a revoked machine would otherwise forge delivery receipts).
+- New drop counters/logs: attestation-invalid drops count as trust
+  rejections; verified attestations refresh the retained binding.
+
+## Validation
+
+- In-process two-agent integration tests (`src/dm_inbox.rs`): spoof (agent
+  key without machine key claims unrevoked machine → rejected), replay
+  (captured attestation, wrong request id / expired → rejected), revocation
+  (origin revoked mid-flight → rejected), offline receiver (cold pipeline,
+  no cache → verifies and delivers), A→B move (fresh B attestation accepted
+  over stale A binding; revoked-A attestation rejected).
+- Mixed-version codec tests (`src/dm.rs`): new bytes decode with the old
+  struct shape (field skipped, signature verifies); old bytes decode with
+  `origin_attestation == None`.
+- Re-run triggers: any change to `DmEnvelope` shape, `build_signed_bytes`,
+  or the inbox pipeline order.
+
+## Notes for AI-assisted work
+
+Drafted with AI assistance; must not be marked Accepted without human
+review.

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -8,6 +8,10 @@
 use crate::error::{IdentityError, Result};
 use crate::groups::kem_envelope::{AgentKemKeypair, KEM_VARIANT};
 use crate::identity::{AgentId, MachineId};
+use ant_quic::crypto::raw_public_keys::pqc::{
+    sign_with_ml_dsa, verify_with_ml_dsa, MlDsaSignature,
+};
+use ant_quic::MlDsaPublicKey;
 use saorsa_gossip_types::TopicId;
 use saorsa_pqc::api::kem::{MlKem, MlKemPublicKey};
 use serde::{Deserialize, Serialize};
@@ -153,6 +157,18 @@ pub struct DmEnvelope {
     /// ML-DSA-65 signature over the domain-separated envelope bytes
     /// computed via `build_signed_bytes()`.
     pub signature: Vec<u8>,
+
+    /// Fresh origin-machine attestation (issue #213). Signed by the
+    /// sender's **machine** ML-DSA-65 key; proves the claimed
+    /// `sender_machine_id` authorized THIS DM. Additive trailing field:
+    /// old receivers skip it (postcard ignores trailing bytes), new
+    /// receivers decode `None` for pre-#213 peers and fall back to the
+    /// retained-binding check. See `docs/adr/0021-dm-origin-machine-attestation.md`.
+    ///
+    /// Deliberately OUTSIDE the agent signature scope (`signed_bytes` is
+    /// unchanged) so mixed-version interop keeps verifying both ways.
+    #[serde(default, deserialize_with = "deserialize_origin_attestation")]
+    pub origin_attestation: Option<DmOriginAttestation>,
 }
 
 /// Envelope body — either a payload DM or an acknowledgement of a prior one.
@@ -217,6 +233,209 @@ pub enum DmAckOutcome {
     /// that prefer silent rejection can set `trust.silent_reject = true`
     /// and skip emitting this ACK entirely.
     RejectedByPolicy { reason: String },
+}
+
+// ─── Origin-machine attestation (issue #213) ──────────────────────────────
+
+/// Domain separator for DM origin-machine attestation signatures.
+///
+/// Mirrors `FORWARD_V2_ATTESTATION_DOMAIN` (#204): a distinct, versioned
+/// prefix so an attestation can never be reinterpreted as any other signed
+/// object in the crate, and a future layout change bumps the suffix so old
+/// attestations fail verification rather than silently re-binding.
+const DM_ORIGIN_ATTESTATION_DOMAIN: &[u8] = b"x0x-dm-origin-attestation.v1";
+
+/// Current [`DmOriginAttestation`] format version.
+pub const DM_ORIGIN_ATTESTATION_VERSION: u16 = 1;
+
+/// Fresh, per-DM proof that the claimed origin machine authorized this
+/// envelope (issue #213).
+///
+/// The sender's **machine** ML-DSA-65 key signs a struct mirroring the
+/// envelope's security-relevant fields. The machine public key travels
+/// with the attestation and is self-certifying —
+/// `MachineId::from_public_key(key)` MUST equal `sender_machine_id` — so
+/// verification needs ZERO prior discovery-cache state: no retained
+/// binding, no announcement, no reachability data.
+///
+/// See `docs/adr/0021-dm-origin-machine-attestation.md` for the full
+/// design, including the portable-move, replay, and downgrade policies.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DmOriginAttestation {
+    /// Attestation format version. Receivers fail closed on unknown
+    /// versions (a present-but-unverifiable attestation is never skipped).
+    pub attestation_version: u16,
+    /// DM protocol version this attestation was minted for — mirrors the
+    /// envelope field and binds the attestation to the protocol generation.
+    pub protocol_version: u16,
+    /// Sender's AgentId — MUST equal the envelope's.
+    pub sender_agent_id: [u8; 32],
+    /// Claimed origin machine — MUST equal the envelope's
+    /// `sender_machine_id` AND `MachineId::from_public_key(machine_public_key)`.
+    pub sender_machine_id: [u8; 32],
+    /// Sender machine's ML-DSA-65 public key. Self-certifying via the hash
+    /// binding to `sender_machine_id`; carried so verification is
+    /// cache-independent (offline / cold-restart receivers).
+    pub machine_public_key: Vec<u8>,
+    /// Recipient's AgentId — replay scope: an attestation captured from a
+    /// DM to Alice cannot be retargeted to Bob.
+    pub recipient_agent_id: [u8; 32],
+    /// The DM's request id — binds the attestation to exactly one logical
+    /// DM (retries of the same DM reuse `request_id`, so one attestation
+    /// covers all retry attempts).
+    pub request_id: [u8; 16],
+    /// Freshness window start — mirrors `DmEnvelope::created_at_unix_ms`.
+    pub created_at_unix_ms: u64,
+    /// Freshness window end — mirrors `DmEnvelope::expires_at_unix_ms`.
+    /// The receiver's timestamp-window check on the envelope covers this
+    /// attestation because the fields MUST match exactly.
+    pub expires_at_unix_ms: u64,
+    /// ML-DSA-65 signature over [`DmOriginAttestation::signed_bytes`],
+    /// produced by the machine secret key.
+    pub signature: Vec<u8>,
+}
+
+/// Why an origin-machine attestation failed verification.
+///
+/// Every variant is a **hard drop** at the receiver (no fallback to the
+/// claimed machine or the retained binding): a present-but-invalid
+/// attestation is an attack or corruption signal, never a legacy peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum OriginAttestationError {
+    /// `attestation_version` is not one this build understands.
+    #[error("unsupported attestation version {0}")]
+    UnsupportedVersion(u16),
+    /// A mirrored field differs from the envelope (agent, machine,
+    /// recipient, request id, timestamps, or protocol version).
+    #[error("attestation fields do not match the envelope")]
+    EnvelopeMismatch,
+    /// `machine_public_key` does not parse as ML-DSA-65.
+    #[error("malformed machine public key")]
+    MalformedPublicKey,
+    /// `machine_public_key` does not hash to `sender_machine_id`.
+    #[error("machine public key does not hash to sender_machine_id")]
+    KeyBindingMismatch,
+    /// The signature is empty or fails ML-DSA-65 verification.
+    #[error("machine attestation signature invalid")]
+    SignatureInvalid,
+}
+
+impl DmOriginAttestation {
+    /// Build an unsigned attestation mirroring `envelope`'s fields, with
+    /// the given machine public key. Call [`Self::sign`] next.
+    #[must_use]
+    pub fn for_envelope(envelope: &DmEnvelope, machine_public_key: Vec<u8>) -> Self {
+        Self {
+            attestation_version: DM_ORIGIN_ATTESTATION_VERSION,
+            protocol_version: envelope.protocol_version,
+            sender_agent_id: envelope.sender_agent_id,
+            sender_machine_id: envelope.sender_machine_id,
+            machine_public_key,
+            recipient_agent_id: envelope.recipient_agent_id,
+            request_id: envelope.request_id,
+            created_at_unix_ms: envelope.created_at_unix_ms,
+            expires_at_unix_ms: envelope.expires_at_unix_ms,
+            signature: Vec::new(),
+        }
+    }
+
+    /// Canonical signed bytes: domain-separated, fixed-layout encoding of
+    /// every field except `signature`. Both ends MUST agree byte-for-byte.
+    #[must_use]
+    pub fn signed_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(
+            DM_ORIGIN_ATTESTATION_DOMAIN.len() + 2 + 2 + 16 + 32 * 3 + 4
+                + self.machine_public_key.len() + 8 * 2,
+        );
+        out.extend_from_slice(DM_ORIGIN_ATTESTATION_DOMAIN);
+        out.extend_from_slice(&self.attestation_version.to_be_bytes());
+        out.extend_from_slice(&self.protocol_version.to_be_bytes());
+        out.extend_from_slice(&self.request_id);
+        out.extend_from_slice(&self.sender_agent_id);
+        out.extend_from_slice(&self.sender_machine_id);
+        out.extend_from_slice(&(self.machine_public_key.len() as u32).to_be_bytes());
+        out.extend_from_slice(&self.machine_public_key);
+        out.extend_from_slice(&self.recipient_agent_id);
+        out.extend_from_slice(&self.created_at_unix_ms.to_be_bytes());
+        out.extend_from_slice(&self.expires_at_unix_ms.to_be_bytes());
+        out
+    }
+
+    /// Sign with the sender's machine keypair. The keypair MUST own
+    /// `sender_machine_id`; a mismatch produces an attestation receivers
+    /// reject with [`OriginAttestationError::KeyBindingMismatch`].
+    ///
+    /// # Errors
+    /// Returns [`DmError::EnvelopeConstruction`] if ML-DSA-65 signing fails.
+    pub fn sign(&mut self, machine_keypair: &crate::identity::MachineKeypair) -> std::result::Result<(), DmError> {
+        let sig = sign_with_ml_dsa(machine_keypair.secret_key(), &self.signed_bytes())
+            .map_err(|e| DmError::EnvelopeConstruction(format!("origin attestation sign: {e:?}")))?;
+        self.signature = sig.as_bytes().to_vec();
+        Ok(())
+    }
+
+    /// Verify the attestation against the envelope it rides in.
+    ///
+    /// Self-contained: parses the carried machine key, checks the hash
+    /// binding to `sender_machine_id`, checks every mirrored field against
+    /// `envelope`, then verifies the ML-DSA-65 signature. Returns the
+    /// attested [`MachineId`] on success.
+    ///
+    /// # Errors
+    /// One of [`OriginAttestationError`]; every failure is a hard drop at
+    /// the receiver.
+    pub fn verify(&self, envelope: &DmEnvelope) -> std::result::Result<MachineId, OriginAttestationError> {
+        if self.attestation_version != DM_ORIGIN_ATTESTATION_VERSION {
+            return Err(OriginAttestationError::UnsupportedVersion(
+                self.attestation_version,
+            ));
+        }
+        if !self.matches_envelope(envelope) {
+            return Err(OriginAttestationError::EnvelopeMismatch);
+        }
+        let pubkey = MlDsaPublicKey::from_bytes(&self.machine_public_key)
+            .map_err(|_| OriginAttestationError::MalformedPublicKey)?;
+        // Hash binding: the carried key MUST own the claimed machine id —
+        // the same `from_public_key == claimed` binding used by ForwardV2
+        // (#204) and CRDT provenance.
+        let derived = MachineId::from_public_key(&pubkey);
+        if derived.as_bytes() != &self.sender_machine_id {
+            return Err(OriginAttestationError::KeyBindingMismatch);
+        }
+        if self.signature.is_empty() {
+            return Err(OriginAttestationError::SignatureInvalid);
+        }
+        let sig = MlDsaSignature::from_bytes(&self.signature)
+            .map_err(|_| OriginAttestationError::SignatureInvalid)?;
+        verify_with_ml_dsa(&pubkey, &self.signed_bytes(), &sig)
+            .map_err(|_| OriginAttestationError::SignatureInvalid)?;
+        Ok(derived)
+    }
+
+    /// True when every mirrored field equals the envelope's.
+    #[must_use]
+    pub fn matches_envelope(&self, envelope: &DmEnvelope) -> bool {
+        self.protocol_version == envelope.protocol_version
+            && self.sender_agent_id == envelope.sender_agent_id
+            && self.sender_machine_id == envelope.sender_machine_id
+            && self.recipient_agent_id == envelope.recipient_agent_id
+            && self.request_id == envelope.request_id
+            && self.created_at_unix_ms == envelope.created_at_unix_ms
+            && self.expires_at_unix_ms == envelope.expires_at_unix_ms
+    }
+}
+
+/// Tolerant deserializer for the trailing attestation field. Old envelopes
+/// end after `signature`; postcard then hits EOF reading the option tag,
+/// which we recover as `None` (legacy peer → retained-binding fallback).
+/// Mirrors the `deserialize_attestations` pattern in `crdt/task_item.rs`.
+fn deserialize_origin_attestation<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<DmOriginAttestation>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<DmOriginAttestation>::deserialize(deserializer).unwrap_or(None))
 }
 
 // ─── Error model ───────────────────────────────────────────────────────────
@@ -533,10 +752,25 @@ pub struct CachedOutcome {
 }
 
 impl RecentDeliveryCache {
-    /// Construct with the recommended defaults (5 min TTL, 10 000 entries).
+    /// Construct with the recommended defaults (630 s TTL, 10 000 entries).
+    ///
+    /// The TTL MUST cover the full exact-replay window: an envelope stays
+    /// valid for `MAX_ENVELOPE_LIFETIME_MS` (600 s) plus up to
+    /// `CLOCK_SKEW_TOLERANCE_MS` (30 s) of accepted sender-ahead skew, and
+    /// the dedupe entry is the ONLY thing absorbing an identical
+    /// re-delivery while the timestamp window still passes (a shorter TTL
+    /// re-opens a replay hole in the 300–600 s band, issue #213 review F1).
+    ///
+    /// Capacity implication: entries now live ~2.1× longer, so the 10 000-
+    /// entry cap holds proportionally more live traffic — bounded at roughly
+    /// a few MiB even with worst-case `RejectedByPolicy` reason strings,
+    /// which is acceptable for the replay-safety invariant.
     #[must_use]
     pub fn with_defaults() -> Self {
-        Self::new(Duration::from_secs(300), 10_000)
+        Self::new(
+            Duration::from_millis(MAX_ENVELOPE_LIFETIME_MS + CLOCK_SKEW_TOLERANCE_MS),
+            10_000,
+        )
     }
 
     /// Custom cache bounds.
@@ -845,6 +1079,27 @@ impl DmEnvelope {
     pub fn dedupe_key(&self) -> DedupeKey {
         DedupeKey::new(self.sender_agent_id, self.request_id)
     }
+
+    /// Verify the origin-machine attestation (issue #213).
+    ///
+    /// - `Ok(None)` — no attestation (legacy pre-#213 peer): the caller
+    ///   falls back to the #184 retained-binding check.
+    /// - `Ok(Some(machine))` — fresh machine-key proof for this DM;
+    ///   supersedes any retained binding.
+    /// - `Err(_)` — present but invalid: hard drop, never fall back.
+    ///
+    /// Freshness is inherited from the envelope's timestamp-window check
+    /// (the attestation mirrors `created_at`/`expires_at` exactly), so the
+    /// caller MUST run `validate_timestamp_window` first — the inbox
+    /// pipeline already does.
+    pub fn verify_origin_attestation(
+        &self,
+    ) -> std::result::Result<Option<MachineId>, OriginAttestationError> {
+        self.origin_attestation
+            .as_ref()
+            .map(|attestation| attestation.verify(self))
+            .transpose()
+    }
 }
 
 // ─── Envelope builder ──────────────────────────────────────────────────────
@@ -905,24 +1160,31 @@ impl EnvelopeBuilder {
 
     /// Build a fully-signed [`DmEnvelope`] from the raw send-site inputs.
     ///
-    /// Wraps the four crypto ops every direct-DM send needs - KEM
+    /// Wraps the five crypto ops every direct-DM send needs - KEM
     /// encapsulation, AEAD encryption, domain-separated signing-bytes
-    /// build, ML-DSA-65 signature - behind one entry point. The `sign`
-    /// closure receives the signing bytes and returns the signature; in
+    /// build, ML-DSA-65 agent signature, and the #213 origin-machine
+    /// attestation - behind one entry point. The `sign`
+    /// closure receives the signing bytes and returns the agent signature; in
     /// production both `dm_send::send_via_gossip` and X0X-0070b's
     /// `try_relay_fallback` pass a closure backed by
     /// `gossip::SigningContext::sign`.
     ///
+    /// `machine_keypair` MUST own `self_machine_id` — it signs the
+    /// origin-machine attestation that lets zero-state receivers
+    /// authenticate this DM's physical origin (issue #213).
+    ///
     /// # Errors
     ///
     /// Returns [`DmError::EnvelopeConstruction`] if KEM encapsulation,
-    /// AEAD encryption, signing-bytes serialisation, or the `sign`
-    /// closure fail.
+    /// AEAD encryption, signing-bytes serialisation, the `sign`
+    /// closure, or the attestation signature fail — or if
+    /// `machine_keypair` does not own `self_machine_id`.
     #[allow(clippy::too_many_arguments)]
     pub fn build_payload_envelope<F>(
         request_id: [u8; 16],
         self_agent_id: &AgentId,
         self_machine_id: &MachineId,
+        machine_keypair: &crate::identity::MachineKeypair,
         recipient_agent_id: &AgentId,
         recipient_kem_public_key: &[u8],
         created_at_unix_ms: u64,
@@ -933,6 +1195,11 @@ impl EnvelopeBuilder {
     where
         F: FnOnce(&[u8]) -> std::result::Result<Vec<u8>, String>,
     {
+        if machine_keypair.machine_id() != *self_machine_id {
+            return Err(DmError::EnvelopeConstruction(
+                "machine keypair does not own self_machine_id".to_string(),
+            ));
+        }
         let body = Self::build_payload_body(
             &request_id,
             self_agent_id.as_bytes(),
@@ -953,12 +1220,21 @@ impl EnvelopeBuilder {
             expires_at_unix_ms,
             body,
             signature: Vec::new(),
+            origin_attestation: None,
         };
         let signed = envelope
             .signed_bytes()
             .map_err(|e| DmError::EnvelopeConstruction(e.to_string()))?;
         envelope.signature =
             sign(&signed).map_err(|e| DmError::EnvelopeConstruction(format!("sign: {e}")))?;
+        // #213: fresh per-DM origin-machine proof. Placed after the agent
+        // signature for clarity only — the attestation is independent of it.
+        let mut attestation = DmOriginAttestation::for_envelope(
+            &envelope,
+            machine_keypair.public_key().as_bytes().to_vec(),
+        );
+        attestation.sign(machine_keypair)?;
+        envelope.origin_attestation = Some(attestation);
         Ok(envelope)
     }
 }
@@ -1243,6 +1519,7 @@ mod tests {
             request_id,
             &sender,
             &machine,
+            &machine_kp,
             &recipient,
             &recipient_kem.public_bytes,
             now,
@@ -1259,6 +1536,12 @@ mod tests {
             !envelope.signature.is_empty(),
             "build_payload_envelope must produce a non-empty signature"
         );
+        // #213: the builder MUST attach a valid origin-machine attestation.
+        let attested = envelope
+            .verify_origin_attestation()
+            .expect("attestation verifies")
+            .expect("attestation present");
+        assert_eq!(attested, machine);
         let signed_bytes = envelope.signed_bytes().expect("signed bytes");
         let sender_pub_bytes = agent_kp.to_bytes().0;
         let pubkey =
@@ -1287,6 +1570,7 @@ mod tests {
             expires_at_unix_ms: now_unix_ms() + 120_000,
             body: ack_body,
             signature: vec![0u8; 64],
+            origin_attestation: None,
         };
         let bytes = env.to_wire_bytes().expect("encode");
         let back = DmEnvelope::from_wire_bytes(&bytes).expect("decode");
@@ -1353,5 +1637,213 @@ mod tests {
         let _rx2 = acks.register(rid2);
         acks.cancel(&rid2);
         assert_eq!(acks.outstanding(), 0);
+    }
+
+    // ── Issue #213: origin-machine attestation ────────────────────────
+
+    /// The pre-#213 envelope shape. Old receivers decode new wire bytes
+    /// with THIS struct: postcard stops after `signature` and ignores the
+    /// trailing attestation. Kept in sync with the historical shape — if
+    /// `DmEnvelope` fields change, update this mirror.
+    #[derive(Debug, Serialize, Deserialize)]
+    struct DmEnvelopeLegacy {
+        protocol_version: u16,
+        request_id: [u8; 16],
+        sender_agent_id: [u8; 32],
+        sender_machine_id: [u8; 32],
+        recipient_agent_id: [u8; 32],
+        created_at_unix_ms: u64,
+        expires_at_unix_ms: u64,
+        body: DmBody,
+        signature: Vec<u8>,
+    }
+
+    /// Build a fully-signed, attested payload envelope + the owning keys.
+    fn attested_fixture() -> (DmEnvelope, crate::identity::AgentKeypair, crate::identity::MachineKeypair) {
+        use crate::gossip::SigningContext;
+        use crate::groups::kem_envelope::AgentKemKeypair;
+        use crate::identity::{AgentKeypair, MachineKeypair};
+
+        let agent_kp = AgentKeypair::generate().expect("agent keypair");
+        let machine_kp = MachineKeypair::generate().expect("machine keypair");
+        let recipient_kem = AgentKemKeypair::generate().expect("recipient KEM");
+        let recipient = AgentKeypair::generate().expect("recipient").agent_id();
+        let signing = SigningContext::from_keypair(&agent_kp);
+        let now = now_unix_ms();
+        let envelope = EnvelopeBuilder::build_payload_envelope(
+            [7u8; 16],
+            &agent_kp.agent_id(),
+            &machine_kp.machine_id(),
+            &machine_kp,
+            &recipient,
+            &recipient_kem.public_bytes,
+            now,
+            now + 60_000,
+            b"attested".to_vec(),
+            |bytes| signing.sign(bytes).map_err(|e| e.to_string()),
+        )
+        .expect("envelope build");
+        (envelope, agent_kp, machine_kp)
+    }
+
+    #[test]
+    fn attestation_verifies_and_returns_attested_machine() {
+        let (envelope, _agent, machine) = attested_fixture();
+        let attested = envelope
+            .verify_origin_attestation()
+            .expect("verify")
+            .expect("present");
+        assert_eq!(attested, machine.machine_id());
+    }
+
+    #[test]
+    fn attestation_absent_decodes_as_none() {
+        let env = DmEnvelope {
+            protocol_version: DM_PROTOCOL_VERSION,
+            request_id: [5u8; 16],
+            sender_agent_id: dummy_agent_id(1),
+            sender_machine_id: dummy_agent_id(11),
+            recipient_agent_id: dummy_agent_id(2),
+            created_at_unix_ms: now_unix_ms(),
+            expires_at_unix_ms: now_unix_ms() + 120_000,
+            body: EnvelopeBuilder::build_ack_body([3u8; 16], DmAckOutcome::Accepted),
+            signature: vec![0u8; 64],
+            origin_attestation: None,
+        };
+        assert_eq!(env.verify_origin_attestation(), Ok(None));
+    }
+
+    #[test]
+    fn attestation_rejects_unsupported_version() {
+        let (mut envelope, _agent, _machine) = attested_fixture();
+        let attestation = envelope.origin_attestation.as_mut().expect("attested");
+        attestation.attestation_version = DM_ORIGIN_ATTESTATION_VERSION + 1;
+        assert_eq!(
+            envelope.verify_origin_attestation(),
+            Err(OriginAttestationError::UnsupportedVersion(
+                DM_ORIGIN_ATTESTATION_VERSION + 1
+            ))
+        );
+    }
+
+    #[test]
+    fn attestation_rejects_field_mismatch() {
+        let (mut envelope, _agent, _machine) = attested_fixture();
+        envelope.request_id = [8u8; 16]; // attestation still names [7; 16]
+        assert_eq!(
+            envelope.verify_origin_attestation(),
+            Err(OriginAttestationError::EnvelopeMismatch)
+        );
+    }
+
+    #[test]
+    fn attestation_rejects_malformed_machine_key() {
+        let (mut envelope, _agent, _machine) = attested_fixture();
+        let attestation = envelope.origin_attestation.as_mut().expect("attested");
+        attestation.machine_public_key = vec![0u8; 7];
+        assert_eq!(
+            envelope.verify_origin_attestation(),
+            Err(OriginAttestationError::MalformedPublicKey)
+        );
+    }
+
+    #[test]
+    fn attestation_rejects_key_binding_mismatch() {
+        use crate::identity::MachineKeypair;
+        let (mut envelope, _agent, _machine) = attested_fixture();
+        let other = MachineKeypair::generate().expect("other machine");
+        let attestation = envelope.origin_attestation.as_mut().expect("attested");
+        attestation.machine_public_key = other.public_key().as_bytes().to_vec();
+        assert_eq!(
+            envelope.verify_origin_attestation(),
+            Err(OriginAttestationError::KeyBindingMismatch)
+        );
+    }
+
+    #[test]
+    fn attestation_rejects_bad_signature() {
+        let (mut envelope, _agent, _machine) = attested_fixture();
+        let attestation = envelope.origin_attestation.as_mut().expect("attested");
+        // Valid-length, wrong-content signature.
+        attestation.signature = vec![0u8; 3293];
+        assert_eq!(
+            envelope.verify_origin_attestation(),
+            Err(OriginAttestationError::SignatureInvalid)
+        );
+        // Empty signature is also invalid.
+        let attestation = envelope.origin_attestation.as_mut().expect("attested");
+        attestation.signature = Vec::new();
+        assert_eq!(
+            envelope.verify_origin_attestation(),
+            Err(OriginAttestationError::SignatureInvalid)
+        );
+    }
+
+    /// Mixed-version: a NEW (attested) envelope MUST decode under the OLD
+    /// struct shape — the old receiver skips the trailing attestation and
+    /// the agent signature still verifies. This is the wire-level proof
+    /// that the additive field does not break pre-#213 receivers.
+    #[test]
+    fn old_receiver_skips_attestation_field() {
+        let (envelope, agent_kp, _machine) = attested_fixture();
+        assert!(envelope.origin_attestation.is_some());
+        let wire = envelope.to_wire_bytes().expect("encode");
+
+        let legacy: DmEnvelopeLegacy =
+            postcard::from_bytes(&wire).expect("old receivers must decode new envelopes");
+        assert_eq!(legacy.request_id, envelope.request_id);
+        assert_eq!(legacy.sender_machine_id, envelope.sender_machine_id);
+        assert_eq!(legacy.signature, envelope.signature);
+
+        // The agent signature scope is unchanged: verifying the legacy
+        // decode against the legacy signed-bytes layout MUST succeed.
+        let legacy_signed = {
+            let body_bytes = postcard::to_stdvec(&legacy.body).expect("body");
+            let mut out = Vec::new();
+            out.extend_from_slice(b"x0x-dm-v1");
+            out.extend_from_slice(&legacy.protocol_version.to_be_bytes());
+            out.extend_from_slice(&legacy.request_id);
+            out.extend_from_slice(&legacy.sender_agent_id);
+            out.extend_from_slice(&legacy.sender_machine_id);
+            out.extend_from_slice(&legacy.recipient_agent_id);
+            out.extend_from_slice(&legacy.created_at_unix_ms.to_be_bytes());
+            out.extend_from_slice(&legacy.expires_at_unix_ms.to_be_bytes());
+            out.extend_from_slice(&body_bytes);
+            out
+        };
+        let pubkey = ant_quic::MlDsaPublicKey::from_bytes(agent_kp.public_key().as_bytes())
+            .expect("pubkey");
+        let sig = ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(
+            &legacy.signature,
+        )
+        .expect("sig");
+        ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+            &pubkey,
+            &legacy_signed,
+            &sig,
+        )
+        .expect("old-shape signed bytes must verify against the agent key");
+    }
+
+    /// Mixed-version reverse: OLD wire bytes (no trailing attestation) MUST
+    /// decode under the NEW struct with `origin_attestation == None`.
+    #[test]
+    fn new_receiver_tolerates_missing_attestation() {
+        let legacy = DmEnvelopeLegacy {
+            protocol_version: DM_PROTOCOL_VERSION,
+            request_id: [9u8; 16],
+            sender_agent_id: dummy_agent_id(3),
+            sender_machine_id: dummy_agent_id(13),
+            recipient_agent_id: dummy_agent_id(4),
+            created_at_unix_ms: now_unix_ms(),
+            expires_at_unix_ms: now_unix_ms() + 60_000,
+            body: EnvelopeBuilder::build_ack_body([1u8; 16], DmAckOutcome::Accepted),
+            signature: vec![0u8; 32],
+        };
+        let wire = postcard::to_stdvec(&legacy).expect("encode legacy");
+        let decoded = DmEnvelope::from_wire_bytes(&wire)
+            .expect("new receivers must decode old envelopes");
+        assert_eq!(decoded.origin_attestation, None);
+        assert_eq!(decoded.request_id, [9u8; 16]);
     }
 }

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -344,8 +344,14 @@ impl DmOriginAttestation {
     #[must_use]
     pub fn signed_bytes(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(
-            DM_ORIGIN_ATTESTATION_DOMAIN.len() + 2 + 2 + 16 + 32 * 3 + 4
-                + self.machine_public_key.len() + 8 * 2,
+            DM_ORIGIN_ATTESTATION_DOMAIN.len()
+                + 2
+                + 2
+                + 16
+                + 32 * 3
+                + 4
+                + self.machine_public_key.len()
+                + 8 * 2,
         );
         out.extend_from_slice(DM_ORIGIN_ATTESTATION_DOMAIN);
         out.extend_from_slice(&self.attestation_version.to_be_bytes());
@@ -367,9 +373,14 @@ impl DmOriginAttestation {
     ///
     /// # Errors
     /// Returns [`DmError::EnvelopeConstruction`] if ML-DSA-65 signing fails.
-    pub fn sign(&mut self, machine_keypair: &crate::identity::MachineKeypair) -> std::result::Result<(), DmError> {
-        let sig = sign_with_ml_dsa(machine_keypair.secret_key(), &self.signed_bytes())
-            .map_err(|e| DmError::EnvelopeConstruction(format!("origin attestation sign: {e:?}")))?;
+    pub fn sign(
+        &mut self,
+        machine_keypair: &crate::identity::MachineKeypair,
+    ) -> std::result::Result<(), DmError> {
+        let sig =
+            sign_with_ml_dsa(machine_keypair.secret_key(), &self.signed_bytes()).map_err(|e| {
+                DmError::EnvelopeConstruction(format!("origin attestation sign: {e:?}"))
+            })?;
         self.signature = sig.as_bytes().to_vec();
         Ok(())
     }
@@ -384,7 +395,10 @@ impl DmOriginAttestation {
     /// # Errors
     /// One of [`OriginAttestationError`]; every failure is a hard drop at
     /// the receiver.
-    pub fn verify(&self, envelope: &DmEnvelope) -> std::result::Result<MachineId, OriginAttestationError> {
+    pub fn verify(
+        &self,
+        envelope: &DmEnvelope,
+    ) -> std::result::Result<MachineId, OriginAttestationError> {
         if self.attestation_version != DM_ORIGIN_ATTESTATION_VERSION {
             return Err(OriginAttestationError::UnsupportedVersion(
                 self.attestation_version,
@@ -1659,7 +1673,11 @@ mod tests {
     }
 
     /// Build a fully-signed, attested payload envelope + the owning keys.
-    fn attested_fixture() -> (DmEnvelope, crate::identity::AgentKeypair, crate::identity::MachineKeypair) {
+    fn attested_fixture() -> (
+        DmEnvelope,
+        crate::identity::AgentKeypair,
+        crate::identity::MachineKeypair,
+    ) {
         use crate::gossip::SigningContext;
         use crate::groups::kem_envelope::AgentKemKeypair;
         use crate::identity::{AgentKeypair, MachineKeypair};
@@ -1811,18 +1829,13 @@ mod tests {
             out.extend_from_slice(&body_bytes);
             out
         };
-        let pubkey = ant_quic::MlDsaPublicKey::from_bytes(agent_kp.public_key().as_bytes())
-            .expect("pubkey");
-        let sig = ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(
-            &legacy.signature,
-        )
-        .expect("sig");
-        ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
-            &pubkey,
-            &legacy_signed,
-            &sig,
-        )
-        .expect("old-shape signed bytes must verify against the agent key");
+        let pubkey =
+            ant_quic::MlDsaPublicKey::from_bytes(agent_kp.public_key().as_bytes()).expect("pubkey");
+        let sig =
+            ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(&legacy.signature)
+                .expect("sig");
+        ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(&pubkey, &legacy_signed, &sig)
+            .expect("old-shape signed bytes must verify against the agent key");
     }
 
     /// Mixed-version reverse: OLD wire bytes (no trailing attestation) MUST
@@ -1841,8 +1854,8 @@ mod tests {
             signature: vec![0u8; 32],
         };
         let wire = postcard::to_stdvec(&legacy).expect("encode legacy");
-        let decoded = DmEnvelope::from_wire_bytes(&wire)
-            .expect("new receivers must decode old envelopes");
+        let decoded =
+            DmEnvelope::from_wire_bytes(&wire).expect("new receivers must decode old envelopes");
         assert_eq!(decoded.origin_attestation, None);
         assert_eq!(decoded.request_id, [9u8; 16]);
     }

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -6,13 +6,13 @@ use crate::contacts::ContactStore;
 use crate::direct::DirectMessaging;
 use crate::dm::{
     decrypt_payload, dm_inbox_topic, now_unix_ms, validate_timestamp_window, DmAckOutcome, DmBody,
-    DmEnvelope, DmPayload, EnvelopeBuilder, InFlightAcks, RecentDeliveryCache, DM_PROTOCOL_VERSION,
-    MAX_ENVELOPE_BYTES,
+    DmEnvelope, DmOriginAttestation, DmPayload, EnvelopeBuilder, InFlightAcks, RecentDeliveryCache,
+    DM_PROTOCOL_VERSION, MAX_ENVELOPE_BYTES,
 };
 use crate::error::{NetworkError, NetworkResult};
 use crate::gossip::{PubSubManager, PubSubMessage, SigningContext, Subscription};
 use crate::groups::kem_envelope::AgentKemKeypair;
-use crate::identity::{AgentId, MachineId};
+use crate::identity::{AgentId, MachineId, MachineKeypair};
 use crate::revocation::RevocationSet;
 use crate::trust::{TrustContext, TrustDecision, TrustEvaluator};
 use bytes::Bytes;
@@ -233,6 +233,7 @@ impl DmInboxService {
         signing: Arc<SigningContext>,
         self_agent_id: AgentId,
         self_machine_id: MachineId,
+        machine_keypair: Arc<MachineKeypair>,
         kem_keypair: Arc<AgentKemKeypair>,
         dm: Arc<DirectMessaging>,
         contacts: Arc<RwLock<ContactStore>>,
@@ -253,6 +254,7 @@ impl DmInboxService {
             signing,
             self_agent_id,
             self_machine_id,
+            machine_keypair,
             kem_keypair,
             dm,
             contacts,
@@ -318,6 +320,10 @@ struct InboxPipeline {
     signing: Arc<SigningContext>,
     self_agent_id: AgentId,
     self_machine_id: MachineId,
+    /// This machine's keypair — signs the #213 origin attestation embedded
+    /// in outbound ACK envelopes, so ACK receivers authenticate the
+    /// acking machine exactly like payload-DM receivers do.
+    machine_keypair: Arc<MachineKeypair>,
     kem_keypair: Arc<AgentKemKeypair>,
     dm: Arc<DirectMessaging>,
     contacts: Arc<RwLock<ContactStore>>,
@@ -417,40 +423,86 @@ impl InboxPipeline {
         }
 
         // Enforcement point 3 — authenticated-origin revocation gate.
-        // The envelope machine is sender-controlled even though the agent signs
-        // it. Prefer the retained machine from an accepted, verified identity
-        // announcement; the claim is only a best-effort fallback for agents
-        // with no authenticated binding.
+        //
+        // Issue #213: prefer the fresh per-DM origin-machine attestation —
+        // a machine-key signature covering this envelope, verifiable with
+        // ZERO prior cache state. When present and valid it supersedes (and
+        // refreshes) the retained binding; when present but invalid the DM
+        // is a hard drop (never fall back — a bad attestation is an attack
+        // signal, not a legacy peer). Only when the attestation is ABSENT
+        // (pre-#213 peer) do we degrade to the #184 retained-binding check,
+        // where the envelope machine claim is sender-controlled: prefer the
+        // retained machine from an accepted, verified identity announcement;
+        // the claim is only a best-effort fallback for agents with no
+        // authenticated binding. See docs/adr/0021-dm-origin-machine-attestation.md.
         let sender_agent_id = AgentId(envelope.sender_agent_id);
         let claimed_machine_id = MachineId(envelope.sender_machine_id);
-        let authenticated_machine_id = self
-            .authenticated_machine_bindings
-            .write()
-            .await
-            .resolve(&sender_agent_id);
-        let sender_machine_id = match authenticated_machine_id {
-            Some(authenticated) if authenticated != claimed_machine_id => {
+        let sender_machine_id = match envelope.verify_origin_attestation() {
+            Ok(Some(attested_machine)) => {
+                tracing::info!(
+                    target: "dm.trace",
+                    stage = "inbound_origin_attested",
+                    sender = %hex::encode(envelope.sender_agent_id),
+                    machine = %hex::encode(attested_machine.as_bytes()),
+                    "DM origin machine authenticated by fresh machine-key attestation"
+                );
+                // Refresh the retained binding so later UNATTESTED DMs from
+                // this agent are checked against the freshest authenticated
+                // machine — this is what lets a portable move A→B displace a
+                // stale binding. Convert ms→s: announcement-sourced bindings
+                // are seconds-granularity and the cache orders by timestamp.
+                record_authenticated_machine_binding(
+                    &self.authenticated_machine_bindings,
+                    sender_agent_id,
+                    attested_machine,
+                    envelope.created_at_unix_ms / 1000,
+                )
+                .await;
+                attested_machine
+            }
+            Err(rejection) => {
                 self.dm.record_incoming_trust_rejected(sender_agent_id);
                 tracing::warn!(
                     target: "dm.trace",
-                    stage = "inbound_origin_machine_mismatch",
+                    stage = "inbound_origin_attestation_invalid",
                     sender = %hex::encode(envelope.sender_agent_id),
                     claimed_machine = %hex::encode(claimed_machine_id.as_bytes()),
-                    authenticated_machine = %hex::encode(authenticated.as_bytes()),
-                    "DM dropped: envelope machine does not match authenticated origin"
+                    rejection = %rejection,
+                    "DM dropped: origin-machine attestation invalid"
                 );
                 return;
             }
-            Some(authenticated) => authenticated,
-            None => {
-                tracing::info!(
-                    target: "dm.trace",
-                    stage = "inbound_origin_machine_claim_fallback",
-                    sender = %hex::encode(envelope.sender_agent_id),
-                    claimed_machine = %hex::encode(claimed_machine_id.as_bytes()),
-                    "DM origin has no authenticated machine binding; checking sender claim only"
-                );
-                claimed_machine_id
+            Ok(None) => {
+                let authenticated_machine_id = self
+                    .authenticated_machine_bindings
+                    .write()
+                    .await
+                    .resolve(&sender_agent_id);
+                match authenticated_machine_id {
+                    Some(authenticated) if authenticated != claimed_machine_id => {
+                        self.dm.record_incoming_trust_rejected(sender_agent_id);
+                        tracing::warn!(
+                            target: "dm.trace",
+                            stage = "inbound_origin_machine_mismatch",
+                            sender = %hex::encode(envelope.sender_agent_id),
+                            claimed_machine = %hex::encode(claimed_machine_id.as_bytes()),
+                            authenticated_machine = %hex::encode(authenticated.as_bytes()),
+                            "DM dropped: envelope machine does not match authenticated origin"
+                        );
+                        return;
+                    }
+                    Some(authenticated) => authenticated,
+                    None => {
+                        tracing::info!(
+                            target: "dm.trace",
+                            stage = "inbound_origin_machine_claim_fallback",
+                            sender = %hex::encode(envelope.sender_agent_id),
+                            claimed_machine = %hex::encode(claimed_machine_id.as_bytes()),
+                            "DM origin has no attestation and no authenticated binding; checking sender claim only"
+                        );
+                        claimed_machine_id
+                    }
+                }
             }
         };
 
@@ -680,11 +732,22 @@ impl InboxPipeline {
             expires_at_unix_ms: expires,
             body,
             signature: Vec::new(),
+            origin_attestation: None,
         };
         let signed = envelope
             .signed_bytes()
             .map_err(|e| NetworkError::SerializationError(format!("ack sign-bytes: {e}")))?;
         envelope.signature = self.signing.sign(&signed)?;
+        // #213: attest the acking machine too — a fake `Accepted` ACK from
+        // a revoked machine would otherwise forge a delivery receipt.
+        let mut attestation = DmOriginAttestation::for_envelope(
+            &envelope,
+            self.machine_keypair.public_key().as_bytes().to_vec(),
+        );
+        attestation.sign(&self.machine_keypair).map_err(|e| {
+            NetworkError::SerializationError(format!("ack origin attestation: {e}"))
+        })?;
+        envelope.origin_attestation = Some(attestation);
         let encoded = envelope
             .to_wire_bytes()
             .map_err(|e| NetworkError::SerializationError(format!("ack encode: {e}")))?;
@@ -784,6 +847,7 @@ mod tests {
                 outcome: crate::dm::DmAckOutcome::Accepted,
             }),
             signature: Vec::new(),
+            origin_attestation: None,
         }
     }
 
@@ -858,6 +922,7 @@ mod tests {
             signing: Arc::new(SigningContext::from_keypair(&recipient)),
             self_agent_id: recipient_agent_id,
             self_machine_id: recipient_machine_id,
+            machine_keypair: Arc::new(MachineKeypair::generate().expect("recipient machine keygen")),
             kem_keypair: Arc::clone(&recipient_kem),
             dm,
             contacts: Arc::new(RwLock::new(contacts)),
@@ -878,26 +943,54 @@ mod tests {
         }
     }
 
-    fn payload_message(
+    /// Build a signed-but-unattested payload envelope, simulating a
+    /// pre-#213 (legacy) sender: agent signature only, no origin attestation.
+    fn craft_unsigned_payload_envelope(
         harness: &InboxHarness,
         sender: &AgentKeypair,
         claimed_machine: MachineId,
         request_byte: u8,
-    ) -> PubSubMessage {
-        let signing = SigningContext::from_keypair(sender);
+    ) -> DmEnvelope {
         let created_at = now_unix_ms();
-        let envelope = EnvelopeBuilder::build_payload_envelope(
-            [request_byte; 16],
-            &sender.agent_id(),
-            &claimed_machine,
-            &harness.recipient_agent_id,
-            &harness.recipient_kem.public_bytes,
+        let body = EnvelopeBuilder::build_payload_body(
+            &[request_byte; 16],
+            sender.agent_id().as_bytes(),
+            harness.recipient_agent_id.as_bytes(),
             created_at,
-            created_at + 60_000,
             b"security regression payload".to_vec(),
-            |bytes| signing.sign(bytes).map_err(|error| error.to_string()),
+            None,
+            &harness.recipient_kem.public_bytes,
         )
-        .expect("build signed payload envelope");
+        .expect("build payload body");
+        DmEnvelope {
+            protocol_version: DM_PROTOCOL_VERSION,
+            request_id: [request_byte; 16],
+            sender_agent_id: *sender.agent_id().as_bytes(),
+            sender_machine_id: *claimed_machine.as_bytes(),
+            recipient_agent_id: *harness.recipient_agent_id.as_bytes(),
+            created_at_unix_ms: created_at,
+            expires_at_unix_ms: created_at + 60_000,
+            body,
+            signature: Vec::new(),
+            origin_attestation: None,
+        }
+    }
+
+    fn sign_envelope_with_agent(envelope: &mut DmEnvelope, sender: &AgentKeypair) {
+        let signed = envelope.signed_bytes().expect("signed_bytes");
+        let sig = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
+            sender.secret_key(),
+            &signed,
+        )
+        .expect("agent sign");
+        envelope.signature = sig.as_bytes().to_vec();
+    }
+
+    fn wrap_in_pubsub(
+        harness: &InboxHarness,
+        sender: &AgentKeypair,
+        envelope: &DmEnvelope,
+    ) -> PubSubMessage {
         PubSubMessage {
             topic: DmInboxService::inbox_topic_name(&harness.recipient_agent_id),
             payload: Bytes::from(envelope.to_wire_bytes().expect("encode envelope")),
@@ -906,6 +999,43 @@ mod tests {
             verified: true,
             trust_level: Some(TrustLevel::Trusted),
         }
+    }
+
+    /// Legacy (pre-#213) sender: signed envelope, NO origin attestation.
+    fn payload_message(
+        harness: &InboxHarness,
+        sender: &AgentKeypair,
+        claimed_machine: MachineId,
+        request_byte: u8,
+    ) -> PubSubMessage {
+        let mut envelope =
+            craft_unsigned_payload_envelope(harness, sender, claimed_machine, request_byte);
+        sign_envelope_with_agent(&mut envelope, sender);
+        wrap_in_pubsub(harness, sender, &envelope)
+    }
+
+    /// #213 sender: signed envelope WITH a valid origin attestation from
+    /// `machine` (which therefore owns `sender_machine_id`).
+    fn attested_payload_message(
+        harness: &InboxHarness,
+        sender: &AgentKeypair,
+        machine: &MachineKeypair,
+        request_byte: u8,
+    ) -> PubSubMessage {
+        let mut envelope = craft_unsigned_payload_envelope(
+            harness,
+            sender,
+            machine.machine_id(),
+            request_byte,
+        );
+        sign_envelope_with_agent(&mut envelope, sender);
+        let mut attestation = DmOriginAttestation::for_envelope(
+            &envelope,
+            machine.public_key().as_bytes().to_vec(),
+        );
+        attestation.sign(machine).expect("machine attest");
+        envelope.origin_attestation = Some(attestation);
+        wrap_in_pubsub(harness, sender, &envelope)
     }
 
     async fn assert_no_delivery(receiver: &mut crate::direct::DirectMessageReceiver) {
@@ -1170,6 +1300,331 @@ mod tests {
             .expect("delivery stream closed");
         assert_eq!(delivered.machine_id, clean_claim);
         assert_eq!(delivered.trust_decision, Some(TrustDecision::Accept));
+    }
+
+    // ── Issue #213: origin-machine attestation acceptance tests ─────────────
+
+    /// #213 SPOOF: an attacker holding the agent key (but NOT machine B's
+    /// key) claims unrevoked machine B in the envelope. The attestation they
+    /// can produce (signed by their own machine A's key) fails the
+    /// key↔machine-id hash binding — hard drop, even with NO retained
+    /// binding and B unrevoked. This is the core #213 acceptance criterion:
+    /// a revoked origin cannot hide behind an unrevoked claim.
+    #[tokio::test]
+    async fn spoof_agent_key_holder_claiming_unrevoked_machine_is_rejected() {
+        let sender = test_keypair();
+        let attacker_machine = MachineKeypair::generate().expect("attacker machine keygen");
+        let unrevoked_b = MachineId([0xB9; 32]);
+        // No retained binding, no revocations: ONLY the attestation gate can
+        // catch this (the #184 fallback alone would accept the claim).
+        let mut harness = make_inbox_harness(&sender, None, None).await;
+
+        let mut envelope =
+            craft_unsigned_payload_envelope(&harness, &sender, unrevoked_b, 0x51);
+        sign_envelope_with_agent(&mut envelope, &sender);
+        // Attacker attaches the best attestation they can mint: their OWN
+        // machine key over fields claiming machine B.
+        let mut attestation = DmOriginAttestation::for_envelope(
+            &envelope,
+            attacker_machine.public_key().as_bytes().to_vec(),
+        );
+        attestation.sign(&attacker_machine).expect("attacker attest");
+        envelope.origin_attestation = Some(attestation);
+        assert_eq!(
+            envelope.verify_origin_attestation(),
+            Err(crate::dm::OriginAttestationError::KeyBindingMismatch)
+        );
+
+        let message = wrap_in_pubsub(&harness, &sender, &envelope);
+        harness.pipeline.handle_incoming(message, false).await;
+
+        assert_no_delivery(&mut harness.receiver).await;
+        assert_eq!(
+            harness
+                .pipeline
+                .dm
+                .diagnostics_snapshot()
+                .stats
+                .incoming_trust_rejected,
+            1,
+            "an invalid attestation must be an observable hard rejection"
+        );
+    }
+
+    /// #213 SPOOF (variant): a forged/garbage attestation signature is a
+    /// hard drop, never a fallback to the claimed machine.
+    #[tokio::test]
+    async fn spoof_forged_attestation_signature_is_rejected() {
+        let sender = test_keypair();
+        let machine = MachineKeypair::generate().expect("machine keygen");
+        let mut harness = make_inbox_harness(&sender, None, None).await;
+
+        let mut envelope =
+            craft_unsigned_payload_envelope(&harness, &sender, machine.machine_id(), 0x52);
+        sign_envelope_with_agent(&mut envelope, &sender);
+        let mut attestation = DmOriginAttestation::for_envelope(
+            &envelope,
+            machine.public_key().as_bytes().to_vec(),
+        );
+        // Garbage signature of the right length class: parses or not, it
+        // must never verify.
+        attestation.signature = vec![0xAB; 3309];
+        envelope.origin_attestation = Some(attestation);
+
+        let message = wrap_in_pubsub(&harness, &sender, &envelope);
+        harness.pipeline.handle_incoming(message, false).await;
+
+        assert_no_delivery(&mut harness.receiver).await;
+        assert_eq!(
+            harness
+                .pipeline
+                .dm
+                .diagnostics_snapshot()
+                .stats
+                .incoming_trust_rejected,
+            1
+        );
+    }
+
+    /// #213 TRANSITION-WINDOW RESIDUAL — pinned, documented behavior (ADR
+    /// 0021 "Downgrade / mixed-version"). An attacker holding the agent key
+    /// STRIPS the attestation entirely: the envelope degrades to the legacy
+    /// claim path, and on a cold receiver with no retained binding the
+    /// claim of unrevoked machine B is accepted even though the true origin
+    /// A is revoked. Under the transition policy (accept-with-binding-
+    /// fallback for unattested DMs) this DM IS delivered — the exact
+    /// residual #213 narrows to unattested senders only.
+    ///
+    /// This test intentionally asserts the residual EXISTS: when the
+    /// `DmCapabilities` attestation hard-require follow-up lands, delivery
+    /// stops and this test must be flipped to `assert_no_delivery` — it
+    /// fails-positive the day the residual actually closes.
+    #[tokio::test]
+    async fn strip_downgrade_residual_delivered_under_transition_policy() {
+        let sender = test_keypair();
+        let true_origin_a = MachineKeypair::generate().expect("origin machine keygen");
+        let unrevoked_b = MachineId([0xB8; 32]);
+        // Cold receiver: NO retained binding. True origin A IS revoked.
+        let mut harness = make_inbox_harness(&sender, None, Some(&true_origin_a)).await;
+
+        // Stripped envelope: agent-signed, no attestation, claims B.
+        let stripped = payload_message(&harness, &sender, unrevoked_b, 0x53);
+        harness.pipeline.handle_incoming(stripped, false).await;
+
+        let delivered = tokio::time::timeout(Duration::from_secs(2), harness.receiver.recv())
+            .await
+            .expect(
+                "transition policy accepts unattested DMs on the claim path — \
+                 flip this to assert_no_delivery when the hard-require lands",
+            )
+            .expect("delivery stream closed");
+        assert_eq!(
+            delivered.machine_id, unrevoked_b,
+            "strip residual: the unattested claim of B is accepted (ADR 0021 residual)"
+        );
+    }
+
+    /// #213 REPLAY: an attestation captured from DM-1 (request R1) is
+    /// re-presented inside DM-2 (request R2) — the attacker re-signs the
+    /// envelope with the (stolen) agent key but cannot mint a fresh machine
+    /// attestation. The request-id field match fails → hard drop.
+    #[tokio::test]
+    async fn replay_captured_attestation_with_new_request_id_is_rejected() {
+        let sender = test_keypair();
+        let machine = MachineKeypair::generate().expect("machine keygen");
+        let mut harness = make_inbox_harness(&sender, None, None).await;
+
+        // Capture: a valid attested DM (request 0x61).
+        let first = attested_payload_message(&harness, &sender, &machine, 0x61);
+        let first_envelope =
+            DmEnvelope::from_wire_bytes(&first.payload).expect("decode first envelope");
+        let captured = first_envelope
+            .origin_attestation
+            .clone()
+            .expect("first envelope attested");
+
+        // Replay: same agent, NEW request id, envelope re-signed by the
+        // agent key — but the captured attestation still names request 0x61.
+        let mut envelope =
+            craft_unsigned_payload_envelope(&harness, &sender, machine.machine_id(), 0x62);
+        sign_envelope_with_agent(&mut envelope, &sender);
+        envelope.origin_attestation = Some(captured);
+        assert_eq!(
+            envelope.verify_origin_attestation(),
+            Err(crate::dm::OriginAttestationError::EnvelopeMismatch)
+        );
+
+        let message = wrap_in_pubsub(&harness, &sender, &envelope);
+        harness.pipeline.handle_incoming(message, false).await;
+
+        assert_no_delivery(&mut harness.receiver).await;
+        assert_eq!(
+            harness
+                .pipeline
+                .dm
+                .diagnostics_snapshot()
+                .stats
+                .incoming_trust_rejected,
+            1
+        );
+    }
+
+    /// #213 REPLAY (variant): an attestation re-presented past its expiry
+    /// window is dropped — the envelope timestamp window covers the
+    /// attestation because the fields must match exactly.
+    #[tokio::test]
+    async fn replay_expired_attestation_is_rejected() {
+        let sender = test_keypair();
+        let machine = MachineKeypair::generate().expect("machine keygen");
+        let mut harness = make_inbox_harness(&sender, None, None).await;
+
+        // Build an honestly-signed envelope + attestation whose window
+        // already closed (created 10 min ago, 60 s lifetime).
+        let created = now_unix_ms().saturating_sub(600_000);
+        let body = EnvelopeBuilder::build_payload_body(
+            &[0x63; 16],
+            sender.agent_id().as_bytes(),
+            harness.recipient_agent_id.as_bytes(),
+            created,
+            b"stale replay".to_vec(),
+            None,
+            &harness.recipient_kem.public_bytes,
+        )
+        .expect("build payload body");
+        let mut envelope = DmEnvelope {
+            protocol_version: DM_PROTOCOL_VERSION,
+            request_id: [0x63; 16],
+            sender_agent_id: *sender.agent_id().as_bytes(),
+            sender_machine_id: *machine.machine_id().as_bytes(),
+            recipient_agent_id: *harness.recipient_agent_id.as_bytes(),
+            created_at_unix_ms: created,
+            expires_at_unix_ms: created + 60_000,
+            body,
+            signature: Vec::new(),
+            origin_attestation: None,
+        };
+        sign_envelope_with_agent(&mut envelope, &sender);
+        let mut attestation = DmOriginAttestation::for_envelope(
+            &envelope,
+            machine.public_key().as_bytes().to_vec(),
+        );
+        attestation.sign(&machine).expect("machine attest");
+        envelope.origin_attestation = Some(attestation);
+        // The attestation itself verifies — only the expiry window rejects.
+        assert!(envelope.verify_origin_attestation().is_ok());
+
+        let message = wrap_in_pubsub(&harness, &sender, &envelope);
+        harness.pipeline.handle_incoming(message, false).await;
+
+        assert_no_delivery(&mut harness.receiver).await;
+    }
+
+    /// #213 REVOCATION: the origin machine is revoked mid-flight — the
+    /// envelope + attestation are both honestly signed by machine A, but A
+    /// enters the receiver's revocation set before the DM arrives. EP3 drops
+    /// on the ATTESTED machine id (not the claim).
+    #[tokio::test]
+    async fn revocation_of_origin_machine_mid_flight_is_rejected() {
+        let sender = test_keypair();
+        let machine = MachineKeypair::generate().expect("machine keygen");
+        // Harness revocation set already holds machine A's self-revocation.
+        let mut harness = make_inbox_harness(&sender, None, Some(&machine)).await;
+
+        let message = attested_payload_message(&harness, &sender, &machine, 0x64);
+        harness.pipeline.handle_incoming(message, false).await;
+
+        assert_no_delivery(&mut harness.receiver).await;
+        assert_eq!(
+            harness
+                .pipeline
+                .dm
+                .diagnostics_snapshot()
+                .stats
+                .incoming_dropped_revoked,
+            1,
+            "a validly-attested DM from a revoked origin machine must hit EP3"
+        );
+    }
+
+    /// #213 OFFLINE RECEIVER: a completely cold receiver — no retained
+    /// binding, no discovery cache, nothing — authenticates the DM's origin
+    /// machine purely from envelope-carried material and delivers.
+    #[tokio::test]
+    async fn offline_cold_receiver_authenticates_origin_with_zero_cache_state() {
+        let sender = test_keypair();
+        let machine = MachineKeypair::generate().expect("machine keygen");
+        let mut harness = make_inbox_harness(&sender, None, None).await;
+
+        let message = attested_payload_message(&harness, &sender, &machine, 0x65);
+        harness.pipeline.handle_incoming(message, false).await;
+
+        let delivered = tokio::time::timeout(Duration::from_secs(2), harness.receiver.recv())
+            .await
+            .expect("delivery timeout")
+            .expect("delivery stream closed");
+        assert_eq!(delivered.sender, sender.agent_id());
+        assert_eq!(
+            delivered.machine_id,
+            machine.machine_id(),
+            "delivery must carry the ATTESTED machine, not just the claim"
+        );
+        assert_eq!(delivered.trust_decision, Some(TrustDecision::Accept));
+    }
+
+    /// #213 A→B MOVE: the agent legitimately moves from machine A to
+    /// machine B. The retained binding still says A, but B's fresh
+    /// attestation supersedes it — the DM is delivered with machine B and
+    /// the binding refreshes. A later A-attested DM (stale origin, A now
+    /// revoked) is rejected. Revoking A does NOT block the valid move.
+    #[tokio::test]
+    async fn portable_move_fresh_b_attestation_accepted_stale_revoked_a_rejected() {
+        let sender = test_keypair();
+        let machine_a = MachineKeypair::generate().expect("machine A keygen");
+        let machine_b = MachineKeypair::generate().expect("machine B keygen");
+        // Retained binding says A (stale announcement); A is then revoked
+        // (compromised) — the move to B must still authenticate.
+        let mut harness =
+            make_inbox_harness(&sender, Some(machine_a.machine_id()), Some(&machine_a)).await;
+
+        // 1. Fresh B attestation: accepted even though the binding says A.
+        let message = attested_payload_message(&harness, &sender, &machine_b, 0x66);
+        harness.pipeline.handle_incoming(message, false).await;
+        let delivered = tokio::time::timeout(Duration::from_secs(2), harness.receiver.recv())
+            .await
+            .expect("delivery timeout")
+            .expect("delivery stream closed");
+        assert_eq!(
+            delivered.machine_id,
+            machine_b.machine_id(),
+            "a valid fresh attestation from B supersedes the stale A binding"
+        );
+
+        // 2. The retained binding refreshes to B (seconds-granularity
+        //    ordering: the fresh attestation outranks the old announcement).
+        assert_eq!(
+            authenticated_machine_binding_for_testing(
+                &harness.pipeline.authenticated_machine_bindings,
+                &sender.agent_id(),
+            )
+            .await,
+            Some(machine_b.machine_id()),
+            "the attested move must refresh the retained binding to B"
+        );
+
+        // 3. Stale A attestation: A is revoked → EP3 rejects.
+        let stale = attested_payload_message(&harness, &sender, &machine_a, 0x67);
+        harness.pipeline.handle_incoming(stale, false).await;
+        assert_eq!(
+            harness
+                .pipeline
+                .dm
+                .diagnostics_snapshot()
+                .stats
+                .incoming_dropped_revoked,
+            1,
+            "a stale attestation from revoked machine A must hit EP3"
+        );
+        assert_no_delivery(&mut harness.receiver).await;
     }
 
     #[tokio::test]

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -922,7 +922,9 @@ mod tests {
             signing: Arc::new(SigningContext::from_keypair(&recipient)),
             self_agent_id: recipient_agent_id,
             self_machine_id: recipient_machine_id,
-            machine_keypair: Arc::new(MachineKeypair::generate().expect("recipient machine keygen")),
+            machine_keypair: Arc::new(
+                MachineKeypair::generate().expect("recipient machine keygen"),
+            ),
             kem_keypair: Arc::clone(&recipient_kem),
             dm,
             contacts: Arc::new(RwLock::new(contacts)),
@@ -978,11 +980,9 @@ mod tests {
 
     fn sign_envelope_with_agent(envelope: &mut DmEnvelope, sender: &AgentKeypair) {
         let signed = envelope.signed_bytes().expect("signed_bytes");
-        let sig = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
-            sender.secret_key(),
-            &signed,
-        )
-        .expect("agent sign");
+        let sig =
+            ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(sender.secret_key(), &signed)
+                .expect("agent sign");
         envelope.signature = sig.as_bytes().to_vec();
     }
 
@@ -1022,17 +1022,11 @@ mod tests {
         machine: &MachineKeypair,
         request_byte: u8,
     ) -> PubSubMessage {
-        let mut envelope = craft_unsigned_payload_envelope(
-            harness,
-            sender,
-            machine.machine_id(),
-            request_byte,
-        );
+        let mut envelope =
+            craft_unsigned_payload_envelope(harness, sender, machine.machine_id(), request_byte);
         sign_envelope_with_agent(&mut envelope, sender);
-        let mut attestation = DmOriginAttestation::for_envelope(
-            &envelope,
-            machine.public_key().as_bytes().to_vec(),
-        );
+        let mut attestation =
+            DmOriginAttestation::for_envelope(&envelope, machine.public_key().as_bytes().to_vec());
         attestation.sign(machine).expect("machine attest");
         envelope.origin_attestation = Some(attestation);
         wrap_in_pubsub(harness, sender, &envelope)
@@ -1319,8 +1313,7 @@ mod tests {
         // catch this (the #184 fallback alone would accept the claim).
         let mut harness = make_inbox_harness(&sender, None, None).await;
 
-        let mut envelope =
-            craft_unsigned_payload_envelope(&harness, &sender, unrevoked_b, 0x51);
+        let mut envelope = craft_unsigned_payload_envelope(&harness, &sender, unrevoked_b, 0x51);
         sign_envelope_with_agent(&mut envelope, &sender);
         // Attacker attaches the best attestation they can mint: their OWN
         // machine key over fields claiming machine B.
@@ -1328,7 +1321,9 @@ mod tests {
             &envelope,
             attacker_machine.public_key().as_bytes().to_vec(),
         );
-        attestation.sign(&attacker_machine).expect("attacker attest");
+        attestation
+            .sign(&attacker_machine)
+            .expect("attacker attest");
         envelope.origin_attestation = Some(attestation);
         assert_eq!(
             envelope.verify_origin_attestation(),
@@ -1362,10 +1357,8 @@ mod tests {
         let mut envelope =
             craft_unsigned_payload_envelope(&harness, &sender, machine.machine_id(), 0x52);
         sign_envelope_with_agent(&mut envelope, &sender);
-        let mut attestation = DmOriginAttestation::for_envelope(
-            &envelope,
-            machine.public_key().as_bytes().to_vec(),
-        );
+        let mut attestation =
+            DmOriginAttestation::for_envelope(&envelope, machine.public_key().as_bytes().to_vec());
         // Garbage signature of the right length class: parses or not, it
         // must never verify.
         attestation.signature = vec![0xAB; 3309];
@@ -1504,10 +1497,8 @@ mod tests {
             origin_attestation: None,
         };
         sign_envelope_with_agent(&mut envelope, &sender);
-        let mut attestation = DmOriginAttestation::for_envelope(
-            &envelope,
-            machine.public_key().as_bytes().to_vec(),
-        );
+        let mut attestation =
+            DmOriginAttestation::for_envelope(&envelope, machine.public_key().as_bytes().to_vec());
         attestation.sign(&machine).expect("machine attest");
         envelope.origin_attestation = Some(attestation);
         // The attestation itself verifies — only the expiry window rejects.

--- a/src/dm_send.rs
+++ b/src/dm_send.rs
@@ -7,7 +7,7 @@ use crate::dm::{
 use crate::dm_inbox::{DmInboxService, DM_BUS_TOPIC};
 use crate::error::IdentityError;
 use crate::gossip::{PubSubManager, SigningContext};
-use crate::identity::{AgentId, MachineId};
+use crate::identity::{AgentId, MachineId, MachineKeypair};
 
 use bytes::Bytes;
 use std::sync::Arc;
@@ -44,12 +44,15 @@ const ACK_LEGACY_BUS_FALLBACK_DELAY: Duration = Duration::from_millis(250);
 pub struct DmSendContext<'a> {
     /// PlumTree pub/sub manager used to publish the envelope.
     pub pubsub: Arc<PubSubManager>,
-    /// Sender signing context (ML-DSA-65).
+    /// Sender signing context (ML-DSA-65 agent key).
     pub signing: &'a SigningContext,
     /// This agent's `AgentId`.
     pub self_agent_id: AgentId,
     /// This agent's `MachineId`.
     pub self_machine_id: MachineId,
+    /// This machine's keypair — signs the #213 origin-machine attestation
+    /// embedded in every envelope. MUST own `self_machine_id`.
+    pub machine_keypair: &'a MachineKeypair,
     /// Shared in-flight ACK registry.
     pub inflight: Arc<InFlightAcks>,
 }
@@ -67,6 +70,7 @@ pub async fn send_via_gossip(
         signing,
         self_agent_id,
         self_machine_id,
+        machine_keypair,
         inflight,
     } = ctx;
     if payload.len() > MAX_PAYLOAD_BYTES {
@@ -90,6 +94,7 @@ pub async fn send_via_gossip(
         request_id,
         &self_agent_id,
         &self_machine_id,
+        machine_keypair,
         &recipient_agent_id,
         recipient_kem_public_key,
         created,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4249,6 +4249,7 @@ impl Agent {
                             signing: &signing,
                             self_agent_id: self.identity.agent_id(),
                             self_machine_id: self.identity.machine_id(),
+                            machine_keypair: self.identity.machine_keypair(),
                             inflight: std::sync::Arc::clone(&self.dm_inflight_acks),
                         },
                         *to,
@@ -4389,6 +4390,7 @@ impl Agent {
             request_id,
             &sender,
             &self.identity.machine_id(),
+            self.identity.machine_keypair(),
             to,
             recipient_kem_public_key,
             now,
@@ -7143,11 +7145,25 @@ impl Agent {
         let signing = std::sync::Arc::new(gossip::SigningContext::from_keypair(
             self.identity.agent_keypair(),
         ));
+        // #213: the inbox signs ACK origin attestations with the machine key.
+        // `MachineKeypair` is not `Clone` (zeroize-on-drop), so reconstruct a
+        // second owned copy from its serialised bytes — the same pattern
+        // `try_relay_fallback` uses for the agent key.
+        let (machine_pub_bytes, machine_sec_bytes) = self.identity.machine_keypair().to_bytes();
+        let machine_keypair = std::sync::Arc::new(
+            identity::MachineKeypair::from_bytes(&machine_pub_bytes, &machine_sec_bytes)
+                .map_err(|e| {
+                    error::IdentityError::Storage(std::io::Error::other(format!(
+                        "DM inbox machine key copy: {e}"
+                    )))
+                })?,
+        );
         let service = dm_inbox::DmInboxService::spawn(
             std::sync::Arc::clone(runtime.pubsub()),
             signing,
             self.identity.agent_id(),
             self.identity.machine_id(),
+            machine_keypair,
             std::sync::Arc::clone(&kem_keypair),
             std::sync::Arc::clone(&self.direct_messaging),
             std::sync::Arc::clone(&self.contact_store),
@@ -14424,6 +14440,7 @@ mod tests {
                     body_ciphertext: Vec::new(),
                 }),
                 signature: Vec::new(),
+                origin_attestation: None,
             },
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7151,12 +7151,13 @@ impl Agent {
         // `try_relay_fallback` uses for the agent key.
         let (machine_pub_bytes, machine_sec_bytes) = self.identity.machine_keypair().to_bytes();
         let machine_keypair = std::sync::Arc::new(
-            identity::MachineKeypair::from_bytes(&machine_pub_bytes, &machine_sec_bytes)
-                .map_err(|e| {
+            identity::MachineKeypair::from_bytes(&machine_pub_bytes, &machine_sec_bytes).map_err(
+                |e| {
                     error::IdentityError::Storage(std::io::Error::other(format!(
                         "DM inbox machine key copy: {e}"
                     )))
-                })?,
+                },
+            )?,
         );
         let service = dm_inbox::DmInboxService::spawn(
             std::sync::Arc::clone(runtime.pubsub()),

--- a/src/peer_relay.rs
+++ b/src/peer_relay.rs
@@ -1018,6 +1018,7 @@ mod tests {
                 body_ciphertext: vec![0u8; 8],
             }),
             signature: vec![0u8; 8],
+            origin_attestation: None,
         }
     }
 

--- a/tests/comprehensive_integration.rs
+++ b/tests/comprehensive_integration.rs
@@ -246,6 +246,7 @@ fn unsigned_ack_envelope(sender_keypair: &AgentKeypair, recipient: AgentId) -> D
             outcome: DmAckOutcome::Accepted,
         }),
         signature: Vec::new(),
+        origin_attestation: None,
     }
 }
 

--- a/tests/peer_relay_integration.rs
+++ b/tests/peer_relay_integration.rs
@@ -761,6 +761,7 @@ fn opaque_inner(
             body_ciphertext: vec![0u8; 8],
         }),
         signature,
+        origin_attestation: None,
     }
 }
 


### PR DESCRIPTION
Closes the #213 acceptance criteria; the strip-to-fallback transition residual is documented and test-pinned (closes when the follow-up DmCapabilities hard-require lands).

- DmOriginAttestation: ML-DSA-65 machine-key signature over sender AgentId + sender MachineId/pubkey + recipient AgentId + request ID + created/expiry + domain separator + protocol version; rides additively in the DM envelope (old peers skip; mixed-version tested both directions)
- Verification is fully self-contained: a receiver with ZERO discovery-cache state authenticates the origin machine (machine-key→MachineId derivation checked before sig verify); restart/LRU-eviction degrade nothing
- Revocation is evaluated against the RESOLVED (attested) machine: a revoked origin A cannot deliver under a claimed unrevoked B — the key-binding mismatch hard-drops; portable A→B moves work via freshness-ordered binding refresh (bounded by a 30s future-cap on envelope timestamps)
- Downgrade policy (ADR 0021): present-and-valid → attested; present-but-invalid → hard drop, NO fallback; absent → #184 retained-binding path (transition residual, test-pinned)
- Dedupe TTL raised to ≥ MAX_ENVELOPE_LIFETIME_MS closing the exact-replay window found in review
- ADR 0021 documents the move policy, replay/expiry, downgrade, offline receivers, and the negative scope (attestation does not cover body)

Integration tests (real PubSubManager/NetworkNode/pipeline counters, not tautologies): spoof, forged signature, replay (new request-id + expired), revocation mid-flight, cold receiver, A→B move, strip-residual pin.

Gates: fmt/clippy clean, 227/227 tests. Adversarial protocol review: SOUND (8/8 criteria) after the TTL reconciliation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds machine-key origin attestation to gossip DMs. The main changes are:

- Machine-signed attestations on payload and ACK envelopes.
- Self-contained origin verification and revocation checks.
- Retained-binding refresh for portable machine moves.
- Longer replay-deduplication lifetime.
- Mixed-version, spoofing, replay, revocation, and cold-receiver tests.
- ADR 0021 for the protocol and downgrade policy.

<h3>Confidence Score: 4/5</h3>

The attestation downgrade and retained-binding update paths need fixes before merging.

- Malformed present attestations can enter the legacy fallback.
- Rejected traffic from a revoked machine can modify retained state.
- Same-second attestations can reverse portable-move ordering.

src/dm.rs and src/dm_inbox.rs

<details open><summary><h3>Security Review</h3></summary>

Malformed attestation data can be treated as an absent legacy field, reopening the claimed-machine fallback. Valid traffic from a revoked machine can also modify retained binding state before the revocation gate rejects it.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dm.rs | Adds the attestation wire format, signing, verification, builder integration, and replay TTL; malformed trailing attestations can degrade to legacy absence. |
| src/dm_inbox.rs | Adds attestation resolution, binding refresh, revocation handling, and attested ACKs; binding updates can be poisoned or reordered. |
| src/dm_send.rs | Threads the sender machine keypair into gossip envelope construction. |
| src/lib.rs | Supplies machine keys to direct gossip, relay fallback, and inbox ACK generation. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Receive DM envelope] --> B[Validate envelope and agent signature]
    B --> C{Origin attestation}
    C -->|Valid| D[Resolve attested machine]
    C -->|Invalid| E[Hard drop]
    C -->|Absent| F[Use retained binding or legacy claim]
    D --> G[Refresh retained binding]
    F --> H[Resolved machine]
    G --> H
    H --> I{Revoked?}
    I -->|Yes| J[Drop]
    I -->|No| K{Body type}
    K -->|Payload| L[Trust, decrypt, dedupe, deliver]
    K -->|ACK| M[Resolve in-flight request]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Receive DM envelope] --> B[Validate envelope and agent signature]
    B --> C{Origin attestation}
    C -->|Valid| D[Resolve attested machine]
    C -->|Invalid| E[Hard drop]
    C -->|Absent| F[Use retained binding or legacy claim]
    D --> G[Refresh retained binding]
    F --> H[Resolved machine]
    G --> H
    H --> I{Revoked?}
    I -->|Yes| J[Drop]
    I -->|No| K{Body type}
    K -->|Payload| L[Trust, decrypt, dedupe, deliver]
    K -->|ACK| M[Resolve in-flight request]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/dm.rs:451
**Malformed Attestation Becomes Legacy Absence**

`unwrap_or(None)` converts every attestation decode error into an absent field, including truncated or malformed data after the option begins. Such an envelope enters the legacy claimed-machine fallback instead of the required present-but-invalid hard drop, so an agent-key holder can bypass machine attestation on a cold receiver.

### Issue 2 of 3
src/dm_inbox.rs:454-460
**Revoked Envelope Poisons Binding State**

This records the attested machine before the revocation check below. A revoked machine with valid keys can therefore replace the retained binding and then be dropped, leaving later legacy traffic from the legitimate machine rejected as a mismatch until a newer accepted update repairs the cache.

### Issue 3 of 3
src/dm_inbox.rs:458
**Timestamp Truncation Reverses Moves**

Dividing by 1000 makes distinct attestations within one second compare equal. If a newer B attestation arrives before a delayed older A attestation from that same second, the cache's `>=` rule lets A overwrite B, causing later unattested traffic from B to be rejected against the stale binding.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/saorsa-labs/x0x/commit/b530e00e976513a1549599d62bdb025603943695) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45241134)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->