### PR TITLE
F1 GSS rotation on admin remove — code + ADR 0024 union (DRAFT)

### DIFF
--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -17,7 +17,12 @@ therefore carries its own evidence rather than referring to it for load-bearing 
 and cannot be cited there, so every such citation is stamped **at `56d0c4b`** in place —
 the F1 implementation commit `56d0c4bc61fbb649042aad8ea42d25d8f0c85c39` on `glm/f1-fix`,
 which changes exactly one file, `src/server/routes/named_groups.rs` (+231/-40). **An
-unstamped citation is at the baseline.** Because that commit touches no other file, cites
+unstamped citation is at the baseline, and a stamp never carries from one citation to the
+next — adjacency is not a scope.** An enumeration may instead **declare** a single resolving
+commit for all of its rows, in words, immediately before them; that declaration governs
+exactly those rows and nothing else. Anything covered by neither an in-place stamp nor such a
+declaration is at the baseline, and no exception is to be inferred from a neighbouring
+citation. Because that commit touches no other file, cites
 into `src/groups/` resolve identically at either. The +231 lines shift everything below
 them, so a `named_groups.rs` number read during implementation review is not the same
 number at the baseline and must be translated rather than carried across.
@@ -473,8 +478,10 @@ operation which could bypass or substitute for it — explicit returns, `?` prop
 `let`-`else` bindings, `match` and `if` arms, and returns from delegated handlers — and
 account for each.** A scan for `return` is a floor, not a completeness proof; this very
 handler ends in a `match` arm that exits without one. The endpoint of that path is the code
-that performs the property, not the code that reads its inputs. For "a survivor can decrypt",
-the path runs to the key derivation at `56d0c4b:src/server/routes/named_groups.rs:12353` and
+that performs the property, not the code that reads its inputs. **Declaration for the worked
+example that follows: every line number in it resolves at `56d0c4b`, in
+`src/server/routes/named_groups.rs`, and none of them at the baseline.** For "a survivor can
+decrypt", the path runs to the key derivation at `:12353` and
 the cipher at `:12367` — not to the stored-secret read at `:12314` — and it contains **ten**
 exits, not the four that precede the read: `:12291` group-not-found, `:12294` withdrawn,
 `:12298` not-a-member, `:12306` TreeKem-plane, `:12315` no-shared-secret, `:12325`
@@ -488,9 +495,12 @@ read would have hidden six of the ten; drawing it at the derivation would still 
 `:12362`.
 
 **A break list is a set of line numbers, so it means nothing without the commit it resolves
-at, and it must be re-resolved at the commit that ships.** The list above states its commit in
-its first citation and the rest of the rows inherit it; that is a requirement, not a
-formatting habit. A gate that adds production code *above* its own interval moves every line
+at, and it must be re-resolved at the commit that ships.** The list above **declares** its
+resolving commit in words before its rows; it does not leave them to inherit a stamp from a
+neighbour, because a declaration is checkable and adjacency is not. That worked example is an
+illustration of the rule and **not a source any receipt may copy from**: its numbers are
+correct at `56d0c4b` and wrong in any tree that adds production lines above those handlers,
+which the F1 gates themselves do. A gate that adds production code *above* its own interval moves every line
 in that interval, so a list written against the commit the gate was designed on can be wrong
 at the commit the gate lives on — and a rebase invalidates a break list exactly as it
 invalidates a diff. This is not hypothetical: on this rule's first use a gate's own production

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -401,22 +401,32 @@ same defect one indirection away. Item 5 asserts against the **stored**
 `GroupInfo`, never against the discarded clone; item 6 is the load-bearing one, because a
 green all-new soak proves nothing about a mixed fleet.
 
-**The expression is not anchored at `^`, because nextest's `test()` predicate matches a
-test's full path from the crate root and the F1 gates are in-crate unit tests.** A gate in
-`server::routes::named_groups::tests` is named `server::routes::named_groups::tests::f1_…`,
-so `test(/^f1_/)` selects nothing and the runner then reports success over an empty set —
-the exact failure this item exists to prevent. Measured on this repo at the implementation
-commit `56d0c4b`: `test(/^server::routes::named_groups::tests::/)` selects 131 tests,
+**The expression is not anchored solely at `^`, because nextest's `test()` predicate matches
+a test's full path from the crate root and some F1 gates — currently items 3 and 7a — are
+nested in-crate unit tests.** A gate in `server::routes::named_groups::tests` is named
+`server::routes::named_groups::tests::f1_…`, so a bare `test(/^f1_/)` cannot reach it.
+Measured on this repo at the implementation commit `56d0c4b`:
+`test(/^server::routes::named_groups::tests::/)` selects 131 tests,
 `test(/^named_groups::tests::/)` selects 0, `test(/::named_groups::tests::/)` selects 131.
-The alternation is required rather than the simpler `test(/::f1_/)` because that form is
-bound to today's placement: a later F1 gate added as an integration test under `tests/`
-has the unqualified name `f1_…` with no `::` in it, and `test()` does not see the binary id,
-so the `::` in `x0x::f1_whatever` cannot supply one. Such a gate would be dropped in
-silence. `(^|::)` selects both shapes and admits no third, since the matched segment must
-still begin with `f1_`. Because a filter can only fail by selecting too few tests while
-still reporting green, **a receipt for this recipe must state how many tests were
-selected**; a count of zero, or one below the number of gates this section requires, is a
-failing receipt regardless of the pass/fail split.
+The `^` branch is retained rather than dropped because this section permits a future F1 gate
+to be written as an integration test under `tests/`: such a gate has the unqualified name
+`f1_…` with no `::` in it, and `test()` does not see the binary id, so the `::` in
+`x0x::f1_whatever` cannot supply one. `test(/::f1_/)` alone would drop it in silence, and
+`test(/^f1_/)` alone drops every nested gate. `(^|::)` selects both shapes and admits no
+third, since the matched segment must still begin with `f1_`.
+
+A filter fails by selecting **too few** tests, and only one of the two ways of doing that is
+caught by the runner. An empty selection is already a hard failure: measured at
+cargo-nextest 0.9.126, a filter matching nothing yields `error: no tests to run` and exit
+code 4, and no `no-tests` key is set in `.config/nextest.toml` at `e3013710d7`, `56d0c4b` or
+this commit, so the default stands. A **non-empty subset** is not caught — a filter that
+selects some required gates and omits others runs them, passes them, and exits 0. That is
+the false green this section must exclude, and it is invisible in a pass/fail split.
+Therefore **a receipt for this recipe must state how many tests were selected**, and a count
+below the number of gate functions this section requires is a failing receipt however green
+the split. Zero is likewise invalid, but by the runner's own exit code rather than by this
+rule — and stating the rule over the required gate count rather than over zero keeps it
+sound if that runner default is ever configured away.
 
 1. Fails on the pinned pre-fix commit (or on a mutation) and passes on the patched tree.
 2. Asserts each surviving member can **decrypt content published at the new epoch** — not

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -433,7 +433,19 @@ many. A receipt therefore names the items it discharges — which may be a subse
 gain gates as the work lands — and the `f1_` functions discharging them, and the selected
 count must equal the length of that list. Below it, the filter dropped a gate, and that is a
 failing receipt however green the split. This section is discharged only once every item
-requiring a gate has been named across those receipts. Zero is likewise
+requiring a gate has been named across those receipts.
+
+**Discharge and acceptance are two different bars, and the gap between them must be named
+here rather than left as a silent exception.** Full discharge is the sentence above. A
+smaller set — the **acceptance-blocking items** — gates acceptance of this ADR; every item
+outside that set still requires its gate, just not before acceptance. Which items block is a
+scope decision by the owner and not a technical one, so it is recorded here by name and
+re-recorded whenever it changes. **As at 2026-07-27 the blocking set is items 2 and 4**
+(David, relayed by Watson, narrowing an earlier ruling that all four then-ungated items had
+to land first); **items 5 and 6 are scheduled follow-up and do not block acceptance.**
+Accepting this ADR while that scheduled set is non-empty means its Validation section is
+knowingly partial at acceptance, and no receipt may be written or read as though the section
+were complete. Zero is likewise
 invalid, but by the runner's own exit code rather than by this rule — and stating the rule
 over a per-receipt list rather than over a fixed count keeps it sound both as further items
 gain gates and if that runner default is ever configured away.

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -76,6 +76,9 @@ reachability unresolved rather than declared defective.
 
 ## Validation
 
+Every control must be shown to fail on the pinned pre-fix commit or on a
+mutation, and to pass on the patched tree.
+
 Acceptance requires independent controls showing that:
 
 - a survivor decrypts content published at the rotated epoch;

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -391,12 +391,32 @@ claim of this shape must be run structurally, not derived from a text search.**
 
 ## Validation
 
-An F1 runner registered as **`just adr-gates-f1`**, filtering `test(/^f1_/)` — one recipe,
-not a parallel harness. Named explicitly because the base commit's justfile has **no**
-`adr-gates` recipe at all (`grep -i adr justfile` at `e3013710d7`: no match), so an ADR
-citing that name would point at a command the branch does not add. Item 5 asserts against the **stored**
+An F1 runner registered as **`just adr-gates-f1`**, filtering `test(/(^|::)f1_/)` — one
+recipe, not a parallel harness. Named explicitly because the base commit's justfile has
+**no** `adr-gates` recipe at all (`grep -i adr justfile` at `e3013710d7`: no match), so an
+ADR citing that name would point at a command the branch does not add. Every F1 gate's test
+function name must begin with `f1_`, and the recipe body must carry this expression
+character for character; a recipe filtering differently from this document reintroduces the
+same defect one indirection away. Item 5 asserts against the **stored**
 `GroupInfo`, never against the discarded clone; item 6 is the load-bearing one, because a
 green all-new soak proves nothing about a mixed fleet.
+
+**The expression is not anchored at `^`, because nextest's `test()` predicate matches a
+test's full path from the crate root and the F1 gates are in-crate unit tests.** A gate in
+`server::routes::named_groups::tests` is named `server::routes::named_groups::tests::f1_…`,
+so `test(/^f1_/)` selects nothing and the runner then reports success over an empty set —
+the exact failure this item exists to prevent. Measured on this repo at the implementation
+commit `56d0c4b`: `test(/^server::routes::named_groups::tests::/)` selects 131 tests,
+`test(/^named_groups::tests::/)` selects 0, `test(/::named_groups::tests::/)` selects 131.
+The alternation is required rather than the simpler `test(/::f1_/)` because that form is
+bound to today's placement: a later F1 gate added as an integration test under `tests/`
+has the unqualified name `f1_…` with no `::` in it, and `test()` does not see the binary id,
+so the `::` in `x0x::f1_whatever` cannot supply one. Such a gate would be dropped in
+silence. `(^|::)` selects both shapes and admits no third, since the matched segment must
+still begin with `f1_`. Because a filter can only fail by selecting too few tests while
+still reporting green, **a receipt for this recipe must state how many tests were
+selected**; a count of zero, or one below the number of gates this section requires, is a
+failing receipt regardless of the pass/fail split.
 
 1. Fails on the pinned pre-fix commit (or on a mutation) and passes on the patched tree.
 2. Asserts each surviving member can **decrypt content published at the new epoch** — not

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -392,9 +392,12 @@ claim of this shape must be run structurally, not derived from a text search.**
   commit has been persisted can still leave a survivor without its envelope. That residue is
   a delivery property of the transport, unchanged by F1 and not addressed here. **No
   validation item reaches it:** Validation item 2 proves survivor decryptability from the
-  envelope; neither it nor the publish-attempt oracle proves delivery. Item 4 asserts the
-  removed member's non-decryption against the published envelopes; items 2 and 4 test the
-  cryptographic behaviour of event objects, not delivery.
+  envelope; neither it nor the publish-attempt oracle proves delivery. Of item 4's three
+  gates, 4c observes the recipient set of the published envelopes — a publish *attempt*
+  recorded in-process, which is construction and not delivery — 4b tests key material below
+  the endpoint, and 4a observes an API refusal. So items 2 and 4 between them test the
+  construction and cryptographic behaviour of event objects and the endpoint's refusals;
+  none of their four gates reaches arrival.
 
 ## Validation
 
@@ -593,7 +596,39 @@ recording no owner at all.
    secret installs under each.
 4. Asserts the removed member's non-decryption against the **published envelopes**, not
    final state: a reseal aimed at the removed member must fail the gate even when the end
-   state looks tidy.
+   state looks tidy. Three gates discharge this item and they are not interchangeable; each
+   is named here with the thing it observes, so the mapping is checkable rather than
+   inferred. Gates are named by test function, not by line, because they are the `f1_`
+   functions the runner above filters on and no coordinate system in this document reaches
+   them.
+   - **4a** — `f1_item4a_removed_caller_refused_at_roster_guard` observes an **API-level
+     refusal**: the removed caller is refused `403` at `secure_group_decrypt`'s roster
+     guard, which fires before any `req` field is read and before any cipher is reached (it
+     asserts the group is GSS-plane, so the refusal cannot be the TreeKem dispatch
+     instead). **4a discharges no part of non-decryption** — it stays green if the crypto
+     is replaced by a pass-through after the membership test. It is here to establish that
+     seam, which is why 4b must be observed below the endpoint, and not as evidence for
+     this item.
+   - **4b** — `f1_item4b_retained_secret_does_not_open_new_epoch_content` observes **key
+     material**: the secret a removed member retains does not open content sealed at the
+     new epoch. Two arms vary only the secret and the new-epoch arm must succeed, so the
+     failure is a measurement rather than a broken harness. Observed on
+     `GroupInfo::derive_message_key` **below the endpoint** — so it proves non-decryption
+     of an equivalently sealed payload, **not of a published envelope**.
+   - **4c** — `f1_item4c_remove_handler_publishes_survivors_not_the_removed_member` is the
+     only gate that observes a **published envelope**: it drives the real remove handler
+     and asserts the recipient of each published `SecureShareDelivered` includes the
+     survivor and excludes the removed member. The assertion is on the recipient set, not a
+     publish count. Observed lane is the metadata-topic publish only; the direct and
+     delayed delivery lanes are named as not observed.
+
+   **The residue, stated rather than left to be inferred:** no single gate asserts both
+   halves of the sentence above at once — a removed member failing to decrypt an envelope
+   that was actually published to them. 4c makes that scenario unconstructible **on the
+   observed lane** by keeping the removed member out of the recipient set, and 4b shows the
+   key such a member retains would not open it; the conjunction itself is **not observed**
+   by any gate. Coverage and ownership are independent axes (above): this item owns it, and
+   no gate covers it.
 5. Covers a missing-KEM survivor **and** a keyed survivor whose seal fails — both assert
    the removal is refused with zero externally visible state change: unchanged
    `secret_epoch` and `shared_secret` in the map, no persisted revision, no published

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -41,19 +41,26 @@ Three properties of the surrounding code shape the fix:
    `security_binding`, withdrawn). A member who never receives the new secret keeps a
    matching `state_hash` forever while decrypting nothing. Any convergence-based
    assertion passes on this bug.
-3. **A survivor without a roster KEM key can still hold the secret.** A non-TreeKEM invite
-   stub reaches `shared_secret: Some(..)` with an active roster whose
+3. **Nothing proves that a survivor without a roster KEM key never held the secret.** A
+   non-TreeKEM invite stub reaches `shared_secret: Some(..)` with an active roster whose
    `kem_public_key_b64` is `None`: `GroupInfo::with_policy` generates a secret for every
    `MlsEncrypted` group (`src/groups/mod.rs:346-354`, installed by field shorthand at
    `:390`); `invite_join_group_info` (`:7632-7638`) clears it only for TreeKEM
    (`:7656-7658`); and the invite snapshot strips every roster ML-KEM key
-   (`src/server/routes/identity.rs:382`, copied at `:7671-7672`). So "no KEM key" does not
-   imply "never held the secret", and there is no positive enrollment invariant that would
-   make it imply that.
+   (`src/server/routes/identity.rs:382`, copied at `:7671-7672`). **Stated at exactly the
+   strength the evidence carries:** that path proves `shared_secret: Some(..)` and
+   `kem_public_key_b64: None` coexist on a reachable state — it does *not* prove that
+   particular secret is the live group secret, because `with_policy` generates it locally
+   and whether it is ever the authority's is an open question (see the final section). What
+   makes the decision is the negative: **no positive enrollment invariant proves a keyless
+   survivor never held the live secret**, and fail-closed is the only safe reading of that
+   gap.
 
 ## Decision Drivers
 
-- A removed member must lose read access at the moment of removal, on both planes.
+- A removed member must be unable to decrypt content published at the rotated epoch, on
+  both planes — the same claim the gate asserts, stated as the goal rather than the looser
+  "loses read access at the moment of removal", which the transport cannot guarantee.
 - Silent partial failure is worse than refusal: a stranded survivor is undetectable
   (driver 2 above), an aborted removal is immediately visible to the caller.
 - The fix must not reproduce ban's ordering, which makes fail-closed impossible.
@@ -194,10 +201,12 @@ requires receiver and `.write()` on one line, so it sees 49 of the 72 in this fi
 | `:7845-7849` | `join_group_via_invite` (`:7712`) |
 | `:12628-12632` | `persist_treekem_and_named_groups_atomic_with_info` (`:12564`) |
 
-**The enumeration is complete, not merely self-consistent.** The 33 production writes live
-in **32** enclosing functions; exactly **14** of those contain no lexical
-`group_membership_lock`; one of the 14 is `#[cfg(test)]`; the remaining **13** are the
-candidate set:
+**The enumeration is complete, not merely self-consistent.** The **33 pre-inline-test-module
+writes** live in **32** enclosing functions; exactly **14** of those contain no lexical
+`group_membership_lock`; one of the 14 is `#[cfg(test)]`; that leaves **13 production
+candidates**. (33 is the pre-`mod tests` count and still includes the `#[cfg(test)]` helper
+subtracted in the table above — the 32 production figure and the 32 enclosing functions are
+different quantities that coincide numerically.)
 
 | fn | decl | write |
 |---|---|---|
@@ -272,9 +281,10 @@ claim of this shape must be run structurally, not derived from a text search.**
 ### Positive
 
 - Removal and ban have the same security outcome on the GSS plane: the removed member
-  loses read access at the moment of removal.
-- No partial rekey is reachable. Either every survivor is resealed or the removal did not
-  happen.
+  **cannot decrypt content published at the rotated epoch**.
+- **No KEM/preflight-induced partial commit is reachable:** either every survivor envelope
+  is buildable or the removal aborts. Scoped deliberately to what the preflight proves —
+  see the delivery limit under Neutral / Operational.
 - Rotation never becomes observable from a failed attempt: the mutation happens on a
   private clone that is dropped.
 - A group can no longer rotate onto an all-zero key through a silent conversion (D5).
@@ -301,10 +311,21 @@ claim of this shape must be run structurally, not derived from a text search.**
   receivers ignore `secret_epoch`. Their behaviour is a gate item, not an assumption.
 - The abort path is a bare `return` inside the block expression opened at `:8458` — no
   transaction, no rollback machinery. An implementation that builds one has misread D2.
+- **The preflight bounds construction, not delivery, and this ADR claims nothing beyond
+  that.** `publish_named_group_metadata_event` (`:1797-1833`) returns `()` and folds both a
+  publish error and a timeout into `tracing::warn!`; the direct path at `:1834` onward is
+  documented as best-effort. So a crash or a failed publish *after* the commit has been
+  persisted can still leave a survivor without its envelope. That residue is a delivery
+  property of the transport, unchanged by F1 and not addressed here; the gate asserts
+  decryptability against the **published envelopes** (Validation item 4) precisely because
+  end state alone cannot see it.
 
 ## Validation
 
-An F1 runner registered under `just adr-gates`. Item 5 asserts against the **stored**
+An F1 runner registered as **`just adr-gates-f1`**, filtering `test(/^f1_/)` — one recipe,
+not a parallel harness. Named explicitly because the base commit's justfile has **no**
+`adr-gates` recipe at all (`grep -i adr justfile` at `e3013710d7`: no match), so an ADR
+citing that name would point at a command the branch does not add. Item 5 asserts against the **stored**
 `GroupInfo`, never against the discarded clone; item 6 is the load-bearing one, because a
 green all-new soak proves nothing about a mixed fleet.
 

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -440,10 +440,11 @@ green all-new soak proves nothing about a mixed fleet.
    That default's effect on the receipt is a race, not a property: fail-fast cancels only
    what is still queued at the instant of failure, so whether either unaffected test is
    omitted depends on scheduling — thread count, ordering, and how long the siblings run.
-   Serially the run has been observed to stop at two of three results; at default
-   parallelism all three are already scheduled when the failure lands, the complete
-   PASS/PASS/FAIL split survives, and the no-flag output differs from the `--no-fail-fast`
-   output only by the line `Cancelling due to test failure:`. **The split is therefore an
+   In Watson's measured matrix the serial no-flag run stopped after two of three results,
+   while in six default-parallel no-flag runs all three tests were already scheduled when
+   the failure landed and the complete PASS/PASS/FAIL split survived — and those runs still
+   reported `Cancelling due to test failure:`. Both halves are observations of that matrix,
+   not guarantees of either scheduling mode. **The split is therefore an
    outcome, not a proof of execution shape — a compliant-looking receipt can be produced
    without the flag**, which is why reporting the split cannot be the criterion. The receipt
    must evidence the invocation. Primary evidence is the exact command, which must contain

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -527,7 +527,13 @@ reads as verified. Hashing the file's head up to the first changed line satisfie
 conditions only when the list sits *after* every line it cites, which is the ordinary shape
 for a break list in a test module citing production above it. A list that sits above its
 citations gets a head region that stops short of them and certifies nothing that matters:
-bound the region around the citations instead, and state its endpoints. Where a list is
+bound the region around the citations instead, and state its endpoints. **Both conditions can
+be met and the receipt still fail**, because a line number below an insertion does not name the
+same content at the parent and at the child: such a region needs **two endpoint pairs, one per
+commit, differing by the edit's line delta** — or to be bound by an anchor in the content
+rather than by line number at all. The ordinary shape needs neither, and the reason is worth
+stating because it is what makes head-hashing sound rather than merely convenient: **an edit
+below a region cannot move the lines above it.** Where a list is
 written against a tree it does not ship in — a review copy, a receipt
 posted before the commit lands — the final-SHA requirement above applies unchanged.
 

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -438,6 +438,58 @@ invalid, but by the runner's own exit code rather than by this rule — and stat
 over a per-receipt list rather than over a fixed count keeps it sound both as further items
 gain gates and if that runner default is ever configured away.
 
+**Break disclosure — required of every gate in this section.** A gate is evidence only
+against the ways of breaking that someone named. Mutation-redness does not establish that a
+gate observes its property: the §3 gates are mutation-red on the `:5908` conjunct and were
+still blind to the survivor being removed alongside the victim, because that break was never
+on anyone's list. So each gate must be accompanied by a list of the breaks considered, and
+for each either **the mutation that turns the gate red, an assertion or precondition in the
+gate that refuses the path, or a statement that the gate does not observe that break and why
+that is accepted.** A refusing precondition ranks with a mutation and is often the honest
+form: a gate asserting an exact plaintext already cannot pass on any error exit, and
+demanding a bespoke mutation per exit would buy ceremony rather than evidence. This is a
+requirement to disclose, not a
+prohibition on assertions: a rule forbidding any assertion a broken property could still
+produce would forbid 7a's own length assertion, which still yields 32 if rotation breaks by
+returning a constant.
+
+A list drawn from the author's imagination fails the same way the gates do — an author names
+the breaks their gate already catches. The minimum content is therefore mechanical: **name
+the target operation and the observation the gate makes of it, then enumerate from the source
+every control-flow exit or alternate dispatch between the gate's entry point and that
+operation which could bypass or substitute for it — explicit returns, `?` propagation,
+`let`-`else` bindings, `match` and `if` arms, and returns from delegated handlers — and
+account for each.** A scan for `return` is a floor, not a completeness proof; this very
+handler ends in a `match` arm that exits without one. The endpoint of that path is the code
+that performs the property, not the code that reads its inputs. For "a survivor can decrypt",
+the path runs to the key derivation at `56d0c4b:src/server/routes/named_groups.rs:12353` and
+the cipher at `:12367` — not to the stored-secret read at `:12314` — and it contains **ten**
+exits, not the four that precede the read: `:12291` group-not-found, `:12294` withdrawn,
+`:12298` not-a-member, `:12306` TreeKem-plane, `:12315` no-shared-secret, `:12325`
+epoch-mismatch, `:12340` bad ciphertext base64, `:12346` bad nonce base64, `:12350` nonce
+length, `:12362` cipher-init failure. Every one yields "decryption did not succeed" — which
+is exactly what a **negative** gate such as item 4 asserts — and none of them authenticates a
+ciphertext: nine never reach the key material at all, and the tenth derives it and then fails
+to construct the cipher. Three of them (`:12340`, `:12346`, `:12350`) are reachable from
+nothing more than a malformed input the gate itself constructs. Drawing the line at the input
+read would have hidden six of the ten; drawing it at the derivation would still have hidden
+`:12362`.
+
+**One exit lies past the target operation, and it is a different kind — do not file it as
+blindness.** The interval above ends at the operation, but what a gate observes is the
+endpoint's *response*, and on the success arm this handler hands its assembled response to a
+shared terminality-recheck helper that can replace it wholesale with a withdrawn-group
+conflict. That helper can suppress a true success; it cannot manufacture one, because the
+response's payload field is encoded inline from the binding the cipher returned and has no
+other source in the handler. So it can only turn a gate red when the property holds — never
+leave one green when the property breaks. That is a **false-negative and test-isolation
+hazard**, refused by a precondition (assert the response is success-shaped before asserting
+the plaintext) together with test hygiene: the helper is driven by a process-global
+forced-withdrawal set keyed by group id, so a gate must use ids of its own and must not
+install that guard. It is recorded under that heading and **not** as an accepted blind spot.
+That term is reserved for a break that can leave a gate green, and it carries no information
+once it also covers breaks that cannot.
+
 1. Fails on the pinned pre-fix commit (or on a mutation) and passes on the patched tree.
 2. Asserts each surviving member can **decrypt content published at the new epoch** — not
    that its `state_hash` matches. Convergence is the wrong assertion (Context, driver 2):
@@ -520,6 +572,21 @@ gain gates and if that runner default is ever configured away.
    `rotate_shared_secret`, or moving rotation out of the handler. D5 does not justify that
    production surface. If a future change gives the wrong-length value a real producer, 7b
    becomes a required gate.
+
+   **Scope: 7b describes the remove handler and nothing else. The other consumer of the same
+   producer fails the opposite way.** `ban_group_member` also calls `rotate_shared_secret()`
+   and also narrows `Vec<u8>` to `[u8; 32]`, but by zero-initialising and copying under a
+   length test with **no `else`** (`:10492-10496`). On a wrong-length secret the array stays
+   all zeros and flows on as `Some(sec)` (`:10521`) into `publish_secure_share` (`:10556`),
+   while `rotate_shared_secret` has already stored the wrong-length value on `next` — so the
+   actor's own record and every sealed envelope would disagree, at a known key. This is not
+   reachable today, for the same reason §2a is not: `src/groups/mod.rs:431` (baseline)
+   hardcodes 32, and 7a now pins it. It is recorded because 7b's "defence in depth" reading
+   was derived from one consumer and is **false of the other** — for remove the 7a gate is
+   the second line of defence, for ban it is the only one. A reader sweeping this file for
+   `[0u8; 32]` will also find `approve_join_request` (`:10893`); that site is **not** the
+   same shape — its length test is on the match arm (`:10892`), so a wrong-length secret
+   fails to match and no zero key is published.
 
 **Review triggers.** Re-run the structural audit above, and re-open D10, if any of these
 change: a new `named_groups.write()` writer is added, the membership-lock boundary moves,

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -424,11 +424,19 @@ commit, so nothing checked in overrides it; environment-level overrides were not
 and are not relied on below. A **non-empty subset** is not caught — a filter that
 selects some required gates and omits others runs them, passes them, and exits 0. That is
 the false green this section must exclude, and it is invisible in a pass/fail split.
-Therefore **a receipt for this recipe must state how many tests were selected**, and a count
-below the number of gate functions this section requires is a failing receipt however green
-the split. Zero is likewise invalid, but by the runner's own exit code rather than by this
-rule — and stating the rule over the required gate count rather than over zero keeps it
-sound if that runner default is ever configured away.
+Therefore **a receipt for this recipe must state how many tests were selected, and must name
+the gate functions that count is made of.** This section fixes no single number and must not
+be read as implying one: item 1 states a property every gate has to have rather than naming
+a gate of its own, item 7a requires exactly three functions, item 7b requires none because
+no gate observes it, and the remaining items each require at least one without fixing how
+many. A receipt therefore names the items it discharges — which may be a subset, since items
+gain gates as the work lands — and the `f1_` functions discharging them, and the selected
+count must equal the length of that list. Below it, the filter dropped a gate, and that is a
+failing receipt however green the split. This section is discharged only once every item
+requiring a gate has been named across those receipts. Zero is likewise
+invalid, but by the runner's own exit code rather than by this rule — and stating the rule
+over a per-receipt list rather than over a fixed count keeps it sound both as further items
+gain gates and if that runner default is ever configured away.
 
 1. Fails on the pinned pre-fix commit (or on a mutation) and passes on the patched tree.
 2. Asserts each surviving member can **decrypt content published at the new epoch** — not

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -418,8 +418,10 @@ third, since the matched segment must still begin with `f1_`.
 A filter fails by selecting **too few** tests, and only one of the two ways of doing that is
 caught by the runner. An empty selection is already a hard failure: measured at
 cargo-nextest 0.9.126, a filter matching nothing yields `error: no tests to run` and exit
-code 4, and no `no-tests` key is set in `.config/nextest.toml` at `e3013710d7`, `56d0c4b` or
-this commit, so the default stands. A **non-empty subset** is not caught — a filter that
+code 4. That measurement was taken in a crate carrying no nextest configuration at all, and
+this repo's `.config/nextest.toml` sets no `no-tests` key at `e3013710d7`, `56d0c4b` or this
+commit, so nothing checked in overrides it; environment-level overrides were not enumerated
+and are not relied on below. A **non-empty subset** is not caught — a filter that
 selects some required gates and omits others runs them, passes them, and exits 0. That is
 the false green this section must exclude, and it is invisible in a pass/fail split.
 Therefore **a receipt for this recipe must state how many tests were selected**, and a count

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -433,8 +433,16 @@ green all-new soak proves nothing about a mixed fleet.
    separate test functions.** Combined into one, the length assertion panics first and the
    other two never run: the receipt would then show only that "7a turned red" and would
    demonstrate nothing about which assertion the mutation pins, leaving the claim in this
-   sub-item unfalsifiable by its own gate. A separate broken-expectation control proves the
-   runner can report red.
+   sub-item unfalsifiable by its own gate. **Three functions are necessary but not
+   sufficient**, because `cargo nextest` is fail-fast by default: with no flag it cancels
+   the run on the first failure, so the two unaffected functions may never be scheduled and
+   the receipt again shows a single result. The repo's `.config/nextest.toml` sets no
+   `fail-fast` key — it is byte-identical at the baseline and at `56d0c4b` — so that default
+   governs here. The mutation receipt must therefore run the three functions under
+   `--no-fail-fast`, or invoke them separately, and must report the PASS/PASS/FAIL split by
+   test name; if it runs through `just adr-gates-f1`, that recipe must itself pass
+   `--no-fail-fast`, otherwise the recipe silently reintroduces the ambiguity this paragraph
+   exists to remove. A separate broken-expectation control proves the runner can report red.
 
    **7b — source-reviewed defence, not a gate. All citations in this sub-item are at
    `56d0c4b` except those naming `src/groups/`, which are at the baseline.** If the 7a

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -1,0 +1,356 @@
+# ADR 0024: GSS Rotation on Admin Remove Is Fail-Closed and Seals Before It Persists
+
+- **Status:** Proposed
+- **Date:** 2026-07-27
+- **Decision owners:** David Irvine
+- **Reviewers:** Sam, Dario (author), Watson
+- **Supersedes:** none — closes a gap in the legacy GSS plane described by ADR 0010
+- **Superseded by:** none
+- **Related:** ADR 0010 (GSS before MLS TreeKEM), ADR 0012 (TreeKEM as the default secure-group plane), ADR 0014 (self-leave is a roster removal), ADR 0016 (flat Admin/Member authority), `~/.buzz/PLANS/F1_GSS_ROTATION_SPEC.md` rev 4.2 (581 lines, implementation spec, outside this repo)
+
+All line citations are `src/server/routes/named_groups.rs` unless stated, at
+`e3013710d7ed69077de9a799dffdbeb5ac80535a`, `git status --porcelain src/` empty.
+The implementation spec lives outside this repository and is mutable; this ADR
+therefore carries its own evidence rather than referring to it for load-bearing facts.
+
+**Citation convention.** Multi-line write sites are cited as **statements** — the full
+statement including `.insert(...)`. The ast-grep pattern used for the audit below matches
+only the sub-expression ending at `.await`, so the matched expression is one line shorter
+than each statement cited here (`:6649-6652` vs `:6649-6653`). Statement ranges are what
+a reader needs to find the write; the expression range is an artefact of the instrument.
+
+## Context
+
+On the legacy GSS plane (ADR 0010 — still the plane grandfathered groups run on),
+`ban_treekem_group_member` rotates the group shared secret and reseals it to the
+survivors, but `remove_named_group_member` does not. **An admin-removed member keeps a
+working group secret and can decrypt everything published after the removal.** Removal
+and ban differ in outcome for the same authority.
+
+Three properties of the surrounding code shape the fix:
+
+1. **Ban is a partial model.** Its statement order up to `seal_commit` at `:10325` is
+   correct and must be followed. Past that line it is the anti-pattern: it commits the
+   roster to the map at `:10334`, persists with `save_named_groups` at `:10338`, and only
+   then seals per-recipient envelopes — so at `:10349` a survivor with no KEM key can only
+   be `warn`ed and skipped. Ban's fail-open is **structural**, a consequence of sealing
+   after persistence, not an unchecked return value.
+2. **A stranded survivor is invisible to consensus.** `shared_secret` is not one of the
+   eight inputs to `compute_state_hash` (`src/groups/state_commit.rs:219-238`:
+   group id, revision, prev hash, roster root, policy hash, public meta hash,
+   `security_binding`, withdrawn). A member who never receives the new secret keeps a
+   matching `state_hash` forever while decrypting nothing. Any convergence-based
+   assertion passes on this bug.
+3. **A survivor without a roster KEM key can still hold the secret.** A non-TreeKEM invite
+   stub reaches `shared_secret: Some(..)` with an active roster whose
+   `kem_public_key_b64` is `None`: `GroupInfo::with_policy` generates a secret for every
+   `MlsEncrypted` group (`src/groups/mod.rs:346-354`, installed by field shorthand at
+   `:390`); `invite_join_group_info` (`:7632-7638`) clears it only for TreeKEM
+   (`:7656-7658`); and the invite snapshot strips every roster ML-KEM key
+   (`src/server/routes/identity.rs:382`, copied at `:7671-7672`). So "no KEM key" does not
+   imply "never held the secret", and there is no positive enrollment invariant that would
+   make it imply that.
+
+## Decision Drivers
+
+- A removed member must lose read access at the moment of removal, on both planes.
+- Silent partial failure is worse than refusal: a stranded survivor is undetectable
+  (driver 2 above), an aborted removal is immediately visible to the caller.
+- The fix must not reproduce ban's ordering, which makes fail-closed impossible.
+- Nothing may write the group secret, or a value derived from it, to a log.
+- The record must distinguish what was **proved** from what was **conservatively
+  assumed**, so a future optimisation can tell which constraints are load-bearing.
+
+## Considered Options
+
+1. **Mirror ban step for step.** Rejected: reproduces the structural fail-open, and the
+   abort would have to undo a persisted save.
+2. **Rotate and reseal, fail open on a survivor whose envelope cannot be built** (skip
+   them, as ban does). Rejected: strands a member who may hold the secret, undetectably.
+3. **Rotate and reseal, fail closed** — build and validate every survivor envelope in
+   memory before any commit, persistence or publication; abort the whole removal on the
+   first failure. **Chosen.**
+
+## Decision
+
+**D1 — Rotate on remove.** The GSS admin-remove path rotates the group shared secret and
+reseals it to every active non-actor survivor, so removal matches ban in effect.
+
+**D2 — Fail closed, for missing and unusable keys alike.** Every survivor envelope is
+built and validated in memory before `seal_commit`. On any missing KEM key, unusable key
+or seal error the handler bare-returns. Ban's `warn + continue` at `:10349-10355` is not
+mirrored. The abort guarantee is stated precisely: `rotate_shared_secret` has *already*
+mutated the clone (`next`, `:8478`) by the time the preflight can fail, so the guarantee
+is that **no rotation becomes live, persisted or published — the rotated clone is
+discarded**, not that nothing was rotated.
+
+**D3 — Ordering is normative, and diverges from ban after `:10325`.** Between `:8481` and
+`:8482`: `remove_member` → `is_encrypted` → `rotate_shared_secret` → fallible secret
+conversion (D5) → collect active non-actor survivors → **build every envelope** → abort on
+any failure → only then `seal_commit` (`:8482`), `named_groups.insert` (`:8494`),
+`save_named_groups` (`:8510`), and finally publish the buffered envelopes and the
+`MemberRemoved` event (`:8524`). Sealing moves **ahead** of persistence; that inversion is
+the whole of D2's mechanism.
+
+**D4 — The preflight needs a side-effect-free builder, not a `#[must_use]`.**
+`publish_secure_share` (`:877-929`) seals *and* broadcasts in one async function, so its
+`bool` only exists after publication and cannot gate anything. A builder covering
+`:888-919` (base64 decode, AAD, KEM seal, event construction) is extracted;
+`publish_secure_share` keeps `:920-928` and its current signature for the approval and ban
+callers. Every builder input exists before `seal_commit` — the AAD is
+`secure_share_aad(group_id, recipient_hex, secret_epoch)` (`:898`), none of whose three
+inputs depends on the sealed commit — so this is a pure reordering, not a restructuring.
+
+**D5 — The `Vec<u8>` → `[u8; 32]` conversion is fallible, and never logs its error.**
+`rotate_shared_secret` returns `Vec<u8>` (`src/groups/mod.rs:429`) while
+`seal_group_secret_to_recipient` requires `&[u8; 32]` (`src/groups/kem_envelope.rs:140-144`).
+Both idioms already in the file are silent: ban's `:10313-10316` leaves `sec` as
+`[0u8; 32]` and rotates the group onto a known-zero key; approval's guard at `:10880`
+falls through to a catch-all that drops the envelope. Neither is acceptable. The
+conversion aborts with a 500. `impl TryFrom<Vec<T>> for [T; N]` has `Error = Vec<T>`, so
+the error value **is the secret material** — only its length may be read or logged.
+Scoped honestly: not a live defect at this commit (`rotate_shared_secret` allocates 32
+bytes at `mod.rs:431`), but it is the one failure mode the fail-closed design does not
+otherwise cover, because sealing a zero secret *succeeds*.
+
+**D6 — Self-removal is rejected before the membership lock.** A self-targeted remove is
+rejected between `:8439` and `:8440`, before the lock at `:8443-8444`. It is not
+redirected: `leave_group` (`:9651-9654`) re-acquires the same per-group lock at
+`:9663-9664` and `tokio::sync::Mutex` is not reentrant, so a redirect self-deadlocks while
+holding that lock. The pre-lock placement also short-circuits a divergence live on the
+TreeKEM plane at this commit — `remove_treekem_named_group_member` sets `treekem_epoch`
+unconditionally at `:9327` and receivers reject it at `:4956-4958` whenever
+`self_leave_auth` holds.
+
+**D7 — The wire stays additive; the apply arm mirrors ban's branch.** `MemberRemoved`
+gains `secret_epoch: Option<u64>` with `#[serde(default)]`; only the GSS sender at `:8512`
+ever populates it. The apply mutator gains ban's `else if` (`:5247-5254`) at `:4979`:
+epoch and `security_binding` are written **unconditionally** and only the secret clear is
+gated on strict `<`. Conditioning the `security_binding` write on local secret state would
+make two receivers in different local states compute different `state_hash` values for the
+same commit — it is a hashed input (`state_commit.rs:219-238`). A step-0 guard rejecting
+`self_leave_auth && secret_epoch.is_some()` sits outside the plane split, as the backstop
+against a crafted `MemberSelf` commit, which validates by construction
+(`state_commit.rs:737`).
+
+**D8 — Availability cost of D2, knowingly accepted.** A group containing any active member
+without a roster KEM key cannot remove anyone until that member publishes one. This is
+taken deliberately while no positive enrollment invariant exists; the remedy is to publish
+the key. If such an invariant is later established, fail-open for the missing-key case
+becomes reconsiderable — by a new ADR, not by an implementation change.
+
+**D9 — Lock-contention cost of the preflight, knowingly accepted.** The preflight places N
+ML-KEM encapsulations inside the `state.named_groups` **write** guard (acquired `:8459`,
+released `:8495`), which is global over every named group, not the per-group membership
+lock. Ban pays none of this because its sealing loop runs after `drop(groups)` at `:10337`.
+For the duration of one removal every named-group operation on the node serialises behind
+it. The work is synchronous — `seal_group_secret_to_recipient` is `pub fn`, not async —
+so there is no await inside the guard and no deadlock risk. We take the contention.
+
+**D10 — Do not drop and re-acquire the map lock mid-preflight. Conservative; its necessity
+is unproven.** `next` is inserted under the same guard that produced it. This is the rule
+D9 is the invoice for: holding the map guard through the preflight is exactly what it
+mandates. Recorded as policy, not as a proved requirement — see the audit below. The rule
+adds no rollback and no compare-and-swap machinery, and knowingly pays D9's cost. We take
+that trade because the failure it forecloses — writing a stale `next` over a concurrent
+write — is silent and unrecoverable, while contention is neither. **A future optimisation
+that drops the guard needs a fresh audit at that commit plus an explicit
+revision/state-hash compare-and-swap, not a lock-gap argument.**
+
+### The audit behind D10, and exactly what it establishes
+
+The membership lock taken at `:8443-8444` is held to the end of the handler, so dropping
+the *map* lock mid-preflight is already safe against every writer that also takes the
+membership lock. The residual risk class is exactly: **writers that mutate an existing
+`GroupInfo` under `named_groups.write()` without the membership lock.**
+
+That class was screened structurally, with ast-grep — the only instrument that sees
+multi-line receiver chains:
+
+```bash
+sg run --lang rust -p '$STATE.named_groups.write().await' --json=stream src
+```
+
+`$STATE` is a metavariable, so it matches any receiver and matches across line breaks.
+Note that `range.start.line` in that output is **0-indexed**; every line number here is
+the 1-indexed value.
+
+| Figure | Value |
+|---|---|
+| structural matches under `src/` | 73 |
+| of those, in `src/server/routes/named_groups.rs` | 72 |
+| the single match elsewhere | `src/server/routes/named_groups/tests/cache_hardening_followup.rs:955` (a test) |
+| before the inline `mod tests` (`#[cfg(test)]` `:14002`, `mod tests` `:14003`) | 33 |
+| less the `#[cfg(test)]` helper write at `:9832` (fn `:9820-9821`) | **32 production** |
+| test-only across `src/` (39 in-module + `:9832` + the file above) | 41 |
+
+**A line grep cannot do this job, and the difference is not cosmetic.** A text pattern
+requires receiver and `.write()` on one line, so it sees 49 of the 72 in this file; the
+23 it misses are exactly the multi-line chains, three of them production:
+
+| statement | enclosing fn |
+|---|---|
+| `:6649-6653` | `create_named_group` (`:6466`) |
+| `:7845-7849` | `join_group_via_invite` (`:7712`) |
+| `:12628-12632` | `persist_treekem_and_named_groups_atomic_with_info` (`:12564`) |
+
+**The enumeration is complete, not merely self-consistent.** The 33 production writes live
+in **32** enclosing functions; exactly **14** of those contain no lexical
+`group_membership_lock`; one of the 14 is `#[cfg(test)]`; the remaining **13** are the
+candidate set:
+
+| fn | decl | write |
+|---|---|---|
+| `publish_group_card_to_discovery_inner` | `:1006` | `:1018` |
+| `store_named_group_info` | `:2062` | `:2067` |
+| `apply_recovered_member_key_package_locked` | `:3684` | `:3718` |
+| `create_named_group` | `:6466` | `:6649` |
+| `add_treekem_named_group_member` | `:8181` | `:8351` |
+| `wipe_local_group_crypto_material` | `:8872` | `:8879` |
+| `retain_withdrawn_group_tombstone` | `:9008` | `:9018` |
+| `drop_local_named_group_state` | `:9036` | `:9045` |
+| `leave_treekem_group` | `:9085` | `:9148` |
+| `remove_treekem_named_group_member` | `:9177` | `:9314` |
+| `ban_treekem_group_member` | `:10416` | `:10539` |
+| `approve_treekem_join_request` | `:10966` | `:11129` |
+| `persist_treekem_and_named_groups_atomic_with_info` | `:12564` | `:12628` |
+| — excluded — `maybe_force_withdrawn_group_for_test` | `:9821` (`#[cfg(test)]` `:9820`) | `:9832` |
+
+Reproduced independently four times (Sam, Dario, Watson, and one further re-derivation).
+Sam derived the 13 by hand first; deriving the same 13 from the structural census is what
+makes the set **exhaustive** rather than merely agreed.
+
+**Screening result: the residual class is empty at this commit.** All 13
+`store_named_group_info` call sites (`:4918, :5051, :5149, :5199, :5301, :5357, :5447,
+:5641, :5685, :5722, :5788, :5887, :6253`) take `resolved_group_key`, the key the
+serialized apply's guard is acquired on at `:4583-4584`. `create_named_group` is the one
+genuinely unlocked map writer and is not a counter-example: it generates a fresh random
+32-byte id at `:6470-6474` and inserts under it (`:6649-6653`), so it does not overwrite
+existing state in intended execution; a random-id collision would be a different defect
+shape, not a basis for this rule.
+
+**Three limits on that negative, stated so it is not over-read:**
+
+- It is a **scoped negative at one commit**: *at `e3013710d7ed69077de9a799dffdbeb5ac80535a`,
+  in the production `src` tree, no path was found that mutates an existing named group
+  outside that group's membership mutex.* It is not a proven invariant and does not hold
+  itself tomorrow. F1 must not silently move the lock boundary on the strength of it.
+- The classifier partitioning locked from unlocked is **textual** ("the body contains
+  `group_membership_lock`, delimited by the next top-level `fn`"). It reproduces the
+  partition exactly; it is **not** proof of lock coverage for the 18 functions marked
+  locked — none was checked for locking the *same key*.
+- The per-delegate chains (the `_locked` helpers and
+  `persist_treekem_and_named_groups_atomic_with_info` running under a parent handler's live
+  guard) rest on Sam's call-site work, not re-derived here.
+
+**The justification originally offered for D10 was refuted and is withdrawn.** Group-card
+import was put forward as a live writer outside the membership lock; it is not.
+`import_group_card` binds a *named* `_membership_guard` at `:11571-11572`, live to the end
+of the function, covering both the map write at `:11682` and the `get_mut` refresh at
+`:11727`; it is the same lock, since `group_membership_lock` normalises through
+`stable_group_id()` (`:4407-4422`) and the stub is inserted under the card's own
+`group_id`. The strongest alternative candidate fails too:
+`publish_group_card_to_discovery_inner` (`:1006`) takes `get_mut` at `:1019` but its only
+`&mut` use is `seal_commit` at `:1027` behind `if reseal` (`:1022`), and its two call sites
+are `:992` (`false`) and `:1003` (`true`, inside `publish_group_card_with_reseal`, which
+takes the membership lock first at `:1001-1002`). This is recorded as **false** precisely
+so a later reader does not rediscover the refutation and delete D10 believing the rule
+rested on it. D10 rests on conservatism, and on nothing else.
+
+### The finding that argues hardest for D10
+
+`join_group_via_invite` writes at `:7845` in multi-line form. Every text search in the
+review missed it — **and it does take the membership lock**, which is why it correctly
+never appeared in the candidate 13. It was invisible and harmless. That is luck, not
+method: an invisible write could as easily have been an unlocked existing-group mutator,
+and the scoped negative would have been false with three reviewers' sign-off on it. It
+surfaced only because a figure flagged as non-blocking was chased anyway. **The next
+claim of this shape must be run structurally, not derived from a text search.**
+
+## Consequences
+
+### Positive
+
+- Removal and ban have the same security outcome on the GSS plane: the removed member
+  loses read access at the moment of removal.
+- No partial rekey is reachable. Either every survivor is resealed or the removal did not
+  happen.
+- Rotation never becomes observable from a failed attempt: the mutation happens on a
+  private clone that is dropped.
+- A group can no longer rotate onto an all-zero key through a silent conversion (D5).
+- The correctness of D10's evidence is now checkable — the audit's instrument, figures and
+  enumeration are recorded, so re-running it is mechanical.
+
+### Negative / Trade-offs
+
+- **Availability (D8):** one active member without a roster KEM key blocks all removals in
+  that group until they publish one.
+- **Contention (D9):** N synchronous ML-KEM encapsulations inside the global
+  `named_groups` write guard; every named-group operation on the node serialises behind
+  one removal.
+- **D10 is conservative policy, not a proved requirement.** It may cost more than it buys;
+  it stays until someone pays for the compare-and-swap design that would let it go.
+- Two documentation contracts must move with the code, or they will mislead the next
+  reader: the fail-open guidance at `:870-875` ("log and proceed without the envelope"),
+  from which the remove path now departs, and the doc comment at `:11815-11823` claiming
+  the legacy GSS rekey path belongs only to the remaining guarded handlers.
+
+### Neutral / Operational
+
+- Rollout is mixed-version by nature: `#[serde(default)]` keeps the wire additive, and old
+  receivers ignore `secret_epoch`. Their behaviour is a gate item, not an assumption.
+- The abort path is a bare `return` inside the block expression opened at `:8458` — no
+  transaction, no rollback machinery. An implementation that builds one has misread D2.
+
+## Validation
+
+An F1 runner registered under `just adr-gates`. Item 5 asserts against the **stored**
+`GroupInfo`, never against the discarded clone; item 6 is the load-bearing one, because a
+green all-new soak proves nothing about a mixed fleet.
+
+1. Fails on the pinned pre-fix commit (or on a mutation) and passes on the patched tree.
+2. Asserts each surviving member can **decrypt content published at the new epoch** — not
+   that its `state_hash` matches. Convergence is the wrong assertion (Context, driver 2):
+   it passes on the bug.
+3. Exercises both publish orderings, metadata-first and envelope-first, and asserts the new
+   secret installs under each.
+4. Asserts the removed member's non-decryption against the **published envelopes**, not
+   final state: a reseal aimed at the removed member must fail the gate even when the end
+   state looks tidy.
+5. Covers a missing-KEM survivor **and** a keyed survivor whose seal fails — both assert
+   the removal is refused with zero externally visible state change: unchanged
+   `secret_epoch` and `shared_secret` in the map, no persisted revision, no published
+   envelope or event. Includes the stripped-roster GSS invite state
+   (`shared_secret: Some(..)` with `kem_public_key_b64: None`) as a concrete instance.
+   This item also gates D3: a ban-shaped implementation that seals after store/save fails
+   the persisted-revision assertion even though its final state looks tidy.
+6. Mixed-version negative control: an old receiver must reproduce the permanent wedge on
+   pre-fix code, and the rollout guard must prevent it.
+7. Covers D5 directly — a rotated secret of the wrong length aborts with zero state change
+   and the group never publishes an envelope sealed to an all-zero key. Unreachable
+   through the public API at this commit, so it is a unit test on the conversion boundary;
+   the test name must say so rather than dress it up as a reachable path.
+
+**Review triggers.** Re-run the structural audit above, and re-open D10, if any of these
+change: a new `named_groups.write()` writer is added, the membership-lock boundary moves,
+or a positive enrollment invariant for roster KEM keys is established (which would reopen
+D8).
+
+## Open, and deliberately not decided here
+
+Whether the secret `GroupInfo::with_policy` generates for an invite stub
+(`src/groups/mod.rs:346-354`, installed at `:390`) is ever the *authority's* secret, or a
+locally-random value the joiner can decrypt nothing with. If the latter, the GSS invite
+path has a separate and possibly worse defect. It is Sam's finding, it needs its own
+record, and it does not change any decision above.
+
+Making D10 a permanent invariant rather than a commit-scoped policy is out of scope: it
+requires a revision/state-hash compare-and-swap design, not an audit.
+
+## Notes for AI-assisted work
+
+AI tools may help draft this ADR, but **must not mark it Accepted without human review**.
+Accepted ADRs are immutable: create a new superseding ADR rather than editing an Accepted
+ADR. David approved the design this ADR records (F1 spec rev 4.2) on 2026-07-27; the
+status flips to Accepted only after Sam's and Watson's review of this file against the
+implementation branches.

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -602,13 +602,15 @@ recording no owner at all.
    functions the runner above filters on and no coordinate system in this document reaches
    them.
    - **4a** — `f1_item4a_removed_caller_refused_at_roster_guard` observes an **API-level
-     refusal**: the removed caller is refused `403` at `secure_group_decrypt`'s roster
-     guard, which fires before any `req` field is read and before any cipher is reached (it
-     asserts the group is GSS-plane, so the refusal cannot be the TreeKem dispatch
-     instead). **4a discharges no part of non-decryption** — it stays green if the crypto
-     is replaced by a pass-through after the membership test. It is here to establish that
-     seam, which is why 4b must be observed below the endpoint, and not as evidence for
-     this item.
+     refusal**: the removed caller is refused with the roster guard's own `not a member`
+     body, not merely a `403` — a decrypt-failure 403 further down the same handler
+     satisfies a status-only assertion while proving the guard did **not** fire. That guard
+     is in `secure_group_decrypt` and fires before any `req` field is read and before any
+     cipher is reached, and the gate asserts the group is GSS-plane, so the refusal cannot
+     be the TreeKem dispatch instead. **4a discharges no part of non-decryption** — it
+     stays green if the crypto is replaced by a pass-through after the membership test. It
+     is here to establish that seam, which is why 4b must be observed below the endpoint,
+     and not as evidence for this item.
    - **4b** — `f1_item4b_retained_secret_does_not_open_new_epoch_content` observes **key
      material**: the secret a removed member retains does not open content sealed at the
      new epoch. Two arms vary only the secret and the new-epoch arm must succeed, so the

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -487,6 +487,31 @@ nothing more than a malformed input the gate itself constructs. Drawing the line
 read would have hidden six of the ten; drawing it at the derivation would still have hidden
 `:12362`.
 
+**A break list is a set of line numbers, so it means nothing without the commit it resolves
+at, and it must be re-resolved at the commit that ships.** The list above states its commit in
+its first citation and the rest of the rows inherit it; that is a requirement, not a
+formatting habit. A gate that adds production code *above* its own interval moves every line
+in that interval, so a list written against the commit the gate was designed on can be wrong
+at the commit the gate lives on — and a rebase invalidates a break list exactly as it
+invalidates a diff. This is not hypothetical: on this rule's first use a gate's own production
+hunks shifted its whole interval by fourteen lines, and a mutation aimed at a line from the
+stale list edited a blank line, did nothing, and reported the entire set green. **Two things
+follow. State the commit each list resolves at, and re-resolve it at the final SHA before the
+receipt is read as evidence. And build every mutation set with at least one arm that MUST go
+red** — that near-miss was caught only because a control arm failed to fail. A set in which
+every arm is expected green cannot distinguish a sound gate from a mutation that never landed.
+
+**The exit inventory is a floor for a second reason: some breaks are not exits at all.** Where
+a gate observes two production operations agreeing with *each other* — an encrypt and a
+decrypt, a writer and a reader, a serialiser and its parser — an edit applied to **both** sides
+leaves the gate green while the format between them moves. No control-flow exit is involved,
+so no enumeration of exits can reach it; it is found only by asking what a matched pair of
+edits would hide. Such a gate observes that the two sides agree, which is the property worth
+having, and does **not** observe that either side still matches what was there before. A
+paired-operation gate must record that as a break it does not observe, and it belongs in the
+blind-spot bucket by the direction test above: it leaves the gate green while something real
+is broken.
+
 **One exit lies past the target operation, and it is a different kind — do not file it as
 blindness.** The interval above ends at the operation, but what a gate observes is the
 endpoint's *response*, and on the success arm this handler hands its assembled response to a

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -432,13 +432,21 @@ green all-new soak proves nothing about a mixed fleet.
    broken-expectation control proves the runner can report red.
 
    **7b — source-reviewed defence, not a gate. All citations in this sub-item are at
-   `56d0c4b`.** If the 7a invariant ever fails despite the gate, the §2a conversion
-   (`:8590-8598`) aborts: its `return api_error(...)` statement (`:8593-8596`) precedes
-   `seal_commit` (`:8640`), the map insert (`:8651`), persistence (`:8667`) and publication
-   (`:8688`). Between the `named_groups.write()` acquisition (`:8548`) and that return, the
-   only mutations are to the private clone `next` (`:8567`), which is dropped on return, so
-   there is no stored, persisted or published state for the abort to change. The `Err(v)`
-   arm (`:8592`) binds the secret-bearing `Vec` solely to read `v.len()` (`:8595`).
+   `56d0c4b` except those naming `src/groups/`, which are at the baseline.** If the 7a
+   invariant ever fails despite the gate, the §2a conversion (`:8590-8598`) aborts: its
+   `return api_error(...)` statement (`:8593-8596`) precedes `seal_commit` (`:8640`), the
+   map insert (`:8651`), persistence (`:8667`) and publication (`:8688`). Between the
+   `named_groups.write()` acquisition (`:8548`) and that return, **no live group entry is
+   mutated**, and the reason is structural rather than an enumeration: the only handle to
+   the entry in that window is the shared reference `info` from `named_groups.get(&id)`
+   (`:8549`), through which no mutation is expressible, and the guard is not used again
+   until the insert at `:8651`. Two private clones *are* mutated and both are discarded on
+   return: the ADR-0016 precheck at `:8563` calls `last_admin_precheck` (`:10169-10175`),
+   which delegates to `last_admin_precheck_error` (`src/groups/mod.rs:268-277`) and applies
+   the caller's roster mutation to its own `proposed` clone (`src/groups/mod.rs:272-273`);
+   the handler then mutates its private `next` clone (`:8567`). So there is no stored,
+   persisted or published state for the abort to change. The `Err(v)` arm (`:8592`) binds
+   the secret-bearing `Vec` solely to read `v.len()` (`:8595`).
    **No gate observes the abort, the zero state change, or the absence of an all-zero-key
    envelope** — the branch has no production producer that can reach it, and the only ways
    to drive it are a `#[cfg(test)]` hook on `GroupInfo`, a test parameter on

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -76,8 +76,10 @@ reachability unresolved rather than declared defective.
 
 ## Validation
 
-Every control must be shown to fail on the pinned pre-fix commit or on a
-mutation, and to pass on the patched tree.
+Every control must be shown to fail when its own source is run against the
+production code at `e3013710d7ed69077de9a799dffdbeb5ac80535a`, or against a
+declared mutation satisfying the break-disclosure requirement below, and to
+pass on the patched tree.
 
 Acceptance requires independent controls showing that:
 
@@ -93,10 +95,44 @@ Acceptance requires independent controls showing that:
 - the rotated-secret producer preserves its length, epoch, and stored-value
   invariants.
 
-Runner, receipt, break-disclosure, mutation, and gate-mapping mechanisms live
-in the [reference chapter](../design/gss-admin-remove-fail-closed.md). As
-recorded on 2026-07-27, survivor decryptability and removed-member exclusion
-block acceptance; abort and mixed-version controls remain required follow-up.
+**Break disclosure — required of every control in this section.**
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+A control is evidence only against the ways of breaking that someone named.
+Mutation-redness does not establish that a control observes its property: the
+metadata-first and envelope-first delivery controls are mutation-red on the
+`src/server/routes/named_groups.rs:5832` conjunct and were still blind to the
+survivor being removed alongside the victim, because that break was never on
+anyone's list. So each control must be accompanied by a list of the breaks
+considered, and for each either **the mutation that makes the control fail, an
+assertion or precondition in the control that refuses the path, or a statement
+that the control does not observe that break and why that is accepted.** A
+refusing precondition ranks with a mutation and is often the honest form: a
+control asserting an exact plaintext already cannot pass on any error exit,
+and demanding a bespoke mutation per exit would buy ceremony rather than
+evidence. This is a requirement to disclose, not a prohibition on assertions:
+a rule forbidding any assertion a broken property could still produce would
+forbid the length assertion on the rotated-secret producer, which still yields
+32 if rotation breaks by returning a constant.
+
+A list drawn from the author's imagination fails the same way the controls do
+— an author names the breaks their control already catches. The minimum content
+is therefore mechanical: **name the target operation and the observation the
+control makes of it, then enumerate from the source every control-flow exit or
+alternate dispatch between the control's entry point and that operation which
+could bypass or substitute for it — explicit returns, `?` propagation,
+`let`-`else` bindings, `match` and `if` arms, and returns from delegated
+handlers — and account for each.** A scan for `return` is a floor, not a
+completeness proof; the `secure_group_decrypt` handler ends in a tail `match`,
+whose arms exit the handler without an explicit `return`. The endpoint of that
+path is the code that performs the property, not the code that reads its
+inputs.
+
+Runner, receipt, mutation, and gate-mapping mechanisms live in the
+[reference chapter](../design/gss-admin-remove-fail-closed.md). As recorded on
+2026-07-27, survivor decryptability and removed-member exclusion block
+acceptance; abort and mixed-version controls remain required follow-up.
 Acceptance with follow-up outstanding is not full validation discharge.
 
 ## Grounding

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -135,7 +135,9 @@ ever populates it. The apply mutator gains ban's `else if` (`:5247-5254`) at `:4
 epoch and `security_binding` are written **unconditionally** and only the secret clear is
 gated on strict `<`. Conditioning the `security_binding` write on local secret state would
 make two receivers in different local states compute different `state_hash` values for the
-same commit — it is a hashed input (`state_commit.rs:219-238`). A step-0 guard rejecting
+same commit — it is a hashed input: the parameter is `state_commit.rs:226` and its
+absorption into the hash buffer is `:237` (`:238` absorbs `withdrawn`, a different input).
+A step-0 guard rejecting
 `self_leave_auth && secret_epoch.is_some()` sits outside the plane split, as the backstop
 against a crafted `MemberSelf` commit, which validates by construction
 (`state_commit.rs:737`).
@@ -315,10 +317,12 @@ claim of this shape must be run structurally, not derived from a text search.**
   that.** `publish_named_group_metadata_event` (`:1797-1833`) returns `()` and folds both a
   publish error and a timeout into `tracing::warn!`; the direct path's own doc comment
   (`:1835-1837`) calls its delivery best-effort. So a crash or a failed publish *after* the
-  commit has been persisted can still leave a survivor without its envelope. That residue is a delivery
-  property of the transport, unchanged by F1 and not addressed here; the gate asserts
-  decryptability against the **published envelopes** (Validation item 4) precisely because
-  end state alone cannot see it.
+  commit has been persisted can still leave a survivor without its envelope. That residue is
+  a delivery property of the transport, unchanged by F1 and not addressed here. **No
+  validation item reaches it:** Validation item 2 proves survivor decryptability from the
+  envelope; neither it nor the publish-attempt oracle proves delivery. Item 4 asserts the
+  removed member's non-decryption against the published envelopes; items 2 and 4 test the
+  cryptographic behaviour of event objects, not delivery.
 
 ## Validation
 

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -502,6 +502,28 @@ install that guard. It is recorded under that heading and **not** as an accepted
 That term is reserved for a break that can leave a gate green, and it carries no information
 once it also covers breaks that cannot.
 
+**Which label a path takes is decided by direction, and one question decides it.** These
+labels collapsed into one another three times during this section's first use: twice by
+filing under the heading reserved for paths that can leave a gate green a path that can only
+turn it red and a path that cannot fire at all, and once by attributing a path to a
+Validation item whose sentence does not reach it. All three are prevented by asking, per
+path, **if this fires, which way does the gate move?**
+
+- **Stays green while the property is broken** — *accepted blind spot.* The only label that
+  requires an accepted-and-why, because it is the only one that costs coverage.
+- **Turns red while the property holds** — *false-negative or test-isolation hazard.*
+  Discharged by a precondition and by test hygiene, never by a mutation: a mutation aimed at
+  it would be a mutation against a correct gate.
+- **Cannot fire** — say *unreachable* and give the reason. It needs no label at all, and
+  borrowing one that means the opposite is worse than leaving the row bare.
+
+Two things that are **not** labels. A mutation and a refusing precondition are *evidence
+forms*; either can discharge a path of any direction, so neither identifies a kind. And "no
+gate observes this" is a statement about **coverage**, which is independent of **ownership** —
+a path may be unobserved and owned by a scheduled item, or unobserved and owned by nothing.
+State which, because a plausible-sounding owner reads as discharged, and that is worse than
+recording no owner at all.
+
 1. Fails on the pinned pre-fix commit (or on a mutation) and passes on the patched tree.
 2. Asserts each surviving member can **decrypt content published at the new epoch** — not
    that its `state_hash` matches. Convergence is the wrong assertion (Context, driver 2):

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -36,9 +36,9 @@ Three properties of the surrounding code shape the fix:
    be `warn`ed and skipped. Ban's fail-open is **structural**, a consequence of sealing
    after persistence, not an unchecked return value.
 2. **A stranded survivor is invisible to consensus.** `shared_secret` is not one of the
-   eight inputs to `compute_state_hash` (`src/groups/state_commit.rs:219-238`:
-   group id, revision, prev hash, roster root, policy hash, public meta hash,
-   `security_binding`, withdrawn). A member who never receives the new secret keeps a
+   eight inputs to `compute_state_hash` — its parameter list, `src/groups/state_commit.rs`
+   `:219-228`, is group id, revision, prev hash, roster root, policy hash, public meta
+   hash, `security_binding`, withdrawn. A member who never receives the new secret keeps a
    matching `state_hash` forever while decrypting nothing. Any convergence-based
    assertion passes on this bug.
 3. **Nothing proves that a survivor without a roster KEM key never held the secret.** A
@@ -313,9 +313,9 @@ claim of this shape must be run structurally, not derived from a text search.**
   transaction, no rollback machinery. An implementation that builds one has misread D2.
 - **The preflight bounds construction, not delivery, and this ADR claims nothing beyond
   that.** `publish_named_group_metadata_event` (`:1797-1833`) returns `()` and folds both a
-  publish error and a timeout into `tracing::warn!`; the direct path at `:1834` onward is
-  documented as best-effort. So a crash or a failed publish *after* the commit has been
-  persisted can still leave a survivor without its envelope. That residue is a delivery
+  publish error and a timeout into `tracing::warn!`; the direct path's own doc comment
+  (`:1835-1837`) calls its delivery best-effort. So a crash or a failed publish *after* the
+  commit has been persisted can still leave a survivor without its envelope. That residue is a delivery
   property of the transport, unchanged by F1 and not addressed here; the gate asserts
   decryptability against the **published envelopes** (Validation item 4) precisely because
   end state alone cannot see it.

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -519,9 +519,16 @@ commit: the SHA does not exist until the bytes containing it are fixed. Such a l
 **declares its parent, and asserts that the cited region is unchanged between that parent and
 the commit carrying the list — with a receipt, not an assurance.** A hash of the region at
 both commits is that receipt; "production is untouched" as a bare parenthetical is not, because
-it is exactly the claim a reader cannot check without redoing the work. The region only has to
-cover the cited lines, so hashing the file's head up to the first changed line is usually
-enough. Where a list is written against a tree it does not ship in — a review copy, a receipt
+it is exactly the claim a reader cannot check without redoing the work. **The region has two
+conditions, and the second is the one that bites: it must contain every cited line, and it
+must contain none of the edit that writes the receipt.** A receipt its own commit invalidates
+is worse than none — the hash is stale the moment it is recorded, and stale in a way that
+reads as verified. Hashing the file's head up to the first changed line satisfies both
+conditions only when the list sits *after* every line it cites, which is the ordinary shape
+for a break list in a test module citing production above it. A list that sits above its
+citations gets a head region that stops short of them and certifies nothing that matters:
+bound the region around the citations instead, and state its endpoints. Where a list is
+written against a tree it does not ship in — a review copy, a receipt
 posted before the commit lands — the final-SHA requirement above applies unchanged.
 
 **The exit inventory is a floor for a second reason: some breaks are not exits at all.** Where

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -416,10 +416,35 @@ green all-new soak proves nothing about a mixed fleet.
    the persisted-revision assertion even though its final state looks tidy.
 6. Mixed-version negative control: an old receiver must reproduce the permanent wedge on
    pre-fix code, and the rollout guard must prevent it.
-7. Covers D5 directly — a rotated secret of the wrong length aborts with zero state change
-   and the group never publishes an envelope sealed to an all-zero key. Unreachable
-   through the public API at this commit, so it is a unit test on the conversion boundary;
-   the test name must say so rather than dress it up as a reachable path.
+7. Covers D5, which is unchanged, split by **evidence class**. The two halves are not
+   interchangeable and 7a does not subsume 7b: 7a pins the invariant §2a defends, 7b is the
+   defence itself and no gate observes it.
+
+   **7a — gate-enforced (producer invariant). Citations in this sub-item are
+   `src/groups/mod.rs` at the baseline.** `GroupInfo::rotate_shared_secret` (`:429-437`) is
+   the sole production producer of the value §2a converts, and allocates it at `:431`. The
+   gate calls that method on a real `GroupInfo` and asserts three linked producer
+   properties: the returned secret is 32 bytes; `secret_epoch` advanced by exactly one
+   (`:433`); the stored `shared_secret` is the same bytes as the returned one (`:434`). The
+   pinning mutation is `vec![0u8; 32]` → `vec![0u8; 31]` at `:431`, and it turns the
+   **length** assertion red and only that one — the epoch and stored-identity assertions
+   survive it, so they are carried by this gate but not pinned by this mutation. A separate
+   broken-expectation control proves the runner can report red.
+
+   **7b — source-reviewed defence, not a gate. All citations in this sub-item are at
+   `56d0c4b`.** If the 7a invariant ever fails despite the gate, the §2a conversion
+   (`:8590-8598`) aborts: its `return api_error(...)` statement (`:8593-8596`) precedes
+   `seal_commit` (`:8640`), the map insert (`:8651`), persistence (`:8667`) and publication
+   (`:8688`). Between the `named_groups.write()` acquisition (`:8548`) and that return, the
+   only mutations are to the private clone `next` (`:8567`), which is dropped on return, so
+   there is no stored, persisted or published state for the abort to change. The `Err(v)`
+   arm (`:8592`) binds the secret-bearing `Vec` solely to read `v.len()` (`:8595`).
+   **No gate observes the abort, the zero state change, or the absence of an all-zero-key
+   envelope** — the branch has no production producer that can reach it, and the only ways
+   to drive it are a `#[cfg(test)]` hook on `GroupInfo`, a test parameter on
+   `rotate_shared_secret`, or moving rotation out of the handler. D5 does not justify that
+   production surface. If a future change gives the wrong-length value a real producer, 7b
+   becomes a required gate.
 
 **Review triggers.** Re-run the structural audit above, and re-open D10, if any of these
 change: a new `named_groups.write()` writer is added, the membership-lock boundary moves,

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -13,6 +13,15 @@ All line citations are `src/server/routes/named_groups.rs` unless stated, at
 The implementation spec lives outside this repository and is mutable; this ADR
 therefore carries its own evidence rather than referring to it for load-bearing facts.
 
+**Two coordinate systems.** Code that F1 itself introduced does not exist at the baseline
+and cannot be cited there, so every such citation is stamped **at `56d0c4b`** in place —
+the F1 implementation commit `56d0c4bc61fbb649042aad8ea42d25d8f0c85c39` on `glm/f1-fix`,
+which changes exactly one file, `src/server/routes/named_groups.rs` (+231/-40). **An
+unstamped citation is at the baseline.** Because that commit touches no other file, cites
+into `src/groups/` resolve identically at either. The +231 lines shift everything below
+them, so a `named_groups.rs` number read during implementation review is not the same
+number at the baseline and must be translated rather than carried across.
+
 **Citation convention.** Multi-line write sites are cited as **statements** — the full
 statement including `.insert(...)`. The ast-grep pattern used for the audit below matches
 only the sub-expression ending at `.await`, so the matched expression is one line shorter
@@ -118,7 +127,10 @@ conversion aborts with a 500. `impl TryFrom<Vec<T>> for [T; N]` has `Error = Vec
 the error value **is the secret material** — only its length may be read or logged.
 Scoped honestly: not a live defect at this commit (`rotate_shared_secret` allocates 32
 bytes at `mod.rs:431`), but it is the one failure mode the fail-closed design does not
-otherwise cover, because sealing a zero secret *succeeds*.
+otherwise cover, because sealing a zero secret *succeeds*. **Scope: D5 binds the remove
+path only.** It does not reach ban's `:10313-10316`, which this ADR leaves as it found it;
+that surviving instance is recorded under Negative / Trade-offs. D5 must not be read as a
+repo-wide property of the conversion.
 
 **D6 — Self-removal is rejected before the membership lock.** A self-targeted remove is
 rejected between `:8439` and `:8440`, before the lock at `:8443-8444`. It is not
@@ -289,7 +301,9 @@ claim of this shape must be run structurally, not derived from a text search.**
   see the delivery limit under Neutral / Operational.
 - Rotation never becomes observable from a failed attempt: the mutation happens on a
   private clone that is dropped.
-- A group can no longer rotate onto an all-zero key through a silent conversion (D5).
+- **The remove path** can no longer rotate onto an all-zero key through a silent conversion
+  (D5). Scoped to the remove path deliberately — see the ban residue under Negative /
+  Trade-offs; D5 is not a repo-wide property and this consequence must not be read as one.
 - The correctness of D10's evidence is now checkable — the audit's instrument, figures and
   enumeration are recorded, so re-running it is mechanical.
 
@@ -297,6 +311,33 @@ claim of this shape must be run structurally, not derived from a text search.**
 
 - **Availability (D8):** one active member without a roster KEM key blocks all removals in
   that group until they publish one.
+- **The clear predicate and the delivery predicate are not the same predicate, and this
+  ADR does not reconcile them.** The receiver clears on an epoch comparison alone —
+  `if old_epoch < secret_epoch { next.shared_secret = None }` (`:5052-5054` **at
+  `56d0c4b`**, in the arm at `:5048-5055`), which does not consult the receiving node's
+  own membership state. The sender selects envelope recipients by roster state:
+  `active_members()` minus the actor (`:8602-8606` **at `56d0c4b`**), and `active_members()`
+  admits only `GroupMemberState::Active` (`src/groups/mod.rs:1080-1082`,
+  `src/groups/member.rs:226-228`). So any node that holds the old secret and is not
+  `Active` on the sender's roster clears it and receives no replacement. For `Removed` and
+  `Banned` that is the intent. For **`Pending` it is undecided** — D2 is written over
+  "survivors" and never states which predicate defines the set. **Nobody has established
+  that a `Pending` node can hold the live secret when the event applies**, so this is an
+  unexamined reachability and availability risk, not a demonstrated defect; it is recorded
+  so the next reader does not have to rediscover it. There is a standing promise in tension
+  with it: the approval path's `(None, _)` arm (`:10895-10900`) logs *"requester will
+  receive via next rekey"* (`:10898`), and both rekey paths draw from `active_members()`,
+  so that promise holds only for a requester who is `Active` when the next rekey runs.
+  **Pre-existing, not introduced here:** ban already pairs the same two predicates — it
+  clears on the epoch alone at `:5251-5253` (in the arm at `:5247-5254`) and selects
+  `remaining_targets` from `active_members()` at `:10317-10320`.
+- **D5 is scoped to the remove path; ban's silent zero-fill survives F1 untouched.** At
+  ban's `:10313-10316` — the site D5 already cites — the rekey still does
+  `let mut sec = [0u8; 32];` and copies only `if sec_vec.len() == 32`, so a wrong-length
+  rotation there seals an **all-zero key** with no error, the exact defect D5 closes in
+  remove. Out of F1's scope by decision, not by oversight, and recorded here so that D5 is
+  not misread as a repo-wide invariant and the surviving instance is not rediscovered as
+  new. This bullet is what the Positive consequence on D5 points at.
 - **Contention (D9):** N synchronous ML-KEM encapsulations inside the global
   `named_groups` write guard; every named-group operation on the node serialises behind
   one removal.
@@ -313,6 +354,30 @@ claim of this shape must be run structurally, not derived from a text search.**
   receivers ignore `secret_epoch`. Their behaviour is a gate item, not an assumption.
 - The abort path is a bare `return` inside the block expression opened at `:8458` — no
   transaction, no rollback machinery. An implementation that builds one has misread D2.
+- **Preflight abort status codes are recorded, not decided.** Cited as the three
+  `return api_error(...)` statements **at `56d0c4b`**, per the convention stated above: the
+  implementation returns **424 FAILED_DEPENDENCY** for a keyless survivor (`:8613-8618`)
+  and for a build/seal failure (`:8630-8635`), and **500** for the wrong-length rotated
+  secret (`:8593-8596`).
+  424 is the honest shape — a dependency the caller can fix (the survivor's published KEM
+  key) is absent; 500 is right for the conversion because §2a is unreachable through the
+  public API, so reaching it is a server bug rather than a client one. No decision in this
+  ADR fixes these, and a future change to them does not require superseding it.
+- **What makes both publish orderings work is one conjunct, and it is load-bearing.** The
+  clear is gated on *strict* `<` (D7), so an envelope that installed first survives the
+  later commit. The reverse ordering — commit first, envelope second at equal epoch —
+  works only because the stale-envelope guard is
+  `if secret_epoch < info.secret_epoch || (secret_epoch == info.secret_epoch &&
+  info.shared_secret.is_some())` (statement `:5831-5835`; the conjunct is `:5832`), whose
+  own doc comment (`:5827-5830`) states the intent. That guard is pre-existing and F1 does
+  not change it — it is cited at the baseline, and its comment names only a *prior
+  `MemberBanned` commit*, because remove had no GSS rotation to produce the same ordering
+  when it was written. Tightening that predicate to
+  `secret_epoch <= info.secret_epoch` would silently strand every survivor on the
+  commit-first ordering: cleared by the commit, then refusing its own replacement, in
+  consensus with a matching `state_hash` and decrypting nothing. That is the F1 failure
+  re-created by a one-token edit, which is why Validation item 3 must be written to fail
+  when the conjunct is deleted rather than merely to exercise both orderings.
 - **The preflight bounds construction, not delivery, and this ADR claims nothing beyond
   that.** `publish_named_group_metadata_event` (`:1797-1833`) returns `()` and folds both a
   publish error and a timeout into `tracing::warn!`; the direct path's own doc comment

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -15,14 +15,16 @@ therefore carries its own evidence rather than referring to it for load-bearing 
 
 **Two coordinate systems.** Code that F1 itself introduced does not exist at the baseline
 and cannot be cited there, so every such citation is stamped **at `56d0c4b`** in place —
-the F1 implementation commit `56d0c4bc61fbb649042aad8ea42d25d8f0c85c39` on `glm/f1-fix`,
-which changes exactly one file, `src/server/routes/named_groups.rs` (+231/-40). **An
+the F1 implementation commit `56d0c4bc61fbb649042aad8ea42d25d8f0c85c39` on `glm/f1-fix`.
+That commit is +11/-5; the whole range `e3013710d7..56d0c4b` is +231/-40. **Both touch
+exactly one file, `src/server/routes/named_groups.rs`** — and it is the *range*, not the
+commit alone, that licenses the carve-out below. **An
 unstamped citation is at the baseline, and a stamp never carries from one citation to the
 next — adjacency is not a scope.** An enumeration may instead **declare** a single resolving
 commit for all of its rows, in words, immediately before them; that declaration governs
 exactly those rows and nothing else. Anything covered by neither an in-place stamp nor such a
 declaration is at the baseline, and no exception is to be inferred from a neighbouring
-citation. Because that commit touches no other file, cites
+citation. Because nothing outside `named_groups.rs` changes anywhere in that range, cites
 into `src/groups/` resolve identically at either. The +231 lines shift everything below
 them, so a `named_groups.rs` number read during implementation review is not the same
 number at the baseline and must be translated rather than carried across.
@@ -318,8 +320,8 @@ claim of this shape must be run structurally, not derived from a text search.**
   that group until they publish one.
 - **The clear predicate and the delivery predicate are not the same predicate, and this
   ADR does not reconcile them.** The receiver clears on an epoch comparison alone —
-  `if old_epoch < secret_epoch { next.shared_secret = None }` (`:5052-5054` **at
-  `56d0c4b`**, in the arm at `:5048-5055`), which does not consult the receiving node's
+  `if old_epoch < secret_epoch { next.shared_secret = None }` (**both of the next two are at
+  `56d0c4b`**: `:5052-5054`, in the arm at `:5048-5055`), which does not consult the receiving node's
   own membership state. The sender selects envelope recipients by roster state:
   `active_members()` minus the actor (`:8602-8606` **at `56d0c4b`**), and `active_members()`
   admits only `GroupMemberState::Active` (`src/groups/mod.rs:1080-1082`,
@@ -457,7 +459,7 @@ gain gates and if that runner default is ever configured away.
 
 **Break disclosure — required of every gate in this section.** A gate is evidence only
 against the ways of breaking that someone named. Mutation-redness does not establish that a
-gate observes its property: the §3 gates are mutation-red on the `:5908` conjunct and were
+gate observes its property: the §3 gates are mutation-red on the `:5832` conjunct and were
 still blind to the survivor being removed alongside the victim, because that break was never
 on anyone's list. So each gate must be accompanied by a list of the breaks considered, and
 for each either **the mutation that turns the gate red, an assertion or precondition in the

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -427,9 +427,14 @@ green all-new soak proves nothing about a mixed fleet.
    properties: the returned secret is 32 bytes; `secret_epoch` advanced by exactly one
    (`:433`); the stored `shared_secret` is the same bytes as the returned one (`:434`). The
    pinning mutation is `vec![0u8; 32]` → `vec![0u8; 31]` at `:431`, and it turns the
-   **length** assertion red and only that one — the epoch and stored-identity assertions
-   survive it, so they are carried by this gate but not pinned by this mutation. A separate
-   broken-expectation control proves the runner can report red.
+   **length** assertion red and only that one — under the mutation the epoch and
+   stored-identity assertions still execute and still pass, so they are carried by this
+   gate but not pinned by this mutation. **The three properties must therefore sit in three
+   separate test functions.** Combined into one, the length assertion panics first and the
+   other two never run: the receipt would then show only that "7a turned red" and would
+   demonstrate nothing about which assertion the mutation pins, leaving the claim in this
+   sub-item unfalsifiable by its own gate. A separate broken-expectation control proves the
+   runner can report red.
 
    **7b — source-reviewed defence, not a gate. All citations in this sub-item are at
    `56d0c4b` except those naming `src/groups/`, which are at the baseline.** If the 7a

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -435,14 +435,27 @@ green all-new soak proves nothing about a mixed fleet.
    demonstrate nothing about which assertion the mutation pins, leaving the claim in this
    sub-item unfalsifiable by its own gate. **Three functions are necessary but not
    sufficient**, because `cargo nextest` is fail-fast by default: with no flag it cancels
-   the run on the first failure, so the two unaffected functions may never be scheduled and
-   the receipt again shows a single result. The repo's `.config/nextest.toml` sets no
-   `fail-fast` key — it is byte-identical at the baseline and at `56d0c4b` — so that default
-   governs here. The mutation receipt must therefore run the three functions under
-   `--no-fail-fast`, or invoke them separately, and must report the PASS/PASS/FAIL split by
-   test name; if it runs through `just adr-gates-f1`, that recipe must itself pass
-   `--no-fail-fast`, otherwise the recipe silently reintroduces the ambiguity this paragraph
-   exists to remove. A separate broken-expectation control proves the runner can report red.
+   the run on the first failure. The repo's `.config/nextest.toml` sets no `fail-fast` key —
+   it is byte-identical at the baseline and at `56d0c4b` — so that default governs here.
+   That default's effect on the receipt is a race, not a property: fail-fast cancels only
+   what is still queued at the instant of failure, so whether either unaffected test is
+   omitted depends on scheduling — thread count, ordering, and how long the siblings run.
+   Serially the run has been observed to stop at two of three results; at default
+   parallelism all three are already scheduled when the failure lands, the complete
+   PASS/PASS/FAIL split survives, and the no-flag output differs from the `--no-fail-fast`
+   output only by the line `Cancelling due to test failure:`. **The split is therefore an
+   outcome, not a proof of execution shape — a compliant-looking receipt can be produced
+   without the flag**, which is why reporting the split cannot be the criterion. The receipt
+   must evidence the invocation. Primary evidence is the exact command, which must contain
+   `--no-fail-fast` or be three separate invocations, one per test; corroborating evidence
+   is the runner's verbatim output naming all three tests. Verbatim output alone does not
+   suffice — it can be excerpted or reformatted, so the absence of `Cancelling due to test
+   failure:` is a tell and not a guarantee. If `just adr-gates-f1` is the recorded
+   invocation, the recipe body must be quoted beside it so that its `--no-fail-fast` is
+   visible; otherwise the recipe silently reintroduces the ambiguity this paragraph exists
+   to remove. `--test-threads=1 --no-fail-fast` is the least ambiguous shape, though serial
+   execution is not required once the flag is explicit. A separate broken-expectation
+   control proves the runner can report red.
 
    **7b — source-reviewed defence, not a gate. All citations in this sub-item are at
    `56d0c4b` except those naming `src/groups/`, which are at the baseline.** If the 7a

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -513,6 +513,17 @@ receipt is read as evidence. And build every mutation set with at least one arm 
 red** — that near-miss was caught only because a control arm failed to fail. A set in which
 every arm is expected green cannot distinguish a sound gate from a mutation that never landed.
 
+**A list committed alongside the code it cites cannot name its own commit, so it takes the
+other form.** Requiring the final SHA is unsatisfiable when the list ships *inside* that
+commit: the SHA does not exist until the bytes containing it are fixed. Such a list therefore
+**declares its parent, and asserts that the cited region is unchanged between that parent and
+the commit carrying the list — with a receipt, not an assurance.** A hash of the region at
+both commits is that receipt; "production is untouched" as a bare parenthetical is not, because
+it is exactly the claim a reader cannot check without redoing the work. The region only has to
+cover the cited lines, so hashing the file's head up to the first changed line is usually
+enough. Where a list is written against a tree it does not ship in — a review copy, a receipt
+posted before the commit lands — the final-SHA requirement above applies unchanged.
+
 **The exit inventory is a floor for a second reason: some breaks are not exits at all.** Where
 a gate observes two production operations agreeing with *each other* — an encrypt and a
 decrypt, a writer and a reader, a serialiser and its parser — an edit applied to **both** sides

--- a/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
+++ b/docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md
@@ -6,740 +6,173 @@
 - **Reviewers:** Sam, Dario (author), Watson
 - **Supersedes:** none — closes a gap in the legacy GSS plane described by ADR 0010
 - **Superseded by:** none
-- **Related:** ADR 0010 (GSS before MLS TreeKEM), ADR 0012 (TreeKEM as the default secure-group plane), ADR 0014 (self-leave is a roster removal), ADR 0016 (flat Admin/Member authority), `~/.buzz/PLANS/F1_GSS_ROTATION_SPEC.md` rev 4.2 (581 lines, implementation spec, outside this repo)
+- **Related:** ADR 0010 (GSS before MLS TreeKEM), ADR 0012 (TreeKEM as the
+  default secure-group plane), ADR 0014 (self-leave is a roster removal), ADR
+  0016 (flat Admin/Member authority), and the governed
+  [GSS admin-remove reference chapter](../design/gss-admin-remove-fail-closed.md)
 
-All line citations are `src/server/routes/named_groups.rs` unless stated, at
-`e3013710d7ed69077de9a799dffdbeb5ac80535a`, `git status --porcelain src/` empty.
-The implementation spec lives outside this repository and is mutable; this ADR
-therefore carries its own evidence rather than referring to it for load-bearing facts.
+## Summary
 
-**Two coordinate systems.** Code that F1 itself introduced does not exist at the baseline
-and cannot be cited there, so every such citation is stamped **at `56d0c4b`** in place —
-the F1 implementation commit `56d0c4bc61fbb649042aad8ea42d25d8f0c85c39` on `glm/f1-fix`.
-That commit is +11/-5; the whole range `e3013710d7..56d0c4b` is +231/-40. **Both touch
-exactly one file, `src/server/routes/named_groups.rs`** — and it is the *range*, not the
-commit alone, that licenses the carve-out below. **An
-unstamped citation is at the baseline, and a stamp never carries from one citation to the
-next — adjacency is not a scope.** An enumeration may instead **declare** a single resolving
-commit for all of its rows, in words, immediately before them; that declaration governs
-exactly those rows and nothing else. Anything covered by neither an in-place stamp nor such a
-declaration is at the baseline, and no exception is to be inferred from a neighbouring
-citation. Because nothing outside `named_groups.rs` changes anywhere in that range, cites
-into `src/groups/` resolve identically at either. The +231 lines shift everything below
-them, so a `named_groups.rs` number read during implementation review is not the same
-number at the baseline and must be translated rather than carried across.
-
-**Citation convention.** Multi-line write sites are cited as **statements** — the full
-statement including `.insert(...)`. The ast-grep pattern used for the audit below matches
-only the sub-expression ending at `.await`, so the matched expression is one line shorter
-than each statement cited here (`:6649-6652` vs `:6649-6653`). Statement ranges are what
-a reader needs to find the write; the expression range is an artefact of the instrument.
+On the legacy GSS plane, administrative removal rotates the shared secret and
+reseals it to every eligible survivor. All envelopes are built before commit,
+persistence, or publication; any preflight failure discards the rotated clone.
+The additive wire change and pre-lock self-removal refusal knowingly trade
+availability and lock contention for a fail-closed boundary.
 
 ## Context
 
-On the legacy GSS plane (ADR 0010 — still the plane grandfathered groups run on),
-`ban_treekem_group_member` rotates the group shared secret and reseals it to the
-survivors, but `remove_named_group_member` does not. **An admin-removed member keeps a
-working group secret and can decrypt everything published after the removal.** Removal
-and ban differ in outcome for the same authority.
-
-Three properties of the surrounding code shape the fix:
-
-1. **Ban is a partial model.** Its statement order up to `seal_commit` at `:10325` is
-   correct and must be followed. Past that line it is the anti-pattern: it commits the
-   roster to the map at `:10334`, persists with `save_named_groups` at `:10338`, and only
-   then seals per-recipient envelopes — so at `:10349` a survivor with no KEM key can only
-   be `warn`ed and skipped. Ban's fail-open is **structural**, a consequence of sealing
-   after persistence, not an unchecked return value.
-2. **A stranded survivor is invisible to consensus.** `shared_secret` is not one of the
-   eight inputs to `compute_state_hash` — its parameter list, `src/groups/state_commit.rs`
-   `:219-228`, is group id, revision, prev hash, roster root, policy hash, public meta
-   hash, `security_binding`, withdrawn. A member who never receives the new secret keeps a
-   matching `state_hash` forever while decrypting nothing. Any convergence-based
-   assertion passes on this bug.
-3. **Nothing proves that a survivor without a roster KEM key never held the secret.** A
-   non-TreeKEM invite stub reaches `shared_secret: Some(..)` with an active roster whose
-   `kem_public_key_b64` is `None`: `GroupInfo::with_policy` generates a secret for every
-   `MlsEncrypted` group (`src/groups/mod.rs:346-354`, installed by field shorthand at
-   `:390`); `invite_join_group_info` (`:7632-7638`) clears it only for TreeKEM
-   (`:7656-7658`); and the invite snapshot strips every roster ML-KEM key
-   (`src/server/routes/identity.rs:382`, copied at `:7671-7672`). **Stated at exactly the
-   strength the evidence carries:** that path proves `shared_secret: Some(..)` and
-   `kem_public_key_b64: None` coexist on a reachable state — it does *not* prove that
-   particular secret is the live group secret, because `with_policy` generates it locally
-   and whether it is ever the authority's is an open question (see the final section). What
-   makes the decision is the negative: **no positive enrollment invariant proves a keyless
-   survivor never held the live secret**, and fail-closed is the only safe reading of that
-   gap.
+Ban rotated the GSS secret while administrative remove did not, so a removed
+member could decrypt later content. Sealing after persistence can also strand
+a survivor after the new epoch is live. State-hash convergence cannot see that
+failure, and no enrollment invariant proves a keyless survivor never held the
+live secret.
 
 ## Decision Drivers
 
-- A removed member must be unable to decrypt content published at the rotated epoch, on
-  both planes — the same claim the gate asserts, stated as the goal rather than the looser
-  "loses read access at the moment of removal", which the transport cannot guarantee.
-- Silent partial failure is worse than refusal: a stranded survivor is undetectable
-  (driver 2 above), an aborted removal is immediately visible to the caller.
-- The fix must not reproduce ban's ordering, which makes fail-closed impossible.
-- Nothing may write the group secret, or a value derived from it, to a log.
-- The record must distinguish what was **proved** from what was **conservatively
-  assumed**, so a future optimisation can tell which constraints are load-bearing.
+- A removed member must not decrypt content published at the rotated epoch.
+- A visible refusal is safer than an undetectably stranded survivor.
+- No failed preflight may make a rotation live, persistent, or published.
+- Secret material and values derived from it must never be logged.
+- Proven constraints and conservative policy must remain distinguishable.
 
 ## Considered Options
 
-1. **Mirror ban step for step.** Rejected: reproduces the structural fail-open, and the
-   abort would have to undo a persisted save.
-2. **Rotate and reseal, fail open on a survivor whose envelope cannot be built** (skip
-   them, as ban does). Rejected: strands a member who may hold the secret, undetectably.
-3. **Rotate and reseal, fail closed** — build and validate every survivor envelope in
-   memory before any commit, persistence or publication; abort the whole removal on the
-   first failure. **Chosen.**
+Mirroring ban is rejected because its seal-after-persist ordering is
+structurally fail-open. Skipping a survivor whose envelope cannot be built is
+rejected because that survivor may hold the live secret. We choose complete
+in-memory preflight followed by one fail-closed commit path.
 
 ## Decision
 
-**D1 — Rotate on remove.** The GSS admin-remove path rotates the group shared secret and
-reseals it to every active non-actor survivor, so removal matches ban in effect.
-
-**D2 — Fail closed, for missing and unusable keys alike.** Every survivor envelope is
-built and validated in memory before `seal_commit`. On any missing KEM key, unusable key
-or seal error the handler bare-returns. Ban's `warn + continue` at `:10349-10355` is not
-mirrored. The abort guarantee is stated precisely: `rotate_shared_secret` has *already*
-mutated the clone (`next`, `:8478`) by the time the preflight can fail, so the guarantee
-is that **no rotation becomes live, persisted or published — the rotated clone is
-discarded**, not that nothing was rotated.
-
-**D3 — Ordering is normative, and diverges from ban after `:10325`.** Between `:8481` and
-`:8482`: `remove_member` → `is_encrypted` → `rotate_shared_secret` → fallible secret
-conversion (D5) → collect active non-actor survivors → **build every envelope** → abort on
-any failure → only then `seal_commit` (`:8482`), `named_groups.insert` (`:8494`),
-`save_named_groups` (`:8510`), and finally publish the buffered envelopes and the
-`MemberRemoved` event (`:8524`). Sealing moves **ahead** of persistence; that inversion is
-the whole of D2's mechanism.
-
-**D4 — The preflight needs a side-effect-free builder, not a `#[must_use]`.**
-`publish_secure_share` (`:877-929`) seals *and* broadcasts in one async function, so its
-`bool` only exists after publication and cannot gate anything. A builder covering
-`:888-919` (base64 decode, AAD, KEM seal, event construction) is extracted;
-`publish_secure_share` keeps `:920-928` and its current signature for the approval and ban
-callers. Every builder input exists before `seal_commit` — the AAD is
-`secure_share_aad(group_id, recipient_hex, secret_epoch)` (`:898`), none of whose three
-inputs depends on the sealed commit — so this is a pure reordering, not a restructuring.
-
-**D5 — The `Vec<u8>` → `[u8; 32]` conversion is fallible, and never logs its error.**
-`rotate_shared_secret` returns `Vec<u8>` (`src/groups/mod.rs:429`) while
-`seal_group_secret_to_recipient` requires `&[u8; 32]` (`src/groups/kem_envelope.rs:140-144`).
-Both idioms already in the file are silent: ban's `:10313-10316` leaves `sec` as
-`[0u8; 32]` and rotates the group onto a known-zero key; approval's guard at `:10880`
-falls through to a catch-all that drops the envelope. Neither is acceptable. The
-conversion aborts with a 500. `impl TryFrom<Vec<T>> for [T; N]` has `Error = Vec<T>`, so
-the error value **is the secret material** — only its length may be read or logged.
-Scoped honestly: not a live defect at this commit (`rotate_shared_secret` allocates 32
-bytes at `mod.rs:431`), but it is the one failure mode the fail-closed design does not
-otherwise cover, because sealing a zero secret *succeeds*. **Scope: D5 binds the remove
-path only.** It does not reach ban's `:10313-10316`, which this ADR leaves as it found it;
-that surviving instance is recorded under Negative / Trade-offs. D5 must not be read as a
-repo-wide property of the conversion.
-
-**D6 — Self-removal is rejected before the membership lock.** A self-targeted remove is
-rejected between `:8439` and `:8440`, before the lock at `:8443-8444`. It is not
-redirected: `leave_group` (`:9651-9654`) re-acquires the same per-group lock at
-`:9663-9664` and `tokio::sync::Mutex` is not reentrant, so a redirect self-deadlocks while
-holding that lock. The pre-lock placement also short-circuits a divergence live on the
-TreeKEM plane at this commit — `remove_treekem_named_group_member` sets `treekem_epoch`
-unconditionally at `:9327` and receivers reject it at `:4956-4958` whenever
-`self_leave_auth` holds.
-
-**D7 — The wire stays additive; the apply arm mirrors ban's branch.** `MemberRemoved`
-gains `secret_epoch: Option<u64>` with `#[serde(default)]`; only the GSS sender at `:8512`
-ever populates it. The apply mutator gains ban's `else if` (`:5247-5254`) at `:4979`:
-epoch and `security_binding` are written **unconditionally** and only the secret clear is
-gated on strict `<`. Conditioning the `security_binding` write on local secret state would
-make two receivers in different local states compute different `state_hash` values for the
-same commit — it is a hashed input: the parameter is `state_commit.rs:226` and its
-absorption into the hash buffer is `:237` (`:238` absorbs `withdrawn`, a different input).
-A step-0 guard rejecting
-`self_leave_auth && secret_epoch.is_some()` sits outside the plane split, as the backstop
-against a crafted `MemberSelf` commit, which validates by construction
-(`state_commit.rs:737`).
-
-**D8 — Availability cost of D2, knowingly accepted.** A group containing any active member
-without a roster KEM key cannot remove anyone until that member publishes one. This is
-taken deliberately while no positive enrollment invariant exists; the remedy is to publish
-the key. If such an invariant is later established, fail-open for the missing-key case
-becomes reconsiderable — by a new ADR, not by an implementation change.
-
-**D9 — Lock-contention cost of the preflight, knowingly accepted.** The preflight places N
-ML-KEM encapsulations inside the `state.named_groups` **write** guard (acquired `:8459`,
-released `:8495`), which is global over every named group, not the per-group membership
-lock. Ban pays none of this because its sealing loop runs after `drop(groups)` at `:10337`.
-For the duration of one removal every named-group operation on the node serialises behind
-it. The work is synchronous — `seal_group_secret_to_recipient` is `pub fn`, not async —
-so there is no await inside the guard and no deadlock risk. We take the contention.
-
-**D10 — Do not drop and re-acquire the map lock mid-preflight. Conservative; its necessity
-is unproven.** `next` is inserted under the same guard that produced it. This is the rule
-D9 is the invoice for: holding the map guard through the preflight is exactly what it
-mandates. Recorded as policy, not as a proved requirement — see the audit below. The rule
-adds no rollback and no compare-and-swap machinery, and knowingly pays D9's cost. We take
-that trade because the failure it forecloses — writing a stale `next` over a concurrent
-write — is silent and unrecoverable, while contention is neither. **A future optimisation
-that drops the guard needs a fresh audit at that commit plus an explicit
-revision/state-hash compare-and-swap, not a lock-gap argument.**
-
-### The audit behind D10, and exactly what it establishes
-
-The membership lock taken at `:8443-8444` is held to the end of the handler, so dropping
-the *map* lock mid-preflight is already safe against every writer that also takes the
-membership lock. The residual risk class is exactly: **writers that mutate an existing
-`GroupInfo` under `named_groups.write()` without the membership lock.**
-
-That class was screened structurally, with ast-grep — the only instrument that sees
-multi-line receiver chains:
-
-```bash
-sg run --lang rust -p '$STATE.named_groups.write().await' --json=stream src
-```
-
-`$STATE` is a metavariable, so it matches any receiver and matches across line breaks.
-Note that `range.start.line` in that output is **0-indexed**; every line number here is
-the 1-indexed value.
-
-| Figure | Value |
-|---|---|
-| structural matches under `src/` | 73 |
-| of those, in `src/server/routes/named_groups.rs` | 72 |
-| the single match elsewhere | `src/server/routes/named_groups/tests/cache_hardening_followup.rs:955` (a test) |
-| before the inline `mod tests` (`#[cfg(test)]` `:14002`, `mod tests` `:14003`) | 33 |
-| less the `#[cfg(test)]` helper write at `:9832` (fn `:9820-9821`) | **32 production** |
-| test-only across `src/` (39 in-module + `:9832` + the file above) | 41 |
-
-**A line grep cannot do this job, and the difference is not cosmetic.** A text pattern
-requires receiver and `.write()` on one line, so it sees 49 of the 72 in this file; the
-23 it misses are exactly the multi-line chains, three of them production:
-
-| statement | enclosing fn |
-|---|---|
-| `:6649-6653` | `create_named_group` (`:6466`) |
-| `:7845-7849` | `join_group_via_invite` (`:7712`) |
-| `:12628-12632` | `persist_treekem_and_named_groups_atomic_with_info` (`:12564`) |
-
-**The enumeration is complete, not merely self-consistent.** The **33 pre-inline-test-module
-writes** live in **32** enclosing functions; exactly **14** of those contain no lexical
-`group_membership_lock`; one of the 14 is `#[cfg(test)]`; that leaves **13 production
-candidates**. (33 is the pre-`mod tests` count and still includes the `#[cfg(test)]` helper
-subtracted in the table above — the 32 production figure and the 32 enclosing functions are
-different quantities that coincide numerically.)
-
-| fn | decl | write |
-|---|---|---|
-| `publish_group_card_to_discovery_inner` | `:1006` | `:1018` |
-| `store_named_group_info` | `:2062` | `:2067` |
-| `apply_recovered_member_key_package_locked` | `:3684` | `:3718` |
-| `create_named_group` | `:6466` | `:6649` |
-| `add_treekem_named_group_member` | `:8181` | `:8351` |
-| `wipe_local_group_crypto_material` | `:8872` | `:8879` |
-| `retain_withdrawn_group_tombstone` | `:9008` | `:9018` |
-| `drop_local_named_group_state` | `:9036` | `:9045` |
-| `leave_treekem_group` | `:9085` | `:9148` |
-| `remove_treekem_named_group_member` | `:9177` | `:9314` |
-| `ban_treekem_group_member` | `:10416` | `:10539` |
-| `approve_treekem_join_request` | `:10966` | `:11129` |
-| `persist_treekem_and_named_groups_atomic_with_info` | `:12564` | `:12628` |
-| — excluded — `maybe_force_withdrawn_group_for_test` | `:9821` (`#[cfg(test)]` `:9820`) | `:9832` |
-
-Reproduced independently four times (Sam, Dario, Watson, and one further re-derivation).
-Sam derived the 13 by hand first; deriving the same 13 from the structural census is what
-makes the set **exhaustive** rather than merely agreed.
-
-**Screening result: the residual class is empty at this commit.** All 13
-`store_named_group_info` call sites (`:4918, :5051, :5149, :5199, :5301, :5357, :5447,
-:5641, :5685, :5722, :5788, :5887, :6253`) take `resolved_group_key`, the key the
-serialized apply's guard is acquired on at `:4583-4584`. `create_named_group` is the one
-genuinely unlocked map writer and is not a counter-example: it generates a fresh random
-32-byte id at `:6470-6474` and inserts under it (`:6649-6653`), so it does not overwrite
-existing state in intended execution; a random-id collision would be a different defect
-shape, not a basis for this rule.
-
-**Three limits on that negative, stated so it is not over-read:**
-
-- It is a **scoped negative at one commit**: *at `e3013710d7ed69077de9a799dffdbeb5ac80535a`,
-  in the production `src` tree, no path was found that mutates an existing named group
-  outside that group's membership mutex.* It is not a proven invariant and does not hold
-  itself tomorrow. F1 must not silently move the lock boundary on the strength of it.
-- The classifier partitioning locked from unlocked is **textual** ("the body contains
-  `group_membership_lock`, delimited by the next top-level `fn`"). It reproduces the
-  partition exactly; it is **not** proof of lock coverage for the 18 functions marked
-  locked — none was checked for locking the *same key*.
-- The per-delegate chains (the `_locked` helpers and
-  `persist_treekem_and_named_groups_atomic_with_info` running under a parent handler's live
-  guard) rest on Sam's call-site work, not re-derived here.
-
-**The justification originally offered for D10 was refuted and is withdrawn.** Group-card
-import was put forward as a live writer outside the membership lock; it is not.
-`import_group_card` binds a *named* `_membership_guard` at `:11571-11572`, live to the end
-of the function, covering both the map write at `:11682` and the `get_mut` refresh at
-`:11727`; it is the same lock, since `group_membership_lock` normalises through
-`stable_group_id()` (`:4407-4422`) and the stub is inserted under the card's own
-`group_id`. The strongest alternative candidate fails too:
-`publish_group_card_to_discovery_inner` (`:1006`) takes `get_mut` at `:1019` but its only
-`&mut` use is `seal_commit` at `:1027` behind `if reseal` (`:1022`), and its two call sites
-are `:992` (`false`) and `:1003` (`true`, inside `publish_group_card_with_reseal`, which
-takes the membership lock first at `:1001-1002`). This is recorded as **false** precisely
-so a later reader does not rediscover the refutation and delete D10 believing the rule
-rested on it. D10 rests on conservatism, and on nothing else.
-
-### The finding that argues hardest for D10
-
-`join_group_via_invite` writes at `:7845` in multi-line form. Every text search in the
-review missed it — **and it does take the membership lock**, which is why it correctly
-never appeared in the candidate 13. It was invisible and harmless. That is luck, not
-method: an invisible write could as easily have been an unlocked existing-group mutator,
-and the scoped negative would have been false with three reviewers' sign-off on it. It
-surfaced only because a figure flagged as non-blocking was chased anyway. **The next
-claim of this shape must be run structurally, not derived from a text search.**
+1. **Rotate on remove.** Reseal the new GSS secret to every active non-actor
+   survivor.
+2. **Fail closed.** Build and validate all survivor envelopes before commit,
+   persistence, or publication. Missing or unusable keys, seal failures, and
+   invalid secret lengths discard the private clone.
+3. **Ordering is normative.** Removal and rotation precede preflight; preflight
+   precedes `seal_commit`; commit precedes map insertion and persistence;
+   buffered envelopes and `MemberRemoved` publish last. Preflight uses a
+   side-effect-free builder.
+4. **Conversion is non-disclosing.** The `Vec<u8>` to `[u8; 32]` conversion is
+   fallible and never logs its secret-bearing error. This binds remove, not ban.
+5. **Self-removal is refused before locking.** It is not redirected while the
+   membership lock is held.
+6. **The wire remains additive.** `MemberRemoved` carries a defaulted optional
+   GSS epoch. Epoch and binding update unconditionally; secret clearing uses
+   strict epoch ordering; a GSS epoch on self-leave is rejected.
+7. **Availability is traded for confidentiality.** A keyless active survivor
+   blocks removal until publishing a key. Relaxation needs a superseding ADR.
+8. **Hold the map lock through preflight.** Dropping it requires a fresh writer
+   audit and explicit revision or state-hash compare-and-swap.
 
 ## Consequences
 
-### Positive
-
-- Removal and ban have the same security outcome on the GSS plane: the removed member
-  **cannot decrypt content published at the rotated epoch**.
-- **No KEM/preflight-induced partial commit is reachable:** either every survivor envelope
-  is buildable or the removal aborts. Scoped deliberately to what the preflight proves —
-  see the delivery limit under Neutral / Operational.
-- Rotation never becomes observable from a failed attempt: the mutation happens on a
-  private clone that is dropped.
-- **The remove path** can no longer rotate onto an all-zero key through a silent conversion
-  (D5). Scoped to the remove path deliberately — see the ban residue under Negative /
-  Trade-offs; D5 is not a repo-wide property and this consequence must not be read as one.
-- The correctness of D10's evidence is now checkable — the audit's instrument, figures and
-  enumeration are recorded, so re-running it is mechanical.
-
-### Negative / Trade-offs
-
-- **Availability (D8):** one active member without a roster KEM key blocks all removals in
-  that group until they publish one.
-- **The clear predicate and the delivery predicate are not the same predicate, and this
-  ADR does not reconcile them.** The receiver clears on an epoch comparison alone —
-  `if old_epoch < secret_epoch { next.shared_secret = None }` (**both of the next two are at
-  `56d0c4b`**: `:5052-5054`, in the arm at `:5048-5055`), which does not consult the receiving node's
-  own membership state. The sender selects envelope recipients by roster state:
-  `active_members()` minus the actor (`:8602-8606` **at `56d0c4b`**), and `active_members()`
-  admits only `GroupMemberState::Active` (`src/groups/mod.rs:1080-1082`,
-  `src/groups/member.rs:226-228`). So any node that holds the old secret and is not
-  `Active` on the sender's roster clears it and receives no replacement. For `Removed` and
-  `Banned` that is the intent. For **`Pending` it is undecided** — D2 is written over
-  "survivors" and never states which predicate defines the set. **Nobody has established
-  that a `Pending` node can hold the live secret when the event applies**, so this is an
-  unexamined reachability and availability risk, not a demonstrated defect; it is recorded
-  so the next reader does not have to rediscover it. There is a standing promise in tension
-  with it: the approval path's `(None, _)` arm (`:10895-10900`) logs *"requester will
-  receive via next rekey"* (`:10898`), and both rekey paths draw from `active_members()`,
-  so that promise holds only for a requester who is `Active` when the next rekey runs.
-  **Pre-existing, not introduced here:** ban already pairs the same two predicates — it
-  clears on the epoch alone at `:5251-5253` (in the arm at `:5247-5254`) and selects
-  `remaining_targets` from `active_members()` at `:10317-10320`.
-- **D5 is scoped to the remove path; ban's silent zero-fill survives F1 untouched.** At
-  ban's `:10313-10316` — the site D5 already cites — the rekey still does
-  `let mut sec = [0u8; 32];` and copies only `if sec_vec.len() == 32`, so a wrong-length
-  rotation there seals an **all-zero key** with no error, the exact defect D5 closes in
-  remove. Out of F1's scope by decision, not by oversight, and recorded here so that D5 is
-  not misread as a repo-wide invariant and the surviving instance is not rediscovered as
-  new. This bullet is what the Positive consequence on D5 points at.
-- **Contention (D9):** N synchronous ML-KEM encapsulations inside the global
-  `named_groups` write guard; every named-group operation on the node serialises behind
-  one removal.
-- **D10 is conservative policy, not a proved requirement.** It may cost more than it buys;
-  it stays until someone pays for the compare-and-swap design that would let it go.
-- Two documentation contracts must move with the code, or they will mislead the next
-  reader: the fail-open guidance at `:870-875` ("log and proceed without the envelope"),
-  from which the remove path now departs, and the doc comment at `:11815-11823` claiming
-  the legacy GSS rekey path belongs only to the remaining guarded handlers.
-
-### Neutral / Operational
-
-- Rollout is mixed-version by nature: `#[serde(default)]` keeps the wire additive, and old
-  receivers ignore `secret_epoch`. Their behaviour is a gate item, not an assumption.
-- The abort path is a bare `return` inside the block expression opened at `:8458` — no
-  transaction, no rollback machinery. An implementation that builds one has misread D2.
-- **Preflight abort status codes are recorded, not decided.** Cited as the three
-  `return api_error(...)` statements **at `56d0c4b`**, per the convention stated above: the
-  implementation returns **424 FAILED_DEPENDENCY** for a keyless survivor (`:8613-8618`)
-  and for a build/seal failure (`:8630-8635`), and **500** for the wrong-length rotated
-  secret (`:8593-8596`).
-  424 is the honest shape — a dependency the caller can fix (the survivor's published KEM
-  key) is absent; 500 is right for the conversion because §2a is unreachable through the
-  public API, so reaching it is a server bug rather than a client one. No decision in this
-  ADR fixes these, and a future change to them does not require superseding it.
-- **What makes both publish orderings work is one conjunct, and it is load-bearing.** The
-  clear is gated on *strict* `<` (D7), so an envelope that installed first survives the
-  later commit. The reverse ordering — commit first, envelope second at equal epoch —
-  works only because the stale-envelope guard is
-  `if secret_epoch < info.secret_epoch || (secret_epoch == info.secret_epoch &&
-  info.shared_secret.is_some())` (statement `:5831-5835`; the conjunct is `:5832`), whose
-  own doc comment (`:5827-5830`) states the intent. That guard is pre-existing and F1 does
-  not change it — it is cited at the baseline, and its comment names only a *prior
-  `MemberBanned` commit*, because remove had no GSS rotation to produce the same ordering
-  when it was written. Tightening that predicate to
-  `secret_epoch <= info.secret_epoch` would silently strand every survivor on the
-  commit-first ordering: cleared by the commit, then refusing its own replacement, in
-  consensus with a matching `state_hash` and decrypting nothing. That is the F1 failure
-  re-created by a one-token edit, which is why Validation item 3 must be written to fail
-  when the conjunct is deleted rather than merely to exercise both orderings.
-- **The preflight bounds construction, not delivery, and this ADR claims nothing beyond
-  that.** `publish_named_group_metadata_event` (`:1797-1833`) returns `()` and folds both a
-  publish error and a timeout into `tracing::warn!`; the direct path's own doc comment
-  (`:1835-1837`) calls its delivery best-effort. So a crash or a failed publish *after* the
-  commit has been persisted can still leave a survivor without its envelope. That residue is
-  a delivery property of the transport, unchanged by F1 and not addressed here. **No
-  validation item reaches it:** Validation item 2 proves survivor decryptability from the
-  envelope; neither it nor the publish-attempt oracle proves delivery. Of item 4's three
-  gates, 4c observes the recipient set of the published envelopes — a publish *attempt*
-  recorded in-process, which is construction and not delivery — 4b tests key material below
-  the endpoint, and 4a observes an API refusal. So items 2 and 4 between them test the
-  construction and cryptographic behaviour of event objects and the endpoint's refusals;
-  none of their four gates reaches arrival.
+Removal and ban gain the same intended GSS confidentiality outcome, and
+preflight cannot partially commit. The cost is refusal for keyless survivors
+and global named-group serialization during preflight. Construction, not
+transport delivery, is guaranteed; ban's zero-fill residue remains out of
+scope. Clear and recipient-selection predicates differ, leaving pending-member
+reachability unresolved rather than declared defective.
 
 ## Validation
 
-An F1 runner registered as **`just adr-gates-f1`**, filtering `test(/(^|::)f1_/)` — one
-recipe, not a parallel harness. Named explicitly because the base commit's justfile has
-**no** `adr-gates` recipe at all (`grep -i adr justfile` at `e3013710d7`: no match), so an
-ADR citing that name would point at a command the branch does not add. Every F1 gate's test
-function name must begin with `f1_`, and the recipe body must carry this expression
-character for character; a recipe filtering differently from this document reintroduces the
-same defect one indirection away. Item 5 asserts against the **stored**
-`GroupInfo`, never against the discarded clone; item 6 is the load-bearing one, because a
-green all-new soak proves nothing about a mixed fleet.
+Acceptance requires independent controls showing that:
 
-**The expression is not anchored solely at `^`, because nextest's `test()` predicate matches
-a test's full path from the crate root and some F1 gates — currently items 3 and 7a — are
-nested in-crate unit tests.** A gate in `server::routes::named_groups::tests` is named
-`server::routes::named_groups::tests::f1_…`, so a bare `test(/^f1_/)` cannot reach it.
-Measured on this repo at the implementation commit `56d0c4b`:
-`test(/^server::routes::named_groups::tests::/)` selects 131 tests,
-`test(/^named_groups::tests::/)` selects 0, `test(/::named_groups::tests::/)` selects 131.
-The `^` branch is retained rather than dropped because this section permits a future F1 gate
-to be written as an integration test under `tests/`: such a gate has the unqualified name
-`f1_…` with no `::` in it, and `test()` does not see the binary id, so the `::` in
-`x0x::f1_whatever` cannot supply one. `test(/::f1_/)` alone would drop it in silence, and
-`test(/^f1_/)` alone drops every nested gate. `(^|::)` selects both shapes and admits no
-third, since the matched segment must still begin with `f1_`.
+- a survivor decrypts content published at the rotated epoch;
+- both metadata-first and envelope-first delivery orderings install the new
+  secret;
+- the removed member is excluded from published survivor envelopes and its
+  retained secret cannot open new-epoch content;
+- missing-key and seal-failure preflights leave stored, persisted, and
+  published state unchanged;
+- an old receiver reproduces the mixed-version wedge and rollout prevents it;
+  and
+- the rotated-secret producer preserves its length, epoch, and stored-value
+  invariants.
 
-A filter fails by selecting **too few** tests, and only one of the two ways of doing that is
-caught by the runner. An empty selection is already a hard failure: measured at
-cargo-nextest 0.9.126, a filter matching nothing yields `error: no tests to run` and exit
-code 4. That measurement was taken in a crate carrying no nextest configuration at all, and
-this repo's `.config/nextest.toml` sets no `no-tests` key at `e3013710d7`, `56d0c4b` or this
-commit, so nothing checked in overrides it; environment-level overrides were not enumerated
-and are not relied on below. A **non-empty subset** is not caught — a filter that
-selects some required gates and omits others runs them, passes them, and exits 0. That is
-the false green this section must exclude, and it is invisible in a pass/fail split.
-Therefore **a receipt for this recipe must state how many tests were selected, and must name
-the gate functions that count is made of.** This section fixes no single number and must not
-be read as implying one: item 1 states a property every gate has to have rather than naming
-a gate of its own, item 7a requires exactly three functions, item 7b requires none because
-no gate observes it, and the remaining items each require at least one without fixing how
-many. A receipt therefore names the items it discharges — which may be a subset, since items
-gain gates as the work lands — and the `f1_` functions discharging them, and the selected
-count must equal the length of that list. Below it, the filter dropped a gate, and that is a
-failing receipt however green the split. This section is discharged only once every item
-requiring a gate has been named across those receipts.
+Runner, receipt, break-disclosure, mutation, and gate-mapping mechanisms live
+in the [reference chapter](../design/gss-admin-remove-fail-closed.md). As
+recorded on 2026-07-27, survivor decryptability and removed-member exclusion
+block acceptance; abort and mixed-version controls remain required follow-up.
+Acceptance with follow-up outstanding is not full validation discharge.
 
-**Discharge and acceptance are two different bars, and the gap between them must be named
-here rather than left as a silent exception.** Full discharge is the sentence above. A
-smaller set — the **acceptance-blocking items** — gates acceptance of this ADR; every item
-outside that set still requires its gate, just not before acceptance. Which items block is a
-scope decision by the owner and not a technical one, so it is recorded here by name and
-re-recorded whenever it changes. **As at 2026-07-27 the blocking set is items 2 and 4**
-(David, relayed by Watson, narrowing an earlier ruling that all four then-ungated items had
-to land first); **items 5 and 6 are scheduled follow-up and do not block acceptance.**
-Accepting this ADR while that scheduled set is non-empty means its Validation section is
-knowingly partial at acceptance, and no receipt may be written or read as though the section
-were complete. Zero is likewise
-invalid, but by the runner's own exit code rather than by this rule — and stating the rule
-over a per-receipt list rather than over a fixed count keeps it sound both as further items
-gain gates and if that runner default is ever configured away.
+## Grounding
 
-**Break disclosure — required of every gate in this section.** A gate is evidence only
-against the ways of breaking that someone named. Mutation-redness does not establish that a
-gate observes its property: the §3 gates are mutation-red on the `:5832` conjunct and were
-still blind to the survivor being removed alongside the victim, because that break was never
-on anyone's list. So each gate must be accompanied by a list of the breaks considered, and
-for each either **the mutation that turns the gate red, an assertion or precondition in the
-gate that refuses the path, or a statement that the gate does not observe that break and why
-that is accepted.** A refusing precondition ranks with a mutation and is often the honest
-form: a gate asserting an exact plaintext already cannot pass on any error exit, and
-demanding a bespoke mutation per exit would buy ceremony rather than evidence. This is a
-requirement to disclose, not a
-prohibition on assertions: a rule forbidding any assertion a broken property could still
-produce would forbid 7a's own length assertion, which still yields 32 if rotation breaks by
-returning a constant.
+### G-001 — Remove and ban had different confidentiality outcomes
 
-A list drawn from the author's imagination fails the same way the gates do — an author names
-the breaks their gate already catches. The minimum content is therefore mechanical: **name
-the target operation and the observation the gate makes of it, then enumerate from the source
-every control-flow exit or alternate dispatch between the gate's entry point and that
-operation which could bypass or substitute for it — explicit returns, `?` propagation,
-`let`-`else` bindings, `match` and `if` arms, and returns from delegated handlers — and
-account for each.** A scan for `return` is a floor, not a completeness proof; this very
-handler ends in a `match` arm that exits without one. The endpoint of that path is the code
-that performs the property, not the code that reads its inputs. **Declaration for the worked
-example that follows: every line number in it resolves at `56d0c4b`, in
-`src/server/routes/named_groups.rs`, and none of them at the baseline.** For "a survivor can
-decrypt", the path runs to the key derivation at `:12353` and
-the cipher at `:12367` — not to the stored-secret read at `:12314` — and it contains **ten**
-exits, not the four that precede the read: `:12291` group-not-found, `:12294` withdrawn,
-`:12298` not-a-member, `:12306` TreeKem-plane, `:12315` no-shared-secret, `:12325`
-epoch-mismatch, `:12340` bad ciphertext base64, `:12346` bad nonce base64, `:12350` nonce
-length, `:12362` cipher-init failure. Every one yields "decryption did not succeed" — which
-is exactly what a **negative** gate such as item 4 asserts — and none of them authenticates a
-ciphertext: nine never reach the key material at all, and the tenth derives it and then fails
-to construct the cipher. Three of them (`:12340`, `:12346`, `:12350`) are reachable from
-nothing more than a malformed input the gate itself constructs. Drawing the line at the input
-read would have hidden six of the ten; drawing it at the derivation would still have hidden
-`:12362`.
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
 
-**A break list is a set of line numbers, so it means nothing without the commit it resolves
-at, and it must be re-resolved at the commit that ships.** The list above **declares** its
-resolving commit in words before its rows; it does not leave them to inherit a stamp from a
-neighbour, because a declaration is checkable and adjacency is not. That worked example is an
-illustration of the rule and **not a source any receipt may copy from**: its numbers are
-correct at `56d0c4b` and wrong in any tree that adds production lines above those handlers,
-which the F1 gates themselves do. A gate that adds production code *above* its own interval moves every line
-in that interval, so a list written against the commit the gate was designed on can be wrong
-at the commit the gate lives on — and a rebase invalidates a break list exactly as it
-invalidates a diff. This is not hypothetical: on this rule's first use a gate's own production
-hunks shifted its whole interval by fourteen lines, and a mutation aimed at a line from the
-stale list edited a blank line, did nothing, and reported the entire set green. **Two things
-follow. State the commit each list resolves at, and re-resolve it at the final SHA before the
-receipt is read as evidence. And build every mutation set with at least one arm that MUST go
-red** — that near-miss was caught only because a control arm failed to fail. A set in which
-every arm is expected green cannot distinguish a sound gate from a mutation that never landed.
+Supports: Context and Decisions 1 through 3.
 
-**A list committed alongside the code it cites cannot name its own commit, so it takes the
-other form.** Requiring the final SHA is unsatisfiable when the list ships *inside* that
-commit: the SHA does not exist until the bytes containing it are fixed. Such a list therefore
-**declares its parent, and asserts that the cited region is unchanged between that parent and
-the commit carrying the list — with a receipt, not an assurance.** A hash of the region at
-both commits is that receipt; "production is untouched" as a bare parenthetical is not, because
-it is exactly the claim a reader cannot check without redoing the work. **The region has two
-conditions, and the second is the one that bites: it must contain every cited line, and it
-must contain none of the edit that writes the receipt.** A receipt its own commit invalidates
-is worse than none — the hash is stale the moment it is recorded, and stale in a way that
-reads as verified. Hashing the file's head up to the first changed line satisfies both
-conditions only when the list sits *after* every line it cites, which is the ordinary shape
-for a break list in a test module citing production above it. A list that sits above its
-citations gets a head region that stops short of them and certifies nothing that matters:
-bound the region around the citations instead, and state its endpoints. **Both conditions can
-be met and the receipt still fail**, because a line number below an insertion does not name the
-same content at the parent and at the child: such a region needs **two endpoint pairs, one per
-commit, differing by the edit's line delta** — or to be bound by an anchor in the content
-rather than by line number at all. The ordinary shape needs neither, and the reason is worth
-stating because it is what makes head-hashing sound rather than merely convenient: **an edit
-below a region cannot move the lines above it.** Where a list is
-written against a tree it does not ship in — a review copy, a receipt
-posted before the commit lands — the final-SHA requirement above applies unchanged.
+In `src/server/routes/named_groups.rs`, ban seals its commit at `:10325`, stores
+the roster at `:10334`, persists at `:10338`, and only then attempts survivor
+envelopes at `:10349-10355`. The administrative remove path did not rotate and
+reseal. This establishes both the confidentiality gap and why ban's later
+ordering is not a fail-closed template.
 
-**The exit inventory is a floor for a second reason: some breaks are not exits at all.** Where
-a gate observes two production operations agreeing with *each other* — an encrypt and a
-decrypt, a writer and a reader, a serialiser and its parser — an edit applied to **both** sides
-leaves the gate green while the format between them moves. No control-flow exit is involved,
-so no enumeration of exits can reach it; it is found only by asking what a matched pair of
-edits would hide. Such a gate observes that the two sides agree, which is the property worth
-having, and does **not** observe that either side still matches what was there before. A
-paired-operation gate must record that as a break it does not observe, and it belongs in the
-blind-spot bucket by the direction test above: it leaves the gate green while something real
-is broken.
+### G-002 — Convergence cannot detect a stranded secret holder
 
-**One exit lies past the target operation, and it is a different kind — do not file it as
-blindness.** The interval above ends at the operation, but what a gate observes is the
-endpoint's *response*, and on the success arm this handler hands its assembled response to a
-shared terminality-recheck helper that can replace it wholesale with a withdrawn-group
-conflict. That helper can suppress a true success; it cannot manufacture one, because the
-response's payload field is encoded inline from the binding the cipher returned and has no
-other source in the handler. So it can only turn a gate red when the property holds — never
-leave one green when the property breaks. That is a **false-negative and test-isolation
-hazard**, refused by a precondition (assert the response is success-shaped before asserting
-the plaintext) together with test hygiene: the helper is driven by a process-global
-forced-withdrawal set keyed by group id, so a gate must use ids of its own and must not
-install that guard. It is recorded under that heading and **not** as an accepted blind spot.
-That term is reserved for a break that can leave a gate green, and it carries no information
-once it also covers breaks that cannot.
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
 
-**Which label a path takes is decided by direction, and one question decides it.** These
-labels collapsed into one another three times during this section's first use: twice by
-filing under the heading reserved for paths that can leave a gate green a path that can only
-turn it red and a path that cannot fire at all, and once by attributing a path to a
-Validation item whose sentence does not reach it. All three are prevented by asking, per
-path, **if this fires, which way does the gate move?**
+Supports: Context and Decision 2.
 
-- **Stays green while the property is broken** — *accepted blind spot.* The only label that
-  requires an accepted-and-why, because it is the only one that costs coverage.
-- **Turns red while the property holds** — *false-negative or test-isolation hazard.*
-  Discharged by a precondition and by test hygiene, never by a mutation: a mutation aimed at
-  it would be a mutation against a correct gate.
-- **Cannot fire** — say *unreachable* and give the reason. It needs no label at all, and
-  borrowing one that means the opposite is worse than leaving the row bare.
+`src/groups/state_commit.rs:219-228` enumerates the state-hash inputs without
+`shared_secret`. A survivor can therefore retain a matching `state_hash` while
+lacking the new secret. Convergence is not a valid oracle for survivor
+decryptability.
 
-Two things that are **not** labels. A mutation and a refusing precondition are *evidence
-forms*; either can discharge a path of any direction, so neither identifies a kind. And "no
-gate observes this" is a statement about **coverage**, which is independent of **ownership** —
-a path may be unobserved and owned by a scheduled item, or unobserved and owned by nothing.
-State which, because a plausible-sounding owner reads as discharged, and that is worse than
-recording no owner at all.
+### G-003 — A keyless state is reachable and no contrary invariant was found
 
-1. Fails on the pinned pre-fix commit (or on a mutation) and passes on the patched tree.
-2. Asserts each surviving member can **decrypt content published at the new epoch** — not
-   that its `state_hash` matches. Convergence is the wrong assertion (Context, driver 2):
-   it passes on the bug.
-3. Exercises both publish orderings, metadata-first and envelope-first, and asserts the new
-   secret installs under each.
-4. Asserts the removed member's non-decryption against the **published envelopes**, not
-   final state: a reseal aimed at the removed member must fail the gate even when the end
-   state looks tidy. Three gates discharge this item and they are not interchangeable; each
-   is named here with the thing it observes, so the mapping is checkable rather than
-   inferred. Gates are named by test function, not by line, because they are the `f1_`
-   functions the runner above filters on and no coordinate system in this document reaches
-   them.
-   - **4a** — `f1_item4a_removed_caller_refused_at_roster_guard` observes an **API-level
-     refusal**: the removed caller is refused with the roster guard's own `not a member`
-     body, not merely a `403` — a decrypt-failure 403 further down the same handler
-     satisfies a status-only assertion while proving the guard did **not** fire. That guard
-     is in `secure_group_decrypt` and fires before any `req` field is read and before any
-     cipher is reached, and the gate asserts the group is GSS-plane, so the refusal cannot
-     be the TreeKem dispatch instead. **4a discharges no part of non-decryption** — it
-     stays green if the crypto is replaced by a pass-through after the membership test. It
-     is here to establish that seam, which is why 4b must be observed below the endpoint,
-     and not as evidence for this item.
-   - **4b** — `f1_item4b_retained_secret_does_not_open_new_epoch_content` observes **key
-     material**: the secret a removed member retains does not open content sealed at the
-     new epoch. Two arms vary only the secret and the new-epoch arm must succeed, so the
-     failure is a measurement rather than a broken harness. Observed on
-     `GroupInfo::derive_message_key` **below the endpoint** — so it proves non-decryption
-     of an equivalently sealed payload, **not of a published envelope**.
-   - **4c** — `f1_item4c_remove_handler_publishes_survivors_not_the_removed_member` is the
-     only gate that observes a **published envelope**: it drives the real remove handler
-     and asserts the recipient of each published `SecureShareDelivered` includes the
-     survivor and excludes the removed member. The assertion is on the recipient set, not a
-     publish count. Observed lane is the metadata-topic publish only; the direct and
-     delayed delivery lanes are named as not observed.
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
 
-   **The residue, stated rather than left to be inferred:** no single gate asserts both
-   halves of the sentence above at once — a removed member failing to decrypt an envelope
-   that was actually published to them. 4c makes that scenario unconstructible **on the
-   observed lane** by keeping the removed member out of the recipient set, and 4b shows the
-   key such a member retains would not open it; the conjunction itself is **not observed**
-   by any gate. Coverage and ownership are independent axes (above): this item owns it, and
-   no gate covers it.
-5. Covers a missing-KEM survivor **and** a keyed survivor whose seal fails — both assert
-   the removal is refused with zero externally visible state change: unchanged
-   `secret_epoch` and `shared_secret` in the map, no persisted revision, no published
-   envelope or event. Includes the stripped-roster GSS invite state
-   (`shared_secret: Some(..)` with `kem_public_key_b64: None`) as a concrete instance.
-   This item also gates D3: a ban-shaped implementation that seals after store/save fails
-   the persisted-revision assertion even though its final state looks tidy.
-6. Mixed-version negative control: an old receiver must reproduce the permanent wedge on
-   pre-fix code, and the rollout guard must prevent it.
-7. Covers D5, which is unchanged, split by **evidence class**. The two halves are not
-   interchangeable and 7a does not subsume 7b: 7a pins the invariant §2a defends, 7b is the
-   defence itself and no gate observes it.
+Supports: Context and Decision 7.
 
-   **7a — gate-enforced (producer invariant). Citations in this sub-item are
-   `src/groups/mod.rs` at the baseline.** `GroupInfo::rotate_shared_secret` (`:429-437`) is
-   the sole production producer of the value §2a converts, and allocates it at `:431`. The
-   gate calls that method on a real `GroupInfo` and asserts three linked producer
-   properties: the returned secret is 32 bytes; `secret_epoch` advanced by exactly one
-   (`:433`); the stored `shared_secret` is the same bytes as the returned one (`:434`). The
-   pinning mutation is `vec![0u8; 32]` → `vec![0u8; 31]` at `:431`, and it turns the
-   **length** assertion red and only that one — under the mutation the epoch and
-   stored-identity assertions still execute and still pass, so they are carried by this
-   gate but not pinned by this mutation. **The three properties must therefore sit in three
-   separate test functions.** Combined into one, the length assertion panics first and the
-   other two never run: the receipt would then show only that "7a turned red" and would
-   demonstrate nothing about which assertion the mutation pins, leaving the claim in this
-   sub-item unfalsifiable by its own gate. **Three functions are necessary but not
-   sufficient**, because `cargo nextest` is fail-fast by default: with no flag it cancels
-   the run on the first failure. The repo's `.config/nextest.toml` sets no `fail-fast` key —
-   it is byte-identical at the baseline and at `56d0c4b` — so that default governs here.
-   That default's effect on the receipt is a race, not a property: fail-fast cancels only
-   what is still queued at the instant of failure, so whether either unaffected test is
-   omitted depends on scheduling — thread count, ordering, and how long the siblings run.
-   In Watson's measured matrix the serial no-flag run stopped after two of three results,
-   while in six default-parallel no-flag runs all three tests were already scheduled when
-   the failure landed and the complete PASS/PASS/FAIL split survived — and those runs still
-   reported `Cancelling due to test failure:`. Both halves are observations of that matrix,
-   not guarantees of either scheduling mode. **The split is therefore an
-   outcome, not a proof of execution shape — a compliant-looking receipt can be produced
-   without the flag**, which is why reporting the split cannot be the criterion. The receipt
-   must evidence the invocation. Primary evidence is the exact command, which must contain
-   `--no-fail-fast` or be three separate invocations, one per test; corroborating evidence
-   is the runner's verbatim output naming all three tests. Verbatim output alone does not
-   suffice — it can be excerpted or reformatted, so the absence of `Cancelling due to test
-   failure:` is a tell and not a guarantee. If `just adr-gates-f1` is the recorded
-   invocation, the recipe body must be quoted beside it so that its `--no-fail-fast` is
-   visible; otherwise the recipe silently reintroduces the ambiguity this paragraph exists
-   to remove. `--test-threads=1 --no-fail-fast` is the least ambiguous shape, though serial
-   execution is not required once the flag is explicit. A separate broken-expectation
-   control proves the runner can report red.
+`GroupInfo::with_policy` creates a secret for encrypted groups
+(`src/groups/mod.rs:346-354`, installed at `src/groups/mod.rs:390`), while the
+non-TreeKEM invite path clears it only for TreeKEM
+(`src/server/routes/named_groups.rs:7632-7638` and `:7656-7658`) and the invite
+snapshot strips roster ML-KEM keys (`src/server/routes/identity.rs:382`, copied
+at `src/server/routes/named_groups.rs:7671-7672`). This proves that
+`shared_secret: Some(..)` and a missing roster KEM key can coexist; it does not
+prove that locally generated secret is the authority's live secret.
 
-   **7b — source-reviewed defence, not a gate. All citations in this sub-item are at
-   `56d0c4b` except those naming `src/groups/`, which are at the baseline.** If the 7a
-   invariant ever fails despite the gate, the §2a conversion (`:8590-8598`) aborts: its
-   `return api_error(...)` statement (`:8593-8596`) precedes `seal_commit` (`:8640`), the
-   map insert (`:8651`), persistence (`:8667`) and publication (`:8688`). Between the
-   `named_groups.write()` acquisition (`:8548`) and that return, **no live group entry is
-   mutated**, and the reason is structural rather than an enumeration: the only handle to
-   the entry in that window is the shared reference `info` from `named_groups.get(&id)`
-   (`:8549`), through which no mutation is expressible, and the guard is not used again
-   until the insert at `:8651`. Two private clones *are* mutated and both are discarded on
-   return: the ADR-0016 precheck at `:8563` calls `last_admin_precheck` (`:10169-10175`),
-   which delegates to `last_admin_precheck_error` (`src/groups/mod.rs:268-277`) and applies
-   the caller's roster mutation to its own `proposed` clone (`src/groups/mod.rs:272-273`);
-   the handler then mutates its private `next` clone (`:8567`). So there is no stored,
-   persisted or published state for the abort to change. The `Err(v)` arm (`:8592`) binds
-   the secret-bearing `Vec` solely to read `v.len()` (`:8595`).
-   **No gate observes the abort, the zero state change, or the absence of an all-zero-key
-   envelope** — the branch has no production producer that can reach it, and the only ways
-   to drive it are a `#[cfg(test)]` hook on `GroupInfo`, a test parameter on
-   `rotate_shared_secret`, or moving rotation out of the handler. D5 does not justify that
-   production surface. If a future change gives the wrong-length value a real producer, 7b
-   becomes a required gate.
+### G-004 — The conservative lock rule was screened, not proved
 
-   **Scope: 7b describes the remove handler and nothing else. The other consumer of the same
-   producer fails the opposite way.** `ban_group_member` also calls `rotate_shared_secret()`
-   and also narrows `Vec<u8>` to `[u8; 32]`, but by zero-initialising and copying under a
-   length test with **no `else`** (`:10492-10496`). On a wrong-length secret the array stays
-   all zeros and flows on as `Some(sec)` (`:10521`) into `publish_secure_share` (`:10556`),
-   while `rotate_shared_secret` has already stored the wrong-length value on `next` — so the
-   actor's own record and every sealed envelope would disagree, at a known key. This is not
-   reachable today, for the same reason §2a is not: `src/groups/mod.rs:431` (baseline)
-   hardcodes 32, and 7a now pins it. It is recorded because 7b's "defence in depth" reading
-   was derived from one consumer and is **false of the other** — for remove the 7a gate is
-   the second line of defence, for ban it is the only one. A reader sweeping this file for
-   `[0u8; 32]` will also find `approve_join_request` (`:10893`); that site is **not** the
-   same shape — its length test is on the match arm (`:10892`), so a wrong-length secret
-   fails to match and no zero key is published.
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
 
-**Review triggers.** Re-run the structural audit above, and re-open D10, if any of these
-change: a new `named_groups.write()` writer is added, the membership-lock boundary moves,
-or a positive enrollment invariant for roster KEM keys is established (which would reopen
-D8).
+Supports: Decision 8.
+
+A syntax-aware census found 73 `named_groups.write()` expressions under
+`src/`, including 32 production writes before the inline test module. The
+review reduced the writers without a lexical membership-lock reference to 13
+production candidates and found no path mutating an existing named group
+outside that group's membership mutex. The negative is commit-scoped and its
+classifier is textual; it is evidence for caution, not a permanent invariant.
+The complete audit and reproduction command are retained in the reference
+chapter.
+
+### G-005 — The landed implementation demonstrates the preflight boundary
+
+Resolves at: `56d0c4bc61fbb649042aad8ea42d25d8f0c85c39`
+
+Supports: Decisions 2 through 6 and Consequences.
+
+In `src/server/routes/named_groups.rs`, the wrong-length conversion aborts at
+`:8590-8598` before `seal_commit` (`:8640`), map insertion (`:8651`),
+persistence (`:8667`), and publication (`:8688`). The survivor set is selected
+at `:8602-8606`, and preflight failures return before the sealed commit becomes
+live. These observations establish the boundary; they do not prove delivery
+after persistence.
 
 ## Open, and deliberately not decided here
 
-Whether the secret `GroupInfo::with_policy` generates for an invite stub
-(`src/groups/mod.rs:346-354`, installed at `:390`) is ever the *authority's* secret, or a
-locally-random value the joiner can decrypt nothing with. If the latter, the GSS invite
-path has a separate and possibly worse defect. It is Sam's finding, it needs its own
-record, and it does not change any decision above.
-
-Making D10 a permanent invariant rather than a commit-scoped policy is out of scope: it
-requires a revision/state-hash compare-and-swap design, not an audit.
+Whether the secret generated for a non-TreeKEM invite stub is ever the
+authority's live secret remains open. Making the map-lock rule permanent also
+remains out of scope; that requires a compare-and-swap design rather than a
+commit-scoped audit.
 
 ## Notes for AI-assisted work
 
-AI tools may help draft this ADR, but **must not mark it Accepted without human review**.
-Accepted ADRs are immutable: create a new superseding ADR rather than editing an Accepted
-ADR. David approved the design this ADR records (F1 spec rev 4.2) on 2026-07-27; the
-status flips to Accepted only after Sam's and Watson's review of this file against the
-implementation branches.
+AI tools may help draft this ADR, but must not mark it Accepted without human
+review. Accepted ADRs are immutable; a later decision requires a superseding
+ADR. The detailed reference chapter remains mutable under this decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ This directory contains architecture decision records for x0x.
 ## Proposed
 
 - [ADR 0021: DM Origin-Machine Attestation for Gossip DMs](./0021-dm-origin-machine-attestation.md) — machine-key attestation of DM origin; codec scaffolding landed (`DmOriginAttestation` in `src/dm.rs`) but enforcement not yet wired
+- [ADR 0024: GSS Rotation on Admin Remove Is Fail-Closed and Seals Before It Persists](./0024-gss-rotation-on-admin-remove-fail-closed.md) — the legacy GSS plane (ADR 0010) rotates and reseals on admin remove as it already does on ban; every survivor envelope is built before `seal_commit`, persistence and publication, and any failure aborts the removal outright; records the accepted availability and map-lock contention costs, and the no-drop map-lock rule as conservative policy whose necessity is unproven
 
 ## Errata (Accepted ADRs are immutable; corrections recorded here)
 

--- a/docs/design/gss-admin-remove-fail-closed.md
+++ b/docs/design/gss-admin-remove-fail-closed.md
@@ -19,6 +19,8 @@ computed from that field; no ADR-side chapter allowlist is maintained.
 Repository-baseline citations in this section resolve at:
 `e3013710d7ed69077de9a799dffdbeb5ac80535a`, with
 `git status --porcelain src/` empty.
+Unless a citation names another file, every bare `:N` or `:N-N` citation
+resolves to `src/server/routes/named_groups.rs`.
 
 **Two coordinate systems.** Code that F1 itself introduced does not exist at the baseline
 and cannot be cited there, so every such citation is stamped **at `56d0c4b`** in place —

--- a/docs/design/gss-admin-remove-fail-closed.md
+++ b/docs/design/gss-admin-remove-fail-closed.md
@@ -1,0 +1,762 @@
+# GSS Admin-Remove Rotation and Fail-Closed Preflight
+
+- **Status:** Draft reference implementation
+- **Governing decision:** [ADR 0024](../adr/0024-gss-rotation-on-admin-remove-fail-closed.md)
+- **Source migration:** ADR 0024 at
+  `111f4f86e3ad11a943473e702d6b46a5e62735c0`
+
+This chapter owns the mutable implementation ordering, audit procedure, gate
+mechanics, receipt schema, and rollout constraints that implement ADR 0024.
+The ADR owns the stable architectural decision and its Grounding appendix owns
+the evidence supporting it. Changes here do not amend the ADR; a mechanism
+that cannot satisfy the ADR requires a superseding decision.
+
+The chapter declares its governing ADR. ADR-to-chapter membership must be
+computed from that field; no ADR-side chapter allowlist is maintained.
+
+## 1. Citation coordinates and convention
+
+Repository-baseline citations in this section resolve at:
+`e3013710d7ed69077de9a799dffdbeb5ac80535a`, with
+`git status --porcelain src/` empty.
+
+**Two coordinate systems.** Code that F1 itself introduced does not exist at the baseline
+and cannot be cited there, so every such citation is stamped **at `56d0c4b`** in place —
+the F1 implementation commit `56d0c4bc61fbb649042aad8ea42d25d8f0c85c39` on `glm/f1-fix`.
+That commit is +11/-5; the whole range `e3013710d7..56d0c4b` is +231/-40. **Both touch
+exactly one file, `src/server/routes/named_groups.rs`** — and it is the *range*, not the
+commit alone, that licenses the carve-out below. **An
+unstamped citation is at the baseline, and a stamp never carries from one citation to the
+next — adjacency is not a scope.** An enumeration may instead **declare** a single resolving
+commit for all of its rows, in words, immediately before them; that declaration governs
+exactly those rows and nothing else. Anything covered by neither an in-place stamp nor such a
+declaration is at the baseline, and no exception is to be inferred from a neighbouring
+citation. Because nothing outside `named_groups.rs` changes anywhere in that range, cites
+into `src/groups/` resolve identically at either. The +231 lines shift everything below
+them, so a `named_groups.rs` number read during implementation review is not the same
+number at the baseline and must be translated rather than carried across.
+
+**Citation convention.** Multi-line write sites are cited as **statements** — the full
+statement including `.insert(...)`. The ast-grep pattern used for the audit below matches
+only the sub-expression ending at `.await`, so the matched expression is one line shorter
+than each statement cited here (`:6649-6652` vs `:6649-6653`). Statement ranges are what
+a reader needs to find the write; the expression range is an artefact of the instrument.
+
+## 2. Remove-path implementation contract
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Resolution scope: named-group and group primitives at the repository baseline.
+This section specifies the implementation shape required by ADR 0024; it does
+not assert that F1 exists at the baseline. Labels D1–D10 are retained source
+mechanism labels; the ADR's eight decision clauses are the governing authority.
+
+**D1 — Rotate on remove.** The GSS admin-remove path rotates the group shared secret and
+reseals it to every active non-actor survivor, so removal matches ban in effect.
+
+**D2 — Fail closed, for missing and unusable keys alike.** Every survivor envelope is
+built and validated in memory before `seal_commit`. On any missing KEM key, unusable key
+or seal error the handler bare-returns. Ban's `warn + continue` at `:10349-10355` is not
+mirrored. The abort guarantee is stated precisely: `rotate_shared_secret` has *already*
+mutated the clone (`next`, `:8478`) by the time the preflight can fail, so the guarantee
+is that **no rotation becomes live, persisted or published — the rotated clone is
+discarded**, not that nothing was rotated.
+
+**D3 — Ordering is normative, and diverges from ban after `:10325`.** Between `:8481` and
+`:8482`: `remove_member` → `is_encrypted` → `rotate_shared_secret` → fallible secret
+conversion (D5) → collect active non-actor survivors → **build every envelope** → abort on
+any failure → only then `seal_commit` (`:8482`), `named_groups.insert` (`:8494`),
+`save_named_groups` (`:8510`), and finally publish the buffered envelopes and the
+`MemberRemoved` event (`:8524`). Sealing moves **ahead** of persistence; that inversion is
+the whole of D2's mechanism.
+
+**D4 — The preflight needs a side-effect-free builder, not a `#[must_use]`.**
+`publish_secure_share` (`:877-929`) seals *and* broadcasts in one async function, so its
+`bool` only exists after publication and cannot gate anything. A builder covering
+`:888-919` (base64 decode, AAD, KEM seal, event construction) is extracted;
+`publish_secure_share` keeps `:920-928` and its current signature for the approval and ban
+callers. Every builder input exists before `seal_commit` — the AAD is
+`secure_share_aad(group_id, recipient_hex, secret_epoch)` (`:898`), none of whose three
+inputs depends on the sealed commit — so this is a pure reordering, not a restructuring.
+
+**D5 — The `Vec<u8>` → `[u8; 32]` conversion is fallible, and never logs its error.**
+`rotate_shared_secret` returns `Vec<u8>` (`src/groups/mod.rs:429`) while
+`seal_group_secret_to_recipient` requires `&[u8; 32]` (`src/groups/kem_envelope.rs:140-144`).
+Both idioms already in the file are silent: ban's `:10313-10316` leaves `sec` as
+`[0u8; 32]` and rotates the group onto a known-zero key; approval's guard at `:10880`
+falls through to a catch-all that drops the envelope. Neither is acceptable. The
+conversion aborts with a 500. `impl TryFrom<Vec<T>> for [T; N]` has `Error = Vec<T>`, so
+the error value **is the secret material** — only its length may be read or logged.
+Scoped honestly: not a live defect at this commit (`rotate_shared_secret` allocates 32
+bytes at `mod.rs:431`), but it is the one failure mode the fail-closed design does not
+otherwise cover, because sealing a zero secret *succeeds*. **Scope: D5 binds the remove
+path only.** It does not reach ban's `:10313-10316`, which this ADR leaves as it found it;
+that surviving instance is recorded under Negative / Trade-offs. D5 must not be read as a
+repo-wide property of the conversion.
+
+**D6 — Self-removal is rejected before the membership lock.** A self-targeted remove is
+rejected between `:8439` and `:8440`, before the lock at `:8443-8444`. It is not
+redirected: `leave_group` (`:9651-9654`) re-acquires the same per-group lock at
+`:9663-9664` and `tokio::sync::Mutex` is not reentrant, so a redirect self-deadlocks while
+holding that lock. The pre-lock placement also short-circuits a divergence live on the
+TreeKEM plane at this commit — `remove_treekem_named_group_member` sets `treekem_epoch`
+unconditionally at `:9327` and receivers reject it at `:4956-4958` whenever
+`self_leave_auth` holds.
+
+**D7 — The wire stays additive; the apply arm mirrors ban's branch.** `MemberRemoved`
+gains `secret_epoch: Option<u64>` with `#[serde(default)]`; only the GSS sender at `:8512`
+ever populates it. The apply mutator gains ban's `else if` (`:5247-5254`) at `:4979`:
+epoch and `security_binding` are written **unconditionally** and only the secret clear is
+gated on strict `<`. Conditioning the `security_binding` write on local secret state would
+make two receivers in different local states compute different `state_hash` values for the
+same commit — it is a hashed input: the parameter is `state_commit.rs:226` and its
+absorption into the hash buffer is `:237` (`:238` absorbs `withdrawn`, a different input).
+A step-0 guard rejecting
+`self_leave_auth && secret_epoch.is_some()` sits outside the plane split, as the backstop
+against a crafted `MemberSelf` commit, which validates by construction
+(`state_commit.rs:737`).
+
+**D8 — Availability cost of D2, knowingly accepted.** A group containing any active member
+without a roster KEM key cannot remove anyone until that member publishes one. This is
+taken deliberately while no positive enrollment invariant exists; the remedy is to publish
+the key. If such an invariant is later established, fail-open for the missing-key case
+becomes reconsiderable — by a new ADR, not by an implementation change.
+
+**D9 — Lock-contention cost of the preflight, knowingly accepted.** The preflight places N
+ML-KEM encapsulations inside the `state.named_groups` **write** guard (acquired `:8459`,
+released `:8495`), which is global over every named group, not the per-group membership
+lock. Ban pays none of this because its sealing loop runs after `drop(groups)` at `:10337`.
+For the duration of one removal every named-group operation on the node serialises behind
+it. The work is synchronous — `seal_group_secret_to_recipient` is `pub fn`, not async —
+so there is no await inside the guard and no deadlock risk. We take the contention.
+
+**D10 — Do not drop and re-acquire the map lock mid-preflight. Conservative; its necessity
+is unproven.** `next` is inserted under the same guard that produced it. This is the rule
+D9 is the invoice for: holding the map guard through the preflight is exactly what it
+mandates. Recorded as policy, not as a proved requirement — see the audit below. The rule
+adds no rollback and no compare-and-swap machinery, and knowingly pays D9's cost. We take
+that trade because the failure it forecloses — writing a stale `next` over a concurrent
+write — is silent and unrecoverable, while contention is neither. **A future optimisation
+that drops the guard needs a fresh audit at that commit plus an explicit
+revision/state-hash compare-and-swap, not a lock-gap argument.**
+
+## 3. D10 writer audit
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Resolution scope: the production `src` tree at the baseline. The audit is a
+commit-scoped screen and does not establish a permanent locking invariant.
+
+The membership lock taken at `:8443-8444` is held to the end of the handler, so dropping
+the *map* lock mid-preflight is already safe against every writer that also takes the
+membership lock. The residual risk class is exactly: **writers that mutate an existing
+`GroupInfo` under `named_groups.write()` without the membership lock.**
+
+That class was screened structurally, with ast-grep — the only instrument that sees
+multi-line receiver chains:
+
+```bash
+sg run --lang rust -p '$STATE.named_groups.write().await' --json=stream src
+```
+
+`$STATE` is a metavariable, so it matches any receiver and matches across line breaks.
+Note that `range.start.line` in that output is **0-indexed**; every line number here is
+the 1-indexed value.
+
+| Figure | Value |
+|---|---|
+| structural matches under `src/` | 73 |
+| of those, in `src/server/routes/named_groups.rs` | 72 |
+| the single match elsewhere | `src/server/routes/named_groups/tests/cache_hardening_followup.rs:955` (a test) |
+| before the inline `mod tests` (`#[cfg(test)]` `:14002`, `mod tests` `:14003`) | 33 |
+| less the `#[cfg(test)]` helper write at `:9832` (fn `:9820-9821`) | **32 production** |
+| test-only across `src/` (39 in-module + `:9832` + the file above) | 41 |
+
+**A line grep cannot do this job, and the difference is not cosmetic.** A text pattern
+requires receiver and `.write()` on one line, so it sees 49 of the 72 in this file; the
+23 it misses are exactly the multi-line chains, three of them production:
+
+| statement | enclosing fn |
+|---|---|
+| `:6649-6653` | `create_named_group` (`:6466`) |
+| `:7845-7849` | `join_group_via_invite` (`:7712`) |
+| `:12628-12632` | `persist_treekem_and_named_groups_atomic_with_info` (`:12564`) |
+
+**The enumeration is complete, not merely self-consistent.** The **33 pre-inline-test-module
+writes** live in **32** enclosing functions; exactly **14** of those contain no lexical
+`group_membership_lock`; one of the 14 is `#[cfg(test)]`; that leaves **13 production
+candidates**. (33 is the pre-`mod tests` count and still includes the `#[cfg(test)]` helper
+subtracted in the table above — the 32 production figure and the 32 enclosing functions are
+different quantities that coincide numerically.)
+
+| fn | decl | write |
+|---|---|---|
+| `publish_group_card_to_discovery_inner` | `:1006` | `:1018` |
+| `store_named_group_info` | `:2062` | `:2067` |
+| `apply_recovered_member_key_package_locked` | `:3684` | `:3718` |
+| `create_named_group` | `:6466` | `:6649` |
+| `add_treekem_named_group_member` | `:8181` | `:8351` |
+| `wipe_local_group_crypto_material` | `:8872` | `:8879` |
+| `retain_withdrawn_group_tombstone` | `:9008` | `:9018` |
+| `drop_local_named_group_state` | `:9036` | `:9045` |
+| `leave_treekem_group` | `:9085` | `:9148` |
+| `remove_treekem_named_group_member` | `:9177` | `:9314` |
+| `ban_treekem_group_member` | `:10416` | `:10539` |
+| `approve_treekem_join_request` | `:10966` | `:11129` |
+| `persist_treekem_and_named_groups_atomic_with_info` | `:12564` | `:12628` |
+| — excluded — `maybe_force_withdrawn_group_for_test` | `:9821` (`#[cfg(test)]` `:9820`) | `:9832` |
+
+Reproduced independently four times (Sam, Dario, Watson, and one further re-derivation).
+Sam derived the 13 by hand first; deriving the same 13 from the structural census is what
+makes the set **exhaustive** rather than merely agreed.
+
+**Screening result: the residual class is empty at this commit.** All 13
+`store_named_group_info` call sites (`:4918, :5051, :5149, :5199, :5301, :5357, :5447,
+:5641, :5685, :5722, :5788, :5887, :6253`) take `resolved_group_key`, the key the
+serialized apply's guard is acquired on at `:4583-4584`. `create_named_group` is the one
+genuinely unlocked map writer and is not a counter-example: it generates a fresh random
+32-byte id at `:6470-6474` and inserts under it (`:6649-6653`), so it does not overwrite
+existing state in intended execution; a random-id collision would be a different defect
+shape, not a basis for this rule.
+
+**Three limits on that negative, stated so it is not over-read:**
+
+- It is a **scoped negative at one commit**: *at `e3013710d7ed69077de9a799dffdbeb5ac80535a`,
+  in the production `src` tree, no path was found that mutates an existing named group
+  outside that group's membership mutex.* It is not a proven invariant and does not hold
+  itself tomorrow. F1 must not silently move the lock boundary on the strength of it.
+- The classifier partitioning locked from unlocked is **textual** ("the body contains
+  `group_membership_lock`, delimited by the next top-level `fn`"). It reproduces the
+  partition exactly; it is **not** proof of lock coverage for the 18 functions marked
+  locked — none was checked for locking the *same key*.
+- The per-delegate chains (the `_locked` helpers and
+  `persist_treekem_and_named_groups_atomic_with_info` running under a parent handler's live
+  guard) rest on Sam's call-site work, not re-derived here.
+
+**The justification originally offered for D10 was refuted and is withdrawn.** Group-card
+import was put forward as a live writer outside the membership lock; it is not.
+`import_group_card` binds a *named* `_membership_guard` at `:11571-11572`, live to the end
+of the function, covering both the map write at `:11682` and the `get_mut` refresh at
+`:11727`; it is the same lock, since `group_membership_lock` normalises through
+`stable_group_id()` (`:4407-4422`) and the stub is inserted under the card's own
+`group_id`. The strongest alternative candidate fails too:
+`publish_group_card_to_discovery_inner` (`:1006`) takes `get_mut` at `:1019` but its only
+`&mut` use is `seal_commit` at `:1027` behind `if reseal` (`:1022`), and its two call sites
+are `:992` (`false`) and `:1003` (`true`, inside `publish_group_card_with_reseal`, which
+takes the membership lock first at `:1001-1002`). This is recorded as **false** precisely
+so a later reader does not rediscover the refutation and delete D10 believing the rule
+rested on it. D10 rests on conservatism, and on nothing else.
+
+### The finding that argues hardest for D10
+
+`join_group_via_invite` writes at `:7845` in multi-line form. Every text search in the
+review missed it — **and it does take the membership lock**, which is why it correctly
+never appeared in the candidate 13. It was invisible and harmless. That is luck, not
+method: an invisible write could as easily have been an unlocked existing-group mutator,
+and the scoped negative would have been false with three reviewers' sign-off on it. It
+surfaced only because a figure flagged as non-blocking was chased anyway. **The next
+claim of this shape must be run structurally, not derived from a text search.**
+
+## 4. Operational boundaries and residues
+
+### Positive
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+- Removal and ban have the same security outcome on the GSS plane: the removed member
+  **cannot decrypt content published at the rotated epoch**.
+- **No KEM/preflight-induced partial commit is reachable:** either every survivor envelope
+  is buildable or the removal aborts. Scoped deliberately to what the preflight proves —
+  see the delivery limit under Neutral / Operational.
+- Rotation never becomes observable from a failed attempt: the mutation happens on a
+  private clone that is dropped.
+- **The remove path** can no longer rotate onto an all-zero key through a silent conversion
+  (D5). Scoped to the remove path deliberately — see the ban residue under Negative /
+  Trade-offs; D5 is not a repo-wide property and this consequence must not be read as one.
+- The correctness of D10's evidence is now checkable — the audit's instrument, figures and
+  enumeration are recorded, so re-running it is mechanical.
+
+### Negative / Trade-offs
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`,
+except citations explicitly marked as resolving at
+`56d0c4bc61fbb649042aad8ea42d25d8f0c85c39`.
+
+- **Availability (D8):** one active member without a roster KEM key blocks all removals in
+  that group until they publish one.
+- **The clear predicate and the delivery predicate are not the same predicate, and this
+  ADR does not reconcile them.** The receiver clears on an epoch comparison alone —
+  `if old_epoch < secret_epoch { next.shared_secret = None }` (**both of the next two are at
+  `56d0c4b`**: `:5052-5054`, in the arm at `:5048-5055`), which does not consult the receiving node's
+  own membership state. The sender selects envelope recipients by roster state:
+  `active_members()` minus the actor (`:8602-8606` **at `56d0c4b`**), and `active_members()`
+  admits only `GroupMemberState::Active` (`src/groups/mod.rs:1080-1082`,
+  `src/groups/member.rs:226-228`). So any node that holds the old secret and is not
+  `Active` on the sender's roster clears it and receives no replacement. For `Removed` and
+  `Banned` that is the intent. For **`Pending` it is undecided** — D2 is written over
+  "survivors" and never states which predicate defines the set. **Nobody has established
+  that a `Pending` node can hold the live secret when the event applies**, so this is an
+  unexamined reachability and availability risk, not a demonstrated defect; it is recorded
+  so the next reader does not have to rediscover it. There is a standing promise in tension
+  with it: the approval path's `(None, _)` arm (`:10895-10900`) logs *"requester will
+  receive via next rekey"* (`:10898`), and both rekey paths draw from `active_members()`,
+  so that promise holds only for a requester who is `Active` when the next rekey runs.
+  **Pre-existing, not introduced here:** ban already pairs the same two predicates — it
+  clears on the epoch alone at `:5251-5253` (in the arm at `:5247-5254`) and selects
+  `remaining_targets` from `active_members()` at `:10317-10320`.
+- **D5 is scoped to the remove path; ban's silent zero-fill survives F1 untouched.** At
+  ban's `:10313-10316` — the site D5 already cites — the rekey still does
+  `let mut sec = [0u8; 32];` and copies only `if sec_vec.len() == 32`, so a wrong-length
+  rotation there seals an **all-zero key** with no error, the exact defect D5 closes in
+  remove. Out of F1's scope by decision, not by oversight, and recorded here so that D5 is
+  not misread as a repo-wide invariant and the surviving instance is not rediscovered as
+  new. This bullet is what the Positive consequence on D5 points at.
+- **Contention (D9):** N synchronous ML-KEM encapsulations inside the global
+  `named_groups` write guard; every named-group operation on the node serialises behind
+  one removal.
+- **D10 is conservative policy, not a proved requirement.** It may cost more than it buys;
+  it stays until someone pays for the compare-and-swap design that would let it go.
+- Two documentation contracts must move with the code, or they will mislead the next
+  reader: the fail-open guidance at `:870-875` ("log and proceed without the envelope"),
+  from which the remove path now departs, and the doc comment at `:11815-11823` claiming
+  the legacy GSS rekey path belongs only to the remaining guarded handlers.
+
+### Neutral / Operational
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`,
+except citations explicitly marked as resolving at
+`56d0c4bc61fbb649042aad8ea42d25d8f0c85c39`.
+
+- Rollout is mixed-version by nature: `#[serde(default)]` keeps the wire additive, and old
+  receivers ignore `secret_epoch`. Their behaviour is a gate item, not an assumption.
+- The abort path is a bare `return` inside the block expression opened at `:8458` — no
+  transaction, no rollback machinery. An implementation that builds one has misread D2.
+- **Preflight abort status codes are recorded, not decided.** Cited as the three
+  `return api_error(...)` statements **at `56d0c4b`**, per the convention stated above: the
+  implementation returns **424 FAILED_DEPENDENCY** for a keyless survivor (`:8613-8618`)
+  and for a build/seal failure (`:8630-8635`), and **500** for the wrong-length rotated
+  secret (`:8593-8596`).
+  424 is the honest shape — a dependency the caller can fix (the survivor's published KEM
+  key) is absent; 500 is right for the conversion because the D5 wrong-length
+  branch is unreachable through the public API, so reaching it is a server bug
+  rather than a client one. No decision in this ADR fixes these, and a future
+  change to them does not require superseding it.
+- **What makes both publish orderings work is one conjunct, and it is load-bearing.** The
+  clear is gated on *strict* `<` (D7), so an envelope that installed first survives the
+  later commit. The reverse ordering — commit first, envelope second at equal epoch —
+  works only because the stale-envelope guard is
+  `if secret_epoch < info.secret_epoch || (secret_epoch == info.secret_epoch &&
+  info.shared_secret.is_some())` (statement `:5831-5835`; the conjunct is `:5832`), whose
+  own doc comment (`:5827-5830`) states the intent. That guard is pre-existing and F1 does
+  not change it — it is cited at the baseline, and its comment names only a *prior
+  `MemberBanned` commit*, because remove had no GSS rotation to produce the same ordering
+  when it was written. Tightening that predicate to
+  `secret_epoch <= info.secret_epoch` would silently strand every survivor on the
+  commit-first ordering: cleared by the commit, then refusing its own replacement, in
+  consensus with a matching `state_hash` and decrypting nothing. That is the F1 failure
+  re-created by a one-token edit, which is why Validation item 3 must be written to fail
+  when the conjunct is deleted rather than merely to exercise both orderings.
+- **The preflight bounds construction, not delivery, and this ADR claims nothing beyond
+  that.** `publish_named_group_metadata_event` (`:1797-1833`) returns `()` and folds both a
+  publish error and a timeout into `tracing::warn!`; the direct path's own doc comment
+  (`:1835-1837`) calls its delivery best-effort. So a crash or a failed publish *after* the
+  commit has been persisted can still leave a survivor without its envelope. That residue is
+  a delivery property of the transport, unchanged by F1 and not addressed here. **No
+  validation item reaches it:** Validation item 2 proves survivor decryptability from the
+  envelope; neither it nor the publish-attempt oracle proves delivery. Of item 4's three
+  gates, 4c observes the recipient set of the published envelopes — a publish *attempt*
+  recorded in-process, which is construction and not delivery — 4b tests key material below
+  the endpoint, and 4a observes an API refusal. So items 2 and 4 between them test the
+  construction and cryptographic behaviour of event objects and the endpoint's refusals;
+  none of their four gates reaches arrival.
+
+## 5. F1 runner and acceptance receipts
+
+Repository-baseline citations in this section resolve at:
+`e3013710d7ed69077de9a799dffdbeb5ac80535a`. Measurements explicitly naming
+the implementation commit resolve at:
+`56d0c4bc61fbb649042aad8ea42d25d8f0c85c39`.
+
+An F1 runner registered as **`just adr-gates-f1`**, filtering `test(/(^|::)f1_/)` — one
+recipe, not a parallel harness. Named explicitly because the base commit's justfile has
+**no** `adr-gates` recipe at all (`grep -i adr justfile` at `e3013710d7`: no match), so an
+ADR citing that name would point at a command the branch does not add. Every F1 gate's test
+function name must begin with `f1_`, and the recipe body must carry this expression
+character for character; a recipe filtering differently from this document reintroduces the
+same defect one indirection away. Item 5 asserts against the **stored**
+`GroupInfo`, never against the discarded clone; item 6 is the load-bearing one, because a
+green all-new soak proves nothing about a mixed fleet.
+
+**The expression is not anchored solely at `^`, because nextest's `test()` predicate matches
+a test's full path from the crate root and some F1 gates — currently items 3 and 7a — are
+nested in-crate unit tests.** A gate in `server::routes::named_groups::tests` is named
+`server::routes::named_groups::tests::f1_…`, so a bare `test(/^f1_/)` cannot reach it.
+Measured on this repo at the implementation commit `56d0c4b`:
+`test(/^server::routes::named_groups::tests::/)` selects 131 tests,
+`test(/^named_groups::tests::/)` selects 0, `test(/::named_groups::tests::/)` selects 131.
+The `^` branch is retained rather than dropped because this section permits a future F1 gate
+to be written as an integration test under `tests/`: such a gate has the unqualified name
+`f1_…` with no `::` in it, and `test()` does not see the binary id, so the `::` in
+`x0x::f1_whatever` cannot supply one. `test(/::f1_/)` alone would drop it in silence, and
+`test(/^f1_/)` alone drops every nested gate. `(^|::)` selects both shapes and admits no
+third, since the matched segment must still begin with `f1_`.
+
+A filter fails by selecting **too few** tests, and only one of the two ways of doing that is
+caught by the runner. An empty selection is already a hard failure: measured at
+cargo-nextest 0.9.126, a filter matching nothing yields `error: no tests to run` and exit
+code 4. That measurement was taken in a crate carrying no nextest configuration at all, and
+this repo's `.config/nextest.toml` sets no `no-tests` key at `e3013710d7`, `56d0c4b` or this
+commit, so nothing checked in overrides it; environment-level overrides were not enumerated
+and are not relied on below. A **non-empty subset** is not caught — a filter that
+selects some required gates and omits others runs them, passes them, and exits 0. That is
+the false green this section must exclude, and it is invisible in a pass/fail split.
+Therefore **a receipt for this recipe must state how many tests were selected, and must name
+the gate functions that count is made of.** This section fixes no single number and must not
+be read as implying one: item 1 states a property every gate has to have rather than naming
+a gate of its own, item 7a requires exactly three functions, item 7b requires none because
+no gate observes it, and the remaining items each require at least one without fixing how
+many. A receipt therefore names the items it discharges — which may be a subset, since items
+gain gates as the work lands — and the `f1_` functions discharging them, and the selected
+count must equal the length of that list. Below it, the filter dropped a gate, and that is a
+failing receipt however green the split. This section is discharged only once every item
+requiring a gate has been named across those receipts.
+
+**Discharge and acceptance are two different bars, and the gap between them must be named
+here rather than left as a silent exception.** Full discharge is the sentence above. A
+smaller set — the **acceptance-blocking items** — gates acceptance of this ADR; every item
+outside that set still requires its gate, just not before acceptance. Which items block is a
+scope decision by the owner and not a technical one, so it is recorded here by name and
+re-recorded whenever it changes. **As at 2026-07-27 the blocking set is items 2 and 4**
+(David, relayed by Watson, narrowing an earlier ruling that all four then-ungated items had
+to land first); **items 5 and 6 are scheduled follow-up and do not block acceptance.**
+Accepting this ADR while that scheduled set is non-empty means its Validation section is
+knowingly partial at acceptance, and no receipt may be written or read as though the section
+were complete. Zero is likewise
+invalid, but by the runner's own exit code rather than by this rule — and stating the rule
+over a per-receipt list rather than over a fixed count keeps it sound both as further items
+gain gates and if that runner default is ever configured away.
+
+## 6. Break disclosure and mutation receipts
+
+The receipt rules in this section are migrated from ADR 0024 at
+`111f4f86e3ad11a943473e702d6b46a5e62735c0`. Code citations in a block
+resolve only at the commit declared in that block. General-rule citations
+before the worked example resolve at:
+`e3013710d7ed69077de9a799dffdbeb5ac80535a`.
+
+**Break disclosure — required of every gate in this section.** A gate is evidence only
+against the ways of breaking that someone named. Mutation-redness does not establish that a
+gate observes its property: the Validation item 3 gates are mutation-red on the `:5832`
+conjunct and were still blind to the survivor being removed alongside the victim, because
+that break was never on anyone's list. So each gate must be accompanied by a list of the breaks considered, and
+for each either **the mutation that turns the gate red, an assertion or precondition in the
+gate that refuses the path, or a statement that the gate does not observe that break and why
+that is accepted.** A refusing precondition ranks with a mutation and is often the honest
+form: a gate asserting an exact plaintext already cannot pass on any error exit, and
+demanding a bespoke mutation per exit would buy ceremony rather than evidence. This is a
+requirement to disclose, not a
+prohibition on assertions: a rule forbidding any assertion a broken property could still
+produce would forbid 7a's own length assertion, which still yields 32 if rotation breaks by
+returning a constant.
+
+A list drawn from the author's imagination fails the same way the gates do — an author names
+the breaks their gate already catches. The minimum content is therefore mechanical: **name
+the target operation and the observation the gate makes of it, then enumerate from the source
+every control-flow exit or alternate dispatch between the gate's entry point and that
+operation which could bypass or substitute for it — explicit returns, `?` propagation,
+`let`-`else` bindings, `match` and `if` arms, and returns from delegated handlers — and
+account for each.** A scan for `return` is a floor, not a completeness proof; this very
+handler ends in a `match` arm that exits without one. The endpoint of that path is the code
+that performs the property, not the code that reads its inputs. **Declaration for the worked
+example that follows: every line number in it resolves at `56d0c4b`, in
+`src/server/routes/named_groups.rs`, and none of them at the baseline.** For "a survivor can
+decrypt", the path runs to the key derivation at `:12353` and
+the cipher at `:12367` — not to the stored-secret read at `:12314` — and it contains **ten**
+exits, not the four that precede the read: `:12291` group-not-found, `:12294` withdrawn,
+`:12298` not-a-member, `:12306` TreeKem-plane, `:12315` no-shared-secret, `:12325`
+epoch-mismatch, `:12340` bad ciphertext base64, `:12346` bad nonce base64, `:12350` nonce
+length, `:12362` cipher-init failure. Every one yields "decryption did not succeed" — which
+is exactly what a **negative** gate such as item 4 asserts — and none of them authenticates a
+ciphertext: nine never reach the key material at all, and the tenth derives it and then fails
+to construct the cipher. Three of them (`:12340`, `:12346`, `:12350`) are reachable from
+nothing more than a malformed input the gate itself constructs. Drawing the line at the input
+read would have hidden six of the ten; drawing it at the derivation would still have hidden
+`:12362`.
+
+**A break list is a set of line numbers, so it means nothing without the commit it resolves
+at, and it must be re-resolved at the commit that ships.** The list above **declares** its
+resolving commit in words before its rows; it does not leave them to inherit a stamp from a
+neighbour, because a declaration is checkable and adjacency is not. That worked example is an
+illustration of the rule and **not a source any receipt may copy from**: its numbers are
+correct at `56d0c4b` and wrong in any tree that adds production lines above those handlers,
+which the F1 gates themselves do. A gate that adds production code *above* its own interval moves every line
+in that interval, so a list written against the commit the gate was designed on can be wrong
+at the commit the gate lives on — and a rebase invalidates a break list exactly as it
+invalidates a diff. This is not hypothetical: on this rule's first use a gate's own production
+hunks shifted its whole interval by fourteen lines, and a mutation aimed at a line from the
+stale list edited a blank line, did nothing, and reported the entire set green. **Two things
+follow. State the commit each list resolves at, and re-resolve it at the final SHA before the
+receipt is read as evidence. And build every mutation set with at least one arm that MUST go
+red** — that near-miss was caught only because a control arm failed to fail. A set in which
+every arm is expected green cannot distinguish a sound gate from a mutation that never landed.
+
+**A list committed alongside the code it cites cannot name its own commit, so it takes the
+other form.** Requiring the final SHA is unsatisfiable when the list ships *inside* that
+commit: the SHA does not exist until the bytes containing it are fixed. Such a list therefore
+**declares its parent, and asserts that the cited region is unchanged between that parent and
+the commit carrying the list — with a receipt, not an assurance.** A hash of the region at
+both commits is that receipt; "production is untouched" as a bare parenthetical is not, because
+it is exactly the claim a reader cannot check without redoing the work. **The region has two
+conditions, and the second is the one that bites: it must contain every cited line, and it
+must contain none of the edit that writes the receipt.** A receipt its own commit invalidates
+is worse than none — the hash is stale the moment it is recorded, and stale in a way that
+reads as verified. Hashing the file's head up to the first changed line satisfies both
+conditions only when the list sits *after* every line it cites, which is the ordinary shape
+for a break list in a test module citing production above it. A list that sits above its
+citations gets a head region that stops short of them and certifies nothing that matters:
+bound the region around the citations instead, and state its endpoints. **Both conditions can
+be met and the receipt still fail**, because a line number below an insertion does not name the
+same content at the parent and at the child: such a region needs **two endpoint pairs, one per
+commit, differing by the edit's line delta** — or to be bound by an anchor in the content
+rather than by line number at all. The ordinary shape needs neither, and the reason is worth
+stating because it is what makes head-hashing sound rather than merely convenient: **an edit
+below a region cannot move the lines above it.** Where a list is
+written against a tree it does not ship in — a review copy, a receipt
+posted before the commit lands — the final-SHA requirement above applies unchanged.
+
+**The exit inventory is a floor for a second reason: some breaks are not exits at all.** Where
+a gate observes two production operations agreeing with *each other* — an encrypt and a
+decrypt, a writer and a reader, a serialiser and its parser — an edit applied to **both** sides
+leaves the gate green while the format between them moves. No control-flow exit is involved,
+so no enumeration of exits can reach it; it is found only by asking what a matched pair of
+edits would hide. Such a gate observes that the two sides agree, which is the property worth
+having, and does **not** observe that either side still matches what was there before. A
+paired-operation gate must record that as a break it does not observe, and it belongs in the
+blind-spot bucket by the direction test above: it leaves the gate green while something real
+is broken.
+
+**One exit lies past the target operation, and it is a different kind — do not file it as
+blindness.** The interval above ends at the operation, but what a gate observes is the
+endpoint's *response*, and on the success arm this handler hands its assembled response to a
+shared terminality-recheck helper that can replace it wholesale with a withdrawn-group
+conflict. That helper can suppress a true success; it cannot manufacture one, because the
+response's payload field is encoded inline from the binding the cipher returned and has no
+other source in the handler. So it can only turn a gate red when the property holds — never
+leave one green when the property breaks. That is a **false-negative and test-isolation
+hazard**, refused by a precondition (assert the response is success-shaped before asserting
+the plaintext) together with test hygiene: the helper is driven by a process-global
+forced-withdrawal set keyed by group id, so a gate must use ids of its own and must not
+install that guard. It is recorded under that heading and **not** as an accepted blind spot.
+That term is reserved for a break that can leave a gate green, and it carries no information
+once it also covers breaks that cannot.
+
+**Which label a path takes is decided by direction, and one question decides it.** These
+labels collapsed into one another three times during this section's first use: twice by
+filing under the heading reserved for paths that can leave a gate green a path that can only
+turn it red and a path that cannot fire at all, and once by attributing a path to a
+Validation item whose sentence does not reach it. All three are prevented by asking, per
+path, **if this fires, which way does the gate move?**
+
+- **Stays green while the property is broken** — *accepted blind spot.* The only label that
+  requires an accepted-and-why, because it is the only one that costs coverage.
+- **Turns red while the property holds** — *false-negative or test-isolation hazard.*
+  Discharged by a precondition and by test hygiene, never by a mutation: a mutation aimed at
+  it would be a mutation against a correct gate.
+- **Cannot fire** — say *unreachable* and give the reason. It needs no label at all, and
+  borrowing one that means the opposite is worse than leaving the row bare.
+
+Two things that are **not** labels. A mutation and a refusing precondition are *evidence
+forms*; either can discharge a path of any direction, so neither identifies a kind. And "no
+gate observes this" is a statement about **coverage**, which is independent of **ownership** —
+a path may be unobserved and owned by a scheduled item, or unobserved and owned by nothing.
+State which, because a plausible-sounding owner reads as discharged, and that is worse than
+recording no owner at all.
+
+## 7. Validation item matrix
+
+The item definitions in this section are migrated from ADR 0024 at
+`111f4f86e3ad11a943473e702d6b46a5e62735c0`. Code citations in a sub-item
+resolve only at the commit declared in that sub-item.
+
+1. Fails on the pinned pre-fix commit (or on a mutation) and passes on the patched tree.
+2. Asserts each surviving member can **decrypt content published at the new epoch** — not
+   that its `state_hash` matches. Convergence is the wrong assertion (ADR Grounding G-002):
+   it passes on the bug.
+3. Exercises both publish orderings, metadata-first and envelope-first, and asserts the new
+   secret installs under each.
+4. Asserts the removed member's non-decryption against the **published envelopes**, not
+   final state: a reseal aimed at the removed member must fail the gate even when the end
+   state looks tidy. Three gates discharge this item and they are not interchangeable; each
+   is named here with the thing it observes, so the mapping is checkable rather than
+   inferred. Gates are named by test function, not by line, because they are the `f1_`
+   functions the runner above filters on and no coordinate system in this document reaches
+   them.
+   - **4a** — `f1_item4a_removed_caller_refused_at_roster_guard` observes an **API-level
+     refusal**: the removed caller is refused with the roster guard's own `not a member`
+     body, not merely a `403` — a decrypt-failure 403 further down the same handler
+     satisfies a status-only assertion while proving the guard did **not** fire. That guard
+     is in `secure_group_decrypt` and fires before any `req` field is read and before any
+     cipher is reached, and the gate asserts the group is GSS-plane, so the refusal cannot
+     be the TreeKem dispatch instead. **4a discharges no part of non-decryption** — it
+     stays green if the crypto is replaced by a pass-through after the membership test. It
+     is here to establish that seam, which is why 4b must be observed below the endpoint,
+     and not as evidence for this item.
+   - **4b** — `f1_item4b_retained_secret_does_not_open_new_epoch_content` observes **key
+     material**: the secret a removed member retains does not open content sealed at the
+     new epoch. Two arms vary only the secret and the new-epoch arm must succeed, so the
+     failure is a measurement rather than a broken harness. Observed on
+     `GroupInfo::derive_message_key` **below the endpoint** — so it proves non-decryption
+     of an equivalently sealed payload, **not of a published envelope**.
+   - **4c** — `f1_item4c_remove_handler_publishes_survivors_not_the_removed_member` is the
+     only gate that observes a **published envelope**: it drives the real remove handler
+     and asserts the recipient of each published `SecureShareDelivered` includes the
+     survivor and excludes the removed member. The assertion is on the recipient set, not a
+     publish count. Observed lane is the metadata-topic publish only; the direct and
+     delayed delivery lanes are named as not observed.
+
+   **The residue, stated rather than left to be inferred:** no single gate asserts both
+   halves of the sentence above at once — a removed member failing to decrypt an envelope
+   that was actually published to them. 4c makes that scenario unconstructible **on the
+   observed lane** by keeping the removed member out of the recipient set, and 4b shows the
+   key such a member retains would not open it; the conjunction itself is **not observed**
+   by any gate. Coverage and ownership are independent axes (above): this item owns it, and
+   no gate covers it.
+5. Covers a missing-KEM survivor **and** a keyed survivor whose seal fails — both assert
+   the removal is refused with zero externally visible state change: unchanged
+   `secret_epoch` and `shared_secret` in the map, no persisted revision, no published
+   envelope or event. Includes the stripped-roster GSS invite state
+   (`shared_secret: Some(..)` with `kem_public_key_b64: None`) as a concrete instance.
+   This item also gates D3: a ban-shaped implementation that seals after store/save fails
+   the persisted-revision assertion even though its final state looks tidy.
+6. Mixed-version negative control: an old receiver must reproduce the permanent wedge on
+   pre-fix code, and the rollout guard must prevent it.
+7. Covers D5, which is unchanged, split by **evidence class**. The two halves are not
+   interchangeable and 7a does not subsume 7b: 7a pins the producer invariant D5 defends,
+   while 7b is the defence itself and no gate observes it.
+
+   **7a — gate-enforced (producer invariant). Citations in this sub-item are
+   `src/groups/mod.rs` at the baseline.** `GroupInfo::rotate_shared_secret` (`:429-437`) is
+   the sole production producer of the value D5 converts, and allocates it at `:431`. The
+   gate calls that method on a real `GroupInfo` and asserts three linked producer
+   properties: the returned secret is 32 bytes; `secret_epoch` advanced by exactly one
+   (`:433`); the stored `shared_secret` is the same bytes as the returned one (`:434`). The
+   pinning mutation is `vec![0u8; 32]` → `vec![0u8; 31]` at `:431`, and it turns the
+   **length** assertion red and only that one — under the mutation the epoch and
+   stored-identity assertions still execute and still pass, so they are carried by this
+   gate but not pinned by this mutation. **The three properties must therefore sit in three
+   separate test functions.** Combined into one, the length assertion panics first and the
+   other two never run: the receipt would then show only that "7a turned red" and would
+   demonstrate nothing about which assertion the mutation pins, leaving the claim in this
+   sub-item unfalsifiable by its own gate. **Three functions are necessary but not
+   sufficient**, because `cargo nextest` is fail-fast by default: with no flag it cancels
+   the run on the first failure. The repo's `.config/nextest.toml` sets no `fail-fast` key —
+   it is byte-identical at the baseline and at `56d0c4b` — so that default governs here.
+   That default's effect on the receipt is a race, not a property: fail-fast cancels only
+   what is still queued at the instant of failure, so whether either unaffected test is
+   omitted depends on scheduling — thread count, ordering, and how long the siblings run.
+   In Watson's measured matrix the serial no-flag run stopped after two of three results,
+   while in six default-parallel no-flag runs all three tests were already scheduled when
+   the failure landed and the complete PASS/PASS/FAIL split survived — and those runs still
+   reported `Cancelling due to test failure:`. Both halves are observations of that matrix,
+   not guarantees of either scheduling mode. **The split is therefore an
+   outcome, not a proof of execution shape — a compliant-looking receipt can be produced
+   without the flag**, which is why reporting the split cannot be the criterion. The receipt
+   must evidence the invocation. Primary evidence is the exact command, which must contain
+   `--no-fail-fast` or be three separate invocations, one per test; corroborating evidence
+   is the runner's verbatim output naming all three tests. Verbatim output alone does not
+   suffice — it can be excerpted or reformatted, so the absence of `Cancelling due to test
+   failure:` is a tell and not a guarantee. If `just adr-gates-f1` is the recorded
+   invocation, the recipe body must be quoted beside it so that its `--no-fail-fast` is
+   visible; otherwise the recipe silently reintroduces the ambiguity this paragraph exists
+   to remove. `--test-threads=1 --no-fail-fast` is the least ambiguous shape, though serial
+   execution is not required once the flag is explicit. A separate broken-expectation
+   control proves the runner can report red.
+
+   **7b — source-reviewed defence, not a gate. All citations in this sub-item are at
+   `56d0c4b` except those naming `src/groups/`, which are at the baseline.** If the 7a
+   invariant ever fails despite the gate, the D5 conversion (`:8590-8598`) aborts: its
+   `return api_error(...)` statement (`:8593-8596`) precedes `seal_commit` (`:8640`), the
+   map insert (`:8651`), persistence (`:8667`) and publication (`:8688`). Between the
+   `named_groups.write()` acquisition (`:8548`) and that return, **no live group entry is
+   mutated**, and the reason is structural rather than an enumeration: the only handle to
+   the entry in that window is the shared reference `info` from `named_groups.get(&id)`
+   (`:8549`), through which no mutation is expressible, and the guard is not used again
+   until the insert at `:8651`. Two private clones *are* mutated and both are discarded on
+   return: the ADR-0016 precheck at `:8563` calls `last_admin_precheck` (`:10169-10175`),
+   which delegates to `last_admin_precheck_error` (`src/groups/mod.rs:268-277`) and applies
+   the caller's roster mutation to its own `proposed` clone (`src/groups/mod.rs:272-273`);
+   the handler then mutates its private `next` clone (`:8567`). So there is no stored,
+   persisted or published state for the abort to change. The `Err(v)` arm (`:8592`) binds
+   the secret-bearing `Vec` solely to read `v.len()` (`:8595`).
+   **No gate observes the abort, the zero state change, or the absence of an all-zero-key
+   envelope** — the branch has no production producer that can reach it, and the only ways
+   to drive it are a `#[cfg(test)]` hook on `GroupInfo`, a test parameter on
+   `rotate_shared_secret`, or moving rotation out of the handler. D5 does not justify that
+   production surface. If a future change gives the wrong-length value a real producer, 7b
+   becomes a required gate.
+
+   **Scope: 7b describes the remove handler and nothing else. The other consumer of the same
+   producer fails the opposite way.** `ban_group_member` also calls `rotate_shared_secret()`
+   and also narrows `Vec<u8>` to `[u8; 32]`, but by zero-initialising and copying under a
+   length test with **no `else`** (`:10492-10496`). On a wrong-length secret the array stays
+   all zeros and flows on as `Some(sec)` (`:10521`) into `publish_secure_share` (`:10556`),
+   while `rotate_shared_secret` has already stored the wrong-length value on `next` — so the
+   actor's own record and every sealed envelope would disagree, at a known key. This is not
+   reachable today, for the same reason the D5 branch is not:
+   `src/groups/mod.rs:431` (baseline) hardcodes 32, and 7a now pins it. It is
+   recorded because 7b's "defence in depth" reading
+   was derived from one consumer and is **false of the other** — for remove the 7a gate is
+   the second line of defence, for ban it is the only one. A reader sweeping this file for
+   `[0u8; 32]` will also find `approve_join_request` (`:10893`); that site is **not** the
+   same shape — its length test is on the match arm (`:10892`), so a wrong-length secret
+   fails to match and no zero key is published.
+
+## 8. Reference-implementation review triggers
+
+**Review triggers.** Re-run the structural audit above, and re-open D10, if any of these
+change: a new `named_groups.write()` writer is added, the membership-lock boundary moves,
+or a positive enrollment invariant for roster KEM keys is established (which would reopen
+D8).
+
+## 9. Open implementation questions
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Whether the secret `GroupInfo::with_policy` generates for an invite stub
+(`src/groups/mod.rs:346-354`, installed at `:390`) is ever the *authority's* secret, or a
+locally-random value the joiner can decrypt nothing with. If the latter, the GSS invite
+path has a separate and possibly worse defect. It is Sam's finding, it needs its own
+record, and it does not change any decision above.
+
+Making D10 a permanent invariant rather than a commit-scoped policy is out of scope: it
+requires a revision/state-hash compare-and-swap design, not an audit.
+
+## 10. Source migration manifest
+
+Resolves at: `111f4f86e3ad11a943473e702d6b46a5e62735c0`
+
+This ledger maps every source line exactly once to its primary destination.
+The ADR carries stable decisions and Grounding evidence; this chapter carries
+mutable mechanisms, detailed audit procedure, gate definitions, and receipt
+rules. Blank lines and headings travel with their enclosing range.
+
+| Source lines | Primary destination |
+|---:|---|
+| 1–10 | ADR register and chapter header |
+| 11–37 | Chapter §1 citation coordinates and convention |
+| 38–45 | ADR Summary and Context |
+| 46–74 | ADR Grounding G-001 through G-003 |
+| 75–96 | ADR Decision Drivers and Considered Options |
+| 97–187 | ADR Decision and Chapter §2 implementation contract |
+| 188–299 | ADR Grounding G-004 and Chapter §3 writer audit |
+| 300–316 | ADR Consequences and Chapter §4 positive boundaries |
+| 317–401 | ADR Consequences, Grounding G-005, and Chapter §4 residues |
+| 402–462 | ADR Validation and Chapter §5 runner receipts |
+| 463–590 | Chapter §6 break disclosure and mutation receipts |
+| 591–722 | ADR Validation and Chapter §7 validation item matrix |
+| 723–738 | ADR Open questions and Chapter §§8–9 |
+| 739–745 | ADR Notes for AI-assisted work |
+
+The ranges are contiguous, non-overlapping, and cover source lines 1–745.
+Future edits update this chapter in place; they do not rewrite the source
+migration or amend the Proposed decision.

--- a/docs/design/gss-admin-remove-fail-closed.md
+++ b/docs/design/gss-admin-remove-fail-closed.md
@@ -447,31 +447,14 @@ resolve only at the commit declared in that block. General-rule citations
 before the worked example resolve at:
 `e3013710d7ed69077de9a799dffdbeb5ac80535a`.
 
-**Break disclosure — required of every gate in this section.** A gate is evidence only
-against the ways of breaking that someone named. Mutation-redness does not establish that a
-gate observes its property: the Validation item 3 gates are mutation-red on the `:5832`
-conjunct and were still blind to the survivor being removed alongside the victim, because
-that break was never on anyone's list. So each gate must be accompanied by a list of the breaks considered, and
-for each either **the mutation that turns the gate red, an assertion or precondition in the
-gate that refuses the path, or a statement that the gate does not observe that break and why
-that is accepted.** A refusing precondition ranks with a mutation and is often the honest
-form: a gate asserting an exact plaintext already cannot pass on any error exit, and
-demanding a bespoke mutation per exit would buy ceremony rather than evidence. This is a
-requirement to disclose, not a
-prohibition on assertions: a rule forbidding any assertion a broken property could still
-produce would forbid 7a's own length assertion, which still yields 32 if rotation breaks by
-returning a constant.
+**Break disclosure is required of every control. The requirement is stated in
+[ADR 0024 `## Validation`](../adr/0024-gss-rotation-on-admin-remove-fail-closed.md#validation)
+and deliberately not restated here.** A mutable chapter cannot hold a normative requirement,
+and two copies of one rule diverge on their first edit. What follows is the worked example of
+applying it and the receipt mechanics the ADR delegates to this chapter.
 
-A list drawn from the author's imagination fails the same way the gates do — an author names
-the breaks their gate already catches. The minimum content is therefore mechanical: **name
-the target operation and the observation the gate makes of it, then enumerate from the source
-every control-flow exit or alternate dispatch between the gate's entry point and that
-operation which could bypass or substitute for it — explicit returns, `?` propagation,
-`let`-`else` bindings, `match` and `if` arms, and returns from delegated handlers — and
-account for each.** A scan for `return` is a floor, not a completeness proof; this very
-handler ends in a `match` arm that exits without one. The endpoint of that path is the code
-that performs the property, not the code that reads its inputs. **Declaration for the worked
-example that follows: every line number in it resolves at `56d0c4b`, in
+**Declaration for the worked example that follows: every line number in it resolves at
+`56d0c4b`, in
 `src/server/routes/named_groups.rs`, and none of them at the baseline.** For "a survivor can
 decrypt", the path runs to the key derivation at `:12353` and
 the cipher at `:12367` — not to the stored-secret read at `:12314` — and it contains **ten**
@@ -499,9 +482,11 @@ invalidates a diff. This is not hypothetical: on this rule's first use a gate's 
 hunks shifted its whole interval by fourteen lines, and a mutation aimed at a line from the
 stale list edited a blank line, did nothing, and reported the entire set green. **Two things
 follow. State the commit each list resolves at, and re-resolve it at the final SHA before the
-receipt is read as evidence. And build every mutation set with at least one arm that MUST go
-red** — that near-miss was caught only because a control arm failed to fail. A set in which
-every arm is expected green cannot distinguish a sound gate from a mutation that never landed.
+receipt is read as evidence. As chapter practice, build every mutation set with at least one
+arm that must go red** — that near-miss was caught only because a control arm failed to fail.
+This practice is not an ADR 0024 requirement, and nothing in the repository enforces it. A
+set in which every arm is expected green cannot distinguish a sound gate from a mutation that
+never landed.
 
 **A list committed alongside the code it cites cannot name its own commit, so it takes the
 other form.** Requiring the final SHA is unsatisfiable when the list ships *inside* that
@@ -581,7 +566,11 @@ The item definitions in this section are migrated from ADR 0024 at
 `111f4f86e3ad11a943473e702d6b46a5e62735c0`. Code citations in a sub-item
 resolve only at the commit declared in that sub-item.
 
-1. Fails on the pinned pre-fix commit (or on a mutation) and passes on the patched tree.
+1. The opening paragraph of
+   [ADR 0024 `## Validation`](../adr/0024-gss-rotation-on-admin-remove-fail-closed.md#validation)
+   states this item's cross-cutting fail/pass evidence property, which binds every control
+   and names no control of its own. This item was promoted into the governing ADR and is
+   deliberately not restated here.
 2. Asserts each surviving member can **decrypt content published at the new epoch** — not
    that its `state_hash` matches. Convergence is the wrong assertion (ADR Grounding G-002):
    it passes on the bug.
@@ -738,7 +727,8 @@ requires a revision/state-hash compare-and-swap design, not an audit.
 
 Resolves at: `111f4f86e3ad11a943473e702d6b46a5e62735c0`
 
-This ledger maps every source line exactly once to its primary destination.
+This ledger records the original migration at the declared commit, mapping every source line
+exactly once to its primary destination; it is not a current map of where text lives.
 The ADR carries stable decisions and Grounding evidence; this chapter carries
 mutable mechanisms, detailed audit procedure, gate definitions, and receipt
 rules. Blank lines and headings travel with their enclosing range.

--- a/docs/design/gss-admin-remove-fail-closed.md
+++ b/docs/design/gss-admin-remove-fail-closed.md
@@ -19,8 +19,9 @@ computed from that field; no ADR-side chapter allowlist is maintained.
 Repository-baseline citations in this section resolve at:
 `e3013710d7ed69077de9a799dffdbeb5ac80535a`, with
 `git status --porcelain src/` empty.
-Unless a citation names another file, every bare `:N` or `:N-N` citation
-resolves to `src/server/routes/named_groups.rs`.
+Throughout this chapter, unless a citation or its governing block declaration
+names another file, every bare `:N` or `:N-N` citation resolves to
+`src/server/routes/named_groups.rs`.
 
 **Two coordinate systems.** Code that F1 itself introduced does not exist at the baseline
 and cannot be cited there, so every such citation is stamped **at `56d0c4b`** in place —

--- a/justfile
+++ b/justfile
@@ -25,6 +25,15 @@ test:
 test-verbose:
     cargo nextest run --all-features --workspace --no-capture
 
+# Run the F1 GSS-rotation ADR gate tests (gate 3 ordering + gate 7a
+# producer). The filter `test(/(^|::)f1_/)` selects the five f1_
+# tests added to `mod tests` in src/server/routes/named_groups.rs. The
+# `(^|::)` form also discovers future top-level integration tests.
+# `--no-fail-fast --test-threads=1` is required so the §7a mutation
+# receipt's PASS/PASS/FAIL split by test name is unambiguous.
+adr-gates-f1:
+    cargo nextest run -p x0x --all-features --no-fail-fast --test-threads=1 -E 'test(/(^|::)f1_/)'
+
 build:
     cargo build --all-features
 

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -16608,8 +16608,11 @@ mod tests {
     //
     // Interval (ADR 0024 break-disclosure rule): `remove_named_group_member`
     // entry (`:8516`) → target operation publish (`:8707`). Resolves at
-    // `9d11d69` (production unchanged from `f52746c`; this commit is
-    // comment-only); re-resolve after any rebase (ADR 0024 `ca85a1d`).
+    // `9d11d69`; receipt (ADR 0024 `9fb3b20`): `head -n 16378` of this file
+    // ⇒ sha256 `89bb14e96b3f71525d5cd3d746eb1a71573b94d462b32986ba64a2d2d5d33ccb`,
+    // identical at `9d11d69` and `6cc03e5`. Highest cite `:12408` < 16378,
+    // and this commit edits no line ≤ 16378, so the hash holds here too.
+    // Re-resolve after any rebase.
     //
     // Break list — every control-flow exit / alternate dispatch in the
     // interval, each with its evidence:
@@ -16798,8 +16801,11 @@ mod tests {
     //
     // Interval (ADR 0024 break-disclosure rule): `secure_group_decrypt` entry
     // (`:12297`) → target operation `cipher.decrypt` (`:12381`). Resolves at
-    // `9d11d69` (production unchanged from `f52746c`; this commit is
-    // comment-only); re-resolve after any rebase (ADR 0024 `ca85a1d`).
+    // `9d11d69`; receipt (ADR 0024 `9fb3b20`): `head -n 16378` of this file
+    // ⇒ sha256 `89bb14e96b3f71525d5cd3d746eb1a71573b94d462b32986ba64a2d2d5d33ccb`,
+    // identical at `9d11d69` and `6cc03e5`. Highest cite `:12408` < 16378,
+    // and this commit edits no line ≤ 16378, so the hash holds here too.
+    // Re-resolve after any rebase.
     //
     // Break list — every control-flow exit / alternate dispatch in the
     // interval, each with its evidence:

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -873,12 +873,76 @@ fn secure_share_aad(group_id: &str, recipient_hex: &str, secret_epoch: u64) -> V
     aad
 }
 
+/// Failure constructing a `SecureShareDelivered` envelope without side effects.
+///
+/// Carries only the failure class — never key material or ciphertext — so
+/// logging the error cannot leak the group secret. Same conservative posture
+/// as F1 §2a constraint 3 (the `Vec<u8>` → `[u8; 32]` conversion's `Err`
+/// payload *is* the secret), applied to the KEM seal path here.
+#[derive(Debug)]
+enum SecureShareError {
+    /// Recipient KEM public key was not valid base64.
+    InvalidKemKey,
+    /// ML-KEM encapsulation or AEAD seal failed.
+    SealFailed,
+}
+
+/// Build — but do not publish — a `SecureShareDelivered` envelope sealed to the
+/// recipient's ML-KEM-768 public key. Side-effect-free: no metadata publish,
+/// no delivery spawn. This is the preflight primitive for the admin-remove
+/// path (F1 §5): it must validate *every* survivor envelope before
+/// `seal_commit` and abort (fail closed) on the first that cannot build.
+///
+/// `publish_secure_share` delegates here and then publishes, preserving its
+/// fail-open contract for approval/ban. The remove path calls this directly
+/// and fails CLOSED — it never proceeds past a survivor whose envelope cannot
+/// be built (F1 §5a).
+fn build_secure_share_event(
+    group_id: &str,
+    recipient_hex: &str,
+    recipient_kem_public_b64: &str,
+    actor_hex: &str,
+    secret: &[u8; 32],
+    secret_epoch: u64,
+) -> Result<NamedGroupMetadataEvent, SecureShareError> {
+    use base64::Engine as _;
+    let recipient_kem_public = BASE64
+        .decode(recipient_kem_public_b64)
+        .map_err(|_| SecureShareError::InvalidKemKey)?;
+    let aad = secure_share_aad(group_id, recipient_hex, secret_epoch);
+    let (kem_ct, aead_nonce, aead_ct) = x0x::groups::kem_envelope::seal_group_secret_to_recipient(
+        &recipient_kem_public,
+        &aad,
+        secret,
+    )
+    .map_err(|_| SecureShareError::SealFailed)?;
+    Ok(NamedGroupMetadataEvent::SecureShareDelivered {
+        group_id: group_id.to_string(),
+        recipient: recipient_hex.to_string(),
+        secret_epoch,
+        kem_ciphertext_b64: BASE64.encode(&kem_ct),
+        aead_nonce_b64: BASE64.encode(aead_nonce),
+        aead_ciphertext_b64: BASE64.encode(&aead_ct),
+        actor: actor_hex.to_string(),
+    })
+}
+
 /// Build and publish a `SecureShareDelivered` envelope sealed to the named
-/// recipient's ML-KEM-768 public key. Used by approval (new member) and
-/// ban-rekey (remaining members). Returns true iff the envelope was sealed
-/// and broadcast. Returns false if the recipient's KEM pubkey is unknown
-/// locally — in that case the caller should log and proceed without the
-/// envelope rather than crashing.
+/// recipient's ML-KEM-768 public key, used by the approval (new member) and
+/// ban-rekey (remaining members) paths.
+///
+/// **Fail-open contract — approval/ban only.** Returns true iff the envelope
+/// was sealed and broadcast; returns false if the recipient's KEM pubkey is
+/// unknown or unusable locally, in which case the caller logs and proceeds
+/// without the envelope rather than crashing. That is the right call for
+/// approval/ban, which have *already* persisted the roster change by the time
+/// they seal and so cannot abort.
+///
+/// The admin-remove path does **not** use this function: it builds every
+/// survivor envelope up front via `build_secure_share_event` and fails CLOSED
+/// (aborting before `seal_commit`) if any cannot be built (F1 §5/§5a). Do not
+/// route remove through here — that would re-introduce the fail-open the F1
+/// design exists to close.
 #[allow(clippy::too_many_arguments)]
 async fn publish_secure_share(
     state: &AppState,
@@ -890,38 +954,29 @@ async fn publish_secure_share(
     secret: &[u8; 32],
     secret_epoch: u64,
 ) -> bool {
-    use base64::Engine as _;
-    let recipient_kem_public = match BASE64.decode(recipient_kem_public_b64) {
-        Ok(b) => b,
-        Err(e) => {
+    let event = match build_secure_share_event(
+        group_id,
+        recipient_hex,
+        recipient_kem_public_b64,
+        actor_hex,
+        secret,
+        secret_epoch,
+    ) {
+        Ok(ev) => ev,
+        Err(SecureShareError::InvalidKemKey) => {
             tracing::warn!(
                 recipient = %LogHexId::agent(&recipient_hex),
-                "publish_secure_share: recipient KEM public key not valid base64: {e}"
+                "publish_secure_share: recipient KEM public key not valid base64"
             );
             return false;
         }
-    };
-    let aad = secure_share_aad(group_id, recipient_hex, secret_epoch);
-    let (kem_ct, aead_nonce, aead_ct) =
-        match x0x::groups::kem_envelope::seal_group_secret_to_recipient(
-            &recipient_kem_public,
-            &aad,
-            secret,
-        ) {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::warn!(recipient = %LogHexId::agent(&recipient_hex), "KEM seal failed: {e}");
-                return false;
-            }
-        };
-    let event = NamedGroupMetadataEvent::SecureShareDelivered {
-        group_id: group_id.to_string(),
-        recipient: recipient_hex.to_string(),
-        secret_epoch,
-        kem_ciphertext_b64: BASE64.encode(&kem_ct),
-        aead_nonce_b64: BASE64.encode(aead_nonce),
-        aead_ciphertext_b64: BASE64.encode(&aead_ct),
-        actor: actor_hex.to_string(),
+        Err(SecureShareError::SealFailed) => {
+            tracing::warn!(
+                recipient = %LogHexId::agent(&recipient_hex),
+                "KEM seal failed for secure-share envelope"
+            );
+            return false;
+        }
     };
     publish_named_group_metadata_event(state, metadata_topic, &event).await;
     spawn_named_group_event_delivery(state, recipient_hex, &event);

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -8544,7 +8544,7 @@ pub(in crate::server) async fn remove_named_group_member(
     let signing_kp = state.agent.identity().agent_keypair();
     let now_ms = now_millis_u64();
 
-    let (metadata_topic, event, members, epoch) = {
+    let (metadata_topic, event, members, epoch, buffered_survivor_envelopes) = {
         let mut named_groups = state.named_groups.write().await;
         let Some(info) = named_groups.get(&id) else {
             return not_found("group not found");
@@ -8568,6 +8568,75 @@ pub(in crate::server) async fn remove_named_group_member(
         next.roster_revision = next.roster_revision.saturating_add(1);
         let revision = next.roster_revision;
         next.remove_member(&agent_id_hex, Some(local_agent_hex.clone()));
+
+        // F1 §2/§2a/§5a — GSS rekey on admin remove. For MlsEncrypted groups:
+        // rotate the shared secret, fallibly convert Vec<u8> → [u8; 32], then
+        // build every survivor envelope in memory (preflight). Any failure
+        // bare-returns *before* seal_commit/insert/save/publish; the rotated
+        // clone `next` is dropped, so no rotation becomes live, persisted or
+        // published. Sealing deliberately sits AHEAD of persistence — do not
+        // mirror ban's post-save `warn + continue`, which is the fail-open
+        // anti-pattern past its `:10325`.
+        let event_group_id = next.stable_group_id().to_string();
+        let mut new_secret_epoch: Option<u64> = None;
+        let mut buffered_survivor_envelopes: Vec<(String, NamedGroupMetadataEvent)> = Vec::new();
+        let is_encrypted =
+            next.policy.confidentiality == x0x::groups::GroupConfidentiality::MlsEncrypted;
+        if is_encrypted {
+            let (sec_vec, ep) = next.rotate_shared_secret();
+            // §2a: the conversion is mandatory (seal needs &[u8;32]) and must
+            // be fallible. `Err(v)` *is* the secret material — bind `v` only
+            // to read its length; never format or log it.
+            let sec: [u8; 32] = match sec_vec.try_into() {
+                Ok(s) => s,
+                Err(v) => {
+                    return api_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("rotated secret has wrong length ({} bytes)", v.len()),
+                    );
+                }
+            };
+            new_secret_epoch = Some(ep);
+            // `remove_member` already excluded the removed member; the actor
+            // (admin) is skipped separately — they already hold the secret.
+            let survivors: Vec<(String, Option<String>)> = next
+                .active_members()
+                .map(|m| (m.agent_id.clone(), m.kem_public_key_b64.clone()))
+                .filter(|(recipient, _)| recipient != &local_agent_hex)
+                .collect();
+            for (recipient_hex, kem_b64) in &survivors {
+                let Some(kem) = kem_b64 else {
+                    // §5 fail-closed: no enrollment invariant proves a keyless
+                    // survivor never held the live secret (a stripped-roster
+                    // GSS invite stub reaches `shared_secret: Some(..)` with
+                    // `kem_public_key_b64: None`). Abort — clone discarded.
+                    return api_error(
+                        StatusCode::FAILED_DEPENDENCY,
+                        format!(
+                            "cannot rotate group secret: survivor {recipient_hex} has no roster KEM key"
+                        ),
+                    );
+                };
+                match build_secure_share_event(
+                    &event_group_id,
+                    recipient_hex,
+                    kem,
+                    &local_agent_hex,
+                    &sec,
+                    ep,
+                ) {
+                    Ok(ev) => buffered_survivor_envelopes.push((recipient_hex.clone(), ev)),
+                    Err(_) => {
+                        return api_error(
+                            StatusCode::FAILED_DEPENDENCY,
+                            format!(
+                                "cannot rotate group secret: survivor {recipient_hex} envelope build failed"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
         let commit = match next.seal_commit(signing_kp, now_ms) {
             Ok(c) => c,
             Err(e) => {
@@ -8578,7 +8647,6 @@ pub(in crate::server) async fn remove_named_group_member(
             }
         };
         let metadata_topic = next.metadata_topic.clone();
-        let event_group_id = next.stable_group_id().to_string();
         let members = named_group_member_values(&next);
         named_groups.insert(id.clone(), next);
         drop(named_groups);
@@ -8605,13 +8673,32 @@ pub(in crate::server) async fn remove_named_group_member(
             agent_id: agent_id_hex.clone(),
             treekem_commit_b64: None,
             treekem_epoch: None,
-            secret_epoch: None,
+            secret_epoch: new_secret_epoch,
             commit: Some(commit),
         };
-        (metadata_topic, event, members, epoch)
+        (
+            metadata_topic,
+            event,
+            members,
+            epoch,
+            buffered_survivor_envelopes,
+        )
     };
 
     publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+    // F1 §5a step 5: publish the buffered survivor envelopes only after the
+    // removal is live and persisted. Each is broadcast on the metadata topic
+    // plus direct + delayed delivery, mirroring publish_secure_share's shape.
+    for (recipient_hex, ev) in &buffered_survivor_envelopes {
+        publish_named_group_metadata_event(&state, &metadata_topic, ev).await;
+        spawn_named_group_event_delivery(&state, recipient_hex, ev);
+        spawn_named_group_event_delivery_after(
+            &state,
+            recipient_hex,
+            ev,
+            GROUP_BACKGROUND_PUBLISH_DELAY,
+        );
+    }
     maybe_publish_group_card_after_state_change(&state, &id).await;
     (
         StatusCode::OK,

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -11996,11 +11996,17 @@ pub(in crate::server) struct SecureDecryptRequest {
 /// TreeKEM-specific transport shape (direct invites/adds and ban/unban).
 ///
 /// Request-access joins and creator removals use real TreeKEM Commit/Welcome or
-/// Commit transport. The remaining guarded handlers still run the legacy GSS
-/// rekey path (`rotate_shared_secret` + per-recipient reseal), which would
-/// silently re-introduce a shared secret and relabel the plane. Refuse those
-/// endpoints loudly until they provide KeyPackage/Welcome or removal Commit
-/// inputs.
+/// Commit transport. The remaining guarded handlers would, if they fell back
+/// to the legacy GSS rekey path (`rotate_shared_secret` + per-recipient
+/// reseal), silently re-introduce a shared secret and relabel the plane — so
+/// this guard refuses them loudly until they provide KeyPackage/Welcome or
+/// removal Commit inputs.
+///
+/// The GSS admin-remove path is a *separate*, intentional caller of
+/// `rotate_shared_secret` + per-recipient reseal (F1 / ADR-0010): it runs only
+/// for GSS-plane groups (this guard returns `None` for them) and fails closed
+/// via `build_secure_share_event`. It is not one of the "remaining guarded
+/// handlers" above and is not refused here.
 fn treekem_membership_unsupported(
     info: &x0x::groups::GroupInfo,
 ) -> Option<(StatusCode, Json<serde_json::Value>)> {

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -637,6 +637,12 @@ pub(in crate::server) enum NamedGroupMetadataEvent {
         /// TreeKEM epoch after applying `treekem_commit_b64`.
         #[serde(default)]
         treekem_epoch: Option<u64>,
+        /// For MlsEncrypted groups, the new GSS secret epoch committed into
+        /// the signed state hash (F1 / ADR-0010). Receivers update the
+        /// security binding before `finalize_applied_commit`, mirroring
+        /// `MemberBanned`.
+        #[serde(default)]
+        secret_epoch: Option<u64>,
         #[serde(default)]
         commit: Option<x0x::groups::GroupStateCommit>,
     },
@@ -8516,6 +8522,7 @@ pub(in crate::server) async fn remove_named_group_member(
             agent_id: agent_id_hex.clone(),
             treekem_commit_b64: None,
             treekem_epoch: None,
+            secret_epoch: None,
             commit: Some(commit),
         };
         (metadata_topic, event, members, epoch)
@@ -9163,6 +9170,7 @@ async fn leave_treekem_group(
         agent_id: local_agent_hex,
         treekem_commit_b64: None,
         treekem_epoch: None,
+        secret_epoch: None,
         commit: Some(commit),
     };
     publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
@@ -9325,6 +9333,7 @@ async fn remove_treekem_named_group_member(
         agent_id: agent_id_hex.clone(),
         treekem_commit_b64: Some(base64::engine::general_purpose::STANDARD.encode(treekem_commit)),
         treekem_epoch: Some(treekem_epoch),
+        secret_epoch: None,
         commit: Some(commit),
     };
     publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
@@ -9705,6 +9714,7 @@ pub(in crate::server) async fn leave_group(
         agent_id: local_agent_hex.clone(),
         treekem_commit_b64: None,
         treekem_epoch: None,
+        secret_epoch: None,
         commit: Some(commit),
     };
     drop(groups);
@@ -15368,6 +15378,7 @@ mod tests {
             agent_id: member_hex.clone(),
             treekem_commit_b64: None,
             treekem_epoch: None,
+            secret_epoch: None,
             commit: Some(commit),
         };
 
@@ -17460,6 +17471,7 @@ mod tests {
             agent_id: "22".repeat(32),
             treekem_commit_b64: None,
             treekem_epoch: None,
+            secret_epoch: None,
             commit: None,
         };
         assert!(!treekem_metadata_event_requires_phase3(&event));
@@ -17575,6 +17587,7 @@ mod tests {
             agent_id: member_hex.clone(),
             treekem_commit_b64: None,
             treekem_epoch: None,
+            secret_epoch: None,
             commit: Some(fake_group_state_commit(&group_id, 3, &member_hex)),
         };
 
@@ -17596,6 +17609,7 @@ mod tests {
             agent_id: member_hex.clone(),
             treekem_commit_b64: None,
             treekem_epoch: None,
+            secret_epoch: None,
             commit: Some(fake_group_state_commit(&group_id, 4, &creator_hex)),
         };
         assert!(!authorized_treekem_membership_event_for_queue(
@@ -17611,6 +17625,7 @@ mod tests {
             agent_id: member_hex.clone(),
             treekem_commit_b64: Some("Yw==".to_string()),
             treekem_epoch: Some(2),
+            secret_epoch: None,
             commit: Some(fake_group_state_commit(&group_id, 5, &admin_hex)),
         };
         assert!(authorized_treekem_membership_event_for_queue(

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -4939,6 +4939,7 @@ async fn apply_named_group_metadata_event_inner_serialized(
             agent_id,
             treekem_commit_b64,
             treekem_epoch,
+            secret_epoch,
             commit,
             ..
         } => {
@@ -4950,6 +4951,13 @@ async fn apply_named_group_metadata_event_inner_serialized(
                 && actor_role.is_some_and(|r| r.at_least(x0x::groups::GroupRole::Admin));
             let self_leave_auth = sender_hex == agent_id && actor == sender_hex;
             if !admin_remove_auth && !self_leave_auth {
+                return false;
+            }
+            // F1 §4 Step 0: a self-leave commit carrying a GSS secret_epoch is
+            // a crafted MemberSelf event — self-removal is rejected at the
+            // sender (§1) and a self-leave never rotates. Reject before the
+            // plane split so it cannot reach the GSS rekey branch.
+            if self_leave_auth && secret_epoch.is_some() {
                 return false;
             }
             let action_kind = if self_leave_auth {
@@ -4982,6 +4990,13 @@ async fn apply_named_group_metadata_event_inner_serialized(
                 if let Some((_, epoch)) = treekem_payload.as_ref() {
                     next.secret_epoch = *epoch;
                     next.security_binding = Some(format!("treekem:epoch={epoch}"));
+                } else if let Some(secret_epoch) = secret_epoch {
+                    let old_epoch = next.secret_epoch;
+                    next.secret_epoch = secret_epoch;
+                    next.security_binding = Some(format!("gss:epoch={secret_epoch}"));
+                    if old_epoch < secret_epoch {
+                        next.shared_secret = None;
+                    }
                 }
             }) else {
                 return false;

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -8458,6 +8458,19 @@ pub(in crate::server) async fn remove_named_group_member(
         }
     };
     let local_agent_hex = hex::encode(state.agent.agent_id().as_bytes());
+    // F1 §1: self-removal is a leave, not a remove. Reject before the
+    // membership lock — `leave_group` re-acquires the same per-group lock and
+    // `tokio::sync::Mutex` is not reentrant, so delegating would self-deadlock
+    // *while holding the lock*, hanging every later op on this group. This
+    // also short-circuits the live TreeKEM self-target divergence
+    // (`remove_treekem` sets `treekem_epoch: Some(..)` unconditionally and
+    // receivers drop the event under `self_leave_auth`).
+    if agent_id_hex == local_agent_hex {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "self-removal is a leave; use DELETE /groups/:id",
+        );
+    }
     // Serialize against concurrent membership applies + other API mutators (see
     // `AppState::group_membership_locks`). Held across the delegation to the
     // TreeKEM helper below, which must NOT re-acquire it (single-level lock).

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -16359,6 +16359,222 @@ mod tests {
         Ok(())
     }
 
+    // ── Gate 4a (item 4, containment): a removed caller is refused at the
+    // roster guard, NOT at the crypto. The observation is the `:12298`
+    // `forbidden("not a member")` return, which precedes the shared_secret
+    // read (`:12314`) and the cipher (`:12367`). This gate pins containment
+    // only and says nothing about key material — item 4's key-material
+    // property is gate 4b, observed below the endpoint.
+    //
+    // Both the roster guard (`:12298`) and a downstream decrypt failure
+    // (`:12394`) return 403, so status alone cannot distinguish them. The
+    // load-bearing observation is the body message "not a member": only the
+    // roster guard produces it.
+    //
+    // Mutation: leave the caller Active (skip `remove_member`) → the roster
+    // guard does not fire → the request falls through to a different response
+    // (decrypt failure / epoch mismatch) whose body is not "not a member" →
+    // the body assertion fails and the gate goes red.
+    #[tokio::test]
+    async fn f1_item4a_removed_caller_refused_at_roster_guard() -> Result<()> {
+        let (state, _dir) = secure_endpoint_test_state().await?;
+        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+        let admin_id = crate::identity::AgentKeypair::generate()?.agent_id();
+        let admin_hex = hex::encode(admin_id.as_bytes());
+
+        let group_id = "f1-item4a-local".to_string();
+        let stable_group_id = "f1-item4a-stable".to_string();
+        let epoch: u64 = 7;
+
+        let mut info = x0x::groups::GroupInfo::with_policy(
+            "f1 item4a containment".to_string(),
+            String::new(),
+            admin_id,
+            group_id.clone(),
+            x0x::groups::GroupPolicyPreset::PrivateSecure.to_policy(),
+        );
+        info.genesis = Some(x0x::groups::state_commit::GroupGenesis::with_existing_id(
+            stable_group_id,
+            admin_hex.clone(),
+            info.created_at,
+            String::new(),
+        ));
+        info.secure_plane = x0x::mls::SecureGroupPlane::Gss;
+        info.secret_epoch = epoch;
+        info.shared_secret = Some(vec![9; 32]);
+        // Caller is added then removed: state == Removed (neither Active nor
+        // Banned), so the `:12296-12298` roster guard fires.
+        info.add_member(
+            local_hex.clone(),
+            x0x::groups::GroupRole::Member,
+            Some(admin_hex.clone()),
+            None,
+        );
+        info.remove_member(&local_hex, Some(admin_hex));
+        info.recompute_state_hash();
+        state
+            .named_groups
+            .write()
+            .await
+            .insert(group_id.clone(), info);
+
+        // The roster guard fires before any `req` field is read. Supply a
+        // well-formed request anyway, so the only thing that can refuse the
+        // caller is the roster guard rather than a 400 on malformed input.
+        let (status, body) = secure_group_decrypt(
+            State(Arc::clone(&state)),
+            Path(group_id.clone()),
+            Json(SecureDecryptRequest {
+                ciphertext_b64: BASE64.encode(b"item4a-ciphertext-not-reached"),
+                nonce_b64: BASE64.encode([0u8; 12]),
+                secret_epoch: epoch,
+            }),
+        )
+        .await;
+
+        // Positive precondition: the group really is GSS-plane (explicit, not
+        // fixture-inherited), so the refusal is the roster guard and not the
+        // TreeKem dispatch at `:12306`.
+        {
+            let groups = state.named_groups.read().await;
+            let stored = groups.get(&group_id).expect("item4a group must be present");
+            assert_eq!(
+                stored.secure_plane,
+                x0x::mls::SecureGroupPlane::Gss,
+                "item4a must exercise the GSS plane"
+            );
+        }
+
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "removed caller must be refused (403)"
+        );
+        let err_msg = body.0.get("error").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            err_msg.contains("not a member"),
+            "refusal must come from the roster guard at :12298 (body error = {err_msg:?}); \
+             a decrypt-failure 403 at :12394 would prove the guard did NOT fire"
+        );
+        Ok(())
+    }
+
+    // ── Gate 4b (item 4, key material): the secret a removed member retains
+    // (S0, pre-rotation) does NOT open content published at the new epoch
+    // (sealed under S1, post-rotation). Observed BELOW the endpoint, because
+    // the endpoint refuses a removed caller at the roster guard and never
+    // reaches the cipher — that is 4a's point. The derivation is public and
+    // pure (`GroupInfo::derive_message_key`), so the property is testable
+    // directly.
+    //
+    // Two arms vary ONLY the secret: same ciphertext, nonce, AAD and epoch;
+    // S0 vs S1 is the sole difference (Watson's constraint ii). The S1 arm
+    // MUST succeed (constraint i) — it is the passing control that turns the
+    // S0 failure into a measurement rather than a broken-harness artifact.
+    //
+    // Mutation: drop `material.extend_from_slice(secret)` from
+    // `GroupInfo::derive_message_key` (`src/groups/mod.rs:743`). The derived
+    // key then no longer depends on the secret, key_s0 == key_s1, S0 opens the
+    // ciphertext, and the `is_err()` assertion fails (gate red).
+    #[test]
+    fn f1_item4b_retained_secret_does_not_open_new_epoch_content() -> Result<()> {
+        use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+        use rand::RngCore;
+
+        // Real producer: `rotate_shared_secret` is the sole production secret
+        // source (the symbol gate 7a pins). S0 is the pre-rotation secret the
+        // removed member retains; S1 is what the new epoch is sealed under.
+        let creator = crate::identity::AgentKeypair::generate()?.agent_id();
+        let mut group = x0x::groups::GroupInfo::with_policy(
+            "f1 item4b key material".to_string(),
+            String::new(),
+            creator,
+            "f1-item4b-local".to_string(),
+            x0x::groups::GroupPolicyPreset::PrivateSecure.to_policy(),
+        );
+        group.genesis = Some(x0x::groups::state_commit::GroupGenesis::with_existing_id(
+            "f1-item4b-stable".to_string(),
+            hex::encode(creator.as_bytes()),
+            group.created_at,
+            String::new(),
+        ));
+        group.secure_plane = x0x::mls::SecureGroupPlane::Gss;
+        let epoch_before: u64 = 7;
+        group.secret_epoch = epoch_before;
+        let s0: Vec<u8> = vec![9; 32]; // retained by the removed member
+        group.shared_secret = Some(s0.clone());
+        group.recompute_state_hash();
+
+        // Real rotation: producer returns S1 and advances the epoch by one.
+        let (s1, epoch_after) = group.rotate_shared_secret();
+        assert_eq!(
+            epoch_after,
+            epoch_before + 1,
+            "rotation advances epoch by one"
+        );
+        assert_eq!(s1.len(), 32, "rotated secret is 32 bytes");
+
+        let group_id = group.stable_group_id().to_string();
+        let plaintext = b"item-4b new-epoch plaintext";
+
+        // Produce ONE real envelope at the new epoch under S1, using the exact
+        // primitives and AAD the production encryptor uses.
+        let key_s1 = x0x::groups::GroupInfo::derive_message_key(&s1, epoch_after, &group_id);
+        let cipher_s1 = chacha20poly1305::ChaCha20Poly1305::new_from_slice(&key_s1)
+            .expect("32-byte key always initializes ChaCha20Poly1305");
+        let aad = format!("x0x.group.secure|{}|{}", group_id, epoch_after);
+        let mut nonce_bytes = [0u8; 12];
+        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+        let nonce = chacha20poly1305::Nonce::from_slice(&nonce_bytes);
+        let ciphertext = cipher_s1
+            .encrypt(
+                nonce,
+                Payload {
+                    msg: plaintext.as_slice(),
+                    aad: aad.as_bytes(),
+                },
+            )
+            .expect("encrypt under S1 must succeed");
+
+        // S0 arm — the retained secret must NOT open new-epoch content. Same
+        // ciphertext, nonce, AAD and epoch as the S1 arm; the secret is the
+        // only difference.
+        let key_s0 = x0x::groups::GroupInfo::derive_message_key(&s0, epoch_after, &group_id);
+        let cipher_s0 = chacha20poly1305::ChaCha20Poly1305::new_from_slice(&key_s0)
+            .expect("32-byte key always initializes ChaCha20Poly1305");
+        let open_s0 = cipher_s0.decrypt(
+            nonce,
+            Payload {
+                msg: &ciphertext,
+                aad: aad.as_bytes(),
+            },
+        );
+        assert!(
+            open_s0.is_err(),
+            "S0 (retained pre-rotation secret) must NOT decrypt new-epoch content; \
+             if this passes, derive_message_key no longer depends on the secret"
+        );
+
+        // S1 arm — passing control. The same envelope opens cleanly under S1,
+        // proving the envelope is well-formed and the S0 failure is
+        // attributable to the key alone.
+        let open_s1 = cipher_s1
+            .decrypt(
+                nonce,
+                Payload {
+                    msg: &ciphertext,
+                    aad: aad.as_bytes(),
+                },
+            )
+            .expect("S1 (post-rotation secret) must decrypt new-epoch content");
+        assert_eq!(
+            open_s1.as_slice(),
+            plaintext,
+            "S1 must recover the exact plaintext"
+        );
+
+        Ok(())
+    }
     fn treekem_metadata_group_info(
         creator: AgentId,
         group_id: &str,

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -16376,14 +16376,14 @@ mod tests {
     }
 
     // ── Gate 4a (item 4, containment): a removed caller is refused at the
-    // roster guard, NOT at the crypto. The observation is the `:12298`
+    // roster guard, NOT at the crypto. The observation is the `:12312`
     // `forbidden("not a member")` return, which precedes the shared_secret
-    // read (`:12314`) and the cipher (`:12367`). This gate pins containment
+    // read (`:12328`) and the cipher (`:12381`). This gate pins containment
     // only and says nothing about key material — item 4's key-material
     // property is gate 4b, observed below the endpoint.
     //
-    // Both the roster guard (`:12298`) and a downstream decrypt failure
-    // (`:12394`) return 403, so status alone cannot distinguish them. The
+    // Both the roster guard (`:12312`) and a downstream decrypt failure
+    // (`:12408`) return 403, so status alone cannot distinguish them. The
     // load-bearing observation is the body message "not a member": only the
     // roster guard produces it.
     //
@@ -16419,7 +16419,7 @@ mod tests {
         info.secret_epoch = epoch;
         info.shared_secret = Some(vec![9; 32]);
         // Caller is added then removed: state == Removed (neither Active nor
-        // Banned), so the `:12296-12298` roster guard fires.
+        // Banned), so the `:12310-12312` roster guard fires.
         info.add_member(
             local_hex.clone(),
             x0x::groups::GroupRole::Member,
@@ -16450,7 +16450,7 @@ mod tests {
 
         // Positive precondition: the group really is GSS-plane (explicit, not
         // fixture-inherited), so the refusal is the roster guard and not the
-        // TreeKem dispatch at `:12306`.
+        // TreeKem dispatch at `:12320`.
         {
             let groups = state.named_groups.read().await;
             let stored = groups.get(&group_id).expect("item4a group must be present");
@@ -16469,8 +16469,8 @@ mod tests {
         let err_msg = body.0.get("error").and_then(|v| v.as_str()).unwrap_or("");
         assert!(
             err_msg.contains("not a member"),
-            "refusal must come from the roster guard at :12298 (body error = {err_msg:?}); \
-             a decrypt-failure 403 at :12394 would prove the guard did NOT fire"
+            "refusal must come from the roster guard at :12312 (body error = {err_msg:?}); \
+             a decrypt-failure 403 at :12408 would prove the guard did NOT fire"
         );
         Ok(())
     }
@@ -16606,18 +16606,42 @@ mod tests {
     // the recorder can only express a publish COUNT, which is the proxy this
     // round exists to stop.
     //
-    // Observed lane: the metadata-topic publish at `:8693` only. The direct
-    // (`:8694`) and delayed (`:8695`) delivery in
+    // Interval (ADR 0024 break-disclosure rule): `remove_named_group_member`
+    // entry (`:8516`) → target operation publish (`:8707`). Resolves at
+    // `9d11d69` (production unchanged from `f52746c`; this commit is
+    // comment-only); re-resolve after any rebase (ADR 0024 `ca85a1d`).
+    //
+    // Break list — every control-flow exit / alternate dispatch in the
+    // interval, each with its evidence:
+    //   :8523 parse-id / :8538 self-removal / :8563 group-not-found /
+    //   :8567 non-admin / :8570 withdrawn / :8573 member-not-found /
+    //   :8577 last-admin — refused by preconditions.
+    //   :8553 TreeKem dispatch — refused (assert secure_plane == Gss).
+    //   :8607 §2a wrong-length abort — UNREACHABLE (producer hardcodes 32B;
+    //     7b). No label: if it fired the handler 500s before any publish and
+    //     this gate goes RED, so it cannot leave the gate green (direction
+    //     test, `e0fc016`/`8053a3d`).
+    //   :8627 missing-KEM / :8644 envelope seal-fail — item 5's property,
+    //     scheduled, not observed.
+    //   :8657 seal_commit — not observed, no owning Validation item. Zero
+    //     state change: `next` is a clone (`:8581`) and nothing publishes,
+    //     saves or inserts between the write-lock (`:8562`) and `insert` (`:8665`);
+    //     both domain Err arms are pre-empted upstream (last-admin `:8577`,
+    //     withdrawn `:8570`), leaving only an ML-DSA signing fault
+    //     (`state_commit.rs:448`).
+    //
+    // Observed lane: the metadata-topic publish at `:8707` only. The direct
+    // (`:8708`) and delayed (`:8709`) delivery in
     // `spawn_named_group_event_delivery` have no `#[cfg(test)]` hook (they
     // spawn straight to `agent.send_direct_with_config`) and are named here as
     // not-observed, not covered.
     //
-    // Mutation (Watson's M5): at `:8603` change `next.active_members()` to
+    // Mutation (Watson's M5): at `:8617` change `next.active_members()` to
     // `next.members_v2.values().filter(|m| !m.is_banned())`. The removed
     // member (state Removed, not Banned) re-enters the survivor set; with a
     // roster KEM key the envelope builds and publishes to them; the recorder
     // captures their hex as a recipient and the "victim not in recipients"
-    // assertion fails (gate red). Reverted before the SHA.
+    // assertion fails (gate red). REQUIRED red arm of the set. Reverted.
     #[tokio::test]
     async fn f1_item4c_remove_handler_publishes_survivors_not_the_removed_member() -> Result<()> {
         let (state, _dir) = secure_endpoint_test_state().await?;
@@ -16626,7 +16650,7 @@ mod tests {
 
         // Distinct agents. Both get real ML-KEM-768 public keys: the survivor
         // so its envelope builds, and the victim so that under the M5 mutation
-        // its re-inclusion reaches the publish rather than the `:8613`
+        // its re-inclusion reaches the publish rather than the `:8627`
         // missing-KEM abort (which would mask the property under test).
         let survivor_hex = hex::encode(
             crate::identity::AgentKeypair::generate()?
@@ -16685,7 +16709,7 @@ mod tests {
             .await
             .insert(group_id.clone(), info);
 
-        // Positive precondition: GSS plane, so the TreeKem dispatch at `:8539`
+        // Positive precondition: GSS plane, so the TreeKem dispatch at `:8553`
         // cannot fire and no recipient set is ever built for a different plane.
         {
             let groups = state.named_groups.read().await;
@@ -16773,22 +16797,24 @@ mod tests {
     // item 2 proves the survivors still can.
     //
     // Interval (ADR 0024 break-disclosure rule): `secure_group_decrypt` entry
-    // (`:12283`) → target operation `cipher.decrypt` (`:12367`).
+    // (`:12297`) → target operation `cipher.decrypt` (`:12381`). Resolves at
+    // `9d11d69` (production unchanged from `f52746c`; this commit is
+    // comment-only); re-resolve after any rebase (ADR 0024 `ca85a1d`).
     //
     // Break list — every control-flow exit / alternate dispatch in the
     // interval, each with its evidence:
-    //   :12291 group-not-found     — refused (installed group)
-    //   :12294 withdrawn           — refused (non-withdrawn group)
-    //   :12298 not-a-member        — MUTATION B + positive membership assert
-    //   :12306 TreeKem dispatch    — refused (assert secure_plane == Gss)
-    //   :12315 no shared secret    — refused (secret installed)
-    //   :12325 epoch mismatch      — refused (matching epoch sent)
-    //   :12340 bad base64 ct       — refused (valid base64)
-    //   :12346 bad base64 nonce    — refused (valid base64)
-    //   :12350 nonce wrong length  — refused (12-byte nonce)
-    //   :12362 cipher init failed  — refused (derive_message_key returns 32B)
-    //   :12394 cipher Err          — MUTATION A (stored-secret byte flip)
-    //   :12382 post-decrypt terminality recheck (→ :10127, hook :10134) —
+    //   :12305 group-not-found     — refused (installed group)
+    //   :12308 withdrawn           — refused (non-withdrawn group)
+    //   :12312 not-a-member        — MUTATION B + positive membership assert
+    //   :12320 TreeKem dispatch    — refused (assert secure_plane == Gss)
+    //   :12328 no shared secret    — refused (secret installed)
+    //   :12339 epoch mismatch      — refused (matching epoch sent)
+    //   :12354 bad base64 ct       — refused (valid base64)
+    //   :12360 bad base64 nonce    — refused (valid base64)
+    //   :12364 nonce wrong length  — refused (12-byte nonce)
+    //   :12376 cipher init failed  — refused (derive_message_key returns 32B)
+    //   :12408 cipher Err          — MUTATION A (stored-secret byte flip)
+    //   :12396 post-decrypt terminality recheck (→ :10141, hook :10148) —
     //     FALSE-NEGATIVE hazard: can suppress a success into a 409 conflict,
     //     cannot manufacture plaintext. Refused by the success-shape
     //     precondition (status 200 + payload present + no conflict). NOT a
@@ -16796,14 +16822,25 @@ mod tests {
     //
     // Mutation A: between the production encrypt and decrypt calls, flip one
     // byte in the stored `shared_secret`. The ciphertext was sealed under the
-    // original; decrypt derives from the flipped secret → wrong key → `:12394`
+    // original; decrypt derives from the flipped secret → wrong key → `:12408`
     // "decryption failed" → the success assertion fails. Shows the gate
-    // observes the cipher path (`:12394`), distinct from the `:12298` roster
+    // observes the cipher path (`:12408`), distinct from the `:12312` roster
     // guard exercised by mutation B.
     //
     // Mutation B: `remove_member(&survivor)` after setup → survivor Removed →
-    // the `:12298` roster guard fires → "not a member" → success assertion
-    // fails. Shows the gate observes active membership at `:12298`.
+    // the `:12312` roster guard fires → "not a member" → success assertion
+    // fails. Shows the gate observes active membership at `:12312`.
+    //
+    // Mutation SYM/ASYM (round-trip teeth — Watson [12] §2 / Dario [13] §1):
+    //   ASYM — change the AAD on the ENCRYPT side only (`:12251`) → this gate
+    //     RED, sole failure (encrypt and decrypt no longer agree). REQUIRED
+    //     red arm of the mutation set (`8053a3d`).
+    //   SYM  — change the AAD on BOTH production sides (`:12251` + `:12380`)
+    //     → all green. ACCEPTED BLIND SPOT (direction test, `8053a3d`):
+    //     symmetric drift is invisible because the gate observes the two
+    //     endpoints agreeing with each other, not with any prior format — a
+    //     compatibility property, not a decryptability one. Nothing in the F1
+    //     set observes it; named, not fixed.
     //
     // Epoch-binding pin: `derive_message_key` mixes the epoch into the key
     // (`groups/mod.rs:744`); Watson's M4 showed nothing in the F1 set observes

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -113,8 +113,9 @@ pub(in crate::server) struct TreeKemCacheMutation {
 }
 
 #[cfg(test)]
-static NAMED_GROUP_METADATA_PUBLISH_ATTEMPTS_FOR_TEST: StdMutex<Vec<(String, String)>> =
-    StdMutex::new(Vec::new());
+static NAMED_GROUP_METADATA_PUBLISH_ATTEMPTS_FOR_TEST: StdMutex<
+    Vec<(String, String, Option<String>)>,
+> = StdMutex::new(Vec::new());
 
 #[cfg(test)]
 static TREEKEM_FINAL_INSTALL_BEFORE_MAP_WRITE_NOTIFY: StdMutex<
@@ -512,6 +513,18 @@ fn named_group_metadata_event_group_id(event: &NamedGroupMetadataEvent) -> &str 
         | NamedGroupMetadataEvent::GroupMetadataUpdated { group_id, .. }
         | NamedGroupMetadataEvent::MemberJoined { group_id, .. }
         | NamedGroupMetadataEvent::SecureShareDelivered { group_id, .. } => group_id,
+    }
+}
+
+/// Test-only extractor mirroring [`named_group_metadata_event_group_id`]: the
+/// hex agent_id of the intended recipient for `SecureShareDelivered`, `None`
+/// for every other variant. Lets the publish-attempt recorder capture the
+/// published recipient set rather than only a publish count.
+#[cfg(test)]
+fn named_group_metadata_event_recipient(event: &NamedGroupMetadataEvent) -> Option<&str> {
+    match event {
+        NamedGroupMetadataEvent::SecureShareDelivered { recipient, .. } => Some(recipient),
+        _ => None,
     }
 }
 
@@ -1865,6 +1878,7 @@ async fn publish_named_group_metadata_event(
         attempts.push((
             metadata_topic.to_string(),
             named_group_metadata_event_group_id(event).to_string(),
+            named_group_metadata_event_recipient(event).map(str::to_string),
         ));
     }
 
@@ -15025,8 +15039,10 @@ mod tests {
         assert!(
             publish_attempts
                 .iter()
-                .any(|(topic, event_group_id)| topic == &metadata_topic
-                    && event_group_id == &stable_group_id),
+                .any(
+                    |(topic, event_group_id, _recipient)| topic == &metadata_topic
+                        && event_group_id == &stable_group_id
+                ),
             "join handler should attempt to publish the joiner-authored MemberJoined request"
         );
         Ok(())
@@ -16573,6 +16589,177 @@ mod tests {
             "S1 must recover the exact plaintext"
         );
 
+        Ok(())
+    }
+
+    // ── Gate 4c (item 4, published recipient set): the recipient set the
+    // remove handler actually publishes to excludes the removed member and
+    // includes each survivor. This is the only SENDER-side gate in the F1 set
+    // — it drives the real `remove_named_group_member` producer path (the gap
+    // Watson's M5 mutation found: 4a/4b are receiver-side / below-endpoint and
+    // never invoke the handler, so a reseal aimed at the removed member was
+    // invisible to the whole suite).
+    //
+    // The recorder is widened (production change above) to capture the
+    // `SecureShareDelivered.recipient` field it previously discarded — without
+    // that, every survivor envelope shares the same `(topic, group_id)` and
+    // the recorder can only express a publish COUNT, which is the proxy this
+    // round exists to stop.
+    //
+    // Observed lane: the metadata-topic publish at `:8693` only. The direct
+    // (`:8694`) and delayed (`:8695`) delivery in
+    // `spawn_named_group_event_delivery` have no `#[cfg(test)]` hook (they
+    // spawn straight to `agent.send_direct_with_config`) and are named here as
+    // not-observed, not covered.
+    //
+    // Mutation (Watson's M5): at `:8603` change `next.active_members()` to
+    // `next.members_v2.values().filter(|m| !m.is_banned())`. The removed
+    // member (state Removed, not Banned) re-enters the survivor set; with a
+    // roster KEM key the envelope builds and publishes to them; the recorder
+    // captures their hex as a recipient and the "victim not in recipients"
+    // assertion fails (gate red). Reverted before the SHA.
+    #[tokio::test]
+    async fn f1_item4c_remove_handler_publishes_survivors_not_the_removed_member() -> Result<()> {
+        let (state, _dir) = secure_endpoint_test_state().await?;
+        let admin_id = state.agent.agent_id();
+        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+
+        // Distinct agents. Both get real ML-KEM-768 public keys: the survivor
+        // so its envelope builds, and the victim so that under the M5 mutation
+        // its re-inclusion reaches the publish rather than the `:8613`
+        // missing-KEM abort (which would mask the property under test).
+        let survivor_hex = hex::encode(
+            crate::identity::AgentKeypair::generate()?
+                .agent_id()
+                .as_bytes(),
+        );
+        let survivor_kem_b64 =
+            BASE64.encode(&x0x::groups::kem_envelope::AgentKemKeypair::generate()?.public_bytes);
+        let victim_hex = hex::encode(
+            crate::identity::AgentKeypair::generate()?
+                .agent_id()
+                .as_bytes(),
+        );
+        let victim_kem_b64 =
+            BASE64.encode(&x0x::groups::kem_envelope::AgentKemKeypair::generate()?.public_bytes);
+
+        let group_id = "f1-item4c-local".to_string();
+        let stable_group_id = "f1-item4c-stable".to_string();
+
+        // Local daemon is admin/creator/actor: the handler signs the commit
+        // with `state.agent.identity().agent_keypair()` and authorizes via
+        // `require_admin_or_above(info, &local_agent_hex)`.
+        let mut info = x0x::groups::GroupInfo::with_policy(
+            "f1 item4c recipient set".to_string(),
+            String::new(),
+            admin_id,
+            group_id.clone(),
+            x0x::groups::GroupPolicyPreset::PrivateSecure.to_policy(),
+        );
+        info.genesis = Some(x0x::groups::state_commit::GroupGenesis::with_existing_id(
+            stable_group_id.clone(),
+            local_hex.clone(),
+            info.created_at,
+            String::new(),
+        ));
+        info.secure_plane = x0x::mls::SecureGroupPlane::Gss;
+        info.add_member_with_kem(
+            survivor_hex.clone(),
+            x0x::groups::GroupRole::Member,
+            Some(local_hex.clone()),
+            None,
+            Some(survivor_kem_b64),
+        );
+        info.add_member_with_kem(
+            victim_hex.clone(),
+            x0x::groups::GroupRole::Member,
+            Some(local_hex.clone()),
+            None,
+            Some(victim_kem_b64),
+        );
+        info.recompute_state_hash();
+        let metadata_topic = info.metadata_topic.clone();
+        state
+            .named_groups
+            .write()
+            .await
+            .insert(group_id.clone(), info);
+
+        // Positive precondition: GSS plane, so the TreeKem dispatch at `:8539`
+        // cannot fire and no recipient set is ever built for a different plane.
+        {
+            let groups = state.named_groups.read().await;
+            let stored = groups.get(&group_id).expect("item4c group present");
+            assert_eq!(
+                stored.secure_plane,
+                x0x::mls::SecureGroupPlane::Gss,
+                "item4c must exercise the GSS remove path, not the TreeKem dispatch"
+            );
+        }
+
+        NAMED_GROUP_METADATA_PUBLISH_ATTEMPTS_FOR_TEST
+            .lock()
+            .expect("publish-attempt recorder poisoned")
+            .clear();
+
+        let (status, body) = response_json(
+            remove_named_group_member(
+                State(Arc::clone(&state)),
+                Path((group_id.clone(), victim_hex.clone())),
+            )
+            .await
+            .into_response(),
+        )
+        .await?;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "admin remove of a member must succeed, body: {body}"
+        );
+
+        // Post-state: victim Removed, survivor still Active (positive).
+        {
+            let groups = state.named_groups.read().await;
+            let stored = groups.get(&group_id).expect("item4c group retained");
+            assert!(
+                !stored.has_active_member(&victim_hex),
+                "victim must be Removed after admin remove"
+            );
+            assert!(
+                stored.has_active_member(&survivor_hex),
+                "survivor must remain Active after admin remove"
+            );
+        }
+
+        // Core 4c observation: the published recipient set. The recorder now
+        // carries `SecureShareDelivered.recipient` alongside topic+group, so
+        // the assertion is on the recipient set, not a publish count.
+        let published_recipients: Vec<String> = NAMED_GROUP_METADATA_PUBLISH_ATTEMPTS_FOR_TEST
+            .lock()
+            .expect("publish-attempt recorder poisoned")
+            .iter()
+            .filter_map(|(topic, gid, recipient)| {
+                (topic == &metadata_topic && gid == &stable_group_id)
+                    .then(|| recipient.clone())
+                    .flatten()
+            })
+            .collect();
+
+        assert!(
+            !published_recipients.is_empty(),
+            "the remove handler must publish at least one survivor envelope"
+        );
+        assert!(
+            !published_recipients.contains(&victim_hex),
+            "the removed member must NOT appear in the published recipient set; \
+             got {published_recipients:?}"
+        );
+        assert!(
+            published_recipients.contains(&survivor_hex),
+            "the survivor must appear in the published recipient set; \
+             got {published_recipients:?}"
+        );
         Ok(())
     }
     fn treekem_metadata_group_info(

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -16762,6 +16762,204 @@ mod tests {
         );
         Ok(())
     }
+    // ── Gate item 2 (survivor decryptability): a survivor — a member still
+    // Active after an admin remove of a peer — CAN decrypt content the system
+    // PUBLISHED at the new epoch. The plaintext is published through the
+    // production `secure_group_encrypt` endpoint and read back through the
+    // production `secure_group_decrypt` endpoint — a true GSS-plane round-trip
+    // (Watson [12] §3 / Dario [13] §2), not an in-test envelope, so encrypt-
+    // side drift (AAD, key sourcing) cannot stay green here. The positive
+    // complement to item 4: item 4 proves the removed member cannot decrypt;
+    // item 2 proves the survivors still can.
+    //
+    // Interval (ADR 0024 break-disclosure rule): `secure_group_decrypt` entry
+    // (`:12283`) → target operation `cipher.decrypt` (`:12367`).
+    //
+    // Break list — every control-flow exit / alternate dispatch in the
+    // interval, each with its evidence:
+    //   :12291 group-not-found     — refused (installed group)
+    //   :12294 withdrawn           — refused (non-withdrawn group)
+    //   :12298 not-a-member        — MUTATION B + positive membership assert
+    //   :12306 TreeKem dispatch    — refused (assert secure_plane == Gss)
+    //   :12315 no shared secret    — refused (secret installed)
+    //   :12325 epoch mismatch      — refused (matching epoch sent)
+    //   :12340 bad base64 ct       — refused (valid base64)
+    //   :12346 bad base64 nonce    — refused (valid base64)
+    //   :12350 nonce wrong length  — refused (12-byte nonce)
+    //   :12362 cipher init failed  — refused (derive_message_key returns 32B)
+    //   :12394 cipher Err          — MUTATION A (stored-secret byte flip)
+    //   :12382 post-decrypt terminality recheck (→ :10127, hook :10134) —
+    //     FALSE-NEGATIVE hazard: can suppress a success into a 409 conflict,
+    //     cannot manufacture plaintext. Refused by the success-shape
+    //     precondition (status 200 + payload present + no conflict). NOT a
+    //     blind spot. `force_post_crypto_withdrawn_ids` is NOT installed.
+    //
+    // Mutation A: between the production encrypt and decrypt calls, flip one
+    // byte in the stored `shared_secret`. The ciphertext was sealed under the
+    // original; decrypt derives from the flipped secret → wrong key → `:12394`
+    // "decryption failed" → the success assertion fails. Shows the gate
+    // observes the cipher path (`:12394`), distinct from the `:12298` roster
+    // guard exercised by mutation B.
+    //
+    // Mutation B: `remove_member(&survivor)` after setup → survivor Removed →
+    // the `:12298` roster guard fires → "not a member" → success assertion
+    // fails. Shows the gate observes active membership at `:12298`.
+    //
+    // Epoch-binding pin: `derive_message_key` mixes the epoch into the key
+    // (`groups/mod.rs:744`); Watson's M4 showed nothing in the F1 set observes
+    // it. A direct pure-fn pair asserts different epochs yield different keys,
+    // complementing 4b (which pins the secret binding).
+    #[tokio::test]
+    async fn f1_item2_survivor_decrypts_new_epoch_content() -> Result<()> {
+        let (state, _dir) = secure_endpoint_test_state().await?;
+        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+        // Admin/creator is a distinct agent; the local daemon is the survivor.
+        let admin_id = crate::identity::AgentKeypair::generate()?.agent_id();
+        let admin_hex = hex::encode(admin_id.as_bytes());
+
+        let group_id = "f1-item2-local".to_string();
+        let stable_group_id = "f1-item2-stable".to_string();
+        let epoch: u64 = 7;
+        let secret: Vec<u8> = vec![0x42; 32];
+
+        let mut info = x0x::groups::GroupInfo::with_policy(
+            "f1 item2 survivor decrypt".to_string(),
+            String::new(),
+            admin_id,
+            group_id.clone(),
+            x0x::groups::GroupPolicyPreset::PrivateSecure.to_policy(),
+        );
+        info.genesis = Some(x0x::groups::state_commit::GroupGenesis::with_existing_id(
+            stable_group_id.clone(),
+            admin_hex.clone(),
+            info.created_at,
+            String::new(),
+        ));
+        info.secure_plane = x0x::mls::SecureGroupPlane::Gss;
+        info.secret_epoch = epoch;
+        info.shared_secret = Some(secret.clone());
+        info.add_member(
+            local_hex.clone(),
+            x0x::groups::GroupRole::Member,
+            Some(admin_hex.clone()),
+            None,
+        );
+        info.recompute_state_hash();
+        state
+            .named_groups
+            .write()
+            .await
+            .insert(group_id.clone(), info);
+
+        // Positive preconditions: GSS plane (explicit, not inherited) and the
+        // survivor really is an Active member.
+        {
+            let groups = state.named_groups.read().await;
+            let stored = groups.get(&group_id).expect("item2 group present");
+            assert_eq!(
+                stored.secure_plane,
+                x0x::mls::SecureGroupPlane::Gss,
+                "item2 must exercise the GSS decrypt path, not the TreeKem dispatch"
+            );
+            assert!(
+                stored.has_active_member(&local_hex),
+                "survivor (local daemon) must be Active before decrypt"
+            );
+        }
+
+        // PUBLISH the plaintext through the production `secure_group_encrypt`
+        // endpoint — content the system actually produced, not minted in-test.
+        // For this group the GSS plane is active, so encrypt derives the key
+        // from `info.secure_message_key()` (the stored secret at `epoch`),
+        // generates a fresh per-message nonce, and seals with the production
+        // AAD. The returned `ciphertext_b64` / `nonce_b64` are what a survivor
+        // would actually receive.
+        let plaintext = b"item2 survivor new-epoch plaintext";
+        let (enc_status, enc_body) = secure_group_encrypt(
+            State(Arc::clone(&state)),
+            Path(group_id.clone()),
+            Json(SecureEncryptRequest {
+                payload_b64: BASE64.encode(plaintext),
+            }),
+        )
+        .await;
+        assert_eq!(
+            enc_status,
+            StatusCode::OK,
+            "production encrypt must succeed for an active survivor; body: {enc_body:?}"
+        );
+        assert_eq!(
+            enc_body.0["ok"].as_bool(),
+            Some(true),
+            "encrypt must report ok, body: {enc_body:?}"
+        );
+        let ciphertext_b64 = enc_body.0["ciphertext_b64"]
+            .as_str()
+            .expect("encrypt response carries ciphertext_b64")
+            .to_string();
+        let nonce_b64 = enc_body.0["nonce_b64"]
+            .as_str()
+            .expect("encrypt response carries nonce_b64")
+            .to_string();
+        assert_eq!(
+            enc_body.0["secret_epoch"].as_u64(),
+            Some(epoch),
+            "encrypt must bind the group's current secret_epoch"
+        );
+
+        // Production endpoint decrypt, as the survivor, of the published
+        // ciphertext (the exact bytes the system just produced above).
+        let (status, body) = secure_group_decrypt(
+            State(Arc::clone(&state)),
+            Path(group_id.clone()),
+            Json(SecureDecryptRequest {
+                ciphertext_b64,
+                nonce_b64,
+                secret_epoch: epoch,
+            }),
+        )
+        .await;
+
+        // Success-shape precondition (refuses the eleventh false-negative
+        // path): status 200 + payload present + ok, NOT a 409 conflict.
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "survivor must decrypt new-epoch content"
+        );
+        assert_eq!(
+            body.0["ok"].as_bool(),
+            Some(true),
+            "decrypt must report ok, body: {body:?}"
+        );
+        let payload_b64 = body.0["payload_b64"]
+            .as_str()
+            .expect("success response carries payload_b64");
+        assert_eq!(
+            BASE64.decode(payload_b64).expect("payload is base64"),
+            plaintext,
+            "decrypted plaintext must match"
+        );
+        assert_eq!(
+            body.0["secret_epoch"].as_u64(),
+            Some(epoch),
+            "echoed epoch must match the ciphertext epoch"
+        );
+
+        // Epoch-binding pin in the derivation (`groups/mod.rs:744`). Nothing
+        // else in the F1 set observes this; 4b pins the secret binding.
+        let key_this = x0x::groups::GroupInfo::derive_message_key(&secret, epoch, &stable_group_id);
+        let key_next =
+            x0x::groups::GroupInfo::derive_message_key(&secret, epoch + 1, &stable_group_id);
+        assert_ne!(
+            key_this, key_next,
+            "derive_message_key must bind the epoch; identical keys across epochs would let a \
+             stale-epoch holder derive the new-epoch key"
+        );
+
+        Ok(())
+    }
+
     fn treekem_metadata_group_info(
         creator: AgentId,
         group_id: &str,

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -15999,6 +15999,366 @@ mod tests {
         Ok(())
     }
 
+    // ── F1 GSS-rotation ADR gate tests (§3 ordering + §7a producer) ─────
+    //
+    // These tests exercise the production apply seam
+    // `apply_named_group_metadata_event` (NOT an interior helper) for the
+    // fail-closed GSS rekey on admin-remove. Gate 3 pins both delivery
+    // orderings of the signed `MemberRemoved` commit and the
+    // `SecureShareDelivered` envelope to the same converged committed state.
+    // Gate 7a pins the real `GroupInfo::rotate_shared_secret` producer.
+
+    struct F1GssRotationFixture {
+        state: Arc<AppState>,
+        _dir: tempfile::TempDir,
+        admin_kp: crate::identity::AgentKeypair,
+        victim_hex: String,
+        group_id: String,
+        new_epoch: u64,
+        new_secret: [u8; 32],
+        committed_state_hash: String,
+        remove_event: NamedGroupMetadataEvent,
+        envelope_event: NamedGroupMetadataEvent,
+    }
+
+    // Build an independent, freshly-keyed fixture: a GSS-plane group whose
+    // separately-generated admin creator authors the rotation, the local
+    // daemon is an active survivor (the envelope recipient), and a third
+    // agent is the removal victim. The committed transition is built by
+    // cloning the installed parent, bumping the roster revision, removing the
+    // victim, rotating the GSS, fallibly converting to `[u8; 32]`, and sealing
+    // the commit under the admin's keypair — exactly the production producer
+    // path. The envelope is sealed to the survivor's KEM public key with the
+    // same AAD the opener recomputes.
+    async fn f1_gss_rotation_fixture(group_tag: &str) -> Result<F1GssRotationFixture> {
+        let (state, _dir) = secure_endpoint_test_state().await?;
+        let admin_kp = crate::identity::AgentKeypair::generate()?;
+        let admin_id = admin_kp.agent_id();
+        let admin_hex = hex::encode(admin_id.as_bytes());
+        let victim_hex = hex::encode(
+            crate::identity::AgentKeypair::generate()?
+                .agent_id()
+                .as_bytes(),
+        );
+        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+
+        let group_id = format!("f1-gss-{group_tag}-local");
+        let stable_group_id = format!("f1-gss-{group_tag}-stable");
+        let parent_epoch: u64 = 7;
+
+        let mut parent = x0x::groups::GroupInfo::with_policy(
+            "f1 gss rotation".to_string(),
+            String::new(),
+            admin_id,
+            group_id.clone(),
+            x0x::groups::GroupPolicyPreset::PrivateSecure.to_policy(),
+        );
+        parent.genesis = Some(x0x::groups::state_commit::GroupGenesis::with_existing_id(
+            stable_group_id.clone(),
+            admin_hex.clone(),
+            parent.created_at,
+            String::new(),
+        ));
+        parent.secure_plane = x0x::mls::SecureGroupPlane::Gss;
+        parent.secret_epoch = parent_epoch;
+        parent.shared_secret = Some(vec![9; 32]);
+        parent.security_binding = Some(format!("gss:epoch={parent_epoch}"));
+        parent.add_member(
+            local_hex.clone(),
+            x0x::groups::GroupRole::Member,
+            Some(admin_hex.clone()),
+            None,
+        );
+        parent.add_member(
+            victim_hex.clone(),
+            x0x::groups::GroupRole::Member,
+            Some(admin_hex.clone()),
+            None,
+        );
+        parent.recompute_state_hash();
+
+        // Install the parent (the survivor daemon's pre-event view) in state.
+        state
+            .named_groups
+            .write()
+            .await
+            .insert(group_id.clone(), parent.clone());
+
+        // Producer-side committed transition: remove victim, rotate GSS, seal.
+        let mut committed = parent.clone();
+        committed.roster_revision = committed.roster_revision.saturating_add(1);
+        let roster_revision = committed.roster_revision;
+        committed.remove_member(&victim_hex, Some(admin_hex.clone()));
+        let (new_secret_vec, new_epoch) = committed.rotate_shared_secret();
+        // §2a: the conversion is mandatory (seal needs `&[u8; 32]`) and must
+        // be fallible. `Err(v)` *is* the secret material — bind `v` only to
+        // read its length; never format or log it.
+        let new_secret: [u8; 32] = match new_secret_vec.try_into() {
+            Ok(s) => s,
+            Err(v) => {
+                return Err(anyhow::anyhow!(
+                    "rotate_shared_secret returned {} bytes; expected 32",
+                    v.len()
+                ));
+            }
+        };
+        let commit = committed.seal_commit(&admin_kp, 1_000)?;
+        let committed_state_hash = committed.state_hash.clone();
+
+        // Seal the rotated secret to the survivor daemon. The opener
+        // recomputes AAD from the event's `group_id` (the stable id) +
+        // recipient + epoch, so the sealer must use the identical binding.
+        let aad = secure_share_aad(&stable_group_id, &local_hex, new_epoch);
+        let (kem_ct, aead_nonce, aead_ct) =
+            x0x::groups::kem_envelope::seal_group_secret_to_recipient(
+                &state.agent_kem_keypair.public_bytes,
+                &aad,
+                &new_secret,
+            )?;
+        let envelope_event = NamedGroupMetadataEvent::SecureShareDelivered {
+            group_id: stable_group_id.clone(),
+            recipient: local_hex,
+            secret_epoch: new_epoch,
+            kem_ciphertext_b64: BASE64.encode(&kem_ct),
+            aead_nonce_b64: BASE64.encode(aead_nonce),
+            aead_ciphertext_b64: BASE64.encode(&aead_ct),
+            actor: admin_hex.clone(),
+        };
+
+        let remove_event = NamedGroupMetadataEvent::MemberRemoved {
+            group_id: stable_group_id,
+            revision: roster_revision,
+            actor: admin_hex.clone(),
+            agent_id: victim_hex.clone(),
+            treekem_commit_b64: None,
+            treekem_epoch: None,
+            secret_epoch: Some(new_epoch),
+            commit: Some(commit),
+        };
+
+        Ok(F1GssRotationFixture {
+            state,
+            _dir,
+            admin_kp,
+            victim_hex,
+            group_id,
+            new_epoch,
+            new_secret,
+            committed_state_hash,
+            remove_event,
+            envelope_event,
+        })
+    }
+
+    // Convergence contract shared by both delivery orderings: after both the
+    // signed remove and the envelope have applied, the stored state must be
+    // identical regardless of arrival order.
+    async fn assert_gss_rotation_converged(
+        state: &Arc<AppState>,
+        group_id: &str,
+        victim_hex: &str,
+        new_epoch: u64,
+        new_secret: &[u8; 32],
+        committed_state_hash: &str,
+    ) -> Result<()> {
+        let groups = state.named_groups.read().await;
+        let Some(info) = groups.get(group_id) else {
+            return Err(anyhow::anyhow!(
+                "converged group missing from storage key {group_id}"
+            ));
+        };
+        assert!(
+            !info.has_active_member(victim_hex),
+            "victim must be Removed after admin-remove convergence"
+        );
+        assert!(
+            info.members_v2
+                .get(victim_hex)
+                .is_some_and(|m| m.is_removed()),
+            "victim roster entry must carry the Removed state"
+        );
+        assert_eq!(
+            info.secret_epoch, new_epoch,
+            "secret_epoch must be the rotated epoch E+1"
+        );
+        assert_eq!(
+            info.security_binding,
+            Some(format!("gss:epoch={new_epoch}")),
+            "security_binding must track the rotated epoch"
+        );
+        assert!(
+            info.shared_secret.as_deref() == Some(new_secret.as_slice()),
+            "shared_secret must be the rotated S1 after convergence"
+        );
+        assert_eq!(
+            info.state_hash, committed_state_hash,
+            "committed state_hash must match the producer-sealed transition"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn f1_gss_rotation_metadata_first_removes_then_installs_envelope() -> Result<()> {
+        let f = f1_gss_rotation_fixture("metadata-first").await?;
+        let sender = f.admin_kp.agent_id();
+
+        // Metadata-first: the signed `MemberRemoved` lands before the
+        // envelope. The apply arm fail-closes the GSS (old epoch E < E+1
+        // wipes `shared_secret` to `None`) but advances epoch/binding from
+        // the signed commit alone.
+        let removed =
+            apply_named_group_metadata_event(&f.state, f.remove_event.clone(), sender, true).await;
+        assert!(
+            removed,
+            "MemberRemoved with a valid signed commit must apply (returns true)"
+        );
+        {
+            let groups = f.state.named_groups.read().await;
+            let Some(info) = groups.get(&f.group_id) else {
+                return Err(anyhow::anyhow!("metadata-first group missing"));
+            };
+            assert_eq!(
+                info.shared_secret, None,
+                "metadata-first intermediate must fail-close shared_secret to None"
+            );
+            assert_eq!(
+                info.secret_epoch, f.new_epoch,
+                "metadata-first intermediate must already carry the rotated epoch"
+            );
+        }
+
+        // The envelope then delivers the fresh secret to the survivor. The
+        // strict-< stale check accepts equal-epoch delivery while the secret
+        // is still absent.
+        let delivered =
+            apply_named_group_metadata_event(&f.state, f.envelope_event.clone(), sender, true)
+                .await;
+        // SecureShareDelivered signals "no rebroadcast" (returns false);
+        // success is observed in stored state, not in this boolean.
+        assert!(
+            !delivered,
+            "SecureShareDelivered returns false; convergence is asserted on stored state"
+        );
+
+        assert_gss_rotation_converged(
+            &f.state,
+            &f.group_id,
+            &f.victim_hex,
+            f.new_epoch,
+            &f.new_secret,
+            &f.committed_state_hash,
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn f1_gss_rotation_envelope_first_installs_then_remove_preserves_secret() -> Result<()> {
+        let f = f1_gss_rotation_fixture("envelope-first").await?;
+        let sender = f.admin_kp.agent_id();
+
+        // Envelope-first: the fresh secret lands before the signed remove.
+        // The strict-< stale check accepts the newer epoch and installs S1.
+        let delivered =
+            apply_named_group_metadata_event(&f.state, f.envelope_event.clone(), sender, true)
+                .await;
+        assert!(
+            !delivered,
+            "SecureShareDelivered returns false; success is observed in stored state"
+        );
+        {
+            let groups = f.state.named_groups.read().await;
+            let Some(info) = groups.get(&f.group_id) else {
+                return Err(anyhow::anyhow!("envelope-first group missing"));
+            };
+            assert!(
+                info.shared_secret.as_deref() == Some(f.new_secret.as_slice()),
+                "envelope-first intermediate must already hold S1"
+            );
+            assert_eq!(
+                info.secret_epoch, f.new_epoch,
+                "envelope-first intermediate must already carry the rotated epoch"
+            );
+        }
+
+        // The signed remove then applies. Because the local epoch already
+        // equals the commit's epoch, the strict `old < new` wipe is a no-op
+        // and the just-installed S1 survives (the secret is preserved).
+        let removed =
+            apply_named_group_metadata_event(&f.state, f.remove_event.clone(), sender, true).await;
+        assert!(
+            removed,
+            "MemberRemoved with a valid signed commit must apply (returns true)"
+        );
+
+        assert_gss_rotation_converged(
+            &f.state,
+            &f.group_id,
+            &f.victim_hex,
+            f.new_epoch,
+            &f.new_secret,
+            &f.committed_state_hash,
+        )
+        .await?;
+        Ok(())
+    }
+
+    // ── Gate 7a: real `GroupInfo::rotate_shared_secret` producer invariants ─
+    fn f1_gss_group_for_rotate() -> Result<x0x::groups::GroupInfo> {
+        let creator = crate::identity::AgentKeypair::generate()?;
+        let mut info = x0x::groups::GroupInfo::with_policy(
+            "f1 rotate producer".to_string(),
+            String::new(),
+            creator.agent_id(),
+            "f1-rotate-producer-local".to_string(),
+            x0x::groups::GroupPolicyPreset::PrivateSecure.to_policy(),
+        );
+        info.secure_plane = x0x::mls::SecureGroupPlane::Gss;
+        info.recompute_state_hash();
+        Ok(info)
+    }
+
+    #[test]
+    fn f1_gss_rotate_shared_secret_producer_returns_32_byte_secret() -> Result<()> {
+        let mut info = f1_gss_group_for_rotate()?;
+        let (secret, _epoch) = info.rotate_shared_secret();
+        assert_eq!(
+            secret.len(),
+            32,
+            "rotate_shared_secret must yield a 32-byte secret"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn f1_gss_rotate_shared_secret_producer_advances_epoch_by_exactly_one() -> Result<()> {
+        let mut info = f1_gss_group_for_rotate()?;
+        let prev_epoch = info.secret_epoch;
+        let (_secret, new_epoch) = info.rotate_shared_secret();
+        assert_eq!(
+            new_epoch,
+            prev_epoch.saturating_add(1),
+            "returned epoch must be exactly prev + 1"
+        );
+        assert_eq!(
+            info.secret_epoch,
+            prev_epoch.saturating_add(1),
+            "stored epoch must be exactly prev + 1"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn f1_gss_rotate_shared_secret_producer_stored_secret_equals_returned_bytes() -> Result<()> {
+        let mut info = f1_gss_group_for_rotate()?;
+        let (secret, _epoch) = info.rotate_shared_secret();
+        assert!(
+            info.shared_secret.as_deref() == Some(secret.as_slice()),
+            "stored shared_secret must be byte-identical to the returned secret"
+        );
+        Ok(())
+    }
+
     fn treekem_metadata_group_info(
         creator: AgentId,
         group_id: &str,


### PR DESCRIPTION
**DRAFT — do not merge.** Two approvals are still outstanding (see *Merge blockers* below). This PR is open so CI runs on the union.

## What this is

The union of the two F1 halves that were developed on separate branches, both stacked on `e301371`:

- **code** — `glm/f1-item2` @ `103fd7a2b381d739bc8a038c9963866193261ce5`
- **ADR** — `sam/adr-0024-restructure` @ `08f1749e64b172ccfd36278e42935b4bdc8319a0`

Built by Kimi as `kimi/f1-union` @ `ad6c1563315ebbd20eed6855744993fe43fe4f24` — two merge commits, both halves genuinely in. `origin/main` (`e301371`) is an ancestor. The union tree is `6f1cdbd9768c014ca8357c9a1699056e1ae6a503`, which is byte-identical to what `git merge-tree --write-tree 103fd7a 08f1749` produced independently before the merge was made.

## Gate result

`just check` at `ad6c156` — x0x's gate is `fmt-check lint build test doc`, all five steps ran:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo build --all-features
cargo nextest run --all-features --workspace
cargo doc --all-features --no-deps
```

```
Summary [51.763s] 2457 tests run: 2457 passed (1 leaky), 245 skipped
JUST_CHECK_EXIT=0
```

Zero `warning:` lines across the whole run. Run in a pristine detached worktree at `ad6c156`; `git status --porcelain` was empty at both the start and the end of the run, and `HEAD` was unchanged at both ends.

Two honest qualifications:

- **245 skipped** is the standing `#[ignore]` population, unchanged from `main` — not something this branch introduces. `just check` runs none of them, on either side.
- **`(1 leaky)`** carries no information. nextest's leak label is load-dependent and the exit code is unmoved by it.

Baselines, with their selectors stated: workspace non-ignored `main` 2448 → this branch 2457; package `-p x0x` 2440 → 2449; ignored 245 on both sides.

## What the nine F1 gates do and do not observe

All nine `f1_*` gates have a measured red arm at `103fd7a`, six of them sole-catcher. Two named blind spots, stated here so they are not discovered later:

- symmetric AAD drift is invisible to all nine;
- item 2 stays green under a mutation that stops `derive_message_key` reading the secret — only 4b catches that.

## Merge blockers

1. **ADR 0024 has not been approved.** `08f1749` is waiting on David's 👍. Nothing in this PR may merge before that.
2. **The ban twin is open.** `src/server/routes/named_groups.rs` carries a second, structurally identical fail-close block: the **remove** path at `:5058`/`:5066-5067` is gated by item 4, and the **ban** path at `:5333`/`:5341-5342` is gated by nothing. Deleting the ban wipe leaves the full workspace suite green — 2457 passed, exit 0 — which is the measurement that says no test observes it. `grep -n 'old_epoch'` over that file returns exactly these four lines, so the population is closed at two. A gate for it is in progress on `minimax/f1-item4ban`.

Line numbers above resolve at `ad6c156` only.

## Not in scope

Items 5 (fail-closed preflight) and 6 (mixed-version fleet) are scheduled follow-up by an explicit ruling of 2026-07-27; ADR 0024's Validation is partial at acceptance by design and says so.

Originating channel: build-team `4cab8fec-eaa4-4911-b394-848bad1de705`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds fail-closed GSS rotation and per-survivor secret resealing to administrative removal.
- Extends `MemberRemoved` with an optional GSS epoch and applies rotations in either metadata/envelope delivery order.
- Prebuilds all survivor envelopes before committing the removal and adds focused F1 gate tests.
- Adds ADR 0024, its implementation and validation reference, and a dedicated `just adr-gates-f1` runner.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until rotated state publication requires successful persistence and active survivors have a reliable recovery path when all envelope deliveries fail.

The handler publishes a new roster and epoch after persistence errors, and its best-effort envelope deliveries can leave an active survivor permanently without the corresponding secret.

**Files Needing Attention:** src/server/routes/named_groups.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routes/named_groups.rs | Implements GSS rotation, receiver application, preflight envelope construction, publication, and extensive tests, but persistence and delivery failures can leave peers on incompatible state or without the rotated key. |
| justfile | Adds a focused nextest recipe selecting the F1 gate tests. |
| docs/adr/0024-gss-rotation-on-admin-remove-fail-closed.md | Records the proposed fail-closed rotation decision and its validation requirements. |
| docs/design/gss-admin-remove-fail-closed.md | Documents implementation ordering, known trade-offs, gate mechanics, and validation receipts. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Admin as Admin remove handler
  participant State as In-memory GroupInfo
  participant Disk as Persistent snapshot
  participant Peers as Surviving peers
  Admin->>State: Remove member and rotate GSS
  Admin->>State: Prebuild survivor envelopes
  Admin->>State: Seal and install commit
  Admin->>Disk: save_named_groups()
  alt persistence succeeds
    Admin->>Peers: Publish MemberRemoved(E+1)
    Admin->>Peers: Publish survivor envelopes(E+1)
  else persistence fails but is only logged
    Admin->>Peers: Publish MemberRemoved(E+1)
    Admin->>Peers: Publish survivor envelopes(E+1)
    Note over State,Disk: Restart reloads the stale roster and epoch
  end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/routes/named_groups.rs:8690
**Failed persistence still publishes rotation**

When `save_named_groups` fails to serialize or write the rotated state, it only logs the error and the handler still publishes `MemberRemoved` and the new survivor envelopes. Peers then advance to a roster and secret epoch that the origin loses on restart, restoring its prior roster and key state and leaving the group on incompatible commit chains.

### Issue 2
src/server/routes/named_groups.rs:8706
**Best-effort delivery strands survivors**

When the metadata publish and both spawned direct deliveries fail, the changed removal has already committed and published an epoch that clears each survivor's old secret, while every envelope failure is only logged. The survivor remains active but has no new secret, so it cannot decrypt subsequent group content and no retry or recovery path restores the key.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Clarify ADR 0024 reference chapter owner..."](https://github.com/saorsa-labs/x0x/commit/b6d5c5f85459335376312669beb6673469af62f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48125449)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Groups: Membership, Discovery, and State Commits](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/groups-messaging.md)

<!-- /greptile_comment -->