### PR TITLE
docs: post-v0.34.2 audit of Start-here docs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -357,6 +357,9 @@ log_level = "info"                    # trace | debug | info | warn | error
 heartbeat_interval_secs = 300         # Re-announce identity every 5 min
 identity_ttl_secs = 900               # Expire stale discoveries after 15 min
 rendezvous_enabled = true             # Global agent findability
+network_id = "x0x.prod"               # Gossip plane isolation (unset = "x0x.prod"; "" = open, no isolation)
+observed_prefix_enabled = false       # Share masked observed-address prefix in beacons (default off)
+zero_peer_restart_secs = 600          # Exit after N s at zero peers so a supervisor restarts us (unset = off)
 ```
 
 ### Storage Locations

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -80,6 +80,9 @@ curl http://127.0.0.1:12700/status
 | POST | `/agent/card/import` | `x0x agent import` | Import a card into contacts (verifies signature; never changes existing trust: floor at existing level, Blocked is sticky) |
 | POST | `/agent/sign` | `x0x agent sign` | Detached ML-DSA-65 signature over caller-supplied bytes |
 | POST | `/agent/verify` | `x0x agent verify` | Verify a detached ML-DSA-65 signature against a caller-supplied public key |
+| GET | `/introduction` | `x0x agent introduction` | Trust-gated introduction card (`?peer=<64-hex>` scopes it to that peer's trust) |
+| POST | `/identity/revoke` | `x0x identity revoke` | Issue a signed key revocation (self-revocation always allowed; revoking a third party requires a user-signed AgentCertificate; exactly one of `agent_id` / `machine_id`) |
+| GET | `/identity/revocations` | `x0x identity revocations` | List signed identity revocations known to this daemon |
 
 ### Announce request body
 

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -166,7 +166,7 @@ async fn main() {
 
 ## Available Endpoints
 
-x0xd exposes 71 REST endpoints. Key categories:
+x0xd exposes 142 REST endpoints. Key categories:
 
 | Category | Endpoints | What you can do |
 |----------|-----------|-----------------|


### PR DESCRIPTION
Audit of the README Start-here trio (SKILL.md, api-reference.md, local-apps.md) against the 142-endpoint registry and a live v0.34.2 daemon. Three staleness fixes; 8+ documented examples spot-verified live with matching shapes; README Start-here bullets confirmed accurate (all named surfaces covered, five example apps as described).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the Start-here documentation for x0x v0.34.2. The main changes are:

- Adds three daemon configuration options and their defaults.
- Documents introduction and identity-revocation endpoints.
- Updates the API registry count from 71 to 142.

<h3>Confidence Score: 4/5</h3>

The documented third-party revocation path does not work and should be corrected before merging.

- The new configuration names and defaults match the daemon.
- The new route methods and CLI spellings match the registered interfaces.
- Foreign-subject revocation returns 403 because the handler omits the required certificate.
- The 142 count covers registered endpoints rather than every route served by the daemon.

docs/api-reference.md and docs/local-apps.md

<details open><summary><h3>Security Review</h3></summary>

The revocation endpoint fails closed, so no authorization bypass is introduced. However, the documentation claims certificate-authorized third-party revocation is available even though the handler never supplies the certificate required by that authorization path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| SKILL.md | Adds configuration keys whose names, defaults, and empty-value behavior match the daemon. |
| docs/api-reference.md | Adds valid route and CLI names but overstates the revocation workflow supported by the handler. |
| docs/local-apps.md | Updates the registry count correctly but describes it as the daemon's complete REST surface. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs/api-reference.md:84
**Third-Party Revocation Always Fails**

The REST handler passes no `AgentCertificate` to `Agent::revoke`, while issuer revocation requires that certificate. Calling `x0x identity revoke` for a foreign agent therefore returns 403 even when the required user-signed certificate exists, so this row advertises an unavailable workflow.

```suggestion
| POST | `/identity/revoke` | `x0x identity revoke` | Issue a signed self-revocation (exactly one of `agent_id` / `machine_id`) |
```

### Issue 2 of 2
docs/local-apps.md:169
**Registry Count Omits Extra Routes**

The value 142 is the size of the endpoint registry, but the daemon also serves `/.well-known/agent-card.json` and `/gui/` outside that registry. Describing 142 as the full exposed REST surface undercounts the routes available to local applications.

```suggestion
x0xd registers 142 REST endpoints, in addition to a small set of routes served outside the registry. Key categories:
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: post-v0.34.2 audit of Start-here d..."](https://github.com/saorsa-labs/x0x/commit/b8bf377122de8d96143a198362ac126b1adc4993) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45377637)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->