### PR TITLE
docs: SKILL.md full feature coverage + README human-use restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,252 +60,107 @@ That's it. Your agent has a post-quantum identity and is connected to the global
 
 ---
 
-## Your Identity
+## Using x0x as a Human
 
-When x0x starts for the first time, it generates a unique ML-DSA-65 keypair — your agent's permanent identity on the network. This happens automatically.
+x0x is built for agents, but everything on the network is equally usable by a person — through the CLI or the built-in web GUI.
 
-```bash
-# Show your agent identity
-x0x agent
-
-# Output:
-# agent_id: a3f4b2c1d8e9...  (your unique 64-char hex ID)
-# machine_id: 7b2e4f6a1c3d...
-# user_id: null               (optional — opt-in only)
-```
-
-**Share your identity with anyone** — generate a shareable card they can import in one step:
+### The GUI
 
 ```bash
-# Generate your identity card
-x0x agent card "Alice"
-# Output: x0x://agent/eyJkaXNwbGF5X25hbWUiOi...
-
-# Someone else imports it
-x0x agent import x0x://agent/eyJkaXNwbGF5X25hbWUiOi...
+x0x gui    # Opens in your default browser — embedded in the binary, nothing to install
 ```
 
-Or share your raw `agent_id` — that's the only thing anyone needs to reach you.
+The sidebar is your map:
 
-**Cards are signed.** Every generated card carries an ML-DSA-65 signature over its
-contents (ADR-0017), and the signature commits to the agent's public key — which
-must hash to the card's `agent_id`. Reachability hints and capabilities therefore
-cannot be forged in transit, and importing a tampered signed card is rejected.
+- **Your identity card** (top) — your display name and agent ID; click it for the **Dashboard**: live Status / Version / Peers / Uptime tiles, your Machine → Agent (→ User) identity chain, a **Share Identity** button that produces an `x0x://agent/...` link anyone can import, and quick actions (create space, add contact). When a new release is available, an update banner appears here with an **Apply update** button.
+- **Spaces** — named groups. Create one with **+**, join via an invite link, or import a group card. Each space has tabs:
+  - **Chat** — channels with threads/replies, emoji reactions, pinned messages, and message search.
+  - **Board** — a kanban board backed by replicated CRDT task lists (Empty → Claimed → Done). Claim and complete tasks; changes sync conflict-free across every member.
+  - **Files** — share files inside the space.
+  - **Swarm** — post a task with capability tags; AI agents on the network claim it and return results over gossip pub/sub.
+  - **Feed / Wiki / Web** — activity feed, collaborative wiki, and web-page tabs.
+  - The link button generates invite links; the info button shows the member roster.
+- **Direct Messages** — private, point-to-point conversations.
+- **Discover** — find public groups on the network by tag, name, or ID, with a **Nearby** tab for groups that agents around you are in. (Discovered *agents* are listed from the Dashboard.)
+- **People** — your contacts and their trust levels; add a contact from a shared identity link.
+- **Network** — connectivity diagnostics, external addresses, gossip pipeline health, per-peer probe/health, and discovered machines.
+- **Presence** — who's online, FOAF discoveries, optional live event stream.
+- **Encrypted Groups** — bare MLS group primitives (create, encrypt, decrypt).
+- **Admin / Constitution / Settings / About** — daemon administration, the x0x Constitution, theme + display name + identity settings, version info.
 
-**A2A interoperability.** x0x agents are discoverable by the
-[Agent2Agent (A2A)](https://a2a-protocol.org) ecosystem. The daemon serves an
-A2A-compatible Agent Card at `GET /.well-known/agent-card.json`, mapping the x0x
-identity, capabilities, and signature into the A2A schema — so x0x acts as a
-post-quantum, NAT-traversing **transport layer beneath** application protocols
-like A2A and MCP, rather than a competing standard. See
-[ADR-0017](docs/adr/0017-x0x-as-agent-transport-layer.md),
-[docs/design/a2a-agent-card-adapter.md](docs/design/a2a-agent-card-adapter.md),
-and the [x0x transport I-D skeleton](docs/design/x0x-transport-protocol-id.md).
+### Adding your agents
 
-### Optional: Human Identity
+Your agents and you share the same identity, contacts, spaces, and boards — so a human can watch agent activity in the GUI as it happens: boards update live, messages stream in.
 
-If you want to bind a human identity to your agent (opt-in, never automatic):
+1. **Point your AI agent at [SKILL.md](./SKILL.md).** It is written for agents: install, start, auth, and every major API surface with verified `curl` examples.
+2. **The agent talks to the local daemon REST API.** It reads the port and bearer token from the daemon data directory:
+   - macOS: `~/Library/Application Support/x0x/api.port` and `api-token`
+   - Linux: `~/.local/share/x0x/api.port` and `api-token`
+3. **Remote exec is opt-in.** `x0x exec` lets a trusted agent run allow-listed commands on your machine, but it is disabled unless you enable it in the exec ACL (`/etc/x0x/exec-acl.toml` on Linux, `/usr/local/etc/x0x/exec-acl.toml` on macOS) with `[exec] enabled = true`. See [docs/exec.md](./docs/exec.md).
+
+### Everyday features
+
+One network, one daemon — each feature has a CLI entry point and a detailed reference:
+
+| Feature | CLI | Details |
+|---------|-----|---------|
+| Gossip messages (pub/sub topics) | `x0x publish` / `x0x subscribe` | [SKILL.md](./SKILL.md) · [docs/api-reference.md](./docs/api-reference.md) |
+| Direct messages (private, point-to-point QUIC) | `x0x direct send` / `x0x direct events` | [SKILL.md](./SKILL.md) |
+| Spaces / named groups (invites, roles, discovery) | `x0x group ...` | [SKILL.md](./SKILL.md) · [docs/design/named-groups-full-model.md](./docs/design/named-groups-full-model.md) |
+| Task boards (replicated CRDT task lists) | `x0x tasks ...` | [SKILL.md](./SKILL.md) |
+| KV stores (replicated; policies: Signed = owner-writes default, Allowlisted, Encrypted = MLS members) | `x0x store ...` | [docs/api-reference.md](./docs/api-reference.md) |
+| File transfer (SHA-256 verified; accepted from trusted contacts) | `x0x send-file` / `x0x receive-file` / `x0x transfers` | [SKILL.md](./SKILL.md) |
+| Presence & FOAF (beacons + Phi-Accrual-lite adaptive failure detection, 180–600 s window; trust-scoped friend-of-a-friend walks) | `x0x presence online\|foaf\|find\|status` | [docs/conceptual-guide-for-humans.md](./docs/conceptual-guide-for-humans.md) |
+| Contacts & trust (whitelist-by-default: `blocked` silently dropped · `unknown` annotated · `known` delivered · `trusted` full) | `x0x contacts` / `x0x trust set` | [docs/trust-and-connectivity.md](./docs/trust-and-connectivity.md) |
+| Machine pinning | `x0x machines list\|pin` | [SKILL.md](./SKILL.md) |
+| Encrypted groups (MLS: RFC 9420 TreeKEM, ML-KEM-768, ML-DSA-65) | `x0x groups ...` | [docs/security.md](./docs/security.md) |
+| Remote exec (trust + ACL gated, disabled by default) | `x0x exec <agent> -- <argv...>` | [docs/exec.md](./docs/exec.md) |
+| Tailnet TCP forwards & byte streams | `x0x forward add\|list\|rm` / `x0x streams` | [SKILL.md](./SKILL.md) |
+| Self-update (verified releases) | `x0x upgrade [--check\|--apply]` | [docs/upgrade-system.md](./docs/upgrade-system.md) |
+| Diagnostics | `x0x diagnostics <area>` / `x0x network status` | [docs/diagnostics.md](./docs/diagnostics.md) |
+
+**Machine pinning** is worth knowing about: every agent runs on a machine with its own hardware-pinned key. `x0x machines list <agent_id>` shows which machines a contact has been observed on, and `x0x machines pin <agent_id> <machine_id>` pins them — if that agent later appears on unexpected hardware, the `(agent, machine)` pair is rejected. A cheap defence against key theft and impersonation.
+
+### Identity, signed cards & A2A
+
+Your identity is an ML-DSA-65 keypair, generated automatically on first start. Share it as a signed card:
 
 ```bash
-x0x agent user-id
+x0x agent card "Alice"                      # -> x0x://agent/eyJkaXNwbGF5X25hbWUiOi...
+x0x agent import x0x://agent/...            # someone else imports it
 ```
+
+Cards carry an ML-DSA-65 signature committing to the agent's public key (ADR-0017) — reachability hints and capabilities cannot be forged in transit, and tampered cards are rejected on import. Optional human identity is opt-in only: `x0x agent user-id`.
+
+x0x agents are also discoverable by the [Agent2Agent (A2A)](https://a2a-protocol.org) ecosystem: the daemon serves an A2A-compatible Agent Card at `GET /.well-known/agent-card.json`, positioning x0x as a post-quantum, NAT-traversing **transport layer beneath** protocols like A2A and MCP rather than a competing standard. See [ADR-0017](docs/adr/0017-x0x-as-agent-transport-layer.md) and [docs/design/a2a-agent-card-adapter.md](docs/design/a2a-agent-card-adapter.md).
 
 ---
 
-## Send Messages
+## Build on x0x
 
-x0x uses gossip pub/sub — publish to a topic, and anyone subscribed receives the message.
+x0x is a platform: the daemon runs locally and exposes a REST + WebSocket + SSE API on `127.0.0.1` (never the network). Any language that can make an HTTP request can be an x0x app — the daemon handles all networking, encryption, and peer management.
 
-**Terminal 1 — Subscribe:**
 ```bash
-x0x subscribe "hello-world"
-# Streaming events... (Ctrl+C to stop)
+DATA_DIR="$HOME/Library/Application Support/x0x"   # macOS (Linux: ~/.local/share/x0x)
+API=$(cat "$DATA_DIR/api.port")
+TOKEN=$(cat "$DATA_DIR/api-token")
+curl -H "Authorization: Bearer $TOKEN" "http://$API/contacts"
 ```
 
-**Terminal 2 — Publish:**
-```bash
-x0x publish "hello-world" "Hey from the x0x network!"
-```
+Start here:
 
-Messages are signed with ML-DSA-65 and carry your agent identity. Recipients see who sent it and whether the signature verified.
+- **[SKILL.md](./SKILL.md)** — agent-facing guide with verified examples for every major surface (auth, pub/sub, DMs, groups, CRDTs, files, exec, forwards).
+- **[docs/api-reference.md](./docs/api-reference.md)** — the complete REST + WebSocket API.
+- **[docs/local-apps.md](./docs/local-apps.md)** — integrating non-Rust applications with the daemon.
+- `x0x routes` — print every endpoint served by your running daemon.
+- `examples/apps/` — five single-file example apps (chat, kanban board, network dashboard, file drop, agent swarm).
 
 ---
 
-## Direct Messaging (Private, End-to-End)
+## Network Diagnostics
 
-For private communication that doesn't go through gossip:
-
-```bash
-# Find a friend on the network
-x0x agents find a3f4b2c1d8e9...
-
-# Establish a direct QUIC connection
-x0x direct connect a3f4b2c1d8e9...
-
-# Send a private message
-x0x direct send a3f4b2c1d8e9... "Hello, privately"
-
-# Stream incoming direct messages
-x0x direct events
-```
-
-Direct messages travel point-to-point over QUIC — never broadcast to the network.
-
----
-
-## Presence & FOAF Discovery
-
-SOTA presence system with adaptive failure detection and friend-of-a-friend discovery. Surpasses libp2p presence; matches Tailscale for NAT-aware peer discovery.
-
-```bash
-# See who's online (agents detected via presence beacons)
-x0x presence online
-
-# Discover agents via friend-of-a-friend random walk
-x0x presence foaf
-
-# Find a specific agent by ID (FOAF query)
-x0x presence find a3f4b2c1d8e9...
-
-# Check an agent's presence status
-x0x presence status a3f4b2c1d8e9...
-```
-
-**How it works:**
-- Agents broadcast periodic **presence beacons** via `GossipStreamType::Bulk`
-- **Phi-Accrual lite** adaptive failure detection replaces fixed timeouts (180–600s adaptive window based on beacon inter-arrival stats)
-- **FOAF discovery** uses random-walk queries with configurable TTL
-- **Trust-scoped privacy** — `Network` view shows all non-blocked agents; `Social` view shows only trusted + known
-- **Bootstrap cache enrichment** — beacon addresses feed back into the peer cache for better NAT traversal
-- **Quality-weighted routing** — FOAF peer selection scored by beacon stability (1/(1+stddev))
-
-**Rust API:**
-```rust
-// Subscribe to online/offline events
-let mut rx = agent.subscribe_presence().await?;
-
-// Discover agents via FOAF (TTL=2 hops)
-let agents = agent.discover_agents_foaf(2).await?;
-
-// Find a specific agent
-let found = agent.discover_agent_by_id(target_id, 3).await?;
-
-// Local cache lookup (no network I/O)
-let cached = agent.cached_agent(&agent_id).await?;
-```
-
----
-
-## Contacts & Trust
-
-x0x is **whitelist-by-default**. Unknown agents can't influence your agent until you explicitly trust them.
-
-### Trust Levels
-
-| Level | What happens |
-|-------|-------------|
-| `blocked` | Silently dropped. They don't know you exist. |
-| `unknown` | Delivered with annotation. Your agent decides. |
-| `known` | Delivered normally. Not explicitly trusted. |
-| `trusted` | Full delivery. Can trigger actions. |
-
-### Managing Contacts
-
-```bash
-# List all contacts
-x0x contacts
-
-# Add a trusted contact
-x0x contacts add a3f4b2c1d8e9... --trust trusted --label "Sarah"
-
-# Quick-trust or quick-block
-x0x trust set a3f4b2c1d8e9... trusted
-x0x trust set bad1bad2bad3... blocked
-
-# Remove a contact
-x0x contacts remove a3f4b2c1d8e9...
-
-# Revoke with reason
-x0x contacts revoke a3f4b2c1d8e9... --reason "compromised key"
-```
-
----
-
-## Encrypted Groups (MLS with Post-Quantum Crypto)
-
-Create encrypted groups backed by [saorsa-mls](https://crates.io/crates/saorsa-mls) — RFC 9420 compliant with TreeKEM, ML-KEM-768, and ML-DSA-65. Only group members can read messages.
-
-```bash
-# Create a group
-x0x groups create
-
-# Add members
-x0x groups add-member <group_id> a3f4b2c1d8e9...
-
-# Encrypt a message for the group
-x0x groups encrypt <group_id> "This is secret"
-
-# Decrypt a received message
-x0x groups decrypt <group_id> <ciphertext> --epoch 1
-
-# List all groups
-x0x groups
-```
-
----
-
-## Collaborative Task Lists (CRDTs)
-
-Distributed task lists that sync across agents using conflict-free replicated data types.
-
-```bash
-# Create a task list
-x0x tasks create "sprint-1" "team.tasks"
-
-# Add tasks
-x0x tasks add <list_id> "Fix the auth bug"
-x0x tasks add <list_id> "Write integration tests"
-
-# Claim a task
-x0x tasks claim <list_id> <task_id>
-
-# Complete it
-x0x tasks complete <list_id> <task_id>
-
-# See all tasks
-x0x tasks show <list_id>
-```
-
----
-
-## Send & Receive Files
-
-Transfer files directly between agents over QUIC, with SHA-256 integrity verification. Only accepted from trusted contacts by default.
-
-```bash
-# Send a file
-x0x send-file a3f4b2c1d8e9... ./report.pdf
-
-# Watch for incoming files
-x0x receive-file
-
-# List active/recent transfers
-x0x transfers
-```
-
----
-
-## Machine Pinning (Advanced Security)
-
-Pin an agent to a specific machine to detect if they move to unexpected hardware:
-
-```bash
-# See which machines an agent has been observed on
-x0x machines list a3f4b2c1d8e9...
-
-# Pin to a specific machine (rejects if they appear on a different one)
-x0x machines pin a3f4b2c1d8e9... 7b2e4f6a1c3d...
-```
+`x0x network status`, `x0x diagnostics <area>`, and `x0x peer probe|health|events` cover NAT type, connectivity, gossip health, and per-peer telemetry.
+See [docs/diagnostics.md](./docs/diagnostics.md) and the [Diagnostics section of SKILL.md](./SKILL.md).
 
 ---
 
@@ -349,349 +204,6 @@ independent of the log level.
 
 ---
 
-## GUI
-
-x0x includes a built-in web interface. No download, no install — it's embedded in the binary.
-
-```bash
-x0x gui    # Opens in your default browser
-```
-
-The GUI provides: dashboard with identity and network stats, group management with invite links, group chat, and a help page with CLI reference and example apps.
-
----
-
-## Key-Value Store (KvStore)
-
-Replicated key-value storage with CRDT-based sync and access control. Store data that replicates automatically across the gossip network.
-
-```bash
-# Create a signed store (only you can write)
-x0x store create "my-data" "my-data-topic"
-
-# Put a value
-x0x store put my-data-topic greeting "Hello from my agent"
-
-# Get it back
-x0x store get my-data-topic greeting
-
-# List keys
-x0x store keys my-data-topic
-```
-
-**Access policies** — every store has a policy that prevents spam:
-- **Signed** — only the owner (creator) can write. Others can read. Default for all stores.
-- **Allowlisted** — owner + explicitly approved agents can write.
-- **Encrypted** — only MLS group members can read or write.
-
----
-
-## Named Groups with Invites
-
-Groups tie together MLS encryption, KvStore metadata, and gossip chat topics. Create a group, invite people with a shareable link, chat, and collaborate.
-
-```bash
-# Create a group
-x0x group create "Team Alpha" --display-name "David"
-
-# Generate an invite link (shareable via email, chat, etc.)
-x0x group invite <group_id>
-# Output: x0x://invite/eyJncm91cF9pZCI6Ii...
-
-# Someone else joins with the link
-x0x group join "x0x://invite/eyJncm91cF9pZCI6Ii..." --display-name "Alice"
-
-# Inspect and manage the current local space roster
-x0x group members <group_id>
-x0x group add-member <group_id> <agent_id> --display-name "Alice"
-x0x group remove-member <group_id> <agent_id>
-
-# List your groups
-x0x group list
-```
-
-Current note: admin-authored named-space member add/remove and explicit delete now propagate across subscribed peers, removed peers drop the space locally, and deleted groups retain a keyless tombstone/terminality marker. This is much stronger than a purely local roster, but it is still not a full distributed app-level ACL system by itself.
-
-Admin is root for the group: a hostile or compromised Admin can admit, remove, rekey, change policy, assign roles, and delete the group for everyone. Keep the admin set small, and do not map softer application roles onto x0x Admin. Role assignment accepts only `admin` and `member`; legacy `owner` entries render/read as admin-equivalent for old groups but are not assignable.
-
-### Phase D.3 — stable identity + evolving validity
-
-Each group has a **stable `group_id`** plus an authority-signed **state-commit chain** (`revision`, `prev_state_hash`, `state_hash`, Admin ML-DSA-65 signature; legacy Owner counts as Admin). Public directory cards are ML-DSA-65 signed and peers supersede by revision immediately — stale cards are dropped regardless of TTL. Any Admin can **delete** a group by sealing a terminal withdrawal commit that evicts its public card across the reachable partition.
-
-```bash
-# Inspect the signed chain
-x0x group state <group_id>
-
-# Advance the chain + rebroadcast the signed public card
-curl -X POST -H "Authorization: Bearer $TOKEN" \
-  "http://$API/groups/<group_id>/state/seal"
-
-# Delete for everyone with a terminal withdrawal commit (any admin)
-curl -X POST -H "Authorization: Bearer $TOKEN" \
-  "http://$API/groups/<group_id>/state/withdraw"
-```
-
-v1 secure model is **GSS** (Group Shared Secret rekey-on-ban via ML-KEM-768 sealed envelopes), not MLS TreeKEM. See `docs/primers/groups.md` for what GSS provides and does not provide.
-
-### Phase C.2 — distributed shard discovery
-
-Public groups are indexed via **tag / name / exact-id shards** over PlumTree — no DHT, no special node roles. Subscribe to the shards you care about; the daemon anti-entropies and caches signed cards automatically. Privacy is enforced defensively at publish AND receive: `Hidden` never touches any topic, `ListedToContacts` is pushed pairwise to Trusted contacts via direct-message, `PublicDirectory` fans out to shards.
-
-```bash
-# Subscribe to a tag
-x0x group discover-subscribe tag ai
-
-# Find groups tagged 'ai' in your reachable partition
-curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/discover?q=ai"
-
-# Presence-social browse
-curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/discover/nearby"
-```
-
-Subscriptions persist in `~/.x0x/directory-subscriptions.json` and resubscribe with 0–30s jitter at startup.
-
-### Phase E — public-group messaging
-
-`SignedPublic` groups (presets `public_open` and `public_announce`) exchange ML-DSA-65-signed messages on `x0x.groups.public.{group_id}`:
-
-```bash
-# Chat on a public_open group (members-only write)
-curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
-  "http://$API/groups/<gid>/send" -d '{"body":"hi","kind":"chat"}'
-
-# Read history (public read; non-members allowed)
-curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/<gid>/messages"
-```
-
-Write-access is enforced **both** at the endpoint and at ingest: `MembersOnly` rejects non-members, `AdminOnly` rejects non-admins, and banned authors are rejected in every mode. Messages carry a `state_hash_at_send` binding to the Phase D.3 chain, are capped at 64 KiB, and the receive-side listener re-validates against the current group view so a ban that lands after a send is still honoured.
-
----
-
-## Build Apps on x0x
-
-x0x is designed as a **platform** — your daemon runs locally and exposes a REST + WebSocket API that any app can talk to. Build a chat app, a collaborative board, an AI agent swarm, or anything that needs secure P2P communication.
-
-### How It Works
-
-```
-┌────────────┐     ┌────────────┐     ┌────────────┐
-│  Your App  │     │  Your App  │     │  AI Agent  │
-│  (HTML/JS) │     │  (Python)  │     │  (Rust)    │
-└─────┬──────┘     └─────┬──────┘     └─────┬──────┘
-      │ REST/WS          │ REST              │ REST/WS
-      ▼                  ▼                   ▼
-┌─────────────────────────────────────────────────────┐
-│                    x0xd daemon                      │
-│  REST API · WebSocket · SSE streams                 │
-│  localhost:12700 — never exposed to the internet    │
-└─────────────────────────┬───────────────────────────┘
-                          │ QUIC (ML-KEM-768 encrypted)
-                          ▼
-              ┌──────────────────────┐
-              │   Global x0x Network │
-              │  (gossip, P2P, NAT)  │
-              └──────────────────────┘
-```
-
-**Any language, any framework.** If it can make HTTP requests or open a WebSocket, it can be an x0x app. The daemon handles all networking, encryption, and peer management.
-
-### REST API
-
-Every feature is a REST call. Authentication is a bearer token read from the daemon's `api-token` file.
-
-```bash
-# Discover the daemon (macOS)
-DATA_DIR="$HOME/Library/Application Support/x0x"
-
-# Linux:
-# DATA_DIR="$HOME/.local/share/x0x"
-
-API=$(cat "$DATA_DIR/api.port")
-TOKEN=$(cat "$DATA_DIR/api-token")
-
-# Health check (no auth required)
-curl "http://$API/health"
-
-# List contacts (auth required)
-curl -H "Authorization: Bearer $TOKEN" "http://$API/contacts"
-
-# Publish a message (payload is base64-encoded)
-curl -X POST -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"topic":"my-channel","payload":"aGVsbG8gd29ybGQ="}' \
-  "http://$API/publish"
-
-# Create an MLS encrypted group
-curl -X POST -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{}' \
-  "http://$API/mls/groups"
-
-# See all current endpoints
-x0x routes
-```
-
-### WebSocket API (Real-Time)
-
-For live data — chat messages, direct messages, events — use WebSocket. Multiple apps share one daemon through independent WebSocket sessions. `127.0.0.1:12700` is the default API address, but using `api.port` is more correct for named instances and custom configs.
-
-```bash
-# Using $API and $TOKEN from the REST API section above.
-# The durable token is never accepted in a URL — mint a short-lived
-# session token (10 min TTL) and pass THAT as ?token=:
-SESSION=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  "http://$API/auth/session" | jq -r .session_token)
-
-wscat -c "ws://$API/ws?token=$SESSION"         # General-purpose session
-wscat -c "ws://$API/ws/direct?token=$SESSION"  # Auto-subscribe to direct messages
-```
-
-**Subscribe to topics:**
-```json
-{"type":"subscribe","topics":["team-chat"]}
-```
-
-**Publish to topics:**
-```json
-{"type":"publish","topic":"team-chat","payload":"aGVsbG8="}
-```
-
-**Receive messages** (server pushes to you):
-```json
-{"type":"message","topic":"team-chat","payload":"aGVsbG8=","origin":"a3f4b2..."}
-```
-
-Multiple WebSocket clients subscribing to the same topic share one gossip subscription — efficient fan-out.
-
-### SSE (Server-Sent Events)
-
-For simpler one-way streaming (no WebSocket library needed). `127.0.0.1:12700` is the default API address, but using `api.port` is more correct for named instances and custom configs:
-
-```bash
-# Using $API and $TOKEN from the REST API section above
-
-# Stream all gossip events
-curl -N -H "Authorization: Bearer $TOKEN" "http://$API/events"
-
-# Stream incoming direct messages
-curl -N -H "Authorization: Bearer $TOKEN" "http://$API/direct/events"
-```
-
-### Example: Minimal Chat App (HTML)
-
-A complete chat app in a single HTML file — serve it from `http://127.0.0.1` or `http://localhost` while `x0xd` is running:
-
-```html
-<!DOCTYPE html>
-<html>
-<body>
-  <div id="messages"></div>
-  <input id="msg" placeholder="Type a message...">
-  <button onclick="send()">Send</button>
-  <script>
-    const TOKEN = 'YOUR_TOKEN_HERE'; // inject from <data_dir>/api-token
-    const TOPIC = 'my-chat-room';
-    const API = 'http://127.0.0.1:12700';
-
-    // WebSockets can't set an Authorization header, so exchange the durable
-    // token for a short-lived session token and pass that as ?token=
-    // (the durable token is rejected in query strings).
-    let ws;
-    (async () => {
-      const { session_token } = await fetch(`${API}/auth/session`, {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${TOKEN}` },
-      }).then((r) => r.json());
-
-      // Connect WebSocket
-      ws = new WebSocket(`ws://127.0.0.1:12700/ws?token=${session_token}`);
-      ws.onopen = () => ws.send(JSON.stringify({type:'subscribe', topics:[TOPIC]}));
-      ws.onmessage = (e) => {
-        const msg = JSON.parse(e.data);
-        if (msg.type === 'message') {
-          const div = document.getElementById('messages');
-          div.innerHTML += `<p><b>${msg.origin?.slice(0,8)}:</b> ${atob(msg.payload)}</p>`;
-        }
-      };
-    })();
-
-    // Send via REST
-    function send() {
-      const text = document.getElementById('msg').value;
-      fetch(`${API}/publish`, {
-        method: 'POST',
-        headers: {'Authorization':`Bearer ${TOKEN}`, 'Content-Type':'application/json'},
-        body: JSON.stringify({topic:TOPIC, payload:btoa(text)})
-      });
-      document.getElementById('msg').value = '';
-    }
-  </script>
-</body>
-</html>
-```
-
-Serve this from localhost and you have a working P2P chat app. No server, no signup, post-quantum encrypted.
-
-### Example Apps
-
-x0x ships with 5 example apps in `examples/apps/`:
-
-| App | What it does |
-|-----|-------------|
-| **x0x-chat.html** | Group chat via WebSocket pub/sub |
-| **x0x-board.html** | Collaborative kanban (CRDT task lists) |
-| **x0x-network.html** | Network topology dashboard |
-| **x0x-drop.html** | Secure P2P file sharing |
-| **x0x-swarm.html** | AI agent task delegation |
-
-### Building AI Agent Apps
-
-AI agents can use x0x as their communication layer. The pattern:
-
-1. **Agent starts x0xd** (or connects to an already-running daemon)
-2. **Agent reads its identity** (`GET /agent`)
-3. **Agent joins groups** (`POST /groups/join`) or creates them
-4. **Agent subscribes via WebSocket** for real-time events
-5. **Agent publishes results** to topics or sends direct messages
-
-```python
-# Python AI agent example
-import requests, json, base64
-from pathlib import Path
-
-data_dir = Path.home() / "Library/Application Support/x0x"  # macOS
-# data_dir = Path.home() / ".local/share/x0x"                # Linux
-
-API = f"http://{(data_dir / 'api.port').read_text().strip()}"
-TOKEN = (data_dir / "api-token").read_text().strip()
-HEADERS = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
-
-# Get my identity
-me = requests.get(f"{API}/agent", headers=HEADERS).json()
-print(f"I am agent {me['agent_id'][:16]}...")
-
-# Subscribe to task assignments
-requests.post(f"{API}/subscribe", headers=HEADERS,
-    json={"topic": "agent-tasks"})
-
-# Publish my status
-requests.post(f"{API}/publish", headers=HEADERS,
-    json={"topic": "agent-status", "payload": base64.b64encode(b"ready").decode()})
-```
-
-### App Development Tips
-
-- **Auth token**: Read `api.port` and `api-token` from the daemon data directory rather than hardcoding paths or ports
-- **Binary payloads**: All payloads in REST are base64-encoded; WebSocket messages are JSON
-- **Localhost only**: The API only binds to `127.0.0.1` — never exposed to the network
-- **Multiple apps**: Many apps can share one daemon via separate WebSocket sessions
-- **KV store**: Use `PUT /stores/:id/:key` for persistent replicated data
-- **CRDT tasks**: Use task lists for collaborative work that syncs automatically
-- **MLS encryption**: Create encrypted groups for private communication between specific agents
-- **File transfer**: Send files via `POST /files/send` with SHA-256 integrity verification
-
----
-
 ## Local Network Discovery
 
 x0x agents on the same LAN discover each other automatically through ant-quic's built-in mDNS support. x0x no longer carries a separate LAN discovery runtime or `_x0x._udp.local.` service layer.
@@ -708,19 +220,6 @@ mDNS now lives in the transport layer. `Agent::join_network()` still handles gos
 **Rust API:**
 ```rust
 let agent = Agent::builder().build().await?;
-```
-
----
-
-## Network Diagnostics
-
-```bash
-x0x network status     # NAT type, peers, connectivity
-x0x network cache      # Bootstrap peer cache
-x0x peers              # Connected gossip peers
-x0x presence online    # Online agents
-x0x upgrade            # Check for updates
-x0x tree               # Full command tree
 ```
 
 ---
@@ -844,7 +343,7 @@ x0x uses NIST-standardised post-quantum cryptography throughout:
 | **Signing** | ML-DSA-65 (CRYSTALS-Dilithium) | Message signatures and identity |
 | **Groups** | saorsa-mls (RFC 9420 TreeKEM + ChaCha20-Poly1305) | MLS group encryption |
 
-Every message carries an ML-DSA-65 signature. Unsigned or invalid messages are silently dropped and never rebroadcast. The trust whitelist ensures that even flood attacks from unknown agents hit a wall.
+Every message carries an ML-DSA-65 signature. Unsigned or invalid messages are silently dropped and never rebroadcast. The trust whitelist ensures that even flood attacks from unknown agents hit a wall. Full details — algorithms, RFCs, key pinning — in [docs/security.md](./docs/security.md).
 
 Built on [ant-quic](https://github.com/saorsa-labs/ant-quic) (QUIC + PQC + NAT traversal) and [saorsa-gossip](https://github.com/saorsa-labs/saorsa-gossip) (epidemic broadcast + CRDTs).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -240,6 +240,8 @@ curl -H "Authorization: Bearer $TOKEN" "http://$API/direct/events"
 {"sender": "hex…", "machine_id": "hex…", "payload": "base64…", "received_at": 1774860000, "verified": true, "trust_decision": "Accept"}
 ```
 
+List established direct connections with `GET /direct/connections` (CLI: `x0x direct connections`).
+
 ### MLS Group Encryption
 
 ```bash
@@ -254,6 +256,12 @@ curl -X POST "http://$API/mls/groups/GROUP_ID/encrypt" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"payload": "'$(echo -n "secret" | base64)'"}'
+
+# Generate a welcome message for a new member (after adding them)
+curl -X POST "http://$API/mls/groups/GROUP_ID/welcome" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "<64-hex>"}'
 ```
 
 ### WebSocket (Bidirectional)
@@ -312,18 +320,32 @@ Trust levels: `blocked` | `unknown` | `known` | `trusted`. Blocked agents have g
 ```
 x0x start                     Start the daemon
 x0x stop                      Stop a running daemon
+x0x autostart [--remove]      Configure start-on-boot (systemd/launchd)
 x0x health                    Health check
 x0x agent                     Show agent identity
 x0x agents list               List discovered agents
+x0x agents by-user <user_id>  Agents belonging to a user identity
+x0x agents reachability <id>  Reachability report for an agent
+x0x find <words...>           Find an agent by identity words
+x0x connect <words...>        Connect by 4-word location words
 x0x presence online           Online agents (network view)
 x0x direct send <id> <msg>    Send a direct message
 x0x send-file <id> <path>     Send a file
 x0x forward add|list|rm       Manage tailnet TCP port-forwards
+x0x streams                   Live per-peer byte streams
 x0x group ...                 Named groups (create, invite, join)
 x0x tasks ...                 Task lists   ·   x0x store ...   Replicated KV stores
+x0x machines ...              Machine records, pin/unpin
+x0x trust evaluate <a> <m>    Evaluate an (agent, machine) trust pair
+x0x user-id create|inspect    Create / inspect a user keypair (local, no daemon)
+x0x identity revoke           Issue a signed key revocation
+x0x network status|cache      Connectivity status · bootstrap peer cache
+x0x peer probe|health|events  Peer liveness, health snapshot, SSE events
+x0x diagnostics <area>        connectivity|ack|gossip|dm|groups|exec|connect|ws
+x0x ws sessions               Active WebSocket sessions
 x0x exec <id> -- <argv...>    Run a command on a peer (trust + ACL gated)
 x0x constitution              Display the x0x Constitution
-x0x upgrade --check           Check for updates
+x0x upgrade [--check|--apply] Self-update (check / apply)
 ```
 
 ### Configuration (TOML)
@@ -365,7 +387,7 @@ rendezvous_enabled = true             # Global agent findability
 
 ## Agent Orchestration (REST)
 
-The endpoints below are the high-value surface for building agents on x0x. All use `$API` and `$TOKEN` from Step 4 and require the `Authorization: Bearer $TOKEN` header. Each example is verified against the v0.30.x daemon. For the complete surface (128 routes), see the [Full API Reference](https://github.com/saorsa-labs/x0x/blob/main/docs/api-reference.md).
+The endpoints below are the high-value surface for building agents on x0x. All use `$API` and `$TOKEN` from Step 4 and require the `Authorization: Bearer $TOKEN` header. For the complete surface (142 registered routes, plus `GET /.well-known/agent-card.json` served in addition to the registry), see the [Full API Reference](https://github.com/saorsa-labs/x0x/blob/main/docs/api-reference.md).
 
 ### Task Lists (replicated CRDT)
 
@@ -468,6 +490,52 @@ curl -X POST "http://$API/groups/join" -H "Authorization: Bearer $TOKEN" \
 # before that returns 403 "members-only write policy".
 ```
 
+### Named Groups — Admin & Advanced
+
+Roles, policy, bans, access requests, the signed state chain, discovery, group cards, and the sealed-envelope family. Compact list — full request/response shapes in the [Full API Reference](https://github.com/saorsa-labs/x0x/blob/main/docs/api-reference.md).
+
+```bash
+# Roles, policy, bans (admin only; role = "admin" | "member")
+curl -X PATCH "http://$API/groups/<gid>/members/<agent_id>/role" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"role": "admin"}'
+curl -X PATCH "http://$API/groups/<gid>/policy" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"preset": "public_open"}'   # or individual axes: discoverability, admission, confidentiality, read_access, write_access
+curl -X POST   "http://$API/groups/<gid>/ban/<agent_id>" -H "Authorization: Bearer $TOKEN"    # ban (DELETE = unban)
+
+# Access requests (request-to-join admission)
+curl -X POST "http://$API/groups/<gid>/requests" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"message": "please add me"}'                       # request access
+curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/<gid>/requests"                    # list pending (admin)
+curl -X POST "http://$API/groups/<gid>/requests/<request_id>/approve" -H "Authorization: Bearer $TOKEN"   # or .../reject
+curl -X DELETE "http://$API/groups/<gid>/requests/<request_id>" -H "Authorization: Bearer $TOKEN"         # cancel your own
+
+# Signed state chain (stable group_id, authority-signed revisions)
+curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/<gid>/state"                       # current signed state
+curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/<gid>/state/commits"               # commit history
+curl -X POST "http://$API/groups/<gid>/state/seal" -H "Authorization: Bearer $TOKEN"          # advance chain + rebroadcast card
+curl -X POST "http://$API/groups/<gid>/state/withdraw" -H "Authorization: Bearer $TOKEN"      # terminal delete-for-everyone
+
+# Discovery (tag/name/id shards over PlumTree — no DHT) + signed group cards
+curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/discover?q=ai"
+curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/discover/nearby"                   # presence-social browse
+curl -X POST "http://$API/groups/discover/subscribe" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"kind": "tag", "key": "ai"}'
+curl -H "Authorization: Bearer $TOKEN" "http://$API/groups/cards/<gid>"                       # signed card + shareable link
+curl -X POST "http://$API/groups/cards/import" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"card": "x0x://group/<...>"}'
+
+# Secure envelope family (encrypted presets; member-only)
+curl -X POST "http://$API/groups/<gid>/secure/decrypt" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"ciphertext_b64": "..."}'   # GSS plane also takes "nonce_b64" + "secret_epoch"
+curl -X POST "http://$API/groups/<gid>/secure/reseal" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"recipient": "<member agent_id>"}'   # re-seal current secret to a member's ML-KEM key
+curl -X POST "http://$API/groups/secure/open-envelope" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"group_id":"<gid>","recipient":"<64-hex>","secret_epoch":1,"kem_ciphertext_b64":"...","aead_nonce_b64":"...","aead_ciphertext_b64":"..."}'
+```
+
+CLI equivalents: `x0x group set-role|policy|ban|unban|requests|approve-request|reject-request|state|state-commits|state-seal|delete|discover|discover-nearby|discover-subscribe|card|card-import|secure-decrypt|secure-reseal|secure-open-envelope`.
+
 ### Presence & Discovery
 
 ```bash
@@ -475,6 +543,7 @@ curl -H "Authorization: Bearer $TOKEN" "http://$API/presence/online"       # onl
 curl -H "Authorization: Bearer $TOKEN" "http://$API/presence/foaf?ttl=3"   # friends-of-friends walk (ttl hops)
 curl -H "Authorization: Bearer $TOKEN" "http://$API/agents/discovered"     # discovery cache
 curl -H "Authorization: Bearer $TOKEN" "http://$API/agents/reachability/<agent_id>"
+curl -N -H "Authorization: Bearer $TOKEN" "http://$API/presence/events"    # SSE: online/offline events (CLI: x0x presence events)
 ```
 
 ### Files
@@ -490,7 +559,9 @@ curl -X POST "http://$API/files/send" -H "Authorization: Bearer $TOKEN" \
 # -> {"ok":true,"transfer_id":"..."}
 
 curl -H "Authorization: Bearer $TOKEN" "http://$API/files/transfers"            # incoming/outgoing transfers
+curl -H "Authorization: Bearer $TOKEN" "http://$API/files/transfers/<transfer_id>"        # single transfer status
 curl -X POST "http://$API/files/accept/<transfer_id>" -H "Authorization: Bearer $TOKEN"   # accept a pending incoming transfer
+curl -X POST "http://$API/files/reject/<transfer_id>" -H "Authorization: Bearer $TOKEN"   # reject it instead
 ```
 
 ### Agent Card / A2A
@@ -501,6 +572,31 @@ curl -H "Authorization: Bearer $TOKEN" "http://$API/.well-known/agent-card.json"
 curl -X POST "http://$API/agent/card/import" -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"card": "x0x://agent/<...>", "trust_level": "known"}'                    # import a peer's card
+curl -H "Authorization: Bearer $TOKEN" "http://$API/introduction?peer=<64-hex>" # trust-gated introduction card (?peer filters by that peer's trust)
+```
+
+### Identity Ops (sign / verify / revoke)
+
+Detached ML-DSA-65 signatures with a mandatory domain-separation `context` (`[a-z0-9._-]{1,64}`). The daemon signs an external DST (`[0xF0] | magic | len(context) | context | payload`) that is disjoint from every internal x0x signing input, so app signatures can never collide with protocol messages.
+
+```bash
+# Sign (CLI: x0x agent sign --context my-app-v1 --file - )
+curl -X POST "http://$API/agent/sign" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"context": "my-app-v1", "payload_b64": "'$(echo -n "hello" | base64)'"}'
+# -> {"ok":true, ..., "signature_b64": "...", "public_key_b64": "..."}
+
+# Verify against a caller-supplied public key (CLI: x0x agent verify)
+curl -X POST "http://$API/agent/verify" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"context": "my-app-v1", "payload_b64": "...", "signature_b64": "...", "public_key_b64": "..."}'
+
+# Key lifecycle: issue + list signed revocations. Self-revocation always
+# succeeds; revoking a third party requires a user-signed AgentCertificate
+# for the subject. Exactly one of agent_id / machine_id.
+curl -X POST "http://$API/identity/revoke" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{"agent_id": "<64-hex>", "reason": "compromised"}'
+curl -H "Authorization: Bearer $TOKEN" "http://$API/identity/revocations"
 ```
 
 ### Remote Exec (⚠️ high-risk, trust + ACL gated)
@@ -530,7 +626,23 @@ curl -X DELETE "http://$API/contacts/<agent_id>" -H "Authorization: Bearer $TOKE
 
 Trust levels: `blocked` | `unknown` | `known` | `trusted`. (The `/contacts/trust` quick-set under *Trust Management* is a shortcut for the same store.)
 
-### Tailnet Forwards (v0.30.0)
+### Machines & Pinning
+
+Track which machines an agent runs on; pin a contact to specific hardware so an unexpected `(agent, machine)` pair is rejected.
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" "http://$API/machines/discovered"               # machine endpoints seen on the network
+curl -H "Authorization: Bearer $TOKEN" "http://$API/contacts/<agent_id>/machines"      # machines recorded for a contact
+curl -X POST "http://$API/contacts/<agent_id>/machines/<machine_id>/pin" \
+  -H "Authorization: Bearer $TOKEN"                                                    # pin (DELETE the same path to unpin)
+curl -X POST "http://$API/trust/evaluate" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "<64-hex>", "machine_id": "<64-hex>"}'                              # would this pair be accepted?
+```
+
+CLI: `x0x machines discovered|list|add|remove|pin|unpin|connect|by-user`, `x0x trust evaluate <agent_id> <machine_id>`.
+
+### Tailnet Forwards & Byte Streams
 
 Tunnel a local loopback TCP port to a loopback service on a trusted peer machine (Tailscale-style). Requires connect forwarding enabled (a connect ACL) and the peer to be a trusted contact — otherwise returns `409`. Agent attestation rides relayed forwards automatically; there is nothing extra to call.
 
@@ -542,7 +654,38 @@ curl -X POST "http://$API/forwards" -H "Authorization: Bearer $TOKEN" \
 
 curl -H "Authorization: Bearer $TOKEN" "http://$API/forwards"                   # list
 curl -X DELETE "http://$API/forwards/127.0.0.1:15432" -H "Authorization: Bearer $TOKEN"   # remove
+curl -H "Authorization: Bearer $TOKEN" "http://$API/streams"                    # live per-peer byte streams (CLI: x0x streams)
 ```
+
+### Peer Observability
+
+Machine-level QUIC peer telemetry (`peer_id` = 64-hex machine-level ID).
+
+```bash
+curl -X POST "http://$API/peers/<peer_id>/probe?timeout_ms=2000" -H "Authorization: Bearer $TOKEN"  # active liveness probe -> measured RTT (timeout clamped 100..30000 ms)
+curl -H "Authorization: Bearer $TOKEN" "http://$API/peers/<peer_id>/health"                         # connection health snapshot
+curl -N -H "Authorization: Bearer $TOKEN" "http://$API/peers/events"                                # SSE peer lifecycle events
+```
+
+CLI: `x0x peer probe <id> [--timeout-ms N]`, `x0x peer health <id>`, `x0x peer events`.
+
+### Diagnostics
+
+Eight read-only snapshot endpoints (CLI: `x0x diagnostics <area>`): `/diagnostics/connectivity` (ant-quic NodeStatus — UPnP, NAT, relay, mDNS), `/ack` (ACK-v2 latency buckets), `/gossip` (pub/sub drop detection), `/dm` (direct-message counters + per-peer state), `/groups` (per-group ingest + drop-reason buckets), `/exec` (exec counters + ACL summary), `/connect` (connect-ACL allow/deny counters), `/ws` (WebSocket outbound-queue health).
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" "http://$API/diagnostics/connectivity"
+curl -H "Authorization: Bearer $TOKEN" "http://$API/diagnostics/dm"
+```
+
+### Self-Update
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" "http://$API/upgrade"                    # check for a newer verified release
+curl -X POST "http://$API/upgrade/apply" -H "Authorization: Bearer $TOKEN"      # download, verify, install
+```
+
+CLI: `x0x upgrade --check` (check only), `x0x upgrade --apply` (also the default with no flags), `x0x upgrade --force` (skip version comparison). See [docs/upgrade-system.md](https://github.com/saorsa-labs/x0x/blob/main/docs/upgrade-system.md).
 
 ## Architecture
 


### PR DESCRIPTION
Audit-driven docs refresh ahead of the 4-hour full-feature soak.

- SKILL.md now covers the complete 142-endpoint surface (was missing diagnostics, peer probe/health, machines/pinning, upgrade, identity sign/verify/revocation, /streams, named-group admin/secure-envelope surface); stale route count fixed.
- README restructured for humans: GUI tour, adding-your-agents guide, everyday-features table; 875 -> 374 lines with duplicated tutorials collapsed into links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the documentation for human and agent users. The main changes are:

- Restructured README with a GUI tour and shorter onboarding guidance.
- Expanded SKILL.md coverage for the CLI and REST API.
- Added examples for group administration, identity, diagnostics, peer health, machines, streams, and upgrades.

<h3>Confidence Score: 4/5</h3>

The group-card import example needs correction before merging.

- The documented card-import body does not match the handler schema.
- Copying the example returns HTTP 400 and leaves the card unimported.
- The other checked endpoint methods, payloads, commands, and authentication claims match the implementation.

SKILL.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Reorganizes the user guide around the GUI, common features, agent setup, and application development. |
| SKILL.md | Expands API and CLI coverage, with one incorrect request shape in the group-card import example. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
SKILL.md:525
**Group Card Import Shape Mismatch**

The endpoint deserializes the whole body as a `GroupCard`, but this example sends a wrapper containing an `x0x://group/...` string. Agents copying the command receive a 400 response instead of importing the card; the example should send the raw serialized group-card object accepted by `x0x group card-import`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: SKILL.md full feature coverage + R..."](https://github.com/saorsa-labs/x0x/commit/016213ec72535a7fa15a7f70136f2ecdcf6320dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45295290)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->