### PR TITLE
feat(net): #132 — per-peer bidirectional stream API with protocol-id framing (Tailnet Phase 1, deliverable 1)

### DIFF
--- a/docs/adr/0022-tailnet-stream-api.md
+++ b/docs/adr/0022-tailnet-stream-api.md
@@ -1,0 +1,186 @@
+# ADR 0022: Tailnet stream API — per-protocol acceptors, connect-ACL gate, bounded backpressure
+
+<!-- File name: docs/adr/0022-tailnet-stream-api.md -->
+
+- **Status:** Proposed
+- **Date:** 2026-07-17
+- **Decision owners:** David Irvine
+- **Reviewers:** x0x core team (independent adversarial review required before Accepted)
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** ADR-0020 (tailnet Phase 1 epic), ADR-0019 (connect ACL), issue #132 (deliverable 1), #131 (connect ACL), #192 (multi-agent fail-closed), ant-quic #180 (`Node::open_bi`/`accept_bi`)
+
+## Context
+
+ADR-0020 shipped the first tailnet byte-stream slice (#132 T1): `Agent::open_peer_stream` /
+`Agent::next_incoming_stream` over ant-quic `open_bi`/`accept_bi`, a single-byte protocol
+prefix for stream typing, and the fail-closed identity gate (verified → revoked → trust
+`Accept`). That left three foundational gaps for everything else the epic builds on top
+(port-forwarder T4, SOCKS5 T5, and any future protocol):
+
+1. **One undifferentiated inbound channel.** Every protocol's streams landed in a single
+   bounded channel drained by `next_incoming_stream`; the consumer had to demux by
+   `stream.protocol()` and *drop* protocols it did not own. Two independent consumers
+   (e.g. forwarder + SOCKS5 listener) could not coexist without an extra in-process demux
+   layer — and a consumer ignoring a protocol silently absorbed its streams.
+2. **No connect-ACL hook at the stream layer.** The #131 per-flow connectivity ACL only
+   ran inside the T4 forwarder, after the forward header was read. A verified + trusted
+   but ACL-unlisted peer could open arbitrary streams to any future protocol listener and
+   only be refused later, per-protocol, if that protocol remembered to gate.
+3. **Backpressure claimed, not proven.** QUIC-native flow control bounds in-flight bytes,
+   and the surfacing channel was bounded — but nothing pinned those bounds to observable
+   test assertions.
+
+This ADR records the as-built design that closes those gaps (issue #132, deliverable 1).
+
+## Decision Drivers
+
+- **Default-closed, fail-closed.** Streams only flow between transport-verified,
+  trust-accepted, non-revoked peers; with an `Enabled` connect ACL, an unlisted peer's
+  stream open is refused. Mirrors the project posture (ADR-0019, exec ACL, EP3/EP4).
+- **No second convention.** One routing mechanism for inbound streams — the protocol
+  byte — used by every consumer, not a per-consumer filter layered on a shared queue.
+- **Backpressure must propagate, never hide.** Bounded channels everywhere; a stalled
+  consumer causes streams to be *reset*, not buffered; byte flow rides QUIC flow control.
+- **Deterministic, network-free unit tests** for every gate decision, plus in-process
+  two-agent integration proofs for the wiring.
+
+## Considered Options
+
+1. **Per-protocol acceptors + stream-layer ACL pair gate (chosen).** The accept loop
+   routes each gated stream by its protocol byte to the single registered acceptor for
+   that protocol (bounded channel, drop-on-full); unregistered protocols fall back to the
+   existing default channel. The accept loop also evaluates a new pure gate,
+   `stream_acl_gate`, after the identity gate: with `ConnectPolicy::Enabled`, every
+   announced agent on the peer machine must be `(AgentId, MachineId)`-listed, else the
+   stream is reset (`PeerNotInConnectAcl`) with zero application bytes exchanged.
+2. **Keep the single channel, add per-consumer filters.** Rejected: every consumer must
+   then correctly drop foreign protocols (a convention, not a boundary), a forgotten
+   filter stalls or absorbs traffic, and boundedness reasoning gets harder per added
+   consumer.
+3. **Push the ACL check into each protocol handler (like T4 does today).** Rejected as
+   the *only* layer: it duplicates the gate per protocol and invites a future protocol to
+   skip it. (It remains correct as an *additional*, target-aware layer — the forwarder
+   keeps its `evaluate_connect_gate` target check.)
+4. **Apply the connect ACL to outbound opens too.** Rejected for Phase 1: the #131 ACL
+   models *inbound* reachability ("who may connect to my loopback targets"). Outbound
+   opens are already verified + trust-gated; reusing the inbound ACL outbound would
+   conflate two policy directions. A dedicated egress policy is a Phase 2 question.
+
+## Decision
+
+### Per-protocol acceptor routing (`src/streams.rs`, `src/lib.rs`)
+
+- `Agent::register_stream_acceptor(protocol) -> NetworkResult<StreamAcceptor>` installs
+  the **single** consumer for a `StreamProtocol`. Duplicate registration fails with
+  `NetworkError::StreamAcceptorConflict`. Dropping the `StreamAcceptor` deregisters it
+  (guard compares channel identity so a stale drop cannot clobber a re-registered
+  successor).
+- The accept loop's per-stream dispatch task routes by the protocol byte **at dispatch
+  time** to the registered acceptor, else to the default channel drained by
+  `Agent::next_incoming_stream` (unchanged for unregistered protocols).
+- Every channel is bounded (`STREAM_ACCEPTOR_CAPACITY = 64` per acceptor; 256 for the
+  default sink) and written with `try_send`: a full channel drops (resets) the stream.
+  Accepted streams are never buffered unboundedly.
+- `ForwardService` is the flagship consumer: it registers `ForwardV1` + `ForwardV2`
+  acceptors at construction (`ForwardService::new` now returns `NetworkResult<Self>` so a
+  registration conflict is visible), and `spawn_inbound` runs one drain loop per acceptor.
+  The old "consume the shared channel and filter by protocol" code is deleted.
+
+### Connect-ACL gate at the stream layer (#131 × #132)
+
+- `Agent::set_connect_policy(Arc<ConnectPolicy>)` installs the loaded policy (the daemon
+  calls it once at startup; default is `Disabled`).
+- The inbound accept loop evaluates `stream_acl_gate(policy, agents, machine_id)` **after
+  the identity gate** (so unverified/untrusted peers learn nothing about the ACL):
+  - `Disabled` ⇒ no constraint (backwards-compatible; the identity gate remains the sole
+    stream boundary, and connect-forwarding stays default-deny at the T4 forwarder).
+  - `Enabled` ⇒ **every** announced agent on the peer machine must be pair-listed, else
+    `PeerNotInConnectAcl` and the stream is reset. The every-agent rule mirrors
+    `forward::decide_inbound` (#192): the QUIC transport authenticates the machine, not
+    the individual agent.
+  - Target membership is *not* checked here — raw streams carry no target. Per-target
+    enforcement stays with the forwarder's `evaluate_connect_gate` call.
+- Outbound `open_peer_stream` is unchanged (identity gate only; see option 4).
+
+### Backpressure contract
+
+- Byte flow: QUIC-native flow control. ant-quic's initial per-stream credit is
+  1 250 000 bytes (`STREAM_RWND`); a writer whose peer stops reading throttles there —
+  it neither completes nor buffers beyond the window (+ in-flight slack).
+- Surfacing: bounded channels with drop-on-full at every hop (ant-quic's app-stream
+  queue, the x0x default sink, each acceptor).
+- Copy loops (`tokio::io::copy` in the forwarder) carry no intermediate buffers beyond
+  their fixed 8 KiB user-space chunk; backpressure propagates end to end.
+
+## Consequences
+
+### Positive
+
+- Multiple independent protocol consumers coexist with no in-process demux layer and no
+  cross-protocol absorption: each owns exactly its protocol's streams.
+- An ACL-unlisted peer's stream open is refused at one unavoidable seam (the accept
+  loop), protecting every current *and future* protocol — a protocol can no longer forget
+  to gate.
+- `PeerNotInConnectAcl` / `StreamAcceptorConflict` are typed errors: testable, loggable,
+  no stringly-typed matches.
+- Boundedness is asserted, not assumed: the acceptor channel depth is pinned to exactly
+  `STREAM_ACCEPTOR_CAPACITY` under surplus, and a stalled reader provably throttles the
+  writer at the flow-control window.
+
+### Negative / Trade-offs
+
+- `ForwardService::new` changed signature (`Self` → `NetworkResult<Self>`) — acceptable:
+  the only constructor caller is the daemon wiring.
+- A consumer that registers an acceptor and stops draining now causes *resets* of new
+  streams rather than queueing them — intended (fail-fast, bounded memory), but operators
+  should know a wedged listener manifests as refused streams, not backlog.
+- The ACL gate checks pair membership, not targets: an `(agent, machine)` listed for one
+  loopback target may open raw streams for any protocol. Rationale: streams have no
+  target semantics; the forwarder still enforces targets per flow. Documented here so the
+  relaxation is explicit.
+- Registration/deregistration uses a `std::sync::Mutex` in the accept-loop dispatch path
+  (route lookup per stream). Critical sections are a few pointer copies and never await —
+  negligible, but noted.
+
+### Neutral / Operational
+
+- `Agent::next_incoming_stream` remains for protocols with no registered acceptor; the
+  existing T1 echo + no-stall integration tests run unchanged against it.
+- Deny telemetry: the accept loop logs `outcome = "deny_acl"` with machine + agent count
+  (no ACL contents) at `info`, matching the existing `deny_gate`/`deny_protocol` lines.
+
+## Validation
+
+- **Unit (`src/streams.rs`)**: `stream_acl_gate_matrix` (Disabled pass-through, listed,
+  unlisted, multi-agent fail-closed, wrong-machine); `acceptor_registration_lifecycle`
+  (conflict, drop-reregister, stale-drop guard, routing fallback, bounded capacity).
+- **Integration (`tests/tailnet_streams_integration.rs`, `#[ignore]` integration tier)**:
+  - `peer_stream_echoes_1mib_both_directions` (pre-existing): open/echo round trip.
+  - `multiplexed_protocols_do_not_interleave`: two protocols over one connection, each
+    acceptor gets only its own stream, default sink stays empty, 1 MiB patterns intact.
+  - `connect_acl_refuses_unlisted_peer_stream`: unlisted (but verified + trusted) peer's
+    stream is never surfaced and its I/O fails (EOF + STOP_SENDING); the listed peer
+    still streams.
+  - `acceptor_channel_is_bounded`: capacity+8 opens surface exactly the capacity; no
+    queued surplus afterwards.
+  - `backpressure_throttles_writer_with_bounded_buffering`: 3 s stalled reader ⇒ writer
+    incomplete **and** ≤ 8 MiB accepted (flow-control bound); drain ⇒ 32 MiB SHA-256
+    intact.
+  - `large_transfer_integrity_8mib`: 8 MiB pattern each direction, SHA-256 verified.
+  - `accept_loop_not_stalled_by_missing_prefix` (pre-existing): accept-loop liveness.
+
+## Phase 1 deferrals (unchanged from ADR-0020)
+
+- SOCKS5 listener (protocol byte `0x02` reserved).
+- Per-target / per-protocol ACL grammar at the stream layer; egress policy for outbound
+  opens (option 4).
+- Mid-stream revocation teardown of long-lived streams (per-accept gate only).
+- LAN / subnet-router / exit-node (non-loopback) targets; device enrollment UX; MagicDNS.
+
+## Notes for AI-assisted work
+
+AI tools may draft this ADR but **must not mark it Accepted without human review**. The
+security invariants — gate order (identity gate, then ACL gate, then protocol handshake,
+then routing), every-agent fail-closed for multi-agent machines, bounded-or-reset
+buffering — must not be softened without a new ADR and adversarial review.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@ This directory contains architecture decision records for x0x.
 ## Proposed
 
 - [ADR 0020: Tailnet Phase 1 — per-peer byte-streams + local port-forwarding](./0020-tailnet-phase-1-byte-streams-and-forwarding.md) — PeerStream over `Node::open_bi`/`accept_bi` with the identity gate inside open/accept; `src/forward/` local port-forwarder gated by the connect ACL (#131/ADR-0019) + key lifecycle (#130); loopback-only Phase 1
+- [ADR 0022: Tailnet stream API — per-protocol acceptors, connect-ACL gate, bounded backpressure](./0022-tailnet-stream-api.md) — protocol-byte routing to single-owner acceptors (bounded, drop-on-full), stream-layer connect-ACL pair gate after the identity gate, QUIC flow-control backpressure with asserted bounds; issue #132 deliverable 1

--- a/src/error.rs
+++ b/src/error.rs
@@ -279,6 +279,24 @@ pub enum NetworkError {
         /// The revoked agent id.
         agent_id: [u8; 32],
     },
+    /// Tailnet byte-stream connect-ACL gate (#131/#132): the peer's
+    /// `(AgentId, MachineId)` pair is not listed in the local connect ACL
+    /// while a [`crate::connect::ConnectPolicy::Enabled`] policy is active
+    /// (default-closed inbound reachability). The stream is refused/reset
+    /// with zero application bytes exchanged.
+    #[error("stream peer not listed in connect ACL: agent {agent_id:?}")]
+    PeerNotInConnectAcl {
+        /// The unlisted agent id.
+        agent_id: [u8; 32],
+    },
+    /// Tailnet byte-stream acceptor registration: an acceptor is already
+    /// registered for the requested [`crate::streams::StreamProtocol`].
+    /// Exactly one consumer may own a protocol's inbound streams.
+    #[error("stream acceptor already registered for protocol byte 0x{protocol_byte:02x}")]
+    StreamAcceptorConflict {
+        /// The protocol prefix byte with a live acceptor.
+        protocol_byte: u8,
+    },
 
     /// Event broadcasting failed.
     #[error("event broadcast error: {0}")]

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -12,10 +12,12 @@
 //!   identity gate), writes the `ForwardHeader`, waits for the peer's
 //!   response, and on `connected` bridges the two with `tokio::io::copy`.
 //! - **Inbound (the peer's accept side — security-critical):** consumes
-//!   `ForwardV1` streams from [`crate::Agent::next_incoming_stream`], reads
+//!   `ForwardV1`/`ForwardV2` streams from its registered protocol acceptors
+//!   ([`crate::Agent::register_stream_acceptor`]), reads
 //!   the header, and calls [`crate::connect::evaluate_connect_gate`] BEFORE
 //!   any `TcpStream::connect`. The stream already cleared the T1 identity
-//!   gate (verified + trust `Accept` + not revoked), so the connect gate is
+//!   gate (verified + trust `Accept` + not revoked) and the stream-layer
+//!   connect-ACL pair gate, so the connect gate is
 //!   passed `verified=true, trust=Some(Accept)`; its job is the ACL
 //!   target-match + loopback re-check. The gate checks **every** agent on
 //!   the peer machine (the QUIC transport authenticates the machine, not
@@ -1040,10 +1042,13 @@ struct ForwardEntry {
     cancel: CancellationToken,
 }
 
-/// Owns the inbound forward consumer + the outbound local listeners.
+/// Owns the inbound forward consumers + the outbound local listeners.
 ///
-/// The inbound loop is the sole consumer of `ForwardV1` streams surfaced by
-/// [`crate::Agent::next_incoming_stream`]; each is gated by `handle_inbound`
+/// The forwarder is the registered acceptor for the `ForwardV1` and
+/// `ForwardV2` stream protocols
+/// ([`crate::Agent::register_stream_acceptor`]): the accept loop routes
+/// identity-gated, ACL-gated forward streams straight to this service's
+/// bounded acceptor channels, and each is gated again by `handle_inbound`
 /// (resolve → `evaluate_connect_gate` → connect loopback → bridge). Outbound
 /// listeners (`add_forward`) accept local TCP, open a peer stream, write the
 /// `ForwardHeader`, and bridge on `connected`.
@@ -1056,6 +1061,16 @@ pub struct ForwardService {
     /// tear down individual listeners and `list` can return them.
     forwards: std::sync::Mutex<Vec<ForwardEntry>>,
     inbound_token: CancellationToken,
+    /// The forwarder-owned protocol acceptors (`ForwardV1`, `ForwardV2`),
+    /// moved into their consumer loops by `spawn_inbound`. `None` once the
+    /// consumers are running (or after shutdown, when dropping the loops'
+    /// acceptor handles deregisters them).
+    inbound_acceptors: std::sync::Mutex<
+        Option<(
+            crate::streams::StreamAcceptor,
+            crate::streams::StreamAcceptor,
+        )>,
+    >,
     /// FIX 3: global + per-peer concurrency caps. Admission requires a global
     /// permit (held for the stream's lifetime) AND a per-peer slot; a stream
     /// beyond either cap is reset + counted rather than spawned unbounded.
@@ -1145,26 +1160,40 @@ fn try_peer_slot(
 impl ForwardService {
     /// Construct a forwarder over a loaded connect policy + its diagnostics.
     ///
+    /// Registers the forwarder as the single acceptor for the `ForwardV1` and
+    /// `ForwardV2` stream protocols ([`crate::Agent::register_stream_acceptor`])
+    /// — inbound forward streams are routed to this service by the accept
+    /// loop, never through a shared demux.
+    ///
     /// `require_attestation` (default `true`) denies inbound ForwardV1 streams
     /// and gates the outbound V1 fallback — set `false` for mixed-version
     /// deployments (#204 must-fix 1).
-    #[must_use]
+    ///
+    /// # Errors
+    /// [`NetworkError::StreamAcceptorConflict`] if another consumer already
+    /// owns one of the forward protocols on this agent (a second
+    /// `ForwardService` on the same agent is refused).
     pub fn new(
         agent: Arc<crate::Agent>,
         policy: Arc<ConnectPolicy>,
         connect_diag: Arc<ConnectDiagnostics>,
         require_attestation: bool,
-    ) -> Self {
+    ) -> NetworkResult<Self> {
+        let acceptor_v1 =
+            agent.register_stream_acceptor(crate::streams::StreamProtocol::ForwardV1)?;
+        let acceptor_v2 =
+            agent.register_stream_acceptor(crate::streams::StreamProtocol::ForwardV2)?;
         let revocation_set = agent.revocation_set();
         let discovery_cache = agent.identity_discovery_cache();
         let contact_store = agent.contact_store();
-        Self {
+        Ok(Self {
             agent,
             policy,
             connect_diag,
             fwd_diag: Arc::new(ForwardDiagnostics::default()),
             forwards: std::sync::Mutex::new(Vec::new()),
             inbound_token: CancellationToken::new(),
+            inbound_acceptors: std::sync::Mutex::new(Some((acceptor_v1, acceptor_v2))),
             inbound_permits: Arc::new(tokio::sync::Semaphore::new(MAX_INBOUND_STREAMS)),
             outbound_permits: Arc::new(tokio::sync::Semaphore::new(MAX_OUTBOUND_STREAMS)),
             per_peer: Arc::new(std::sync::Mutex::new(HashMap::new())),
@@ -1172,7 +1201,7 @@ impl ForwardService {
             discovery_cache,
             contact_store,
             require_attestation,
-        }
+        })
     }
 
     /// Forwarder-owned diagnostics (connect-failed + active-stream counters).
@@ -1195,67 +1224,84 @@ impl ForwardService {
         admit_to(permits, &self.per_peer, peer)
     }
 
-    /// Start the inbound consumer loop. Spawns a task that surfaces
-    /// `ForwardV1` streams to `handle_inbound`. Returns immediately.
+    /// Start the inbound consumer loops — one per registered forward-protocol
+    /// acceptor (`ForwardV1`, `ForwardV2`). Idempotent: a second call finds
+    /// the acceptors already moved into their loops and returns without
+    /// spawning duplicates. Returns immediately.
     pub fn spawn_inbound(self: &Arc<Self>) {
+        let acceptors = self
+            .inbound_acceptors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        let Some((acceptor_v1, acceptor_v2)) = acceptors else {
+            tracing::debug!(
+                target: "x0x::forward",
+                "inbound forward consumers already started — ignoring duplicate spawn"
+            );
+            return;
+        };
+        self.spawn_acceptor_loop(acceptor_v1);
+        self.spawn_acceptor_loop(acceptor_v2);
+    }
+
+    /// Drain one protocol acceptor until shutdown or accept-loop stop,
+    /// handing each surfaced stream to [`Self::spawn_stream_handler`].
+    fn spawn_acceptor_loop(self: &Arc<Self>, mut acceptor: crate::streams::StreamAcceptor) {
         let this = Arc::clone(self);
         let token = self.inbound_token.clone();
         tokio::spawn(async move {
-            tracing::info!(target: "x0x::forward", "inbound forward consumer started");
+            tracing::info!(
+                target: "x0x::forward",
+                protocol = ?acceptor.protocol(),
+                "inbound forward consumer started"
+            );
             loop {
                 let stream = tokio::select! {
                     _ = token.cancelled() => break,
-                    s = this.agent.next_incoming_stream() => match s {
+                    s = acceptor.next() => match s {
                         Some(s) => s,
                         None => break,
                     },
                 };
-                if !matches!(
-                    stream.protocol(),
-                    crate::streams::StreamProtocol::ForwardV1
-                        | crate::streams::StreamProtocol::ForwardV2
-                ) {
-                    // T5 (SOCKS5) owns 0x02; drop non-forward streams.
-                    tracing::debug!(
-                        target: "x0x::forward",
-                        protocol = ?stream.protocol(),
-                        "non-forward inbound stream — not handled by the forwarder"
-                    );
-                    continue;
-                }
-                // FIX 3: cap admission before spawning. Over-cap streams are
-                // reset (dropped) + counted rather than spawning unbounded.
-                let peer_agent = stream.agent();
-                let admission = match this.admit(peer_agent, true) {
-                    Some(a) => a,
-                    None => {
-                        this.fwd_diag.record_over_cap();
-                        tracing::info!(
-                            target: "x0x::forward",
-                            agent = %hex::encode(peer_agent.as_bytes()),
-                            "inbound forward refused: concurrency cap reached — resetting"
-                        );
-                        continue;
-                    }
-                };
-                let this = Arc::clone(&this);
-                tokio::spawn(async move {
-                    let _admission = admission;
-                    this.fwd_diag.enter_stream();
-                    let _leave = StreamLeaveGuard(Arc::clone(&this.fwd_diag));
-                    let inbound_ctx = InboundCtx {
-                        policy: Arc::clone(&this.policy),
-                        connect_diag: Arc::clone(&this.connect_diag),
-                        fwd_diag: Arc::clone(&this.fwd_diag),
-                        revocation_set: Arc::clone(&this.revocation_set),
-                        discovery_cache: Arc::clone(&this.discovery_cache),
-                        contact_store: Arc::clone(&this.contact_store),
-                        own_machine_id: this.agent.machine_id(),
-                        require_attestation: this.require_attestation,
-                    };
-                    handle_inbound(stream, &inbound_ctx).await;
-                });
+                this.spawn_stream_handler(stream);
             }
+        });
+    }
+
+    /// Admit one inbound forward stream (FIX 3 concurrency caps) and spawn
+    /// its `handle_inbound` task. Over-cap streams are reset (dropped) +
+    /// counted rather than spawning unbounded.
+    fn spawn_stream_handler(self: &Arc<Self>, stream: PeerStream) {
+        let peer_agent = stream.agent();
+        let admission = match self.admit(peer_agent, true) {
+            Some(a) => a,
+            None => {
+                self.fwd_diag.record_over_cap();
+                tracing::info!(
+                    target: "x0x::forward",
+                    agent = %hex::encode(peer_agent.as_bytes()),
+                    "inbound forward refused: concurrency cap reached — resetting"
+                );
+                return;
+            }
+        };
+        let this = Arc::clone(self);
+        tokio::spawn(async move {
+            let _admission = admission;
+            this.fwd_diag.enter_stream();
+            let _leave = StreamLeaveGuard(Arc::clone(&this.fwd_diag));
+            let inbound_ctx = InboundCtx {
+                policy: Arc::clone(&this.policy),
+                connect_diag: Arc::clone(&this.connect_diag),
+                fwd_diag: Arc::clone(&this.fwd_diag),
+                revocation_set: Arc::clone(&this.revocation_set),
+                discovery_cache: Arc::clone(&this.discovery_cache),
+                contact_store: Arc::clone(&this.contact_store),
+                own_machine_id: this.agent.machine_id(),
+                require_attestation: this.require_attestation,
+            };
+            handle_inbound(stream, &inbound_ctx).await;
         });
     }
     /// Register a local forward: bind `local_addr`, and for each accepted TCP

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,8 +340,7 @@ pub struct Agent {
     /// the daemon installs the loaded policy at startup via
     /// [`Agent::set_connect_policy`]. `std` RwLock: gate reads are a brief
     /// clone of the inner `Arc`, never held across an await.
-    connect_policy:
-        std::sync::Arc<std::sync::RwLock<std::sync::Arc<connect::ConnectPolicy>>>,
+    connect_policy: std::sync::Arc<std::sync::RwLock<std::sync::Arc<connect::ConnectPolicy>>>,
 }
 
 /// Closed-flag task registry for deterministic Agent teardown.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,16 @@ pub struct Agent {
     /// surfacing inbound [`streams::PeerStream`]s that have cleared the
     /// identity gate, plus an idempotent started-flag for the accept loop.
     stream_accept: std::sync::Arc<streams::StreamAccept>,
+    /// Connect ACL (#131) consulted by the inbound byte-stream accept loop
+    /// (#132): with an `Enabled` policy, every announced agent on the peer
+    /// machine must be pair-listed or the stream is reset
+    /// ([`error::NetworkError::PeerNotInConnectAcl`]). Defaults to
+    /// [`connect::ConnectPolicy::default`] (Disabled ⇒ no ACL constraint);
+    /// the daemon installs the loaded policy at startup via
+    /// [`Agent::set_connect_policy`]. `std` RwLock: gate reads are a brief
+    /// clone of the inner `Arc`, never held across an await.
+    connect_policy:
+        std::sync::Arc<std::sync::RwLock<std::sync::Arc<connect::ConnectPolicy>>>,
 }
 
 /// Closed-flag task registry for deterministic Agent teardown.
@@ -8522,13 +8532,74 @@ impl Agent {
         ))
     }
 
-    /// Await the next inbound byte-stream that has cleared the identity gate.
+    /// Await the next inbound byte-stream that has cleared the identity gate
+    /// **and whose protocol has no registered acceptor**.
     ///
     /// Returns `None` when the accept loop has stopped (e.g. after shutdown).
-    /// The T4 forwarder consumes accepted streams through this method.
+    /// Protocols with a registered acceptor
+    /// ([`Self::register_stream_acceptor`]) are routed there instead — this
+    /// default sink never sees them.
     pub async fn next_incoming_stream(&self) -> Option<streams::PeerStream> {
         let mut rx = self.stream_accept.receiver().lock().await;
         rx.recv().await
+    }
+
+    /// Register the single consumer for one stream protocol.
+    ///
+    /// Returns a bounded [`streams::StreamAcceptor`] (capacity
+    /// [`streams::STREAM_ACCEPTOR_CAPACITY`]) that surfaces inbound
+    /// [`streams::PeerStream`]s for `protocol` after they have cleared the
+    /// identity gate, the connect-ACL gate, and the protocol handshake.
+    /// The T4 forwarder owns `ForwardV1`/`ForwardV2` this way; a T5 SOCKS5
+    /// listener would register `SocksV1`.
+    ///
+    /// Exactly one acceptor may be live per protocol: a duplicate
+    /// registration fails with
+    /// [`error::NetworkError::StreamAcceptorConflict`]. Dropping the
+    /// acceptor deregisters it — subsequent streams for the protocol fall
+    /// back to the default sink ([`Self::next_incoming_stream`]).
+    ///
+    /// # Errors
+    /// [`error::NetworkError::StreamAcceptorConflict`] if an acceptor is
+    /// already registered for `protocol`.
+    pub fn register_stream_acceptor(
+        &self,
+        protocol: streams::StreamProtocol,
+    ) -> error::NetworkResult<streams::StreamAcceptor> {
+        self.stream_accept.register(protocol)
+    }
+
+    /// Install the connect ACL policy (#131) consulted by the inbound
+    /// byte-stream accept loop.
+    ///
+    /// With [`connect::ConnectPolicy::Enabled`], an inbound stream is only
+    /// surfaced when **every** announced agent on the peer machine is
+    /// `(AgentId, MachineId)`-listed in the ACL (fail-closed, mirroring the
+    /// forwarder's every-agent rule, #192); an unlisted peer's stream is
+    /// reset with zero application bytes exchanged. With
+    /// [`connect::ConnectPolicy::Disabled`] (the default) no ACL constraint
+    /// applies and the identity gate remains the sole stream boundary —
+    /// connect-forwarding itself stays default-deny at the T4 forwarder.
+    ///
+    /// The daemon calls this once at startup with the loaded policy; library
+    /// embedders that want ACL-gated streams do the same.
+    pub fn set_connect_policy(&self, policy: std::sync::Arc<connect::ConnectPolicy>) {
+        let mut guard = self
+            .connect_policy
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = policy;
+    }
+
+    /// The currently installed connect ACL policy (defaults to
+    /// [`connect::ConnectPolicy::Disabled`] — see [`Self::set_connect_policy`]).
+    #[must_use]
+    pub fn connect_policy(&self) -> std::sync::Arc<connect::ConnectPolicy> {
+        let guard = self
+            .connect_policy
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        std::sync::Arc::clone(&guard)
     }
 
     /// Start the inbound byte-stream accept loop (idempotent).
@@ -8536,9 +8607,13 @@ impl Agent {
     /// Called automatically by [`Agent::join_network`]. The loop is the SOLE
     /// consumer of [`network::NetworkNode::accept_bi`]; every inbound stream
     /// clears the identity gate (machine has a known agent → not revoked →
-    /// trust `Accept`) and the protocol handshake before being surfaced via
-    /// [`Self::next_incoming_stream`]. A stream that fails the gate is reset
-    /// (its halves are dropped) with zero application bytes exchanged.
+    /// trust `Accept`), then the connect-ACL gate ([`Self::set_connect_policy`]
+    /// — every announced agent pair-listed when the policy is `Enabled`),
+    /// then the protocol handshake, before being routed by protocol byte to
+    /// the registered acceptor ([`Self::register_stream_acceptor`]) or the
+    /// default sink ([`Self::next_incoming_stream`]). A stream that fails a
+    /// gate is reset (its halves are dropped) with zero application bytes
+    /// exchanged.
     fn start_stream_accept_loop(&self) {
         if !self.stream_accept.start_once() {
             return;
@@ -8549,6 +8624,7 @@ impl Agent {
         let discovery_cache = std::sync::Arc::clone(&self.identity_discovery_cache);
         let contact_store = std::sync::Arc::clone(&self.contact_store);
         let revocation_set = std::sync::Arc::clone(&self.revocation_set);
+        let connect_policy = std::sync::Arc::clone(&self.connect_policy);
         let incoming = std::sync::Arc::clone(&self.stream_accept);
         let token = self.shutdown_token.clone();
 
@@ -8647,6 +8723,30 @@ impl Agent {
                 let agents: Vec<identity::AgentId> =
                     agents.into_iter().map(|(a, _)| a).collect();
 
+                // Connect-ACL gate (#131 × #132): with an Enabled policy every
+                // announced agent on this machine must be pair-listed in the
+                // ACL; an unlisted peer's stream is reset here with zero
+                // application bytes exchanged (fail-closed second layer,
+                // mirrors forward::decide_inbound's every-agent rule, #192).
+                // A Disabled policy adds no constraint.
+                let policy = {
+                    let guard = connect_policy
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    std::sync::Arc::clone(&guard)
+                };
+                if let Err(e) = streams::stream_acl_gate(&policy, &agents, &machine_id) {
+                    tracing::info!(
+                        target: "x0x::streams",
+                        machine = %hex::encode(machine_id.as_bytes()),
+                        agent_count = agents.len(),
+                        outcome = "deny_acl",
+                        error = %e,
+                        "inbound stream denied at connect-ACL gate (unlisted peer)"
+                    );
+                    continue;
+                }
+
                 // DISPATCH (DoS hardening, issue #132): the protocol-prefix
                 // read + surfacing run in a per-stream task so a peer that
                 // opens a stream and never sends the prefix cannot block this
@@ -8686,11 +8786,18 @@ impl Agent {
                     };
                     let peer_stream =
                         streams::PeerStream::new(agents, machine_id, protocol, send, recv);
-                    // try_send so a slow consumer cannot pile up accepted
-                    // streams in memory; a full channel drops the stream.
-                    if incoming_for_task.sender().try_send(peer_stream).is_err() {
+                    // Route by protocol byte to the registered acceptor (or
+                    // the default sink), then try_send so a slow consumer
+                    // cannot pile up accepted streams in memory; a full
+                    // channel drops (resets) the stream.
+                    if incoming_for_task
+                        .sender_for(protocol)
+                        .try_send(peer_stream)
+                        .is_err()
+                    {
                         tracing::debug!(
                             target: "x0x::streams",
+                            protocol = ?protocol,
                             "incoming-stream channel full; dropping accepted stream"
                         );
                     }
@@ -10197,6 +10304,9 @@ impl AgentBuilder {
             peer_relay,
             relay_candidates,
             stream_accept: std::sync::Arc::new(streams::StreamAccept::new(256)),
+            connect_policy: std::sync::Arc::new(std::sync::RwLock::new(std::sync::Arc::new(
+                connect::ConnectPolicy::default(),
+            ))),
         })
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -922,20 +922,28 @@ pub async fn serve_with_options(
         mpsc::channel::<x0x::dm_inbox::DmTypedPayload>(1024);
     let exec_service = x0x::exec::ExecService::spawn(Arc::clone(&agent), exec_policy, exec_dm_rx);
 
-    // Tailnet forwarder (#132 T4): build the connect-ACL diagnostics + the
-    // ForwardService. The inbound consumer is the sole reader of
-    // ForwardV1 streams and gates each at `evaluate_connect_gate` before any
-    // local connect. Only spawn when connect is enabled by policy.
+    // Tailnet streams + forwarder (#131 × #132): install the loaded connect
+    // policy on the agent so the inbound byte-stream accept loop refuses
+    // streams from ACL-unlisted peers (default-closed when the policy is
+    // Enabled; no ACL constraint when Disabled). Then build the connect-ACL
+    // diagnostics + the ForwardService, whose inbound consumers are the
+    // registered acceptors for the ForwardV1/ForwardV2 stream protocols and
+    // gate each stream at `evaluate_connect_gate` before any local connect.
+    // Only spawn the forwarder when connect is enabled by policy.
+    agent.set_connect_policy(Arc::new(connect_policy.clone()));
     let connect_diagnostics = Arc::new(x0x::connect::ConnectDiagnostics::new(
         connect_policy.summary(),
     ));
     let forward_service = if connect_policy.enabled() {
-        let fs = Arc::new(x0x::forward::ForwardService::new(
-            Arc::clone(&agent),
-            Arc::new(connect_policy.clone()),
-            Arc::clone(&connect_diagnostics),
-            config.forward.require_attestation,
-        ));
+        let fs = Arc::new(
+            x0x::forward::ForwardService::new(
+                Arc::clone(&agent),
+                Arc::new(connect_policy.clone()),
+                Arc::clone(&connect_diagnostics),
+                config.forward.require_attestation,
+            )
+            .context("failed to register forwarder stream acceptors")?,
+        );
         fs.spawn_inbound();
         Some(fs)
     } else {

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -99,9 +99,8 @@ pub(crate) struct StreamAccept {
     /// Live per-protocol acceptor senders, keyed by the protocol-prefix byte.
     /// A `std` mutex: registration/deregistration/route-lookup critical
     /// sections are a handful of pointer copies, never held across an await.
-    acceptors: std::sync::Mutex<
-        std::collections::HashMap<u8, tokio::sync::mpsc::Sender<PeerStream>>,
-    >,
+    acceptors:
+        std::sync::Mutex<std::collections::HashMap<u8, tokio::sync::mpsc::Sender<PeerStream>>>,
     started: std::sync::atomic::AtomicBool,
 }
 
@@ -716,7 +715,9 @@ mod tests {
         let dup = accept.register(StreamProtocol::SocksV1);
         assert!(matches!(
             dup,
-            Err(NetworkError::StreamAcceptorConflict { protocol_byte: 0x02 })
+            Err(NetworkError::StreamAcceptorConflict {
+                protocol_byte: 0x02
+            })
         ));
 
         // Registered protocol routes to the acceptor; unregistered routes to

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -61,7 +61,7 @@
 //! with zero application bytes exchanged.
 //!
 //! Inbound only, a **second** layer then runs: the connect-ACL gate
-//! ([`stream_acl_gate`], #131). With an `Enabled` connect policy every
+//! (`stream_acl_gate`, #131). With an `Enabled` connect policy every
 //! announced agent on the peer machine must be `(AgentId, MachineId)`-listed
 //! or the stream is reset (`PeerNotInConnectAcl`); a `Disabled` policy adds
 //! no constraint. These chokepoints are what make the T4 inbound forwarder

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -1,4 +1,4 @@
-//! Per-peer bidirectional byte-streams over ant-quic (tailnet Phase 1, #132 T1).
+//! Per-peer bidirectional byte-streams over ant-quic (tailnet Phase 1, #132).
 //!
 //! Builds on [`ant_quic::Node::open_bi`] / [`ant_quic::Node::accept_bi`] to
 //! expose reliable, backpressure-correct byte-streams between two x0x peers.
@@ -20,11 +20,22 @@
 //!
 //! `0x00` is reserved (treated as unknown → reset). See `StreamProtocol`.
 //!
-//! ## Identity gate — fail closed, in fixed order
+//! ## Consumption: per-protocol acceptors
+//!
+//! Inbound streams that clear both gates (below) and the protocol handshake
+//! are routed by the prefix byte: [`crate::Agent::register_stream_acceptor`]
+//! installs the single consumer for a protocol (e.g. the T4 forwarder owns
+//! `ForwardV1`/`ForwardV2`); protocols without a registered acceptor fall
+//! back to the default channel drained by
+//! [`crate::Agent::next_incoming_stream`]. Every channel is bounded — a
+//! stalled consumer causes new streams to be reset, never buffered
+//! unboundedly, and the byte flow itself rides QUIC flow control.
+//!
+//! ## Gates — fail closed, in fixed order
 //!
 //! Both the outbound open ([`crate::Agent::open_peer_stream`]) and the inbound
-//! accept loop enforce the same gate, in this order, before any application
-//! byte is sent or read:
+//! accept loop enforce the identity gate, in this order, before any
+//! application byte is sent or read:
 //!
 //! 1. **transport-verified** — ant-quic authenticates the peer's `MachineId`
 //!    at the QUIC/TLS layer; an unauthenticated connection can never yield a
@@ -47,52 +58,205 @@
 //!
 //! Any failure produces a typed `NetworkError` (`PeerNotVerified` /
 //! `PeerTrustRejected` / `PeerRevoked`) and the stream is refused or reset
-//! with zero application bytes exchanged. This chokepoint is what makes the
-//! T4 inbound forwarder safe by construction: it receives only streams that
-//! have already cleared the identity gate.
+//! with zero application bytes exchanged.
+//!
+//! Inbound only, a **second** layer then runs: the connect-ACL gate
+//! ([`stream_acl_gate`], #131). With an `Enabled` connect policy every
+//! announced agent on the peer machine must be `(AgentId, MachineId)`-listed
+//! or the stream is reset (`PeerNotInConnectAcl`); a `Disabled` policy adds
+//! no constraint. These chokepoints are what make the T4 inbound forwarder
+//! safe by construction: it receives only streams that have already cleared
+//! both gates.
 
 use crate::error::{NetworkError, NetworkResult};
 use crate::identity::MachineId;
 
+/// Capacity of each per-protocol acceptor channel. Bounded so a consumer
+/// that stops draining cannot pile up accepted streams in memory: a full
+/// acceptor makes the dispatch task drop (reset) the stream instead.
+pub const STREAM_ACCEPTOR_CAPACITY: usize = 64;
+
 /// Shared state for the inbound byte-stream accept loop.
 ///
-/// Owns the bounded channel that surfaces identity-gated [`PeerStream`]s to
-/// the consumer (the T4 forwarder / a test), plus an idempotent started-flag
-/// so [`crate::Agent`] starts exactly one accept loop even if
+/// Owns the bounded default channel that surfaces identity-gated
+/// [`PeerStream`]s for protocols with no registered acceptor, the registry of
+/// per-protocol acceptor channels, plus an idempotent started-flag so
+/// [`crate::Agent`] starts exactly one accept loop even if
 /// `join_network` races.
+///
+/// ## Routing
+///
+/// Once a stream has cleared the identity gate, the connect-ACL gate, and
+/// the protocol handshake, the dispatch task routes it by its protocol-prefix
+/// byte: a protocol with a registered [`StreamAcceptor`] goes to that
+/// acceptor's bounded channel; anything else goes to the default channel
+/// drained by [`crate::Agent::next_incoming_stream`]. Either way a full
+/// channel drops (resets) the stream — backpressure is never hidden behind
+/// unbounded buffering.
 pub(crate) struct StreamAccept {
     tx: tokio::sync::mpsc::Sender<PeerStream>,
     rx: std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<PeerStream>>>,
+    /// Live per-protocol acceptor senders, keyed by the protocol-prefix byte.
+    /// A `std` mutex: registration/deregistration/route-lookup critical
+    /// sections are a handful of pointer copies, never held across an await.
+    acceptors: std::sync::Mutex<
+        std::collections::HashMap<u8, tokio::sync::mpsc::Sender<PeerStream>>,
+    >,
     started: std::sync::atomic::AtomicBool,
 }
 
 impl StreamAccept {
-    /// New accept state with a bounded surfacing channel.
+    /// New accept state with a bounded default surfacing channel.
     pub(crate) fn new(capacity: usize) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(capacity);
         Self {
             tx,
             rx: std::sync::Arc::new(tokio::sync::Mutex::new(rx)),
+            acceptors: std::sync::Mutex::new(std::collections::HashMap::new()),
             started: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
-    /// Sender half for the accept loop to push gated streams onto.
+    /// Sender half for the accept loop to push gated streams onto when no
+    /// per-protocol acceptor is registered. Test-only: production routing
+    /// goes through [`Self::sender_for`].
+    #[cfg(test)]
     pub(crate) fn sender(&self) -> &tokio::sync::mpsc::Sender<PeerStream> {
         &self.tx
     }
 
-    /// Receiver half for the consumer to drain accepted streams.
+    /// Receiver half for the consumer to drain accepted streams that carry a
+    /// protocol with no registered acceptor.
     pub(crate) fn receiver(
         &self,
     ) -> &std::sync::Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<PeerStream>>> {
         &self.rx
     }
 
+    /// The dispatch channel for `protocol`: the registered acceptor's sender
+    /// when one is live, otherwise the default channel. The lookup runs in
+    /// the per-stream dispatch task (after the prefix read), so registration
+    /// ordering relative to in-flight streams is well-defined: a stream
+    /// routes by the registry state at dispatch time.
+    pub(crate) fn sender_for(
+        &self,
+        protocol: StreamProtocol,
+    ) -> tokio::sync::mpsc::Sender<PeerStream> {
+        let acceptors = self
+            .acceptors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        acceptors
+            .get(&protocol.as_u8())
+            .cloned()
+            .unwrap_or_else(|| self.tx.clone())
+    }
+
+    /// Register the single acceptor for `protocol` (bounded channel of
+    /// [`STREAM_ACCEPTOR_CAPACITY`]). Fails with
+    /// [`NetworkError::StreamAcceptorConflict`] when an acceptor is already
+    /// live for the protocol — exactly one consumer may own a protocol.
+    /// Dropping the returned [`StreamAcceptor`] deregisters it, so a
+    /// restarting consumer can re-register (and in-flight dispatches then
+    /// fall back to the default channel).
+    pub(crate) fn register(
+        self: &std::sync::Arc<Self>,
+        protocol: StreamProtocol,
+    ) -> NetworkResult<StreamAcceptor> {
+        let (tx, rx) = tokio::sync::mpsc::channel(STREAM_ACCEPTOR_CAPACITY);
+        let mut acceptors = self
+            .acceptors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if acceptors.contains_key(&protocol.as_u8()) {
+            return Err(NetworkError::StreamAcceptorConflict {
+                protocol_byte: protocol.as_u8(),
+            });
+        }
+        acceptors.insert(protocol.as_u8(), tx.clone());
+        Ok(StreamAcceptor {
+            protocol,
+            rx,
+            tx,
+            registry: std::sync::Arc::clone(self),
+        })
+    }
+
+    /// Remove the acceptor for `protocol`, but only if the registry still
+    /// holds *this* acceptor's channel — a re-registered successor must not
+    /// be clobbered by a stale acceptor's drop.
+    fn deregister(&self, protocol: StreamProtocol, tx: &tokio::sync::mpsc::Sender<PeerStream>) {
+        let mut acceptors = self
+            .acceptors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if acceptors
+            .get(&protocol.as_u8())
+            .is_some_and(|live| live.same_channel(tx))
+        {
+            acceptors.remove(&protocol.as_u8());
+        }
+    }
+
     /// Try to mark the accept loop as started. Returns `true` if this call is
     /// the winner (the loop should start); `false` if a loop is already running.
     pub(crate) fn start_once(&self) -> bool {
         !self.started.swap(true, std::sync::atomic::Ordering::AcqRel)
+    }
+}
+
+/// Owned receiver for one protocol's inbound byte-streams.
+///
+/// Obtained from [`crate::Agent::register_stream_acceptor`]. Each
+/// [`StreamAcceptor`] is the single consumer for its
+/// [`StreamProtocol`]: streams arrive here only after the identity gate,
+/// the connect-ACL gate, and the protocol handshake have all cleared, so a
+/// consumer never sees an unverified/untrusted/unlisted peer. The channel is
+/// bounded ([`STREAM_ACCEPTOR_CAPACITY`]); a consumer that stops draining
+/// causes new streams to be reset rather than buffered.
+///
+/// Dropping the acceptor deregisters it: subsequent streams for the protocol
+/// route to the default channel ([`crate::Agent::next_incoming_stream`]).
+pub struct StreamAcceptor {
+    protocol: StreamProtocol,
+    rx: tokio::sync::mpsc::Receiver<PeerStream>,
+    /// Kept for channel-identity comparison at drop (see `deregister`).
+    tx: tokio::sync::mpsc::Sender<PeerStream>,
+    registry: std::sync::Arc<StreamAccept>,
+}
+
+impl StreamAcceptor {
+    /// The protocol this acceptor owns.
+    #[must_use]
+    pub fn protocol(&self) -> StreamProtocol {
+        self.protocol
+    }
+
+    /// Await the next inbound stream for this protocol. Returns `None` when
+    /// the accept loop has stopped (e.g. after agent shutdown).
+    pub async fn next(&mut self) -> Option<PeerStream> {
+        self.rx.recv().await
+    }
+
+    /// Number of streams currently queued in this acceptor (channel depth).
+    /// Exposed so tests and operators can assert the depth stays bounded.
+    #[must_use]
+    pub fn queued(&self) -> usize {
+        self.rx.len()
+    }
+
+    /// Non-blocking poll for an already-queued stream. Returns `None` when
+    /// nothing is queued (or the accept loop has stopped). Primarily for
+    /// tests asserting bounded channel depth.
+    #[must_use]
+    pub fn try_next(&mut self) -> Option<PeerStream> {
+        self.rx.try_recv().ok()
+    }
+}
+
+impl Drop for StreamAcceptor {
+    fn drop(&mut self) {
+        self.registry.deregister(self.protocol, &self.tx);
     }
 }
 
@@ -140,6 +304,44 @@ pub(crate) fn stream_gate(
         return Err(NetworkError::PeerTrustRejected {
             agent_id: agent_id.0,
         });
+    }
+    Ok(())
+}
+
+/// Connect-ACL gate for inbound byte-streams (#131 hooked into #132).
+///
+/// Second fail-closed layer, evaluated by the inbound accept loop **after**
+/// the identity gate (so only verified + trusted + non-revoked peers can
+/// even reach it — they learn nothing about the ACL's contents otherwise).
+///
+/// * [`crate::connect::ConnectPolicy::Disabled`] ⇒ no ACL constraint: the
+///   identity gate remains the sole boundary (backwards-compatible with
+///   pre-ACL peers; connect-forwarding stays default-deny at the forwarder).
+/// * [`crate::connect::ConnectPolicy::Enabled`] ⇒ **every** agent announced
+///   on the peer machine must be listed as an `(AgentId, MachineId)` pair in
+///   the ACL, else [`NetworkError::PeerNotInConnectAcl`]. The every-agent
+///   rule mirrors `forward::decide_inbound` (#192): the QUIC transport
+///   authenticates the machine, not the individual agent, so a single
+///   unlisted agent on the machine fails the whole stream closed.
+///
+/// Pure function so the Disabled/Enabled × listed/unlisted × multi-agent
+/// matrix is fast unit-testable without a network. Target membership is NOT
+/// checked here — raw byte-streams carry no target; per-target enforcement
+/// stays with the T4 forwarder's `evaluate_connect_gate` call.
+pub(crate) fn stream_acl_gate(
+    policy: &crate::connect::ConnectPolicy,
+    agents: &[crate::identity::AgentId],
+    machine_id: &MachineId,
+) -> NetworkResult<()> {
+    let crate::connect::ConnectPolicy::Enabled(acl) = policy else {
+        return Ok(());
+    };
+    for agent_id in agents {
+        if acl.entry_for(agent_id, machine_id).is_none() {
+            return Err(NetworkError::PeerNotInConnectAcl {
+                agent_id: agent_id.0,
+            });
+        }
     }
     Ok(())
 }
@@ -428,5 +630,125 @@ mod tests {
             stream_gate(&agent, accept, true, false, true),
             Err(NetworkError::PeerRevoked { agent_id }) if agent_id == agent.0
         ));
+    }
+
+    /// Build an Enabled connect policy listing exactly the given
+    /// `(agent, machine)` pairs (one dummy loopback target each — the
+    /// stream-layer ACL gate checks pair membership only, never targets).
+    fn enabled_policy_listing(
+        pairs: &[(crate::identity::AgentId, MachineId)],
+    ) -> crate::connect::ConnectPolicy {
+        let allow = pairs
+            .iter()
+            .map(|(agent_id, machine_id)| crate::connect::ConnectAllowEntry {
+                description: None,
+                agent_id: *agent_id,
+                machine_id: *machine_id,
+                targets: vec!["127.0.0.1:22".parse().expect("loopback literal")],
+            })
+            .collect();
+        crate::connect::ConnectPolicy::Enabled(crate::connect::ConnectAcl {
+            loaded_from: std::path::Path::new("/test").to_path_buf(),
+            loaded_at_unix_ms: 0,
+            allow,
+        })
+    }
+
+    // #131 × #132: the inbound stream connect-ACL gate. Disabled policy adds
+    // no constraint (identity gate remains the boundary); Enabled policy
+    // requires EVERY announced agent on the peer machine to be pair-listed —
+    // one unlisted agent fails the stream closed (#192).
+    #[test]
+    fn stream_acl_gate_matrix() {
+        use crate::error::NetworkError;
+        use crate::identity::AgentId;
+
+        let machine = MachineId([7u8; 32]);
+        let listed = AgentId([1u8; 32]);
+        let also_listed = AgentId([2u8; 32]);
+        let unlisted = AgentId([3u8; 32]);
+
+        // Disabled ⇒ no constraint, even for a peer listing nobody.
+        let disabled = crate::connect::ConnectPolicy::default();
+        assert!(stream_acl_gate(&disabled, &[unlisted], &machine).is_ok());
+
+        let policy = enabled_policy_listing(&[(listed, machine), (also_listed, machine)]);
+
+        // All agents listed ⇒ pass.
+        assert!(stream_acl_gate(&policy, &[listed], &machine).is_ok());
+        assert!(stream_acl_gate(&policy, &[listed, also_listed], &machine).is_ok());
+
+        // Single unlisted agent ⇒ PeerNotInConnectAcl naming that agent.
+        assert!(matches!(
+            stream_acl_gate(&policy, &[unlisted], &machine),
+            Err(NetworkError::PeerNotInConnectAcl { agent_id }) if agent_id == unlisted.0
+        ));
+
+        // Multi-agent fail-closed: one unlisted agent on the machine denies
+        // the whole stream, even though another agent is listed.
+        assert!(matches!(
+            stream_acl_gate(&policy, &[listed, unlisted], &machine),
+            Err(NetworkError::PeerNotInConnectAcl { agent_id }) if agent_id == unlisted.0
+        ));
+
+        // Pair matching is exact: the listed agent on a DIFFERENT machine is
+        // not listed at all.
+        let other_machine = MachineId([8u8; 32]);
+        assert!(matches!(
+            stream_acl_gate(&policy, &[listed], &other_machine),
+            Err(NetworkError::PeerNotInConnectAcl { agent_id }) if agent_id == listed.0
+        ));
+    }
+
+    // Acceptor registry: one acceptor per protocol; drop deregisters; a stale
+    // drop must not clobber a re-registered successor; routing falls back to
+    // the default channel for unregistered protocols; channels are bounded.
+    #[test]
+    fn acceptor_registration_lifecycle() {
+        let accept = std::sync::Arc::new(StreamAccept::new(8));
+
+        // Bounded channel at the documented capacity.
+        let first = accept.register(StreamProtocol::SocksV1).expect("register");
+        assert_eq!(first.tx.capacity(), STREAM_ACCEPTOR_CAPACITY);
+        assert_eq!(first.protocol(), StreamProtocol::SocksV1);
+
+        // Second registration for the same protocol conflicts (typed error).
+        let dup = accept.register(StreamProtocol::SocksV1);
+        assert!(matches!(
+            dup,
+            Err(NetworkError::StreamAcceptorConflict { protocol_byte: 0x02 })
+        ));
+
+        // Registered protocol routes to the acceptor; unregistered routes to
+        // the default channel.
+        assert!(accept
+            .sender_for(StreamProtocol::SocksV1)
+            .same_channel(&first.tx));
+        assert!(accept
+            .sender_for(StreamProtocol::ForwardV1)
+            .same_channel(accept.sender()));
+
+        // Drop deregisters: re-registration succeeds and routing follows.
+        let stale_tx = first.tx.clone();
+        drop(first);
+        let second = accept
+            .register(StreamProtocol::SocksV1)
+            .expect("re-register after drop");
+        assert!(accept
+            .sender_for(StreamProtocol::SocksV1)
+            .same_channel(&second.tx));
+
+        // A stale deregister (old acceptor's channel id) must NOT clobber the
+        // live successor.
+        accept.deregister(StreamProtocol::SocksV1, &stale_tx);
+        assert!(accept
+            .sender_for(StreamProtocol::SocksV1)
+            .same_channel(&second.tx));
+
+        // Dropping the successor returns routing to the default channel.
+        drop(second);
+        assert!(accept
+            .sender_for(StreamProtocol::SocksV1)
+            .same_channel(accept.sender()));
     }
 }

--- a/tests/tailnet_streams_integration.rs
+++ b/tests/tailnet_streams_integration.rs
@@ -288,21 +288,605 @@ async fn accept_loop_not_stalled_by_missing_prefix() {
         .expect("open raw stream");
 
     // (2) alice then opens a normal ForwardV1 stream (writes its prefix).
+    //     Paced behind the raw open: ant-quic's connection driver can
+    //     permanently strand the first frames of burst-opened streams on an
+    //     otherwise-idle connection (see `acceptor_channel_is_bounded`), and
+    //     the normal stream carries no post-prefix bytes here that would
+    //     re-trigger the driver — an unpaced open can strand its prefix frame
+    //     and wedge this proof. A timed-out open is therefore replaced by a
+    //     fresh one (the connection stays healthy for new streams), exactly
+    //     as in the boundedness test.
+    tokio::time::sleep(Duration::from_millis(250)).await;
     let bob_agent_id = bob.agent_id();
-    let alice_for_open = Arc::clone(&alice);
-    let normal = tokio::spawn(async move {
-        alice_for_open
-            .open_peer_stream(&bob_agent_id, StreamProtocol::ForwardV1)
+    let mut surfaced = None;
+    for _attempt in 0..4 {
+        let alice_for_open = Arc::clone(&alice);
+        let normal = tokio::spawn(async move {
+            alice_for_open
+                .open_peer_stream(&bob_agent_id, StreamProtocol::ForwardV1)
+                .await
+                .expect("open normal stream")
+        });
+        // (3) bob must surface the NORMAL stream promptly despite the silent
+        //     one. Before FIX 1 the accept loop would be blocked on the
+        //     silent prefix read and no attempt would ever surface.
+        match take_incoming(&bob, Duration::from_secs(5)).await {
+            Some(stream) => {
+                surfaced = Some(stream);
+                break;
+            }
+            None => normal.abort(), // stranded open; replace it
+        }
+    }
+    let surfaced = surfaced.expect("accept loop was stalled by the missing-prefix stream");
+    assert_eq!(surfaced.protocol(), StreamProtocol::ForwardV1);
+}
+
+// ---------------------------------------------------------------------------
+// Shared harness for the deliverable-1 tests below (acceptor routing, ACL
+// gate, backpressure, large-transfer integrity).
+// ---------------------------------------------------------------------------
+
+/// Connect two joined agents over loopback and fixture both directions of the
+/// identity gate (discovery-cache binding + `Trusted` contact). Returns once
+/// ant-quic reports the connection established on BOTH sides.
+async fn link_pair(a: &Arc<x0x::Agent>, b: &Arc<x0x::Agent>) {
+    let a_network = a.network().expect("a network").clone();
+    let b_network = b.network().expect("b network").clone();
+    let b_addr = normalize_loopback(b_network.bound_addr().await.expect("b bound"));
+
+    let connected = a_network
+        .connect_addr(b_addr)
+        .await
+        .expect("a connects to b");
+    assert_eq!(connected.0, b.machine_id().0);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if a_network
+            .is_connected(&ant_quic::PeerId(b.machine_id().0))
             .await
-            .expect("open normal stream")
+            && b_network
+                .is_connected(&ant_quic::PeerId(a.machine_id().0))
+                .await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        a_network
+            .is_connected(&ant_quic::PeerId(b.machine_id().0))
+            .await,
+        "a→b connected"
+    );
+    assert!(
+        b_network
+            .is_connected(&ant_quic::PeerId(a.machine_id().0))
+            .await,
+        "b→a connected"
+    );
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_secs();
+    let a_addr = normalize_loopback(a_network.bound_addr().await.expect("a bound"));
+    a.insert_discovered_agent_for_testing(discovered_agent(b, b_addr, now_secs))
+        .await;
+    a.set_contact_trusted_for_testing(b.agent_id()).await;
+    b.insert_discovered_agent_for_testing(discovered_agent(a, a_addr, now_secs))
+        .await;
+    b.set_contact_trusted_for_testing(a.agent_id()).await;
+}
+
+/// Deterministic position-dependent pattern (xorshift64) — any dropped,
+/// duplicated, reordered, or cross-contaminated byte breaks the checksum.
+fn xorshift_pattern(len: usize, seed: u64) -> Vec<u8> {
+    let mut state = seed | 1; // xorshift degenerates at 0
+    let mut out = Vec::with_capacity(len);
+    while out.len() < len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.extend_from_slice(&state.to_le_bytes());
+    }
+    out.truncate(len);
+    out
+}
+
+/// Two protocol ids multiplexed over ONE connection must not interleave:
+/// each registered acceptor surfaces exactly its own protocol's stream, the
+/// default sink stays empty, and per-stream byte streams arrive intact.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback; binds UDP. Integration tier. Proves per-protocol acceptor demux."]
+async fn multiplexed_protocols_do_not_interleave() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some(alice) = build_agent(&dir, "alice").await else {
+        return;
+    };
+    let Some(bob) = build_agent(&dir, "bob").await else {
+        return;
+    };
+    let alice = Arc::new(alice);
+    let bob = Arc::new(bob);
+
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+    link_pair(&alice, &bob).await;
+
+    // bob owns both protocols via registered acceptors.
+    let mut socks_acceptor = bob
+        .register_stream_acceptor(StreamProtocol::SocksV1)
+        .expect("register socks");
+    let mut fwd_acceptor = bob
+        .register_stream_acceptor(StreamProtocol::ForwardV2)
+        .expect("register fwd");
+    // Single-owner invariant: a duplicate registration is a typed conflict.
+    assert!(matches!(
+        bob.register_stream_acceptor(StreamProtocol::SocksV1),
+        Err(x0x::error::NetworkError::StreamAcceptorConflict { protocol_byte: 0x02 })
+    ));
+
+    // alice opens one stream of each protocol over the same connection.
+    // Serially, confirming each surfacing before the next open: burst-opened
+    // streams can strand in ant-quic's connection driver under load (see
+    // `acceptor_channel_is_bounded`), while single opens on a calm connection
+    // deliver reliably. The PROOF — concurrent 1 MiB transfers over the two
+    // protocols — is unaffected by how the streams were opened.
+    let bob_agent = bob.agent_id();
+    let mut s_socks = alice
+        .open_peer_stream(&bob_agent, StreamProtocol::SocksV1)
+        .await
+        .expect("open socks stream");
+    let mut b_socks = tokio::time::timeout(Duration::from_secs(30), socks_acceptor.next())
+        .await
+        .expect("socks acceptor timed out")
+        .expect("socks stream");
+    let mut s_fwd = alice
+        .open_peer_stream(&bob_agent, StreamProtocol::ForwardV2)
+        .await
+        .expect("open fwd stream");
+    let mut b_fwd = tokio::time::timeout(Duration::from_secs(30), fwd_acceptor.next())
+        .await
+        .expect("fwd acceptor timed out")
+        .expect("fwd stream");
+    assert_eq!(b_socks.protocol(), StreamProtocol::SocksV1);
+    assert_eq!(b_fwd.protocol(), StreamProtocol::ForwardV2);
+
+    // The default sink sees nothing: both protocols have registered owners.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(500), bob.next_incoming_stream())
+            .await
+            .is_err(),
+        "registered protocols must not leak into the default sink"
+    );
+
+    // 1 MiB of distinct position-dependent patterns per stream, written
+    // concurrently over the shared connection. Any cross-talk between the two
+    // streams corrupts a pattern and fails the equality check.
+    let p_socks = xorshift_pattern(1024 * 1024, 0x50C5);
+    let p_fwd = xorshift_pattern(1024 * 1024, 0xF02D);
+    assert_ne!(p_socks, p_fwd, "patterns must be distinct");
+
+    let (w_socks, w_fwd, r_socks, r_fwd) = tokio::join!(
+        async { s_socks.send_mut().write_all(&p_socks).await },
+        async { s_fwd.send_mut().write_all(&p_fwd).await },
+        async {
+            let mut buf = vec![0u8; p_socks.len()];
+            b_socks
+                .recv_mut()
+                .read_exact(&mut buf)
+                .await
+                .map(|_| buf)
+        },
+        async {
+            let mut buf = vec![0u8; p_fwd.len()];
+            b_fwd.recv_mut().read_exact(&mut buf).await.map(|_| buf)
+        },
+    );
+    w_socks.expect("socks write");
+    w_fwd.expect("fwd write");
+    assert_eq!(r_socks.expect("socks read"), p_socks, "socks stream integrity");
+    assert_eq!(r_fwd.expect("fwd read"), p_fwd, "fwd stream integrity");
+}
+
+/// ACL-refused peer cannot open: with an `Enabled` connect ACL that lists
+/// only alice, carol (verified + trusted but unlisted) gets her stream reset
+/// by bob's accept loop — never surfaced, writes fail, reads hit EOF — while
+/// the listed alice still streams fine.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "three-agent loopback; binds UDP. Integration tier. Proves the #131 stream ACL gate."]
+async fn connect_acl_refuses_unlisted_peer_stream() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some(alice) = build_agent(&dir, "alice").await else {
+        return;
+    };
+    let Some(bob) = build_agent(&dir, "bob").await else {
+        return;
+    };
+    let Some(carol) = build_agent(&dir, "carol").await else {
+        return;
+    };
+    let alice = Arc::new(alice);
+    let bob = Arc::new(bob);
+    let carol = Arc::new(carol);
+
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+    carol.join_network().await.expect("carol joins");
+
+    // Carol clears bob's identity gate (verified + trusted) — the ACL must be
+    // the layer that refuses her, not trust.
+    link_pair(&alice, &bob).await;
+    link_pair(&carol, &bob).await;
+
+    // bob: Enabled connect ACL listing ONLY (alice.agent, alice.machine).
+    let policy = x0x::connect::ConnectPolicy::Enabled(x0x::connect::ConnectAcl {
+        loaded_from: "test".into(),
+        loaded_at_unix_ms: 0,
+        allow: vec![x0x::connect::ConnectAllowEntry {
+            description: None,
+            agent_id: alice.agent_id(),
+            machine_id: alice.machine_id(),
+            targets: vec!["127.0.0.1:22".parse().expect("loopback literal")],
+        }],
+    });
+    bob.set_connect_policy(Arc::new(policy));
+    let mut acceptor = bob
+        .register_stream_acceptor(StreamProtocol::SocksV1)
+        .expect("register socks");
+
+    // ── Unlisted carol: open is refused ──────────────────────────────────
+    // The QUIC-level open succeeds; bob's accept loop clears her through the
+    // identity gate and then resets the stream at the ACL gate.
+    let mut carol_stream = carol
+        .open_peer_stream(&bob.agent_id(), StreamProtocol::SocksV1)
+        .await
+        .expect("carol QUIC-level open");
+
+    // bob must never surface her stream.
+    assert!(
+        tokio::time::timeout(Duration::from_secs(3), acceptor.next())
+            .await
+            .is_err(),
+        "unlisted peer's stream must not be surfaced"
+    );
+
+    // Carol observes the refusal: bob dropped the stream halves, so her read
+    // hits EOF (FIN from the dropped send half)…
+    let mut buf = [0u8; 16];
+    let read = tokio::time::timeout(
+        Duration::from_secs(10),
+        carol_stream.recv_mut().read(&mut buf),
+    )
+    .await
+    .expect("refused stream read must settle")
+    .expect("refused stream read must not error (FIN, not reset)");
+    assert!(read.is_none(), "refused stream reads EOF, got {read:?}");
+
+    // …and her writes fail (STOP_SENDING from the dropped recv half). Retry
+    // a few times: the STOP_SENDING frame may lag the FIN by a packet.
+    let mut write_error = None;
+    for _ in 0..50 {
+        match carol_stream.send_mut().write_all(&[0xABu8; 64 * 1024]).await {
+            Ok(()) => tokio::time::sleep(Duration::from_millis(20)).await,
+            Err(e) => {
+                write_error = Some(e);
+                break;
+            }
+        }
+    }
+    assert!(
+        write_error.is_some(),
+        "refused stream writes must fail (STOP_SENDING)"
+    );
+
+    // ── Listed alice: still opens and echoes ─────────────────────────────
+    let mut alice_stream = alice
+        .open_peer_stream(&bob.agent_id(), StreamProtocol::SocksV1)
+        .await
+        .expect("alice open");
+    let mut b_stream = tokio::time::timeout(Duration::from_secs(15), acceptor.next())
+        .await
+        .expect("listed peer must be surfaced")
+        .expect("alice stream");
+    assert_eq!(b_stream.protocol(), StreamProtocol::SocksV1);
+
+    let payload = xorshift_pattern(64 * 1024, 0xA11CE);
+    let (w, r) = tokio::join!(
+        async { alice_stream.send_mut().write_all(&payload).await },
+        async {
+            let mut buf = vec![0u8; payload.len()];
+            b_stream.recv_mut().read_exact(&mut buf).await.map(|_| buf)
+        },
+    );
+    w.expect("alice write");
+    assert_eq!(r.expect("bob read"), payload, "listed peer integrity");
+}
+
+/// The acceptor channel is provably bounded: its depth never exceeds
+/// `STREAM_ACCEPTOR_CAPACITY`, and while it is pinned full every surplus
+/// stream is dropped (reset) at `try_send` — never buffered.
+///
+/// Opens are PACED (~100 ms apart): ant-quic's connection driver can strand
+/// the first frames of burst-opened streams for tens of seconds on an
+/// otherwise-idle connection (a wake landing mid-cycle is lost once the
+/// driver slot is empty; isolated in a two-`NetworkNode` repro where 8
+/// back-to-back `open_bi` calls deliver only ~3-7 streams within 45 s, while
+/// 100 ms-paced opens all deliver within microseconds). Pacing is a
+/// test-harness technique so the boundedness assertions exercise delivery,
+/// not the upstream driver race.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback; binds UDP. Integration tier. Proves bounded acceptor depth."]
+async fn acceptor_channel_is_bounded() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some(alice) = build_agent(&dir, "alice").await else {
+        return;
+    };
+    let Some(bob) = build_agent(&dir, "bob").await else {
+        return;
+    };
+    let alice = Arc::new(alice);
+    let bob = Arc::new(bob);
+
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+    link_pair(&alice, &bob).await;
+
+    let mut acceptor = bob
+        .register_stream_acceptor(StreamProtocol::SocksV1)
+        .expect("register socks");
+
+    const CAP: usize = x0x::streams::STREAM_ACCEPTOR_CAPACITY;
+    const SURPLUS: usize = 8;
+    /// Per-open landing deadline. Serial opens on a calm connection land in
+    /// milliseconds; the deadline only fires for streams stranded by the
+    /// ant-quic burst-open frame-stranding race (isolated in a two-
+    /// `NetworkNode` repro: a burst of 8 `open_bi` calls permanently strands
+    /// ~1-5 streams' first frames on an idle connection, while fresh streams
+    /// opened afterwards deliver normally — so a timed-out open is simply
+    /// replaced by another open below).
+    const LAND_DEADLINE: Duration = Duration::from_secs(10);
+
+    let bob_agent = bob.agent_id();
+    let mut held: Vec<x0x::streams::PeerStream> = Vec::new();
+
+    // Serial fill to exactly capacity: open one, wait for it to land, repeat.
+    // A stranded open (rare) is replaced by a fresh one — the connection
+    // stays healthy for new streams even when an earlier burst frames never
+    // transmit.
+    while acceptor.queued() < CAP {
+        let before = acceptor.queued();
+        held.push(
+            alice
+                .open_peer_stream(&bob_agent, StreamProtocol::SocksV1)
+                .await
+                .expect("open stream"),
+        );
+        let deadline = Instant::now() + LAND_DEADLINE;
+        while acceptor.queued() == before && Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+    assert_eq!(acceptor.queued(), CAP, "channel filled to exactly capacity");
+
+    // Surplus: 8 more streams. While the channel stays pinned full, every
+    // surplus dispatch hits `try_send` on a full channel and is dropped.
+    // The observation window asserts the invariant continuously: depth NEVER
+    // exceeds CAP.
+    for _ in 0..SURPLUS {
+        held.push(
+            alice
+                .open_peer_stream(&bob_agent, StreamProtocol::SocksV1)
+                .await
+                .expect("open surplus stream"),
+        );
+        // Give each surplus stream time to deliver + dispatch before the next.
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        assert_eq!(
+            acceptor.queued(),
+            CAP,
+            "boundedness violated mid-surplus: depth exceeded capacity"
+        );
+    }
+    let window = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < window {
+        assert_eq!(
+            acceptor.queued(),
+            CAP,
+            "boundedness violated: depth exceeded capacity (surplus was buffered)"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Draining yields exactly the capacity.
+    let mut drained = 0usize;
+    while acceptor.try_next().is_some() {
+        drained += 1;
+    }
+    assert_eq!(drained, CAP, "channel held exactly its capacity");
+    drop(held);
+}
+
+/// Backpressure is real and bounded: with a stalled reader the writer
+/// throttles at the QUIC flow-control window (~1.25 MiB stream credit) — it
+/// neither completes nor buffers unboundedly — then finishes with full
+/// integrity once the reader drains.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback; binds UDP. Integration tier. Proves bounded backpressure."]
+async fn backpressure_throttles_writer_with_bounded_buffering() {
+    use sha2::Digest;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const TOTAL: usize = 32 * 1024 * 1024;
+    const WCHUNK: usize = 64 * 1024;
+    const RCHUNK: usize = 256 * 1024;
+    /// ant-quic's per-stream initial flow-control credit is 1_250_000 bytes
+    /// (STREAM_RWND); allow generous in-flight slack but far below TOTAL.
+    const STALL_BOUND: usize = 8 * 1024 * 1024;
+
+    let dir = TempDir::new().expect("tmpdir");
+    let Some(alice) = build_agent(&dir, "alice").await else {
+        return;
+    };
+    let Some(bob) = build_agent(&dir, "bob").await else {
+        return;
+    };
+    let alice = Arc::new(alice);
+    let bob = Arc::new(bob);
+
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+    link_pair(&alice, &bob).await;
+
+    let mut alice_stream = alice
+        .open_peer_stream(&bob.agent_id(), StreamProtocol::SocksV1)
+        .await
+        .expect("open stream");
+    let mut bob_stream = take_incoming(&bob, Duration::from_secs(15))
+        .await
+        .expect("bob accepted");
+
+    let pattern = xorshift_pattern(TOTAL, 0xBAACC4ED);
+    let expected_hash = sha2::Sha256::digest(&pattern);
+
+    // Writer task: push the whole pattern, publishing progress.
+    let written = Arc::new(AtomicUsize::new(0));
+    let written_in_task = Arc::clone(&written);
+    let writer = tokio::spawn(async move {
+        let mut offset = 0usize;
+        while offset < TOTAL {
+            let end = (offset + WCHUNK).min(TOTAL);
+            alice_stream
+                .send_mut()
+                .write_all(&pattern[offset..end])
+                .await
+                .expect("write chunk");
+            offset = end;
+            written_in_task.store(offset, Ordering::Release);
+        }
+        offset
     });
 
-    // (3) bob must surface the NORMAL stream promptly despite the silent one.
-    //     Before FIX 1 the accept loop would be blocked on the silent prefix
-    //     read and this would time out.
-    let surfaced = take_incoming(&bob, Duration::from_secs(8))
+    // Stall the reader: the writer must throttle at the flow-control window.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let stalled = written.load(Ordering::Acquire);
+    assert!(
+        !writer.is_finished(),
+        "writer completed with a stalled reader — backpressure is broken"
+    );
+    assert!(stalled > 0, "writer should have made initial progress");
+    assert!(
+        stalled <= STALL_BOUND,
+        "stalled writer accepted {stalled} bytes — exceeds the flow-control bound \
+         (stream window + slack), i.e. unbounded buffering"
+    );
+
+    // Drain: the writer unblocks and every byte arrives intact.
+    let mut hasher = sha2::Sha256::new();
+    let mut rbuf = vec![0u8; RCHUNK];
+    for _ in 0..(TOTAL / RCHUNK) {
+        bob_stream
+            .recv_mut()
+            .read_exact(&mut rbuf)
+            .await
+            .expect("read chunk");
+        hasher.update(&rbuf);
+    }
+    let completed = writer.await.expect("writer join");
+    assert_eq!(completed, TOTAL);
+    assert_eq!(
+        hasher.finalize(),
+        expected_hash,
+        "32 MiB transfer integrity after backpressure"
+    );
+}
+
+/// Large-transfer integrity: 8 MiB deterministic pattern each direction over
+/// one stream, SHA-256 verified.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback; binds UDP. Integration tier. Proves 8 MiB transfer integrity."]
+async fn large_transfer_integrity_8mib() {
+    use sha2::Digest;
+
+    const LEN: usize = 8 * 1024 * 1024;
+    const CHUNK: usize = 256 * 1024;
+
+    let dir = TempDir::new().expect("tmpdir");
+    let Some(alice) = build_agent(&dir, "alice").await else {
+        return;
+    };
+    let Some(bob) = build_agent(&dir, "bob").await else {
+        return;
+    };
+    let alice = Arc::new(alice);
+    let bob = Arc::new(bob);
+
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+    link_pair(&alice, &bob).await;
+
+    let mut alice_stream = alice
+        .open_peer_stream(&bob.agent_id(), StreamProtocol::ForwardV2)
         .await
-        .expect("accept loop was stalled by the missing-prefix stream");
-    let _ = normal.await;
-    assert_eq!(surfaced.protocol(), StreamProtocol::ForwardV1);
+        .expect("open stream");
+    let mut bob_stream = take_incoming(&bob, Duration::from_secs(15))
+        .await
+        .expect("bob accepted");
+
+    let p_ab = xorshift_pattern(LEN, 0xA2B);
+    let p_ba = xorshift_pattern(LEN, 0xB2A);
+
+    // alice → bob
+    let p_ab_ref = &p_ab;
+    let (w, r) = tokio::join!(
+        async { alice_stream.send_mut().write_all(p_ab_ref).await },
+        async {
+            let mut buf = vec![0u8; LEN];
+            let mut got = 0usize;
+            while got < LEN {
+                let end = (got + CHUNK).min(LEN);
+                bob_stream
+                    .recv_mut()
+                    .read_exact(&mut buf[got..end])
+                    .await
+                    .expect("read a→b");
+                got = end;
+            }
+            buf
+        },
+    );
+    w.expect("write a→b");
+    assert_eq!(
+        sha2::Sha256::digest(&r),
+        sha2::Sha256::digest(&p_ab),
+        "alice→bob 8 MiB checksum"
+    );
+
+    // bob → alice
+    let p_ba_ref = &p_ba;
+    let (w, r) = tokio::join!(
+        async { bob_stream.send_mut().write_all(p_ba_ref).await },
+        async {
+            let mut buf = vec![0u8; LEN];
+            let mut got = 0usize;
+            while got < LEN {
+                let end = (got + CHUNK).min(LEN);
+                alice_stream
+                    .recv_mut()
+                    .read_exact(&mut buf[got..end])
+                    .await
+                    .expect("read b→a");
+                got = end;
+            }
+            buf
+        },
+    );
+    w.expect("write b→a");
+    assert_eq!(
+        sha2::Sha256::digest(&r),
+        sha2::Sha256::digest(&p_ba),
+        "bob→alice 8 MiB checksum"
+    );
 }

--- a/tests/tailnet_streams_integration.rs
+++ b/tests/tailnet_streams_integration.rs
@@ -425,7 +425,9 @@ async fn multiplexed_protocols_do_not_interleave() {
     // Single-owner invariant: a duplicate registration is a typed conflict.
     assert!(matches!(
         bob.register_stream_acceptor(StreamProtocol::SocksV1),
-        Err(x0x::error::NetworkError::StreamAcceptorConflict { protocol_byte: 0x02 })
+        Err(x0x::error::NetworkError::StreamAcceptorConflict {
+            protocol_byte: 0x02
+        })
     ));
 
     // alice opens one stream of each protocol over the same connection.
@@ -474,11 +476,7 @@ async fn multiplexed_protocols_do_not_interleave() {
         async { s_fwd.send_mut().write_all(&p_fwd).await },
         async {
             let mut buf = vec![0u8; p_socks.len()];
-            b_socks
-                .recv_mut()
-                .read_exact(&mut buf)
-                .await
-                .map(|_| buf)
+            b_socks.recv_mut().read_exact(&mut buf).await.map(|_| buf)
         },
         async {
             let mut buf = vec![0u8; p_fwd.len()];
@@ -487,7 +485,11 @@ async fn multiplexed_protocols_do_not_interleave() {
     );
     w_socks.expect("socks write");
     w_fwd.expect("fwd write");
-    assert_eq!(r_socks.expect("socks read"), p_socks, "socks stream integrity");
+    assert_eq!(
+        r_socks.expect("socks read"),
+        p_socks,
+        "socks stream integrity"
+    );
     assert_eq!(r_fwd.expect("fwd read"), p_fwd, "fwd stream integrity");
 }
 
@@ -569,7 +571,11 @@ async fn connect_acl_refuses_unlisted_peer_stream() {
     // a few times: the STOP_SENDING frame may lag the FIN by a packet.
     let mut write_error = None;
     for _ in 0..50 {
-        match carol_stream.send_mut().write_all(&[0xABu8; 64 * 1024]).await {
+        match carol_stream
+            .send_mut()
+            .write_all(&[0xABu8; 64 * 1024])
+            .await
+        {
             Ok(()) => tokio::time::sleep(Duration::from_millis(20)).await,
             Err(e) => {
                 write_error = Some(e);


### PR DESCRIPTION
Epic deliverable 1 (the epic stays open — forwarder service, SOCKS5, REST/CLI, VPS proof are later deliverables):

- Per-peer bidirectional byte streams over ant-quic open_bi/accept_bi, exposed through Agent/NetworkNode: open_stream(peer, protocol_id) + per-protocol registered acceptors
- Protocol-id framing: single-byte prefix per stream (0x01/0x02/0x03 assigned, everything else refused with StreamProtocolUnknown — never a panic); QUIC stream isolation + ant-quic's internal demux means gossip/DM/message traffic cannot interleave with named streams
- Default-closed per the epic's security posture: inbound stream opens are gated by the SAME ConnectAcl::entry_for lookup #131 uses (one data structure, no second convention), evaluated before any application byte surfaces; outbound ACL deliberately deferred (ADR 0022 documents why — #131 models inbound reachability)
- Backpressure provably bounded end-to-end: QUIC flow control + 64-deep acceptor channels + try_send (full ⇒ reset, never unbounded queue); PeerStream holds no intermediate buffer — a stalled reader throttles the writer through flow control (proven by a stalled-reader test asserting both unfinished-writer AND ≤8MiB accepted of 32MiB)
- Lifecycle: fin propagates; error/disconnect cleans acceptor registrations
- ADR 0022: framing design, ACL integration, backpressure budget, Phase-1 deferrals

Integration suite (ignored tier, daemon-spawning): round-trip, multiplex non-interleave, ACL refuse, bounded channel, 8MiB SHA-256 integrity, stalled-reader backpressure — 7/7 pass in isolation (parallel run can contention-flake like all daemon suites).

Gates: fmt/clippy clean. Adversarial review: SOUND (7/7 claims).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds protocol-specific bidirectional streams with ACL gating and bounded backpressure. The main changes are:

- Per-protocol stream acceptors with bounded channels.
- An inbound connect-ACL gate before protocol dispatch.
- Dedicated ForwardV1 and ForwardV2 consumer loops.
- Integration tests for routing, refusal, backpressure, and integrity.
- ADR documentation for the new stream API.

<h3>Confidence Score: 4/5</h3>

The startup cleanup path needs a fix before merging; the pre-spawn shutdown path should also release its registrations.

- Forwarder registration failure can leave the already-started agent active.
- Shutting down an unstarted forwarder can block replacement construction.
- The core ACL and bounded routing paths otherwise appear consistent.

src/server/mod.rs and src/forward.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/streams.rs | Adds bounded protocol acceptors, RAII deregistration, protocol routing, and the stream-level ACL helper. |
| src/lib.rs | Adds acceptor and connect-policy APIs and applies the ACL before protocol dispatch. |
| src/forward.rs | Moves inbound forwarding to dedicated acceptors, but shutdown does not release acceptors that were never spawned. |
| src/server/mod.rs | Installs the stream policy and creates the forwarder, but the new constructor failure path skips agent shutdown. |
| tests/tailnet_streams_integration.rs | Adds coverage for protocol isolation, ACL refusal, bounded queues, backpressure, and large transfers. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[QUIC accept_bi] --> B[Resolve peer machine agents]
    B --> C[Identity and revocation gate]
    C --> D[Connect ACL gate]
    D --> E[Read protocol prefix]
    E --> F{Registered acceptor?}
    F -->|Yes| G[Protocol acceptor channel]
    F -->|No| H[Default stream channel]
    G --> I[Protocol consumer]
    I --> J[Application I/O]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[QUIC accept_bi] --> B[Resolve peer machine agents]
    B --> C[Identity and revocation gate]
    C --> D[Connect ACL gate]
    D --> E[Read protocol prefix]
    E --> F{Registered acceptor?}
    F -->|Yes| G[Protocol acceptor channel]
    F -->|No| H[Default stream channel]
    G --> I[Protocol consumer]
    I --> J[Application I/O]
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/forward.rs`, line 1482-1483 ([link](https://github.com/saorsa-labs/x0x/blob/1237144ace05cbd4b41884b735509c1b79f48991/src/forward.rs#L1482-L1483)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unstarted Acceptors Survive Shutdown**

   When `shutdown()` runs before `spawn_inbound()`, cancellation stops no consumer task and the acceptors remain inside `inbound_acceptors`. A replacement `ForwardService` on the same agent then receives `StreamAcceptorConflict`, even though the previous service was shut down.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/forward.rs
   Line: 1482-1483

   Comment:
   **Unstarted Acceptors Survive Shutdown**

   When `shutdown()` runs before `spawn_inbound()`, cancellation stops no consumer task and the acceptors remain inside `inbound_acceptors`. A replacement `ForwardService` on the same agent then receives `StreamAcceptorConflict`, even though the previous service was shut down.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/server/mod.rs:943
**Startup Error Skips Agent Shutdown**

If either forward protocol already has an acceptor, this `?` returns after the agent and its network tasks have started but without calling `agent.shutdown().await`. The daemon reports startup failure while those tasks and sockets can remain active, violating the cleanup rule documented above the agent construction.

### Issue 2 of 2
src/forward.rs:1482-1483
**Unstarted Acceptors Survive Shutdown**

When `shutdown()` runs before `spawn_inbound()`, cancellation stops no consumer task and the acceptors remain inside `inbound_acceptors`. A replacement `ForwardService` on the same agent then receives `StreamAcceptorConflict`, even though the previous service was shut down.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/saorsa-labs/x0x/commit/1237144ace05cbd4b41884b735509c1b79f48991) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45236309)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->