### PR TITLE
feat(sync): #240 — digest-verified convergence evidence for checkpoint-less recovery

### DIFF
--- a/src/crdt/delta.rs
+++ b/src/crdt/delta.rs
@@ -12,7 +12,7 @@
 //!
 //! This significantly reduces bandwidth usage in collaborative scenarios.
 
-use crate::crdt::{Result, TaskId, TaskItem, TaskList};
+use crate::crdt::{Result, TaskId, TaskItem, TaskList, TaskListId};
 use saorsa_gossip_crdt_sync::{DeltaCrdt, LwwRegister};
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
@@ -104,6 +104,34 @@ impl TaskListDelta {
             && self.task_updates.is_empty()
             && self.ordering_update.is_none()
             && self.name_update.is_none()
+    }
+
+    /// Digest over the full-state content this delta serves, when the delta
+    /// is full-state-shaped (issue #240).
+    ///
+    /// A `TaskList::full_delta` always carries BOTH the ordering and name
+    /// registers; incremental deltas carry at most one of them, so `None`
+    /// cleanly excludes non-full-state shapes. Callers MUST additionally
+    /// require the added-task count to equal the holder's declared
+    /// `entry_count` before treating a digest match as a verified full
+    /// serve. The digest commits to the carried tasks' RESOLVED observable
+    /// fields in sorted task-id order (see
+    /// [`TaskItem::hash_resolved_fields`]) — identical to what
+    /// [`TaskList::served_digest`] computes over local state, so a receiver
+    /// holding exactly the served content produces the same digest.
+    pub(crate) fn served_digest(&self, list_id: &TaskListId) -> Option<[u8; 32]> {
+        self.ordering_update.as_ref()?;
+        self.name_update.as_ref()?;
+        let mut h = blake3::Hasher::new();
+        h.update(crate::crdt::task_list::SERVED_DIGEST_DOMAIN);
+        h.update(list_id.as_bytes());
+        let mut ids: Vec<&TaskId> = self.added_tasks.keys().collect();
+        ids.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        for id in ids {
+            h.update(id.as_bytes());
+            self.added_tasks[id].0.hash_resolved_fields(&mut h);
+        }
+        Some(*h.finalize().as_bytes())
     }
 }
 

--- a/src/crdt/delta.rs
+++ b/src/crdt/delta.rs
@@ -159,7 +159,12 @@ impl TaskList {
     /// with `merge_delta`, whose upsert/LWW semantics make a full snapshot a
     /// safe superset of any incremental change — this is the producer used to
     /// answer cold-start state requests (see `TaskListSync`). The OR-Set tags
-    /// are synthetic because the receiver re-derives membership on merge.
+    /// are synthetic because the receiver re-derives membership on merge —
+    /// but they must be FRESH per entry (F3, fix-loop): the digest-verified
+    /// adopt prunes stale tasks with a local observe-remove, which
+    /// tombstones the tags a previous full delta used, and a hardcoded tag
+    /// would then be silently rejected on a later serve that re-adds the
+    /// task — a permanent re-add deadlock.
     #[must_use]
     pub fn full_delta(&self) -> TaskListDelta {
         let mut delta = TaskListDelta::new(self.version());
@@ -167,7 +172,7 @@ impl TaskList {
         let ordered = self.tasks_ordered();
         for task in &ordered {
             let task_id = *task.id();
-            let tag = (PeerId::new([0u8; 32]), 0);
+            let tag = (PeerId::new([0u8; 32]), self.next_seq());
             delta.added_tasks.insert(task_id, ((*task).clone(), tag));
         }
 

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -1847,4 +1847,53 @@ mod tests {
             "a tampered marker must not wedge recovery from a genuine holder"
         );
     }
+
+    /// WHY (F3, fix-loop — tombstone + hardcoded-tag deadlock): the adopt's
+    /// prune is a local observe-remove, tombstoning the tags a previous
+    /// full delta used. With a hardcoded synthetic tag, a later serve
+    /// re-adding the same task would be silently rejected forever. Full
+    /// deltas now mint FRESH tags, so a re-served task is accepted.
+    #[test]
+    fn pruned_task_is_accepted_when_re_served_with_fresh_tags() {
+        let mut holder = TaskList::new(list_id(1), "List".to_string(), peer(1));
+        holder
+            .add_task(make_task(1, peer(1)), peer(1), 1)
+            .expect("add t1");
+        holder
+            .add_task(make_task(2, peer(1)), peer(1), 2)
+            .expect("add t2");
+
+        // The replica absorbs a first full serve (both tasks).
+        let mut replica = TaskList::new(list_id(1), "List".to_string(), peer(2));
+        let s1 = holder.full_delta();
+        replica.merge_delta(&s1, peer(1)).expect("serve 1");
+        assert_eq!(replica.task_count(), 2);
+
+        // The holder deletes the task; the next VERIFIED serve prunes it
+        // (tombstoning the first serve's synthetic tag locally).
+        let doomed = TaskId::from_bytes([2; 32]);
+        holder.remove_task(&doomed).expect("delete");
+        let s2 = holder.full_delta();
+        assert_eq!(
+            s2.served_digest(&list_id(1)),
+            Some(holder.served_digest()),
+            "the serve must carry the holder's declared digest"
+        );
+        replica.merge_delta(&s2, peer(1)).expect("serve 2");
+        assert_eq!(replica.prune_to_served_set(&s2), 1);
+        assert!(replica.get_task(&doomed).is_none());
+
+        // The holder RE-ADDS the task: a later serve must be accepted —
+        // pre-fix, its synthetic tag was tombstoned by the prune and the
+        // re-add silently dropped.
+        holder
+            .add_task(make_task(2, peer(1)), peer(1), 3)
+            .expect("re-add");
+        let s3 = holder.full_delta();
+        replica.merge_delta(&s3, peer(1)).expect("serve 3");
+        assert!(
+            replica.get_task(&doomed).is_some(),
+            "a re-served task must be accepted after a prune"
+        );
+    }
 }

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -161,11 +161,7 @@ struct TaskServedEvidence {
 /// content). Otherwise (only v1 markers seen — old peers) the legacy weak
 /// rule: a marker AND local non-emptiness. No evidence is NEVER
 /// convergence.
-fn tasklist_converged(
-    ev: &TaskServedEvidence,
-    task_count: usize,
-    local_digest: [u8; 32],
-) -> bool {
+fn tasklist_converged(ev: &TaskServedEvidence, task_count: usize, local_digest: [u8; 32]) -> bool {
     if !ev.digests.is_empty() {
         let any_nonempty = ev.digests.values().any(|d| d.entry_count > 0);
         return ev
@@ -1463,7 +1459,8 @@ mod tests {
         assert_eq!(inc.served_digest(&list_id(1)), None);
 
         // Different membership ⇒ different digest.
-        b.add_task(make_task(9, peer(2)), peer(2), 2).expect("add b2");
+        b.add_task(make_task(9, peer(2)), peer(2), 2)
+            .expect("add b2");
         assert_ne!(a.served_digest(), b.served_digest());
     }
 
@@ -1739,9 +1736,7 @@ mod tests {
             .publish(topic.to_string(), bytes::Bytes::from(encoded))
             .await
             .expect("publish full delta");
-        let marker = TaskListSyncMessage::StateServed {
-            responder: peer(1),
-        };
+        let marker = TaskListSyncMessage::StateServed { responder: peer(1) };
         let marker_bytes = bincode::serialize(&marker).expect("serialize v1 marker");
         pubsub
             .publish(side.clone(), bytes::Bytes::from(marker_bytes))

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -97,6 +97,94 @@ enum TaskListSyncMessage {
         /// The declaring holder (receivers skip their own echo).
         responder: PeerId,
     },
+    /// A holder's digest-committed declaration that it has answered a
+    /// `StateRequest` (issue #240): `digest` commits to the FULL served
+    /// task set (see `TaskList::served_digest`), so a requester can verify
+    /// "served us, completely" against its OWN state instead of trusting
+    /// that the full delta and the marker both arrived (the v1 cross-topic
+    /// loss window). A requester stops only when its local digest matches a
+    /// declared digest — a lost full delta leaves the local digest
+    /// different, so it keeps asking.
+    ///
+    /// Empty holders declare the digest of the empty set, which any empty
+    /// requester can compute locally — two empty replicas verifiably agree
+    /// on the empty state, so converging on empty is now CORRECT (not the
+    /// false convergence the v1 silence rule defended against), and the
+    /// genuinely-empty chatter tail terminates. Because the digest is
+    /// self-verifying, an empty declaration needs no full-delta broadcast
+    /// to witness.
+    ///
+    /// Wire compatibility: additive variant, same precedent as the v1
+    /// marker — older peers fail to deserialize it and skip the message;
+    /// new peers treat v1 markers as weaker evidence when no v2 digest has
+    /// been seen. The marker rides along with the full-state broadcast
+    /// (never separately) when there is state to serve.
+    StateServedV2 {
+        /// The declaring holder (receivers skip their own echo).
+        responder: PeerId,
+        /// Canonical BLAKE3 digest over the served task set.
+        digest: [u8; 32],
+        /// Number of tasks in the served set — a cheap shape check for the
+        /// verified full-replace adopt path (and useful in logs).
+        entry_count: u32,
+    },
+}
+
+/// One responder's latest v2 digest declaration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ServedState {
+    /// The declared content digest.
+    digest: [u8; 32],
+    /// The declared number of tasks.
+    entry_count: u32,
+}
+
+/// Aggregated `StateServed`/`StateServedV2` evidence observed by one
+/// replica's responder loop, consumed by its bootstrap requester to decide
+/// convergence.
+#[derive(Debug, Default)]
+struct TaskServedEvidence {
+    /// A v1 marker from some holder (weak evidence — old peers).
+    saw_v1: bool,
+    /// Latest digest declaration per responder (bounded by mesh size — a
+    /// responder's newer declaration REPLACES its older one, so a replayed
+    /// stale serve can never roll a verified full-replace adopt backwards).
+    digests: std::collections::HashMap<PeerId, ServedState>,
+}
+
+/// Convergence rule for the bootstrap tail (pure for unit-testing).
+///
+/// When any v2 digest declarations exist, the local digest must match one
+/// of them — with the data-bearing-claim-wins rule: if any declaration is
+/// non-empty, only a non-empty match converges (an empty holder's
+/// declaration must not retire a requester while a full holder advertised
+/// content). Otherwise (only v1 markers seen — old peers) the legacy weak
+/// rule: a marker AND local non-emptiness. No evidence is NEVER
+/// convergence.
+fn tasklist_converged(
+    ev: &TaskServedEvidence,
+    task_count: usize,
+    local_digest: [u8; 32],
+) -> bool {
+    if !ev.digests.is_empty() {
+        let any_nonempty = ev.digests.values().any(|d| d.entry_count > 0);
+        return ev
+            .digests
+            .values()
+            .any(|d| d.digest == local_digest && (d.entry_count > 0 || !any_nonempty));
+    }
+    ev.saw_v1 && task_count > 0
+}
+
+/// Disarms the bootstrap-active flag on ANY requester exit path (converged,
+/// silenced, cancelled, torn down) so the listener's digest-verified
+/// full-replace adopt can never fire outside the bootstrap window.
+struct BootstrapGuard(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl Drop for BootstrapGuard {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
 /// Synchronization wrapper for a TaskList.
@@ -240,6 +328,18 @@ impl TaskListSync {
         let mut sub = self.pubsub.subscribe(self.topic.clone()).await;
         let task_list = Arc::clone(&self.task_list);
         let listener_cancel = self.cancel.clone();
+        // StateServed evidence: written by the responder loop (which owns
+        // the side-topic subscription), read by the listener (verified
+        // full-replace adopt, issue #240) and the bootstrap requester
+        // (convergence). Created BEFORE the loops so all three share it.
+        let served_evidence = Arc::new(std::sync::Mutex::new(TaskServedEvidence::default()));
+        // Armed only while the bootstrap requester runs: the verified
+        // full-replace adopt fires exclusively in that window — a converged
+        // replica must never let a divergent holder's serve truncate state
+        // it legitimately holds.
+        let bootstrap_active = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let listener_served = Arc::clone(&served_evidence);
+        let listener_bootstrap_active = Arc::clone(&bootstrap_active);
 
         spawn(Box::pin(async move {
             loop {
@@ -265,6 +365,41 @@ impl TaskListSync {
                         let mut list = task_list.write().await;
                         if let Err(e) = list.merge_delta(&delta, peer_id) {
                             tracing::warn!("Failed to merge remote delta: {}", e);
+                        } else if listener_bootstrap_active
+                            .load(std::sync::atomic::Ordering::Relaxed)
+                        {
+                            // Digest-verified full-replace adopt (issue
+                            // #240, deletion cold-sync): while
+                            // bootstrapping, when the sender's latest v2
+                            // declaration matches this delta's served
+                            // content (digest AND task count), the delta IS
+                            // that holder's complete state — prune local
+                            // tasks it does not carry. Without verification
+                            // any holder could truncate local state at
+                            // will.
+                            let declared = listener_served
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .digests
+                                .get(&peer_id)
+                                .copied();
+                            if let Some(declared) = declared {
+                                let list_id = *list.id();
+                                if delta.added_tasks.len() == declared.entry_count as usize
+                                    && delta
+                                        .served_digest(&list_id)
+                                        .is_some_and(|dg| dg == declared.digest)
+                                {
+                                    let pruned = list.prune_to_served_set(&delta);
+                                    if pruned > 0 {
+                                        tracing::info!(
+                                            "pruned {pruned} stale task(s) after \
+                                             digest-verified full serve for list {}",
+                                            list.id()
+                                        );
+                                    }
+                                }
+                            }
                         }
                     }
                     Err(e) => {
@@ -284,10 +419,6 @@ impl TaskListSync {
         let responder_pubsub = Arc::clone(&self.pubsub);
         let responder_topic = self.topic.clone();
         let sync_topic = self.state_sync_topic();
-        // StateServed evidence: written by the responder loop (which owns
-        // the side-topic subscription), read by the bootstrap requester to
-        // decide convergence.
-        let served_evidence = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let responder_served = Arc::clone(&served_evidence);
         let responder_cancel = self.cancel.clone();
         let local_peer_id = self.local_peer_id;
@@ -322,60 +453,93 @@ impl TaskListSync {
                         if requester == local_peer_id {
                             continue;
                         }
-                        // The StateServed marker is published ONLY alongside
-                        // an actual full-delta publish: a marker must
-                        // witness a real broadcast — one sent for a
-                        // cooldown-suppressed response could convince a
-                        // requester that never received the state to stop
-                        // asking (round-3 review). A requester inside the
-                        // window is served by its next scheduled attempt.
-                        // Checked BEFORE building the full delta — no point
-                        // cloning the whole list for a suppressed response.
-                        let cooled_down = last_full_response.is_some_and(|t| {
-                            t.elapsed()
-                                < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
-                        });
-                        if cooled_down {
-                            continue;
-                        }
-                        // Empty holders stay entirely silent — no response,
-                        // no marker (see StateServed docs).
-                        let full = {
-                            let list = responder_list.read().await;
-                            if list.task_count() == 0 {
+                        let mut markers: Vec<TaskListSyncMessage> = Vec::new();
+                        if responder_list.read().await.task_count() == 0 {
+                            // Empty holder: the v2 digest of the empty set
+                            // is universally computable, so an empty
+                            // requester verifies it locally and stops
+                            // (issue #240; no broadcast to witness because
+                            // there is nothing to serve, and no cooldown —
+                            // damping exists to bound FULL-state storms).
+                            // v1 behavior is preserved for old peers:
+                            // silence (two empty replicas must not talk
+                            // each other into a false converged-empty under
+                            // the unverifiable v1 rule).
+                            let digest = responder_list.read().await.served_digest();
+                            markers.push(TaskListSyncMessage::StateServedV2 {
+                                responder: local_peer_id,
+                                digest,
+                                entry_count: 0,
+                            });
+                        } else {
+                            // The StateServed markers are published ONLY
+                            // alongside an actual full-delta publish: a
+                            // marker must witness a real broadcast — one
+                            // sent for a cooldown-suppressed response could
+                            // convince a requester that never received the
+                            // state to stop asking (round-3 review). A
+                            // requester inside the window is served by its
+                            // next scheduled attempt. Checked BEFORE
+                            // building the full delta — no point cloning
+                            // the whole list for a suppressed response.
+                            let cooled_down = last_full_response.is_some_and(|t| {
+                                t.elapsed()
+                                    < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
+                            });
+                            if cooled_down {
                                 continue;
                             }
-                            list.full_delta()
-                        };
-                        let Ok(serialized) = encode_delta(local_peer_id, &full) else {
-                            continue;
-                        };
-                        if let Err(e) = responder_pubsub
-                            .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
-                            .await
-                        {
-                            tracing::warn!("TaskList state-response publish failed: {e}");
-                            continue;
+                            // One snapshot for the full delta AND the v2
+                            // digest, so the declaration commits to exactly
+                            // what was broadcast.
+                            let (full, digest, count) = {
+                                let list = responder_list.read().await;
+                                (
+                                    list.full_delta(),
+                                    list.served_digest(),
+                                    list.task_count() as u32,
+                                )
+                            };
+                            let Ok(serialized) = encode_delta(local_peer_id, &full) else {
+                                continue;
+                            };
+                            if let Err(e) = responder_pubsub
+                                .publish(responder_topic.clone(), bytes::Bytes::from(serialized))
+                                .await
+                            {
+                                tracing::warn!("TaskList state-response publish failed: {e}");
+                                continue;
+                            }
+                            last_full_response = Some(tokio::time::Instant::now());
+                            markers.push(TaskListSyncMessage::StateServed {
+                                responder: local_peer_id,
+                            });
+                            // The v2 marker rides along with the broadcast
+                            // it commits to — never separately
+                            // (response-storm damping, issue #240).
+                            markers.push(TaskListSyncMessage::StateServedV2 {
+                                responder: local_peer_id,
+                                digest,
+                                entry_count: count,
+                            });
                         }
-                        last_full_response = Some(tokio::time::Instant::now());
-                        let marker = TaskListSyncMessage::StateServed {
-                            responder: local_peer_id,
-                        };
-                        match bincode::serialize(&marker) {
-                            Ok(serialized) => {
-                                if let Err(e) = responder_pubsub
-                                    .publish(sync_topic.clone(), bytes::Bytes::from(serialized))
-                                    .await
-                                {
+                        for marker in markers {
+                            match bincode::serialize(&marker) {
+                                Ok(serialized) => {
+                                    if let Err(e) = responder_pubsub
+                                        .publish(sync_topic.clone(), bytes::Bytes::from(serialized))
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "TaskList state-served marker publish failed: {e}"
+                                        );
+                                    }
+                                }
+                                Err(e) => {
                                     tracing::warn!(
-                                        "TaskList state-served marker publish failed: {e}"
+                                        "TaskList state-served marker serialize failed: {e}"
                                     );
                                 }
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    "TaskList state-served marker serialize failed: {e}"
-                                );
                             }
                         }
                     }
@@ -388,7 +552,35 @@ impl TaskListSync {
                         // the requester still requires local non-emptiness
                         // — a forged marker cannot inject state and stops
                         // recovery no earlier than a real holder could.
-                        responder_served.store(true, std::sync::atomic::Ordering::Relaxed);
+                        responder_served
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .saw_v1 = true;
+                    }
+                    TaskListSyncMessage::StateServedV2 {
+                        responder,
+                        digest,
+                        entry_count,
+                    } => {
+                        if responder == local_peer_id {
+                            continue; // our own marker echoed back
+                        }
+                        // Trust note: the digest is SELF-VERIFYING — a
+                        // forged declaration can only match local state
+                        // that actually equals the declared content, so a
+                        // forgery's worst case is the requester keeps
+                        // asking (the same bound as a forged v1 marker).
+                        responder_served
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .digests
+                            .insert(
+                                responder,
+                                ServedState {
+                                    digest,
+                                    entry_count,
+                                },
+                            );
                     }
                 }
             }
@@ -420,7 +612,13 @@ impl TaskListSync {
             let stopped = Arc::clone(&self.stopped);
             let requester_cancel = self.cancel.clone();
             let requester_served = Arc::clone(&served_evidence);
+            let requester_bootstrap_active = Arc::clone(&bootstrap_active);
+            bootstrap_active.store(true, std::sync::atomic::Ordering::Relaxed);
             spawn(Box::pin(async move {
+                // Disarms the adopt window on ANY exit (converged, silenced,
+                // cancelled, torn down) — the listener's verified
+                // full-replace adopt must never fire outside bootstrap.
+                let _guard = BootstrapGuard(requester_bootstrap_active);
                 for (attempt, delay_secs) in state_request_delays().enumerate() {
                     tokio::select! {
                         // cancel_sync tears down every loop promptly, even
@@ -436,15 +634,27 @@ impl TaskListSync {
                     // StateServed marker (a holder actually answered) AND
                     // local state — mere non-emptiness can be faked by one
                     // incremental delta while full history is still missing
-                    // (round-2 review).
+                    // (round-2 review). v2 digest evidence makes the check
+                    // exact (issue #240): the requester stops only when its
+                    // OWN content digest matches a holder's declaration —
+                    // including the universally-computable empty digest,
+                    // which lets a genuinely-empty list fall silent.
                     if attempt >= STATE_REQUEST_RETRY_SECS.len() {
                         let Some(list) = requester_list.upgrade() else {
                             return; // sync torn down — nothing left to bootstrap
                         };
-                        if requester_served.load(std::sync::atomic::Ordering::Relaxed)
-                            && list.read().await.task_count() > 0
-                        {
-                            return; // a holder served us and we hold state
+                        let (count, local_digest) = {
+                            let l = list.read().await;
+                            (l.task_count(), l.served_digest())
+                        };
+                        let converged = {
+                            let ev = requester_served
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            tasklist_converged(&ev, count, local_digest)
+                        };
+                        if converged {
+                            return; // a holder served us and local state matches
                         }
                     }
                     let request = TaskListSyncMessage::StateRequest {
@@ -1123,6 +1333,518 @@ mod tests {
             converged,
             "the infinite tail must recover state from a holder that \
              returns after the old hard cap (zombie subscription, issue #238)"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #240: digest-verified convergence evidence
+    // ------------------------------------------------------------------
+
+    /// Drain every side-topic `StateRequest` from `from` already queued on
+    /// `probe` without blocking (the 1ms virtual timeout yields immediately
+    /// under the paused clock when the queue is empty).
+    async fn drain_state_requests(probe: &mut crate::gossip::Subscription, from: PeerId) -> usize {
+        let mut n = 0;
+        while let Ok(Some(msg)) = tokio::time::timeout(Duration::from_millis(1), probe.recv()).await
+        {
+            if let Ok(TaskListSyncMessage::StateRequest { requester }) =
+                bincode::deserialize::<TaskListSyncMessage>(&msg.payload)
+            {
+                if requester == from {
+                    n += 1;
+                }
+            }
+        }
+        n
+    }
+
+    /// WHY (issue #240): the convergence rule must weigh v2 digest evidence
+    /// above the weak v1 rule, with the data-bearing-claim-wins tiebreak —
+    /// and NO evidence is NEVER convergence.
+    #[test]
+    fn tasklist_convergence_rule() {
+        const D1: [u8; 32] = [1u8; 32];
+        const D2: [u8; 32] = [2u8; 32];
+        const D_EMPTY: [u8; 32] = [9u8; 32];
+        let none = TaskServedEvidence::default();
+        assert!(!tasklist_converged(&none, 0, D1));
+        assert!(!tasklist_converged(&none, 5, D1));
+
+        // v1 weak rule: marker + local non-emptiness.
+        let v1 = TaskServedEvidence {
+            saw_v1: true,
+            digests: std::collections::HashMap::new(),
+        };
+        assert!(!tasklist_converged(&v1, 0, D1));
+        assert!(tasklist_converged(&v1, 3, D1));
+
+        // v2 digest gate: match stops, mismatch keeps asking, and v2
+        // outranks the weak v1 rule.
+        let mut ev = TaskServedEvidence::default();
+        ev.digests.insert(
+            peer(9),
+            ServedState {
+                digest: D1,
+                entry_count: 2,
+            },
+        );
+        assert!(tasklist_converged(&ev, 2, D1));
+        assert!(!tasklist_converged(&ev, 1, D2));
+        ev.saw_v1 = true;
+        assert!(
+            !tasklist_converged(&ev, 1, D2),
+            "v2 declarations outrank weak v1 evidence"
+        );
+
+        // Empty-holder declarations converge an empty requester only when
+        // every declaration is empty (data-bearing claim wins).
+        let mut ev_empty = TaskServedEvidence::default();
+        ev_empty.digests.insert(
+            peer(9),
+            ServedState {
+                digest: D_EMPTY,
+                entry_count: 0,
+            },
+        );
+        assert!(tasklist_converged(&ev_empty, 0, D_EMPTY));
+        ev_empty.digests.insert(
+            peer(10),
+            ServedState {
+                digest: D1,
+                entry_count: 2,
+            },
+        );
+        assert!(
+            !tasklist_converged(&ev_empty, 0, D_EMPTY),
+            "a data-bearing declaration outranks the empty one — keep asking"
+        );
+        assert!(tasklist_converged(&ev_empty, 2, D1));
+    }
+
+    /// WHY: the v2 digest commits to the served task set so a requester can
+    /// verify completeness LOCALLY. It must be deterministic across
+    /// replicas, sensitive to membership, insensitive to name/ordering
+    /// metadata, and bound to the list id; a full delta's carried digest
+    /// must equal the serving list's local digest.
+    #[test]
+    fn served_digest_is_deterministic_content_bound_and_metadata_independent() {
+        let mut a = TaskList::new(list_id(1), "alpha".to_string(), peer(1));
+        let mut b = TaskList::new(list_id(1), "beta".to_string(), peer(2));
+        assert_eq!(
+            a.served_digest(),
+            b.served_digest(),
+            "empty lists with the same id digest alike (name is not content)"
+        );
+        let c = TaskList::new(list_id(2), "alpha".to_string(), peer(1));
+        assert_ne!(
+            a.served_digest(),
+            c.served_digest(),
+            "the list id binds the digest (cross-list replay defense)"
+        );
+
+        // The same task in both lists ⇒ the same digest, however it got
+        // there (OR-Set writer tags are transport, not content).
+        let task = make_task(7, peer(3));
+        a.add_task(task.clone(), peer(1), 1).expect("add a");
+        b.add_task(task, peer(2), 1).expect("add b");
+        assert_eq!(a.served_digest(), b.served_digest());
+
+        // A full delta's served digest equals the local digest; an
+        // incremental delta is not full-state-shaped and must not
+        // impersonate a serve.
+        let full = a.full_delta();
+        assert_eq!(full.served_digest(&list_id(1)), Some(a.served_digest()));
+        let inc = TaskListDelta::for_add(
+            TaskId::from_bytes([8; 32]),
+            make_task(8, peer(1)),
+            (peer(1), 1),
+            2,
+        );
+        assert_eq!(inc.served_digest(&list_id(1)), None);
+
+        // Different membership ⇒ different digest.
+        b.add_task(make_task(9, peer(2)), peer(2), 2).expect("add b2");
+        assert_ne!(a.served_digest(), b.served_digest());
+    }
+
+    /// WHY (issue #240, residual 1 — the cross-topic loss window): the full
+    /// delta travels on the main topic, its marker on the side topic, with
+    /// no delivery coupling. If the delta is lost while the marker
+    /// survives, the v1 rule stopped a non-empty requester with incomplete
+    /// history. With the v2 digest the requester detects the mismatch
+    /// (local {t2} vs declared {t1,t2}) and keeps asking until the real
+    /// state arrives.
+    #[tokio::test(start_paused = true)]
+    async fn lost_full_delta_with_surviving_marker_keeps_requester_asking() {
+        let node = make_node().await;
+        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        let topic = "tasks-240-lost-broadcast";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        // The full holder state (offline for now): {t1, t2}.
+        let mut holder_list = TaskList::new(list_id(1), "Test List".to_string(), peer(1));
+        holder_list
+            .add_task(make_task(1, peer(1)), peer(1), 1)
+            .expect("holder t1");
+        holder_list
+            .add_task(make_task(2, peer(1)), peer(1), 2)
+            .expect("holder t2");
+
+        // The joiner starts EMPTY (a non-empty task list never bootstraps
+        // — only empty lists run the requester).
+        let joiner_list = TaskList::new(list_id(1), "Test List".to_string(), peer(2));
+        let joiner =
+            TaskListSync::new(joiner_list, Arc::clone(&pubsub), topic.to_string(), peer(2))
+                .expect("joiner sync");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+        joiner.start().await.expect("start joiner");
+
+        // "One live incremental delta": the joiner ends up holding only t2,
+        // cloned out of the holder's own full delta so the resolved fields
+        // are byte-identical and the post-recovery digests can match
+        // exactly. Merged directly into the store — this is the state the
+        // live-gossip bait leaves behind.
+        let t2_only = {
+            let full = holder_list.full_delta();
+            let (id, (task, tag)) = full
+                .added_tasks
+                .iter()
+                .find(|(id, _)| *id.as_bytes() == [2; 32])
+                .expect("t2 in full delta");
+            let mut d = TaskListDelta::new(1);
+            d.added_tasks.insert(*id, (task.clone(), *tag));
+            d
+        };
+        joiner
+            .write()
+            .await
+            .merge_delta(&t2_only, peer(1))
+            .expect("seed t2");
+
+        // The loss window: the marker survives, the full delta does not.
+        let marker = TaskListSyncMessage::StateServedV2 {
+            responder: peer(1),
+            digest: holder_list.served_digest(),
+            entry_count: 2,
+        };
+        let bytes = bincode::serialize(&marker).expect("serialize marker");
+        pubsub
+            .publish(side.clone(), bytes::Bytes::from(bytes))
+            .await
+            .expect("publish marker");
+
+        // Well past the front burst the requester must STILL be asking —
+        // its local digest ({t2}) does not match the declaration ({t1,t2}).
+        let mut requests = 0;
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            requests += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert!(
+            requests > 0,
+            "a requester whose full delta was lost must keep asking (digest mismatch)"
+        );
+        assert_eq!(
+            joiner.read().await.task_count(),
+            1,
+            "the lost broadcast never arrived"
+        );
+
+        // The real holder returns: the next serve delivers {t1,t2}, the
+        // local digest then matches the declaration, and the tail stops.
+        let holder =
+            TaskListSync::new(holder_list, Arc::clone(&pubsub), topic.to_string(), peer(1))
+                .expect("holder sync");
+        holder.start().await.expect("start holder");
+
+        let historical = TaskId::from_bytes([1; 32]);
+        let mut recovered = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if joiner.read().await.get_task(&historical).is_some() {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(
+            recovered,
+            "the still-alive requester must recover the lost task"
+        );
+
+        // Convergence is terminal: no further requests.
+        tokio::time::sleep(Duration::from_secs(160)).await;
+        drain_state_requests(&mut probe, peer(2)).await;
+        let mut relapse = 0;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            relapse += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert_eq!(relapse, 0, "a digest-matched requester must fall silent");
+    }
+
+    /// WHY (issue #240, residual 2 — deletion cold-sync): a full delta
+    /// carries only live tasks, so a plain merge could never delete a stale
+    /// replica's obsolete tasks. The digest-verified full-replace adopt
+    /// closes that: the serve's delta content is bound to the holder's
+    /// declared digest, so pruning local tasks it omits is safe.
+    #[tokio::test(start_paused = true)]
+    async fn digest_verified_full_serve_prunes_stale_tasks() {
+        let node = make_node().await;
+        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        let topic = "tasks-240-prune-stale";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        // Holder: only t1.
+        let mut holder_list = TaskList::new(list_id(1), "Test List".to_string(), peer(1));
+        holder_list
+            .add_task(make_task(1, peer(1)), peer(1), 1)
+            .expect("holder t1");
+
+        // Stale joiner: starts EMPTY (only empty lists run the requester),
+        // then state lands the way it would in production — t1 (from the
+        // holder's full delta, byte-identical) and t_stale (an obsolete
+        // task the holder deleted while this replica was away) merge
+        // directly into the store before the holder ever comes online.
+        let joiner_list = TaskList::new(list_id(1), "Test List".to_string(), peer(2));
+        let joiner =
+            TaskListSync::new(joiner_list, Arc::clone(&pubsub), topic.to_string(), peer(2))
+                .expect("joiner sync");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+        joiner.start().await.expect("start joiner");
+        let t1_only = {
+            let full = holder_list.full_delta();
+            let (id, (task, tag)) = full
+                .added_tasks
+                .iter()
+                .find(|(id, _)| *id.as_bytes() == [1; 32])
+                .expect("t1 in full delta");
+            let mut d = TaskListDelta::new(1);
+            d.added_tasks.insert(*id, (task.clone(), *tag));
+            d
+        };
+        {
+            let mut l = joiner.write().await;
+            l.merge_delta(&t1_only, peer(1)).expect("seed t1");
+            l.add_task(make_task(9, peer(2)), peer(2), 1)
+                .expect("seed stale task");
+        }
+
+        let holder =
+            TaskListSync::new(holder_list, Arc::clone(&pubsub), topic.to_string(), peer(1))
+                .expect("holder sync");
+        holder.start().await.expect("start holder");
+
+        // The verified adopt must remove the stale task while t1 stays.
+        let stale = TaskId::from_bytes([9; 32]);
+        let mut pruned = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            let l = joiner.read().await;
+            if l.get_task(&stale).is_none() && l.task_count() == 1 {
+                pruned = true;
+                break;
+            }
+        }
+        assert!(
+            pruned,
+            "the digest-verified full serve must prune the stale task \
+             (deletion cold-sync)"
+        );
+
+        // And convergence follows: local state now equals the declared
+        // digest, so the requester falls silent.
+        tokio::time::sleep(Duration::from_secs(160)).await;
+        drain_state_requests(&mut probe, peer(2)).await;
+        let mut relapse = 0;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            relapse += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert_eq!(relapse, 0, "the requester must stop once the digests match");
+    }
+
+    /// WHY (issue #240, residual 3 — genuinely-empty chatter): the v1 rule
+    /// kept every empty list requesting forever (~1 side-topic message per
+    /// 5 minutes) because an empty holder had to stay silent (two empty
+    /// replicas must not talk each other into a FALSE converged-empty).
+    /// The v2 digest of the empty set is universally computable, so an
+    /// empty holder can now declare authoritative emptiness any empty
+    /// requester verifies locally — converging on empty is verifiably
+    /// CORRECT, and the chatter tail terminates.
+    #[tokio::test(start_paused = true)]
+    async fn empty_holder_v2_marker_terminates_empty_requester() {
+        let node = make_node().await;
+        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        let topic = "tasks-240-empty-silence";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        // Both lists genuinely EMPTY.
+        let joiner_list = TaskList::new(list_id(1), "Test List".to_string(), peer(2));
+        let joiner =
+            TaskListSync::new(joiner_list, Arc::clone(&pubsub), topic.to_string(), peer(2))
+                .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+        let holder_list = TaskList::new(list_id(1), "Test List".to_string(), peer(1));
+        let holder =
+            TaskListSync::new(holder_list, Arc::clone(&pubsub), topic.to_string(), peer(1))
+                .expect("holder sync");
+        holder.start().await.expect("start holder");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+
+        // Warm-up: the front burst fires and the empty holder's v2
+        // declarations arrive; convergence should follow within a few tail
+        // checks.
+        tokio::time::sleep(Duration::from_secs(160)).await;
+        drain_state_requests(&mut probe, peer(2)).await;
+        let mut late = 0;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            late += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert_eq!(
+            late, 0,
+            "an empty holder's verifiable digest must terminate the empty \
+             requester's tail (genuinely-empty lists converge silently)"
+        );
+    }
+
+    /// WHY: wire compatibility is additive — a fleet with only v1 (older)
+    /// responders must behave exactly as before: a v1 marker plus local
+    /// state converges the requester. The v2 machinery must not require
+    /// v2 markers to make progress against old peers.
+    #[tokio::test(start_paused = true)]
+    async fn v1_marker_from_old_peer_still_converges() {
+        let node = make_node().await;
+        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        let topic = "tasks-240-v1-compat";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        let joiner_list = TaskList::new(list_id(1), "Test List".to_string(), peer(2));
+        let joiner =
+            TaskListSync::new(joiner_list, Arc::clone(&pubsub), topic.to_string(), peer(2))
+                .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+
+        // An "old peer" answers a request: full delta on the main topic,
+        // v1 StateServed marker on the side topic — never a v2 marker.
+        tokio::time::sleep(Duration::from_secs(20)).await;
+        let mut holder_list = TaskList::new(list_id(1), "Test List".to_string(), peer(1));
+        holder_list
+            .add_task(make_task(1, peer(1)), peer(1), 1)
+            .expect("holder t1");
+        let full = holder_list.full_delta();
+        let encoded = encode_delta(peer(1), &full).expect("encode full");
+        pubsub
+            .publish(topic.to_string(), bytes::Bytes::from(encoded))
+            .await
+            .expect("publish full delta");
+        let marker = TaskListSyncMessage::StateServed {
+            responder: peer(1),
+        };
+        let marker_bytes = bincode::serialize(&marker).expect("serialize v1 marker");
+        pubsub
+            .publish(side.clone(), bytes::Bytes::from(marker_bytes))
+            .await
+            .expect("publish v1 marker");
+
+        let historical = TaskId::from_bytes([1; 32]);
+        let mut recovered = false;
+        for _ in 0..60 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if joiner.read().await.get_task(&historical).is_some() {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(recovered, "the old peer's full delta must merge");
+
+        // Weak-evidence convergence: v1 marker + local state ⇒ the tail stops.
+        tokio::time::sleep(Duration::from_secs(160)).await;
+        drain_state_requests(&mut probe, peer(2)).await;
+        let mut late = 0;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            late += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert_eq!(
+            late, 0,
+            "v1 evidence from an old peer must still converge the requester"
+        );
+    }
+
+    /// WHY: a v2 marker whose digest does not correspond to any state the
+    /// requester can hold (forged or corrupt) must NEVER converge it — the
+    /// digest is self-verifying, so a bad declaration can only delay, never
+    /// cause, convergence. Nor may it wedge later recovery: a genuine
+    /// holder's fresh declaration replaces the bad one (per-responder
+    /// latest-wins).
+    #[tokio::test(start_paused = true)]
+    async fn tampered_digest_is_rejected_and_does_not_wedge_recovery() {
+        let node = make_node().await;
+        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        let topic = "tasks-240-tampered";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        let joiner_list = TaskList::new(list_id(1), "Test List".to_string(), peer(2));
+        let joiner =
+            TaskListSync::new(joiner_list, Arc::clone(&pubsub), topic.to_string(), peer(2))
+                .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+
+        // The tampered marker: a random digest no real state can match.
+        let marker = TaskListSyncMessage::StateServedV2 {
+            responder: peer(1),
+            digest: [0xAB; 32],
+            entry_count: 2,
+        };
+        let bytes = bincode::serialize(&marker).expect("serialize marker");
+        pubsub
+            .publish(side.clone(), bytes::Bytes::from(bytes))
+            .await
+            .expect("publish tampered marker");
+
+        // The requester keeps asking: its (empty) local digest can never
+        // equal the forged declaration.
+        let mut requests = 0;
+        for _ in 0..8 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            requests += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert!(
+            requests > 0,
+            "a tampered digest must not converge the requester"
+        );
+        assert_eq!(
+            joiner.read().await.task_count(),
+            0,
+            "no state can have been adopted from a forged declaration"
+        );
+
+        // The genuine holder appears; its fresh declaration replaces the
+        // tampered one (per-responder latest-wins) and recovery completes.
+        let mut holder_list = TaskList::new(list_id(1), "Test List".to_string(), peer(1));
+        holder_list
+            .add_task(make_task(1, peer(1)), peer(1), 1)
+            .expect("holder t1");
+        let holder =
+            TaskListSync::new(holder_list, Arc::clone(&pubsub), topic.to_string(), peer(1))
+                .expect("holder sync");
+        holder.start().await.expect("start holder");
+
+        let historical = TaskId::from_bytes([1; 32]);
+        let mut recovered = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if joiner.read().await.get_task(&historical).is_some() {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(
+            recovered,
+            "a tampered marker must not wedge recovery from a genuine holder"
         );
     }
 }

--- a/src/crdt/task_item.rs
+++ b/src/crdt/task_item.rs
@@ -598,6 +598,74 @@ impl TaskItem {
             })
     }
 
+    /// Feed this task's RESOLVED observable fields into `h` in a canonical
+    /// length-delimited encoding (issue #240 served-state digest).
+    ///
+    /// Covers exactly the fields [`TaskList::state_fingerprint`] resolves —
+    /// title, description, priority, current checkbox state, claim and
+    /// completion winners, assignee — so two replicas with identical
+    /// RESOLVED state hash identically even when their raw OR-Set element
+    /// sets differ (e.g. after one of them compacted a delivery). Every
+    /// variable-length field is length-prefixed (64-bit LE) so the encoding
+    /// is unambiguous; options carry a 1-byte presence tag; enum variants a
+    /// 1-byte discriminant. Deterministic across platforms and builds: no
+    /// `Hash` impls, no HashMap iteration.
+    pub(crate) fn hash_resolved_fields(&self, h: &mut blake3::Hasher) {
+        fn lp(h: &mut blake3::Hasher, data: &[u8]) {
+            h.update(&(data.len() as u64).to_le_bytes());
+            h.update(data);
+        }
+        fn record(h: &mut blake3::Hasher, rec: Option<(&crate::identity::AgentId, u64)>) {
+            match rec {
+                Some((agent, ts)) => {
+                    h.update(&[1u8]);
+                    h.update(agent.as_bytes());
+                    h.update(&ts.to_le_bytes());
+                }
+                None => {
+                    h.update(&[0u8]);
+                }
+            }
+        }
+        lp(h, self.title().as_bytes());
+        lp(h, self.description().as_bytes());
+        h.update(&[self.priority()]);
+        match self.current_state() {
+            CheckboxState::Empty => {
+                h.update(&[0u8]);
+            }
+            CheckboxState::Claimed {
+                agent_id,
+                timestamp,
+            } => {
+                h.update(&[1u8]);
+                h.update(agent_id.as_bytes());
+                h.update(&timestamp.to_le_bytes());
+            }
+            CheckboxState::Done {
+                agent_id,
+                timestamp,
+            } => {
+                h.update(&[2u8]);
+                h.update(agent_id.as_bytes());
+                h.update(&timestamp.to_le_bytes());
+            }
+        };
+        let claim = self.claim_record();
+        record(h, claim.as_ref().map(|(a, t)| (a, *t)));
+        let done = self.completion_record();
+        record(h, done.as_ref().map(|(a, t)| (a, *t)));
+        match self.assignee() {
+            Some(agent) => {
+                h.update(&[1u8]);
+                h.update(agent.as_bytes());
+            }
+            None => {
+                h.update(&[0u8]);
+            }
+        }
+    }
+
     /// Merge another TaskItem into this one.
     ///
     /// Combines the OR-Sets and LWW-Registers according to their

--- a/src/crdt/task_list.rs
+++ b/src/crdt/task_list.rs
@@ -14,7 +14,7 @@
 //!
 //! This provides eventual consistency with deterministic conflict resolution.
 
-use crate::crdt::{CrdtError, Result, TaskId, TaskItem};
+use crate::crdt::{CrdtError, Result, TaskId, TaskItem, TaskListDelta};
 use crate::identity::AgentId;
 use saorsa_gossip_crdt_sync::{LwwRegister, OrSet};
 use saorsa_gossip_types::PeerId;
@@ -88,6 +88,9 @@ impl std::fmt::Display for TaskListId {
 fn default_seq_counter() -> Arc<AtomicU64> {
     Arc::new(AtomicU64::new(0))
 }
+
+/// Domain-separation tag for served-state digest hashing (issue #240).
+pub(crate) const SERVED_DIGEST_DOMAIN: &[u8] = b"x0x.tasklist.served.digest.v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskList {
@@ -247,6 +250,65 @@ impl TaskList {
         if self.state_fingerprint() != before_fingerprint {
             self.version += 1;
         }
+    }
+
+    /// The content digest this list declares in a `StateServedV2` marker
+    /// when it serves its full state (issue #240).
+    ///
+    /// Canonical BLAKE3 over the list id and every live task's RESOLVED
+    /// observable fields (sorted by task id — see
+    /// [`TaskItem::hash_resolved_fields`]). Deliberately EXCLUDES the name
+    /// and ordering registers: a fresh joiner constructs its replica with a
+    /// placeholder name, so a name-binding digest could never match, and
+    /// both registers ride every full delta (LWW) so they converge with the
+    /// task set anyway. The list id binds the digest to one logical list, so
+    /// a marker replayed onto another list's side topic can never verify.
+    /// The empty set's digest is universally computable — that is what lets
+    /// an EMPTY holder authoritatively terminate an empty requester's
+    /// bootstrap tail: two empty replicas verifiably agree on the empty
+    /// state, so converging on empty is now CORRECT, not false convergence.
+    #[must_use]
+    pub(crate) fn served_digest(&self) -> [u8; 32] {
+        let mut h = blake3::Hasher::new();
+        h.update(SERVED_DIGEST_DOMAIN);
+        h.update(self.id.as_bytes());
+        let mut ids: Vec<&TaskId> = self.task_data.keys().collect();
+        ids.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        for id in ids {
+            h.update(id.as_bytes());
+            self.task_data[id].hash_resolved_fields(&mut h);
+        }
+        *h.finalize().as_bytes()
+    }
+
+    /// Remove local tasks absent from a digest-verified full-state serve
+    /// (`delta.added_tasks` is then the verified complete task set).
+    ///
+    /// This is the deletion cold-sync path (issue #240): a plain full-delta
+    /// merge only upserts, so tasks the holder deleted while this replica
+    /// was away would otherwise linger forever. Each stale task is removed
+    /// via [`delta_remove_task`](Self::delta_remove_task) — a LOCAL
+    /// observe-remove (its current tags are tombstoned, so a later re-add
+    /// with fresh tags still wins; the tombstones also reject cache replays
+    /// of the pre-delete adds) — the same semantics as merging a removal
+    /// delta.
+    ///
+    /// Callers MUST have verified the delta against the serving holder's
+    /// declared digest first — without that binding, any holder could
+    /// truncate local state at will.
+    pub(crate) fn prune_to_served_set(&mut self, delta: &TaskListDelta) -> usize {
+        let stale: Vec<TaskId> = self
+            .task_data
+            .keys()
+            .filter(|id| !delta.added_tasks.contains_key(*id))
+            .copied()
+            .collect();
+        let mut pruned = 0;
+        for id in stale {
+            self.delta_remove_task(&id);
+            pruned += 1;
+        }
+        pruned
     }
 
     /// Return the next monotonically-increasing sequence number.

--- a/src/kv/delta.rs
+++ b/src/kv/delta.rs
@@ -106,6 +106,26 @@ impl KvStoreDelta {
             && self.allowlist_removals.is_none()
             && self.owner_checkpoint.is_none()
     }
+
+    /// Digest over the full-state content this delta serves, when the delta
+    /// is full-state-shaped (issue #240).
+    ///
+    /// A `KvStore::full_delta` always carries `name_update`; incremental
+    /// puts/updates do not, so `None` cleanly excludes them. (Owner
+    /// remove-deltas DO carry `name_update` when a checkpoint rides along —
+    /// which is why callers MUST additionally require the added-entry count
+    /// to equal the holder's declared `entry_count` before treating a digest
+    /// match as a verified full serve: a remove-delta's empty `added` set
+    /// could otherwise impersonate a declared empty state.)
+    pub(crate) fn served_digest(&self, store_id: &crate::kv::KvStoreId) -> Option<[u8; 32]> {
+        self.name_update.as_ref()?;
+        let pairs: Vec<(&str, &KvEntry)> = self
+            .added
+            .iter()
+            .map(|(k, (e, _))| (k.as_str(), e))
+            .collect();
+        Some(crate::kv::store::served_content_digest(store_id, &pairs))
+    }
 }
 
 /// Implement `DeltaCrdt` trait for KvStore.

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -384,6 +384,17 @@ fn lp_bytes(buf: &mut Vec<u8>, data: &[u8]) {
 /// byte-for-byte on identical content. The empty set's digest is universally
 /// computable — that is what lets an EMPTY holder declare authoritative
 /// emptiness to an empty requester.
+///
+/// Unlike [`content_root`] it also EXCLUDES `created_at` (F1, fix-loop):
+/// [`KvEntry::merge`] preserves the EARLIEST `created_at`, so when an owner
+/// deletes and re-creates a key, a replica holding the original entry keeps
+/// `T1` while the owner commits `T2` — a digest committing `created_at`
+/// would NEVER match and the bootstrap would wedge at capped cadence
+/// forever. `created_at` is display provenance, not merge-converged content
+/// (`updated_at` IS merge-stable: max-wins, so both sides agree on it after
+/// the serve merges). The checkpoint `content_root` keeps `created_at`
+/// because checkpoint adoption is a full REPLACE verified byte-for-byte —
+/// no merge semantics, so the commitment there is exact.
 #[must_use]
 pub(crate) fn served_content_digest(
     store_id: &KvStoreId,
@@ -395,9 +406,31 @@ pub(crate) fn served_content_digest(
     let mut sorted = entries.to_vec();
     sorted.sort_by(|a, b| a.0.cmp(b.0));
     for (outer_key, entry) in &sorted {
-        h.update(&entry_commitment_bytes(outer_key, entry));
+        h.update(&served_entry_commitment_bytes(outer_key, entry));
     }
     *h.finalize().as_bytes()
+}
+
+/// Canonical length-delimited encoding of one entry's merge-converged
+/// fields for the served-state digest. Identical to
+/// [`entry_commitment_bytes`] MINUS `created_at` — see
+/// [`served_content_digest`] for why.
+fn served_entry_commitment_bytes(outer_key: &str, entry: &KvEntry) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(256);
+    lp_bytes(&mut buf, outer_key.as_bytes());
+    lp_bytes(&mut buf, entry.key.as_bytes());
+    lp_bytes(&mut buf, &entry.value);
+    lp_bytes(&mut buf, &entry.content_hash);
+    lp_bytes(&mut buf, entry.content_type.as_bytes());
+    let mut meta: Vec<_> = entry.metadata.iter().collect();
+    meta.sort_by(|a, b| a.0.cmp(b.0));
+    buf.extend_from_slice(&(meta.len() as u64).to_le_bytes());
+    for (mk, mv) in &meta {
+        lp_bytes(&mut buf, mk.as_bytes());
+        lp_bytes(&mut buf, mv.as_bytes());
+    }
+    buf.extend_from_slice(&entry.updated_at.to_le_bytes());
+    buf
 }
 
 /// Full-field entry equality for the AppendOnly freeze.
@@ -1666,7 +1699,18 @@ impl KvStore {
         // cloning the whole key set into an intermediate HashSet first.
         for key in self.keys.elements() {
             if let Some(entry) = self.entries.get(key) {
-                let tag = (PeerId::new([0u8; 32]), 0);
+                // Synthetic tags must be FRESH per entry (F3, fix-loop):
+                // the digest-verified adopt prunes stale keys with a local
+                // observe-remove, which tombstones the tags a previous full
+                // delta used. A hardcoded tag would then be silently
+                // rejected on a later serve that re-adds the key — a
+                // permanent re-add deadlock. Minting from the store's own
+                // counter guarantees a re-serve's tag is never one this
+                // store has issued before (snapshot persistence floors the
+                // counter across restarts, so that holds after a restart
+                // too). The zero peer id is fine: tags are scoped per key,
+                // and uniqueness over time is what the tombstones require.
+                let tag = (PeerId::new([0u8; 32]), self.next_seq());
                 delta.added.insert(key.clone(), (entry.clone(), tag));
             }
         }

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -226,6 +226,9 @@ const CHECKPOINT_SIG_DOMAIN: &[u8] = b"x0x.store.checkpoint.sig.v1";
 /// Domain-separation tag for content-root hashing.
 const CHECKPOINT_ROOT_DOMAIN: &[u8] = b"x0x.store.checkpoint.root.v2";
 
+/// Domain-separation tag for served-state digest hashing (issue #240).
+const SERVED_DIGEST_DOMAIN: &[u8] = b"x0x.store.served.digest.v1";
+
 /// Owner-signed content provenance for a store snapshot.
 ///
 /// Decouples "who relays" from "who authored": the signature is content-level
@@ -364,6 +367,37 @@ fn entry_commitment_bytes(outer_key: &str, entry: &KvEntry) -> Vec<u8> {
 fn lp_bytes(buf: &mut Vec<u8>, data: &[u8]) {
     buf.extend_from_slice(&(data.len() as u64).to_le_bytes());
     buf.extend_from_slice(data);
+}
+
+/// Deterministic canonical BLAKE3 digest over the active entry set alone.
+///
+/// This is the content commitment carried by `StateServedV2` markers (issue
+/// #240): a serving holder declares it, and a bootstrapping requester
+/// recomputes it over its OWN state, stopping only when they match. Unlike
+/// [`content_root`] it deliberately EXCLUDES the store name — a fresh joiner
+/// constructs its replica with a placeholder name, so a name-binding digest
+/// could never match (and the name is LWW metadata, not entry history; it
+/// rides every delta anyway). The store id binds the digest to one logical
+/// store, so a marker replayed onto another store's side topic can never
+/// verify. Entries are sorted by outer key and committed with the same
+/// canonical encoding as [`content_root`], so holder and requester agree
+/// byte-for-byte on identical content. The empty set's digest is universally
+/// computable — that is what lets an EMPTY holder declare authoritative
+/// emptiness to an empty requester.
+#[must_use]
+pub(crate) fn served_content_digest(
+    store_id: &KvStoreId,
+    entries: &[(&str, &KvEntry)],
+) -> [u8; 32] {
+    let mut h = blake3::Hasher::new();
+    h.update(SERVED_DIGEST_DOMAIN);
+    h.update(store_id.as_bytes());
+    let mut sorted = entries.to_vec();
+    sorted.sort_by(|a, b| a.0.cmp(b.0));
+    for (outer_key, entry) in &sorted {
+        h.update(&entry_commitment_bytes(outer_key, entry));
+    }
+    *h.finalize().as_bytes()
 }
 
 /// Full-field entry equality for the AppendOnly freeze.
@@ -1648,6 +1682,48 @@ impl KvStore {
         // (the checkpoint's owner signature survives re-wrap).
         delta.owner_checkpoint = self.latest_checkpoint.clone();
         delta
+    }
+
+    /// The content digest this store declares in a `StateServedV2` marker
+    /// when it serves its full state (issue #240). Computed over the active
+    /// entry set — see [`served_content_digest`].
+    pub(crate) fn served_digest(&self) -> [u8; 32] {
+        served_content_digest(&self.id, &self.checkpoint_pairs())
+    }
+
+    /// Remove local keys absent from a digest-verified full-state serve
+    /// (`delta.added` is then the verified complete entry set).
+    ///
+    /// This is the checkpoint-less deletion cold-sync path (issue #240): a
+    /// plain full-delta merge only upserts, so keys the holder deleted while
+    /// this replica was away would otherwise linger forever. Each stale key
+    /// is removed with a LOCAL observe-remove (its current tags are
+    /// tombstoned, so a later re-add with fresh tags still wins) and dropped
+    /// from `entries` — the same semantics the `delta.removed` merge path
+    /// applies. Never for AppendOnly stores: keys are immutable there
+    /// (mirrors the `removed` guard in `merge_delta`).
+    ///
+    /// Callers MUST have verified the delta against the serving holder's
+    /// declared digest (and its sender authorization) first — without that
+    /// binding, any holder could truncate local state at will.
+    pub(crate) fn prune_to_served_set(&mut self, delta: &KvStoreDelta) -> usize {
+        if matches!(self.policy, AccessPolicy::AppendOnly) {
+            return 0;
+        }
+        let stale: Vec<String> = self
+            .keys
+            .elements()
+            .into_iter()
+            .filter(|k| !delta.added.contains_key(k.as_str()))
+            .cloned()
+            .collect();
+        let mut pruned = 0;
+        for key in stale {
+            let _ = self.keys.remove(&key);
+            self.entries.remove(key.as_str());
+            pruned += 1;
+        }
+        pruned
     }
 }
 

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -131,11 +131,51 @@ enum KvSyncMessage {
         /// convergence gate for checkpoint-bearing stores.
         checkpoint_seq: Option<u64>,
     },
+    /// A holder's digest-committed declaration that it has answered a
+    /// `StateRequest` (issue #240): `digest` commits to the FULL served
+    /// entry set (see `served_content_digest`), so a requester can verify
+    /// "served us, completely" against its OWN state instead of trusting
+    /// that the full delta and the marker both arrived (the v1 cross-topic
+    /// loss window). A requester stops only when its local digest matches a
+    /// declared digest — a lost full delta leaves the local digest
+    /// different, so it keeps asking.
+    ///
+    /// Empty holders (owner or not) declare the digest of the empty set,
+    /// which any empty requester can compute locally — authoritative
+    /// emptiness without an owner, terminating the genuinely-empty chatter
+    /// tail (v1 behavior for old peers is unchanged: only the OWNER declares
+    /// emptiness there). Because the digest is self-verifying, an empty
+    /// declaration needs no full-delta broadcast to witness.
+    ///
+    /// Wire compatibility: additive variant, same precedent as
+    /// `OwnerAnnounce`/`StateServed` — older peers fail to deserialize it
+    /// and skip the message; new peers treat v1 markers as weaker evidence
+    /// when no v2 digest has been seen. The marker rides along with the
+    /// full-state broadcast (never separately) when there is state to serve.
+    StateServedV2 {
+        /// The declaring holder (receivers skip their own echo).
+        responder: PeerId,
+        /// Canonical BLAKE3 digest over the served entry set.
+        digest: [u8; 32],
+        /// Number of entries in the served set — a cheap shape check for the
+        /// verified full-replace adopt path (and useful in logs).
+        entry_count: u32,
+    },
 }
 
-/// Aggregated `StateServed` evidence observed by one replica's responder
-/// loop, consumed by its bootstrap requester to decide convergence.
-#[derive(Debug, Default, Clone, Copy)]
+/// One responder's latest v2 digest declaration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ServedState {
+    /// The declared content digest.
+    digest: [u8; 32],
+    /// The declared number of entries.
+    entry_count: u32,
+}
+
+/// Aggregated `StateServed`/`StateServedV2` evidence observed by one
+/// replica's responder loop, consumed by its bootstrap requester to decide
+/// convergence.
+#[derive(Debug, Default, Clone)]
 struct ServedEvidence {
     /// A holder declared non-empty state.
     saw_nonempty: bool,
@@ -143,6 +183,21 @@ struct ServedEvidence {
     saw_owner_empty: bool,
     /// Highest checkpoint sequence any holder declared.
     max_checkpoint_seq: u64,
+    /// Latest digest declaration per responder (bounded by mesh size — a
+    /// responder's newer declaration REPLACES its older one, so a replayed
+    /// stale serve can never roll a verified full-replace adopt backwards).
+    digests: std::collections::HashMap<PeerId, ServedState>,
+}
+
+/// Disarms the bootstrap-active flag on ANY requester exit path (converged,
+/// silenced, cancelled, torn down) so the listener's digest-verified
+/// full-replace adopt can never fire outside the bootstrap window.
+struct BootstrapGuard(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl Drop for BootstrapGuard {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
 /// Convergence rule for the bootstrap tail (pure for unit-testing).
@@ -150,15 +205,32 @@ struct ServedEvidence {
 /// Strongest available evidence wins:
 /// - a declared checkpoint sequence must be matched by this replica's own
 ///   high-water mark (exact, survives partial/lost responses);
-/// - otherwise a declared non-empty holder requires local non-emptiness
-///   (best-effort — documented limit for checkpoint-less state);
-/// - otherwise only an owner-declared-empty store counts as converged.
+/// - otherwise, when any v2 digest declarations exist, the local digest
+///   must match one of them — with the data-bearing-claim-wins rule: if any
+///   declaration is non-empty, only a non-empty match converges (an empty
+///   holder's declaration must not retire a requester while a full holder
+///   advertised content);
+/// - otherwise (only v1 markers seen — old peers) the legacy weak rules:
+///   declared non-empty requires local non-emptiness; emptiness counts only
+///   when the owner declared it.
 ///
 /// No evidence at all (`ServedEvidence::default()`) is NEVER convergence.
-fn bootstrap_converged(ev: ServedEvidence, is_empty: bool, highest_checkpoint_seq: u64) -> bool {
+fn bootstrap_converged(
+    ev: &ServedEvidence,
+    is_empty: bool,
+    highest_checkpoint_seq: u64,
+    local_digest: [u8; 32],
+) -> bool {
     if ev.max_checkpoint_seq > 0 {
-        highest_checkpoint_seq >= ev.max_checkpoint_seq
-    } else if ev.saw_nonempty {
+        return highest_checkpoint_seq >= ev.max_checkpoint_seq;
+    }
+    if !ev.digests.is_empty() {
+        let any_nonempty = ev.digests.values().any(|d| d.entry_count > 0);
+        return ev.digests.values().any(|d| {
+            d.digest == local_digest && (d.entry_count > 0 || !any_nonempty)
+        });
+    }
+    if ev.saw_nonempty {
         !is_empty
     } else {
         ev.saw_owner_empty
@@ -413,6 +485,19 @@ impl KvStoreSync {
 
         let loop_persist_ctx = persist_ctx.clone();
         let listener_cancel = self.cancel.clone();
+        // StateServed evidence: written by the responder loop (which owns
+        // the side-topic subscription), read by the listener (verified
+        // full-replace adopt, issue #240) and the bootstrap requester
+        // (convergence). Created BEFORE the loops so all three share it.
+        let served_evidence = Arc::new(std::sync::Mutex::new(ServedEvidence::default()));
+        // Armed only while the bootstrap requester runs: the verified
+        // full-replace adopt fires exclusively in that window — a converged
+        // replica must never let a divergent holder's serve truncate state
+        // it legitimately holds.
+        let bootstrap_active =
+            Arc::new(std::sync::atomic::AtomicBool::new(bootstrap_needed));
+        let listener_served = Arc::clone(&served_evidence);
+        let listener_bootstrap_active = Arc::clone(&bootstrap_active);
         spawn(Box::pin(async move {
             loop {
                 let msg = tokio::select! {
@@ -446,7 +531,55 @@ impl KvStoreSync {
                             // The gossip V2 wire format includes a verified AgentId.
                             let writer = msg.sender.as_ref();
                             match s.merge_delta(&delta, peer_id, writer) {
-                                Ok(()) => true,
+                                Ok(()) => {
+                                    // Digest-verified full-replace adopt
+                                    // (issue #240, checkpoint-less deletion
+                                    // cold-sync): while bootstrapping, when
+                                    // the sender's latest v2 declaration
+                                    // matches this delta's served content
+                                    // (digest AND entry count), the delta IS
+                                    // that holder's complete state — prune
+                                    // local keys it does not carry. Gated on
+                                    // the sender being an AUTHORIZED writer:
+                                    // merge_delta silently ignores
+                                    // unauthorized deltas, and the prune
+                                    // must not apply what the merge would
+                                    // not. Without verification any holder
+                                    // could truncate local state at will.
+                                    if listener_bootstrap_active
+                                        .load(std::sync::atomic::Ordering::Relaxed)
+                                    {
+                                        let declared = listener_served
+                                            .lock()
+                                            .unwrap_or_else(
+                                                std::sync::PoisonError::into_inner,
+                                            )
+                                            .digests
+                                            .get(&peer_id)
+                                            .copied();
+                                        if let Some(declared) = declared {
+                                            let authorized =
+                                                writer.is_some_and(|w| s.is_authorized(w));
+                                            if authorized
+                                                && delta.added.len()
+                                                    == declared.entry_count as usize
+                                                && delta
+                                                    .served_digest(s.id())
+                                                    .is_some_and(|dg| dg == declared.digest)
+                                            {
+                                                let pruned = s.prune_to_served_set(&delta);
+                                                if pruned > 0 {
+                                                    tracing::info!(
+                                                        "pruned {pruned} stale key(s) after \
+                                                         digest-verified full serve for store {}",
+                                                        s.id()
+                                                    );
+                                                }
+                                            }
+                                        }
+                                    }
+                                    true
+                                }
                                 Err(e) => {
                                     tracing::warn!("Failed to merge KvStore delta: {e}");
                                     false
@@ -492,10 +625,6 @@ impl KvStoreSync {
         let sync_topic = self.state_sync_topic();
         let local_peer_id = self.local_peer_id;
         let local_agent_id = self.local_agent_id;
-        // StateServed evidence: written by the responder loop (which owns
-        // the side-topic subscription), read by the bootstrap requester to
-        // decide convergence.
-        let served_evidence = Arc::new(std::sync::Mutex::new(ServedEvidence::default()));
         let responder_served = Arc::clone(&served_evidence);
         let responder_cancel = self.cancel.clone();
         spawn(Box::pin(async move {
@@ -579,7 +708,7 @@ impl KvStoreSync {
                                 < std::time::Duration::from_secs(STATE_RESPONSE_COOLDOWN_SECS)
                         });
                         // Snapshot state once for the full-delta and the
-                        // StateServed marker below. A full response is
+                        // StateServed markers below. A full response is
                         // served when the store is non-empty, OR when it is
                         // empty but holds an owner checkpoint: the
                         // checkpoint-adopt merge path is a full REPLACE
@@ -588,8 +717,11 @@ impl KvStoreSync {
                         // deleted-to-empty store cold-syncs to a stale
                         // replica (round-3 review — an empty owner must not
                         // be silent while stale holders keep advertising
-                        // obsolete state).
-                        let (full, is_empty, is_owner, checkpoint_seq, has_payload) = {
+                        // obsolete state). The v2 digest is computed over
+                        // the SAME snapshot as the full delta, so the
+                        // declaration always commits to exactly what was
+                        // broadcast.
+                        let (full, is_empty, is_owner, checkpoint_seq, has_payload, served) = {
                             let s = responder_store.read().await;
                             let is_owner =
                                 local_agent_id.is_some() && s.owner() == local_agent_id.as_ref();
@@ -597,9 +729,13 @@ impl KvStoreSync {
                                 (s.highest_checkpoint_seq > 0).then_some(s.highest_checkpoint_seq);
                             let has_payload = !s.is_empty() || s.latest_checkpoint.is_some();
                             let full = (has_payload && !cooled_down).then(|| s.full_delta());
-                            (full, s.is_empty(), is_owner, cp, has_payload)
+                            let served = (
+                                s.served_digest(),
+                                s.checkpoint_pairs().len() as u32,
+                            );
+                            (full, s.is_empty(), is_owner, cp, has_payload, served)
                         };
-                        let mut marker = None;
+                        let mut markers: Vec<KvSyncMessage> = Vec::new();
                         if let Some(full) = full {
                             if let Ok(serialized) = encode_delta(local_peer_id, &full) {
                                 if let Err(e) = responder_pubsub
@@ -612,26 +748,49 @@ impl KvStoreSync {
                                     tracing::warn!("KvStore state-response publish failed: {e}");
                                 } else {
                                     last_full_response = Some(tokio::time::Instant::now());
-                                    marker = Some(KvSyncMessage::StateServed {
+                                    markers.push(KvSyncMessage::StateServed {
                                         responder: local_peer_id,
                                         empty: is_empty,
                                         checkpoint_seq,
                                     });
+                                    // The v2 marker rides along with the
+                                    // broadcast it commits to — never
+                                    // separately (response-storm damping,
+                                    // issue #240).
+                                    markers.push(KvSyncMessage::StateServedV2 {
+                                        responder: local_peer_id,
+                                        digest: served.0,
+                                        entry_count: served.1,
+                                    });
                                 }
                             }
-                        } else if !has_payload && is_owner {
-                            // Checkpoint-less empty owner: nothing to serve,
-                            // and only the OWNER may declare emptiness — an
-                            // empty non-owner replica stays silent so
-                            // bootstrapping replicas can never talk each
-                            // other into a false "converged empty".
-                            marker = Some(KvSyncMessage::StateServed {
+                        } else if !has_payload {
+                            // Checkpoint-less empty. The v2 digest of the
+                            // empty set is universally computable, so ANY
+                            // empty holder may declare it — an empty
+                            // requester verifies locally and stops (issue
+                            // #240; no broadcast to witness because there
+                            // is nothing to serve).
+                            markers.push(KvSyncMessage::StateServedV2 {
                                 responder: local_peer_id,
-                                empty: true,
-                                checkpoint_seq: None,
+                                digest: served.0,
+                                entry_count: 0,
                             });
+                            if is_owner {
+                                // v1 behavior for older peers is unchanged:
+                                // only the OWNER declares emptiness — an
+                                // empty non-owner replica stays silent on
+                                // v1 so bootstrapping replicas can never
+                                // talk each other into a false "converged
+                                // empty".
+                                markers.push(KvSyncMessage::StateServed {
+                                    responder: local_peer_id,
+                                    empty: true,
+                                    checkpoint_seq: None,
+                                });
+                            }
                         }
-                        if let Some(marker) = marker {
+                        for marker in markers {
                             match bincode::serialize(&marker) {
                                 Ok(serialized) => {
                                     if let Err(e) = responder_pubsub
@@ -697,6 +856,35 @@ impl KvStoreSync {
                         if let Some(seq) = checkpoint_seq.filter(|_| owner_verified) {
                             ev.max_checkpoint_seq = ev.max_checkpoint_seq.max(seq);
                         }
+                    }
+                    KvSyncMessage::StateServedV2 {
+                        responder,
+                        digest,
+                        entry_count,
+                    } => {
+                        if responder == local_peer_id {
+                            continue; // our own marker echoed back
+                        }
+                        // Trust note: the digest is SELF-VERIFYING — a
+                        // forged declaration can only match local state
+                        // that actually equals the declared content, so a
+                        // forgery's worst case is the requester keeps
+                        // asking (the same bound as a forged v1 marker).
+                        // The verified full-replace adopt additionally
+                        // requires the full-delta SENDER to be an
+                        // authorized writer (see the listener), so a
+                        // marker alone can never truncate anything.
+                        responder_served
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .digests
+                            .insert(
+                                responder,
+                                ServedState {
+                                    digest,
+                                    entry_count,
+                                },
+                            );
                     }
                     KvSyncMessage::OwnerAnnounce {
                         owner,
@@ -783,7 +971,12 @@ impl KvStoreSync {
             let stopped = Arc::clone(&self.stopped);
             let requester_cancel = self.cancel.clone();
             let requester_served = Arc::clone(&served_evidence);
+            let requester_bootstrap_active = Arc::clone(&bootstrap_active);
             spawn(Box::pin(async move {
+                // Disarms the adopt window on ANY exit (converged, silenced,
+                // cancelled, torn down) — the listener's verified
+                // full-replace adopt must never fire outside bootstrap.
+                let _guard = BootstrapGuard(requester_bootstrap_active);
                 for (attempt, delay_secs) in state_request_delays().enumerate() {
                     tokio::select! {
                         // cancel_sync tears down every loop promptly, even
@@ -801,19 +994,23 @@ impl KvStoreSync {
                     // state (`bootstrap_converged`) — NOT mere non-emptiness,
                     // which a single incremental delta can fake while the
                     // full historical state is still missing (round-2
-                    // review).
+                    // review). v2 digest evidence makes the check exact for
+                    // checkpoint-less state (issue #240): the requester
+                    // stops only when its OWN content digest matches a
+                    // holder's declaration.
                     if attempt >= STATE_REQUEST_RETRY_SECS.len() {
                         let Some(store) = requester_store.upgrade() else {
                             return; // sync torn down — nothing left to bootstrap
                         };
-                        let ev = *requester_served
+                        let ev = requester_served
                             .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner);
-                        let (is_empty, cp_hwm) = {
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .clone();
+                        let (is_empty, cp_hwm, local_digest) = {
                             let s = store.read().await;
-                            (s.is_empty(), s.highest_checkpoint_seq)
+                            (s.is_empty(), s.highest_checkpoint_seq, s.served_digest())
                         };
-                        if bootstrap_converged(ev, is_empty, cp_hwm) {
+                        if bootstrap_converged(&ev, is_empty, cp_hwm, local_digest) {
                             return; // a holder served us and local state matches
                         }
                     }
@@ -1533,50 +1730,101 @@ mod tests {
     /// correctly — checkpoint match is exact; declared-non-empty requires
     /// local state; emptiness counts only when the owner declared it; and
     /// NO evidence is NEVER convergence (a replica that heard nothing keeps
-    /// asking, whatever its local state looks like).
+    /// asking, whatever its local state looks like). Issue #240 adds the
+    /// digest gate: when v2 declarations exist they OUTRANK the weak v1
+    /// rules, and a data-bearing declaration outranks an empty one.
     #[test]
     fn bootstrap_convergence_rule() {
+        const D1: [u8; 32] = [1u8; 32];
+        const D2: [u8; 32] = [2u8; 32];
+        const D_EMPTY: [u8; 32] = [9u8; 32];
         let none = ServedEvidence::default();
         // No evidence: never converged, empty or not.
-        assert!(!bootstrap_converged(none, true, 0));
-        assert!(!bootstrap_converged(none, false, 9));
+        assert!(!bootstrap_converged(&none, true, 0, D1));
+        assert!(!bootstrap_converged(&none, false, 9, D1));
 
         // Checkpoint evidence is exact: local HWM must reach it.
         let cp = ServedEvidence {
             saw_nonempty: true,
             saw_owner_empty: false,
             max_checkpoint_seq: 5,
+            digests: std::collections::HashMap::new(),
         };
-        assert!(!bootstrap_converged(cp, false, 4), "behind the served HWM");
-        assert!(bootstrap_converged(cp, false, 5));
-        assert!(bootstrap_converged(cp, false, 7));
+        assert!(!bootstrap_converged(&cp, false, 4, D1), "behind the served HWM");
+        assert!(bootstrap_converged(&cp, false, 5, D1));
+        assert!(bootstrap_converged(&cp, false, 7, D1));
 
         // Non-empty holder, no checkpoint: local non-emptiness required.
         let nonempty = ServedEvidence {
             saw_nonempty: true,
             saw_owner_empty: false,
             max_checkpoint_seq: 0,
+            digests: std::collections::HashMap::new(),
         };
-        assert!(!bootstrap_converged(nonempty, true, 0));
-        assert!(bootstrap_converged(nonempty, false, 0));
+        assert!(!bootstrap_converged(&nonempty, true, 0, D1));
+        assert!(bootstrap_converged(&nonempty, false, 0, D1));
 
         // Owner-declared empty (and nothing stronger): converged even empty.
         let owner_empty = ServedEvidence {
             saw_nonempty: false,
             saw_owner_empty: true,
             max_checkpoint_seq: 0,
+            digests: std::collections::HashMap::new(),
         };
-        assert!(bootstrap_converged(owner_empty, true, 0));
+        assert!(bootstrap_converged(&owner_empty, true, 0, D1));
         // A non-empty holder claim outranks owner-empty when both were seen.
         let mixed = ServedEvidence {
             saw_nonempty: true,
             saw_owner_empty: true,
             max_checkpoint_seq: 0,
+            digests: std::collections::HashMap::new(),
         };
         assert!(
-            !bootstrap_converged(mixed, true, 0),
+            !bootstrap_converged(&mixed, true, 0, D1),
             "divergent holders: the data-bearing claim must win, keep asking"
         );
+
+        // ---- v2 digest evidence (issue #240) ----
+        let digest_ev = |decls: &[(&[u8; 32], u32)]| ServedEvidence {
+            saw_nonempty: false,
+            saw_owner_empty: false,
+            max_checkpoint_seq: 0,
+            digests: decls
+                .iter()
+                .enumerate()
+                .map(|(i, (d, c))| {
+                    (
+                        peer(i as u8 + 10),
+                        ServedState {
+                            digest: **d,
+                            entry_count: *c,
+                        },
+                    )
+                })
+                .collect(),
+        };
+        // Match stops: local digest equals a declared non-empty digest.
+        let ev = digest_ev(&[(&D1, 3)]);
+        assert!(bootstrap_converged(&ev, false, 0, D1));
+        // Mismatch keeps asking — the lost-full-delta window is closed.
+        assert!(!bootstrap_converged(&ev, false, 0, D2));
+        // Weak v1 evidence must NOT rescue a digest mismatch.
+        let mut ev_v1_too = digest_ev(&[(&D1, 3)]);
+        ev_v1_too.saw_nonempty = true;
+        assert!(
+            !bootstrap_converged(&ev_v1_too, false, 0, D2),
+            "v2 declarations outrank weak v1 evidence"
+        );
+        // Empty-holder declarations converge an empty requester (and ONLY
+        // when every declaration is empty).
+        let ev_empty = digest_ev(&[(&D_EMPTY, 0)]);
+        assert!(bootstrap_converged(&ev_empty, true, 0, D_EMPTY));
+        let ev_divergent = digest_ev(&[(&D_EMPTY, 0), (&D1, 2)]);
+        assert!(
+            !bootstrap_converged(&ev_divergent, true, 0, D_EMPTY),
+            "a data-bearing declaration outranks the empty one — keep asking"
+        );
+        assert!(bootstrap_converged(&ev_divergent, false, 0, D1));
     }
 
     /// WHY (round-2 review — P1: restored non-empty replicas still became
@@ -2000,6 +2248,577 @@ mod tests {
             policy_ok,
             "the owner announce must refresh the replica policy \
              (transient `signed` misreport, issue #238)"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #240: digest-verified convergence evidence
+    // ------------------------------------------------------------------
+
+    /// Drain every side-topic `StateRequest` from `from` already queued on
+    /// `probe` without blocking (the 1ms virtual timeout yields immediately
+    /// under the paused clock when the queue is empty).
+    async fn drain_state_requests(probe: &mut crate::gossip::Subscription, from: PeerId) -> usize {
+        let mut n = 0;
+        while let Ok(Some(msg)) = tokio::time::timeout(Duration::from_millis(1), probe.recv()).await
+        {
+            if let Ok(KvSyncMessage::StateRequest { requester }) =
+                bincode::deserialize::<KvSyncMessage>(&msg.payload)
+            {
+                if requester == from {
+                    n += 1;
+                }
+            }
+        }
+        n
+    }
+
+    /// WHY: the v2 digest commits to the served entry set so a requester
+    /// can verify completeness LOCALLY. It must be deterministic across
+    /// replicas, sensitive to content, insensitive to the (placeholder)
+    /// name, and bound to the store id; a full delta's carried digest must
+    /// equal the serving store's local digest.
+    #[test]
+    fn served_digest_is_deterministic_content_bound_and_name_independent() {
+        let owner = agent(1);
+        let mut a = KvStore::new(
+            store_id(1),
+            "alpha".to_string(),
+            owner,
+            AccessPolicy::Signed,
+        );
+        let mut b = KvStore::new(
+            store_id(1),
+            "beta".to_string(),
+            owner,
+            AccessPolicy::Signed,
+        );
+        // Empty stores: same id ⇒ same digest; the name is not content.
+        assert_eq!(a.served_digest(), b.served_digest());
+        let c = KvStore::new(
+            store_id(2),
+            "alpha".to_string(),
+            owner,
+            AccessPolicy::Signed,
+        );
+        assert_ne!(
+            a.served_digest(),
+            c.served_digest(),
+            "the store id binds the digest (cross-store replay defense)"
+        );
+
+        // The same entry bytes in both stores ⇒ the same digest, however
+        // they got there (writer tags are transport, not content).
+        let entry = KvEntry::new("k".to_string(), b"v".to_vec(), "text/plain".to_string());
+        let mut d1 = KvStoreDelta::new(1);
+        d1.added.insert("k".to_string(), (entry, (peer(1), 1)));
+        a.merge_delta(&d1, peer(1), Some(&owner)).expect("merge a");
+        b.merge_delta(&d1, peer(1), Some(&owner)).expect("merge b");
+        assert_eq!(a.served_digest(), b.served_digest());
+
+        // A delta's served digest exists only for full-state shapes
+        // (name_update present), and then equals the local digest.
+        assert_eq!(
+            d1.served_digest(&store_id(1)),
+            None,
+            "incremental shape must not impersonate a full serve"
+        );
+        d1.name_update = Some(a.name_register().clone());
+        assert_eq!(d1.served_digest(&store_id(1)), Some(a.served_digest()));
+
+        // Different membership ⇒ different digest.
+        let entry2 = KvEntry::new("k2".to_string(), b"w".to_vec(), "text/plain".to_string());
+        let mut d2 = KvStoreDelta::new(2);
+        d2.added.insert("k2".to_string(), (entry2, (peer(1), 2)));
+        b.merge_delta(&d2, peer(1), Some(&owner)).expect("merge b2");
+        assert_ne!(a.served_digest(), b.served_digest());
+    }
+
+    /// WHY (issue #240, residual 1 — the cross-topic loss window): the full
+    /// delta travels on the main topic, its marker on the side topic, with
+    /// no delivery coupling. If the delta is lost while the marker
+    /// survives, the v1 rule stopped a non-empty requester with incomplete
+    /// history. With the v2 digest the requester detects the mismatch
+    /// (local {k2} vs declared {k1,k2}) and keeps asking until the real
+    /// state arrives.
+    #[tokio::test(start_paused = true)]
+    async fn lost_full_delta_with_surviving_marker_keeps_requester_asking() {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-240-lost-broadcast";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        // The full holder state (owner offline for now): {k1, k2}.
+        let mut owned = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner_id,
+            AccessPolicy::Signed,
+        );
+        owned
+            .put("k1".to_string(), b"v1".to_vec(), "text/plain".to_string(), peer(1))
+            .expect("k1");
+        owned
+            .put("k2".to_string(), b"v2".to_vec(), "text/plain".to_string(), peer(1))
+            .expect("k2");
+
+        // The joiner holds only k2 — "one live incremental delta" — with
+        // entry bytes IDENTICAL to the holder's (merged out of the holder's
+        // own full delta), so the post-recovery digests can match exactly.
+        let mut replica = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner_id),
+            crate::kv::store::AnchorChannel::RestParam,
+        );
+        let k2_only = {
+            let full = owned.full_delta();
+            let (key, (entry, tag)) = full
+                .added
+                .iter()
+                .find(|(k, _)| k.as_str() == "k2")
+                .expect("k2 in full delta");
+            let mut d = KvStoreDelta::new(1);
+            d.added.insert(key.clone(), (entry.clone(), *tag));
+            d
+        };
+        replica
+            .merge_delta(&k2_only, peer(1), Some(&owner_id))
+            .expect("seed k2");
+        let joiner = KvStoreSync::new(
+            replica,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+
+        // The loss window: the marker survives, the full delta does not.
+        // Publish ONLY the v2 marker the holder would have sent.
+        let marker = KvSyncMessage::StateServedV2 {
+            responder: peer(1),
+            digest: owned.served_digest(),
+            entry_count: 2,
+        };
+        let bytes = bincode::serialize(&marker).expect("serialize marker");
+        pubsub
+            .publish(side.clone(), bytes::Bytes::from(bytes))
+            .await
+            .expect("publish marker");
+
+        // Well past the front burst the requester must STILL be asking —
+        // its local digest ({k2}) does not match the declaration ({k1,k2}).
+        let mut requests = 0;
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            requests += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert!(
+            requests > 0,
+            "a requester whose full delta was lost must keep asking (digest mismatch)"
+        );
+        assert!(
+            joiner.read().await.get("k1").is_none(),
+            "the lost broadcast never arrived"
+        );
+
+        // The real holder returns: the next serve delivers {k1,k2}, the
+        // local digest then matches the declaration, and the tail stops.
+        let owner_sync = KvStoreSync::new(
+            owned,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(owner_id),
+        )
+        .expect("owner sync");
+        owner_sync.start().await.expect("start owner");
+
+        let mut recovered = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if joiner.read().await.get("k1").is_some() {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(
+            recovered,
+            "the still-alive requester must recover the lost key"
+        );
+
+        // Convergence is terminal: no further requests.
+        tokio::time::sleep(Duration::from_secs(160)).await;
+        drain_state_requests(&mut probe, peer(2)).await;
+        let mut relapse = 0;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            relapse += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert_eq!(relapse, 0, "a digest-matched requester must fall silent");
+    }
+
+    /// WHY (issue #240, residual 2 — deletion cold-sync): a checkpoint-less
+    /// full delta carries only live entries, so a plain merge could never
+    /// delete a stale replica's obsolete keys. The digest-verified
+    /// full-replace adopt closes that: the serve's delta content is bound
+    /// to the holder's declared digest, so pruning local keys it omits is
+    /// safe. A plain v1-era merge leaves the stale key in place (the
+    /// pre-#240 behavior the issue describes).
+    #[tokio::test(start_paused = true)]
+    async fn digest_verified_full_serve_prunes_stale_keys() {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-240-prune-stale";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        // Owner: checkpoint-less, holding only k_live.
+        let mut owned = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner_id,
+            AccessPolicy::Signed,
+        );
+        owned
+            .put(
+                "k_live".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner put");
+
+        // Stale replica: k_live (byte-identical, from the owner's own full
+        // delta) PLUS k_stale, an obsolete key the owner deleted while the
+        // replica was away. Started FIRST so its subscriptions are fully
+        // registered before any response can be published (in-process
+        // paused-time harness).
+        let mut replica = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner_id),
+            crate::kv::store::AnchorChannel::Persistence,
+        );
+        let live_only = {
+            let full = owned.full_delta();
+            let (key, (entry, tag)) = full
+                .added
+                .iter()
+                .find(|(k, _)| k.as_str() == "k_live")
+                .expect("k_live in full delta");
+            let mut d = KvStoreDelta::new(1);
+            d.added.insert(key.clone(), (entry.clone(), *tag));
+            d
+        };
+        replica
+            .merge_delta(&live_only, peer(1), Some(&owner_id))
+            .expect("seed k_live");
+        replica
+            .put(
+                "k_stale".to_string(),
+                b"obsolete".to_vec(),
+                "text/plain".to_string(),
+                peer(2),
+            )
+            .expect("seed stale key");
+        let joiner = KvStoreSync::new(
+            replica,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+
+        let owner_sync = KvStoreSync::new(
+            owned,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(owner_id),
+        )
+        .expect("owner sync");
+        owner_sync.start().await.expect("start owner");
+
+        // The verified adopt must remove the stale key while k_live stays.
+        let mut pruned = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            let s = joiner.read().await;
+            if s.get("k_stale").is_none() && s.get("k_live").is_some() {
+                pruned = true;
+                break;
+            }
+        }
+        assert!(
+            pruned,
+            "the digest-verified full serve must prune the stale key \
+             (checkpoint-less deletion cold-sync)"
+        );
+
+        // And convergence follows: local state now equals the declared
+        // digest, so the requester falls silent.
+        tokio::time::sleep(Duration::from_secs(160)).await;
+        drain_state_requests(&mut probe, peer(2)).await;
+        let mut relapse = 0;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            relapse += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert_eq!(relapse, 0, "the requester must stop once the digests match");
+    }
+
+    /// WHY (issue #240, residual 3 — genuinely-empty chatter): the v1 rule
+    /// kept every empty checkpoint-less replica requesting forever (~1
+    /// side-topic message per 5 minutes) because an empty non-owner holder
+    /// had to stay silent. The v2 digest of the empty set is universally
+    /// computable, so an empty holder can now declare authoritative
+    /// emptiness ANY empty requester verifies locally — two empty replicas
+    /// converging on empty is verifiably CORRECT, not false convergence.
+    #[tokio::test(start_paused = true)]
+    async fn empty_holder_v2_marker_terminates_empty_requester() {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-240-empty-silence";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        // Both EMPTY non-owner replicas anchored on the (offline) owner.
+        let joiner = KvStoreSync::new(
+            KvStore::new_replica(
+                store_id(1),
+                String::new(),
+                Some(owner_id),
+                crate::kv::store::AnchorChannel::RestParam,
+            ),
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+        let holder = KvStoreSync::new(
+            KvStore::new_replica(
+                store_id(1),
+                String::new(),
+                Some(owner_id),
+                crate::kv::store::AnchorChannel::RestParam,
+            ),
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(agent(3)),
+        )
+        .expect("holder sync");
+        holder.start().await.expect("start holder");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+
+        // Warm-up: the front burst fires and the empty holder's v2
+        // declarations arrive; convergence should follow within a few tail
+        // checks.
+        tokio::time::sleep(Duration::from_secs(160)).await;
+        drain_state_requests(&mut probe, peer(2)).await;
+        let mut late = 0;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            late += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert_eq!(
+            late, 0,
+            "an empty holder's verifiable digest must terminate the empty \
+             requester's tail (genuinely-empty stores converge silently)"
+        );
+    }
+
+    /// WHY: wire compatibility is additive — a fleet with only v1 (older)
+    /// responders must behave exactly as before: a v1 marker plus local
+    /// state converges the requester. The v2 machinery must not require
+    /// v2 markers to make progress against old peers.
+    #[tokio::test(start_paused = true)]
+    async fn v1_marker_from_old_peer_still_converges() {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-240-v1-compat";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        let joiner = KvStoreSync::new(
+            KvStore::new_replica(
+                store_id(1),
+                String::new(),
+                Some(owner_id),
+                crate::kv::store::AnchorChannel::RestParam,
+            ),
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+
+        // An "old peer" answers a request: full delta on the main topic,
+        // v1 StateServed marker on the side topic — never a v2 marker.
+        tokio::time::sleep(Duration::from_secs(20)).await;
+        let mut owned = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner_id,
+            AccessPolicy::Signed,
+        );
+        owned
+            .put("k1".to_string(), b"v1".to_vec(), "text/plain".to_string(), peer(1))
+            .expect("k1");
+        let full = owned.full_delta();
+        let encoded = encode_delta(peer(1), &full).expect("encode full");
+        pubsub
+            .publish(topic.to_string(), bytes::Bytes::from(encoded))
+            .await
+            .expect("publish full delta");
+        let marker = KvSyncMessage::StateServed {
+            responder: peer(1),
+            empty: false,
+            checkpoint_seq: None,
+        };
+        let marker_bytes = bincode::serialize(&marker).expect("serialize v1 marker");
+        pubsub
+            .publish(side.clone(), bytes::Bytes::from(marker_bytes))
+            .await
+            .expect("publish v1 marker");
+
+        let mut recovered = false;
+        for _ in 0..60 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if joiner.read().await.get("k1").is_some() {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(recovered, "the old peer's full delta must merge");
+
+        // Weak-evidence convergence: v1 marker + local state ⇒ the tail stops.
+        tokio::time::sleep(Duration::from_secs(160)).await;
+        drain_state_requests(&mut probe, peer(2)).await;
+        let mut late = 0;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            late += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert_eq!(
+            late, 0,
+            "v1 evidence from an old peer must still converge the requester"
+        );
+    }
+
+    /// WHY: a v2 marker whose digest does not correspond to any state the
+    /// requester can hold (forged or corrupt) must NEVER converge it — the
+    /// digest is self-verifying, so a bad declaration can only delay, never
+    /// cause, convergence. Nor may it wedge later recovery: a genuine
+    /// holder's fresh declaration replaces the bad one (per-responder
+    /// latest-wins).
+    #[tokio::test(start_paused = true)]
+    async fn tampered_digest_is_rejected_and_does_not_wedge_recovery() {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-240-tampered";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        let joiner = KvStoreSync::new(
+            KvStore::new_replica(
+                store_id(1),
+                String::new(),
+                Some(owner_id),
+                crate::kv::store::AnchorChannel::RestParam,
+            ),
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+
+        // The tampered marker: a random digest no real state can match.
+        let marker = KvSyncMessage::StateServedV2 {
+            responder: peer(1),
+            digest: [0xAB; 32],
+            entry_count: 2,
+        };
+        let bytes = bincode::serialize(&marker).expect("serialize marker");
+        pubsub
+            .publish(side.clone(), bytes::Bytes::from(bytes))
+            .await
+            .expect("publish tampered marker");
+
+        // The requester keeps asking: its (empty) local digest can never
+        // equal the forged declaration.
+        let mut requests = 0;
+        for _ in 0..8 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            requests += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert!(
+            requests > 0,
+            "a tampered digest must not converge the requester"
+        );
+        assert!(
+            joiner.read().await.is_empty(),
+            "no state can have been adopted from a forged declaration"
+        );
+
+        // The genuine holder appears; its fresh declaration replaces the
+        // tampered one (per-responder latest-wins) and recovery completes.
+        let mut owned = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner_id,
+            AccessPolicy::Signed,
+        );
+        owned
+            .put("k1".to_string(), b"v1".to_vec(), "text/plain".to_string(), peer(1))
+            .expect("k1");
+        let owner_sync = KvStoreSync::new(
+            owned,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(owner_id),
+        )
+        .expect("owner sync");
+        owner_sync.start().await.expect("start owner");
+
+        let mut recovered = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if joiner.read().await.get("k1").is_some() {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(
+            recovered,
+            "a tampered marker must not wedge recovery from a genuine holder"
         );
     }
 }

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -558,9 +558,49 @@ impl KvStoreSync {
                                             .get(&peer_id)
                                             .copied();
                                         if let Some(declared) = declared {
-                                            let authorized =
-                                                writer.is_some_and(|w| s.is_authorized(w));
-                                            if authorized
+                                            // Prune authority (F2,
+                                            // fix-loop): absence from a
+                                            // verified serve proves
+                                            // deletion ONLY when the
+                                            // sender is the SOLE possible
+                                            // content author. Under
+                                            // Signed that is the anchored
+                                            // owner — and every key this
+                                            // replica can hold was
+                                            // admitted under that same
+                                            // auth (or an owner-signed
+                                            // checkpoint), so the owner's
+                                            // serve is complete about all
+                                            // of them. Under Allowlisted
+                                            // the owner's serve can be
+                                            // legitimately incomplete
+                                            // about co-writers' keys (an
+                                            // owner that has not merged
+                                            // an allowlisted write would
+                                            // otherwise TRUNCATE it), so
+                                            // pruning is disabled there —
+                                            // deletions still propagate
+                                            // via live `removed` deltas,
+                                            // and the digest mismatch
+                                            // resolves when the owner
+                                            // absorbs the co-write and
+                                            // re-serves. (The review's
+                                            // alternative count guard —
+                                            // prune only when local-count
+                                            // <= declared-count — was
+                                            // rejected: the residual-2
+                                            // stale replica is exactly a
+                                            // local SUPERSET of the serve,
+                                            // so that rule disables
+                                            // pruning precisely where
+                                            // deletion cold-sync needs
+                                            // it.)
+                                            let sole_author = matches!(
+                                                s.policy(),
+                                                AccessPolicy::Signed
+                                            ) && writer.is_some()
+                                                && s.owner() == writer;
+                                            if sole_author
                                                 && delta.added.len()
                                                     == declared.entry_count as usize
                                                 && delta
@@ -2820,5 +2860,304 @@ mod tests {
             recovered,
             "a tampered marker must not wedge recovery from a genuine holder"
         );
+    }
+
+    /// WHY (F1, fix-loop — delete+recreate wedge): `KvEntry::merge`
+    /// preserves the EARLIEST `created_at`, so a replica holding the
+    /// original entry and an owner that deleted+re-created the key
+    /// permanently disagree on `created_at`. A served digest committing it
+    /// could never match and the requester would wedge at capped cadence
+    /// forever. The digest excludes `created_at` (merge-converged fields
+    /// only), so the re-created key converges.
+    #[tokio::test(start_paused = true)]
+    async fn recreated_key_converges_after_owner_delete_and_recreate() {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-240-recreate";
+        let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
+
+        // The ORIGINAL entry, as the replica synced it before going offline.
+        let mut owned = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner_id,
+            AccessPolicy::Signed,
+        );
+        owned
+            .put("k".to_string(), b"v1".to_vec(), "text/plain".to_string(), peer(1))
+            .expect("original put");
+        // Age the replica's copy deterministically: even in the same
+        // wall-clock millisecond, the replica's created/updated timestamps
+        // are strictly older than the re-created entry's.
+        let mut aged = owned.get("k").expect("original entry").clone();
+        aged.created_at -= 10_000;
+        aged.updated_at -= 10_000;
+
+        // The owner DELETES and RE-CREATES the key while the replica is
+        // away: the owner's entry now carries a fresh created_at.
+        owned.remove("k").expect("owner delete");
+        owned
+            .put("k".to_string(), b"v2".to_vec(), "text/plain".to_string(), peer(1))
+            .expect("owner recreate");
+
+        // The replica returns holding the ORIGINAL (aged) entry.
+        let mut replica = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner_id),
+            crate::kv::store::AnchorChannel::Persistence,
+        );
+        let mut seed = KvStoreDelta::new(1);
+        seed.added.insert("k".to_string(), (aged, (peer(1), 1)));
+        replica
+            .merge_delta(&seed, peer(1), Some(&owner_id))
+            .expect("seed original entry");
+        let joiner = KvStoreSync::new(
+            replica,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+        let mut probe = pubsub.subscribe(side.clone()).await;
+        let owner_sync = KvStoreSync::new(
+            owned,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(owner_id),
+        )
+        .expect("owner sync");
+        owner_sync.start().await.expect("start owner");
+
+        // The re-created value must arrive…
+        let mut recovered = false;
+        for _ in 0..200 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if joiner.read().await.get("k").map(|e| e.value.clone())
+                == Some(b"v2".to_vec())
+            {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(recovered, "the re-created entry must merge");
+
+        // …and the requester must CONVERGE, not wedge on the created_at
+        // mismatch (the pre-fix failure mode).
+        tokio::time::sleep(Duration::from_secs(160)).await;
+        drain_state_requests(&mut probe, peer(2)).await;
+        let mut relapse = 0;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            relapse += drain_state_requests(&mut probe, peer(2)).await;
+        }
+        assert_eq!(
+            relapse, 0,
+            "a delete+recreate must not wedge the requester on created_at"
+        );
+    }
+
+    /// WHY (F2, fix-loop — multi-writer truncation): absence from a
+    /// verified serve proves deletion ONLY when the sender is the sole
+    /// possible content author. In an Allowlisted store the owner's serve
+    /// can be legitimately incomplete about co-writers' keys, so the adopt
+    /// must NOT prune there — otherwise an owner-only serve truncates an
+    /// allowlisted writer's legitimate key during the bootstrap window.
+    #[tokio::test(start_paused = true)]
+    async fn allowlisted_writer_key_survives_owner_only_serve() {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner_id = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let topic = "kv-240-allowlisted";
+        let writer = agent(7);
+
+        // Owner: Allowlisted, holding only k_owner.
+        let mut owned = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner_id,
+            AccessPolicy::Allowlisted,
+        );
+        owned.allow_writer(writer, &owner_id).expect("allow writer");
+        owned
+            .put(
+                "k_owner".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("owner put");
+
+        // Replica: anchored on the owner and already POLICY-AWARE (a
+        // restored replica has the allowlist persisted; the merge below
+        // requires it — under the Signed default the writer's key would be
+        // rejected outright). It holds k_owner (aged copy from the owner's
+        // own delta — the serve must refresh its updated_at, proving the
+        // verified adopt path actually ran) and k_writer, written by the
+        // allowlisted writer, which the owner has NOT merged.
+        let mut replica = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner_id),
+            crate::kv::store::AnchorChannel::Persistence,
+        );
+        replica
+            .learn_ownership(
+                owner_id,
+                AccessPolicy::Allowlisted,
+                owned.policy_version(),
+                &owner_id,
+            )
+            .expect("learn policy");
+        // The replica must also know the allowlist itself (learned via
+        // owner-gated deltas in production) or the writer's key merge is
+        // rejected by access control.
+        replica.allow_writer(writer, &owner_id).expect("learn allowlist");
+        let k_owner_seed = {
+            let full = owned.full_delta();
+            let (key, (entry, tag)) = full
+                .added
+                .iter()
+                .find(|(k, _)| k.as_str() == "k_owner")
+                .expect("k_owner in full delta");
+            let mut aged = entry.clone();
+            aged.created_at -= 10_000;
+            aged.updated_at -= 10_000;
+            let mut d = KvStoreDelta::new(1);
+            d.added.insert(key.clone(), (aged, *tag));
+            d
+        };
+        replica
+            .merge_delta(&k_owner_seed, peer(1), Some(&owner_id))
+            .expect("seed k_owner");
+        let writer_entry = KvEntry::new(
+            "k_writer".to_string(),
+            b"w".to_vec(),
+            "text/plain".to_string(),
+        );
+        let mut writer_delta = KvStoreDelta::new(2);
+        writer_delta
+            .added
+            .insert("k_writer".to_string(), (writer_entry, (peer(7), 1)));
+        replica
+            .merge_delta(&writer_delta, peer(7), Some(&writer))
+            .expect("seed k_writer");
+        let owner_updated_at = owned
+            .get("k_owner")
+            .expect("owner entry")
+            .updated_at;
+
+        let joiner = KvStoreSync::new(
+            replica,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(2),
+            Some(agent(2)),
+        )
+        .expect("joiner sync");
+        joiner.start().await.expect("start joiner");
+        let owner_sync = KvStoreSync::new(
+            owned,
+            Arc::clone(&pubsub),
+            topic.to_string(),
+            peer(1),
+            Some(owner_id),
+        )
+        .expect("owner sync");
+        owner_sync.start().await.expect("start owner");
+
+        // Drive several serve windows (the requester keeps asking — its
+        // digest {k_owner,k_writer} never matches the owner's {k_owner}
+        // declaration until the owner absorbs the co-write).
+        let mut serve_landed = false;
+        for _ in 0..60 {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            let s = joiner.read().await;
+            assert!(
+                s.get("k_writer").is_some(),
+                "an owner-only serve must NOT prune an allowlisted writer's key"
+            );
+            if s.get("k_owner").map(|e| e.updated_at) == Some(owner_updated_at)
+            {
+                serve_landed = true;
+            }
+        }
+        assert!(
+            serve_landed,
+            "the owner's verified serve must have merged (aged entry refreshed)"
+        );
+    }
+
+    /// WHY (F3, fix-loop — tombstone + hardcoded-tag deadlock): the adopt's
+    /// prune is a local observe-remove, tombstoning the tags a previous
+    /// full delta used. With a hardcoded synthetic tag, a later serve
+    /// re-adding the same key would be silently rejected forever. Full
+    /// deltas now mint FRESH tags, so a re-served key is accepted.
+    #[test]
+    fn pruned_key_is_accepted_when_re_served_with_fresh_tags() {
+        let owner = agent(1);
+        let mut holder = KvStore::new(
+            store_id(1),
+            "log".to_string(),
+            owner,
+            AccessPolicy::Signed,
+        );
+        holder
+            .put("k_live".to_string(), b"v".to_vec(), "text/plain".to_string(), peer(1))
+            .expect("put live");
+        holder
+            .put("k_doomed".to_string(), b"x".to_vec(), "text/plain".to_string(), peer(1))
+            .expect("put doomed");
+
+        // The replica absorbs a first full serve (both keys).
+        let mut replica = KvStore::new_replica(
+            store_id(1),
+            String::new(),
+            Some(owner),
+            crate::kv::store::AnchorChannel::RestParam,
+        );
+        let s1 = holder.full_delta();
+        replica
+            .merge_delta(&s1, peer(1), Some(&owner))
+            .expect("serve 1");
+        assert!(replica.get("k_doomed").is_some());
+
+        // The holder deletes the key; the next VERIFIED serve prunes it
+        // (tombstoning the first serve's synthetic tag locally).
+        holder.remove("k_doomed").expect("delete");
+        let s2 = holder.full_delta();
+        assert_eq!(
+            s2.served_digest(&store_id(1)),
+            Some(holder.served_digest()),
+            "the serve must carry the holder's declared digest"
+        );
+        replica
+            .merge_delta(&s2, peer(1), Some(&owner))
+            .expect("serve 2");
+        assert_eq!(replica.prune_to_served_set(&s2), 1);
+        assert!(replica.get("k_doomed").is_none());
+
+        // The holder RE-ADDS the key: a later serve must be accepted —
+        // pre-fix, its synthetic tag was tombstoned by the prune and the
+        // re-add silently dropped.
+        holder
+            .put("k_doomed".to_string(), b"y".to_vec(), "text/plain".to_string(), peer(1))
+            .expect("re-add");
+        let s3 = holder.full_delta();
+        replica
+            .merge_delta(&s3, peer(1), Some(&owner))
+            .expect("serve 3");
+        let entry = replica
+            .get("k_doomed")
+            .expect("a re-served key must be accepted after a prune");
+        assert_eq!(entry.value, b"y");
     }
 }

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -226,9 +226,10 @@ fn bootstrap_converged(
     }
     if !ev.digests.is_empty() {
         let any_nonempty = ev.digests.values().any(|d| d.entry_count > 0);
-        return ev.digests.values().any(|d| {
-            d.digest == local_digest && (d.entry_count > 0 || !any_nonempty)
-        });
+        return ev
+            .digests
+            .values()
+            .any(|d| d.digest == local_digest && (d.entry_count > 0 || !any_nonempty));
     }
     if ev.saw_nonempty {
         !is_empty
@@ -494,8 +495,7 @@ impl KvStoreSync {
         // full-replace adopt fires exclusively in that window — a converged
         // replica must never let a divergent holder's serve truncate state
         // it legitimately holds.
-        let bootstrap_active =
-            Arc::new(std::sync::atomic::AtomicBool::new(bootstrap_needed));
+        let bootstrap_active = Arc::new(std::sync::atomic::AtomicBool::new(bootstrap_needed));
         let listener_served = Arc::clone(&served_evidence);
         let listener_bootstrap_active = Arc::clone(&bootstrap_active);
         spawn(Box::pin(async move {
@@ -551,9 +551,7 @@ impl KvStoreSync {
                                     {
                                         let declared = listener_served
                                             .lock()
-                                            .unwrap_or_else(
-                                                std::sync::PoisonError::into_inner,
-                                            )
+                                            .unwrap_or_else(std::sync::PoisonError::into_inner)
                                             .digests
                                             .get(&peer_id)
                                             .copied();
@@ -595,11 +593,10 @@ impl KvStoreSync {
                                             // pruning precisely where
                                             // deletion cold-sync needs
                                             // it.)
-                                            let sole_author = matches!(
-                                                s.policy(),
-                                                AccessPolicy::Signed
-                                            ) && writer.is_some()
-                                                && s.owner() == writer;
+                                            let sole_author =
+                                                matches!(s.policy(), AccessPolicy::Signed)
+                                                    && writer.is_some()
+                                                    && s.owner() == writer;
                                             if sole_author
                                                 && delta.added.len()
                                                     == declared.entry_count as usize
@@ -769,10 +766,7 @@ impl KvStoreSync {
                                 (s.highest_checkpoint_seq > 0).then_some(s.highest_checkpoint_seq);
                             let has_payload = !s.is_empty() || s.latest_checkpoint.is_some();
                             let full = (has_payload && !cooled_down).then(|| s.full_delta());
-                            let served = (
-                                s.served_digest(),
-                                s.checkpoint_pairs().len() as u32,
-                            );
+                            let served = (s.served_digest(), s.checkpoint_pairs().len() as u32);
                             (full, s.is_empty(), is_owner, cp, has_payload, served)
                         };
                         let mut markers: Vec<KvSyncMessage> = Vec::new();
@@ -1790,7 +1784,10 @@ mod tests {
             max_checkpoint_seq: 5,
             digests: std::collections::HashMap::new(),
         };
-        assert!(!bootstrap_converged(&cp, false, 4, D1), "behind the served HWM");
+        assert!(
+            !bootstrap_converged(&cp, false, 4, D1),
+            "behind the served HWM"
+        );
         assert!(bootstrap_converged(&cp, false, 5, D1));
         assert!(bootstrap_converged(&cp, false, 7, D1));
 
@@ -2327,12 +2324,7 @@ mod tests {
             owner,
             AccessPolicy::Signed,
         );
-        let mut b = KvStore::new(
-            store_id(1),
-            "beta".to_string(),
-            owner,
-            AccessPolicy::Signed,
-        );
+        let mut b = KvStore::new(store_id(1), "beta".to_string(), owner, AccessPolicy::Signed);
         // Empty stores: same id ⇒ same digest; the name is not content.
         assert_eq!(a.served_digest(), b.served_digest());
         let c = KvStore::new(
@@ -2399,10 +2391,20 @@ mod tests {
             AccessPolicy::Signed,
         );
         owned
-            .put("k1".to_string(), b"v1".to_vec(), "text/plain".to_string(), peer(1))
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
             .expect("k1");
         owned
-            .put("k2".to_string(), b"v2".to_vec(), "text/plain".to_string(), peer(1))
+            .put(
+                "k2".to_string(),
+                b"v2".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
             .expect("k2");
 
         // The joiner holds only k2 — "one live incremental delta" — with
@@ -2724,7 +2726,12 @@ mod tests {
             AccessPolicy::Signed,
         );
         owned
-            .put("k1".to_string(), b"v1".to_vec(), "text/plain".to_string(), peer(1))
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
             .expect("k1");
         let full = owned.full_delta();
         let encoded = encode_delta(peer(1), &full).expect("encode full");
@@ -2836,7 +2843,12 @@ mod tests {
             AccessPolicy::Signed,
         );
         owned
-            .put("k1".to_string(), b"v1".to_vec(), "text/plain".to_string(), peer(1))
+            .put(
+                "k1".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
             .expect("k1");
         let owner_sync = KvStoreSync::new(
             owned,
@@ -2887,7 +2899,12 @@ mod tests {
             AccessPolicy::Signed,
         );
         owned
-            .put("k".to_string(), b"v1".to_vec(), "text/plain".to_string(), peer(1))
+            .put(
+                "k".to_string(),
+                b"v1".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
             .expect("original put");
         // Age the replica's copy deterministically: even in the same
         // wall-clock millisecond, the replica's created/updated timestamps
@@ -2900,7 +2917,12 @@ mod tests {
         // away: the owner's entry now carries a fresh created_at.
         owned.remove("k").expect("owner delete");
         owned
-            .put("k".to_string(), b"v2".to_vec(), "text/plain".to_string(), peer(1))
+            .put(
+                "k".to_string(),
+                b"v2".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
             .expect("owner recreate");
 
         // The replica returns holding the ORIGINAL (aged) entry.
@@ -2939,9 +2961,7 @@ mod tests {
         let mut recovered = false;
         for _ in 0..200 {
             tokio::time::sleep(Duration::from_secs(5)).await;
-            if joiner.read().await.get("k").map(|e| e.value.clone())
-                == Some(b"v2".to_vec())
-            {
+            if joiner.read().await.get("k").map(|e| e.value.clone()) == Some(b"v2".to_vec()) {
                 recovered = true;
                 break;
             }
@@ -3020,7 +3040,9 @@ mod tests {
         // The replica must also know the allowlist itself (learned via
         // owner-gated deltas in production) or the writer's key merge is
         // rejected by access control.
-        replica.allow_writer(writer, &owner_id).expect("learn allowlist");
+        replica
+            .allow_writer(writer, &owner_id)
+            .expect("learn allowlist");
         let k_owner_seed = {
             let full = owned.full_delta();
             let (key, (entry, tag)) = full
@@ -3050,10 +3072,7 @@ mod tests {
         replica
             .merge_delta(&writer_delta, peer(7), Some(&writer))
             .expect("seed k_writer");
-        let owner_updated_at = owned
-            .get("k_owner")
-            .expect("owner entry")
-            .updated_at;
+        let owner_updated_at = owned.get("k_owner").expect("owner entry").updated_at;
 
         let joiner = KvStoreSync::new(
             replica,
@@ -3085,8 +3104,7 @@ mod tests {
                 s.get("k_writer").is_some(),
                 "an owner-only serve must NOT prune an allowlisted writer's key"
             );
-            if s.get("k_owner").map(|e| e.updated_at) == Some(owner_updated_at)
-            {
+            if s.get("k_owner").map(|e| e.updated_at) == Some(owner_updated_at) {
                 serve_landed = true;
             }
         }
@@ -3104,17 +3122,22 @@ mod tests {
     #[test]
     fn pruned_key_is_accepted_when_re_served_with_fresh_tags() {
         let owner = agent(1);
-        let mut holder = KvStore::new(
-            store_id(1),
-            "log".to_string(),
-            owner,
-            AccessPolicy::Signed,
-        );
+        let mut holder = KvStore::new(store_id(1), "log".to_string(), owner, AccessPolicy::Signed);
         holder
-            .put("k_live".to_string(), b"v".to_vec(), "text/plain".to_string(), peer(1))
+            .put(
+                "k_live".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
             .expect("put live");
         holder
-            .put("k_doomed".to_string(), b"x".to_vec(), "text/plain".to_string(), peer(1))
+            .put(
+                "k_doomed".to_string(),
+                b"x".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
             .expect("put doomed");
 
         // The replica absorbs a first full serve (both keys).
@@ -3149,7 +3172,12 @@ mod tests {
         // pre-fix, its synthetic tag was tombstoned by the prune and the
         // re-add silently dropped.
         holder
-            .put("k_doomed".to_string(), b"y".to_vec(), "text/plain".to_string(), peer(1))
+            .put(
+                "k_doomed".to_string(),
+                b"y".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
             .expect("re-add");
         let s3 = holder.full_delta();
         replica


### PR DESCRIPTION
Closes #240 (the three #238 residuals) with a StateServedV2 digest/frontier handshake:

- **Residual 1 (cross-topic loss window):** StateServedV2 carries a content digest + entry count; a bootstrap requester stops only when its LOCAL digest matches a holder's declaration. A lost full delta with a surviving marker leaves a digest mismatch — the requester keeps asking instead of stopping on incomplete history. 'Served someone' becomes 'served us, completely'.
- **Residual 2 (deletion cold-sync):** digest-verified full-replace adopt — a serve that matches the declared digest AND count AND comes from the sole author (Signed policy, gossip-verified sender == owner) prunes the replica's stale keys via prune_to_served_set. Gated so Allowlisted/AppendOnly/multi-writer state can never be truncated by a serve.
- **Residual 3 (empty chatter):** an empty holder's v2 declaration (empty digest is universally computable) terminates an empty requester's tail; a data-bearing claim always wins over an empty declaration.
- **Wire compat:** additive bincode variant; v1 markers from old peers still converge (tested); mixed-version safe both directions.
- **Review-driven hardening (fix-loop commit):** digest excludes created_at (merge keeps earliest — would wedge on delete+re-create; regression test proves convergence); prune gated to sole-author Signed serves (multi-writer test); fresh tags in full_delta (prune-then-re-add test).

Gates: fmt/clippy clean, 53/53 sync tests incl. paused-clock virtual-time cases. Two adversarial review rounds: initial NOT-SOUND (3 findings) → all closed with regression tests, re-review SOUND.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds digest-verified convergence for checkpoint-less recovery. The main changes are:

- Adds `StateServedV2` digest and entry-count declarations.
- Adds canonical served-state digests for task lists and KV stores.
- Prunes stale tasks and keys after a verified full serve.
- Adds empty-state convergence and fresh full-delta tags.
- Adds compatibility and recovery tests.

<h3>Confidence Score: 4/5</h3>

Empty evidence can stop recovery before non-empty state arrives, and synthetic tags can be reused after pruning.

- Early empty responses can leave historical tasks or entries unrecovered.
- Zero-peer synthetic tags are not unique across holders.
- Digest binding and the KV sole-author pruning gate otherwise limit destructive adoption.

src/crdt/sync.rs, src/kv/sync.rs, src/crdt/delta.rs, and src/kv/store.rs

<details open><summary><h3>Security Review</h3></summary>

Checkpoint-less empty declarations can end bootstrap before authoritative non-empty state arrives. In the KV path, an empty non-owner or another mesh participant can trigger this state-loss condition.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/crdt/delta.rs | Adds full-state digest calculation and fresh synthetic tags, but tag uniqueness does not extend across holders. |
| src/crdt/sync.rs | Adds digest evidence, verified pruning, and empty convergence; an early empty response can stop recovery. |
| src/crdt/task_item.rs | Adds deterministic hashing of resolved task fields. |
| src/crdt/task_list.rs | Adds served-state hashing and stale-task pruning. |
| src/kv/delta.rs | Adds digest calculation for full-state-shaped KV deltas. |
| src/kv/store.rs | Adds canonical served-state hashing and stale-key pruning, but synthetic tags can collide across holders. |
| src/kv/sync.rs | Adds digest-based convergence and owner-gated pruning; non-owner empty evidence can stop bootstrap early. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant R as Empty requester
    participant E as Empty holder
    participant F as Data-bearing holder
    R->>E: StateRequest
    R->>F: StateRequest
    E-->>R: StateServedV2(empty digest)
    R->>R: Local digest matches
    R->>R: Bootstrap terminates
    F-->>R: Delayed non-empty response
    Note over R,F: Historical state may remain unrecovered
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant R as Empty requester
    participant E as Empty holder
    participant F as Data-bearing holder
    R->>E: StateRequest
    R->>F: StateRequest
    E-->>R: StateServedV2(empty digest)
    R->>R: Local digest matches
    R->>R: Bootstrap terminates
    F-->>R: Delayed non-empty response
    Note over R,F: Historical state may remain unrecovered
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/crdt/sync.rs:452-459
**Empty Holder Ends Recovery Early**

When an empty replica responds before a replica that holds tasks, the requester matches this empty digest and stops bootstrapping. The later data-bearing declaration cannot win if it was not observed before the convergence check, so historical tasks can remain unrecovered.

### Issue 2 of 4
src/kv/sync.rs:801-806
**Non-Owner Empty State Ends Bootstrap**

A checkpoint-less empty non-owner can respond before the owner that holds entries, causing an empty requester to match this digest and terminate bootstrap. Since the requester then stops asking for full state, the owner's existing entries can remain unrecovered.

### Issue 3 of 4
src/crdt/delta.rs:175
**Synthetic Tags Collide Across Holders**

Every holder uses the zero peer ID with its own sequence counter, so two holders can emit the same tag for the same task. If a receiver has tombstoned that tag during pruning, a later full serve from the other holder can reuse it and fail to re-add the task permanently.

### Issue 4 of 4
src/kv/store.rs:1713
**Synthetic Tags Collide Across Stores**

All holders mint tags under the same zero peer ID while maintaining independent counters, so separate holders can issue the same tag for one key. Once pruning tombstones that tag, a later full serve from another holder can reuse it and leave the re-added key missing.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style: cargo fmt"](https://github.com/saorsa-labs/x0x/commit/28bbf389ff62478b82bbf6644ccf2470473d2a37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45223307)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->