### PR TITLE
ADR-0023: durable local history as a core x0xd capability (Proposed)

### DIFF
--- a/docs/adr/0023-durable-local-history.md
+++ b/docs/adr/0023-durable-local-history.md
@@ -1,0 +1,183 @@
+# ADR 0023: Durable Local History Is a Core x0x Capability
+
+- **Status:** Proposed
+- **Date:** 2026-07-22
+- **Decision owners:** David Irvine
+- **Reviewers:** <pending>
+- **Supersedes:** none (extends the storage posture of ADR 0015)
+- **Superseded by:** none
+- **Related:** x0x-nostr-bridge spike (2026-07-21), ADR 0009/0013 (receive-pump shedding), ADR 0012 (TreeKEM), ADR 0015 (no app-layer at-rest encryption), issue #110 (embedded `serve()`), tic-tac-toe frontend (saorsa-labs/tic-tac-toe)
+
+## Context
+
+x0x today persists *state* but not *communication*. Across daemon restarts we
+keep: identity keys, TreeKEM group snapshots, revocation sets, KV stores,
+CRDT task lists, the group state-commit chain, and the bootstrap cache. We do
+**not** keep: direct messages (`dm_inbox.rs` is an in-memory map, a documented
+v1 non-goal of the DM design), group message history (`/groups/:id/messages`
+serves an in-memory listener buffer), or any pub/sub payloads. MLS-encrypted
+groups expose no plaintext history at all.
+
+Two events forced this decision:
+
+1. **The x0x-nostr-bridge spike (2026-07-21).** To run an unmodified Nostr
+   workspace client (Block's Buzz) against x0x, the bridge had to add a
+   SQLite event store — durable history with query and full-text search —
+   because the workspace product category is unusable without it. The store
+   was not Nostr plumbing; it was the capability x0x itself lacked.
+2. **Agents need memory.** x0x positions itself as the agent-to-agent
+   transport. An agent that loses its conversation record on every restart
+   cannot audit what it agreed to, resume work, or be held accountable. For
+   the agent-workspace use case (tic-tac-toe, symphony), history is not a
+   feature — it is the substrate.
+
+The tension: x0x's gossip plane is deliberately fire-and-forget (epidemic
+broadcast, bounded queues, shed-under-pressure per ADR 0009/0013), and our
+privacy posture (ADR 0015) is that local disk is protected by OS user
+isolation + full-disk encryption, not by app-layer crypto. Durable history
+must not compromise either.
+
+## Decision Drivers
+
+- Agent accountability and resumability require a durable, queryable local
+  record of communication.
+- The workspace product category (Buzz-parity via tic-tac-toe) requires
+  history + search; the bridge spike proved the shape and the demand.
+- PQC end-to-end differentiation: history over native x0x envelopes keeps
+  ML-DSA-65 authorship; the bridge's Schnorr-signed store cannot.
+- The gossip receive path must never block on disk (ADR 0009/0013).
+- Participant-held data philosophy (ADR 0006): each node records what it
+  witnessed; there is no global archive to query or poison.
+- Unbounded disk growth is unacceptable on long-lived daemons.
+
+## Considered Options
+
+1. **Durable history as a core, default-on x0xd capability (SQLite).**
+2. Durable history as an opt-in feature flag, default off.
+3. Keep history an application concern (each app ships its own store, as the
+   nostr-bridge did).
+4. Extend the existing bincode-file persistence (no SQL dependency).
+
+Option 2 makes the flagship use case (agent memory) a configuration
+afterthought and forks the ecosystem into daemons-with-memory and
+daemons-without. Option 3 duplicates a hard-to-get-right store (write-path
+backpressure, retention, search) into every app and loses the shared CLI/API
+surface. Option 4 cannot serve bounded-latency scoped queries or full-text
+search, which are the point.
+
+## Decision
+
+We will make **durable local history a core x0xd capability, enabled by
+default**, implemented on SQLite (bundled `rusqlite`, no system dependency)
+in the instance data directory (`~/.x0x/history.db`; per-instance for named
+instances).
+
+**Message-class taxonomy.** Every stored surface is classified once, in code:
+
+| Class | Semantics | Examples |
+|---|---|---|
+| **Durable** | Append to history, subject to retention | DMs (sent + received), named-group messages, application topics that opt in |
+| **Replaceable** | Latest-per-key only | Agent cards, presence-adjacent profile state |
+| **Ephemeral** | Never written | Presence beacons, typing/control frames, discovery anti-entropy, upgrade manifests, keepalives |
+
+Transport/control traffic is ephemeral by definition; history records
+*communication*, not protocol chatter.
+
+**Write path.** History writes go through a dedicated writer task fed by a
+bounded channel. Under pressure the writer sheds (counted,
+`history_dropped_full`) — the receive pump and DM/group hot paths never
+block on disk. This is the ADR 0009/0013 posture applied to storage.
+
+**MLS groups.** We store **reader-side decrypted plaintext**. TreeKEM epochs
+rotate; retaining ciphertext would orphan history at every epoch advance.
+Forward secrecy is a wire property; local plaintext-at-rest is exactly the
+ADR 0015 posture (OS user isolation + FDE), and stored history is
+**local-only — never served to the network** (see non-goals).
+
+**Retention.** Default-on but bounded: `[history]` config with
+`enabled = true`, `max_bytes` (default 1 GiB), optional `max_age_days`,
+optional per-scope overrides. A periodic reaper (same pattern as
+`discovery_cache_reaper`) enforces bounds by evicting oldest-first.
+
+**API surface** (registered in `ENDPOINTS`, so CLI + parity tests follow
+automatically):
+
+- `GET /history?scope=dm:<agent_id>|group:<id>|topic:<name>&since&until&limit`
+- `GET /history/search?q=<fts>&scope=…` (FTS5)
+- WS/SSE subscriptions gain an optional `backfill` mode: stored events
+  first, then a `live` marker, then the live stream (the one protocol shape
+  worth taking from NIP-01's REQ→EOSE).
+- `DELETE /history?scope=…` — local deletion only.
+
+`dm_inbox` and the group in-memory buffers become read-through caches over
+the store; `/groups/:id/messages` becomes store-backed and restart-stable.
+
+**Library embedders** (issue #110 context): `AgentBuilder` gains
+`.with_history(HistoryConfig | Disabled)`; the daemon defaults on, the bare
+library defaults off so embedding stays zero-footprint unless asked.
+
+**Non-goals of this ADR (explicitly deferred):**
+
+- **Serving history to the network.** V1 history is a private local record
+  of what this node witnessed/decrypted. Cross-node backfill/anti-entropy
+  (e.g. over ADR 0022 byte streams) is a separate future ADR with its own
+  trust model.
+- Network-propagated deletion/redaction.
+- History export/import tooling.
+
+## Consequences
+
+### Positive
+
+- Agents (and tic-tac-toe) get restart-stable memory, scoped query, and
+  full-text search from the daemon they already run.
+- One hardened store instead of N per-app stores; the bridge's tested
+  design (parameterized SQL, FTS5, replaceable semantics, size caps) is
+  lifted rather than reinvented.
+- PQC story stays intact end-to-end: history rows are native x0x envelopes
+  with ML-DSA-65 authorship.
+- Participant-held philosophy preserved: no archive servers, no global
+  query surface, nothing new to attack remotely.
+
+### Negative / Trade-offs
+
+- First SQL dependency in x0x core (bundled rusqlite; ~1 MB binary growth,
+  new fuzz/audit surface in the query builders — mitigated by binding every
+  user value, as the bridge does).
+- Plaintext-at-rest for decrypted MLS content on the local disk. This is
+  ADR 0015's stance, but history makes it *larger*; documentation must say
+  so plainly.
+- Disk usage on busy daemons; bounded by retention, but eviction means
+  history is a window, not an archive.
+- Write amplification on gossip-heavy nodes; bounded writer + shed counters
+  make it observable, not free.
+
+### Neutral / Operational
+
+- `history.db` joins the per-instance data dir; multi-instance (`--name`)
+  isolation comes for free.
+- Test daemons already use per-instance temp dirs; restart-survival tests
+  become possible and required.
+- Registry-driven parity means `x0x history …` CLI commands appear with the
+  endpoints.
+
+## Validation
+
+- Unit: insert/query/replace/ephemeral-never-stored/retention-eviction/FTS
+  round-trips.
+- Integration: send DM → restart daemon → `GET /history` returns it
+  (the restart-survival test that is impossible today).
+- Backpressure: flood the gossip plane; assert the receive pump never
+  blocks on the writer and `history_dropped_full` counts the shed.
+- Parity: `api_coverage.rs` / `parity_cli.rs` enforce endpoint + CLI
+  coverage automatically once registered.
+- Product: tic-tac-toe's acceptance suite reads history-after-restart and
+  search as its first two assertions — the proof point this exists for.
+- Review trigger: if cross-node backfill is proposed, it requires a new ADR;
+  this ADR's local-only privacy claim is load-bearing.
+
+## Notes for AI-assisted work
+
+AI tools may help draft this ADR, but **must not mark it Accepted without
+human review**. Accepted ADRs are immutable: create a new superseding ADR
+rather than editing an Accepted ADR.

--- a/docs/adr/0023-durable-local-history.md
+++ b/docs/adr/0023-durable-local-history.md
@@ -1,6 +1,6 @@
 # ADR 0023: Durable Local History Is a Core x0x Capability
 
-- **Status:** Proposed
+- **Status:** Accepted (2026-07-22)
 - **Date:** 2026-07-22
 - **Decision owners:** David Irvine
 - **Reviewers:** <pending>

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ This directory contains architecture decision records for x0x.
 - [ADR 0019: Connect ACL — Default-Closed Connectivity Policy](./0019-connect-acl-default-closed.md) — default-closed connect policy engine (`src/connect/`) with fail-closed load and `/diagnostics/connect` (accepted 2026-07-22)
 - [ADR 0020: Tailnet Phase 1 — per-peer byte-streams + local port-forwarding](./0020-tailnet-phase-1-byte-streams-and-forwarding.md) — PeerStream over `Node::open_bi`/`accept_bi` with the identity gate inside open/accept; `src/forward.rs` local port-forwarder gated by the connect ACL (#131/ADR-0019) + key lifecycle (#130); loopback-only Phase 1 (accepted 2026-07-22)
 - [ADR 0022: Tailnet stream API — per-protocol acceptors, connect-ACL gate, bounded backpressure](./0022-tailnet-stream-api.md) — protocol-byte routing to single-owner acceptors (bounded, drop-on-full), stream-layer connect-ACL pair gate after the identity gate, QUIC flow-control backpressure with asserted bounds; issue #132 deliverable 1 (accepted 2026-07-22)
+- [ADR 0023: Durable Local History Is a Core x0x Capability](./0023-durable-local-history.md) (accepted 2026-07-22) — default-on SQLite history store in x0xd (durable/replaceable/ephemeral taxonomy, bounded shed-on-full writer, local-only — never served to the network); lifts the nostr-bridge spike's store design; substrate for tic-tac-toe
 
 ## Accepted (Phase 1 Functionally Complete)
 
@@ -32,7 +33,6 @@ This directory contains architecture decision records for x0x.
 ## Proposed
 
 - [ADR 0021: DM Origin-Machine Attestation for Gossip DMs](./0021-dm-origin-machine-attestation.md) — machine-key attestation of DM origin; codec scaffolding landed (`DmOriginAttestation` in `src/dm.rs`) but enforcement not yet wired
-- [ADR 0023: Durable Local History Is a Core x0x Capability](./0023-durable-local-history.md) — default-on SQLite history store in x0xd (durable/replaceable/ephemeral taxonomy, bounded shed-on-full writer, local-only — never served to the network); lifts the nostr-bridge spike's store design; substrate for tic-tac-toe
 
 ## Errata (Accepted ADRs are immutable; corrections recorded here)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ This directory contains architecture decision records for x0x.
 ## Proposed
 
 - [ADR 0021: DM Origin-Machine Attestation for Gossip DMs](./0021-dm-origin-machine-attestation.md) — machine-key attestation of DM origin; codec scaffolding landed (`DmOriginAttestation` in `src/dm.rs`) but enforcement not yet wired
+- [ADR 0023: Durable Local History Is a Core x0x Capability](./0023-durable-local-history.md) — default-on SQLite history store in x0xd (durable/replaceable/ephemeral taxonomy, bounded shed-on-full writer, local-only — never served to the network); lifts the nostr-bridge spike's store design; substrate for tic-tac-toe
 
 ## Errata (Accepted ADRs are immutable; corrections recorded here)
 


### PR DESCRIPTION
Proposes making durable local history a **default-on core capability** of x0xd, per the deep-dive decision (2026-07-22).

Key points:
- SQLite (bundled rusqlite) at `~/.x0x/history.db`, per-instance
- Message taxonomy: **durable** (DMs, group messages, opt-in topics) / **replaceable** (latest-per-key) / **ephemeral** (presence, control — never stored)
- Bounded shed-on-full writer — the receive pump never blocks on disk (ADR-0009/0013 posture)
- MLS groups store reader-side decrypted plaintext (epochs rotate; ciphertext would orphan history) — ADR-0015 at-rest posture, **local-only, never served to the network**
- Retention reaper (`[history] max_bytes` default 1 GiB), `/history` + `/history/search` (FTS5) + WS backfill-then-live, registry-driven CLI parity
- Non-goals: cross-node backfill (future ADR), network deletion, export tooling
- Lifts the x0x-nostr-bridge spike's tested store design; substrate for **tic-tac-toe** (the pure-x0x workspace frontend)

Status is Proposed — @dirvine to review and accept per governance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR proposes durable local history as a core x0xd capability. The main changes are:

- Default-on per-instance SQLite history with bounded retention.
- Durable, replaceable, and ephemeral message classes.
- History query, FTS5 search, deletion, and subscription backfill APIs.
- An opt-in history configuration for library embedders.
- An ADR index entry for the proposed decision.

<h3>Confidence Score: 4/5</h3>

The ADR should not be accepted until message durability, physical disk limits, and the local-only API boundary are defined consistently.

- Queue pressure and shutdown can lose messages that callers already consider accepted.
- SQL eviction alone does not enforce the promised physical disk bound.
- Backfill and deletion can cross the stated local-only security boundary on a non-loopback listener.

docs/adr/0023-durable-local-history.md

<details open><summary><h3>Security Review</h3></summary>

The proposed HTTP and WS/SSE surfaces do not preserve the absolute local-only guarantee when x0xd binds off-loopback. Backfill can expose decrypted MLS history remotely, and deletion has no stated scope-level authorization boundary.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/adr/0023-durable-local-history.md | Defines durable history, retention, search, and API behavior, but leaves conflicting durability, disk-bound, and network-access contracts. |
| docs/adr/README.md | Adds an accurate index entry for the proposed ADR. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[DM, group, or opted-in topic] --> B[Hot path]
    B --> C{Bounded history queue}
    C -->|Available| D[SQLite writer]
    C -->|Full| E[Drop and count]
    D --> F[(History DB and FTS5)]
    F --> G[Retention reaper]
    F --> H[History and search API]
    F --> I[WS/SSE backfill]
    F --> J[Delete API]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 7 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 7
docs/adr/0023-durable-local-history.md:87-89
**Acknowledged Messages Lose Durability**

When the history channel is full, a received DM can already have been acknowledged and a group message can already have been delivered before its history write is shed. The sender sees success, but the promised durable accountability record permanently omits the message.

### Issue 2 of 7
docs/adr/0023-durable-local-history.md:87-89
**Shutdown Drops Queued History**

A successful enqueue is not a durable commit. During graceful shutdown, the daemon currently gives tracked tasks a limited drain period and then aborts stragglers; without an explicit close, drain, commit, and join contract for this writer, queued messages can disappear after restart even though the channel accepted them.

### Issue 3 of 7
docs/adr/0023-durable-local-history.md:98-100
**Eviction Does Not Bound Disk**

Oldest-first SQL deletion does not by itself reduce SQLite's physical disk use: deleted pages remain on the freelist, while WAL and FTS5 storage can add separate bytes. A busy daemon can therefore stay above `max_bytes` after the reaper runs unless the decision defines file accounting, checkpointing, and page reclamation.

### Issue 4 of 7
docs/adr/0023-durable-local-history.md:99-100
**Scope Limits Evict Wrong Records**

The decision combines per-scope overrides with a single oldest-first reaper but does not require scope-aware eviction. If one scope exceeds its override, global oldest-first deletion can remove records from a different scope that remains below its own limit, causing avoidable history loss.

### Issue 5 of 7
docs/adr/0023-durable-local-history.md:106
**Retention Leaves Stale Search Rows**

Retention and local deletion remove primary history rows, but the decision does not require the FTS5 index to be updated in the same transaction. An external-content or separately populated FTS table can retain evicted messages, so search may return deleted content or row references that no longer resolve.

### Issue 6 of 7
docs/adr/0023-durable-local-history.md:107-109
**Backfill Breaks Local-Only Boundary**

Existing WS/SSE subscriptions are HTTP control-plane endpoints, and x0xd supports a configurable non-loopback bind. In that deployment, backfill sends stored MLS plaintext off-host to a session-token holder, contradicting the load-bearing promise that history is never served to the network.

### Issue 7 of 7
docs/adr/0023-durable-local-history.md:110
**Bearer Token Deletes Every Scope**

The proposed endpoint accepts an arbitrary scope but defines no scope ownership or separate local-administrator boundary. When the control plane is exposed off-host, any accepted bearer or session token can delete another agent's DM, group, or topic history, despite “local deletion” only describing propagation.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(adr): propose ADR-0023 — durable lo..."](https://github.com/saorsa-labs/x0x/commit/c9b108a21e464e919d8b9f36345d099efc92c5f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46214460)</sub>

> Greptile also left **7 inline comments** on this PR.

<!-- /greptile_comment -->