### PR TITLE
feat(voice): 1:1 voice call demo — full pipeline over the mesh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,11 +89,17 @@ tikv-jemalloc-ctl = { version = "0.6", optional = true }
 # Voice adapters (saorsa-webrtc V1.1/V1.2): trait surfaces only — no
 # webrtc-rs, no codecs. `quic-native` matches x0x's transport philosophy.
 [dependencies.saorsa-webrtc-core]
-version = "0.4.0"
+version = "0.5.0"
 optional = true
 default-features = false
 features = ["quic-native"]
 
+# Real Opus for the voice pipeline (re-exported as `x0x::voice::codecs` so
+# apps get the codec matching the transport without a second dep to pin).
+# Default features = real Opus only; no video codecs.
+[dependencies.saorsa-webrtc-codecs]
+version = "0.5.0"
+optional = true
 
 [features]
 # jemalloc with aggressive purge — eliminates the 50 MB heap-to-RSS
@@ -106,7 +112,7 @@ jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 profile-heap = ["dep:dhat"]
 # Voice/video adapters for saorsa-webrtc: X0xSignaling over DMs and
 # X0xLinkTransport over ADR-0022 byte streams (StreamProtocol::WebRtcV1).
-voice = ["dep:saorsa-webrtc-core"]
+voice = ["dep:saorsa-webrtc-core", "dep:saorsa-webrtc-codecs"]
 
 [dev-dependencies]
 # `start_paused` virtual-clock tests for the state-request bootstrap tail
@@ -152,6 +158,14 @@ test = false
 [[bench]]
 name = "gossip_dispatch_throughput"
 harness = false
+
+[[example]]
+name = "voice_call"
+required-features = ["voice"]
+
+[[test]]
+name = "voice_e2e"
+required-features = ["voice"]
 
 [workspace]
 members = [

--- a/examples/voice_call.rs
+++ b/examples/voice_call.rs
@@ -1,0 +1,352 @@
+//! 1:1 voice call demo — the full pipeline over the x0x mesh.
+//!
+//! Two in-process agents on loopback: QUIC-native signaling over real DMs
+//! (`CapabilityExchange → ConnectionConfirm → ConnectionReady`), then five
+//! seconds of a synthesized speech-band tone (440 Hz + 1200 Hz) as 20 ms
+//! frames — **real Opus** encode → `AudioDatagram` wire framing →
+//! `X0xLinkTransport` Audio lane (ADR-0022 `StreamProtocol::WebRtcV1`) →
+//! **jitter buffer** → Opus decode — with per-frame one-way latency stats
+//! and jitter counters printed at the end.
+//!
+//! Lane mode: **Reliable** (a single ordered ADR-0022 byte stream per
+//! lane). The saorsa-webrtc `AudioLaneMode::Datagram` path exists in
+//! `saorsa-webrtc-core 0.5.0` over raw ant-quic connections, but the x0x
+//! adapter seam (`X0xLinkTransport` over `PeerStream`) does not expose an
+//! unreliable lane yet — that is V1.2/V1.3 follow-up work, noted in
+//! `docs/design/` upstream. The datagram *wire format* and the jitter
+//! buffer run end-to-end here regardless, so the playout path is the real
+//! one.
+//!
+//! Run:
+//! ```text
+//! cargo run --features voice --example voice_call
+//! ```
+//!
+//! Real microphone → speaker on two machines (manual Studio run): pair
+//! this demo's transport with the `saorsa-webrtc-audio` crate's capture /
+//! playout (`cargo run -p saorsa-webrtc-audio --example loopback 10` in
+//! the saorsa-webrtc repo proves the device path; wiring mic → this
+//! sender loop is the tic-tac-toe M-voice milestone, kept out of x0x so
+//! the daemon crate carries no cpal/device dependency).
+
+use std::f64::consts::TAU;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use saorsa_webrtc_core::link_transport::{LinkTransport, StreamType};
+use saorsa_webrtc_core::signaling::{SignalingMessage, SignalingTransport};
+use saorsa_webrtc_core::{AudioDatagram, JitterBuffer, JitterConfig, JitterEvent};
+use x0x::network::NetworkConfig;
+use x0x::voice::codecs::opus::{
+    samples_per_20ms, AudioFrame, Channels, OpusDecoder, OpusEncoder, OpusEncoderConfig, SampleRate,
+};
+use x0x::voice::{VoicePeerId, X0xLinkTransport, X0xSignaling};
+use x0x::DiscoveredAgent;
+
+const CALL_SECS: usize = 5;
+const FRAMES: usize = CALL_SECS * 50; // 20 ms frames
+const TONE_A_HZ: f64 = 440.0;
+const TONE_B_HZ: f64 = 1200.0;
+
+fn loopback_network_config() -> NetworkConfig {
+    NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr literal")),
+        bootstrap_nodes: Vec::new(),
+        ..NetworkConfig::default()
+    }
+}
+
+async fn build_agent(dir: &tempfile::TempDir, name: &str) -> x0x::Agent {
+    x0x::Agent::builder()
+        .with_machine_key(dir.path().join(format!("{name}-machine.key")))
+        .with_agent_key_path(dir.path().join(format!("{name}-agent.key")))
+        .with_contact_store_path(dir.path().join(format!("{name}-contacts.json")))
+        .with_peer_cache_dir(dir.path().join(format!("{name}-peer-cache")))
+        .with_network_config(loopback_network_config())
+        .build()
+        .await
+        .expect("agent build")
+}
+
+fn normalize_loopback(addr: std::net::SocketAddr) -> std::net::SocketAddr {
+    if addr.ip().is_unspecified() {
+        std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            addr.port(),
+        )
+    } else {
+        addr
+    }
+}
+
+fn discovered_agent(
+    agent: &x0x::Agent,
+    addr: std::net::SocketAddr,
+    now_secs: u64,
+) -> DiscoveredAgent {
+    DiscoveredAgent {
+        agent_id: agent.agent_id(),
+        machine_id: agent.machine_id(),
+        user_id: None,
+        addresses: vec![addr],
+        announced_at: now_secs,
+        last_seen: now_secs,
+        machine_public_key: Vec::new(),
+        nat_type: None,
+        can_receive_direct: Some(true),
+        is_relay: None,
+        is_coordinator: None,
+        reachable_via: Vec::new(),
+        relay_candidates: Vec::new(),
+        cert_not_after: None,
+        agent_certificate: None,
+        agent_public_key: Vec::new(),
+    }
+}
+
+/// 20 ms of the speech-band test tone at 48 kHz mono.
+fn tone_frame(frame_idx: usize, samples: usize) -> Vec<i16> {
+    let sr = SampleRate::Hz48000.as_hz() as f64;
+    (0..samples)
+        .map(|i| {
+            let t = (frame_idx * samples + i) as f64 / sr;
+            let v = 0.4 * (TAU * TONE_A_HZ * t).sin() + 0.3 * (TAU * TONE_B_HZ * t).sin();
+            (v * i16::MAX as f64 * 0.5) as i16
+        })
+        .collect()
+}
+
+/// Goertzel power of `freq` in `pcm` (48 kHz).
+fn goertzel(pcm: &[i16], freq: f64) -> f64 {
+    let sr = f64::from(SampleRate::Hz48000.as_hz());
+    let w = TAU * freq / sr;
+    let coeff = 2.0 * w.cos();
+    let (mut s1, mut s2) = (0.0f64, 0.0f64);
+    for &x in pcm {
+        let s0 = f64::from(x) + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    (s1 * s1 + s2 * s2 - coeff * s1 * s2) / pcm.len() as f64
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_millis() as u64
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() {
+    let dir = tempfile::TempDir::new().expect("tmpdir");
+    println!("── x0x voice call demo: {CALL_SECS}s, {FRAMES} × 20ms frames, real Opus ──");
+
+    // Two agents, mutual trust, loopback (mirrors the tailnet harness).
+    let alice = Arc::new(build_agent(&dir, "alice").await);
+    let bob = Arc::new(build_agent(&dir, "bob").await);
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let bob_addr = normalize_loopback(bob_network.bound_addr().await.expect("bob bound"));
+    let alice_addr = normalize_loopback(alice_network.bound_addr().await.expect("alice bound"));
+    alice_network
+        .connect_addr(bob_addr)
+        .await
+        .expect("alice connects to bob");
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+    let alice_peer = ant_quic::PeerId(alice.machine_id().0);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if alice_network.is_connected(&bob_peer).await
+            && bob_network.is_connected(&alice_peer).await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let now_secs = now_ms() / 1000;
+    alice
+        .insert_discovered_agent_for_testing(discovered_agent(&bob, bob_addr, now_secs))
+        .await;
+    alice.set_contact_trusted_for_testing(bob.agent_id()).await;
+    bob.insert_discovered_agent_for_testing(discovered_agent(&alice, alice_addr, now_secs))
+        .await;
+    bob.set_contact_trusted_for_testing(alice.agent_id()).await;
+
+    // Signaling: CapabilityExchange → ConnectionConfirm → ConnectionReady.
+    let alice_sig = X0xSignaling::new(Arc::clone(&alice));
+    let bob_sig = X0xSignaling::new(Arc::clone(&bob));
+    alice_sig
+        .send_message(
+            &VoicePeerId(bob.agent_id()),
+            SignalingMessage::CapabilityExchange {
+                session_id: "demo-call".into(),
+                audio: true,
+                video: false,
+                data_channel: false,
+                max_bandwidth_kbps: 64,
+                quic_endpoint: None,
+            },
+        )
+        .await
+        .expect("capability exchange");
+    let (from, _) = bob_sig.receive_message().await.expect("bob rx capex");
+    bob_sig
+        .send_message(
+            &from,
+            SignalingMessage::ConnectionConfirm {
+                session_id: "demo-call".into(),
+                audio: true,
+                video: false,
+                data_channel: false,
+                max_bandwidth_kbps: 64,
+                quic_endpoint: None,
+            },
+        )
+        .await
+        .expect("connection confirm");
+    let _ = alice_sig.receive_message().await.expect("alice rx confirm");
+    alice_sig
+        .send_message(
+            &VoicePeerId(bob.agent_id()),
+            SignalingMessage::ConnectionReady {
+                session_id: "demo-call".into(),
+            },
+        )
+        .await
+        .expect("connection ready");
+    let _ = bob_sig.receive_message().await.expect("bob rx ready");
+    println!("signaling complete (CapabilityExchange → ConnectionConfirm → ConnectionReady)");
+
+    // Media lanes.
+    let mut alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id());
+    let mut bob_link = X0xLinkTransport::new(Arc::clone(&bob), alice.agent_id());
+    bob_link.start().await.expect("bob link");
+    alice_link.start().await.expect("alice link");
+    let peer = alice_link.default_peer().expect("default peer");
+
+    // Receiver task: lane → AudioDatagram::decode → jitter → Opus decode.
+    let receiver = tokio::spawn(async move {
+        let mut jitter = JitterBuffer::new(JitterConfig::default());
+        let mut decoder = OpusDecoder::new(SampleRate::Hz48000, Channels::Mono).expect("decoder");
+        let mut pcm: Vec<i16> = Vec::with_capacity(FRAMES * 960);
+        let mut latencies_ms: Vec<u64> = Vec::with_capacity(FRAMES);
+        let mut delivered = 0usize;
+        let mut gaps = 0usize;
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while delivered + gaps < FRAMES && Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Ok(Ok((_, ty, data))) = tokio::time::timeout(remaining, bob_link.receive()).await
+            else {
+                break;
+            };
+            if ty != StreamType::Audio {
+                continue;
+            }
+            let dg = AudioDatagram::decode(data.into()).expect("wire decode");
+            latencies_ms.push(now_ms().saturating_sub(dg.timestamp_ms));
+            jitter.push(dg);
+            for ev in jitter.poll_ready() {
+                match ev {
+                    JitterEvent::Frame(f) => {
+                        let frame = decoder.decode(&f.payload).expect("opus decode");
+                        pcm.extend_from_slice(&frame.data);
+                        delivered += 1;
+                    }
+                    JitterEvent::Gap { .. } => gaps += 1,
+                }
+            }
+        }
+        // Drain anything the reorder window still holds.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        for ev in jitter.poll_ready() {
+            match ev {
+                JitterEvent::Frame(f) => {
+                    let frame = decoder.decode(&f.payload).expect("opus decode");
+                    pcm.extend_from_slice(&frame.data);
+                    delivered += 1;
+                }
+                JitterEvent::Gap { .. } => gaps += 1,
+            }
+        }
+        let _ = bob_link.stop().await;
+        (pcm, latencies_ms, delivered, gaps, jitter.counters())
+    });
+
+    // Sender: tone → Opus → AudioDatagram wire bytes → Audio lane, paced.
+    let samples = samples_per_20ms(SampleRate::Hz48000);
+    let mut encoder = OpusEncoder::new(OpusEncoderConfig::default()).expect("encoder");
+    let mut interval = tokio::time::interval(Duration::from_millis(20));
+    for seq in 0..FRAMES {
+        interval.tick().await;
+        let frame = AudioFrame {
+            data: tone_frame(seq, samples),
+            sample_rate: SampleRate::Hz48000,
+            channels: Channels::Mono,
+            timestamp: (seq * 20) as u64,
+        };
+        let payload = encoder.encode(&frame).expect("opus encode");
+        let dg = AudioDatagram {
+            seq: seq as u32,
+            timestamp_ms: now_ms(),
+            flags: 0,
+            payload,
+        };
+        let wire = dg.encode().expect("wire encode");
+        alice_link
+            .send(&peer, StreamType::Audio, &wire)
+            .await
+            .expect("send frame");
+    }
+    println!("sender done: {FRAMES} frames encoded + sent");
+
+    let (pcm, latencies_ms, delivered, gaps, counters) = receiver.await.expect("receiver task");
+    let _ = alice_link.stop().await;
+
+    // Tone verification: target frequencies must dominate an off-frequency.
+    let p_a = goertzel(&pcm, TONE_A_HZ);
+    let p_b = goertzel(&pcm, TONE_B_HZ);
+    let p_off = goertzel(&pcm, 700.0).max(1e-9);
+    let mut sorted = latencies_ms.clone();
+    sorted.sort_unstable();
+    let pct = |p: f64| -> u64 {
+        if sorted.is_empty() {
+            0
+        } else {
+            sorted[((sorted.len() as f64 - 1.0) * p) as usize]
+        }
+    };
+
+    println!("── results ──");
+    println!(
+        "frames: sent={FRAMES} delivered={delivered} gaps={gaps} ({:.1}% delivered post-jitter)",
+        100.0 * delivered as f64 / FRAMES as f64
+    );
+    println!(
+        "one-way frame latency ms: p50={} p95={} max={}",
+        pct(0.50),
+        pct(0.95),
+        sorted.last().copied().unwrap_or(0)
+    );
+    println!(
+        "jitter counters: delivered={} reordered={} late_dropped={} duplicates={} gaps_emitted={}",
+        counters.delivered,
+        counters.reordered,
+        counters.late_dropped,
+        counters.duplicates_dropped,
+        counters.gaps_emitted
+    );
+    println!(
+        "tone check (Goertzel power): 440Hz={:.1}dB over off-band, 1200Hz={:.1}dB over off-band",
+        10.0 * (p_a / p_off).log10(),
+        10.0 * (p_b / p_off).log10()
+    );
+    println!(
+        "lane mode: Reliable (ordered ADR-0022 stream; datagram lane = V1.2/V1.3 seam follow-up)"
+    );
+
+    alice.shutdown().await;
+    bob.shutdown().await;
+}

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -24,6 +24,11 @@ mod signaling;
 pub use link_transport::X0xLinkTransport;
 pub use signaling::{VoicePeerId, X0xSignaling};
 
+/// The codec crate matching this transport (real Opus; video codecs stay
+/// feature-gated upstream). Re-exported so applications pin exactly one
+/// voice dependency: `x0x` with the `voice` feature.
+pub use saorsa_webrtc_codecs as codecs;
+
 /// Typed DM prefix for voice signaling frames.
 ///
 /// Re-exported from the history taxonomy module, which owns the constant so

--- a/tests/voice_e2e.rs
+++ b/tests/voice_e2e.rs
@@ -1,0 +1,283 @@
+//! Voice pipeline e2e (feature `voice`, integration tier).
+//!
+//! Asserts the full 1:1 pipeline the `voice_call` example demonstrates:
+//! real Opus encode → `AudioDatagram` wire framing → `X0xLinkTransport`
+//! Audio lane → jitter buffer → Opus decode, between two in-process
+//! agents on loopback. 250 frames (5 s): ≥99 % delivered post-jitter,
+//! decoded tone dominates an off-band frequency (SNR sanity vs the
+//! synthesized source), p95 one-way frame latency < 100 ms.
+//!
+//! `#[ignore]`: binds real UDP sockets and waits on loopback convergence
+//! (integration tier, like `voice_adapters.rs`).
+
+#![cfg(feature = "voice")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::f64::consts::TAU;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use saorsa_webrtc_core::link_transport::{LinkTransport, StreamType};
+use saorsa_webrtc_core::{AudioDatagram, JitterBuffer, JitterConfig, JitterEvent};
+use tempfile::TempDir;
+use x0x::network::NetworkConfig;
+use x0x::voice::codecs::opus::{
+    samples_per_20ms, AudioFrame, Channels, OpusDecoder, OpusEncoder, OpusEncoderConfig, SampleRate,
+};
+use x0x::voice::X0xLinkTransport;
+use x0x::DiscoveredAgent;
+
+const FRAMES: usize = 250;
+const TONE_A_HZ: f64 = 440.0;
+const TONE_B_HZ: f64 = 1200.0;
+
+fn loopback_network_config() -> NetworkConfig {
+    NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr literal")),
+        bootstrap_nodes: Vec::new(),
+        ..NetworkConfig::default()
+    }
+}
+
+fn is_network_bind_permission_error(error: &impl std::fmt::Display) -> bool {
+    let message = error.to_string();
+    message.contains("Operation not permitted")
+        && (message.contains("bind UDP socket")
+            || message.contains("network initialization failed"))
+}
+
+async fn build_agent(dir: &TempDir, name: &str) -> Option<x0x::Agent> {
+    match x0x::Agent::builder()
+        .with_machine_key(dir.path().join(format!("{name}-machine.key")))
+        .with_agent_key_path(dir.path().join(format!("{name}-agent.key")))
+        .with_contact_store_path(dir.path().join(format!("{name}-contacts.json")))
+        .with_peer_cache_dir(dir.path().join(format!("{name}-peer-cache")))
+        .with_network_config(loopback_network_config())
+        .build()
+        .await
+    {
+        Ok(agent) => Some(agent),
+        Err(e) if is_network_bind_permission_error(&e) => None,
+        Err(e) => panic!("agent build failed: {e}"),
+    }
+}
+
+fn normalize_loopback(addr: std::net::SocketAddr) -> std::net::SocketAddr {
+    if addr.ip().is_unspecified() {
+        std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            addr.port(),
+        )
+    } else {
+        addr
+    }
+}
+
+fn discovered_agent(
+    agent: &x0x::Agent,
+    addr: std::net::SocketAddr,
+    now_secs: u64,
+) -> DiscoveredAgent {
+    DiscoveredAgent {
+        agent_id: agent.agent_id(),
+        machine_id: agent.machine_id(),
+        user_id: None,
+        addresses: vec![addr],
+        announced_at: now_secs,
+        last_seen: now_secs,
+        machine_public_key: Vec::new(),
+        nat_type: None,
+        can_receive_direct: Some(true),
+        is_relay: None,
+        is_coordinator: None,
+        reachable_via: Vec::new(),
+        relay_candidates: Vec::new(),
+        cert_not_after: None,
+        agent_certificate: None,
+        agent_public_key: Vec::new(),
+    }
+}
+
+async fn trusted_pair(dir: &TempDir) -> Option<(Arc<x0x::Agent>, Arc<x0x::Agent>)> {
+    let alice = Arc::new(build_agent(dir, "alice").await?);
+    let bob = Arc::new(build_agent(dir, "bob").await?);
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let bob_addr = normalize_loopback(bob_network.bound_addr().await.expect("bob bound"));
+    let alice_addr = normalize_loopback(alice_network.bound_addr().await.expect("alice bound"));
+    alice_network
+        .connect_addr(bob_addr)
+        .await
+        .expect("alice connects to bob");
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+    let alice_peer = ant_quic::PeerId(alice.machine_id().0);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if alice_network.is_connected(&bob_peer).await
+            && bob_network.is_connected(&alice_peer).await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_secs();
+    alice
+        .insert_discovered_agent_for_testing(discovered_agent(&bob, bob_addr, now_secs))
+        .await;
+    alice.set_contact_trusted_for_testing(bob.agent_id()).await;
+    bob.insert_discovered_agent_for_testing(discovered_agent(&alice, alice_addr, now_secs))
+        .await;
+    bob.set_contact_trusted_for_testing(alice.agent_id()).await;
+    Some((alice, bob))
+}
+
+fn tone_frame(frame_idx: usize, samples: usize) -> Vec<i16> {
+    let sr = f64::from(SampleRate::Hz48000.as_hz());
+    (0..samples)
+        .map(|i| {
+            let t = (frame_idx * samples + i) as f64 / sr;
+            let v = 0.4 * (TAU * TONE_A_HZ * t).sin() + 0.3 * (TAU * TONE_B_HZ * t).sin();
+            (v * f64::from(i16::MAX) * 0.5) as i16
+        })
+        .collect()
+}
+
+fn goertzel(pcm: &[i16], freq: f64) -> f64 {
+    let sr = f64::from(SampleRate::Hz48000.as_hz());
+    let w = TAU * freq / sr;
+    let coeff = 2.0 * w.cos();
+    let (mut s1, mut s2) = (0.0f64, 0.0f64);
+    for &x in pcm {
+        let s0 = f64::from(x) + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    (s1 * s1 + s2 * s2 - coeff * s1 * s2) / pcm.len() as f64
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_millis() as u64
+}
+
+/// Full pipeline: 250 Opus frames through wire framing, the Audio lane,
+/// and the jitter buffer — asserting delivery, audio fidelity, latency.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback voice pipeline; binds UDP + waits on convergence. Integration tier."]
+async fn voice_pipeline_delivers_decodable_audio() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    let mut alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id());
+    let mut bob_link = X0xLinkTransport::new(Arc::clone(&bob), alice.agent_id());
+    bob_link.start().await.expect("bob link");
+    alice_link.start().await.expect("alice link");
+    let peer = alice_link.default_peer().expect("default peer");
+
+    let receiver = tokio::spawn(async move {
+        let mut jitter = JitterBuffer::new(JitterConfig::default());
+        let mut decoder = OpusDecoder::new(SampleRate::Hz48000, Channels::Mono).expect("decoder");
+        let mut pcm: Vec<i16> = Vec::new();
+        let mut latencies_ms: Vec<u64> = Vec::new();
+        let mut delivered = 0usize;
+        let mut gaps = 0usize;
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while delivered + gaps < FRAMES && Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Ok(Ok((_, ty, data))) = tokio::time::timeout(remaining, bob_link.receive()).await
+            else {
+                break;
+            };
+            if ty != StreamType::Audio {
+                continue;
+            }
+            let dg = AudioDatagram::decode(data.into()).expect("wire decode");
+            latencies_ms.push(now_ms().saturating_sub(dg.timestamp_ms));
+            jitter.push(dg);
+            for ev in jitter.poll_ready() {
+                match ev {
+                    JitterEvent::Frame(f) => {
+                        pcm.extend_from_slice(
+                            &decoder.decode(&f.payload).expect("opus decode").data,
+                        );
+                        delivered += 1;
+                    }
+                    JitterEvent::Gap { .. } => gaps += 1,
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        for ev in jitter.poll_ready() {
+            match ev {
+                JitterEvent::Frame(f) => {
+                    pcm.extend_from_slice(&decoder.decode(&f.payload).expect("opus decode").data);
+                    delivered += 1;
+                }
+                JitterEvent::Gap { .. } => gaps += 1,
+            }
+        }
+        let _ = bob_link.stop().await;
+        (pcm, latencies_ms, delivered, gaps)
+    });
+
+    let samples = samples_per_20ms(SampleRate::Hz48000);
+    let mut encoder = OpusEncoder::new(OpusEncoderConfig::default()).expect("encoder");
+    for seq in 0..FRAMES {
+        let frame = AudioFrame {
+            data: tone_frame(seq, samples),
+            sample_rate: SampleRate::Hz48000,
+            channels: Channels::Mono,
+            timestamp: (seq * 20) as u64,
+        };
+        let payload = encoder.encode(&frame).expect("opus encode");
+        let dg = AudioDatagram {
+            seq: seq as u32,
+            timestamp_ms: now_ms(),
+            flags: 0,
+            payload,
+        };
+        let wire = dg.encode().expect("wire encode");
+        alice_link
+            .send(&peer, StreamType::Audio, &wire)
+            .await
+            .expect("send frame");
+    }
+
+    let (pcm, latencies_ms, delivered, gaps) = receiver.await.expect("receiver task");
+    let _ = alice_link.stop().await;
+
+    // ≥99% delivered post-jitter.
+    assert!(
+        delivered * 100 >= FRAMES * 99,
+        "delivered {delivered}/{FRAMES} (gaps {gaps}) — below 99%"
+    );
+
+    // Decoded audio is the tone, not noise: both targets ≥ 20 dB over off-band.
+    let p_a = goertzel(&pcm, TONE_A_HZ);
+    let p_b = goertzel(&pcm, TONE_B_HZ);
+    let p_off = goertzel(&pcm, 700.0).max(1e-9);
+    assert!(
+        p_a / p_off > 100.0 && p_b / p_off > 100.0,
+        "decoded tone SNR too low: 440Hz ratio {:.1}, 1200Hz ratio {:.1}",
+        p_a / p_off,
+        p_b / p_off
+    );
+
+    // p95 one-way < 100 ms on loopback.
+    let mut sorted = latencies_ms;
+    sorted.sort_unstable();
+    let p95 = sorted[((sorted.len() as f64 - 1.0) * 0.95) as usize];
+    assert!(p95 < 100, "p95 one-way frame latency {p95} ms ≥ 100 ms");
+
+    alice.shutdown().await;
+    bob.shutdown().await;
+}


### PR DESCRIPTION
The capstone demo: two x0x agents, QUIC-native signaling over real DMs, then 5 s of synthesized speech-band audio through **real Opus → AudioDatagram wire framing → the WebRtcV1 Audio lane → jitter buffer → decode**, with tone verification (Goertzel) and latency stats.

Measured (loopback, `cargo run --features voice --example voice_call`):
- 250/250 frames delivered post-jitter, 0 gaps
- one-way frame latency p50=0 ms / p95=1 ms / max=1 ms
- jitter counters: 250 delivered, 0 reordered/late/duplicate
- decoded tone 75.3 dB (440 Hz) and 72.8 dB (1200 Hz) over off-band

Also: `tests/voice_e2e.rs` asserts the same pipeline (≥99 % delivery, SNR sanity, p95 < 100 ms; integration tier, `--run-ignored`); `saorsa-webrtc-core` bumped 0.4.0 → 0.5.0; `saorsa-webrtc-codecs` re-exported as `x0x::voice::codecs` (apps pin exactly one voice dependency).

Lane mode is Reliable (ordered ADR-0022 stream). The datagram lane exists in core 0.5.0 but the x0x adapter seam doesn't expose an unreliable lane yet — documented as the V1.2/V1.3 follow-up. Real mic→speaker on the Studios pairs this with `saorsa-webrtc-audio`'s loopback example (recipe in the example header); cpal stays out of the x0x crate deliberately.

Gates: fmt clean, clippy --all-features -D warnings clean, rustdoc -D warnings clean, plain `cargo check` compiles zero webrtc crates, voice_adapters + voice_e2e 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a complete two-agent voice pipeline over the mesh. The main changes are:

- Adds the optional Opus codec dependency and public voice codec re-export.
- Adds a voice-call example with signaling, framed audio transport, jitter buffering, decoding, and statistics.
- Adds an ignored loopback integration test for delivery, tone quality, and latency.
- Updates the WebRTC core dependency to version 0.5.0.

<h3>Confidence Score: 4/5</h3>

The connection setup can enter an unbounded signaling wait and should be fixed before merging.

- Expiration of the ten-second connection deadline does not stop the example.
- Restricted-network test runs can succeed without exercising the pipeline.
- The integration test sends a burst rather than the paced stream used by the demo.

examples/voice_call.rs and tests/voice_e2e.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the WebRTC core, adds the optional codec dependency, and registers feature-gated voice targets. |
| src/voice/mod.rs | Re-exports the codec crate through the feature-gated voice module. |
| examples/voice_call.rs | Adds the full signaling and paced media demo, but ignores connection deadline expiry before unbounded signaling waits. |
| tests/voice_e2e.rs | Adds end-to-end voice checks, but restricted-network runs can pass without testing and the sender does not reproduce paced audio behavior. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as Alice
    participant B as Bob
    participant S as Voice Signaling
    participant L as Audio Lane
    participant J as Jitter Buffer
    participant O as Opus Decoder
    A->>B: Establish QUIC connection
    A->>S: CapabilityExchange
    B->>S: ConnectionConfirm
    A->>S: ConnectionReady
    loop 250 audio frames
        A->>L: Opus AudioDatagram
        L->>J: Decode wire frame
        J->>O: Release ready payload
    end
    O-->>B: Decoded PCM and statistics
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
examples/voice_call.rs:160-168
**Expired Connection Deadline Is Ignored**

When loopback connectivity does not converge within ten seconds, this loop falls through and starts signaling anyway. The following `receive_message()` calls have no timeout, so the demo can hang indefinitely instead of reporting the failed connection.

```suggestion
    let deadline = Instant::now() + Duration::from_secs(10);
    let connected = loop {
        if alice_network.is_connected(&bob_peer).await
            && bob_network.is_connected(&alice_peer).await
        {
            break true;
        }
        if Instant::now() >= deadline {
            break false;
        }
        tokio::time::sleep(Duration::from_millis(20)).await;
    };
    assert!(connected, "agents did not connect within 10 seconds");
```

### Issue 2 of 3
tests/voice_e2e.rs:181-183
**Restricted Network Silently Passes Test**

When agent creation fails with the recognized UDP permission error, this branch returns successfully without exercising any assertion. An explicitly invoked integration run in a restricted CI environment therefore reports the voice pipeline test as passed even though no pipeline ran.

### Issue 3 of 3
tests/voice_e2e.rs:232-253
**Burst Sender Skips Paced Behavior**

This loop sends all 250 frames as fast as possible, while the demonstrated voice path emits one frame every 20 ms. The latency and jitter assertions can pass for a burst even if timer-based jitter-buffer behavior fails during the paced five-second flow this test claims to cover.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(voice): 1:1 voice call demo — full ..."](https://github.com/saorsa-labs/x0x/commit/89594897471ea226b4692828598ee46d9dbdf99c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46497074)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->