### PR TITLE
fix(net): #206 — isolate co-located gossip planes (mDNS/cache path gating)

### DIFF
--- a/docs/trust-and-connectivity.md
+++ b/docs/trust-and-connectivity.md
@@ -101,3 +101,76 @@ revoke that agent.
 (`relay_refused_not_a_contact`, `relay_refused_blocked`, `relay_refused_rate_limited`,
 `relay_refused_bandwidth_exceeded`) plus `relay_forward_bytes` (total bytes
 committed to forward) so operators can see and alert on refusals.
+
+## Gossip-plane isolation (#206)
+
+Co-located daemons (prod + testnet on one host) discovered each other via
+ant-quic's first-party mDNS (`_ant-quic._udp.local.`, no namespace) and
+auto-connected, regardless of `--no-hard-coded-bootstrap`. Every transport
+connection became a gossip carrier — PlumTree eager sets are seeded from
+the live connection table — so revocations and CRDT state crossed planes,
+and the cross-plane peer persisted in each plane's bootstrap cache, making
+the contamination survive restarts.
+
+### The plane hello
+
+`NetworkConfig.network_id = Some(id)` puts a node on a named gossip plane.
+Every new connection (any source: mDNS auto-connect, bootstrap dial, cache
+redial, inbound accept) then exchanges a one-frame plane hello
+(`[0x20][len][plane_id]` on the gossip data channel; unknown to older
+peers, who drop it harmlessly):
+
+- **Matching plane** → the peer is *cleared* and becomes gossip-eligible.
+- **Mismatched plane** → the peer is evicted from the bootstrap cache and
+  disconnected with a `PolicyRejection` tombstone (never proactively
+  redialed). Hard refusal.
+- **No hello** (pre-#206 code, open-plane embedders) → the peer is held
+  out of gossip sets for a 10 s legacy grace window, then admitted. This
+  keeps rolling upgrades from partitioning the fleet; full isolation
+  requires both sides on the new code.
+
+Until cleared, a peer is excluded from eager sets, membership keepalives,
+and CRDT sync targets, and its inbound gossip frames are dropped — the
+handshake window carries no gossip in either direction. The DM bytes
+(0x10/0x11) deliberately bypass the gate: direct messaging is
+authenticated agent-to-agent traffic, and an agent deliberately bridging
+planes is operator behaviour, not a discovery bug.
+
+### Configuration
+
+| TOML `network_id` | Effective plane |
+|---|---|
+| unset | `x0x.prod` (well-known default; prod, `x0xd-443`, and personal named instances all land here and keep meshing) |
+| `""` (empty) | open — no isolation (embedders/legacy rigs that deliberately bridge) |
+| any valid id | that plane, e.g. `"x0x.testnet"` |
+
+Plane ids are ≤64 bytes of ASCII alphanumerics plus `.`, `-`, `_`
+(`x0x::network::validate_plane_id`). The library default
+(`NetworkConfig::default()`) is open; the daemon maps unset to
+`x0x.prod`, so **planes are isolated by default once each declares its
+id** — the co-located testnet needs one line in
+`/etc/x0x/config-testnet.toml`:
+
+```toml
+network_id = "x0x.testnet"
+```
+
+The bootstrap peer cache is now strictly per-data-dir
+(`<data_dir>/peers`); the former shared-default arm (the #189 shape) is
+removed.
+
+### Downstream (ant-quic) need
+
+x0x cannot disable ant-quic's mDNS or set its namespace today:
+`ant-quic` 0.27.33's `NodeConfig` (the API x0x uses) exposes no mDNS
+knob — `MdnsConfig` (enabled / service / namespace / auto_connect) only
+exists on `P2pConfig`, which `Node::with_config` fills with
+`DiscoveryPolicy::current_default()` (mDNS on, `namespace: None`,
+auto-connect on). The gossip-layer plane hello above is therefore the
+enforcement point, and cross-plane mDNS auto-connects still happen and
+are refused after one frame (small connect/refuse churn per mDNS
+re-resolution). The proper downstream fix is a `NodeConfig` mDNS knob so
+x0x can map `network_id` → mDNS namespace (cross-plane peers are then
+never dial candidates at all) and/or disable mDNS entirely for
+server-class daemons. Filed as a doc note here until an ant-quic release
+ships the surface.

--- a/src/gossip/pubsub.rs
+++ b/src/gossip/pubsub.rs
@@ -690,9 +690,11 @@ impl PubSubManager {
     /// for existing topics. Without this, a peer that connects after a topic
     /// is subscribed would never receive messages on that topic from this node.
     pub async fn refresh_topic_peers(&self) {
+        // Issue #206: plane-gated peer view — only plane-cleared peers may
+        // enter PlumTree eager sets.
         let peers: Vec<PeerId> = self
             .network
-            .connected_peers()
+            .gossip_plane_peers()
             .await
             .into_iter()
             .map(|peer| PeerId::new(peer.0))
@@ -748,9 +750,10 @@ impl PubSubManager {
 
     /// Initialize PlumTree peers for a topic from currently connected peers.
     async fn initialize_topic_peers(&self, topic: TopicId) {
+        // Issue #206: plane-gated peer view (see refresh_topic_peers).
         let peers: Vec<PeerId> = self
             .network
-            .connected_peers()
+            .gossip_plane_peers()
             .await
             .into_iter()
             .map(|peer| PeerId::new(peer.0))

--- a/src/gossip/runtime.rs
+++ b/src/gossip/runtime.rs
@@ -1021,7 +1021,9 @@ impl GossipRuntime {
             *guard = Some(peer_sync_handle);
         }
 
-        // Keepalive: send a SWIM Ping to every connected peer every 15 seconds.
+        // Keepalive: send a SWIM Ping to every connected plane-cleared peer
+        // every 15 seconds (issue #206: peers held at the plane gate get no
+        // keepalives — we want their QUIC to idle out, not stay warm).
         // This prevents QUIC idle timeout (30s) from dropping direct connections
         // that were established via auto-connect. Without this, connections with
         // no application traffic are closed by QUIC after 30s of inactivity.
@@ -1032,7 +1034,7 @@ impl GossipRuntime {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
-                let peers = keepalive_network.connected_peers().await;
+                let peers = keepalive_network.gossip_plane_peers().await;
                 for peer in peers {
                     let gossip_peer = PeerId::new(peer.0);
                     if let Err(e) = keepalive_membership.send_ping(gossip_peer).await {

--- a/src/network.rs
+++ b/src/network.rs
@@ -2739,9 +2739,7 @@ impl NetworkNode {
             debug!("NetworkNode plane gatekeeper started");
             let mut lifecycle = {
                 let guard = node.read().await;
-                guard
-                    .as_ref()
-                    .map(|node| node.subscribe_all_peer_events())
+                guard.as_ref().map(|node| node.subscribe_all_peer_events())
             };
             loop {
                 let event = tokio::select! {
@@ -2776,8 +2774,7 @@ impl NetworkNode {
                         ant_quic::PeerId(peer_id),
                         ant_quic::PeerLifecycleEvent::Established { .. },
                     ) => {
-                        plane_note_connected(&plane_id, &plane_peers, &node, peer_id, false)
-                            .await;
+                        plane_note_connected(&plane_id, &plane_peers, &node, peer_id, false).await;
                     }
                     GatekeeperEvent::Lifecycle(
                         ant_quic::PeerId(peer_id),
@@ -2786,8 +2783,7 @@ impl NetworkNode {
                         // A fresh connection generation for a peer we may
                         // already have cleared: re-gate until its hello on
                         // the new connection re-verifies the plane.
-                        plane_note_connected(&plane_id, &plane_peers, &node, peer_id, true)
-                            .await;
+                        plane_note_connected(&plane_id, &plane_peers, &node, peer_id, true).await;
                     }
                     GatekeeperEvent::Network(NetworkEvent::PeerDisconnected {
                         peer_id, ..
@@ -3372,15 +3368,10 @@ impl NetworkNode {
                         // penalty — the peer simply stays pending.
                         if type_byte == PLANE_HELLO_STREAM_TYPE {
                             let len = data.get(1).map(|b| usize::from(*b));
-                            let plane_bytes =
-                                len.and_then(|n| data.get(2..2 + n));
+                            let plane_bytes = len.and_then(|n| data.get(2..2 + n));
                             match plane_bytes.and_then(|b| std::str::from_utf8(b).ok()) {
-                                Some(their_plane)
-                                    if validate_plane_id(their_plane).is_ok() =>
-                                {
-                                    plane_node
-                                        .plane_handle_hello(peer_id, their_plane)
-                                        .await;
+                                Some(their_plane) if validate_plane_id(their_plane).is_ok() => {
+                                    plane_node.plane_handle_hello(peer_id, their_plane).await;
                                 }
                                 _ => {
                                     warn!(

--- a/src/network.rs
+++ b/src/network.rs
@@ -1044,6 +1044,15 @@ const PLANE_LEGACY_GRACE: Duration = Duration::from_secs(10);
 /// requires a daemon restart, well outside this window's risk envelope.
 const PLANE_REVERIFY_TTL: Duration = Duration::from_secs(600);
 
+/// How often the gatekeeper re-sends our plane hello to peers still Pending
+/// (issue #206). The connect-time hello send is best-effort on a connection
+/// that may still be settling; without a retry, one lost hello leaves both
+/// sides Pending until [`PLANE_LEGACY_GRACE`] silently admits a NEW-code
+/// cross-plane peer as legacy. Retrying every 2s gives ~4 further chances
+/// inside the grace window, so legacy admission is reserved for peers that
+/// genuinely never speak the hello protocol.
+const PLANE_HELLO_RETRY_INTERVAL: Duration = Duration::from_secs(2);
+
 /// Per-peer gossip-plane state, tracked only when plane isolation is
 /// configured (`NetworkConfig::network_id` is `Some`).
 #[derive(Debug, Clone, Copy)]
@@ -2812,8 +2821,37 @@ impl NetworkNode {
                 let guard = node.read().await;
                 guard.as_ref().map(|node| node.subscribe_all_peer_events())
             };
+            // Hello sends are best-effort on a connection that may still be
+            // settling; a lost hello must not degrade a new-code cross-plane
+            // peer into a legacy-grace admit. Re-send to every still-Pending
+            // peer on a short tick until it clears, is refused, or the grace
+            // admits it as genuinely legacy.
+            let mut rehello = tokio::time::interval(PLANE_HELLO_RETRY_INTERVAL);
+            rehello.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
                 let event = tokio::select! {
+                    _ = rehello.tick() => {
+                        let pending: Vec<AntPeerId> = {
+                            let map = match plane_peers.lock() {
+                                Ok(m) => m,
+                                Err(poisoned) => poisoned.into_inner(),
+                            };
+                            map.iter()
+                                .filter(|(_, s)| matches!(s, PlanePeerState::Pending { .. }))
+                                .map(|(p, _)| *p)
+                                .collect()
+                        };
+                        if !pending.is_empty() {
+                            let frame = build_plane_hello_frame(&plane_id);
+                            let guard = node.read().await;
+                            if let Some(node) = guard.as_ref() {
+                                for peer in pending {
+                                    let _ = node.send(&peer, &frame).await;
+                                }
+                            }
+                        }
+                        continue;
+                    }
                     event = events.recv() => {
                         match event {
                             Ok(event) => GatekeeperEvent::Network(event),

--- a/src/network.rs
+++ b/src/network.rs
@@ -1024,6 +1024,16 @@ pub const MAX_PLANE_ID_LEN: usize = 64;
 /// only ever gates truly legacy peers.
 const PLANE_LEGACY_GRACE: Duration = Duration::from_secs(10);
 
+/// How long a successful plane verification stays trusted across connection
+/// generations (issue #206). Connection churn (mutual-dial supersedes,
+/// proactive reconnects) replaces connections many times per minute under
+/// load; a peer whose hello already matched our plane must not lose gossip
+/// eligibility — and have its in-flight gossip frames (including DM-inbox
+/// delivery) dropped — on every generation. A mismatched hello still refuses
+/// the peer immediately and purges this cache; a plane change in practice
+/// requires a daemon restart, well outside this window's risk envelope.
+const PLANE_REVERIFY_TTL: Duration = Duration::from_secs(600);
+
 /// Per-peer gossip-plane state, tracked only when plane isolation is
 /// configured (`NetworkConfig::network_id` is `Some`).
 #[derive(Debug, Clone, Copy)]
@@ -1467,6 +1477,13 @@ pub struct NetworkNode {
     /// grace expiry. Mismatched peers are tombstoned + disconnected and
     /// removed here.
     plane_peers: Arc<Mutex<HashMap<AntPeerId, PlanePeerState>>>,
+    /// Last successful plane verification per peer (issue #206). Unlike
+    /// [`Self::plane_peers`] this survives disconnects and connection
+    /// replacement: within [`PLANE_REVERIFY_TTL`] a reconnecting peer is
+    /// re-admitted as [`PlanePeerState::Cleared`] instead of re-gated, so
+    /// connection churn cannot black-hole its gossip frames. Purged on a
+    /// mismatched hello.
+    plane_cleared_at: Arc<Mutex<HashMap<AntPeerId, Instant>>>,
     /// Handles to the background tasks spawned at construction (receiver, accept
     /// loop, connection-pool eviction).
     ///
@@ -1633,6 +1650,7 @@ impl NetworkNode {
             liveness_repair_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_LIVENESS_REPAIRS)),
             reconnect_suppressions: Arc::new(Mutex::new(HashMap::new())),
             plane_peers: Arc::new(Mutex::new(HashMap::new())),
+            plane_cleared_at: Arc::new(Mutex::new(HashMap::new())),
             background_tasks: Arc::new(Mutex::new(Vec::new())),
         };
 
@@ -2624,10 +2642,15 @@ impl NetworkNode {
         };
         let now = Instant::now();
         // A peer with no recorded connect event (e.g. the gatekeeper task has
-        // not dequeued it yet) enters as pending-from-now.
-        let entry = map
-            .entry(*peer)
-            .or_insert(PlanePeerState::Pending { since: now });
+        // not dequeued it yet) enters as pending-from-now — unless its plane
+        // was verified within [`PLANE_REVERIFY_TTL`], in which case it stays
+        // cleared across the connection generation (issue #206 churn fix).
+        let seed = if plane_recently_cleared(&self.plane_cleared_at, peer) {
+            PlanePeerState::Cleared
+        } else {
+            PlanePeerState::Pending { since: now }
+        };
+        let entry = map.entry(*peer).or_insert(seed);
         match entry {
             PlanePeerState::Cleared => true,
             PlanePeerState::Pending { since } => {
@@ -2671,11 +2694,14 @@ impl NetworkNode {
             return;
         };
         if their_plane == our_plane {
-            let mut map = match self.plane_peers.lock() {
-                Ok(m) => m,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            map.insert(peer, PlanePeerState::Cleared);
+            {
+                let mut map = match self.plane_peers.lock() {
+                    Ok(m) => m,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                map.insert(peer, PlanePeerState::Cleared);
+            }
+            record_plane_cleared(&self.plane_cleared_at, peer);
             tracing::debug!(
                 target: "x0x::connect",
                 peer_id_prefix = %hex_prefix(&peer.0, 4),
@@ -2697,6 +2723,13 @@ impl NetworkNode {
                 Err(poisoned) => poisoned.into_inner(),
             };
             map.remove(&peer);
+        }
+        {
+            let mut cleared = match self.plane_cleared_at.lock() {
+                Ok(m) => m,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            cleared.remove(&peer);
         }
         if let Some(cache) = &self.bootstrap_cache {
             cache.remove(&peer).await;
@@ -2732,6 +2765,7 @@ impl NetworkNode {
             return tokio::spawn(async {});
         };
         let plane_peers = Arc::clone(&self.plane_peers);
+        let plane_cleared_at = Arc::clone(&self.plane_cleared_at);
         let node = Arc::clone(&self.node);
         let mut events = self.event_sender.subscribe();
 
@@ -2774,7 +2808,15 @@ impl NetworkNode {
                         ant_quic::PeerId(peer_id),
                         ant_quic::PeerLifecycleEvent::Established { .. },
                     ) => {
-                        plane_note_connected(&plane_id, &plane_peers, &node, peer_id, false).await;
+                        plane_note_connected(
+                            &plane_id,
+                            &plane_peers,
+                            &plane_cleared_at,
+                            &node,
+                            peer_id,
+                            false,
+                        )
+                        .await;
                     }
                     GatekeeperEvent::Lifecycle(
                         ant_quic::PeerId(peer_id),
@@ -2783,7 +2825,15 @@ impl NetworkNode {
                         // A fresh connection generation for a peer we may
                         // already have cleared: re-gate until its hello on
                         // the new connection re-verifies the plane.
-                        plane_note_connected(&plane_id, &plane_peers, &node, peer_id, true).await;
+                        plane_note_connected(
+                            &plane_id,
+                            &plane_peers,
+                            &plane_cleared_at,
+                            &node,
+                            peer_id,
+                            true,
+                        )
+                        .await;
                     }
                     GatekeeperEvent::Network(NetworkEvent::PeerDisconnected {
                         peer_id, ..
@@ -3653,30 +3703,63 @@ enum GatekeeperEvent {
 /// entry is kept (the peer's hello may have raced ahead and already cleared
 /// it); with `reset = true` (lifecycle `Replaced`) the peer is re-gated
 /// until its hello on the new connection generation re-verifies the plane.
+/// Record a successful plane verification for `peer` (issue #206), pruning
+/// expired entries opportunistically so the map stays bounded.
+fn record_plane_cleared(cleared_at: &Arc<Mutex<HashMap<AntPeerId, Instant>>>, peer: AntPeerId) {
+    let mut map = match cleared_at.lock() {
+        Ok(m) => m,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let now = Instant::now();
+    if map.len() >= 1024 {
+        map.retain(|_, at| now.duration_since(*at) < PLANE_REVERIFY_TTL);
+    }
+    map.insert(peer, now);
+}
+
+/// True if `peer`'s plane was verified within [`PLANE_REVERIFY_TTL`].
+fn plane_recently_cleared(
+    cleared_at: &Arc<Mutex<HashMap<AntPeerId, Instant>>>,
+    peer: &AntPeerId,
+) -> bool {
+    let map = match cleared_at.lock() {
+        Ok(m) => m,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    map.get(peer)
+        .is_some_and(|at| at.elapsed() < PLANE_REVERIFY_TTL)
+}
+
 async fn plane_note_connected(
     plane_id: &str,
     plane_peers: &Arc<Mutex<HashMap<AntPeerId, PlanePeerState>>>,
+    plane_cleared_at: &Arc<Mutex<HashMap<AntPeerId, Instant>>>,
     node: &Arc<RwLock<Option<Node>>>,
     peer_id: [u8; 32],
     reset: bool,
 ) {
     let peer = ant_quic::PeerId(peer_id);
+    // A peer whose plane was verified within PLANE_REVERIFY_TTL keeps its
+    // clearance across connection generations: churn (supersedes, proactive
+    // reconnects) must not re-gate it and black-hole its gossip frames. The
+    // hello is still (re)sent below, so a genuine plane change is refused by
+    // the mismatch path, which also purges the clearance.
+    let seed = if plane_recently_cleared(plane_cleared_at, &peer) {
+        PlanePeerState::Cleared
+    } else {
+        PlanePeerState::Pending {
+            since: Instant::now(),
+        }
+    };
     {
         let mut map = match plane_peers.lock() {
             Ok(m) => m,
             Err(poisoned) => poisoned.into_inner(),
         };
         if reset {
-            map.insert(
-                peer,
-                PlanePeerState::Pending {
-                    since: Instant::now(),
-                },
-            );
+            map.insert(peer, seed);
         } else {
-            map.entry(peer).or_insert(PlanePeerState::Pending {
-                since: Instant::now(),
-            });
+            map.entry(peer).or_insert(seed);
         }
     }
     let frame = build_plane_hello_frame(plane_id);

--- a/src/network.rs
+++ b/src/network.rs
@@ -3404,7 +3404,7 @@ impl NetworkNode {
                         // bypass this gate — the DM plane is authenticated
                         // agent-to-agent traffic, out of #206's gossip-plane
                         // scope (see docs/trust-and-connectivity.md).
-                        if matches!(GossipStreamType::from_byte(type_byte), Some(_))
+                        if GossipStreamType::from_byte(type_byte).is_some()
                             && !plane_node.plane_gate_allows(&peer_id)
                         {
                             continue;

--- a/src/network.rs
+++ b/src/network.rs
@@ -245,6 +245,26 @@ pub struct NetworkConfig {
     /// `[peer_relay] enabled = true` in TOML.
     #[serde(default)]
     pub peer_relay: PeerRelayConfig,
+
+    /// Gossip-plane identifier (issue #206).
+    ///
+    /// When `Some(id)`, this node exchanges a plane hello on every new
+    /// connection and refuses gossip traffic with peers on a different
+    /// plane: mismatched peers are disconnected with a
+    /// [`DisconnectReason::PolicyRejection`] tombstone (never proactively
+    /// redialed, evicted from the bootstrap cache), and every peer stays
+    /// ineligible as a gossip carrier — PlumTree eager sets, pubsub/CRDT
+    /// fanout, inbound gossip frames — until plane-cleared. Peers that
+    /// present no hello (pre-#206 code, open-plane embedders) are admitted
+    /// as legacy after a short grace window so rolling upgrades do not
+    /// partition the fleet.
+    ///
+    /// `None` (library default) = open plane: no hellos sent, no gating —
+    /// identical to pre-#206 behaviour. The x0xd daemon maps an unset TOML
+    /// `network_id` to the well-known prod plane instead; see
+    /// `server::DaemonConfig::resolved_network_id`.
+    #[serde(default)]
+    pub network_id: Option<String>,
 }
 
 /// X0X-0070b: TOML-shaped configuration for the peer-relay fallback
@@ -459,6 +479,7 @@ impl Default for NetworkConfig {
             max_peers_per_ip: 3,
             port_mapping_enabled: true,
             peer_relay: PeerRelayConfig::default(),
+            network_id: None,
         }
     }
 }
@@ -984,6 +1005,70 @@ pub const DIRECT_MESSAGE_STREAM_TYPE: u8 = 0x10;
 /// clean.
 pub const RELAYED_DM_STREAM_TYPE: u8 = 0x11;
 
+/// Stream type byte for the gossip-plane hello handshake (issue #206).
+///
+/// Sits in x0x's control region above the DM bytes. Frame layout:
+/// `[0x20][len: u8][plane_id: len bytes UTF-8]`. Older peers without this
+/// receiver arm hit the "Unknown stream type byte" path at the inbound
+/// parser and drop the frame — wire-additive demux, forward-compat clean
+/// (same pattern as [`RELAYED_DM_STREAM_TYPE`]).
+pub const PLANE_HELLO_STREAM_TYPE: u8 = 0x20;
+
+/// Maximum plane-id length accepted on the wire (bytes of UTF-8).
+pub const MAX_PLANE_ID_LEN: usize = 64;
+
+/// Grace window for peers that never send a plane hello (legacy pre-#206
+/// peers and open-plane embedders). A pending peer is admitted as legacy
+/// after this elapses. New-code cross-plane peers present a mismatched hello
+/// within milliseconds of connecting, long before grace expiry, so the grace
+/// only ever gates truly legacy peers.
+const PLANE_LEGACY_GRACE: Duration = Duration::from_secs(10);
+
+/// Per-peer gossip-plane state, tracked only when plane isolation is
+/// configured (`NetworkConfig::network_id` is `Some`).
+#[derive(Debug, Clone, Copy)]
+enum PlanePeerState {
+    /// Connected; awaiting the peer's plane hello. Gossip to and from this
+    /// peer is held until the peer is cleared.
+    Pending {
+        /// When the connection was registered (drives legacy grace).
+        since: Instant,
+    },
+    /// Plane verified: the peer's hello matched our plane, or the peer was
+    /// admitted as legacy after [`PLANE_LEGACY_GRACE`].
+    Cleared,
+}
+
+/// Validate a gossip-plane identifier (issue #206).
+///
+/// Plane ids ride the plane-hello frame length-prefixed with a `u8`, so they
+/// are bounded to [`MAX_PLANE_ID_LEN`] bytes of UTF-8. The character set is
+/// deliberately boring — ASCII alphanumerics plus `.`, `-`, `_` — so ids can
+/// double as config tokens, log labels, and future DNS-safe names.
+///
+/// # Errors
+///
+/// Returns a human-readable reason when the id is empty, too long, or
+/// contains characters outside the allowed set.
+pub fn validate_plane_id(id: &str) -> Result<(), String> {
+    if id.is_empty() {
+        return Err("plane id must not be empty".to_string());
+    }
+    if id.len() > MAX_PLANE_ID_LEN {
+        return Err(format!(
+            "plane id exceeds {MAX_PLANE_ID_LEN} bytes ({} given)",
+            id.len()
+        ));
+    }
+    if let Some(bad) = id
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_')))
+    {
+        return Err(format!("plane id contains invalid character {bad:?}"));
+    }
+    Ok(())
+}
+
 /// X0X-0070b: triple shipped on the inbound RelayedDm channel.
 ///
 /// 1. `AntPeerId` - the ant-quic PeerId of the *relay* peer (the QUIC
@@ -1375,6 +1460,13 @@ pub struct NetworkNode {
     /// ignoring an operator teardown. See [`DisconnectReason`] and
     /// [`NetworkNode::is_reconnect_suppressed`].
     reconnect_suppressions: Arc<Mutex<HashMap<[u8; 32], ReconnectSuppression>>>,
+    /// Gossip-plane bookkeeping per connected peer (issue #206). Populated
+    /// only when `config.network_id` is `Some`: peers start
+    /// [`PlanePeerState::Pending`] and are promoted to
+    /// [`PlanePeerState::Cleared`] by a matching plane hello or by legacy
+    /// grace expiry. Mismatched peers are tombstoned + disconnected and
+    /// removed here.
+    plane_peers: Arc<Mutex<HashMap<AntPeerId, PlanePeerState>>>,
     /// Handles to the background tasks spawned at construction (receiver, accept
     /// loop, connection-pool eviction).
     ///
@@ -1478,6 +1570,13 @@ impl NetworkNode {
             builder = builder.bootstrap_cache(cache_config);
         }
 
+        // Issue #206: validate the gossip-plane id up front so a malformed
+        // value fails node construction loudly instead of silently disabling
+        // isolation.
+        if let Some(id) = &config.network_id {
+            validate_plane_id(id).map_err(NetworkError::NodeCreation)?;
+        }
+
         let node = Node::with_config(builder.build()).await.map_err(|e| {
             NetworkError::NodeCreation(format!("Failed to create ant-quic node: {}", e))
         })?;
@@ -1533,20 +1632,26 @@ impl NetworkNode {
             liveness_last_ready: Arc::new(Mutex::new(HashMap::new())),
             liveness_repair_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_LIVENESS_REPAIRS)),
             reconnect_suppressions: Arc::new(Mutex::new(HashMap::new())),
+            plane_peers: Arc::new(Mutex::new(HashMap::new())),
             background_tasks: Arc::new(Mutex::new(Vec::new())),
         };
 
         let receiver = network_node.spawn_receiver();
         let accept = network_node.spawn_accept_loop();
         let eviction = network_node.spawn_connection_pool_eviction();
+        let plane_gatekeeper = network_node.spawn_plane_gatekeeper();
         // Record the handles so `shutdown` can abort them (letting it take the
         // node write lock and shut the node down without deadlocking). This runs
         // at construction before the node is shared, so there is no contention;
         // if the lock is somehow poisoned, recover the guard rather than panic
         // (the handles are only used for clean teardown).
         match network_node.background_tasks.lock() {
-            Ok(mut tasks) => tasks.extend([receiver, accept, eviction]),
-            Err(poisoned) => poisoned.into_inner().extend([receiver, accept, eviction]),
+            Ok(mut tasks) => tasks.extend([receiver, accept, eviction, plane_gatekeeper]),
+            Err(poisoned) => {
+                poisoned
+                    .into_inner()
+                    .extend([receiver, accept, eviction, plane_gatekeeper])
+            }
         }
 
         Ok(network_node)
@@ -2501,6 +2606,209 @@ impl NetworkNode {
         live
     }
 
+    /// Gossip-plane gate (issue #206).
+    ///
+    /// Returns `true` when gossip traffic with `peer` is plane-allowed:
+    /// always when isolation is off (`network_id` unset); only for
+    /// plane-cleared peers when on. Pending peers are promoted to
+    /// legacy-cleared once [`PLANE_LEGACY_GRACE`] elapses — peers running
+    /// pre-#206 code never send a hello, and refusing them forever would
+    /// partition a mixed-version fleet.
+    fn plane_gate_allows(&self, peer: &AntPeerId) -> bool {
+        if self.config.network_id.is_none() {
+            return true;
+        }
+        let mut map = match self.plane_peers.lock() {
+            Ok(m) => m,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let now = Instant::now();
+        // A peer with no recorded connect event (e.g. the gatekeeper task has
+        // not dequeued it yet) enters as pending-from-now.
+        let entry = map
+            .entry(*peer)
+            .or_insert(PlanePeerState::Pending { since: now });
+        match entry {
+            PlanePeerState::Cleared => true,
+            PlanePeerState::Pending { since } => {
+                if now.duration_since(*since) >= PLANE_LEGACY_GRACE {
+                    *entry = PlanePeerState::Cleared;
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Connected peers eligible as gossip carriers under plane isolation
+    /// (issue #206): all connected peers when isolation is off, only
+    /// plane-cleared peers when on. Use this instead of
+    /// [`Self::connected_peers`] when seeding gossip peer sets (PlumTree
+    /// eager sets, membership keepalives) so a cross-plane or not-yet-
+    /// verified peer never enters the gossip plane.
+    pub(crate) async fn gossip_plane_peers(&self) -> Vec<AntPeerId> {
+        let connected = self.connected_peers().await;
+        if self.config.network_id.is_none() {
+            return connected;
+        }
+        connected
+            .into_iter()
+            .filter(|peer| self.plane_gate_allows(peer))
+            .collect()
+    }
+
+    /// Handle an inbound plane hello (issue #206).
+    ///
+    /// Matching plane: the peer is cleared for gossip. Mismatched plane:
+    /// the peer is a cross-plane contaminant — it is evicted from the
+    /// bootstrap cache (so it cannot persist into the next restart's
+    /// Phase 0/1 redials) and disconnected with a
+    /// [`DisconnectReason::PolicyRejection`] tombstone so no reconnect
+    /// path re-dials it.
+    async fn plane_handle_hello(&self, peer: AntPeerId, their_plane: &str) {
+        let Some(our_plane) = &self.config.network_id else {
+            return;
+        };
+        if their_plane == our_plane {
+            let mut map = match self.plane_peers.lock() {
+                Ok(m) => m,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            map.insert(peer, PlanePeerState::Cleared);
+            tracing::debug!(
+                target: "x0x::connect",
+                peer_id_prefix = %hex_prefix(&peer.0, 4),
+                plane = %our_plane,
+                "gossip-plane peer cleared"
+            );
+            return;
+        }
+        tracing::warn!(
+            target: "x0x::connect",
+            peer_id_prefix = %hex_prefix(&peer.0, 4),
+            our_plane = %our_plane,
+            their_plane = %their_plane,
+            "gossip-plane mismatch: refusing cross-plane peer (issue #206)"
+        );
+        {
+            let mut map = match self.plane_peers.lock() {
+                Ok(m) => m,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            map.remove(&peer);
+        }
+        if let Some(cache) = &self.bootstrap_cache {
+            cache.remove(&peer).await;
+        }
+        if let Err(e) = self
+            .disconnect_with_reason(&peer, DisconnectReason::PolicyRejection)
+            .await
+        {
+            tracing::debug!(
+                target: "x0x::connect",
+                peer_id_prefix = %hex_prefix(&peer.0, 4),
+                error = %e,
+                "cross-plane peer disconnect after plane mismatch failed"
+            );
+        }
+    }
+
+    /// Spawn the plane gatekeeper task (issue #206).
+    ///
+    /// Subscribes to BOTH connection signals:
+    /// - the x0x network event stream (outbound dials, inbound accepts,
+    ///   pool/admin disconnects), and
+    /// - ant-quic's peer-lifecycle stream, which additionally covers
+    ///   connections ant-quic creates internally — first-party mDNS
+    ///   auto-connect, the #206 contamination vector — without any x0x
+    ///   dial or accept passing through `NetworkEvent::PeerConnected`.
+    ///
+    /// On connect it registers the peer as plane-pending and sends our
+    /// plane hello; on disconnect it drops the bookkeeping so a later
+    /// reconnect re-verifies. A no-op task when isolation is off.
+    fn spawn_plane_gatekeeper(&self) -> tokio::task::JoinHandle<()> {
+        let Some(plane_id) = self.config.network_id.clone() else {
+            return tokio::spawn(async {});
+        };
+        let plane_peers = Arc::clone(&self.plane_peers);
+        let node = Arc::clone(&self.node);
+        let mut events = self.event_sender.subscribe();
+
+        tokio::spawn(async move {
+            debug!("NetworkNode plane gatekeeper started");
+            let mut lifecycle = {
+                let guard = node.read().await;
+                guard
+                    .as_ref()
+                    .map(|node| node.subscribe_all_peer_events())
+            };
+            loop {
+                let event = tokio::select! {
+                    event = events.recv() => {
+                        match event {
+                            Ok(event) => GatekeeperEvent::Network(event),
+                            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                            Err(broadcast::error::RecvError::Closed) => break,
+                        }
+                    }
+                    lifecycle_event = async {
+                        match lifecycle.as_mut() {
+                            Some(rx) => rx.recv().await,
+                            None => std::future::pending().await,
+                        }
+                    } => {
+                        match lifecycle_event {
+                            Ok((peer, event)) => GatekeeperEvent::Lifecycle(peer, event),
+                            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                            Err(broadcast::error::RecvError::Closed) => {
+                                // Node is gone (shutdown): stop listening on
+                                // this arm but keep draining network events.
+                                lifecycle = None;
+                                continue;
+                            }
+                        }
+                    }
+                };
+                match event {
+                    GatekeeperEvent::Network(NetworkEvent::PeerConnected { peer_id, .. })
+                    | GatekeeperEvent::Lifecycle(
+                        ant_quic::PeerId(peer_id),
+                        ant_quic::PeerLifecycleEvent::Established { .. },
+                    ) => {
+                        plane_note_connected(&plane_id, &plane_peers, &node, peer_id, false)
+                            .await;
+                    }
+                    GatekeeperEvent::Lifecycle(
+                        ant_quic::PeerId(peer_id),
+                        ant_quic::PeerLifecycleEvent::Replaced { .. },
+                    ) => {
+                        // A fresh connection generation for a peer we may
+                        // already have cleared: re-gate until its hello on
+                        // the new connection re-verifies the plane.
+                        plane_note_connected(&plane_id, &plane_peers, &node, peer_id, true)
+                            .await;
+                    }
+                    GatekeeperEvent::Network(NetworkEvent::PeerDisconnected {
+                        peer_id, ..
+                    })
+                    | GatekeeperEvent::Lifecycle(
+                        ant_quic::PeerId(peer_id),
+                        ant_quic::PeerLifecycleEvent::Closed { .. },
+                    ) => {
+                        let mut map = match plane_peers.lock() {
+                            Ok(m) => m,
+                            Err(poisoned) => poisoned.into_inner(),
+                        };
+                        map.remove(&ant_quic::PeerId(peer_id));
+                    }
+                    _ => {}
+                }
+            }
+            debug!("NetworkNode plane gatekeeper stopped");
+        })
+    }
+
     /// Get list of connected peer IDs.
     ///
     /// # Returns
@@ -2916,6 +3224,10 @@ impl NetworkNode {
         let recv_pump_diagnostics = Arc::clone(&self.recv_pump_diagnostics);
         let direct_tx = self.direct_tx.clone();
         let relayed_dm_tx = self.relayed_dm_tx.clone();
+        // Clone of the node for the plane-hello arm + plane gate (issue
+        // #206). The task is aborted before `shutdown` drops the ant-quic
+        // node, so the clone cannot outlive the transport.
+        let plane_node = self.clone();
 
         tokio::spawn(async move {
             debug!("NetworkNode receiver task started");
@@ -3049,6 +3361,52 @@ impl NetworkNode {
                                 error!("Failed to forward RelayedDm: {}", e);
                                 break;
                             }
+                            continue;
+                        }
+
+                        // Issue #206: plane hello handshake.
+                        //   [0x20][len: u8][plane_id: len bytes UTF-8]
+                        // A matching hello clears the peer for gossip; a
+                        // mismatched hello refuses it (disconnect +
+                        // tombstone). Malformed frames are dropped without
+                        // penalty — the peer simply stays pending.
+                        if type_byte == PLANE_HELLO_STREAM_TYPE {
+                            let len = data.get(1).map(|b| usize::from(*b));
+                            let plane_bytes =
+                                len.and_then(|n| data.get(2..2 + n));
+                            match plane_bytes.and_then(|b| std::str::from_utf8(b).ok()) {
+                                Some(their_plane)
+                                    if validate_plane_id(their_plane).is_ok() =>
+                                {
+                                    plane_node
+                                        .plane_handle_hello(peer_id, their_plane)
+                                        .await;
+                                }
+                                _ => {
+                                    warn!(
+                                        "[1/6 network] dropping malformed plane hello: {} bytes from peer {:?}",
+                                        data.len(),
+                                        peer_id,
+                                    );
+                                }
+                            }
+                            continue;
+                        }
+
+                        // Issue #206: gossip-plane gate. Peers that are not
+                        // plane-cleared (hello outstanding, legacy grace not
+                        // yet elapsed) may not carry gossip traffic in either
+                        // direction — this is what stops a cross-plane mDNS
+                        // auto-connect from contaminating revocation sets and
+                        // CRDT state during the handshake window.
+                        //
+                        // Note: the DM bytes (0x10/0x11) above deliberately
+                        // bypass this gate — the DM plane is authenticated
+                        // agent-to-agent traffic, out of #206's gossip-plane
+                        // scope (see docs/trust-and-connectivity.md).
+                        if matches!(GossipStreamType::from_byte(type_byte), Some(_))
+                            && !plane_node.plane_gate_allows(&peer_id)
+                        {
                             continue;
                         }
 
@@ -3277,6 +3635,76 @@ pub(crate) fn hex_prefix(bytes: &[u8; 32], n: usize) -> String {
     s
 }
 
+/// Build a plane-hello frame (issue #206): `[0x20][len: u8][plane_id]`.
+/// `plane_id` is validated at node construction, so the length always fits
+/// the `u8` prefix.
+fn build_plane_hello_frame(plane_id: &str) -> Vec<u8> {
+    let mut frame = Vec::with_capacity(2 + plane_id.len());
+    frame.push(PLANE_HELLO_STREAM_TYPE);
+    frame.push(plane_id.len() as u8);
+    frame.extend_from_slice(plane_id.as_bytes());
+    frame
+}
+
+/// Event union for the plane gatekeeper's two connection signals (issue
+/// #206): x0x network events and ant-quic peer-lifecycle events.
+enum GatekeeperEvent {
+    /// x0x-level network event (dials, accepts, disconnects).
+    Network(NetworkEvent),
+    /// ant-quic peer-lifecycle event — covers connections ant-quic creates
+    /// internally (mDNS auto-connect) that never surface as
+    /// [`NetworkEvent::PeerConnected`].
+    Lifecycle(ant_quic::PeerId, ant_quic::PeerLifecycleEvent),
+}
+
+/// Gatekeeper connect handler (issue #206): register the peer as
+/// plane-pending and send our plane hello. With `reset = false` an existing
+/// entry is kept (the peer's hello may have raced ahead and already cleared
+/// it); with `reset = true` (lifecycle `Replaced`) the peer is re-gated
+/// until its hello on the new connection generation re-verifies the plane.
+async fn plane_note_connected(
+    plane_id: &str,
+    plane_peers: &Arc<Mutex<HashMap<AntPeerId, PlanePeerState>>>,
+    node: &Arc<RwLock<Option<Node>>>,
+    peer_id: [u8; 32],
+    reset: bool,
+) {
+    let peer = ant_quic::PeerId(peer_id);
+    {
+        let mut map = match plane_peers.lock() {
+            Ok(m) => m,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if reset {
+            map.insert(
+                peer,
+                PlanePeerState::Pending {
+                    since: Instant::now(),
+                },
+            );
+        } else {
+            map.entry(peer).or_insert(PlanePeerState::Pending {
+                since: Instant::now(),
+            });
+        }
+    }
+    let frame = build_plane_hello_frame(plane_id);
+    let node = Arc::clone(node);
+    tokio::spawn(async move {
+        let guard = node.read().await;
+        if let Some(node) = guard.as_ref() {
+            if let Err(e) = node.send(&peer, &frame).await {
+                tracing::debug!(
+                    target: "x0x::connect",
+                    peer_id_prefix = %hex_prefix(&peer.0, 4),
+                    error = %e,
+                    "plane hello send failed"
+                );
+            }
+        }
+    });
+}
+
 /// Convert ant-quic PeerId to saorsa-gossip PeerId
 fn ant_to_gossip_peer_id(ant_id: &AntPeerId) -> GossipPeerId {
     GossipPeerId::new(ant_id.0)
@@ -3377,6 +3805,21 @@ impl saorsa_gossip_transport::GossipTransport for NetworkNode {
     ) -> anyhow::Result<()> {
         let ant_peer = gossip_to_ant_peer_id(&peer);
 
+        // Issue #206: hold gossip sends to peers that have not cleared the
+        // plane gate (hello outstanding / legacy grace). Reported as success
+        // so a briefly-pending same-plane peer is not pruned from overlay
+        // views for what is effectively a sub-second handshake delay; gossip
+        // is loss-tolerant and the frames flow once the peer clears.
+        if !self.plane_gate_allows(&ant_peer) {
+            debug!(
+                "[1/6 network] send: holding {:?} ({} bytes) — peer {:?} not plane-cleared",
+                stream_type,
+                data.len(),
+                peer
+            );
+            return Ok(());
+        }
+
         // Prepare message: [stream_type_byte | data]
         let mut buf = Vec::with_capacity(1 + data.len());
         buf.push(stream_type.to_byte());
@@ -3409,7 +3852,9 @@ impl saorsa_gossip_transport::GossipTransport for NetworkNode {
     }
 
     async fn connected_peer_ids(&self) -> Vec<GossipPeerId> {
-        self.connected_peers()
+        // Issue #206: only plane-cleared peers may enter gossip overlay
+        // state (membership views, CRDT sync targets).
+        self.gossip_plane_peers()
             .await
             .into_iter()
             .map(|peer| ant_to_gossip_peer_id(&peer))
@@ -4076,6 +4521,7 @@ async fn test_mesh_connections_are_bidirectional() {
             max_peers_per_ip: 3,
             port_mapping_enabled: true,
             peer_relay: PeerRelayConfig::default(),
+            network_id: None,
         };
 
         let node = NetworkNode::new(config, None, None).await.unwrap();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -35,7 +35,7 @@ pub use state::{
     default_api_address, default_bind_address, default_data_dir, validate_instance_name,
     DaemonConfig, InstanceName, ServeOptions, ServerHandle, DEFAULT_QUIC_PORT,
 };
-use state::{shared_cache_dir, AppState, CachedUpgradeCheck, DaemonUpdateConfig};
+use state::{AppState, CachedUpgradeCheck, DaemonUpdateConfig};
 use ws::{ws_diagnostics, ws_direct_handler, ws_handler, ws_sessions, WsOutboundStats};
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
@@ -743,18 +743,29 @@ pub async fn serve_with_options(
 
     // Create agent
     //
-    // Peer cache is scoped per data_dir when a custom data_dir is configured
-    // (e.g., for named instances or test setups). This prevents VPS peer
-    // addresses from previous runs polluting local-only configurations.
-    // When using the default data_dir, the shared cache is used so that the
-    // main daemon benefits from cached peers across restarts.
-    let cache_dir = if config.data_dir != default_data_dir() {
+    // Peer cache is strictly per-data-dir (issue #206): co-located daemons
+    // must never share a bootstrap cache, or peers learned on one gossip
+    // plane leak into another plane's restart redials (the #189
+    // shared-default-path shape). The previous `shared_cache_dir()` arm
+    // collapsed to the same path when data_dir was default, but made the
+    // sharing explicit and silently reachable for embedders passing
+    // `DaemonConfig::default()` — removed, not rehabilitated. Multi-process
+    // collision on one cache dir is fenced by ant-quic's cache file locking.
+    let cache_dir = {
         let dir = config.data_dir.join("peers");
         let _ = std::fs::create_dir_all(&dir);
         dir
-    } else {
-        shared_cache_dir().join("peers")
     };
+    // Issue #206: resolve the effective gossip plane. Unset TOML
+    // `network_id` maps to the well-known prod plane so co-located daemons
+    // are isolated by default; an explicit empty string opts out (open).
+    let network_id = config.resolved_network_id();
+    match &network_id {
+        Some(id) => tracing::info!(network_id = %id, "Gossip plane isolation enabled"),
+        None => tracing::warn!(
+            "Gossip plane isolation DISABLED (network_id = \"\") — this daemon will \n             exchange gossip with every plane, including cross-plane mDNS peers"
+        ),
+    }
     let network_config = NetworkConfig {
         bind_addr: Some(bind_address),
         bootstrap_nodes: config.resolved_bootstrap_peers(),
@@ -768,6 +779,7 @@ pub async fn serve_with_options(
         // single invocation without editing the config file.
         port_mapping_enabled: config.port_mapping_enabled && !cli_no_port_mapping,
         peer_relay: config.peer_relay.clone(),
+        network_id,
     };
 
     let contacts_path = config.data_dir.join("contacts.json");
@@ -796,10 +808,15 @@ pub async fn serve_with_options(
     // NOTE: --no-hard-coded-bootstrap clears only the *embedded* global
     // bootstrap network; an explicit `bootstrap_peers` list in the config
     // file is honored verbatim (see DaemonConfig::resolved_bootstrap_peers).
-    // mDNS LAN discovery and the peer cache remain active by design so that:
+    // ant-quic's first-party mDNS LAN discovery and the peer cache remain
+    // active by design so that:
     //   - Local mesh (two laptops on WiFi) still works via mDNS
     //   - FOAF presence discovery still finds peers
     //   - Previously-seen peers can reconnect via cache
+    // mDNS-discovered co-located daemons can no longer bridge gossip
+    // planes, though: every connection exchanges a plane hello, and peers
+    // on a different `network_id` plane are refused at the gossip layer
+    // (issue #206).
 
     if let Some(ref id_dir) = identity_dir {
         builder = builder

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -782,12 +782,12 @@ mod tests {
         // A config file without the key must parse with network_id unset
         // (serde default), so existing deployments upgrade cleanly onto
         // the prod plane.
-        let cfg: DaemonConfig = toml::from_str("bind_address = '[::]:5483'")
-            .expect("minimal TOML parses");
+        let cfg: DaemonConfig =
+            toml::from_str("bind_address = '[::]:5483'").expect("minimal TOML parses");
         assert_eq!(cfg.network_id, None);
 
-        let cfg: DaemonConfig = toml::from_str("network_id = 'x0x.testnet'")
-            .expect("network_id TOML parses");
+        let cfg: DaemonConfig =
+            toml::from_str("network_id = 'x0x.testnet'").expect("network_id TOML parses");
         assert_eq!(cfg.network_id.as_deref(), Some("x0x.testnet"));
     }
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -331,7 +331,7 @@ pub struct DaemonConfig {
     /// Gossip-plane identifier (issue #206, TOML: `network_id`).
     ///
     /// - Unset → the daemon joins the well-known prod plane
-    ///   ([`PROD_PLANE_ID`]) and refuses gossip traffic with peers that
+    ///   (`PROD_PLANE_ID`) and refuses gossip traffic with peers that
     ///   declare a different plane. This is the safe default: co-located
     ///   daemons are only same-plane if they are *both* undeclared, which
     ///   mirrors today's shared-bootstrap deployments (prod, `x0xd-443`,
@@ -507,7 +507,7 @@ impl DaemonConfig {
 
     /// Resolve `network_id` to the effective gossip-plane id (issue #206).
     ///
-    /// - `None` (unset) → `Some(`[`PROD_PLANE_ID`]`)` — planes isolated by
+    /// - `None` (unset) → `Some(PROD_PLANE_ID)` — planes isolated by
     ///   default: any daemon declaring a different plane is refused.
     /// - `Some("")` → `None` — explicit opt-out (open plane, pre-#206
     ///   behaviour).

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -327,6 +327,22 @@ pub struct DaemonConfig {
     /// (#204 must-fix 1).
     #[serde(default)]
     pub(super) forward: x0x::forward::ForwardConfig,
+
+    /// Gossip-plane identifier (issue #206, TOML: `network_id`).
+    ///
+    /// - Unset → the daemon joins the well-known prod plane
+    ///   ([`PROD_PLANE_ID`]) and refuses gossip traffic with peers that
+    ///   declare a different plane. This is the safe default: co-located
+    ///   daemons are only same-plane if they are *both* undeclared, which
+    ///   mirrors today's shared-bootstrap deployments (prod, `x0xd-443`,
+    ///   personal named instances).
+    /// - `""` (explicit empty) → open plane: no isolation at all. Escape
+    ///   hatch for embedders and legacy test rigs that deliberately bridge.
+    /// - Any other value → that plane, e.g. `network_id = "x0x.testnet"`
+    ///   for the co-located testnet. Validated by
+    ///   [`x0x::network::validate_plane_id`].
+    #[serde(default)]
+    pub network_id: Option<String>,
 }
 
 /// Default QUIC port: 5483 (LIVE on a phone keypad).
@@ -361,16 +377,11 @@ pub fn default_data_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("/var/lib/x0x"))
 }
 
-/// Shared cache directory used by ALL instances (not per-instance).
-/// This is always the base `x0x` dir, never `x0x-<name>`.
-pub(super) fn shared_cache_dir() -> PathBuf {
-    let dir = dirs::data_dir()
-        .map(|d| d.join("x0x"))
-        .unwrap_or_else(|| PathBuf::from("/var/lib/x0x"));
-    // Ensure it exists
-    let _ = std::fs::create_dir_all(&dir);
-    dir
-}
+/// The well-known gossip plane every x0xd joins when its TOML does not
+/// declare a `network_id` (issue #206). Prod, `x0xd-443`, and unnamed
+/// personal instances all land here, preserving today's mesh; a co-located
+/// second plane (testnet, experiments) declares its own id and is refused.
+pub const PROD_PLANE_ID: &str = "x0x.prod";
 
 fn default_log_level() -> String {
     // Privacy by default for operators outside our fleet (issue #85): without
@@ -493,6 +504,24 @@ impl DaemonConfig {
             .clone()
             .unwrap_or_else(default_bootstrap_peers)
     }
+
+    /// Resolve `network_id` to the effective gossip-plane id (issue #206).
+    ///
+    /// - `None` (unset) → `Some(`[`PROD_PLANE_ID`]`)` — planes isolated by
+    ///   default: any daemon declaring a different plane is refused.
+    /// - `Some("")` → `None` — explicit opt-out (open plane, pre-#206
+    ///   behaviour).
+    /// - `Some(id)` → `Some(id)` verbatim; validity is enforced at
+    ///   `NetworkNode` construction via
+    ///   [`x0x::network::validate_plane_id`].
+    #[must_use]
+    pub fn resolved_network_id(&self) -> Option<String> {
+        match &self.network_id {
+            None => Some(PROD_PLANE_ID.to_string()),
+            Some(id) if id.is_empty() => None,
+            Some(id) => Some(id.clone()),
+        }
+    }
 }
 
 impl Default for DaemonConfig {
@@ -522,6 +551,7 @@ impl Default for DaemonConfig {
             group_card_republish_interval_secs: None,
             directory_resubscribe_jitter_ms: None,
             forward: x0x::forward::ForwardConfig::default(),
+            network_id: None,
         }
     }
 }
@@ -713,6 +743,53 @@ pub(super) struct CachedUpgradeCheck {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolved_network_id_maps_unset_to_prod_and_empty_to_open() {
+        // Issue #206: the daemon default must isolate planes — an unset
+        // TOML `network_id` joins the well-known prod plane (isolation
+        // ON), and only an explicit empty string opts out.
+        let unset = DaemonConfig::default();
+        assert_eq!(
+            unset.resolved_network_id().as_deref(),
+            Some(PROD_PLANE_ID),
+            "unset network_id must resolve to the well-known prod plane"
+        );
+
+        let open = DaemonConfig {
+            network_id: Some(String::new()),
+            ..DaemonConfig::default()
+        };
+        assert_eq!(
+            open.resolved_network_id(),
+            None,
+            "explicit empty network_id must opt out (open plane)"
+        );
+
+        let testnet = DaemonConfig {
+            network_id: Some("x0x.testnet".to_string()),
+            ..DaemonConfig::default()
+        };
+        assert_eq!(
+            testnet.resolved_network_id().as_deref(),
+            Some("x0x.testnet"),
+            "explicit network_id is honored verbatim"
+        );
+    }
+
+    #[test]
+    fn network_id_toml_roundtrip_defaults_to_unset() {
+        // A config file without the key must parse with network_id unset
+        // (serde default), so existing deployments upgrade cleanly onto
+        // the prod plane.
+        let cfg: DaemonConfig = toml::from_str("bind_address = '[::]:5483'")
+            .expect("minimal TOML parses");
+        assert_eq!(cfg.network_id, None);
+
+        let cfg: DaemonConfig = toml::from_str("network_id = 'x0x.testnet'")
+            .expect("network_id TOML parses");
+        assert_eq!(cfg.network_id.as_deref(), Some("x0x.testnet"));
+    }
 
     // The two canonical messages enforced by `InstanceName::try_from`.
     // `x0xd::resolve_instance_startup` propagates these verbatim (bare `?`,

--- a/tests/gossip_plane_isolation.rs
+++ b/tests/gossip_plane_isolation.rs
@@ -1,0 +1,238 @@
+//! Issue #206: co-located gossip planes must be isolated.
+//!
+//! Two daemons on one host (prod + testnet) discovered each other via
+//! ant-quic's first-party mDNS auto-connect and exchanged gossip traffic —
+//! a revocation minted on the testnet plane persisted into prod revocation
+//! sets. The fix exchanges a plane hello on every connection and refuses
+//! gossip traffic with mismatched peers (disconnect + tombstone + cache
+//! eviction); peers are not gossip-eligible until plane-cleared.
+//!
+//! These tests run the crossing in-process: a manual `connect_addr` stands
+//! in for the mDNS auto-connect (ant-quic skips mDNS on loopback-only
+//! endpoints); the transport connection is the same carrier either way.
+
+use std::time::Duration;
+
+use x0x::network::{validate_plane_id, NetworkConfig};
+use x0x::Agent;
+
+const TOPIC: &str = "x0x.test.plane-isolation.v1";
+
+async fn build_agent(dir: &std::path::Path, name: &str, network_id: Option<&str>) -> Agent {
+    let network_config = NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr")),
+        bootstrap_nodes: Vec::new(),
+        network_id: network_id.map(str::to_string),
+        ..NetworkConfig::default()
+    };
+    Agent::builder()
+        .with_machine_key(dir.join(format!("{name}-machine.key")))
+        .with_agent_key_path(dir.join(format!("{name}-agent.key")))
+        .with_contact_store_path(dir.join(format!("{name}-contacts.json")))
+        .with_peer_cache_dir(dir.join(format!("{name}-peers")))
+        .with_network_config(network_config)
+        .build()
+        .await
+        .unwrap_or_else(|e| panic!("build {name}: {e}"))
+}
+
+/// Dial `b` from `a` and wait until both sides register the connection.
+async fn connect_pair(a: &Agent, b: &Agent) {
+    let b_addr = b.bound_addr().await.expect("b bound addr");
+    let a_network = a.network().expect("a network");
+    let connected = a_network
+        .connect_addr(b_addr)
+        .await
+        .expect("a dials b");
+    assert_eq!(connected.0, b.machine_id().0, "a connected to b's identity");
+
+    let b_peer = ant_quic::PeerId(b.machine_id().0);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        if a_network.is_connected(&b_peer).await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("a never registered the connection to b");
+}
+
+/// Receive until `want` arrives (skipping the publisher's own local echo,
+/// which PlumTree delivers to the publisher's own subscription) or the
+/// deadline expires. Returns `true` iff `want` was delivered.
+async fn recv_payload(sub: &mut x0x::Subscription, want: &[u8], within: Duration) -> bool {
+    tokio::time::timeout(within, async {
+        while let Some(msg) = sub.recv().await {
+            if msg.payload == want {
+                return true;
+            }
+        }
+        false
+    })
+    .await
+    .unwrap_or(false)
+}
+
+/// Carrier proof, isolation OFF: two open-plane agents on one host exchange
+/// gossip over a co-located connection. This is the pre-#206 behaviour the
+/// issue reported; it must keep working when no plane is configured.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn open_plane_pair_exchanges_gossip() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let alice = build_agent(dir.path(), "alice", None).await;
+    let bob = build_agent(dir.path(), "bob", None).await;
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+
+    let mut alice_sub = alice.subscribe(TOPIC).await.expect("alice sub");
+    let mut bob_sub = bob.subscribe(TOPIC).await.expect("bob sub");
+    connect_pair(&alice, &bob).await;
+    // Let the 1s eager-set refresh tick pick up the new peer.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let payload = b"open-plane carrier proof".to_vec();
+    bob.publish(TOPIC, payload.clone()).await.expect("bob publishes");
+    assert!(
+        recv_payload(&mut alice_sub, &payload, Duration::from_secs(15)).await,
+        "alice should receive from bob on the open plane"
+    );
+
+    // And the reverse direction, to prove symmetric carrier behaviour.
+    let payload2 = b"open-plane reverse".to_vec();
+    alice
+        .publish(TOPIC, payload2.clone())
+        .await
+        .expect("alice publishes");
+    assert!(
+        recv_payload(&mut bob_sub, &payload2, Duration::from_secs(15)).await,
+        "bob should receive from alice on the open plane"
+    );
+}
+
+/// Isolation ON: two co-located agents configured on DIFFERENT planes must
+/// not exchange gossip, and the cross-plane connection must be refused
+/// (disconnected + tombstoned) once the plane hellos are exchanged.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cross_plane_pair_does_not_exchange_gossip() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let prod = build_agent(dir.path(), "prod", Some("x0x.test.prod")).await;
+    let testnet = build_agent(dir.path(), "testnet", Some("x0x.test.testnet")).await;
+    prod.join_network().await.expect("prod joins");
+    testnet.join_network().await.expect("testnet joins");
+
+    let mut prod_sub = prod.subscribe(TOPIC).await.expect("prod sub");
+    let mut testnet_sub = testnet.subscribe(TOPIC).await.expect("testnet sub");
+    connect_pair(&prod, &testnet).await;
+
+    // Publish in both directions across the (initially connected) link.
+    // Neither may be delivered to the other side: the plane gate holds
+    // frames from non-cleared peers, and the mismatched hellos refuse the
+    // connection. (Each side DOES see its own publish echoed locally; the
+    // assertions below only look for the foreign payload.)
+    testnet
+        .publish(TOPIC, b"testnet junk payload".to_vec())
+        .await
+        .expect("testnet publishes");
+    prod.publish(TOPIC, b"prod payload".to_vec())
+        .await
+        .expect("prod publishes");
+
+    let (prod_saw_testnet, testnet_saw_prod) = tokio::join!(
+        recv_payload(&mut prod_sub, b"testnet junk payload", Duration::from_secs(6)),
+        recv_payload(&mut testnet_sub, b"prod payload", Duration::from_secs(6)),
+    );
+    assert!(
+        !prod_saw_testnet,
+        "prod must not receive testnet's cross-plane publish"
+    );
+    assert!(
+        !testnet_saw_prod,
+        "testnet must not receive prod's cross-plane publish"
+    );
+
+    // Hard isolation: the mismatched hello must tear the connection down on
+    // both sides and keep it down (PolicyRejection tombstone).
+    let prod_network = prod.network().expect("prod network");
+    let testnet_peer = ant_quic::PeerId(testnet.machine_id().0);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut disconnected = false;
+    while tokio::time::Instant::now() < deadline {
+        if !prod_network.is_connected(&testnet_peer).await {
+            disconnected = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        disconnected,
+        "prod should have disconnected the cross-plane testnet peer"
+    );
+    // Stay-down check across several eager-set refresh ticks.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert!(
+        !prod_network.is_connected(&testnet_peer).await,
+        "cross-plane peer must stay disconnected (tombstoned)"
+    );
+}
+
+/// Isolation ON, same plane: two agents configured with the SAME plane id
+/// must converge exactly as before — plane hellos clear immediately.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn same_plane_pair_converges() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let one = build_agent(dir.path(), "one", Some("x0x.test.same")).await;
+    let two = build_agent(dir.path(), "two", Some("x0x.test.same")).await;
+    one.join_network().await.expect("one joins");
+    two.join_network().await.expect("two joins");
+
+    let mut one_sub = one.subscribe(TOPIC).await.expect("one sub");
+    connect_pair(&one, &two).await;
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let payload = b"same-plane convergence".to_vec();
+    two.publish(TOPIC, payload.clone()).await.expect("two publishes");
+    assert!(
+        recv_payload(&mut one_sub, &payload, Duration::from_secs(15)).await,
+        "same-plane peer should receive"
+    );
+}
+
+/// Mixed fleet: a plane-gated agent and an open-plane (legacy/embedder)
+/// agent must still converge — the gated side admits the hello-less peer
+/// after the legacy grace window instead of partitioning.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gated_and_open_pair_converges_after_legacy_grace() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let gated = build_agent(dir.path(), "gated", Some("x0x.test.gated")).await;
+    let open = build_agent(dir.path(), "open", None).await;
+    gated.join_network().await.expect("gated joins");
+    open.join_network().await.expect("open joins");
+
+    let mut open_sub = open.subscribe(TOPIC).await.expect("open sub");
+    connect_pair(&gated, &open).await;
+
+    // The gated side holds the open peer at the plane gate until the legacy
+    // grace (10s) promotes it; publish only after that window plus the 1s
+    // eager-set refresh tick.
+    tokio::time::sleep(Duration::from_secs(12)).await;
+    let payload = b"legacy-grace convergence".to_vec();
+    gated
+        .publish(TOPIC, payload.clone())
+        .await
+        .expect("gated publishes");
+    assert!(
+        recv_payload(&mut open_sub, &payload, Duration::from_secs(15)).await,
+        "open peer should receive after legacy grace"
+    );
+}
+
+#[test]
+fn plane_id_validation() {
+    assert!(validate_plane_id("x0x.prod").is_ok());
+    assert!(validate_plane_id("x0x.testnet-01_eu").is_ok());
+    assert!(validate_plane_id("").is_err());
+    assert!(validate_plane_id("has space").is_err());
+    assert!(validate_plane_id("slash/invalid").is_err());
+    assert!(validate_plane_id(&"a".repeat(65)).is_err());
+    assert!(validate_plane_id(&"a".repeat(64)).is_ok());
+}

--- a/tests/gossip_plane_isolation.rs
+++ b/tests/gossip_plane_isolation.rs
@@ -40,10 +40,7 @@ async fn build_agent(dir: &std::path::Path, name: &str, network_id: Option<&str>
 async fn connect_pair(a: &Agent, b: &Agent) {
     let b_addr = b.bound_addr().await.expect("b bound addr");
     let a_network = a.network().expect("a network");
-    let connected = a_network
-        .connect_addr(b_addr)
-        .await
-        .expect("a dials b");
+    let connected = a_network.connect_addr(b_addr).await.expect("a dials b");
     assert_eq!(connected.0, b.machine_id().0, "a connected to b's identity");
 
     let b_peer = ant_quic::PeerId(b.machine_id().0);
@@ -91,7 +88,9 @@ async fn open_plane_pair_exchanges_gossip() {
     tokio::time::sleep(Duration::from_millis(1500)).await;
 
     let payload = b"open-plane carrier proof".to_vec();
-    bob.publish(TOPIC, payload.clone()).await.expect("bob publishes");
+    bob.publish(TOPIC, payload.clone())
+        .await
+        .expect("bob publishes");
     assert!(
         recv_payload(&mut alice_sub, &payload, Duration::from_secs(15)).await,
         "alice should receive from bob on the open plane"
@@ -138,7 +137,11 @@ async fn cross_plane_pair_does_not_exchange_gossip() {
         .expect("prod publishes");
 
     let (prod_saw_testnet, testnet_saw_prod) = tokio::join!(
-        recv_payload(&mut prod_sub, b"testnet junk payload", Duration::from_secs(6)),
+        recv_payload(
+            &mut prod_sub,
+            b"testnet junk payload",
+            Duration::from_secs(6)
+        ),
         recv_payload(&mut testnet_sub, b"prod payload", Duration::from_secs(6)),
     );
     assert!(
@@ -190,7 +193,9 @@ async fn same_plane_pair_converges() {
     tokio::time::sleep(Duration::from_millis(1500)).await;
 
     let payload = b"same-plane convergence".to_vec();
-    two.publish(TOPIC, payload.clone()).await.expect("two publishes");
+    two.publish(TOPIC, payload.clone())
+        .await
+        .expect("two publishes");
     assert!(
         recv_payload(&mut one_sub, &payload, Duration::from_secs(15)).await,
         "same-plane peer should receive"


### PR DESCRIPTION
Closes the leak half of #206 (the inert revocation record in prod sets still needs the coordinated-restart cleanup from the issue's ops note).

**Root cause (confirmed with local two-daemon repro):** ant-quic 0.27.33 defaults mDNS to enabled + namespace-None + auto-connect, and x0x's NodeConfig exposes no mDNS knob. Co-located daemons auto-connected via loopback mDNS regardless of bootstrap configuration, and gossip (incl. the revocation topic) flowed across. Second path also closed: the shared bootstrap-cache directory is removed — cache is now strictly per-data-dir.

**Fix (x0x-side, no ant-quic change required):** a plane-hello handshake + plane gate on every gossip carrier:
- Every connection (mDNS auto-connect, dial, accept — all traverse the single register_connected_peer chokepoint) exchanges a plane hello; mismatched planes get a permanent PolicyRejection tombstone + bootstrap-cache eviction (never re-dialed)
- Gate enforced both directions: outbound gossip send, inbound gossip frames (0x00/0x01/0x02), PlumTree eager sets, membership keepalives, overlay peer views. DM plane (0x10/0x11) deliberately bypasses — authenticated agent-to-agent traffic is out of #206's scope
- Same-plane co-located peers converge identically to pre-fix (same_plane_pair_converges); default isolation preserves prod safety
- Isolation tests: cross_plane_pair_does_not_exchange_gossip, same_plane_pair_converges, gated_and_open_pair_converges_after_legacy_grace — all non-tautological (open pair proves the carrier works without the gate)

Gates: fmt/clippy clean, 11/11 isolation tests. Adversarial review: SOUND — mechanism re-derived and confirmed, all crossing paths traced and gated, no over-gating, no lock-held-across-await.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds gossip-plane isolation for co-located daemons. The main changes are:

- A plane-hello handshake and per-peer gossip gate.
- Plane-aware pubsub, membership, keepalive, and transport peer views.
- Per-data-directory bootstrap caches.
- Daemon configuration, documentation, and isolation tests.

<h3>Confidence Score: 4/5</h3>

The plane admission and pending-send paths need fixes before merging.

- Silent peers become gossip-eligible without proving their plane.
- Cached clearance is reused before a new connection is verified.
- Pending sends discard messages while reporting success.

src/network.rs

<details open><summary><h3>Security Review</h3></summary>

The new plane boundary is not fail-closed. Peers without a valid hello become gossip-eligible after the legacy timeout, and recently cleared identities bypass verification when a new connection is established.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Adds handshake, lifecycle, reconnect, and transport gating logic; three admission or delivery paths can violate the intended gossip contract. |
| src/gossip/pubsub.rs | Changes topic initialization and refresh to use the plane-filtered peer view. |
| src/gossip/runtime.rs | Restricts membership keepalives to plane-cleared peers. |
| src/server/mod.rs | Scopes the bootstrap cache to the data directory and wires the resolved plane into the network. |
| src/server/state.rs | Adds backward-compatible plane configuration and production-plane defaults. |
| tests/gossip_plane_isolation.rs | Adds isolation and convergence tests but does not cover silent peers, reconnects after a plane change, or publications during handshake. |
| docs/trust-and-connectivity.md | Documents the plane protocol, configuration, compatibility grace, and cache isolation. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Connection established] --> B{Recent clearance cached?}
    B -- Yes --> C[Immediately cleared]
    B -- No --> D[Pending]
    D --> E{Valid hello received?}
    E -- Matching --> F[Cleared for gossip]
    E -- Mismatching --> G[Evict and reject]
    E -- Missing or malformed --> H{Ten-second grace elapsed?}
    H -- No --> D
    H -- Yes --> F
    C --> I[Gossip allowed]
    F --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Connection established] --> B{Recent clearance cached?}
    B -- Yes --> C[Immediately cleared]
    B -- No --> D[Pending]
    D --> E{Valid hello received?}
    E -- Matching --> F[Cleared for gossip]
    E -- Mismatching --> G[Evict and reject]
    E -- Missing or malformed --> H{Ten-second grace elapsed?}
    H -- No --> D
    H -- Yes --> F
    C --> I[Gossip allowed]
    F --> I
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/network.rs:2703-2706
**Silent Peers Bypass Isolation**

A connected peer that never sends a valid plane hello is promoted to `Cleared` after ten seconds. An old, misconfigured, or hostile cross-plane peer can then enter overlay sets and exchange gossip, recreating the state leak that this gate is intended to prevent.

### Issue 2 of 3
src/network.rs:3853-3857
**Cached Clearance Skips Reverification**

When a persistent peer identity reconnects within ten minutes, this seed marks the new connection `Cleared` before its hello arrives. If that daemon restarted with a different plane, gossip can cross the boundary until the mismatching hello is processed; the same seed also prevents the `reset` path from actually re-gating a replaced connection.

### Issue 3 of 3
src/network.rs:3991-4000
**Pending Sends Report False Success**

When a same-plane connection is still awaiting its hello, this path drops the gossip frame but reports success to the overlay. A publication sent during that window can be treated as delivered without any retry or peer-failure reconciliation, so a revocation or CRDT update can be missing from the newly connected peer until another update repairs it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(net): #206 — retry plane hellos to P..."](https://github.com/saorsa-labs/x0x/commit/49e0bf38c6cdc36f9ed11cff7c04246a1d441b22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45247857)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->