### PR TITLE
feat(a2a): #112 — A2A-over-x0x envelope codec + unary binding (increment 1)

### DIFF
--- a/src/a2a/binding.rs
+++ b/src/a2a/binding.rs
@@ -26,7 +26,7 @@
 //!   additive.
 //!
 //! Delivery uses `send_direct_with_config` preferring the `RawQuicAcked`
-//! path (design §4 delivery proof), falling back per [`DmSendConfig`]
+//! path (design §4 delivery proof), falling back per `DmSendConfig`
 //! policy when no live raw connection exists.
 //!
 //! Streaming (`message/stream`), push notifications, and large-artifact

--- a/src/a2a/binding.rs
+++ b/src/a2a/binding.rs
@@ -115,8 +115,7 @@ impl BindingEnvelope {
 
 /// Serialize an envelope for the DM wire, enforcing the DM payload cap.
 pub fn encode_envelope(envelope: &BindingEnvelope) -> Result<Vec<u8>, BindingError> {
-    let bytes =
-        serde_json::to_vec(envelope).map_err(|e| BindingError::Encode(e.to_string()))?;
+    let bytes = serde_json::to_vec(envelope).map_err(|e| BindingError::Encode(e.to_string()))?;
     if bytes.len() > crate::direct::MAX_DIRECT_PAYLOAD_SIZE {
         return Err(BindingError::PayloadTooLarge {
             len: bytes.len(),
@@ -318,9 +317,8 @@ pub enum BindingError {
 /// Application handler for one A2A method: params in, JSON-RPC result or
 /// error out. Handlers run in their own tasks so a slow handler never
 /// blocks the receive loop.
-pub type BindingHandler = Arc<
-    dyn Fn(Option<Value>) -> BoxFuture<'static, Result<Value, JsonRpcError>> + Send + Sync,
->;
+pub type BindingHandler =
+    Arc<dyn Fn(Option<Value>) -> BoxFuture<'static, Result<Value, JsonRpcError>> + Send + Sync>;
 
 /// Per-session configuration.
 #[derive(Debug, Clone)]
@@ -650,9 +648,8 @@ mod tests {
 
     #[test]
     fn envelope_round_trips_request() {
-        let envelope =
-            BindingEnvelope::new(KIND_REQUEST, "corr-1".to_string(), &sample_request())
-                .expect("build envelope");
+        let envelope = BindingEnvelope::new(KIND_REQUEST, "corr-1".to_string(), &sample_request())
+            .expect("build envelope");
         assert_eq!(envelope.binding, X0X_BINDING_VERSION);
         let bytes = encode_envelope(&envelope).expect("encode");
         let decoded = decode_envelope(&bytes).expect("decode");
@@ -669,11 +666,10 @@ mod tests {
             JsonRpcError::method_not_found("tasks/resubscribe"),
             Value::String("corr-9".to_string()),
         );
-        let envelope =
-            BindingEnvelope::new(KIND_RESPONSE, "corr-9".to_string(), &response)
-                .expect("build envelope");
-        let decoded = decode_envelope(&encode_envelope(&envelope).expect("encode"))
-            .expect("decode");
+        let envelope = BindingEnvelope::new(KIND_RESPONSE, "corr-9".to_string(), &response)
+            .expect("build envelope");
+        let decoded =
+            decode_envelope(&encode_envelope(&envelope).expect("encode")).expect("decode");
         let parsed: JsonRpcResponse =
             serde_json::from_value(decoded.jsonrpc).expect("parse jsonrpc");
         let error = parsed.error.expect("error object");
@@ -683,9 +679,8 @@ mod tests {
 
     #[test]
     fn wire_shape_matches_design_sketch() {
-        let envelope =
-            BindingEnvelope::new(KIND_REQUEST, "corr-1".to_string(), &sample_request())
-                .expect("build envelope");
+        let envelope = BindingEnvelope::new(KIND_REQUEST, "corr-1".to_string(), &sample_request())
+            .expect("build envelope");
         let value: Value =
             serde_json::from_slice(&encode_envelope(&envelope).expect("encode")).expect("json");
         assert_eq!(value["x0xBinding"], json!("a2a/1"));

--- a/src/a2a/binding.rs
+++ b/src/a2a/binding.rs
@@ -442,6 +442,14 @@ impl BindingSession {
         // Insert BEFORE sending: a fast peer can answer before the send
         // returns, and the receive loop must find the waiter.
         self.inner.in_flight.insert(corr_id.clone(), tx);
+        // Every exit path other than successful delivery — send failure,
+        // timeout, or the caller dropping this future mid-flight — removes
+        // the waiter via the guard. After successful delivery the receive
+        // loop already consumed the entry, so the removal is a no-op.
+        let _cleanup = InFlightCleanup {
+            in_flight: &self.inner.in_flight,
+            corr_id: corr_id.clone(),
+        };
 
         if let Err(err) = self
             .inner
@@ -449,7 +457,6 @@ impl BindingSession {
             .send_direct_with_config(peer, bytes, self.inner.config.send_config.clone())
             .await
         {
-            self.inner.in_flight.remove(&corr_id);
             return Err(BindingError::Send(err));
         }
         debug!(%corr_id, method, "a2a request sent");
@@ -458,7 +465,6 @@ impl BindingSession {
             Ok(Ok(response)) => response,
             Ok(Err(_sender_dropped)) => return Err(BindingError::Closed),
             Err(_elapsed) => {
-                self.inner.in_flight.remove(&corr_id);
                 return Err(BindingError::Timeout(self.inner.config.request_timeout));
             }
         };
@@ -474,6 +480,26 @@ impl Drop for BindingSession {
         if let Ok(mut tasks) = self.inner.handler_tasks.lock() {
             tasks.abort_all();
         }
+    }
+}
+
+/// RAII cleanup for one in-flight `call`.
+///
+/// Removes the corrId from the in-flight map on EVERY exit path of
+/// [`BindingSession::call`]: send failure, timeout, and — critically —
+/// caller cancellation (the caller dropping the `call` future, e.g. an
+/// HTTP client disconnect) when the peer never responds. After successful
+/// delivery the receive loop has already consumed the entry, so the
+/// removal is a no-op. Without this, cancelled calls leak waiters and the
+/// map grows unboundedly.
+struct InFlightCleanup<'a> {
+    in_flight: &'a DashMap<String, oneshot::Sender<JsonRpcResponse>>,
+    corr_id: String,
+}
+
+impl Drop for InFlightCleanup<'_> {
+    fn drop(&mut self) {
+        self.in_flight.remove(&self.corr_id);
     }
 }
 
@@ -522,6 +548,11 @@ async fn receive_loop(inner: Arc<SessionInner>, mut rx: crate::direct::DirectMes
                 };
                 // Reap completed handler tasks so the set stays bounded.
                 while tasks.try_join_next().is_some() {}
+                // TODO(#112 streaming increment): handler tasks are
+                // spawned uncapped — a flood of inbound requests spawns a
+                // task each. Add a semaphore cap on concurrent handlers
+                // (backpressure for chatty streams, design §10.3) when the
+                // streaming increment lands.
                 tasks.spawn(async move {
                     handler_inner.handle_request(sender, envelope).await;
                 });

--- a/src/a2a/binding.rs
+++ b/src/a2a/binding.rs
@@ -1,0 +1,742 @@
+//! A2A-over-x0x transport binding — envelope codec + unary request/response.
+//!
+//! Increment 1 of GitHub issue #112 (ADR-0017 workstream #3), implementing
+//! §4 of `docs/design/a2a-over-x0x-binding.md`: unary A2A JSON-RPC methods
+//! (`message/send`, `tasks/get`, `tasks/cancel`, …) carried over x0x direct
+//! messages with `corrId` correlation. "A2A semantics, x0x delivery."
+//!
+//! Wire envelope — versioned and additive:
+//!
+//! ```json
+//! {
+//!   "x0xBinding": "a2a/1",
+//!   "corrId": "<uuid>",
+//!   "kind": "request",
+//!   "jsonrpc": { "jsonrpc": "2.0", "method": "message/send", "params": {}, "id": "<uuid>" }
+//! }
+//! ```
+//!
+//! Forward-compat rules (both directions):
+//!
+//! - Receivers skip envelopes whose `x0xBinding` version they do not speak.
+//! - Receivers skip unknown `kind` values, so later increments (streaming,
+//!   push) can add kinds without breaking old peers. `kind` is therefore a
+//!   plain string on the wire, not a closed enum.
+//! - Unknown JSON members are ignored (serde default), keeping additions
+//!   additive.
+//!
+//! Delivery uses `send_direct_with_config` preferring the `RawQuicAcked`
+//! path (design §4 delivery proof), falling back per [`DmSendConfig`]
+//! policy when no live raw connection exists.
+//!
+//! Streaming (`message/stream`), push notifications, and large-artifact
+//! transfer are later increments (design §5–7) and are intentionally absent
+//! here; the served Agent Card keeps `capabilities.streaming` /
+//! `pushNotifications` at `false`.
+
+use crate::dm::{DmError, DmSendConfig};
+use crate::identity::AgentId;
+use crate::Agent;
+use dashmap::DashMap;
+use futures::future::BoxFuture;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tokio::task::JoinSet;
+use tracing::{debug, trace, warn};
+use uuid::Uuid;
+
+/// Binding wire version carried in the `x0xBinding` envelope member.
+///
+/// `<name>/<major>` token: receivers skip envelopes whose version they do
+/// not understand, and skip unknown `kind` values, so new envelope kinds
+/// stay additive.
+pub const X0X_BINDING_VERSION: &str = "a2a/1";
+
+/// Envelope `kind` for a JSON-RPC request.
+pub const KIND_REQUEST: &str = "request";
+/// Envelope `kind` for a JSON-RPC response.
+pub const KIND_RESPONSE: &str = "response";
+
+/// JSON-RPC version member (always `"2.0"`).
+const JSONRPC_2_0: &str = "2.0";
+
+/// JSON-RPC 2.0 error code: parse error.
+pub const JSONRPC_PARSE_ERROR: i64 = -32700;
+/// JSON-RPC 2.0 error code: invalid request.
+pub const JSONRPC_INVALID_REQUEST: i64 = -32600;
+/// JSON-RPC 2.0 error code: method not found.
+pub const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
+/// JSON-RPC 2.0 error code: internal error.
+pub const JSONRPC_INTERNAL_ERROR: i64 = -32603;
+
+// ─── Envelope ─────────────────────────────────────────────────────────────
+
+/// One binding envelope — the DM payload unit for A2A-over-x0x traffic.
+///
+/// `kind` is a plain string (not a closed enum) so envelopes carrying kinds
+/// introduced by later increments still decode on old peers, which skip
+/// them. `jsonrpc` carries the verbatim A2A JSON-RPC 2.0 body.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BindingEnvelope {
+    /// Binding version token — must equal [`X0X_BINDING_VERSION`].
+    #[serde(rename = "x0xBinding")]
+    pub binding: String,
+    /// Correlation id tying a response to its request.
+    #[serde(rename = "corrId")]
+    pub corr_id: String,
+    /// Envelope kind — `request` / `response` today; unknown kinds decode
+    /// fine and are skipped by the receive loop.
+    pub kind: String,
+    /// Verbatim JSON-RPC 2.0 request or response object.
+    pub jsonrpc: Value,
+}
+
+impl BindingEnvelope {
+    /// Build an envelope at the current wire version, serializing the
+    /// JSON-RPC body verbatim.
+    pub fn new(
+        kind: &str,
+        corr_id: String,
+        jsonrpc: &impl Serialize,
+    ) -> Result<Self, BindingError> {
+        Ok(Self {
+            binding: X0X_BINDING_VERSION.to_string(),
+            corr_id,
+            kind: kind.to_string(),
+            jsonrpc: serde_json::to_value(jsonrpc)
+                .map_err(|e| BindingError::Encode(e.to_string()))?,
+        })
+    }
+}
+
+/// Serialize an envelope for the DM wire, enforcing the DM payload cap.
+pub fn encode_envelope(envelope: &BindingEnvelope) -> Result<Vec<u8>, BindingError> {
+    let bytes =
+        serde_json::to_vec(envelope).map_err(|e| BindingError::Encode(e.to_string()))?;
+    if bytes.len() > crate::direct::MAX_DIRECT_PAYLOAD_SIZE {
+        return Err(BindingError::PayloadTooLarge {
+            len: bytes.len(),
+            max: crate::direct::MAX_DIRECT_PAYLOAD_SIZE,
+        });
+    }
+    Ok(bytes)
+}
+
+/// Decode an envelope, rejecting binding versions this peer does not speak.
+///
+/// Unknown `kind` values and unknown JSON members are *not* errors — they
+/// decode successfully and callers skip them (additive evolution).
+pub fn decode_envelope(bytes: &[u8]) -> Result<BindingEnvelope, BindingError> {
+    let envelope: BindingEnvelope =
+        serde_json::from_slice(bytes).map_err(|e| BindingError::Malformed(e.to_string()))?;
+    if envelope.binding != X0X_BINDING_VERSION {
+        return Err(BindingError::UnsupportedVersion(envelope.binding));
+    }
+    Ok(envelope)
+}
+
+/// Cheap probe of a DM payload: the `x0xBinding` version token, if this is
+/// an A2A binding envelope at all. The DM channel is shared with other x0x
+/// protocols, so the receive loop probes before fully decoding.
+#[must_use]
+pub fn probe_binding_version(bytes: &[u8]) -> Option<String> {
+    #[derive(Deserialize)]
+    struct Probe {
+        #[serde(rename = "x0xBinding")]
+        binding: Option<String>,
+    }
+    serde_json::from_slice::<Probe>(bytes).ok()?.binding
+}
+
+// ─── JSON-RPC 2.0 ─────────────────────────────────────────────────────────
+
+/// A JSON-RPC 2.0 request — the `jsonrpc` member of a `request` envelope.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JsonRpcRequest {
+    /// Always `"2.0"`.
+    pub jsonrpc: String,
+    /// A2A method name (e.g. `message/send`).
+    pub method: String,
+    /// Method params, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+    /// Request id — the binding mirrors the envelope `corrId` here.
+    pub id: Value,
+}
+
+impl JsonRpcRequest {
+    /// Build a request at JSON-RPC version 2.0.
+    #[must_use]
+    pub fn new(method: impl Into<String>, params: Option<Value>, id: Value) -> Self {
+        Self {
+            jsonrpc: JSONRPC_2_0.to_string(),
+            method: method.into(),
+            params,
+            id,
+        }
+    }
+}
+
+/// A JSON-RPC 2.0 response — the `jsonrpc` member of a `response` envelope.
+///
+/// Carries exactly one of `result` / `error`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JsonRpcResponse {
+    /// Always `"2.0"`.
+    pub jsonrpc: String,
+    /// Success result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    /// Error object.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+    /// Request id echoed back.
+    pub id: Value,
+}
+
+impl JsonRpcResponse {
+    /// A successful response.
+    #[must_use]
+    pub fn result(result: Value, id: Value) -> Self {
+        Self {
+            jsonrpc: JSONRPC_2_0.to_string(),
+            result: Some(result),
+            error: None,
+            id,
+        }
+    }
+
+    /// An error response.
+    #[must_use]
+    pub fn error(error: JsonRpcError, id: Value) -> Self {
+        Self {
+            jsonrpc: JSONRPC_2_0.to_string(),
+            result: None,
+            error: Some(error),
+            id,
+        }
+    }
+}
+
+/// A JSON-RPC 2.0 error object.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct JsonRpcError {
+    /// Error code (e.g. [`JSONRPC_METHOD_NOT_FOUND`]).
+    pub code: i64,
+    /// Human-readable message.
+    pub message: String,
+    /// Optional structured data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl JsonRpcError {
+    /// Build an error with no data member.
+    #[must_use]
+    pub fn new(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    /// `-32601` — the peer has no handler registered for this method.
+    #[must_use]
+    pub fn method_not_found(method: &str) -> Self {
+        Self::new(
+            JSONRPC_METHOD_NOT_FOUND,
+            format!("method not found: {method}"),
+        )
+    }
+
+    /// `-32600` — the envelope's `jsonrpc` member is not a valid request.
+    #[must_use]
+    pub fn invalid_request(reason: impl Into<String>) -> Self {
+        Self::new(JSONRPC_INVALID_REQUEST, reason)
+    }
+
+    /// `-32603` — internal failure (e.g. unparseable response body).
+    #[must_use]
+    pub fn internal(reason: impl Into<String>) -> Self {
+        Self::new(JSONRPC_INTERNAL_ERROR, reason)
+    }
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────
+
+/// Errors surfaced by the A2A-over-x0x binding.
+#[derive(Debug, thiserror::Error)]
+pub enum BindingError {
+    /// Payload is not a well-formed binding envelope.
+    #[error("malformed binding envelope: {0}")]
+    Malformed(String),
+    /// Envelope carried an `x0xBinding` version this peer does not speak.
+    #[error("unsupported x0xBinding version {0:?}")]
+    UnsupportedVersion(String),
+    /// Serializing an envelope or JSON-RPC body failed.
+    #[error("envelope encode failed: {0}")]
+    Encode(String),
+    /// Envelope exceeded the direct-message payload cap.
+    #[error("envelope too large: {len} bytes (max {max})")]
+    PayloadTooLarge {
+        /// Actual encoded size.
+        len: usize,
+        /// Wire cap.
+        max: usize,
+    },
+    /// The direct-message send itself failed.
+    #[error("direct send failed: {0}")]
+    Send(#[from] DmError),
+    /// No correlated response arrived within the configured timeout.
+    #[error("request timed out after {0:?}")]
+    Timeout(Duration),
+    /// The peer answered with a JSON-RPC error object.
+    #[error("remote error {code}: {message}")]
+    Remote {
+        /// JSON-RPC error code.
+        code: i64,
+        /// Human-readable message.
+        message: String,
+        /// Optional structured data.
+        data: Option<Value>,
+    },
+    /// Response carried neither (or both) `result` and `error`.
+    #[error("invalid JSON-RPC response: {0}")]
+    InvalidResponse(String),
+    /// The session was shut down while a request was in flight.
+    #[error("binding session closed")]
+    Closed,
+}
+
+// ─── Session ──────────────────────────────────────────────────────────────
+
+/// Application handler for one A2A method: params in, JSON-RPC result or
+/// error out. Handlers run in their own tasks so a slow handler never
+/// blocks the receive loop.
+pub type BindingHandler = Arc<
+    dyn Fn(Option<Value>) -> BoxFuture<'static, Result<Value, JsonRpcError>> + Send + Sync,
+>;
+
+/// Per-session configuration.
+#[derive(Debug, Clone)]
+pub struct BindingConfig {
+    /// Max wait for a correlated response before
+    /// [`BindingSession::call`] fails with [`BindingError::Timeout`].
+    pub request_timeout: Duration,
+    /// DM send behaviour for requests and responses. The default prefers
+    /// the `RawQuicAcked` path (design §4 delivery proof) and falls back
+    /// per [`DmSendConfig`] policy.
+    pub send_config: DmSendConfig,
+}
+
+impl Default for BindingConfig {
+    fn default() -> Self {
+        Self {
+            request_timeout: Duration::from_secs(30),
+            send_config: DmSendConfig {
+                prefer_raw_quic_if_connected: true,
+                raw_quic_receive_ack_timeout: Some(Duration::from_secs(4)),
+                ..DmSendConfig::default()
+            },
+        }
+    }
+}
+
+struct SessionInner {
+    agent: Arc<Agent>,
+    /// method name → handler.
+    handlers: DashMap<String, BindingHandler>,
+    /// corrId → waiter for the matching response.
+    in_flight: DashMap<String, oneshot::Sender<JsonRpcResponse>>,
+    /// Spawned per-request handler tasks; aborted on session drop.
+    handler_tasks: Mutex<JoinSet<()>>,
+    config: BindingConfig,
+}
+
+/// One agent's A2A-over-x0x endpoint — both client (`call`) and server
+/// (registered handlers) over the shared DM channel.
+///
+/// A background receive task (spawned by [`BindingSession::start`]) consumes
+/// this agent's direct messages, dispatches `request` envelopes to handlers,
+/// answers them, and correlates `response` envelopes to in-flight `call`s.
+/// Dropping the session aborts the receive task and any in-flight handlers.
+pub struct BindingSession {
+    inner: Arc<SessionInner>,
+    receive_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl BindingSession {
+    /// Start a session on `agent`, spawning the DM receive loop.
+    ///
+    /// Safe to start before `join_network`: the loop simply sees no traffic
+    /// until the DM channel is live.
+    #[must_use]
+    pub fn start(agent: Arc<Agent>, config: BindingConfig) -> Self {
+        let inner = Arc::new(SessionInner {
+            agent,
+            handlers: DashMap::new(),
+            in_flight: DashMap::new(),
+            handler_tasks: Mutex::new(JoinSet::new()),
+            config,
+        });
+        let rx = inner.agent.subscribe_direct();
+        let loop_inner = Arc::clone(&inner);
+        let receive_task = tokio::spawn(async move { receive_loop(loop_inner, rx).await });
+        Self {
+            inner,
+            receive_task: Mutex::new(Some(receive_task)),
+        }
+    }
+
+    /// Register `handler` for an A2A method (e.g. `message/send`).
+    /// Re-registering replaces the previous handler.
+    pub fn register_handler<F, Fut>(&self, method: &str, handler: F)
+    where
+        F: Fn(Option<Value>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Value, JsonRpcError>> + Send + 'static,
+    {
+        self.inner.handlers.insert(
+            method.to_string(),
+            Arc::new(move |params| Box::pin(handler(params)) as BoxFuture<'static, _>),
+        );
+    }
+
+    /// Number of `call`s currently awaiting a correlated response.
+    #[must_use]
+    pub fn in_flight_len(&self) -> usize {
+        self.inner.in_flight.len()
+    }
+
+    /// Call a unary A2A method on `peer` and await its correlated response.
+    ///
+    /// Correlation: a fresh `corrId` (uuid) is registered in the in-flight
+    /// map *before* the request DM is sent, so a fast peer's answer can
+    /// never be missed. On timeout the entry is removed and a late response
+    /// is skipped by the receive loop.
+    ///
+    /// # Errors
+    ///
+    /// - [`BindingError::Send`] if the request DM could not be delivered.
+    /// - [`BindingError::Timeout`] if no response arrives within
+    ///   `config.request_timeout`.
+    /// - [`BindingError::Remote`] if the peer answered with a JSON-RPC
+    ///   error (e.g. `-32601` for an unregistered method).
+    /// - [`BindingError::InvalidResponse`] for a malformed response body.
+    pub async fn call(
+        &self,
+        peer: &AgentId,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<Value, BindingError> {
+        let corr_id = Uuid::new_v4().to_string();
+        let request = JsonRpcRequest::new(method, params, Value::String(corr_id.clone()));
+        let envelope = BindingEnvelope::new(KIND_REQUEST, corr_id.clone(), &request)?;
+        let bytes = encode_envelope(&envelope)?;
+
+        let (tx, rx) = oneshot::channel();
+        // Insert BEFORE sending: a fast peer can answer before the send
+        // returns, and the receive loop must find the waiter.
+        self.inner.in_flight.insert(corr_id.clone(), tx);
+
+        if let Err(err) = self
+            .inner
+            .agent
+            .send_direct_with_config(peer, bytes, self.inner.config.send_config.clone())
+            .await
+        {
+            self.inner.in_flight.remove(&corr_id);
+            return Err(BindingError::Send(err));
+        }
+        debug!(%corr_id, method, "a2a request sent");
+
+        let response = match tokio::time::timeout(self.inner.config.request_timeout, rx).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(_sender_dropped)) => return Err(BindingError::Closed),
+            Err(_elapsed) => {
+                self.inner.in_flight.remove(&corr_id);
+                return Err(BindingError::Timeout(self.inner.config.request_timeout));
+            }
+        };
+        response_into_result(response)
+    }
+}
+
+impl Drop for BindingSession {
+    fn drop(&mut self) {
+        if let Ok(Some(task)) = self.receive_task.lock().map(|mut slot| slot.take()) {
+            task.abort();
+        }
+        if let Ok(mut tasks) = self.inner.handler_tasks.lock() {
+            tasks.abort_all();
+        }
+    }
+}
+
+/// Translate a decoded response into the caller-visible result.
+fn response_into_result(response: JsonRpcResponse) -> Result<Value, BindingError> {
+    match (response.result, response.error) {
+        (Some(value), None) => Ok(value),
+        (None, Some(error)) => Err(BindingError::Remote {
+            code: error.code,
+            message: error.message,
+            data: error.data,
+        }),
+        (result, error) => Err(BindingError::InvalidResponse(format!(
+            "exactly one of result/error required (result present: {}, error present: {})",
+            result.is_some(),
+            error.is_some()
+        ))),
+    }
+}
+
+async fn receive_loop(inner: Arc<SessionInner>, mut rx: crate::direct::DirectMessageReceiver) {
+    while let Some(msg) = rx.recv().await {
+        // Cheap probe first: the DM channel is shared with other x0x
+        // protocols — non-binding payloads are skipped without log spam.
+        let Some(version) = probe_binding_version(&msg.payload) else {
+            continue;
+        };
+        if version != X0X_BINDING_VERSION {
+            debug!(%version, "skipping A2A binding envelope with unsupported version");
+            continue;
+        }
+        let envelope = match decode_envelope(&msg.payload) {
+            Ok(envelope) => envelope,
+            Err(err) => {
+                warn!(%err, "dropping malformed A2A binding envelope");
+                continue;
+            }
+        };
+        match envelope.kind.as_str() {
+            KIND_REQUEST => {
+                let handler_inner = Arc::clone(&inner);
+                let sender = msg.sender;
+                let Ok(mut tasks) = inner.handler_tasks.lock() else {
+                    warn!("handler task set poisoned; dropping request");
+                    continue;
+                };
+                // Reap completed handler tasks so the set stays bounded.
+                while tasks.try_join_next().is_some() {}
+                tasks.spawn(async move {
+                    handler_inner.handle_request(sender, envelope).await;
+                });
+            }
+            KIND_RESPONSE => inner.handle_response(envelope),
+            other => {
+                // Additive evolution: newer peers may send kinds we do not
+                // know (stream, stream-end, …). Skip, don't fail.
+                trace!(kind = %other, "skipping unknown A2A binding envelope kind");
+            }
+        }
+    }
+    debug!("a2a binding receive loop ended (DM channel closed)");
+}
+
+impl SessionInner {
+    async fn handle_request(&self, peer: AgentId, envelope: BindingEnvelope) {
+        let response = match serde_json::from_value::<JsonRpcRequest>(envelope.jsonrpc) {
+            Ok(request) => self.dispatch(request).await,
+            Err(err) => JsonRpcResponse::error(
+                JsonRpcError::invalid_request(format!("not a JSON-RPC 2.0 request: {err}")),
+                Value::Null,
+            ),
+        };
+        let result = BindingEnvelope::new(KIND_RESPONSE, envelope.corr_id, &response)
+            .and_then(|response_envelope| encode_envelope(&response_envelope));
+        let bytes = match result {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                warn!(%err, "failed to encode A2A response; dropping");
+                return;
+            }
+        };
+        if let Err(err) = self
+            .agent
+            .send_direct_with_config(&peer, bytes, self.config.send_config.clone())
+            .await
+        {
+            warn!(%err, "failed to send A2A response");
+        }
+    }
+
+    async fn dispatch(&self, request: JsonRpcRequest) -> JsonRpcResponse {
+        // Clone the Arc and drop the map guard before awaiting — a handler
+        // may re-enter the session (nested calls) and must not deadlock.
+        let handler = self
+            .handlers
+            .get(&request.method)
+            .map(|entry| Arc::clone(entry.value()));
+        let Some(handler) = handler else {
+            return JsonRpcResponse::error(
+                JsonRpcError::method_not_found(&request.method),
+                request.id,
+            );
+        };
+        match handler(request.params).await {
+            Ok(result) => JsonRpcResponse::result(result, request.id),
+            Err(error) => JsonRpcResponse::error(error, request.id),
+        }
+    }
+
+    fn handle_response(&self, envelope: BindingEnvelope) {
+        let Some((_, waiter)) = self.in_flight.remove(&envelope.corr_id) else {
+            // Late answer to a timed-out request, duplicate, or not ours.
+            trace!(
+                corr_id = %envelope.corr_id,
+                "no in-flight request for A2A response; skipping"
+            );
+            return;
+        };
+        let response = match serde_json::from_value::<JsonRpcResponse>(envelope.jsonrpc) {
+            Ok(response) => response,
+            Err(err) => JsonRpcResponse::error(
+                JsonRpcError::internal(format!("unparseable JSON-RPC response: {err}")),
+                Value::Null,
+            ),
+        };
+        // The waiter may have raced a timeout and gone away; that is fine.
+        let _ = waiter.send(response);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_request() -> JsonRpcRequest {
+        JsonRpcRequest::new(
+            "message/send",
+            Some(json!({"message": {"parts": [{"kind": "text", "text": "ping"}]}})),
+            Value::String("corr-1".to_string()),
+        )
+    }
+
+    #[test]
+    fn envelope_round_trips_request() {
+        let envelope =
+            BindingEnvelope::new(KIND_REQUEST, "corr-1".to_string(), &sample_request())
+                .expect("build envelope");
+        assert_eq!(envelope.binding, X0X_BINDING_VERSION);
+        let bytes = encode_envelope(&envelope).expect("encode");
+        let decoded = decode_envelope(&bytes).expect("decode");
+        assert_eq!(decoded, envelope);
+        let request: JsonRpcRequest =
+            serde_json::from_value(decoded.jsonrpc).expect("parse jsonrpc");
+        assert_eq!(request.method, "message/send");
+        assert_eq!(request.jsonrpc, "2.0");
+    }
+
+    #[test]
+    fn envelope_round_trips_error_response() {
+        let response = JsonRpcResponse::error(
+            JsonRpcError::method_not_found("tasks/resubscribe"),
+            Value::String("corr-9".to_string()),
+        );
+        let envelope =
+            BindingEnvelope::new(KIND_RESPONSE, "corr-9".to_string(), &response)
+                .expect("build envelope");
+        let decoded = decode_envelope(&encode_envelope(&envelope).expect("encode"))
+            .expect("decode");
+        let parsed: JsonRpcResponse =
+            serde_json::from_value(decoded.jsonrpc).expect("parse jsonrpc");
+        let error = parsed.error.expect("error object");
+        assert_eq!(error.code, JSONRPC_METHOD_NOT_FOUND);
+        assert!(parsed.result.is_none());
+    }
+
+    #[test]
+    fn wire_shape_matches_design_sketch() {
+        let envelope =
+            BindingEnvelope::new(KIND_REQUEST, "corr-1".to_string(), &sample_request())
+                .expect("build envelope");
+        let value: Value =
+            serde_json::from_slice(&encode_envelope(&envelope).expect("encode")).expect("json");
+        assert_eq!(value["x0xBinding"], json!("a2a/1"));
+        assert_eq!(value["corrId"], json!("corr-1"));
+        assert_eq!(value["kind"], json!("request"));
+        assert_eq!(value["jsonrpc"]["jsonrpc"], json!("2.0"));
+        assert_eq!(value["jsonrpc"]["method"], json!("message/send"));
+    }
+
+    #[test]
+    fn decode_preserves_unknown_kind_and_members() {
+        // A future `stream` envelope with members this version does not
+        // know must still decode — additive evolution (design §5 kinds).
+        let bytes = br#"{"x0xBinding":"a2a/1","corrId":"c","kind":"stream","seq":7,"jsonrpc":{}}"#;
+        let envelope = decode_envelope(bytes).expect("decode");
+        assert_eq!(envelope.kind, "stream");
+        assert_eq!(envelope.corr_id, "c");
+    }
+
+    #[test]
+    fn decode_rejects_unsupported_version() {
+        let bytes = br#"{"x0xBinding":"a2a/2","corrId":"c","kind":"request","jsonrpc":{}}"#;
+        let err = decode_envelope(bytes).expect_err("must reject");
+        assert!(matches!(err, BindingError::UnsupportedVersion(v) if v == "a2a/2"));
+    }
+
+    #[test]
+    fn decode_rejects_malformed_payload() {
+        let err = decode_envelope(b"not json at all").expect_err("must reject");
+        assert!(matches!(err, BindingError::Malformed(_)));
+    }
+
+    #[test]
+    fn probe_distinguishes_binding_payloads() {
+        assert_eq!(probe_binding_version(b"plain-text-dm"), None);
+        assert_eq!(probe_binding_version(br#"{"other":"json"}"#), None);
+        assert_eq!(
+            probe_binding_version(
+                br#"{"x0xBinding":"a2a/1","corrId":"c","kind":"request","jsonrpc":{}}"#
+            ),
+            Some("a2a/1".to_string())
+        );
+    }
+
+    #[test]
+    fn response_into_result_variants() {
+        let ok = response_into_result(JsonRpcResponse::result(json!({"ok": true}), Value::Null));
+        assert_eq!(ok.expect("result"), json!({"ok": true}));
+
+        let err = response_into_result(JsonRpcResponse::error(
+            JsonRpcError::method_not_found("nope"),
+            Value::Null,
+        ))
+        .expect_err("remote error");
+        assert!(matches!(
+            err,
+            BindingError::Remote {
+                code: JSONRPC_METHOD_NOT_FOUND,
+                ..
+            }
+        ));
+
+        let both = JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            result: Some(Value::Null),
+            error: Some(JsonRpcError::internal("x")),
+            id: Value::Null,
+        };
+        assert!(matches!(
+            response_into_result(both),
+            Err(BindingError::InvalidResponse(_))
+        ));
+
+        let neither = JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            result: None,
+            error: None,
+            id: Value::Null,
+        };
+        assert!(matches!(
+            response_into_result(neither),
+            Err(BindingError::InvalidResponse(_))
+        ));
+    }
+}

--- a/src/a2a/mod.rs
+++ b/src/a2a/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! This is the *discovery* half of A2A interop (ADR-0017,
 //! `docs/design/a2a-agent-card-adapter.md`). The *delivery* half — the
-//! A2A-over-x0x message binding — lives in [`binding`] (issue #112):
+//! A2A-over-x0x message binding — lives in the `binding` submodule (issue #112):
 //! increment 1 ships the envelope codec + unary request/response
 //! correlation; streaming, push notifications, and large artifacts are
 //! later increments, so `capabilities.streaming` / `pushNotifications`

--- a/src/a2a/mod.rs
+++ b/src/a2a/mod.rs
@@ -6,9 +6,15 @@
 //!
 //! This is the *discovery* half of A2A interop (ADR-0017,
 //! `docs/design/a2a-agent-card-adapter.md`). The *delivery* half — the
-//! A2A-over-x0x message binding — is a tracked follow-up and is intentionally
-//! NOT implemented here; `capabilities.streaming` / `pushNotifications` stay
-//! `false` until that lands.
+//! A2A-over-x0x message binding — lives in [`binding`] (issue #112):
+//! increment 1 ships the envelope codec + unary request/response
+//! correlation; streaming, push notifications, and large artifacts are
+//! later increments, so `capabilities.streaming` / `pushNotifications`
+//! stay `false` until those land.
+
+/// A2A-over-x0x transport binding (issue #112): envelope codec + unary
+/// request/response over the DM channel.
+pub mod binding;
 
 use crate::groups::card::AgentCard;
 use serde::{Deserialize, Serialize};
@@ -307,6 +313,17 @@ mod tests {
         // Enabled: exec appears.
         let enabled = a2a_card_from(&card, &ctx(true));
         assert!(enabled.skills.iter().any(|s| s.id == "exec"));
+    }
+
+    #[test]
+    fn capability_flags_stay_disabled_until_streaming_and_push_ship() {
+        // Issue #112 increment 1 lands the unary binding only — the served
+        // card MUST stay honest: streaming / push are not implemented.
+        let kp = AgentKeypair::generate().expect("kp");
+        let card = signed_card(&kp);
+        let a2a = a2a_card_from(&card, &ctx(false));
+        assert!(!a2a.capabilities.streaming);
+        assert!(!a2a.capabilities.push_notifications);
     }
 
     #[test]

--- a/tests/a2a_binding_integration.rs
+++ b/tests/a2a_binding_integration.rs
@@ -1,0 +1,467 @@
+//! Integration tests for the A2A-over-x0x binding (issue #112, increment 1).
+//!
+//! Two in-process agents exchange A2A unary JSON-RPC calls over the real
+//! DM path (loopback QUIC, `RawQuicAcked`-preferred):
+//!
+//! - round-trip success for `message/send`, `tasks/get`, `tasks/cancel`
+//! - unknown method → JSON-RPC `-32601` error
+//! - request timeout fires and the in-flight map is cleaned up
+//! - concurrent interleaving keeps `corrId` correlation intact
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use x0x::a2a::binding::{
+    BindingConfig, BindingError, BindingSession, JsonRpcError, JSONRPC_METHOD_NOT_FOUND,
+};
+use x0x::network::NetworkConfig;
+use x0x::{Agent, DiscoveredAgent};
+use serde_json::Value;
+
+fn loopback_network_config() -> NetworkConfig {
+    NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr literal")),
+        bootstrap_nodes: Vec::new(),
+        port_mapping_enabled: false,
+        ..NetworkConfig::default()
+    }
+}
+
+fn normalize_loopback(addr: std::net::SocketAddr) -> std::net::SocketAddr {
+    if addr.ip().is_unspecified() {
+        std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            addr.port(),
+        )
+    } else {
+        addr
+    }
+}
+
+fn is_network_bind_permission_error(error: &impl std::fmt::Display) -> bool {
+    let message = error.to_string();
+    message.contains("Operation not permitted")
+        && (message.contains("All socket binds failed")
+            || message.contains("Failed to bind UDP socket")
+            || message.contains("bind UDP socket")
+            || message.contains("network initialization failed"))
+}
+
+fn discovered_agent(agent: &Agent, addr: std::net::SocketAddr, now_secs: u64) -> DiscoveredAgent {
+    DiscoveredAgent {
+        agent_id: agent.agent_id(),
+        machine_id: agent.machine_id(),
+        user_id: None,
+        addresses: vec![addr],
+        announced_at: now_secs,
+        last_seen: now_secs,
+        machine_public_key: vec![],
+        nat_type: None,
+        can_receive_direct: Some(true),
+        is_relay: None,
+        is_coordinator: None,
+        reachable_via: Vec::new(),
+        relay_candidates: Vec::new(),
+        cert_not_after: None,
+        agent_certificate: None,
+        agent_public_key: Vec::new(),
+    }
+}
+
+/// Helper to create a loopback-only test agent with isolated storage.
+async fn create_loopback_test_agent(
+    temp_dir: &TempDir,
+    name: &str,
+) -> Result<Option<Agent>, Box<dyn std::error::Error>> {
+    let machine_key_path = temp_dir.path().join(format!("{name}_machine.key"));
+    let agent_key_path = temp_dir.path().join(format!("{name}_agent.key"));
+    let contacts_path = temp_dir.path().join(format!("{name}_contacts.json"));
+
+    match Agent::builder()
+        .with_machine_key(machine_key_path)
+        .with_agent_key_path(agent_key_path)
+        .with_contact_store_path(contacts_path)
+        .with_peer_cache_disabled()
+        .with_network_config(loopback_network_config())
+        .build()
+        .await
+    {
+        Ok(agent) => Ok(Some(agent)),
+        Err(error) if is_network_bind_permission_error(&error) => Ok(None),
+        Err(error) => Err(Box::new(error)),
+    }
+}
+
+struct BindingPair {
+    bob_id: x0x::identity::AgentId,
+    alice_session: Arc<BindingSession>,
+    bob_session: Arc<BindingSession>,
+}
+
+/// Bring up two loopback agents on the real DM path, each with a binding
+/// session. Returns `None` when the sandbox forbids UDP binds (same skip
+/// convention as the DM integration tests).
+async fn setup_pair(
+    temp_dir: &TempDir,
+    alice_request_timeout: Duration,
+) -> Result<Option<BindingPair>, Box<dyn std::error::Error>> {
+    let Some(alice) = create_loopback_test_agent(temp_dir, "alice").await? else {
+        return Ok(None);
+    };
+    let Some(bob) = create_loopback_test_agent(temp_dir, "bob").await? else {
+        return Ok(None);
+    };
+
+    alice.join_network().await?;
+    bob.join_network().await?;
+
+    let alice = Arc::new(alice);
+    let bob = Arc::new(bob);
+
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let alice_addr = normalize_loopback(alice_network.bound_addr().await.expect("alice bound"));
+    let bob_addr = normalize_loopback(bob_network.bound_addr().await.expect("bob bound"));
+    let alice_peer = ant_quic::PeerId(alice.machine_id().0);
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+
+    let connected = alice_network.connect_addr(bob_addr).await?;
+    assert_eq!(connected.0, bob.machine_id().0);
+
+    // The binding is bidirectional (requests alice→bob, responses bob→alice),
+    // so wait for BOTH directions of the QUIC connection to be visible.
+    let connected_deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < connected_deadline {
+        if alice_network.is_connected(&bob_peer).await
+            && bob_network.is_connected(&alice_peer).await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(alice_network.is_connected(&bob_peer).await);
+    assert!(bob_network.is_connected(&alice_peer).await);
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_secs();
+    alice
+        .insert_discovered_agent_for_testing(discovered_agent(&bob, bob_addr, now_secs))
+        .await;
+    bob.insert_discovered_agent_for_testing(discovered_agent(&alice, alice_addr, now_secs))
+        .await;
+    alice
+        .direct_messaging()
+        .mark_connected(bob.agent_id(), bob.machine_id())
+        .await;
+    bob.direct_messaging()
+        .mark_connected(alice.agent_id(), alice.machine_id())
+        .await;
+
+    let alice_config = BindingConfig {
+        request_timeout: alice_request_timeout,
+        ..BindingConfig::default()
+    };
+    let alice_session = Arc::new(BindingSession::start(Arc::clone(&alice), alice_config));
+    let bob_session = Arc::new(BindingSession::start(
+        Arc::clone(&bob),
+        BindingConfig::default(),
+    ));
+
+    Ok(Some(BindingPair {
+        bob_id: bob.agent_id(),
+        alice_session,
+        bob_session,
+    }))
+}
+
+/// Register the three A2A unary methods of this increment with canned,
+/// A2A-shaped responses that echo identifying bits of the params so tests
+/// can verify correlation.
+fn register_a2a_handlers(session: &BindingSession) {
+    session.register_handler("message/send", |params| async move {
+        let text = params
+            .as_ref()
+            .and_then(|p| p.get("message"))
+            .and_then(|m| m.get("parts"))
+            .and_then(|parts| parts.get(0))
+            .and_then(|part| part.get("text"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        Ok(serde_json::json!({
+            "kind": "message",
+            "messageId": format!("msg-{text}"),
+            "role": "agent",
+            "parts": [{"kind": "text", "text": format!("ack:{text}")}],
+        }))
+    });
+
+    session.register_handler("tasks/get", |params| async move {
+        let id = task_id(params.as_ref());
+        Ok(serde_json::json!({
+            "kind": "task",
+            "id": id,
+            "status": {"state": "completed", "timestamp": "2026-07-17T00:00:00Z"},
+        }))
+    });
+
+    session.register_handler("tasks/cancel", |params| async move {
+        let id = task_id(params.as_ref());
+        Ok(serde_json::json!({
+            "kind": "task",
+            "id": id,
+            "status": {"state": "canceled", "timestamp": "2026-07-17T00:00:00Z"},
+        }))
+    });
+}
+
+fn task_id(params: Option<&Value>) -> String {
+    params
+        .and_then(|p| p.get("id"))
+        .and_then(Value::as_str)
+        .unwrap_or("task-unknown")
+        .to_string()
+}
+
+fn message_send_params(text: &str) -> Value {
+    serde_json::json!({
+        "message": {
+            "kind": "message",
+            "messageId": format!("req-{text}"),
+            "role": "user",
+            "parts": [{"kind": "text", "text": text}],
+        }
+    })
+}
+
+/// Round-trip: alice completes message/send + tasks/get + tasks/cancel
+/// against bob over the real DM path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unary_round_trip_over_dm() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new().unwrap();
+    let Some(pair) = setup_pair(&temp_dir, Duration::from_secs(30)).await? else {
+        return Ok(());
+    };
+    register_a2a_handlers(&pair.bob_session);
+
+    let message = pair
+        .alice_session
+        .call(
+            &pair.bob_id,
+            "message/send",
+            Some(message_send_params("hello-a2a")),
+        )
+        .await?;
+    assert_eq!(message["kind"], Value::String("message".to_string()));
+    assert_eq!(message["role"], Value::String("agent".to_string()));
+    assert_eq!(message["parts"][0]["text"], Value::String("ack:hello-a2a".to_string()));
+
+    let task = pair
+        .alice_session
+        .call(
+            &pair.bob_id,
+            "tasks/get",
+            Some(serde_json::json!({"id": "task-42"})),
+        )
+        .await?;
+    assert_eq!(task["id"], Value::String("task-42".to_string()));
+    assert_eq!(
+        task["status"]["state"],
+        Value::String("completed".to_string())
+    );
+
+    let cancelled = pair
+        .alice_session
+        .call(
+            &pair.bob_id,
+            "tasks/cancel",
+            Some(serde_json::json!({"id": "task-42"})),
+        )
+        .await?;
+    assert_eq!(cancelled["id"], Value::String("task-42".to_string()));
+    assert_eq!(
+        cancelled["status"]["state"],
+        Value::String("canceled".to_string())
+    );
+
+    // Completed calls drain from the in-flight map.
+    assert_eq!(pair.alice_session.in_flight_len(), 0);
+    Ok(())
+}
+
+/// Unknown method: bob has no handler registered, so alice receives a
+/// JSON-RPC `-32601` error.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unknown_method_returns_jsonrpc_error() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new().unwrap();
+    let Some(pair) = setup_pair(&temp_dir, Duration::from_secs(30)).await? else {
+        return Ok(());
+    };
+    register_a2a_handlers(&pair.bob_session);
+
+    let err = pair
+        .alice_session
+        .call(&pair.bob_id, "message/stream", None)
+        .await
+        .expect_err("unregistered method must fail");
+    match err {
+        BindingError::Remote { code, message, .. } => {
+            assert_eq!(code, JSONRPC_METHOD_NOT_FOUND);
+            assert!(message.contains("message/stream"));
+        }
+        other => panic!("expected BindingError::Remote, got {other:?}"),
+    }
+    assert_eq!(pair.alice_session.in_flight_len(), 0);
+    Ok(())
+}
+
+/// Timeout: bob's handler never answers; alice's call times out, the
+/// in-flight entry is removed, and the session stays healthy for a
+/// follow-up call (no cross-talk with the stalled request).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn request_timeout_fires_and_session_stays_healthy(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new().unwrap();
+    let Some(pair) = setup_pair(&temp_dir, Duration::from_millis(500)).await? else {
+        return Ok(());
+    };
+    register_a2a_handlers(&pair.bob_session);
+    pair.bob_session.register_handler("work/stall", |_params| {
+        std::future::pending::<Result<Value, JsonRpcError>>()
+    });
+
+    let started = Instant::now();
+    let err = pair
+        .alice_session
+        .call(&pair.bob_id, "work/stall", None)
+        .await
+        .expect_err("stalled handler must time out");
+    assert!(
+        matches!(err, BindingError::Timeout(d) if d == Duration::from_millis(500)),
+        "expected 500ms timeout, got {err:?}"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(10),
+        "timeout should fire at the configured 500ms, not hang"
+    );
+    // Timed-out request is evicted from the in-flight map.
+    assert_eq!(pair.alice_session.in_flight_len(), 0);
+
+    // The stall handler occupies only its own task: a follow-up unary call
+    // still round-trips.
+    let message = pair
+        .alice_session
+        .call(&pair.bob_id, "message/send", Some(message_send_params("after-timeout")))
+        .await?;
+    assert_eq!(
+        message["parts"][0]["text"],
+        Value::String("ack:after-timeout".to_string())
+    );
+    Ok(())
+}
+
+/// Concurrent interleaving: many in-flight unary calls across all three A2A
+/// methods (plus a delayed echo method) must each receive their own
+/// correlated response — corrIds never cross.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_calls_do_not_cross_correlation() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new().unwrap();
+    let Some(pair) = setup_pair(&temp_dir, Duration::from_secs(30)).await? else {
+        return Ok(());
+    };
+    register_a2a_handlers(&pair.bob_session);
+    pair.bob_session.register_handler("work/echo", |params| async move {
+        let i = params
+            .as_ref()
+            .and_then(|p| p.get("i"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        // Deterministic scatter so responses arrive out of order.
+        tokio::time::sleep(Duration::from_millis(((i * 37) % 5) * 10)).await;
+        Ok(serde_json::json!({"i": i, "echoed": true}))
+    });
+
+    let mut set = tokio::task::JoinSet::new();
+    for lane in 0..4u64 {
+        let session = Arc::clone(&pair.alice_session);
+        let bob_id = pair.bob_id;
+        set.spawn(async move {
+            session
+                .call(
+                    &bob_id,
+                    "message/send",
+                    Some(message_send_params(&format!("lane-{lane}"))),
+                )
+                .await
+                .map(|v| ("message/send".to_string(), lane, v))
+        });
+        let session = Arc::clone(&pair.alice_session);
+        let bob_id = pair.bob_id;
+        set.spawn(async move {
+            session
+                .call(
+                    &bob_id,
+                    "tasks/get",
+                    Some(serde_json::json!({"id": format!("get-{lane}")})),
+                )
+                .await
+                .map(|v| ("tasks/get".to_string(), lane, v))
+        });
+        let session = Arc::clone(&pair.alice_session);
+        let bob_id = pair.bob_id;
+        set.spawn(async move {
+            session
+                .call(
+                    &bob_id,
+                    "tasks/cancel",
+                    Some(serde_json::json!({"id": format!("cancel-{lane}")})),
+                )
+                .await
+                .map(|v| ("tasks/cancel".to_string(), lane, v))
+        });
+        let session = Arc::clone(&pair.alice_session);
+        let bob_id = pair.bob_id;
+        set.spawn(async move {
+            session
+                .call(&bob_id, "work/echo", Some(serde_json::json!({"i": lane})))
+                .await
+                .map(|v| ("work/echo".to_string(), lane, v))
+        });
+    }
+
+    let mut completed = 0usize;
+    while let Some(joined) = set.join_next().await {
+        let (method, lane, value) = joined.expect("call task panicked")?;
+        match method.as_str() {
+            "message/send" => assert_eq!(
+                value["parts"][0]["text"],
+                Value::String(format!("ack:lane-{lane}"))
+            ),
+            "tasks/get" => {
+                assert_eq!(value["id"], Value::String(format!("get-{lane}")));
+                assert_eq!(
+                    value["status"]["state"],
+                    Value::String("completed".to_string())
+                );
+            }
+            "tasks/cancel" => {
+                assert_eq!(value["id"], Value::String(format!("cancel-{lane}")));
+                assert_eq!(
+                    value["status"]["state"],
+                    Value::String("canceled".to_string())
+                );
+            }
+            "work/echo" => assert_eq!(value["i"], Value::from(lane)),
+            other => panic!("unexpected method {other}"),
+        }
+        completed += 1;
+    }
+    assert_eq!(completed, 16);
+    assert_eq!(pair.alice_session.in_flight_len(), 0);
+    Ok(())
+}

--- a/tests/a2a_binding_integration.rs
+++ b/tests/a2a_binding_integration.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 
+use serde_json::Value;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -19,7 +20,6 @@ use x0x::a2a::binding::{
 };
 use x0x::network::NetworkConfig;
 use x0x::{Agent, DiscoveredAgent};
-use serde_json::Value;
 
 fn loopback_network_config() -> NetworkConfig {
     NetworkConfig {
@@ -259,7 +259,10 @@ async fn unary_round_trip_over_dm() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     assert_eq!(message["kind"], Value::String("message".to_string()));
     assert_eq!(message["role"], Value::String("agent".to_string()));
-    assert_eq!(message["parts"][0]["text"], Value::String("ack:hello-a2a".to_string()));
+    assert_eq!(
+        message["parts"][0]["text"],
+        Value::String("ack:hello-a2a".to_string())
+    );
 
     let task = pair
         .alice_session
@@ -324,8 +327,8 @@ async fn unknown_method_returns_jsonrpc_error() -> Result<(), Box<dyn std::error
 /// in-flight entry is removed, and the session stays healthy for a
 /// follow-up call (no cross-talk with the stalled request).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn request_timeout_fires_and_session_stays_healthy(
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn request_timeout_fires_and_session_stays_healthy() -> Result<(), Box<dyn std::error::Error>>
+{
     let temp_dir = TempDir::new().unwrap();
     let Some(pair) = setup_pair(&temp_dir, Duration::from_millis(500)).await? else {
         return Ok(());
@@ -356,7 +359,11 @@ async fn request_timeout_fires_and_session_stays_healthy(
     // still round-trips.
     let message = pair
         .alice_session
-        .call(&pair.bob_id, "message/send", Some(message_send_params("after-timeout")))
+        .call(
+            &pair.bob_id,
+            "message/send",
+            Some(message_send_params("after-timeout")),
+        )
         .await?;
     assert_eq!(
         message["parts"][0]["text"],
@@ -369,8 +376,7 @@ async fn request_timeout_fires_and_session_stays_healthy(
 /// (HTTP-client-disconnect shape) and the peer never responds — the
 /// in-flight entry MUST be removed, not leaked for the session's life.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn dropped_call_future_cleans_in_flight_entry(
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn dropped_call_future_cleans_in_flight_entry() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new().unwrap();
     let Some(pair) = setup_pair(&temp_dir, Duration::from_secs(30)).await? else {
         return Ok(());
@@ -393,7 +399,9 @@ async fn dropped_call_future_cleans_in_flight_entry(
     // Caller "disconnects": the call future is dropped while awaiting a
     // response that will never come.
     handle.abort();
-    let join_err = handle.await.expect_err("aborted task must join as cancelled");
+    let join_err = handle
+        .await
+        .expect_err("aborted task must join as cancelled");
     assert!(join_err.is_cancelled());
 
     assert_eq!(
@@ -414,16 +422,17 @@ async fn concurrent_calls_do_not_cross_correlation() -> Result<(), Box<dyn std::
         return Ok(());
     };
     register_a2a_handlers(&pair.bob_session);
-    pair.bob_session.register_handler("work/echo", |params| async move {
-        let i = params
-            .as_ref()
-            .and_then(|p| p.get("i"))
-            .and_then(Value::as_u64)
-            .unwrap_or(0);
-        // Deterministic scatter so responses arrive out of order.
-        tokio::time::sleep(Duration::from_millis(((i * 37) % 5) * 10)).await;
-        Ok(serde_json::json!({"i": i, "echoed": true}))
-    });
+    pair.bob_session
+        .register_handler("work/echo", |params| async move {
+            let i = params
+                .as_ref()
+                .and_then(|p| p.get("i"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            // Deterministic scatter so responses arrive out of order.
+            tokio::time::sleep(Duration::from_millis(((i * 37) % 5) * 10)).await;
+            Ok(serde_json::json!({"i": i, "echoed": true}))
+        });
 
     let mut set = tokio::task::JoinSet::new();
     for lane in 0..4u64 {

--- a/tests/a2a_binding_integration.rs
+++ b/tests/a2a_binding_integration.rs
@@ -365,6 +365,45 @@ async fn request_timeout_fires_and_session_stays_healthy(
     Ok(())
 }
 
+/// Caller cancellation: the caller drops the `call` future mid-flight
+/// (HTTP-client-disconnect shape) and the peer never responds — the
+/// in-flight entry MUST be removed, not leaked for the session's life.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dropped_call_future_cleans_in_flight_entry(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new().unwrap();
+    let Some(pair) = setup_pair(&temp_dir, Duration::from_secs(30)).await? else {
+        return Ok(());
+    };
+    pair.bob_session.register_handler("work/stall", |_params| {
+        std::future::pending::<Result<Value, JsonRpcError>>()
+    });
+
+    let session = Arc::clone(&pair.alice_session);
+    let bob_id = pair.bob_id;
+    let handle = tokio::spawn(async move { session.call(&bob_id, "work/stall", None).await });
+
+    // Wait until the request is registered in-flight.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while pair.alice_session.in_flight_len() == 0 && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(pair.alice_session.in_flight_len(), 1);
+
+    // Caller "disconnects": the call future is dropped while awaiting a
+    // response that will never come.
+    handle.abort();
+    let join_err = handle.await.expect_err("aborted task must join as cancelled");
+    assert!(join_err.is_cancelled());
+
+    assert_eq!(
+        pair.alice_session.in_flight_len(),
+        0,
+        "dropped call future must not leak its in-flight waiter"
+    );
+    Ok(())
+}
+
 /// Concurrent interleaving: many in-flight unary calls across all three A2A
 /// methods (plus a delayed echo method) must each receive their own
 /// correlated response — corrIds never cross.


### PR DESCRIPTION
First increment of #112 (stays open for streaming/push/artifacts + live cross-client validation):

- Envelope codec ({x0xBinding, corrId, kind, jsonrpc}) over RawQuicAcked DM — versioned + additive: unknown versions/kinds are skipped cleanly, forward-added members tolerated
- Unary methods message/send, tasks/get, tasks/cancel with request/response correlation: UUIDv4 corrIds, waiter registered before send, timeout cleans the in-flight map, late responses dropped (never misdelivered), caller-cancellation cleans up via drop guard (review M1)
- JSON-RPC errors: -32601 unknown method, -32600 malformed, -32603 internal (incl. oversized-response path, review L1)
- Capability flags in the served AgentCard stay FALSE (streaming/push not shipped — regression-pinned)

Integration tests over the real two-agent DM path: round-trip, unknown method, timeout, concurrent interleaving (no corrId cross-talk), dropped-call-future cleanup.

Gates: fmt/clippy clean, 24/24 targeted + 5/5 integration tests. Adversarial review: SOUND (6/6 claims) after the cancellation-leak fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the first unary A2A-over-x0x transport binding. The main changes are:

- A versioned envelope codec over direct messages.
- Correlated unary JSON-RPC calls with timeout and cancellation cleanup.
- Asynchronous method handlers and response dispatch.
- Integration tests for round trips, errors, timeouts, cancellation, and concurrency.
- Capability tests keeping streaming and push disabled.

<h3>Confidence Score: 4/5</h3>

The response-validation and unbounded-handler paths need fixes before merging.

- Oversized results are silently converted into caller timeouts.
- Invalid JSON-RPC versions and response IDs are accepted.
- Responses are not tied to the peer selected by the caller.
- Slow inbound handlers can accumulate without a limit.
- Waiter registration, cancellation cleanup, and late-response dropping are otherwise sound.

src/a2a/binding.rs

<details open><summary><h3>Security Review</h3></summary>

Inbound requests can create an unbounded number of handler tasks. Responses are also correlated without binding them to the authenticated peer requested by the caller, allowing response substitution if another agent obtains an active correlation ID.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/a2a/binding.rs | Adds the envelope codec and unary session runtime, with gaps in response validation, oversized-result handling, panic handling, and request admission control. |
| src/a2a/mod.rs | Exports the binding module and pins unimplemented streaming and push capabilities to false. |
| tests/a2a_binding_integration.rs | Covers the main direct-message flow, correlation, timeout, cancellation, and concurrent calls. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant Client as Client BindingSession
    participant DM as x0x Direct Messaging
    participant Server as Server BindingSession
    participant Handler

    Caller->>Client: call(peer, method, params)
    Client->>Client: Generate corrId and register waiter
    Client->>DM: Request envelope
    DM->>Server: DirectMessage with authenticated source
    Server->>Handler: Dispatch params
    Handler-->>Server: Result or error
    Server->>DM: Response envelope
    DM->>Client: DirectMessage with response
    Note over Client: Validate source, corrId, JSON-RPC id, and version
    Client-->>Caller: Result or BindingError
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant Client as Client BindingSession
    participant DM as x0x Direct Messaging
    participant Server as Server BindingSession
    participant Handler

    Caller->>Client: call(peer, method, params)
    Client->>Client: Generate corrId and register waiter
    Client->>DM: Request envelope
    DM->>Server: DirectMessage with authenticated source
    Server->>Handler: Dispatch params
    Handler-->>Server: Result or error
    Server->>DM: Response envelope
    DM->>Client: DirectMessage with response
    Note over Client: Validate source, corrId, JSON-RPC id, and version
    Client-->>Caller: Result or BindingError
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 6 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 6
src/a2a/binding.rs:582-586
**Oversized Results Become Timeouts**

When a handler returns a result larger than the direct-message limit, this branch drops the response instead of sending the documented `-32603` error. The caller then waits until its request timeout even though the server has already finished processing the request.

### Issue 2 of 6
src/a2a/binding.rs:596-609
**Invalid JSON-RPC Versions Reach Handlers**

`JsonRpcRequest` accepts any string in `jsonrpc`, and dispatch never checks that it equals `"2.0"`. A request containing `"jsonrpc":"1.0"` or another value therefore invokes the application handler instead of returning `-32600`.

### Issue 3 of 6
src/a2a/binding.rs:615-624
**Responses Are Not Bound To Peers**

The waiter records only a correlation ID, and this path completes it without checking the authenticated DM source against the peer passed to `call`. If another reachable agent learns an in-flight correlation ID, its response can win the race and supply attacker-controlled data for a call addressed to a different peer.

### Issue 4 of 6
src/a2a/binding.rs:624-632
**Response Identity Is Not Validated**

After matching the envelope `corrId`, this path accepts a response without requiring `jsonrpc == "2.0"` or checking that its JSON-RPC `id` matches the request. A peer can return a mismatched or non-2.0 response that `call` reports as the requested operation's result.

### Issue 5 of 6
src/a2a/binding.rs:549-556
**Inbound Handlers Have No Bound**

Every request starts a task without a concurrency limit. A reachable peer can repeatedly invoke a slow or pending handler, causing live tasks and their captured request state to grow until the runtime or process is exhausted; reaping completed tasks does not bound pending ones.

### Issue 6 of 6
src/a2a/binding.rs:607-612
**Handler Panics Drop The Response**

If a registered handler panics, the spawned task exits without producing a JSON-RPC error. The remote caller remains blocked until the full request timeout instead of receiving an internal-error response.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix rustdoc intra-doc links to pri..."](https://github.com/saorsa-labs/x0x/commit/c8a712e88efcbd0d7072704850e84e5973a307b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45237802)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->