### PR TITLE
feat(voice): X0xSignaling + WebRtcV1 stream lane — saorsa-webrtc integration (V1.1/V1.2)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,6 +5,12 @@
 # Acknowledge unmaintained crate warnings that are NOT security vulnerabilities.
 # These are transitive dependencies we cannot directly control.
 ignore = [
+    # audiopus_sys 0.2.2 - marked unmaintained (RUSTSEC-2025-0008)
+    # No security vulnerability; transitive via saorsa-webrtc-codecs -> opus
+    # (voice feature). Revisit when the opus crate migrates its sys binding
+    # or saorsa-webrtc-codecs switches bindings.
+    "RUSTSEC-2025-0008",
+
     # bincode 1.3.3 - marked unmaintained (RUSTSEC-2025-0141)
     # No security vulnerability; bincode 2.x is not a drop-in replacement.
     # Used for serialization in x0x core. Will migrate when bincode 2 stabilizes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,15 @@ dhat = { version = "0.3", optional = true }
 tikv-jemallocator = { version = "0.6", optional = true }
 tikv-jemalloc-ctl = { version = "0.6", optional = true }
 
+# Voice adapters (saorsa-webrtc V1.1/V1.2): trait surfaces only — no
+# webrtc-rs, no codecs. `quic-native` matches x0x's transport philosophy.
+[dependencies.saorsa-webrtc-core]
+version = "0.4.0"
+optional = true
+default-features = false
+features = ["quic-native"]
+
+
 [features]
 # jemalloc with aggressive purge — eliminates the 50 MB heap-to-RSS
 # amplification glibc was producing. Opt-in (not default) so library
@@ -95,6 +104,9 @@ jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 # Enable dhat heap profiling in x0xd. Outputs dhat-heap.json at exit.
 # Build: cargo build --bin x0xd --features profile-heap
 profile-heap = ["dep:dhat"]
+# Voice/video adapters for saorsa-webrtc: X0xSignaling over DMs and
+# X0xLinkTransport over ADR-0022 byte streams (StreamProtocol::WebRtcV1).
+voice = ["dep:saorsa-webrtc-core"]
 
 [dev-dependencies]
 # `start_paused` virtual-clock tests for the state-request bootstrap tail

--- a/src/error.rs
+++ b/src/error.rs
@@ -489,6 +489,30 @@ impl From<rusqlite::Error> for HistoryError {
 /// Standard Result type for x0x history operations.
 pub type HistoryResult<T> = std::result::Result<T, HistoryError>;
 
+/// Errors from the voice adapters (`voice` feature — saorsa-webrtc
+/// signaling over DMs and media over `StreamProtocol::WebRtcV1`).
+#[derive(Debug, thiserror::Error)]
+pub enum VoiceError {
+    /// A signaling message failed JSON (de)serialization.
+    #[error("voice signaling serialization: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    /// The DM path refused or failed to deliver a signaling message.
+    #[error("voice signaling send failed: {0}")]
+    SignalingSend(String),
+
+    /// The inbound signaling channel closed (agent shut down).
+    #[error("voice signaling channel closed")]
+    ChannelClosed,
+
+    /// A voice peer id string was not 32 bytes of hex.
+    #[error("invalid voice peer id: {0}")]
+    InvalidPeerId(String),
+}
+
+/// Standard Result type for x0x voice operations.
+pub type VoiceResult<T> = std::result::Result<T, VoiceError>;
+
 #[cfg(test)]
 mod network_tests {
     #![allow(clippy::unwrap_used)]

--- a/src/history/classify.rs
+++ b/src/history/classify.rs
@@ -21,6 +21,12 @@ pub const LTC_CARD_FRAME_PREFIX: &[u8] = b"X0X-LTC-CARD-V1\n";
 /// KV-store delta DM fallback (`server::routes::stores::KV_STORE_DELTA_DM_PREFIX`).
 /// The KV store is its own durable surface.
 pub const KV_STORE_DELTA_DM_PREFIX: &[u8] = b"X0X-KV-DELTA-V1\n";
+/// Voice signaling frames (`voice` feature, saorsa-webrtc V1.1). Call
+/// setup/teardown control traffic — Ephemeral like all signaling; the
+/// conversation itself is media, not DM history. The const lives here
+/// (not in the feature-gated voice module) so classification and the
+/// deny-test hold even when the `voice` feature is off.
+pub const VOICE_SIGNALING_DM_PREFIX: &[u8] = b"x0x-voice-sig-v1\n";
 
 /// JSON `"type"` tag values that are protocol plumbing (never recorded):
 /// file-transfer chunk traffic plus the `WelcomeBlobMessage` /
@@ -71,6 +77,7 @@ pub fn classify_dm_payload(payload: &[u8]) -> DmPayloadClass {
     if payload.starts_with(GROUP_PUBLIC_MESSAGE_DM_PREFIX)
         || payload.starts_with(LTC_CARD_FRAME_PREFIX)
         || payload.starts_with(KV_STORE_DELTA_DM_PREFIX)
+        || payload.starts_with(VOICE_SIGNALING_DM_PREFIX)
         || payload.starts_with(crate::exec::protocol::EXEC_DM_PREFIX)
     {
         return DmPayloadClass::Ephemeral;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,12 @@ pub mod files;
 /// Durable local history store (ADR-0023).
 pub mod history;
 
+/// Voice adapters for saorsa-webrtc (`voice` feature): signaling over DMs
+/// (`X0xSignaling`) and media lanes over ADR-0022 byte streams
+/// (`X0xLinkTransport`, `StreamProtocol::WebRtcV1`).
+#[cfg(feature = "voice")]
+pub mod voice;
+
 pub mod connect;
 /// Secure Tier-1 remote exec protocol and runtime.
 pub mod exec;

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -372,6 +372,13 @@ pub enum StreamProtocol {
     /// machine, then ACL-checks that specific agent. Closes the unannounced-
     /// agent window documented in `docs/connect-acl.md`.
     ForwardV2 = 0x03,
+    /// WebRTC media lane (saorsa-webrtc V1.2, `voice` feature). The first
+    /// byte **after** this prefix is the saorsa-webrtc `StreamType`
+    /// (0x20–0x24: audio/video/screen/rtcp/data), so multiple media lanes
+    /// nest inside one x0x protocol byte. Identity gate + connect-ACL pair
+    /// gate apply exactly as for every other protocol; there is no
+    /// voice-specific bypass.
+    WebRtcV1 = 0x04,
 }
 
 impl StreamProtocol {
@@ -383,6 +390,7 @@ impl StreamProtocol {
             0x01 => Some(Self::ForwardV1),
             0x02 => Some(Self::SocksV1),
             0x03 => Some(Self::ForwardV2),
+            0x04 => Some(Self::WebRtcV1),
             _ => None,
         }
     }
@@ -532,6 +540,7 @@ mod tests {
             StreamProtocol::ForwardV1,
             StreamProtocol::SocksV1,
             StreamProtocol::ForwardV2,
+            StreamProtocol::WebRtcV1,
         ] {
             assert_eq!(StreamProtocol::from_u8(p.as_u8()), Some(p));
         }
@@ -543,7 +552,7 @@ mod tests {
         for byte in 0x00u8..=0xFF {
             let parsed = StreamProtocol::from_u8(byte);
             match byte {
-                0x01..=0x03 => {
+                0x01..=0x04 => {
                     assert!(parsed.is_some(), "byte {byte:#x} should parse")
                 }
                 _ => assert_eq!(parsed, None, "byte {byte:#x} must be unknown"),

--- a/src/voice/link_transport.rs
+++ b/src/voice/link_transport.rs
@@ -1,0 +1,311 @@
+//! [`LinkTransport`] over ADR-0022 byte streams (saorsa-webrtc V1.2).
+//!
+//! Wire shape per stream: the x0x protocol prefix
+//! ([`StreamProtocol::WebRtcV1`], `0x04`) is written/consumed by the
+//! existing open/accept machinery; the **first application byte** is the
+//! saorsa-webrtc [`StreamType`] (0x20–0x24); every frame after that is
+//! `u32-BE length ‖ payload`. One x0x stream per `(direction, StreamType)`
+//! lane, opened lazily on first send.
+//!
+//! Addressing: x0x reaches peers by [`AgentId`], not socket address — the
+//! target agent is fixed at construction and [`LinkTransport::connect`]'s
+//! `SocketAddr` argument is recorded for display only. Every open and
+//! accept passes the identity gate, trust evaluation, revocation checks,
+//! and the connect-ACL pair gate exactly like `ForwardV1/V2` streams.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use saorsa_webrtc_core::link_transport::{
+    LinkTransport, LinkTransportError, PeerConnection, StreamType,
+};
+use tokio::sync::{mpsc, Mutex};
+
+use crate::identity::AgentId;
+use crate::streams::{PeerStream, StreamProtocol};
+use crate::Agent;
+
+/// Bound on the inbound frame queue. Media consumers drain continuously;
+/// a full queue drops the oldest pressure onto QUIC flow control (the
+/// per-stream reader simply awaits), so this bounds memory, not loss.
+const INBOUND_QUEUE_DEPTH: usize = 1024;
+
+/// Upper bound on a single framed payload (1 MiB). Voice frames are
+/// ~200 bytes; anything near this bound is a protocol violation and the
+/// lane is dropped.
+const MAX_FRAME_BYTES: u32 = 1024 * 1024;
+
+/// Outbound lane: the send half of an opened `WebRtcV1` stream, keyed by
+/// [`StreamType`]. The recv half is parked alongside so the peer's stream
+/// state stays open for the lane's lifetime.
+struct OutboundLane {
+    send: ant_quic::HighLevelSendStream,
+    _recv: ant_quic::HighLevelRecvStream,
+}
+
+/// [`LinkTransport`] over x0x `WebRtcV1` peer streams.
+pub struct X0xLinkTransport {
+    agent: Arc<Agent>,
+    remote: AgentId,
+    remote_addr_hint: std::sync::Mutex<SocketAddr>,
+    running: AtomicBool,
+    lanes: Mutex<HashMap<u8, OutboundLane>>,
+    inbound_tx: mpsc::Sender<(PeerConnection, StreamType, Vec<u8>)>,
+    inbound: Mutex<mpsc::Receiver<(PeerConnection, StreamType, Vec<u8>)>>,
+    accepted_peers_tx: mpsc::Sender<PeerConnection>,
+    accepted_peers: Mutex<mpsc::Receiver<PeerConnection>>,
+    acceptor_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl X0xLinkTransport {
+    /// Create a transport bound to one remote agent (1:1 call scope).
+    #[must_use]
+    pub fn new(agent: Arc<Agent>, remote: AgentId) -> Self {
+        let (inbound_tx, inbound_rx) = mpsc::channel(INBOUND_QUEUE_DEPTH);
+        let (accepted_tx, accepted_rx) = mpsc::channel(16);
+        Self {
+            agent,
+            remote,
+            remote_addr_hint: std::sync::Mutex::new(placeholder_addr()),
+            running: AtomicBool::new(false),
+            lanes: Mutex::new(HashMap::new()),
+            inbound_tx,
+            inbound: Mutex::new(inbound_rx),
+            accepted_peers_tx: accepted_tx,
+            accepted_peers: Mutex::new(accepted_rx),
+            acceptor_task: Mutex::new(None),
+        }
+    }
+
+    /// The fixed remote agent this transport talks to.
+    #[must_use]
+    pub fn remote_agent(&self) -> AgentId {
+        self.remote
+    }
+
+    fn peer_connection(&self) -> PeerConnection {
+        let addr = self
+            .remote_addr_hint
+            .lock()
+            .map(|a| *a)
+            .unwrap_or_else(|poisoned| *poisoned.into_inner());
+        PeerConnection {
+            peer_id: hex::encode(self.remote.0),
+            remote_addr: addr,
+        }
+    }
+
+    /// Reader loop for one inbound stream: demux the [`StreamType`] byte,
+    /// then forward length-prefixed frames until EOF/error.
+    async fn drive_inbound_stream(
+        mut stream: PeerStream,
+        inbound_tx: mpsc::Sender<(PeerConnection, StreamType, Vec<u8>)>,
+        accepted_tx: mpsc::Sender<PeerConnection>,
+    ) {
+        let peer_conn = PeerConnection {
+            peer_id: hex::encode(stream.agent().0),
+            remote_addr: placeholder_addr(),
+        };
+        let recv = stream.recv_mut();
+
+        let mut ty = [0u8; 1];
+        if recv.read_exact(&mut ty).await.is_err() {
+            return;
+        }
+        let Some(stream_type) = StreamType::try_from_u8(ty[0]) else {
+            tracing::warn!(target: "voice", byte = ty[0], "unknown media StreamType; lane dropped");
+            return;
+        };
+        // Surface the accepted peer once per inbound lane (accept() feed).
+        let _ = accepted_tx.try_send(peer_conn.clone());
+
+        loop {
+            let mut len_buf = [0u8; 4];
+            if recv.read_exact(&mut len_buf).await.is_err() {
+                return; // peer closed the lane
+            }
+            let len = u32::from_be_bytes(len_buf);
+            if len == 0 || len > MAX_FRAME_BYTES {
+                tracing::warn!(target: "voice", len, "invalid frame length; lane dropped");
+                return;
+            }
+            let mut frame = vec![0u8; len as usize];
+            if recv.read_exact(&mut frame).await.is_err() {
+                return;
+            }
+            if inbound_tx
+                .send((peer_conn.clone(), stream_type, frame))
+                .await
+                .is_err()
+            {
+                return; // transport dropped
+            }
+        }
+    }
+}
+
+fn placeholder_addr() -> SocketAddr {
+    // x0x addresses peers by identity; the socket address in
+    // `PeerConnection` is informational only for this transport.
+    SocketAddr::from(([127, 0, 0, 1], 0))
+}
+
+fn lt_err(context: &str, e: impl std::fmt::Display) -> LinkTransportError {
+    LinkTransportError::IoError(format!("{context}: {e}"))
+}
+
+#[async_trait]
+impl LinkTransport for X0xLinkTransport {
+    async fn start(&mut self) -> Result<(), LinkTransportError> {
+        if self.running.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
+        let mut acceptor = self
+            .agent
+            .register_stream_acceptor(StreamProtocol::WebRtcV1)
+            .map_err(|e| lt_err("register WebRtcV1 acceptor", e))?;
+        let inbound_tx = self.inbound_tx.clone();
+        let accepted_tx = self.accepted_peers_tx.clone();
+        let task = tokio::spawn(async move {
+            while let Some(stream) = acceptor.next().await {
+                tokio::spawn(Self::drive_inbound_stream(
+                    stream,
+                    inbound_tx.clone(),
+                    accepted_tx.clone(),
+                ));
+            }
+        });
+        *self.acceptor_task.lock().await = Some(task);
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), LinkTransportError> {
+        self.running.store(false, Ordering::SeqCst);
+        if let Some(task) = self.acceptor_task.lock().await.take() {
+            task.abort();
+        }
+        self.lanes.lock().await.clear();
+        Ok(())
+    }
+
+    async fn is_running(&self) -> bool {
+        self.running.load(Ordering::SeqCst)
+    }
+
+    async fn local_addr(&self) -> Result<SocketAddr, LinkTransportError> {
+        let network = self
+            .agent
+            .network()
+            .ok_or(LinkTransportError::NotConnected)?;
+        network
+            .bound_addr()
+            .await
+            .ok_or(LinkTransportError::NotConnected)
+    }
+
+    async fn connect(&mut self, addr: SocketAddr) -> Result<PeerConnection, LinkTransportError> {
+        if let Ok(mut hint) = self.remote_addr_hint.lock() {
+            *hint = addr;
+        }
+        // Streams open lazily per lane in `send`; connection-level
+        // reachability, identity, trust, and ACL are enforced there by
+        // `Agent::open_peer_stream`.
+        Ok(self.peer_connection())
+    }
+
+    async fn accept(&mut self) -> Result<Option<PeerConnection>, LinkTransportError> {
+        Ok(self.accepted_peers.lock().await.recv().await)
+    }
+
+    async fn send(
+        &self,
+        _peer: &PeerConnection,
+        stream_type: StreamType,
+        data: &[u8],
+    ) -> Result<(), LinkTransportError> {
+        let len = u32::try_from(data.len())
+            .ok()
+            .filter(|l| *l > 0 && *l <= MAX_FRAME_BYTES)
+            .ok_or_else(|| {
+                LinkTransportError::SendError(format!("frame length {} out of range", data.len()))
+            })?;
+
+        let mut lanes = self.lanes.lock().await;
+        if let std::collections::hash_map::Entry::Vacant(slot) = lanes.entry(stream_type.as_u8()) {
+            let mut stream = self
+                .agent
+                .open_peer_stream(&self.remote, StreamProtocol::WebRtcV1)
+                .await
+                .map_err(|e| LinkTransportError::SendError(format!("open WebRtcV1 lane: {e}")))?;
+            stream
+                .send_mut()
+                .write_all(&[stream_type.as_u8()])
+                .await
+                .map_err(|e| lt_err("write StreamType byte", e))?;
+            let (send, recv) = stream.into_split();
+            slot.insert(OutboundLane { send, _recv: recv });
+        }
+        // Entry guaranteed by the insert above; avoid unwrap per house rules.
+        let Some(lane) = lanes.get_mut(&stream_type.as_u8()) else {
+            return Err(LinkTransportError::SendError(
+                "lane vanished during send".to_owned(),
+            ));
+        };
+        lane.send
+            .write_all(&len.to_be_bytes())
+            .await
+            .map_err(|e| lt_err("write frame length", e))?;
+        lane.send
+            .write_all(data)
+            .await
+            .map_err(|e| lt_err("write frame body", e))?;
+        Ok(())
+    }
+
+    async fn receive(&self) -> Result<(PeerConnection, StreamType, Vec<u8>), LinkTransportError> {
+        self.inbound
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or(LinkTransportError::NotConnected)
+    }
+
+    fn default_peer(&self) -> Result<PeerConnection, LinkTransportError> {
+        Ok(self.peer_connection())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn webrtc_protocol_byte_is_pinned() {
+        // 0x04 is wire surface shared with saorsa-webrtc deployments.
+        assert_eq!(StreamProtocol::WebRtcV1.as_u8(), 0x04);
+        assert_eq!(
+            StreamProtocol::from_u8(0x04),
+            Some(StreamProtocol::WebRtcV1)
+        );
+    }
+
+    #[test]
+    fn media_stream_types_do_not_collide_with_x0x_protocol_bytes() {
+        // Inner StreamType bytes (0x20-0x24) must stay disjoint from the
+        // outer x0x StreamProtocol range so a truncated prefix can never
+        // alias between the two layers.
+        for ty in [
+            StreamType::Audio,
+            StreamType::Video,
+            StreamType::Screen,
+            StreamType::RtcpFeedback,
+            StreamType::Data,
+        ] {
+            assert!(StreamProtocol::from_u8(ty.as_u8()).is_none());
+        }
+    }
+}

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -1,0 +1,32 @@
+//! Voice adapters for `saorsa-webrtc` (feature `voice`).
+//!
+//! Implements the two seams the saorsa-webrtc revival design (V1.1/V1.2)
+//! assigns to x0x:
+//!
+//! * [`X0xSignaling`] — [`saorsa_webrtc_core::signaling::SignalingTransport`]
+//!   over x0x direct messages. Signaling frames ride the DM path with the
+//!   [`crate::history::classify::VOICE_SIGNALING_DM_PREFIX`] typed prefix and
+//!   are classified **Ephemeral** (never recorded to history).
+//! * [`X0xLinkTransport`] — [`saorsa_webrtc_core::link_transport::LinkTransport`]
+//!   over ADR-0022 byte streams using
+//!   [`crate::streams::StreamProtocol::WebRtcV1`] (`0x04`). The byte after
+//!   the x0x protocol prefix is the saorsa-webrtc
+//!   [`saorsa_webrtc_core::link_transport::StreamType`] (0x20–0x24), so
+//!   audio/video/control lanes nest inside one gated x0x stream protocol.
+//!
+//! Both adapters sit **behind** the existing identity gate, trust
+//! evaluation, revocation checks, and the connect-ACL pair gate — voice
+//! traffic gets no special path through any of them.
+
+mod link_transport;
+mod signaling;
+
+pub use link_transport::X0xLinkTransport;
+pub use signaling::{VoicePeerId, X0xSignaling};
+
+/// Typed DM prefix for voice signaling frames.
+///
+/// Re-exported from the history taxonomy module, which owns the constant so
+/// classification (and its deny-test) hold even when the `voice` feature is
+/// disabled.
+pub use crate::history::classify::VOICE_SIGNALING_DM_PREFIX;

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -3,11 +3,11 @@
 //! Implements the two seams the saorsa-webrtc revival design (V1.1/V1.2)
 //! assigns to x0x:
 //!
-//! * [`X0xSignaling`] — [`saorsa_webrtc_core::signaling::SignalingTransport`]
+//! * [`X0xSignaling`](crate::voice::X0xSignaling) — [`saorsa_webrtc_core::signaling::SignalingTransport`]
 //!   over x0x direct messages. Signaling frames ride the DM path with the
 //!   [`crate::history::classify::VOICE_SIGNALING_DM_PREFIX`] typed prefix and
 //!   are classified **Ephemeral** (never recorded to history).
-//! * [`X0xLinkTransport`] — [`saorsa_webrtc_core::link_transport::LinkTransport`]
+//! * [`X0xLinkTransport`](crate::voice::X0xLinkTransport) — [`saorsa_webrtc_core::link_transport::LinkTransport`]
 //!   over ADR-0022 byte streams using
 //!   [`crate::streams::StreamProtocol::WebRtcV1`] (`0x04`). The byte after
 //!   the x0x protocol prefix is the saorsa-webrtc

--- a/src/voice/signaling.rs
+++ b/src/voice/signaling.rs
@@ -1,0 +1,185 @@
+//! [`SignalingTransport`] over x0x direct messages (saorsa-webrtc V1.1).
+//!
+//! QUIC-native call setup needs three messages
+//! (`CapabilityExchange → ConnectionConfirm → ConnectionReady`), each a
+//! small serde enum. They ride the existing DM path — ML-KEM-768 sealed,
+//! ML-DSA-65 signed, trust- and revocation-gated — prefixed with
+//! [`VOICE_SIGNALING_DM_PREFIX`] so the ADR-0023 taxonomy classifies them
+//! Ephemeral (signaling is control traffic, not conversation history).
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use saorsa_webrtc_core::signaling::{SignalingMessage, SignalingTransport};
+use tokio::sync::{mpsc, Mutex};
+
+use crate::error::VoiceError;
+use crate::identity::AgentId;
+use crate::Agent;
+
+use super::VOICE_SIGNALING_DM_PREFIX;
+
+/// Depth of the inbound signaling queue. Signaling is three messages per
+/// call setup plus teardown; 256 absorbs any realistic burst, and overflow
+/// drops (counted via `tracing::warn!`) rather than blocking the DM
+/// subscriber fan-out.
+const SIGNALING_QUEUE_DEPTH: usize = 256;
+
+/// Voice peer identity: an [`AgentId`] with a **round-trippable** textual
+/// form (full 64-char lowercase hex).
+///
+/// `AgentId`'s own `Display` is a truncated debug form; the
+/// [`SignalingTransport`] contract wants `Display`/`FromStr` to round-trip,
+/// so this newtype provides the parseable encoding without touching core
+/// identity types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VoicePeerId(pub AgentId);
+
+impl std::fmt::Display for VoicePeerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.0 .0))
+    }
+}
+
+impl FromStr for VoicePeerId {
+    type Err = VoiceError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = hex::decode(s).map_err(|e| VoiceError::InvalidPeerId(e.to_string()))?;
+        let arr: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| VoiceError::InvalidPeerId(format!("expected 32 bytes, got {s:?}")))?;
+        Ok(Self(AgentId(arr)))
+    }
+}
+
+/// [`SignalingTransport`] implementation over x0x DMs.
+///
+/// A background task drains the agent's direct-message subscription,
+/// filters for the voice prefix, and feeds parsed messages into a bounded
+/// queue that [`SignalingTransport::receive_message`] drains. Non-voice
+/// DMs are ignored (other subscribers receive their own clones — the DM
+/// fan-out is per-subscriber).
+pub struct X0xSignaling {
+    agent: Arc<Agent>,
+    inbound: Mutex<mpsc::Receiver<(VoicePeerId, SignalingMessage)>>,
+    reader: tokio::task::JoinHandle<()>,
+}
+
+impl X0xSignaling {
+    /// Attach a signaling transport to a running agent.
+    #[must_use]
+    pub fn new(agent: Arc<Agent>) -> Self {
+        let (tx, rx) = mpsc::channel(SIGNALING_QUEUE_DEPTH);
+        let mut direct = agent.subscribe_direct();
+        let reader = tokio::spawn(async move {
+            while let Some(msg) = direct.recv().await {
+                let Some(body) = msg.payload.strip_prefix(VOICE_SIGNALING_DM_PREFIX) else {
+                    continue;
+                };
+                match serde_json::from_slice::<SignalingMessage>(body) {
+                    Ok(parsed) => {
+                        if tx.try_send((VoicePeerId(msg.sender), parsed)).is_err() {
+                            tracing::warn!(
+                                target: "voice",
+                                "signaling queue full or closed; dropping inbound frame"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "voice",
+                            error = %e,
+                            "undecodable voice signaling frame dropped"
+                        );
+                    }
+                }
+            }
+        });
+        Self {
+            agent,
+            inbound: Mutex::new(rx),
+            reader,
+        }
+    }
+
+    /// The local agent identity in voice-peer form.
+    #[must_use]
+    pub fn local_peer_id(&self) -> VoicePeerId {
+        VoicePeerId(self.agent.agent_id())
+    }
+}
+
+impl Drop for X0xSignaling {
+    fn drop(&mut self) {
+        self.reader.abort();
+    }
+}
+
+#[async_trait]
+impl SignalingTransport for X0xSignaling {
+    type PeerId = VoicePeerId;
+    type Error = VoiceError;
+
+    async fn send_message(
+        &self,
+        peer: &Self::PeerId,
+        message: SignalingMessage,
+    ) -> Result<(), Self::Error> {
+        let body = serde_json::to_vec(&message)?;
+        let mut payload = Vec::with_capacity(VOICE_SIGNALING_DM_PREFIX.len() + body.len());
+        payload.extend_from_slice(VOICE_SIGNALING_DM_PREFIX);
+        payload.extend_from_slice(&body);
+        self.agent
+            .send_direct(&peer.0, payload)
+            .await
+            .map_err(|e| VoiceError::SignalingSend(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn receive_message(&self) -> Result<(Self::PeerId, SignalingMessage), Self::Error> {
+        self.inbound
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or(VoiceError::ChannelClosed)
+    }
+
+    async fn discover_peer_endpoint(
+        &self,
+        _peer: &Self::PeerId,
+    ) -> Result<Option<std::net::SocketAddr>, Self::Error> {
+        // QUIC-native flow: ant-quic owns NAT traversal and addressing; no
+        // endpoint discovery is required at the signaling layer.
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn voice_peer_id_round_trips() {
+        let id = VoicePeerId(AgentId([0xAB; 32]));
+        let text = id.to_string();
+        assert_eq!(text.len(), 64);
+        let parsed: VoicePeerId = text.parse().expect("round trip");
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn voice_peer_id_rejects_bad_input() {
+        assert!(VoicePeerId::from_str("zz").is_err());
+        assert!(VoicePeerId::from_str(&"ab".repeat(31)).is_err());
+    }
+
+    #[test]
+    fn prefix_literal_is_pinned() {
+        // The wire prefix is protocol surface — changing it breaks live
+        // calls between versions. Bump deliberately, never accidentally.
+        assert_eq!(VOICE_SIGNALING_DM_PREFIX, b"x0x-voice-sig-v1\n");
+    }
+}

--- a/tests/history_wiring.rs
+++ b/tests/history_wiring.rs
@@ -39,6 +39,8 @@ fn ephemeral_family_payloads() -> Vec<(&'static str, Vec<u8>)> {
     ltc_card.extend_from_slice(b"frame");
     let mut exec = x0x::exec::protocol::EXEC_DM_PREFIX.to_vec();
     exec.extend_from_slice(b"exec-frame");
+    let mut voice_sig = x0x::history::classify::VOICE_SIGNALING_DM_PREFIX.to_vec();
+    voice_sig.extend_from_slice(br#"{"type":"connection_ready","session_id":"call-1"}"#);
 
     vec![
         ("file-chunk", chunk),
@@ -76,6 +78,7 @@ fn ephemeral_family_payloads() -> Vec<(&'static str, Vec<u8>)> {
         ("kv-delta-dm-frame", kv_delta),
         ("ltc-card-frame", ltc_card),
         ("exec-frame", exec),
+        ("voice-signaling-frame", voice_sig),
     ]
 }
 

--- a/tests/voice_adapters.rs
+++ b/tests/voice_adapters.rs
@@ -1,0 +1,313 @@
+//! Voice adapters integration proof (saorsa-webrtc V1.1/V1.2, `voice`
+//! feature).
+//!
+//! Two in-process agents on loopback complete the QUIC-native signaling
+//! flow (`CapabilityExchange → ConnectionConfirm → ConnectionReady`) over
+//! real DMs via [`x0x::voice::X0xSignaling`], then exchange audio-sized
+//! frames over [`x0x::voice::X0xLinkTransport`]
+//! (`StreamProtocol::WebRtcV1`, inner `StreamType::Audio` lane), plus the
+//! connect-ACL negative path.
+//!
+//! Network-bound tests are `#[ignore]` (integration tier, like
+//! `tailnet_streams_integration.rs`): they bind real UDP sockets and wait
+//! on loopback convergence.
+
+#![cfg(feature = "voice")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use saorsa_webrtc_core::link_transport::{LinkTransport, StreamType};
+use saorsa_webrtc_core::signaling::{SignalingMessage, SignalingTransport};
+use tempfile::TempDir;
+use x0x::network::NetworkConfig;
+use x0x::voice::{X0xLinkTransport, X0xSignaling};
+use x0x::DiscoveredAgent;
+
+fn loopback_network_config() -> NetworkConfig {
+    NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr literal")),
+        bootstrap_nodes: Vec::new(),
+        ..NetworkConfig::default()
+    }
+}
+
+fn is_network_bind_permission_error(error: &impl std::fmt::Display) -> bool {
+    let message = error.to_string();
+    message.contains("Operation not permitted")
+        && (message.contains("bind UDP socket")
+            || message.contains("network initialization failed"))
+}
+
+async fn build_agent(dir: &TempDir, name: &str) -> Option<x0x::Agent> {
+    match x0x::Agent::builder()
+        .with_machine_key(dir.path().join(format!("{name}-machine.key")))
+        .with_agent_key_path(dir.path().join(format!("{name}-agent.key")))
+        .with_contact_store_path(dir.path().join(format!("{name}-contacts.json")))
+        .with_peer_cache_dir(dir.path().join(format!("{name}-peer-cache")))
+        .with_network_config(loopback_network_config())
+        .build()
+        .await
+    {
+        Ok(agent) => Some(agent),
+        Err(e) if is_network_bind_permission_error(&e) => None,
+        Err(e) => panic!("agent build failed: {e}"),
+    }
+}
+
+fn normalize_loopback(addr: std::net::SocketAddr) -> std::net::SocketAddr {
+    if addr.ip().is_unspecified() {
+        std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            addr.port(),
+        )
+    } else {
+        addr
+    }
+}
+
+fn discovered_agent(
+    agent: &x0x::Agent,
+    addr: std::net::SocketAddr,
+    now_secs: u64,
+) -> DiscoveredAgent {
+    DiscoveredAgent {
+        agent_id: agent.agent_id(),
+        machine_id: agent.machine_id(),
+        user_id: None,
+        addresses: vec![addr],
+        announced_at: now_secs,
+        last_seen: now_secs,
+        machine_public_key: Vec::new(),
+        nat_type: None,
+        can_receive_direct: Some(true),
+        is_relay: None,
+        is_coordinator: None,
+        reachable_via: Vec::new(),
+        relay_candidates: Vec::new(),
+        cert_not_after: None,
+        agent_certificate: None,
+        agent_public_key: Vec::new(),
+    }
+}
+
+/// Build a connected, mutually trusted alice/bob pair (tailnet harness
+/// pattern). Returns None when the sandbox forbids UDP binds.
+async fn trusted_pair(dir: &TempDir) -> Option<(Arc<x0x::Agent>, Arc<x0x::Agent>)> {
+    let alice = Arc::new(build_agent(dir, "alice").await?);
+    let bob = Arc::new(build_agent(dir, "bob").await?);
+
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let bob_addr = normalize_loopback(bob_network.bound_addr().await.expect("bob bound"));
+    let alice_addr = normalize_loopback(alice_network.bound_addr().await.expect("alice bound"));
+
+    let connected = alice_network
+        .connect_addr(bob_addr)
+        .await
+        .expect("alice connects to bob");
+    assert_eq!(connected.0, bob.machine_id().0);
+
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+    let alice_peer = ant_quic::PeerId(alice.machine_id().0);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if alice_network.is_connected(&bob_peer).await
+            && bob_network.is_connected(&alice_peer).await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_secs();
+    alice
+        .insert_discovered_agent_for_testing(discovered_agent(&bob, bob_addr, now_secs))
+        .await;
+    alice.set_contact_trusted_for_testing(bob.agent_id()).await;
+    bob.insert_discovered_agent_for_testing(discovered_agent(&alice, alice_addr, now_secs))
+        .await;
+    bob.set_contact_trusted_for_testing(alice.agent_id()).await;
+
+    Some((alice, bob))
+}
+
+/// Full V1 proof: three-message QUIC-native signaling over real DMs, then
+/// 50 byte-identical audio frames over the `WebRtcV1` Audio lane.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback voice proof; binds UDP + waits on convergence. Integration tier."]
+async fn signaling_flow_then_audio_frames_over_webrtc_lane() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    let alice_sig = X0xSignaling::new(Arc::clone(&alice));
+    let bob_sig = X0xSignaling::new(Arc::clone(&bob));
+    let bob_voice_id = alice_sig.local_peer_id(); // silence unused warnings symmetrically
+    let _ = bob_voice_id;
+
+    // CapabilityExchange: alice → bob.
+    alice_sig
+        .send_message(
+            &x0x::voice::VoicePeerId(bob.agent_id()),
+            SignalingMessage::CapabilityExchange {
+                session_id: "call-1".into(),
+                audio: true,
+                video: false,
+                data_channel: false,
+                max_bandwidth_kbps: 64,
+                quic_endpoint: None,
+            },
+        )
+        .await
+        .expect("send capability exchange");
+    let (from, msg) = tokio::time::timeout(Duration::from_secs(20), bob_sig.receive_message())
+        .await
+        .expect("bob receives within deadline")
+        .expect("bob receive ok");
+    assert_eq!(from.0, alice.agent_id(), "sender attribution");
+    assert!(
+        matches!(msg, SignalingMessage::CapabilityExchange { ref session_id, audio: true, .. } if session_id == "call-1"),
+        "unexpected first message: {msg:?}"
+    );
+
+    // ConnectionConfirm: bob → alice.
+    bob_sig
+        .send_message(
+            &from,
+            SignalingMessage::ConnectionConfirm {
+                session_id: "call-1".into(),
+                audio: true,
+                video: false,
+                data_channel: false,
+                max_bandwidth_kbps: 64,
+                quic_endpoint: None,
+            },
+        )
+        .await
+        .expect("send connection confirm");
+    let (_, msg) = tokio::time::timeout(Duration::from_secs(20), alice_sig.receive_message())
+        .await
+        .expect("alice receives within deadline")
+        .expect("alice receive ok");
+    assert!(
+        matches!(msg, SignalingMessage::ConnectionConfirm { ref session_id, .. } if session_id == "call-1")
+    );
+
+    // ConnectionReady: alice → bob.
+    alice_sig
+        .send_message(
+            &x0x::voice::VoicePeerId(bob.agent_id()),
+            SignalingMessage::ConnectionReady {
+                session_id: "call-1".into(),
+            },
+        )
+        .await
+        .expect("send connection ready");
+    let (_, msg) = tokio::time::timeout(Duration::from_secs(20), bob_sig.receive_message())
+        .await
+        .expect("bob receives ready")
+        .expect("bob receive ok");
+    assert!(matches!(msg, SignalingMessage::ConnectionReady { .. }));
+
+    // Media: 50 audio-sized frames alice → bob on the Audio lane.
+    let mut alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id());
+    let mut bob_link = X0xLinkTransport::new(Arc::clone(&bob), alice.agent_id());
+    bob_link.start().await.expect("bob link starts");
+    alice_link.start().await.expect("alice link starts");
+
+    let frames: Vec<Vec<u8>> = (0u8..50)
+        .map(|i| {
+            let mut f = vec![i; 200]; // opus-frame-sized
+            f[0] = i; // sequence marker
+            f
+        })
+        .collect();
+    let peer = alice_link.default_peer().expect("default peer");
+    for frame in &frames {
+        alice_link
+            .send(&peer, StreamType::Audio, frame)
+            .await
+            .expect("send audio frame");
+    }
+
+    let mut received = Vec::with_capacity(frames.len());
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while received.len() < frames.len() && Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, bob_link.receive()).await {
+            Ok(Ok((_, ty, data))) => {
+                assert_eq!(ty, StreamType::Audio);
+                received.push(data);
+            }
+            Ok(Err(e)) => panic!("bob receive failed: {e}"),
+            Err(_) => break,
+        }
+    }
+    assert_eq!(received.len(), frames.len(), "all frames delivered");
+    // Single ordered QUIC stream per lane ⇒ order and bytes both hold.
+    assert_eq!(received, frames, "byte-identical, in order");
+
+    alice_link.stop().await.expect("alice stop");
+    bob_link.stop().await.expect("bob stop");
+    alice.shutdown().await;
+    bob.shutdown().await;
+}
+
+/// Connect-ACL negative path: the pair gate is an **inbound** gate
+/// (`stream_acl_gate`, #131 — outbound relies on the identity gate). With
+/// an Enabled policy on bob that does not list alice, bob's accept loop
+/// rejects the `WebRtcV1` stream — no lane surfaces, no frame is
+/// delivered. The voice protocol gets no ACL bypass.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback ACL denial; binds UDP + waits on convergence. Integration tier."]
+async fn connect_acl_denies_unlisted_voice_peer() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    // Bob enables a policy listing a random pair that is NOT
+    // (alice, alice-machine) — alice becomes an unlisted peer inbound.
+    let stranger_agent = x0x::identity::AgentId([0x55; 32]);
+    let stranger_machine = x0x::identity::MachineId([0x66; 32]);
+    bob.set_connect_policy(Arc::new(x0x::connect::ConnectPolicy::Enabled(
+        x0x::connect::ConnectAcl {
+            loaded_from: std::path::Path::new("/test").to_path_buf(),
+            loaded_at_unix_ms: 0,
+            allow: vec![x0x::connect::ConnectAllowEntry {
+                description: None,
+                agent_id: stranger_agent,
+                machine_id: stranger_machine,
+                targets: vec!["127.0.0.1:22".parse().expect("loopback literal")],
+            }],
+        },
+    )));
+
+    let mut bob_link = X0xLinkTransport::new(Arc::clone(&bob), alice.agent_id());
+    bob_link.start().await.expect("bob link starts");
+    let mut alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id());
+    alice_link.start().await.expect("alice link starts");
+
+    // Alice's open/first-write may succeed locally (the reset races the
+    // handshake); what MUST hold is that bob never surfaces the lane.
+    let peer = alice_link.default_peer().expect("default peer");
+    let _ = alice_link.send(&peer, StreamType::Audio, &[0u8; 200]).await;
+
+    let nothing = tokio::time::timeout(Duration::from_secs(5), bob_link.receive()).await;
+    assert!(
+        nothing.is_err(),
+        "bob must not receive frames from an ACL-unlisted peer: {nothing:?}"
+    );
+
+    alice.shutdown().await;
+    bob.shutdown().await;
+}


### PR DESCRIPTION
The x0x side of the voice stack for tic-tac-toe, consuming the just-published `saorsa-webrtc-core 0.4.0` from crates.io behind an optional `voice` feature (plain builds compile zero webrtc crates — verified).

- **`X0xSignaling`**: `SignalingTransport` over real x0x DMs (`x0x-voice-sig-v1` payload family, classified **Ephemeral** in the ADR-0023 taxonomy + deny-tested); QUIC-native flow, no SDP/ICE.
- **`StreamProtocol::WebRtcV1 = 0x04`** + `X0xLinkTransport` over ADR-0022 PeerStreams (inner webrtc StreamType nesting, bytes pinned by tests); **connect-ACL gate intact** — negative test proves an unlisted peer's lane never surfaces.
- Integration proof: two agents complete CapabilityExchange→ConnectionConfirm→ConnectionReady over DMs, then 50/50 byte-identical in-order audio frames on the Audio lane.
- `VoicePeerId` newtype (full-hex Display/FromStr round-trip without touching core identity types).

Gates: clippy `--all-features -D warnings` clean, fmt clean, voice integration tests 2/2 (independently re-run), history deny-suite 13/13.

Companion work merged/pushed in saorsa-webrtc: datagram lane + mandatory jitter buffer (`feat/v1-datagram-lane`), `saorsa-webrtc-audio` cpal crate (`feat/v1-audio`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds x0x adapters for the saorsa WebRTC voice stack. The main changes are:

- Optional `saorsa-webrtc-core` integration behind the `voice` feature.
- Ephemeral voice signaling over direct messages.
- A new `WebRtcV1` stream protocol and framed media lanes.
- Voice identity, history, ACL, and integration tests.

<h3>Confidence Score: 4/5</h3>

Concurrent calls can mix inbound media, and transport shutdown does not fully stop or close its media paths.

- The agent permits only one acceptor for the shared voice protocol.
- Failed startup and failed lane writes leave stale state behind.
- Reader tasks and receive channels remain active after shutdown.
- Signaling queue pressure can silently lose required setup messages.

src/voice/link_transport.rs and src/voice/signaling.rs

<details open><summary><h3>Security Review</h3></summary>

Inbound WebRTC streams are dispatched through one agent-wide protocol acceptor rather than by call or remote peer. Concurrent calls can therefore route one call's media into another transport's receive queue.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voice/link_transport.rs | Adds framed media transport, but concurrent-call routing, startup recovery, lane recovery, and shutdown handling can fail. |
| src/voice/signaling.rs | Adds DM-backed signaling and peer ID conversion; bounded non-blocking delivery can discard required handshake messages. |
| src/streams.rs | Adds the pinned WebRtcV1 protocol byte to the existing stream registry. |
| src/history/classify.rs | Classifies the voice signaling prefix as ephemeral history traffic. |
| Cargo.toml | Adds the optional saorsa-webrtc-core dependency and voice feature. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Q[Agent QUIC accept loop] -->|WebRtcV1| R[Single protocol acceptor]
    A[Call A transport] -->|registers first| R
    B[Call B transport] -->|registration conflict| R
    S[Call B inbound stream] --> Q
    R --> I[Call A inbound queue]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 7 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 7
src/voice/link_transport.rs:166-169
**Protocol Acceptor Mixes Calls**

Each transport registers the same agent-wide `WebRtcV1` acceptor, while the registry allows only one acceptor per protocol. With two simultaneous calls on one agent, the second transport cannot start and its inbound streams are routed to the first transport, so media from one call can surface in another call's receive queue.

### Issue 2 of 7
src/voice/link_transport.rs:162-169
**Failed Start Leaves Running State**

`running` becomes true before acceptor registration succeeds. If registration returns `StreamAcceptorConflict` or another error, the next `start()` returns `Ok(())` without installing an acceptor, leaving the transport unable to receive media even after the original conflict is gone.

### Issue 3 of 7
src/voice/link_transport.rs:249-264
**Failed Lane Remains Cached**

The lane enters the map before the first frame is fully written. If writing the frame length or body fails during a connection reset, later sends reuse the same broken stream and fail indefinitely, so that media lane cannot recover until the whole transport is stopped.

### Issue 4 of 7
src/voice/link_transport.rs:185-191
**Lane Readers Survive Stop**

`stop()` aborts the accept loop but not the per-stream reader tasks spawned by it. Existing streams can therefore continue adding frames and peer events after shutdown or during a later start cycle, causing stale call media to appear after the transport has stopped.

### Issue 5 of 7
src/voice/link_transport.rs:223-240
**Stopped Transport Reopens Lanes**

`send()` never checks `running`. After `stop()` clears the lane map, a concurrent or later send can open and cache a new QUIC stream while the transport remains stopped, so shutdown does not prevent new traffic and a later restart can reuse a stream created outside its lifecycle.

### Issue 6 of 7
src/voice/link_transport.rs:268-274
**Receive Hangs After Stop**

The transport keeps `inbound_tx` alive when `stop()` returns, so an empty `receive()` cannot observe channel closure. A call loop waiting for the receive side to terminate can block forever after a clean shutdown.

### Issue 7 of 7
src/voice/signaling.rs:81-88
**Queue Pressure Drops Handshake Frames**

When the signaling consumer stalls and 256 messages accumulate, `try_send` drops each new frame without reporting an error to the signaling state machine. Losing a required capability, confirmation, or ready message leaves the call setup waiting indefinitely even though DM delivery succeeded.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(voice): X0xSignaling + WebRtcV1 str..."](https://github.com/saorsa-labs/x0x/commit/daf33c818276616d94dd2c102fa72b2028e65fad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46294526)</sub>

> Greptile also left **7 inline comments** on this PR.

<!-- /greptile_comment -->