### PR TITLE
fix(health): #262 — degraded /health on sustained zero peers + opt-in zero-peer restart watchdog

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,6 +17,14 @@ Examples:
 {"ok":true,"status":"healthy","version":"<x.y.z>","peers":4,"uptime_secs":300}
 ```
 
+`status` is `"healthy"`, or `"degraded"` when the daemon has had zero peers
+for its whole uptime past a 120 s bootstrap grace (issue #262 — the wedged
+transport signal; `ok` stays `true` because the process itself is alive). A
+degraded response carries a `degraded_reason` string. Fleet deployments under
+a supervisor can additionally set `zero_peer_restart_secs = <secs>` in the
+daemon TOML to make the process exit (for `Restart=always` self-heal) after
+that long at zero peers — off by default.
+
 ```json
 {"ok":true,"agent_id":"...","machine_id":"...","user_id":null}
 ```

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -469,6 +469,48 @@ pub async fn serve_with_options(
         mpsc::channel::<x0x::dm_inbox::DmTypedPayload>(1024);
     let exec_service = x0x::exec::ExecService::spawn(Arc::clone(&agent), exec_policy, exec_dm_rx);
 
+    // Zero-peer watchdog (issue #262): opt-in supervised self-heal for the
+    // wedged-transport state (process alive, API healthy, socket silent,
+    // peers pinned at 0). Samples every 30s; after `window` seconds of
+    // CONTINUOUS zero peers (plus the same startup grace) it attempts a
+    // graceful shutdown and hard-exits 30s later so the known shutdown hang
+    // cannot defeat the restart. Only meaningful under a supervisor
+    // (systemd Restart=always) — off by default.
+    if let Some(window) = config.zero_peer_restart_secs {
+        let watchdog_agent = Arc::clone(&agent);
+        let watchdog_shutdown = shutdown_tx.clone();
+        tokio::spawn(async move {
+            let window = std::time::Duration::from_secs(window.max(60));
+            let mut zero_since: Option<std::time::Instant> = None;
+            // Startup grace: give bootstrap the same window before arming.
+            tokio::time::sleep(window).await;
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                let peers = watchdog_agent
+                    .peers()
+                    .await
+                    .map(|p| p.len())
+                    .unwrap_or(usize::MAX);
+                if peers == 0 {
+                    let since = *zero_since.get_or_insert_with(std::time::Instant::now);
+                    if since.elapsed() >= window {
+                        tracing::error!(
+                            window_secs = window.as_secs(),
+                            "zero-peer watchdog tripped (issue #262): no peers for the \
+                             full window — transport presumed wedged; exiting for \
+                             supervisor restart"
+                        );
+                        let _ = watchdog_shutdown.send(()).await;
+                        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                        std::process::exit(86);
+                    }
+                } else {
+                    zero_since = None;
+                }
+            }
+        });
+    }
+
     // Tailnet streams + forwarder (#131 × #132): install the loaded connect
     // policy on the agent so the inbound byte-stream accept loop refuses
     // streams from ACL-unlisted peers (default-closed when the policy is

--- a/src/server/routes/status.rs
+++ b/src/server/routes/status.rs
@@ -27,6 +27,30 @@ pub(in crate::server) struct HealthData {
     version: String,
     peers: usize,
     uptime_secs: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    degraded_reason: Option<String>,
+}
+
+/// Classify liveness for `GET /health` (issue #262).
+///
+/// A daemon that has been up past the bootstrap grace window with ZERO peers
+/// is not "healthy" — the prod NYC bootstrap sat in exactly that state for
+/// 6+ hours (wedged transport, silent socket) while fleet monitoring read
+/// `healthy` and stayed quiet. `ok` remains `true` (the process is alive and
+/// serving); `status: "degraded"` is the monitorable signal.
+fn classify_health(peers: usize, uptime_secs: u64) -> (&'static str, Option<String>) {
+    const ZERO_PEER_GRACE_SECS: u64 = 120;
+    if peers == 0 && uptime_secs >= ZERO_PEER_GRACE_SECS {
+        (
+            "degraded",
+            Some(format!(
+                "zero peers for the whole uptime window (>{ZERO_PEER_GRACE_SECS}s); \
+                 transport may be wedged or the network unreachable"
+            )),
+        )
+    } else {
+        ("healthy", None)
+    }
 }
 
 /// Rich runtime status response.
@@ -51,14 +75,17 @@ pub(in crate::server) async fn health(
     State(state): State<Arc<AppState>>,
 ) -> Json<ApiResponse<HealthData>> {
     let peers = state.agent.peers().await.map(|p| p.len()).unwrap_or(0);
+    let uptime_secs = state.start_time.elapsed().as_secs();
+    let (status, degraded_reason) = classify_health(peers, uptime_secs);
 
     Json(ApiResponse {
         ok: true,
         data: HealthData {
-            status: "healthy".to_string(),
+            status: status.to_string(),
             version: x0x::VERSION.to_string(),
             peers,
-            uptime_secs: state.start_time.elapsed().as_secs(),
+            uptime_secs,
+            degraded_reason,
         },
     })
 }
@@ -184,4 +211,36 @@ pub(in crate::server) async fn get_constitution_json() -> impl IntoResponse {
         "status": x0x::constitution::CONSTITUTION_STATUS,
         "content": x0x::constitution::CONSTITUTION_MD,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_health;
+
+    /// WHY (issue #262): a wedged-transport daemon — up for hours, zero
+    /// peers, silent socket — must not read `healthy` to fleet monitoring.
+    /// That exact state hid the NYC prod bootstrap outage for 6+ hours.
+    #[test]
+    fn zero_peers_past_grace_is_degraded() {
+        let (status, reason) = classify_health(0, 121);
+        assert_eq!(status, "degraded");
+        assert!(reason.is_some(), "degraded must carry a reason");
+    }
+
+    /// Startup gets a grace window: bootstrap takes seconds-to-a-minute, and
+    /// flagging a freshly started daemon would page on every restart.
+    #[test]
+    fn zero_peers_within_grace_is_still_healthy() {
+        let (status, reason) = classify_health(0, 30);
+        assert_eq!(status, "healthy");
+        assert!(reason.is_none());
+    }
+
+    /// Any live peer means the transport works — healthy regardless of age.
+    #[test]
+    fn connected_daemon_is_healthy() {
+        let (status, reason) = classify_health(1, 999_999);
+        assert_eq!(status, "healthy");
+        assert!(reason.is_none());
+    }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -353,6 +353,22 @@ pub struct DaemonConfig {
     ///   [`x0x::network::validate_plane_id`].
     #[serde(default)]
     pub network_id: Option<String>,
+
+    /// Zero-peer watchdog (issue #262, TOML: `zero_peer_restart_secs`).
+    ///
+    /// When set, the daemon exits after `peers == 0` has held continuously
+    /// for this many seconds (a startup grace of the same length applies).
+    /// Intended for supervised deployments (`systemd Restart=always`): a
+    /// wedged transport — process alive, API answering, socket silent, the
+    /// state the NYC prod bootstrap sat in for 6+ hours — self-heals via
+    /// supervisor restart. The exit first attempts graceful shutdown, then
+    /// hard-exits (code 86) after 30s so a hung shutdown cannot defeat it.
+    ///
+    /// Default: unset (off). Do NOT set this on unsupervised daemons or
+    /// machines that are legitimately offline for long stretches — the
+    /// process will exit without anything to restart it.
+    #[serde(default)]
+    pub zero_peer_restart_secs: Option<u64>,
 }
 
 /// Default QUIC port: 5483 (LIVE on a phone keypad).
@@ -563,6 +579,7 @@ impl Default for DaemonConfig {
             directory_resubscribe_jitter_ms: None,
             forward: x0x::forward::ForwardConfig::default(),
             network_id: None,
+            zero_peer_restart_secs: None,
         }
     }
 }
@@ -1057,5 +1074,19 @@ mod tests {
         let config: DaemonConfig =
             toml::from_str("observed_prefix_enabled = true").expect("opt-in parses");
         assert!(config.observed_prefix_enabled);
+    }
+
+    #[test]
+    fn zero_peer_restart_defaults_off_and_parses_opt_in() {
+        // Issue #262: the watchdog exits the PROCESS — it must be impossible
+        // to arm by accident. Off in every construction path; only an
+        // explicit TOML key enables it (supervised fleet deployments).
+        let config: DaemonConfig = toml::from_str("").expect("empty config parses");
+        assert!(config.zero_peer_restart_secs.is_none());
+        assert!(DaemonConfig::default().zero_peer_restart_secs.is_none());
+
+        let config: DaemonConfig =
+            toml::from_str("zero_peer_restart_secs = 900").expect("opt-in parses");
+        assert_eq!(config.zero_peer_restart_secs, Some(900));
     }
 }


### PR DESCRIPTION
Closes the monitoring half of #262 and adds the operational self-heal.

- `GET /health` → `status: "degraded"` + `degraded_reason` when peers == 0 past a 120s grace (the exact state that hid the NYC outage for 6+ hours).
- Opt-in `zero_peer_restart_secs` daemon config: process exits after sustained zero peers for supervisor restart (graceful first, hard exit(86) after 30s). Default off.
- api-reference documented; unit tests for classification + config default-off.

The ant-quic transport wedge root-cause stays open in #262 — with degraded health + the watchdog, the next occurrence will be caught in minutes and leave a fresh forensic window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds zero-peer health reporting and an opt-in restart watchdog. The main changes are:

- A degraded `/health` response after the bootstrap grace.
- A configurable zero-peer watchdog for supervised daemons.
- Documentation and unit tests for the new behavior.

<h3>Confidence Score: 4/5</h3>

The watchdog timing and health classification paths need fixes before merging.

- The watchdog can take roughly twice the configured window to request a restart.
- A brief peer loss after the grace period is reported as sustained degradation immediately.
- Peer-query failures are reported as real zero-peer outages.
- Values below 60 seconds do not retain their configured meaning.

src/server/mod.rs and src/server/routes/status.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/mod.rs | Adds the restart watchdog, but its timing applies the configured window twice and silently clamps small values. |
| src/server/routes/status.rs | Adds degraded health classification, but uses process uptime instead of zero-peer duration and converts peer-query errors into zero peers. |
| src/server/state.rs | Adds the optional watchdog setting with a default-off configuration and parsing tests. |
| docs/api-reference.md | Documents degraded health and watchdog behavior, including the intended sustained-zero semantics. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Daemon starts] --> B{Watchdog enabled?}
    B -- No --> C[Continue normally]
    B -- Yes --> D[Sleep configured window]
    D --> E[Poll peers every 30 seconds]
    E --> F{Peers are zero?}
    F -- No --> G[Clear zero_since]
    G --> E
    F -- Yes --> H{zero_since elapsed >= window?}
    H -- No --> E
    H -- Yes --> I[Request graceful shutdown]
    I --> J[Wait 30 seconds]
    J --> K[Hard exit with code 86]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Daemon starts] --> B{Watchdog enabled?}
    B -- No --> C[Continue normally]
    B -- Yes --> D[Sleep configured window]
    D --> E[Poll peers every 30 seconds]
    E --> F{Peers are zero?}
    F -- No --> G[Clear zero_since]
    G --> E
    F -- Yes --> H{zero_since elapsed >= window?}
    H -- No --> E
    H -- Yes --> I[Request graceful shutdown]
    I --> J[Wait 30 seconds]
    J --> K[Hard exit with code 86]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/server/mod.rs:486-496
**Restart Window Applied Twice**

With zero peers from startup, the task first sleeps for `window`, waits 30 seconds for its first sample, and only then starts `zero_since`. A configured value of 900 seconds therefore trips after about 1,830 seconds, not after the documented 900-second sustained-zero interval, delaying recovery by roughly another full window.

### Issue 2 of 4
src/server/routes/status.rs:44
**Uptime Replaces Zero-Peer Duration**

This condition measures process uptime rather than the current zero-peer streak. If a daemon has peers for an hour and then briefly drops to zero, the next health request immediately reports `degraded` and claims zero peers for the whole uptime window instead of waiting for 120 seconds of sustained zero peers.

### Issue 3 of 4
src/server/routes/status.rs:77
**Peer Query Errors Become Outages**

When `Agent::peers()` returns `network not initialized`, `unwrap_or(0)` turns that failure into an observed empty peer set. After 120 seconds, an intentionally unnetworked or failed-to-initialize daemon is reported as a sustained transport wedge, so monitoring cannot distinguish a query failure from a real zero-peer state.

### Issue 4 of 4
src/server/mod.rs:483
**Configured Values Are Silently Clamped**

Values below 60 seconds are accepted by TOML but silently changed to 60 seconds here. For example, `zero_peer_restart_secs = 30` does not provide the documented 30-second window, leaving operators with recovery timing that differs from the supplied configuration.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(health): #262 — /health reports degr..."](https://github.com/saorsa-labs/x0x/commit/88ef78c18d45efb10ce9ed3827e233d6a0e1edfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45326436)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->