### PR TITLE
docs(agents): gate execution rules — never mask gate exit codes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Re-run after every code change. Do not silence warnings with `#[allow(...)]` unl
 - **NEVER pipe a gate through `tail`/`head`/`grep` in a `&&` chain.** `cargo clippy ... 2>&1 | tail -5 && cargo nextest run ...` exits with `tail`'s status, so a FAILING clippy reads as success and the chain continues. Run each gate as its own command with its own exit code; if a pipeline is unavoidable, prefix with `set -o pipefail`, and print full output on failure — not a truncated tail.
 - **Gates must pass on the exact tree that gets pushed.** Re-run after every amend/fixup/review-loop commit, not just once early in the session. A gate pass on an earlier commit proves nothing about the pushed one.
 - **Every agent that lands commits owns a gate pass over its own diff** (workers, reviewers, orchestrators alike). "The next agent runs the gate" is how rustfmt/clippy failures end up in PRs. If you were told to skip gates, the agent that pushes MUST run them — no exceptions.
-- **A `| tail`-style output filter is fine for readability only AFTER the gate's exit code has been captured and checked** (`GATE_OUTPUT=$(cargo clippy ... 2>&1); echo $?; echo "$GATE_OUTPUT" | tail -20`).
+- **A `| tail`-style output filter is fine for readability only AFTER the gate's exit code has been captured and checked** (`GATE_OUTPUT=$(cargo clippy ... 2>&1) || { echo "$GATE_OUTPUT"; exit 1; }; echo "$GATE_OUTPUT" | tail -20`).
 
 External validation pipelines (clawpatch, CI) gate on the standard `--all-targets -- -D warnings` clippy check. Do **not** add extra `-D clippy::panic`, `-D clippy::unwrap_used`, `-D clippy::expect_used`, or similar custom denies for this gate; those trip on existing test code and are stricter than CI.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,13 @@
 
 Re-run after every code change. Do not silence warnings with `#[allow(...)]` unless the surrounding code already does. If a fix cannot pass these checks, report what failed — do NOT submit a known-failing patch.
 
+### Gate execution rules (learned the hard way — red PRs shipped through these holes)
+
+- **NEVER pipe a gate through `tail`/`head`/`grep` in a `&&` chain.** `cargo clippy ... 2>&1 | tail -5 && cargo nextest run ...` exits with `tail`'s status, so a FAILING clippy reads as success and the chain continues. Run each gate as its own command with its own exit code; if a pipeline is unavoidable, prefix with `set -o pipefail`, and print full output on failure — not a truncated tail.
+- **Gates must pass on the exact tree that gets pushed.** Re-run after every amend/fixup/review-loop commit, not just once early in the session. A gate pass on an earlier commit proves nothing about the pushed one.
+- **Every agent that lands commits owns a gate pass over its own diff** (workers, reviewers, orchestrators alike). "The next agent runs the gate" is how rustfmt/clippy failures end up in PRs. If you were told to skip gates, the agent that pushes MUST run them — no exceptions.
+- **A `| tail`-style output filter is fine for readability only AFTER the gate's exit code has been captured and checked** (`GATE_OUTPUT=$(cargo clippy ... 2>&1); echo $?; echo "$GATE_OUTPUT" | tail -20`).
+
 External validation pipelines (clawpatch, CI) gate on the standard `--all-targets -- -D warnings` clippy check. Do **not** add extra `-D clippy::panic`, `-D clippy::unwrap_used`, `-D clippy::expect_used`, or similar custom denies for this gate; those trip on existing test code and are stricter than CI.
 
 ---


### PR DESCRIPTION
Learned from red PRs this sprint (rustfmt/clippy failures that reached review):

- **NEVER pipe a gate through tail/head/grep in a && chain** — pipeline exits with the filter's status, so a failing clippy reads as success and the chain continues. Separate commands with their own exit codes, or set -o pipefail.
- **Gates must pass on the exact tree that gets pushed** — re-run after every amend/fixup/review-loop commit.
- **Every agent that lands commits owns a gate pass over its own diff** — 'the next agent runs the gate' is how failures reach PRs.

Same rules added to the global Codex policy (~/.codex/AGENTS.md) so the review/cleanup team's sessions get them too.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds stricter execution rules for agent-run quality gates. The main changes are:

- Prohibits status-masking output pipelines around gates.
- Requires gates to run on the exact tree being pushed.
- Assigns gate ownership to every agent that lands commits.
- Allows filtered output only after checking the gate result.

<h3>Confidence Score: 4/5</h3>

The gate-status example can still let a failed clippy run appear successful and needs correction before merging.

- The surrounding rules clearly require failed gates to stop the workflow.
- The example prints the captured status instead of enforcing it.
- Its final output pipeline normally leaves the shell with a successful status.

AGENTS.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds gate-execution policy, but the filtering example prints and then loses the failed gate status. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
AGENTS.md:16
**Captured Status Is Not Enforced**

When clippy fails, `echo $?` prints the failure status but replaces it with `echo`'s success status. The final `tail` pipeline also normally exits successfully, so a later chained command or push can proceed despite the failed gate.

```suggestion
- **A `| tail`-style output filter is fine for readability only AFTER the gate's exit code has been captured and checked** (`GATE_OUTPUT=$(cargo clippy ... 2>&1); GATE_STATUS=$?; if [ "$GATE_STATUS" -ne 0 ]; then printf '%s\n' "$GATE_OUTPUT"; exit "$GATE_STATUS"; fi; printf '%s\n' "$GATE_OUTPUT" | tail -20`).
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): gate execution rules — nev..."](https://github.com/saorsa-labs/x0x/commit/b2883d9dbb68a793b8d0fce705c6726daedb20ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45223225)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->