### PR TITLE
ADR 0025: required gates must prove observation completeness (Accepted)

### DIFF
--- a/docs/adr/0025-required-gates-prove-observation-completeness.md
+++ b/docs/adr/0025-required-gates-prove-observation-completeness.md
@@ -344,6 +344,15 @@ performs both actions, and its call site contains no separate success return.
 `record_skip("reason"); return Ok(())` is forbidden because recognizing it
 would require the audit to infer statement domination.
 
+The one allowed helper is pinned to an exact definition rather than accepted
+by a name pattern. Governance verifies that definition emits the
+machine-readable record and owns a positive-control fixture outside the
+workspace's discovered test inventory. The audit invokes that fixture through
+the required dispatcher as a subprocess and passes only when the helper fires
+and the dispatcher exits non-zero. The fixture is not an ordinary test and is
+not placed in a functional tier: either placement would make the required
+inventory permanently red or certify the wrong execution context.
+
 The helper is diagnostic accounting, not an observation or a bypass. Its
 record maps to `declared-not-executed-with-reason`, never to
 `executed-and-passed`:
@@ -437,6 +446,15 @@ Enforcement requires both:
 1. API readback of the configured rule and exact required status context; and
 2. an intentionally red pull request that GitHub refuses to merge.
 
+Dispatcher failure propagation has its own governance negative control,
+separate from the transient red pull request. Governance owns a deliberately
+failing fixture outside the workspace's discovered test inventory and invokes
+the required dispatcher over it as a subprocess. The audit passes only when
+the dispatcher reports the executed failure and exits non-zero. The fixture is
+not an ordinary test and is not assigned to a functional tier, because either
+placement would make a normal required run permanently red or exercise a
+different context from the one being certified.
+
 Security Audit, Claude Code, or another context that does not produce a
 substantive pass/fail test observation cannot substitute for the required
 test context.
@@ -496,9 +514,10 @@ There is no verified current substantive green baseline context. Rollout is:
    the current smaller CI inventory is complete.
 3. Introduce the registry, dispatcher, inventory reconciliation,
    syntax-aware test-exit audit, single skip-recording helper, skip
-   reconciliation, and tier jobs in advisory mode; absorb the three existing
-   scheduling overrides and the default profile's termination policy into the
-   registry. At this stage the dispatcher intentionally retains
+   reconciliation, the two governance-owned out-of-inventory control fixtures,
+   and tier jobs in advisory mode; absorb the three existing scheduling
+   overrides and the default profile's termination policy into the registry.
+   At this stage the dispatcher intentionally retains
    `--run-ignored default`. Before execution it emits a temporary
    `declared-not-executed-with-reason` outcome for each ignored identity that
    remains selected in that context, scoped to this advisory migration and
@@ -593,6 +612,11 @@ Before the comprehensive status can become required:
   direct success return from a precondition or destructuring failure arm; the
   only allowed success exit is the single skip-exit construct, whose call site
   contains no separate return;
+- governance pins that skip-exit construct to one exact definition and its
+  out-of-inventory positive-control fixture proves that the helper records a
+  skip and makes the required dispatcher exit non-zero;
+- an out-of-inventory deliberately failing fixture proves that the required
+  dispatcher reports semantic failure and exits non-zero;
 - a required run records zero skips, zero declared-not-executed outcomes, and
   propagates semantic failure;
 - regeneration commands and validation tests are distinct;

--- a/docs/adr/0025-required-gates-prove-observation-completeness.md
+++ b/docs/adr/0025-required-gates-prove-observation-completeness.md
@@ -60,6 +60,11 @@ The measured repository state illustrates the gap:
 - local `just` recipes, CI workflows, and two orphaned shell scripts select
   ignored tests with separately maintained commands;
 - no CI workflow invokes `just`, so local and CI gates share no dispatcher;
+- `.config/nextest.toml` separately owns three
+  `profile.default.overrides` filtersets that assign the serialized
+  `quic-localhost` test group; these change scheduling rather than selection,
+  but they are already a hand-maintained tier definition outside any
+  registry;
 - a structural evidence sweep over `tests/**` found 33 early-success sites
   across 27 non-ignored test functions; an independent reproduction found 29
   candidate dormant sites, then source review reclassified seven as
@@ -89,6 +94,16 @@ Tool constraints also shape the decision. cargo-nextest 0.9.126 can select
 with `--run-ignored default|only|all`. It cannot select the reason string in
 `#[ignore = "..."]`. Its test groups control scheduling, and this version has
 no `test_group(...)` filterset predicate.
+
+Its experimental `libtest-json-plus` stream also does not emit a per-test
+ignored or skipped outcome. In a measured default run over a binary with seven
+ignored tests and one active test, all eight identities emitted `started`,
+only the active test emitted a terminal `ok`, and nextest reported the other
+seven only in its aggregate skipped count. Absence of a terminal event
+therefore cannot mean "declared not run": the same shape would also occur if a
+selected test stopped before producing a result. This matters because the
+repository's default nextest profile can terminate slow tests after ten
+60-second periods.
 
 Finally, a green command is not a merge gate by itself. `main` currently has
 no verified substantive green baseline context suitable for protection and no
@@ -217,7 +232,10 @@ tier definition owns:
 
 A single dispatcher consumes the registry. Hand-written tier-specific nextest
 commands, inline workflow exclusions, and separately maintained test lists
-are forbidden.
+are forbidden. The three existing `quic-localhost` scheduling overrides are
+migration inputs: their selectors and concurrency policy must move under the
+registry, and any generated nextest configuration must be derived from it
+rather than maintained as a second source.
 
 `run-required` iterates the registry definitions for `default` and
 `required-isolated`; `just check` invokes `run-required`. CI derives its
@@ -236,24 +254,54 @@ Governance follows the result rather than rejecting token shapes: for example,
 `|| true` may preserve captured output only when a later fail-closed check
 turns the captured failure into a failing status.
 
-### 4. Reconcile selection and terminal-result inventories in every context
+### 4. Reconcile selection and one positive outcome per discovered identity
 
 The registry-derived required inventory is the union of `default` and
 `required-isolated`. Each required local and CI context emits its effective
 selected inventory before execution and reconciles it against that required
-inventory.
+inventory. Selection is derived from registry selectors before the runner's
+ignore-state disposition is applied. During the advisory migration, an
+ignored identity in the default complement therefore remains selected even
+though it receives a declared not-executed outcome.
 
-After execution, each required context emits the set of discovered test
-identities that produced a terminal result in that run and reconciles that set
-against the same registry-derived required inventory. Selected-set equality is
-necessary but insufficient: the required run fails when a required test
-produced no result or when an unselected test identity produced one.
+Each context also emits exactly one positive outcome for every discovered test
+identity from this closed set:
 
-The initial dispatcher may obtain terminal results from cargo-nextest 0.9.126
+- `executed-and-passed`: the identity was selected and emitted a passing
+  per-test terminal event;
+- `executed-and-failed`: the identity was selected and emitted a failing
+  per-test terminal event;
+- `declared-not-selected`: the registry declares that identity's tier out of
+  scope for this context; or
+- `declared-not-executed-with-reason`: the dispatcher or declared skip helper
+  positively records why an otherwise selected identity did not execute its
+  promised observation.
+
+Accounting an `executed-and-failed` outcome does not convert semantic failure
+into success; the dispatcher still returns a failing status.
+
+A `started` event is not terminal. `declared-not-selected` must come from the
+registry before execution. `declared-not-executed-with-reason` may come only
+from a dispatcher declaration made before execution or from the
+machine-readable skip helper; it is never inferred from a missing runner
+event.
+
+The dispatcher reconciles the outcome table one-to-one against nextest
+discovery, the effective selected inventory, and the runner's own
+run/pass/fail/not-run totals. An identity with zero or multiple outcomes
+fails the run. A selected identity with no terminal event and no positive
+declared-not-executed record fails the run. A terminal event for an identity
+declared unselected or not executed also fails the run. Selected-set equality
+is necessary but insufficient.
+
+The initial dispatcher may obtain executed outcomes from cargo-nextest 0.9.126
 with `NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1` and
 `--message-format libtest-json-plus`. Because that interface is experimental,
-the dispatcher owns the environment flag and parser and fails closed when the
-machine-readable result stream is unavailable or malformed.
+the registry version-pins the recognized raw event-to-outcome mapping, and the
+dispatcher owns the environment flag and parser. Unknown events or an
+unavailable or malformed stream fail closed. The dispatcher reconciles
+explicit not-run declarations with nextest's aggregate skipped/not-run count;
+it does not translate raw event absence into an outcome.
 
 A context-specific difference may exist only when the registry declares it
 with a reason, owner, and expiry. It cannot be expressed as an inline
@@ -272,7 +320,8 @@ The default behavior is to fail with the unmet precondition.
 Where Rust's test harness cannot express a native skip result, test code may
 use one declared helper that emits a machine-readable skip record keyed to
 the discovered test identity. The helper is diagnostic accounting, not a
-success escape:
+success escape. Its record maps to
+`declared-not-executed-with-reason`, never to `executed-and-passed`:
 
 - a required dispatcher fails if its recorded skip count is non-zero;
 - a scheduled external or soak context fails if its promised infrastructure
@@ -344,9 +393,9 @@ behavior.
 - the observation-completeness governance audit.
 
 Pull-request CI invokes the same registry-derived required dispatcher and
-publishes the same selected-inventory, terminal-result, and skip-accounting
+publishes the same selected-inventory, closed-outcome, and skip-accounting
 receipt. Coverage tooling may add instrumentation, but it may not silently
-shrink the required inventory or omit terminal results.
+shrink the required inventory or omit an outcome.
 
 ### 9. A merge gate requires proven branch enforcement
 
@@ -375,12 +424,15 @@ multi-tier matches                         0
 unreachable declared tiers                 0
 undeclared required-context divergence     0
 hand-written exclusion filtersets          0
+non-registry scheduling overrides          0
 dispatcher bypasses                        0
 silent early-success paths                 0
 regeneration-as-passing-test paths          0
 required-run recorded skips                0
-required tests with no reported result      0
-reported results outside selected inventory 0
+identities without exactly one outcome      0
+executed identities without terminal event  0
+outcome / runner-summary mismatches          0
+required-run declared-not-executed outcomes 0
 legacy baseline allowlist                  0
 ```
 
@@ -392,7 +444,10 @@ integration-test runtime-precondition paths, two further live unit-test
 self-void paths, 22 dormant self-void paths, ten already-fail-closed success
 returns that must become explicit divergence, two regeneration escape
 hatches, and fragmented legacy runners are migration work. Moving a bypass
-from one container to another does not satisfy the policy.
+from one container to another does not satisfy the policy. The three existing
+`quic-localhost` scheduling overrides are also migration work under the
+registry's single-source rule; the measured tailnet backpressure case matches
+none of them and currently receives no declared isolation.
 
 ### 11. Enforcement order is part of the decision
 
@@ -407,10 +462,17 @@ There is no verified current substantive green baseline context. Rollout is:
    the current smaller CI inventory is complete.
 3. Introduce the registry, dispatcher, inventory reconciliation,
    syntax-aware test-exit audit, single skip-recording helper, skip
-   reconciliation, and tier jobs in advisory mode. At this stage the
-   dispatcher intentionally retains `--run-ignored default`: discovery and
-   governance account for all ignored tests, but the new dispatcher does not
-   execute them or claim a comprehensive receipt.
+   reconciliation, and tier jobs in advisory mode; absorb the three existing
+   scheduling overrides into the registry. At this stage the dispatcher
+   intentionally retains `--run-ignored default`. Before execution it emits a
+   temporary `declared-not-executed-with-reason` outcome for each ignored
+   identity that remains selected in that context, scoped to this advisory
+   migration and reconciled with nextest's aggregate skipped count. That
+   declaration has an owner and expires at step 5; it is derived from
+   discovered ignore state, not a per-test allowlist.
+   Outcome accounting can therefore pass honestly while the separate
+   comprehensive-readiness receipt reports the remaining migration work. The
+   dispatcher does not claim comprehensive coverage.
 4. Migrate the currently live integration-test and unit-test
    runtime-precondition paths, convert already-fail-closed success returns to
    explicit divergence, and move regeneration out of validation tests. Do not
@@ -433,6 +495,8 @@ There is no verified current substantive green baseline context. Rollout is:
 - Local and CI selection derive from one executable definition.
 - The gate proves both selection and observation; a selected-but-self-voiding
   test can no longer masquerade as coverage.
+- Every discovered identity has a positive, closed-set outcome; raw absence
+  can no longer mean either "ignored" or "process died."
 - Isolation, external infrastructure, and soak budgets remain expressible
   without creating a defect quarantine.
 - Required status claims become independently testable through inventory
@@ -444,7 +508,7 @@ There is no verified current substantive green baseline context. Rollout is:
   precondition paths, regeneration escape hatches, and legacy runners.
 - A syntax-aware Rust audit and machine-readable skip reconciliation add
   tooling that must be maintained with test-language changes.
-- Terminal-result reconciliation initially depends on cargo-nextest's
+- Executed-outcome reconciliation initially depends on cargo-nextest's
   experimental `libtest-json-plus` interface; its adapter must fail closed and
   be reviewed when nextest changes the format or stabilizes a replacement.
 - Required local and pull-request gates will take longer because
@@ -459,6 +523,8 @@ There is no verified current substantive green baseline context. Rollout is:
 - `#[ignore = "..."]` remains useful metadata for cargo's ordinary runner,
   but no longer decides routing.
 - The registry defines policies and selectors, not an exhaustive test list.
+- The registry also owns scheduling selectors currently hand-maintained as
+  nextest profile overrides.
 - Target-level namespaces classify homogeneous binaries efficiently; mixed
   binaries pay the cost of module/test-level naming.
 - Context-specific inventory divergence is visible, owned, and expiring
@@ -477,17 +543,21 @@ Before the comprehensive status can become required:
 - every declared tier is reachable from every context it names;
 - `just check` and pull-request CI emit and reconcile their effective
   selected inventories against the registry-derived required inventory;
-- each required run emits a machine-readable terminal result for every
-  required test identity, emits none outside its selected inventory, and
-  fails when the result stream is missing or malformed;
-- coverage uses the same required inventory and terminal-result
+- each context assigns exactly one declared closed-set outcome to every
+  discovered identity;
+- every executed outcome has a matching per-test terminal event, every
+  not-selected or not-executed outcome is positively declared rather than
+  inferred from absence, and outcome counts reconcile with nextest's own
+  run/pass/fail/not-run totals;
+- coverage uses the same required inventory and closed-outcome
   reconciliation;
 - governance finds no hand-written tier commands or inline workflow
-  exclusions outside the dispatcher;
+  exclusions or scheduling overrides outside the dispatcher/registry;
 - a syntax-aware audit over integration tests and unit-test modules finds no
   direct success return from a precondition or destructuring failure arm
   outside the declared skip helper;
-- a required run records zero skips and propagates semantic failure;
+- a required run records zero skips, zero declared-not-executed outcomes, and
+  propagates semantic failure;
 - regeneration commands and validation tests are distinct;
 - the migration receipt in Decision 10 is all zero;
 - API readback shows the exact comprehensive status required for `main`,

--- a/docs/adr/0025-required-gates-prove-observation-completeness.md
+++ b/docs/adr/0025-required-gates-prove-observation-completeness.md
@@ -3,7 +3,7 @@
 - **Status:** Proposed — pre-consensus (Kimi ruling outstanding)
 - **Date:** 2026-07-28
 - **Decision owners:** David Irvine
-- **Reviewers:** Dario (draft review pending); Kimi (required ruling outstanding); Watson (evidence verification)
+- **Reviewers:** Dario (amended-draft review pending); Kimi (required ruling outstanding); Watson (evidence verification)
 - **Supersedes:** none
 - **Superseded by:** none
 - **Related:** `justfile`, `.github/workflows/ci.yml`,
@@ -58,7 +58,10 @@ The measured repository state illustrates the gap:
 - those workflow filters remove five non-ignored tests from Coverage, so the
   245-test ignore census cannot see the divergence;
 - local `just` recipes, CI workflows, and two orphaned shell scripts select
-  ignored tests with separately maintained commands;
+  ignored tests with separately maintained commands; the orphaned shell
+  runner graph also reaches `tests/runners/x0x_test_runner.py`, which has its
+  own retry accounting and is not invoked directly by a tracked workflow or
+  `justfile` recipe;
 - no CI workflow invokes `just`, so local and CI gates share no dispatcher;
 - `.config/nextest.toml` separately owns three
   `profile.default.overrides` filtersets that assign the serialized
@@ -224,18 +227,26 @@ tier definition owns:
 - its positive `binary(...)` / `test(...)` selector;
 - every permitted context-specific exclusion;
 - local, pull-request, external, and scheduled execution contexts;
-- scheduling, isolation, concurrency, and timeout policy;
+- scheduling, isolation, concurrency, timeout, termination, and retry policy;
 - infrastructure preconditions;
 - failure policy;
 - owner; and
 - reason and expiry for any declared context-specific divergence.
 
-A single dispatcher consumes the registry. Hand-written tier-specific nextest
-commands, inline workflow exclusions, and separately maintained test lists
-are forbidden. The three existing `quic-localhost` scheduling overrides are
-migration inputs: their selectors and concurrency policy must move under the
-registry, and any generated nextest configuration must be derived from it
-rather than maintained as a second source.
+A single dispatcher consumes the registry. Any policy that affects selection,
+scheduling, isolation, concurrency, timeout, termination, or retry behavior
+for a required tier must be derived from the registry, irrespective of the
+tool or file in which that policy is expressed. A workflow, nextest profile,
+script, `justfile` recipe, or successor container may consume generated policy
+but may not become an independent authority.
+
+Hand-written tier-specific nextest commands, inline workflow exclusions, and
+separately maintained test lists are known violations of that property, not a
+closed taxonomy. The three existing `quic-localhost` scheduling overrides and
+the default profile's slow-test termination policy are migration inputs. Their
+selectors and execution policy must move under the registry, and any generated
+nextest configuration must be derived from it rather than maintained as a
+second source.
 
 `run-required` iterates the registry definitions for `default` and
 `required-isolated`; `just check` invokes `run-required`. CI derives its
@@ -280,11 +291,19 @@ identity from this closed set:
 Accounting an `executed-and-failed` outcome does not convert semantic failure
 into success; the dispatcher still returns a failing status.
 
-A `started` event is not terminal. `declared-not-selected` must come from the
-registry before execution. `declared-not-executed-with-reason` may come only
-from a dispatcher declaration made before execution or from the
-machine-readable skip helper; it is never inferred from a missing runner
-event.
+A `started` event is evidence only that an identity appeared in the stream,
+not that it executed: ignored tests emit `started` without running.
+`declared-not-selected` must come from the registry before execution.
+`declared-not-executed-with-reason` may come only from a dispatcher
+declaration made before execution or from the machine-readable skip helper; it
+is never inferred from a missing runner event.
+
+During rollout steps 3 and 4, the sole temporary authority for declaring an
+ignored default-complement identity not executed is the dispatcher's pre-run
+discovery of runner ignore state, reconciled with the runner's aggregate
+not-run count. It is not a per-test registry entry or allowlist. After step 5
+removes that migration state, the registry's context and tier policy is the
+only authority for a pre-run not-selected declaration.
 
 The dispatcher reconciles the outcome table one-to-one against nextest
 discovery, the effective selected inventory, and the runner's own
@@ -318,10 +337,16 @@ An unmet runtime precondition may not resolve to an ordinary passing test.
 The default behavior is to fail with the unmet precondition.
 
 Where Rust's test harness cannot express a native skip result, test code may
-use one declared helper that emits a machine-readable skip record keyed to
-the discovered test identity. The helper is diagnostic accounting, not a
-success escape. Its record maps to
-`declared-not-executed-with-reason`, never to `executed-and-passed`:
+use one declared skip-exit helper that emits a machine-readable skip record
+keyed to the discovered test identity and exits the test. The helper must be
+the exit operation itself: one macro or equivalent syntax-level construct
+performs both actions, and its call site contains no separate success return.
+`record_skip("reason"); return Ok(())` is forbidden because recognizing it
+would require the audit to infer statement domination.
+
+The helper is diagnostic accounting, not an observation or a bypass. Its
+record maps to `declared-not-executed-with-reason`, never to
+`executed-and-passed`:
 
 - a required dispatcher fails if its recorded skip count is non-zero;
 - a scheduled external or soak context fails if its promised infrastructure
@@ -329,9 +354,9 @@ success escape. Its record maps to
 - a tier not scheduled in a context is accounted for by the registry, not by
   a passing test.
 
-Within a test function's own control-flow scope, every
-precondition-failure or destructuring-failure arm must diverge through an
-assertion, `panic!`, `unreachable!`, or the declared skip helper. Direct
+Within a test function's own control-flow scope, every precondition-failure or
+destructuring-failure arm must either diverge through an assertion, `panic!`,
+or `unreachable!`, or exit through the declared skip-exit helper. Direct
 success returns such as `return;`, `return Ok(())`, and
 `let ... else { return Ok(()) }` are forbidden. An assertion-dominated
 destructuring arm must use explicit divergence rather than retain an
@@ -339,11 +364,12 @@ unreachable success return.
 
 The audit must be syntax-aware and cover integration-test functions and unit
 test modules. It distinguishes a return from the test function from a return
-inside a nested closure or async block, and recognizes only the declared skip
-helper as an allowed success-exit mechanism. It does not try to infer whether
-an assertion dominates a success return, and it does not grep for `return`,
-`Ok(())`, or a "skipping" message. The current brace-depth censuses may seed
-the implementation and migration, but are not the normative audit.
+inside a nested closure or async block, and recognizes only the single
+skip-exit construct as an allowed success-exit mechanism. It does not try to
+infer whether an assertion or a preceding skip-record call dominates a
+success return, and it does not grep for `return`, `Ok(())`, or a "skipping"
+message. The current brace-depth censuses may seed the implementation and
+migration, but are not the normative audit.
 
 ### 6. Regeneration and validation are separate entry points
 
@@ -368,8 +394,11 @@ semantics:
   regression normally;
 - if the current behavior is intended, convert the test to a passing
   characterization and track any desired semantic change separately; or
-- if intent is unresolved, keep the semantic decision visibly open in an
-  issue with an owner and expiry, without counting it as coverage.
+- if intent is unresolved, remove the disputed test from the executable suite
+  rather than ignoring or tiering it, preserve the reproducer and competing
+  expectations in an issue with an owner and expiry, and do not claim the
+  property as covered until the decision produces either a normal regression
+  or an honest characterization test.
 
 `Flaky` requires measured pass/fail evidence. Even measured intermittence is
 evidence for diagnosis, not a permanent tier. The historically retry-passing
@@ -425,6 +454,7 @@ unreachable declared tiers                 0
 undeclared required-context divergence     0
 hand-written exclusion filtersets          0
 non-registry scheduling overrides          0
+required-tier policy not registry-derived  0
 dispatcher bypasses                        0
 silent early-success paths                 0
 regeneration-as-passing-test paths          0
@@ -443,11 +473,15 @@ The 196 bare ignore attributes, current workflow exclusions, 31 live
 integration-test runtime-precondition paths, two further live unit-test
 self-void paths, 22 dormant self-void paths, ten already-fail-closed success
 returns that must become explicit divergence, two regeneration escape
-hatches, and fragmented legacy runners are migration work. Moving a bypass
-from one container to another does not satisfy the policy. The three existing
-`quic-localhost` scheduling overrides are also migration work under the
-registry's single-source rule; the measured tailnet backpressure case matches
-none of them and currently receives no declared isolation.
+hatches, and fragmented legacy runners are migration work. The legacy runner
+scope includes two orphaned shell entry points and
+`tests/runners/x0x_test_runner.py`, which those scripts invoke and which owns
+retry accounting of its own. Moving a bypass from one container to another
+does not satisfy the policy. The three existing `quic-localhost` scheduling
+overrides and the default profile's slow-test termination policy are also
+migration work under the registry's single-source rule; the measured tailnet
+backpressure case matches none of those test groups and currently receives no
+declared isolation.
 
 ### 11. Enforcement order is part of the decision
 
@@ -463,13 +497,14 @@ There is no verified current substantive green baseline context. Rollout is:
 3. Introduce the registry, dispatcher, inventory reconciliation,
    syntax-aware test-exit audit, single skip-recording helper, skip
    reconciliation, and tier jobs in advisory mode; absorb the three existing
-   scheduling overrides into the registry. At this stage the dispatcher
-   intentionally retains `--run-ignored default`. Before execution it emits a
-   temporary `declared-not-executed-with-reason` outcome for each ignored
-   identity that remains selected in that context, scoped to this advisory
-   migration and reconciled with nextest's aggregate skipped count. That
-   declaration has an owner and expires at step 5; it is derived from
-   discovered ignore state, not a per-test allowlist.
+   scheduling overrides and the default profile's termination policy into the
+   registry. At this stage the dispatcher intentionally retains
+   `--run-ignored default`. Before execution it emits a temporary
+   `declared-not-executed-with-reason` outcome for each ignored identity that
+   remains selected in that context, scoped to this advisory migration and
+   reconciled with nextest's aggregate skipped count. That declaration has an
+   owner and expires at step 5; it is derived from discovered ignore state,
+   not a per-test allowlist.
    Outcome accounting can therefore pass honestly while the separate
    comprehensive-readiness receipt reports the remaining migration work. The
    dispatcher does not claim comprehensive coverage.
@@ -551,11 +586,13 @@ Before the comprehensive status can become required:
   run/pass/fail/not-run totals;
 - coverage uses the same required inventory and closed-outcome
   reconciliation;
-- governance finds no hand-written tier commands or inline workflow
-  exclusions or scheduling overrides outside the dispatcher/registry;
+- governance proves every required-tier selection, scheduling, isolation,
+  concurrency, timeout, termination, and retry policy is derived from the
+  registry, in whatever file or tool expresses it;
 - a syntax-aware audit over integration tests and unit-test modules finds no
-  direct success return from a precondition or destructuring failure arm
-  outside the declared skip helper;
+  direct success return from a precondition or destructuring failure arm; the
+  only allowed success exit is the single skip-exit construct, whose call site
+  contains no separate return;
 - a required run records zero skips, zero declared-not-executed outcomes, and
   propagates semantic failure;
 - regeneration commands and validation tests are distinct;

--- a/docs/adr/0025-required-gates-prove-observation-completeness.md
+++ b/docs/adr/0025-required-gates-prove-observation-completeness.md
@@ -1,0 +1,512 @@
+# ADR 0025: Required Gates Must Prove Observation Completeness
+
+- **Status:** Proposed — pre-consensus (Kimi ruling outstanding)
+- **Date:** 2026-07-28
+- **Decision owners:** David Irvine
+- **Reviewers:** Dario (draft review pending); Kimi (required ruling outstanding); Watson (evidence verification)
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** `justfile`, `.github/workflows/ci.yml`,
+  `.github/workflows/integration.yml`, `.config/nextest.toml`, `tests/**`;
+  Buzz measurement event
+  `b1dc8e11e419913f4cba0d86f49c8e638c4ce9296fb54bb65d1ad4ea1372fe6c`
+
+> **Pre-consensus draft:** David has selected default-run with a declared,
+> machine-checkable opt-out. The remaining design records the current Sam and
+> Dario position plus Watson's verified corrections. Kimi's ruling on the
+> remaining clauses is outstanding. This ADR must not be presented as
+> consensus, marked Accepted, or implemented before that review and David's
+> explicit approval.
+
+## Context
+
+x0x's test commands can report success without observing all of the properties
+the repository treats as covered. The investigation began with `#[ignore]`,
+but the failure is not specific to an attribute. At commit
+`e3013710d7ed69077de9a799dffdbeb5ac80535a`, at least three mechanisms have
+the same effect:
+
+1. `#[ignore]` keeps a discovered test out of the ordinary test run.
+2. A hand-written nextest exclusion keeps a non-ignored test out of one CI
+   context.
+3. A runtime precondition returns success before the test reaches its
+   assertions, so the harness records `PASS` rather than an unmet
+   precondition.
+
+These mechanisms defeat different audits. Counting ignored tests cannot find
+workflow exclusions. Comparing selected inventories cannot find a selected
+test that returns success before observing its property. Naming each current
+mechanism would leave the policy open to the next container.
+
+The governing problem is therefore property-level:
+
+> A required gate may report success only if it can account for every
+> discovered test, the tier and required context that selected it, whether it
+> executed its promised observation, and every declared reason it did not.
+
+The measured repository state illustrates the gap:
+
+- nextest discovers 2,685 test cases across 30 binaries, including 245 ignored
+  tests; 196 ignores are bare and 49 carry a reason;
+- `just test`, CI Test Suite, and CI Coverage have three different effective
+  inventories;
+- CI Test Suite excludes
+  `binary(x0x_0041_synthetic_kill_restart)`;
+- CI Coverage additionally excludes
+  `binary(x0x_0041_prefer_newest_test)` and
+  `binary(named_group_join_metadata_event)`;
+- those workflow filters remove five non-ignored tests from Coverage, so the
+  245-test ignore census cannot see the divergence;
+- local `just` recipes, CI workflows, and two orphaned shell scripts select
+  ignored tests with separately maintained commands;
+- no CI workflow invokes `just`, so local and CI gates share no dispatcher;
+- a structural evidence sweep over `tests/**` found 33 early-success sites
+  across 27 non-ignored test functions; an independent reproduction found 29
+  candidate dormant sites, then source review reclassified seven as
+  fail-closed and left 22 genuine dormant self-void sites across 12 ignored
+  test functions;
+- two of the 33 live sites are regeneration escape hatches; the other 31 are
+  runtime-precondition paths across 25 test functions;
+- a follow-up over unit-test modules found two further live self-void paths in
+  `src/exec/service.rs`, including an issue-118 regression guard, plus three
+  already-fail-closed success returns that the syntactic rule below will make
+  explicit;
+- three separately defined `build_or_skip_network_bind_error`-style helpers
+  institutionalize the silent-success convention; and
+- 15 of the 22 genuine dormant self-void sites are in
+  `tailnet_streams_integration`, so enabling ignored cohorts before
+  observation accounting exists could manufacture a green migration result.
+
+The structural sweeps are evidence, not the proposed implementation. A
+brace-depth walk misclassified returns from nested async blocks and closures;
+a lookback heuristic misclassified assertion-dominated returns. The shipping
+audit must be syntax-aware, cover integration tests and unit-test modules, and
+enforce a syntactic test-exit rule that does not depend on heuristic data-flow
+classification or log messages.
+
+Tool constraints also shape the decision. cargo-nextest 0.9.126 can select
+`binary(...)` and `test(...)` filtersets and can choose ignore-state behavior
+with `--run-ignored default|only|all`. It cannot select the reason string in
+`#[ignore = "..."]`. Its test groups control scheduling, and this version has
+no `test_group(...)` filterset predicate.
+
+Finally, a green command is not a merge gate by itself. `main` currently has
+no verified substantive green baseline context suitable for protection and no
+verified rule requiring the comprehensive test status. Recent substantive
+workflows include failures; Security Audit's scheduled green runs do not
+exercise the test suite, and Claude Code has produced skipped rather than
+pass/fail conclusions. Selecting whichever context looks green would create
+another proxy.
+
+## Decision Drivers
+
+- New tests must run by default. A missing or mistyped opt-out must increase
+  execution rather than silently reduce it.
+- Required local and CI contexts must be derived from one execution
+  definition rather than independently maintained command lines.
+- A gate must account for both selection and actual observation; inventory
+  equality alone is insufficient.
+- Runtime preconditions must be observable and machine-reconciled.
+- Isolation, external infrastructure, and soak budgets are legitimate
+  scheduling concerns, but `flaky` and `known-defect` are not opt-out tiers.
+- The design must be enforceable with the nextest capabilities actually
+  present in the repository.
+- Branch protection must be proven with both configuration readback and a
+  merge-blocking negative control.
+- Migration must not grandfather the mechanisms that created the current
+  blind spots.
+
+## Considered Options
+
+1. **Curated allowlist of tests that must run.**
+2. **Use `#[ignore]` and its reason string as the routing authority.**
+3. **Use nextest test-group membership as the routing authority.**
+4. **Run by default; declare only non-default tiers in a source-carried
+   namespace, with one executable registry and observation accounting.**
+
+Option 1 is rejected because completeness would depend on continuously adding
+new tests to a second list. A forgotten entry removes coverage.
+
+Option 2 is rejected because nextest exposes only the ignored bit, not the
+reason string, and one bit cannot route required-isolated, external, and soak
+work independently.
+
+Option 3 is rejected because test groups are scheduling configuration, not an
+opt-out property, and nextest 0.9.126 cannot select a test group in a
+filterset.
+
+Option 4 is selected. It makes ordinary execution the fail-safe complement of
+explicit non-default selectors and makes the registry the executable source
+of routing, reachability, and observation policy.
+
+## Decision
+
+### 1. Scope the policy to observation, not to current bypass mechanisms
+
+The policy governs anything that allows a declared gate to report success
+without observing a property it promises to observe. `#[ignore]`, workflow
+filtersets, runtime early-success returns, retry-only success, and
+environment-controlled regeneration paths are known instances, not a closed
+taxonomy.
+
+Governance must test the invariant, not merely search for those tokens.
+
+### 2. Default is the complement
+
+Every discovered test is classified mechanically:
+
+- if it matches no non-default selector, it is in `default`;
+- if it matches exactly one non-default selector, it is in that tier;
+- if it matches more than one non-default selector, governance fails.
+
+Ordinary tests do not carry a `default_*` name and the registry does not
+enumerate them. Requiring that would recreate the rejected allowlist across
+the ordinary suite.
+
+Only non-default tiers carry a source-level, machine-selectable namespace:
+
+- use an integration-target name when the whole binary has one non-default
+  policy;
+- use a module or test-name namespace when one binary contains multiple
+  policies.
+
+The non-default selectors must be pairwise disjoint. A missing or mistyped
+non-default namespace falls into `default` and runs.
+
+Where cargo's ordinary runner must also skip a non-default case,
+`#[ignore = "..."]` remains structured human-readable metadata. It is not the
+routing authority. In the enforced steady state, the primary dispatcher uses
+`--run-ignored all`, so an unclassified ignore does not disappear from the
+default inventory. The advisory migration stage in Decision 11 deliberately
+retains `--run-ignored default` until the dormant self-void paths are migrated
+and the ignored cohort is ready to activate.
+
+The initial tiers are:
+
+| Tier | Required execution |
+|---|---|
+| `default` | `just check` and pull-request CI |
+| `required-isolated` | `just check` and pull-request CI, after compilation with declared isolation/concurrency |
+| `external` | only in the context that supplies its declared infrastructure |
+| `soak` | on its declared schedule and budget |
+
+There is no `flaky` or `known-defect` tier.
+
+A compile-contention measurement for
+`tailnet_streams_integration::backpressure_throttles_writer_with_bounded_buffering`
+produced four passes and one `bob accepted` failure while clean workspace
+builds were active, versus five passes in five unloaded controls. All ten test
+invocations were compile-free, and the loaded tests began and ended while
+their competing builds remained active. This sample supports
+`required-isolated` placement without claiming statistical proof of
+causation. That tier remains required locally and in pull-request CI.
+
+### 3. One executable registry owns routing and reachability
+
+The registry enumerates tier definitions, not individual default tests. Each
+tier definition owns:
+
+- its positive `binary(...)` / `test(...)` selector;
+- every permitted context-specific exclusion;
+- local, pull-request, external, and scheduled execution contexts;
+- scheduling, isolation, concurrency, and timeout policy;
+- infrastructure preconditions;
+- failure policy;
+- owner; and
+- reason and expiry for any declared context-specific divergence.
+
+A single dispatcher consumes the registry. Hand-written tier-specific nextest
+commands, inline workflow exclusions, and separately maintained test lists
+are forbidden.
+
+`run-required` iterates the registry definitions for `default` and
+`required-isolated`; `just check` invokes `run-required`. CI derives its
+required and scheduled matrices from the same registry and invokes the same
+dispatcher.
+
+The invariant is one execution definition per tier, reachable in every
+context that definition declares. It is not "exactly one process" or "exactly
+one call site": local and CI contexts may invoke the same definition.
+
+Reachability is proven from the dispatcher graph. A command that merely
+appears in an otherwise orphaned shell script does not prove execution.
+
+Required dispatchers must propagate semantic failure to a failing status.
+Governance follows the result rather than rejecting token shapes: for example,
+`|| true` may preserve captured output only when a later fail-closed check
+turns the captured failure into a failing status.
+
+### 4. Reconcile selection and terminal-result inventories in every context
+
+The registry-derived required inventory is the union of `default` and
+`required-isolated`. Each required local and CI context emits its effective
+selected inventory before execution and reconciles it against that required
+inventory.
+
+After execution, each required context emits the set of discovered test
+identities that produced a terminal result in that run and reconciles that set
+against the same registry-derived required inventory. Selected-set equality is
+necessary but insufficient: the required run fails when a required test
+produced no result or when an unselected test identity produced one.
+
+The initial dispatcher may obtain terminal results from cargo-nextest 0.9.126
+with `NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1` and
+`--message-format libtest-json-plus`. Because that interface is experimental,
+the dispatcher owns the environment flag and parser and fails closed when the
+machine-readable result stream is unavailable or malformed.
+
+A context-specific difference may exist only when the registry declares it
+with a reason, owner, and expiry. It cannot be expressed as an inline
+workflow filter. A known product or dependency defect is not a permitted
+reason.
+
+The same accounting applies to external and soak tiers: a tier that is not
+scheduled in a context is accounted for by its registry execution policy,
+not by running a test that returns success without infrastructure.
+
+### 5. A selected test must account for whether it observed its property
+
+An unmet runtime precondition may not resolve to an ordinary passing test.
+The default behavior is to fail with the unmet precondition.
+
+Where Rust's test harness cannot express a native skip result, test code may
+use one declared helper that emits a machine-readable skip record keyed to
+the discovered test identity. The helper is diagnostic accounting, not a
+success escape:
+
+- a required dispatcher fails if its recorded skip count is non-zero;
+- a scheduled external or soak context fails if its promised infrastructure
+  is absent; and
+- a tier not scheduled in a context is accounted for by the registry, not by
+  a passing test.
+
+Within a test function's own control-flow scope, every
+precondition-failure or destructuring-failure arm must diverge through an
+assertion, `panic!`, `unreachable!`, or the declared skip helper. Direct
+success returns such as `return;`, `return Ok(())`, and
+`let ... else { return Ok(()) }` are forbidden. An assertion-dominated
+destructuring arm must use explicit divergence rather than retain an
+unreachable success return.
+
+The audit must be syntax-aware and cover integration-test functions and unit
+test modules. It distinguishes a return from the test function from a return
+inside a nested closure or async block, and recognizes only the declared skip
+helper as an allowed success-exit mechanism. It does not try to infer whether
+an assertion dominates a success return, and it does not grep for `return`,
+`Ok(())`, or a "skipping" message. The current brace-depth censuses may seed
+the implementation and migration, but are not the normative audit.
+
+### 6. Regeneration and validation are separate entry points
+
+An environment variable may not turn a required validation test into a green
+regeneration no-op. Artifact generation moves to an explicit non-test command
+such as an `xtask` or equivalent dispatcher action. Required tests always
+validate the committed artifact.
+
+Until those paths are separated, the required dispatcher rejects the
+regeneration environment variables and the structural audit continues to
+report the early-success paths.
+
+### 7. Known defects cannot be stored in an observation bypass
+
+No ignore, exclusion, early-success precondition, retry-only success, or
+successor mechanism may store a deterministic product or dependency defect.
+
+The two CRDT convergence cases must be triaged against intended conflict
+semantics:
+
+- if the expectation is correct, fix the product or dependency and run the
+  regression normally;
+- if the current behavior is intended, convert the test to a passing
+  characterization and track any desired semantic change separately; or
+- if intent is unresolved, keep the semantic decision visibly open in an
+  issue with an owner and expiry, without counting it as coverage.
+
+`Flaky` requires measured pass/fail evidence. Even measured intermittence is
+evidence for diagnosis, not a permanent tier. The historically retry-passing
+`x0x_0041_synthetic_kill_restart` exclusion therefore requires an owner and a
+resolution rather than continued storage in a workflow filter.
+
+An environmental requirement may justify an `external` tier only when the
+registry names the infrastructure, owning context, owner, and fail-closed
+behavior.
+
+### 8. `just check` and CI use the same required dispatcher
+
+`just check` includes:
+
+- formatting;
+- lint;
+- build;
+- documentation;
+- the `default` test filter;
+- the `required-isolated` filter; and
+- the observation-completeness governance audit.
+
+Pull-request CI invokes the same registry-derived required dispatcher and
+publishes the same selected-inventory, terminal-result, and skip-accounting
+receipt. Coverage tooling may add instrumentation, but it may not silently
+shrink the required inventory or omit terminal results.
+
+### 9. A merge gate requires proven branch enforcement
+
+A CI command is advisory until `main` has a ruleset or branch-protection rule
+requiring its exact status context. The rule covers administrators and normal
+pushes, with only a documented break-glass bypass.
+
+Enforcement requires both:
+
+1. API readback of the configured rule and exact required status context; and
+2. an intentionally red pull request that GitHub refuses to merge.
+
+Security Audit, Claude Code, or another context that does not produce a
+substantive pass/fail test observation cannot substitute for the required
+test context.
+
+### 10. No open-ended grandfathering
+
+The ADR may be reviewed before migration, but the comprehensive status cannot
+be required or described as complete until the final receipt is green:
+
+```text
+bare #[ignore]                              0
+non-default tests outside registry naming  0
+multi-tier matches                         0
+unreachable declared tiers                 0
+undeclared required-context divergence     0
+hand-written exclusion filtersets          0
+dispatcher bypasses                        0
+silent early-success paths                 0
+regeneration-as-passing-test paths          0
+required-run recorded skips                0
+required tests with no reported result      0
+reported results outside selected inventory 0
+legacy baseline allowlist                  0
+```
+
+There is deliberately no `unclassified default test` metric: a discovered
+test that matches no non-default selector is default by construction.
+
+The 196 bare ignore attributes, current workflow exclusions, 31 live
+integration-test runtime-precondition paths, two further live unit-test
+self-void paths, 22 dormant self-void paths, ten already-fail-closed success
+returns that must become explicit divergence, two regeneration escape
+hatches, and fragmented legacy runners are migration work. Moving a bypass
+from one container to another does not satisfy the policy.
+
+### 11. Enforcement order is part of the decision
+
+There is no verified current substantive green baseline context. Rollout is:
+
+1. Produce substantive green CI and Build runs on `main` at a recorded SHA,
+   and record every effective test inventory at that SHA. The next approved
+   substantive merge may provide this anchor; if either workflow is red,
+   stop and diagnose that SHA.
+2. Protect those exact observed contexts, including administrators, and read
+   the rule back. This is a provisional branch-control anchor, not proof that
+   the current smaller CI inventory is complete.
+3. Introduce the registry, dispatcher, inventory reconciliation,
+   syntax-aware test-exit audit, single skip-recording helper, skip
+   reconciliation, and tier jobs in advisory mode. At this stage the
+   dispatcher intentionally retains `--run-ignored default`: discovery and
+   governance account for all ignored tests, but the new dispatcher does not
+   execute them or claim a comprehensive receipt.
+4. Migrate the currently live integration-test and unit-test
+   runtime-precondition paths, convert already-fail-closed success returns to
+   explicit divergence, and move regeneration out of validation tests. Do not
+   activate ignored cohorts before this observation machinery exists.
+5. Migrate every dormant early-success path and classify all 245 ignored
+   tests. Only then switch the primary dispatcher to `--run-ignored all`,
+   activate the ignored cohorts, remove undeclared workflow exclusions, and
+   reach the comprehensive zero receipt.
+6. Require the exact comprehensive status and prove an intentionally red
+   pull request cannot merge.
+7. Only then remove the fragmented legacy runners and supersede the
+   provisional baseline context.
+
+## Consequences
+
+### Positive
+
+- New tests run by default even when their author forgets the policy
+  namespace.
+- Local and CI selection derive from one executable definition.
+- The gate proves both selection and observation; a selected-but-self-voiding
+  test can no longer masquerade as coverage.
+- Isolation, external infrastructure, and soak budgets remain expressible
+  without creating a defect quarantine.
+- Required status claims become independently testable through inventory
+  receipts, protection readback, and a negative merge control.
+
+### Negative / Trade-offs
+
+- The migration covers all 245 ignores, existing workflow exclusions, silent
+  precondition paths, regeneration escape hatches, and legacy runners.
+- A syntax-aware Rust audit and machine-readable skip reconciliation add
+  tooling that must be maintained with test-language changes.
+- Terminal-result reconciliation initially depends on cargo-nextest's
+  experimental `libtest-json-plus` interface; its adapter must fail closed and
+  be reviewed when nextest changes the format or stabilizes a replacement.
+- Required local and pull-request gates will take longer because
+  `required-isolated` remains required rather than being silently deferred.
+- Some currently green tests will become explicit failures when their
+  preconditions are unavailable.
+- External and soak jobs need declared owners, infrastructure contracts,
+  schedules, and budgets.
+
+### Neutral / Operational
+
+- `#[ignore = "..."]` remains useful metadata for cargo's ordinary runner,
+  but no longer decides routing.
+- The registry defines policies and selectors, not an exhaustive test list.
+- Target-level namespaces classify homogeneous binaries efficiently; mixed
+  binaries pay the cost of module/test-level naming.
+- Context-specific inventory divergence is visible, owned, and expiring
+  rather than forbidden in all circumstances.
+- The measured tailnet backpressure case belongs in `required-isolated`; that
+  changes scheduling within the required set, not whether the property is
+  required.
+
+## Validation
+
+Before the comprehensive status can become required:
+
+- nextest discovery plus registry evaluation shows every test in the default
+  complement or exactly one non-default tier;
+- all non-default selectors are pairwise disjoint;
+- every declared tier is reachable from every context it names;
+- `just check` and pull-request CI emit and reconcile their effective
+  selected inventories against the registry-derived required inventory;
+- each required run emits a machine-readable terminal result for every
+  required test identity, emits none outside its selected inventory, and
+  fails when the result stream is missing or malformed;
+- coverage uses the same required inventory and terminal-result
+  reconciliation;
+- governance finds no hand-written tier commands or inline workflow
+  exclusions outside the dispatcher;
+- a syntax-aware audit over integration tests and unit-test modules finds no
+  direct success return from a precondition or destructuring failure arm
+  outside the declared skip helper;
+- a required run records zero skips and propagates semantic failure;
+- regeneration commands and validation tests are distinct;
+- the migration receipt in Decision 10 is all zero;
+- API readback shows the exact comprehensive status required for `main`,
+  including administrators; and
+- an intentionally red pull request is refused merge.
+
+Review triggers after acceptance:
+
+- a new test harness, runner, retry layer, coverage tool, or workflow that can
+  change the effective inventory;
+- a new mechanism that can convert an unmet observation into success;
+- a new non-default tier or context-specific divergence;
+- a branch-protection or status-context rename; or
+- evidence that the static audit cannot recognize a Rust control-flow form
+  used by the test suite.
+
+## Notes for AI-assisted work
+
+AI tools may help draft this ADR, but **must not mark it Accepted without
+human review**. This draft is explicitly pre-consensus until Kimi rules and
+David approves it. Accepted ADRs are immutable: create a new superseding ADR
+rather than editing an Accepted ADR.

--- a/docs/adr/0025-required-gates-prove-observation-completeness.md
+++ b/docs/adr/0025-required-gates-prove-observation-completeness.md
@@ -3,763 +3,138 @@
 - **Status:** Proposed — pre-consensus (Kimi ruling outstanding)
 - **Date:** 2026-07-28
 - **Decision owners:** David Irvine
-- **Reviewers:** Dario (amended-draft review pending); Kimi (required ruling outstanding); Watson (evidence verification)
+- **Reviewers:** Dario; Kimi (required ruling outstanding); Watson
 - **Supersedes:** none
 - **Superseded by:** none
-- **Related:** `justfile`, `.github/workflows/ci.yml`,
-  `.github/workflows/integration.yml`, `.config/nextest.toml`, `tests/**`;
-  Buzz measurement event
-  `b1dc8e11e419913f4cba0d86f49c8e638c4ce9296fb54bb65d1ad4ea1372fe6c`
 
-> **Pre-consensus draft:** David has selected default-run with a declared,
-> machine-checkable opt-out. The remaining design records the current Sam and
-> Dario position plus Watson's verified corrections. Kimi's ruling on the
-> remaining clauses is outstanding. This ADR must not be presented as
-> consensus, marked Accepted, or implemented before that review and David's
-> explicit approval.
+## Summary
+
+A required gate may pass only when it can account for everything it promises to test and prove that each required observation occurred. New tests run by default; only explicit, machine-checkable opt-outs may remove work from a context. One executable authority defines classification and reachability for local and CI execution. Detailed schemas, algorithms, pseudocode, and rollout mechanics belong in governed mutable reference material.
 
 ## Context
 
-x0x's test commands can report success without observing all of the properties
-the repository treats as covered. The investigation began with `#[ignore]`,
-but the failure is not specific to an attribute. At commit
-`e3013710d7ed69077de9a799dffdbeb5ac80535a`, at least three mechanisms have
-the same effect:
+A green test command is not proof of coverage. A test may be undiscovered, excluded, ignored, selected but never reach its assertion, or converted into success by an unmet precondition. Audits of one mechanism cannot prove the absence of the others.
 
-1. `#[ignore]` keeps a discovered test out of the ordinary test run.
-2. A hand-written nextest exclusion keeps a non-ignored test out of one CI
-   context.
-3. A runtime precondition returns success before the test reaches its
-   assertions, so the harness records `PASS` rather than an unmet
-   precondition.
+The architectural requirement is therefore about observation, not today's syntax: a required gate must account for the complete discovered set, the authority that selected or excluded each member, and whether each required observation actually completed.
 
-These mechanisms defeat different audits. Counting ignored tests cannot find
-workflow exclusions. Comparing selected inventories cannot find a selected
-test that returns success before observing its property. Naming each current
-mechanism would leave the policy open to the next container.
-
-The governing problem is therefore property-level:
-
-> A required gate may report success only if it can account for every
-> discovered test, the tier and required context that selected it, whether it
-> executed its promised observation, and every declared reason it did not.
-
-The measured repository state illustrates the gap:
-
-- nextest discovers 2,685 test cases across 30 binaries, including 245 ignored
-  tests; 196 ignores are bare and 49 carry a reason;
-- `just test`, CI Test Suite, and CI Coverage have three different effective
-  inventories;
-- CI Test Suite excludes
-  `binary(x0x_0041_synthetic_kill_restart)`;
-- CI Coverage additionally excludes
-  `binary(x0x_0041_prefer_newest_test)` and
-  `binary(named_group_join_metadata_event)`;
-- those workflow filters remove five non-ignored tests from Coverage, so the
-  245-test ignore census cannot see the divergence;
-- local `just` recipes, CI workflows, and two orphaned shell scripts select
-  ignored tests with separately maintained commands; the orphaned shell
-  runner graph also reaches `tests/runners/x0x_test_runner.py`, which has its
-  own retry accounting and is not invoked directly by a tracked workflow or
-  `justfile` recipe;
-- no CI workflow invokes `just`, so local and CI gates share no dispatcher;
-- `.config/nextest.toml` separately owns three
-  `profile.default.overrides` filtersets that assign the serialized
-  `quic-localhost` test group; these change scheduling rather than selection,
-  but they are already a hand-maintained tier definition outside any
-  registry;
-- a structural evidence sweep over `tests/**` found 33 early-success sites
-  across 27 non-ignored test functions; an independent reproduction found 29
-  candidate dormant sites, then source review reclassified seven as
-  fail-closed and left 22 genuine dormant self-void sites across 12 ignored
-  test functions;
-- two of the 33 live sites are regeneration escape hatches; the other 31 are
-  runtime-precondition paths across 25 test functions;
-- a follow-up over unit-test modules found two further live self-void paths in
-  `src/exec/service.rs`, including an issue-118 regression guard, plus three
-  already-fail-closed success returns that the syntactic rule below will make
-  explicit;
-- three separately defined `build_or_skip_network_bind_error`-style helpers
-  institutionalize the silent-success convention; and
-- 15 of the 22 genuine dormant self-void sites are in
-  `tailnet_streams_integration`, so enabling ignored cohorts before
-  observation accounting exists could manufacture a green migration result.
-
-The structural sweeps are evidence, not the proposed implementation. A
-brace-depth walk misclassified returns from nested async blocks and closures;
-a lookback heuristic misclassified assertion-dominated returns. The shipping
-audit must be syntax-aware, cover integration tests and unit-test modules, and
-enforce a syntactic test-exit rule that does not depend on heuristic data-flow
-classification or log messages.
-
-Tool constraints also shape the decision. cargo-nextest 0.9.126 can select
-`binary(...)` and `test(...)` filtersets and can choose ignore-state behavior
-with `--run-ignored default|only|all`. It cannot select the reason string in
-`#[ignore = "..."]`. Its test groups control scheduling, and this version has
-no `test_group(...)` filterset predicate.
-
-Its experimental `libtest-json-plus` stream also does not emit a per-test
-ignored or skipped outcome. In a measured default run over a binary with seven
-ignored tests and one active test, all eight identities emitted `started`,
-only the active test emitted a terminal `ok`, and nextest reported the other
-seven only in its aggregate skipped count. Absence of a terminal event
-therefore cannot mean "declared not run": the same shape would also occur if a
-selected test stopped before producing a result. This matters because the
-repository's default nextest profile can terminate slow tests after ten
-60-second periods.
-
-Finally, a green command is not a merge gate by itself. `main` currently has
-no verified substantive green baseline context suitable for protection and no
-verified rule requiring the comprehensive test status. Recent substantive
-workflows include failures; Security Audit's scheduled green runs do not
-exercise the test suite, and Claude Code has produced skipped rather than
-pass/fail conclusions. Selecting whichever context looks green would create
-another proxy.
+For this decision, a test's **required observation** is the property for which the gate claims coverage. It is complete only when the test executes the checks that evaluate that property and produces a terminal pass or fail result.
 
 ## Decision Drivers
 
-- New tests must run by default. A missing or mistyped opt-out must increase
-  execution rather than silently reduce it.
-- Required local and CI contexts must be derived from one execution
-  definition rather than independently maintained command lines.
-- A gate must account for both selection and actual observation; inventory
-  equality alone is insufficient.
-- Runtime preconditions must be observable and machine-reconciled.
-- Isolation, external infrastructure, and soak budgets are legitimate
-  scheduling concerns, but `flaky` and `known-defect` are not opt-out tiers.
-- The design must be enforceable with the nextest capabilities actually
-  present in the repository.
-- Branch protection must be proven with both configuration readback and a
-  merge-blocking negative control.
-- Migration must not grandfather the mechanisms that created the current
-  blind spots.
+- Forgetting policy metadata must increase execution, not reduce it.
+- Local and CI gates must derive from one execution authority.
+- Selection alone is insufficient; required observation must be proven.
+- Legitimate isolation, infrastructure, and scheduling needs must remain expressible without becoming defect quarantine. [G-001]
+- Merge enforcement must be demonstrated, not inferred from a green command.
 
 ## Considered Options
 
-1. **Curated allowlist of tests that must run.**
-2. **Use `#[ignore]` and its reason string as the routing authority.**
-3. **Use nextest test-group membership as the routing authority.**
-4. **Run by default; declare only non-default tiers in a source-carried
-   namespace, with one executable registry and observation accounting.**
-
-Option 1 is rejected because completeness would depend on continuously adding
-new tests to a second list. A forgotten entry removes coverage.
-
-Option 2 is rejected because nextest exposes only the ignored bit, not the
-reason string, and one bit cannot route required-isolated, external, and soak
-work independently.
-
-Option 3 is rejected because test groups are scheduling configuration, not an
-opt-out property, and nextest 0.9.126 cannot select a test group in a
-filterset.
-
-Option 4 is selected. It makes ordinary execution the fail-safe complement of
-explicit non-default selectors and makes the registry the executable source
-of routing, reachability, and observation policy.
+A maintained allowlist is rejected because omissions silently remove coverage. Runner-specific ignore metadata, scheduling groups, and workflow filters are rejected as routing authorities because each describes only one container. We choose default execution as the mechanically computed complement of explicit non-default declarations, governed by one executable authority.
 
 ## Decision
 
-### 1. Scope the policy to observation, not to current bypass mechanisms
+1. **Default is the complement.** Every discovered test belongs either to ordinary required execution or to exactly one explicit non-default declaration. No ordinary-test allowlist exists. A missing or mistyped declaration makes the test run by default; overlapping declarations fail governance.
 
-The policy governs anything that allows a declared gate to report success
-without observing a property it promises to observe. `#[ignore]`, workflow
-filtersets, runtime early-success returns, retry-only success, and
-environment-controlled regeneration paths are known instances, not a closed
-taxonomy.
+2. **One authority owns execution policy.** Required local and pull-request CI execution derive classification, reachability, and observation policy from the same executable source. Nothing outside that authority may change a required inventory or its execution policy, in whatever file or tool expresses it. No mode inside the authority may narrow, replace, or extend a required run's inventory, and no selection path for such a mode may accept a caller-supplied target. A required run is reachable from the authority; a command that merely exists in a file is not evidence that it executes.
 
-Governance must test the invariant, not merely search for those tokens.
+3. **Passing requires positive, closed accounting.** Every required run accounts for each discovered test exactly once: required to execute, or declared out of scope before execution. A required selected test passes only when its required observation completes and produces a matching terminal result. Missing output, a start event, inventory equality, or a self-reported zero is not proof. An observation that cannot be read, parsed, or recognised is a failure of the gate, not an absence of evidence; an unrecognised value is never an extensibility point. Complete accounting never converts a semantic test failure into success.
 
-### 2. Default is the complement
+4. **Non-observation cannot masquerade as coverage.** Non-observation, however it arises and in whatever file or tool expresses it, may not resolve to an ordinary pass. Runtime preconditions, regeneration paths, retry-only results, and other bypasses are examples rather than a closed taxonomy. Legitimate context differences are explicit, machine-checkable, owned, expiring where temporary, and reconciled against the discovered set. Neither flakiness nor a known defect is a ground for a non-default declaration.
 
-Every discovered test is classified mechanically:
-
-- if it matches no non-default selector, it is in `default`;
-- if it matches exactly one non-default selector, it is in that tier;
-- if it matches more than one non-default selector, governance fails.
-
-Ordinary tests do not carry a `default_*` name and the registry does not
-enumerate them. Requiring that would recreate the rejected allowlist across
-the ordinary suite.
-
-Only non-default tiers carry a source-level, machine-selectable namespace:
-
-- use an integration-target name when the whole binary has one non-default
-  policy;
-- use a module or test-name namespace when one binary contains multiple
-  policies.
-
-`governance-fixture` uses the reserved source-level
-`governance_fixture_*` integration-target, module, or test-name namespace under
-the same rule. The registry pairs every namespace match with one exact fixture
-identity; an identity list is not an exception to selector-based
-classification.
-
-The non-default selectors must be pairwise disjoint. A missing or mistyped
-non-default namespace falls into `default` and runs.
-
-Where cargo's ordinary runner must also skip a non-default case,
-`#[ignore = "..."]` remains structured human-readable metadata. It is not the
-routing authority. In the enforced steady state, the primary dispatcher uses
-`--run-ignored all`, so an unclassified ignore does not disappear from the
-default inventory. The advisory migration stage in Decision 11 deliberately
-retains `--run-ignored default` until the dormant self-void paths are migrated
-and the ignored cohort is ready to activate.
-
-The initial tiers are:
-
-| Tier | Required execution |
-|---|---|
-| `default` | `just check` and pull-request CI |
-| `required-isolated` | `just check` and pull-request CI, after compilation with declared isolation/concurrency |
-| `external` | only in the context that supplies its declared infrastructure |
-| `soak` | on its declared schedule and budget |
-| `governance-fixture` | source namespace `governance_fixture_*`; only in the registry-declared `fixture` context; never in a functional required inventory |
-
-There is no `flaky` or `known-defect` tier.
-
-`governance-fixture` is a non-functional control tier, not a product-test
-opt-out. It contains only the exact governance fixtures that certify the
-dispatcher itself and is unreachable through ordinary or required-tier
-selectors.
-
-A compile-contention measurement for
-`tailnet_streams_integration::backpressure_throttles_writer_with_bounded_buffering`
-produced four passes and one `bob accepted` failure while clean workspace
-builds were active, versus five passes in five unloaded controls. All ten test
-invocations were compile-free, and the loaded tests began and ended while
-their competing builds remained active. This sample supports
-`required-isolated` placement without claiming statistical proof of
-causation. That tier remains required locally and in pull-request CI.
-
-### 3. One executable registry owns routing and reachability
-
-The registry enumerates tier definitions, not individual default tests. Its
-context schema contains `local`, `pull-request`, `external`, `scheduled`, and
-`fixture`. Each functional tier definition owns:
-
-- its positive `binary(...)` / `test(...)` selector;
-- every permitted context-specific exclusion;
-- the non-fixture execution contexts in which it runs;
-- scheduling, isolation, concurrency, timeout, termination, and retry policy;
-- infrastructure preconditions;
-- failure policy;
-- owner; and
-- reason and expiry for any declared context-specific divergence.
-
-The non-functional `governance-fixture` definition instead owns its positive
-source-namespace selector, the exact fixture identities matched by that
-selector, and the `fixture` context. The selector classifies each fixture out
-of the `default` complement; it is not a fixture-mode selection authority. The
-closed identity list is what a fixture key resolves to. Every listed identity
-must match the selector exactly once, every discovered selector match must be
-listed, and no functional test may match it. The `fixture` context has one
-entry point and is the only context permitted to select those identities.
-
-A single dispatcher consumes the registry. Any policy that affects selection,
-scheduling, isolation, concurrency, timeout, termination, or retry behavior
-for a required tier must be derived from the registry, irrespective of the
-tool or file in which that policy is expressed. A workflow, nextest profile,
-script, `justfile` recipe, or successor container may consume generated policy
-but may not become an independent authority.
-
-Hand-written tier-specific nextest commands, inline workflow exclusions, and
-separately maintained test lists are known violations of that property, not a
-closed taxonomy. The three existing `quic-localhost` scheduling overrides and
-the default profile's slow-test termination policy are migration inputs. Their
-selectors and execution policy must move under the registry, and any generated
-nextest configuration must be derived from it rather than maintained as a
-second source.
-
-`run-required` iterates the registry definitions for `default` and
-`required-isolated`; `just check` invokes `run-required`. CI derives its
-required and scheduled matrices from the same registry and invokes the same
-dispatcher.
-
-The dispatcher exposes exactly one registry-declared governance-fixture target
-mode as the sole entry point for the `fixture` context. It accepts only a
-closed registry fixture key, never a caller-supplied selector or arbitrary
-target, and resolves that key only to exact identities in the
-`governance-fixture` tier. It executes the same runner adapter, outcome mapping,
-reconciliation, and semantic-failure propagation path as a required run. A
-governance audit may invoke that mode as a separate self-test, but the mode
-cannot supply, replace, narrow, or extend the inventory of any required local
-or CI context.
-
-The invariant is one execution definition per tier, reachable in every
-context that definition declares. It is not "exactly one process" or "exactly
-one call site": local and CI contexts may invoke the same definition.
-
-Reachability is proven from the dispatcher graph. A command that merely
-appears in an otherwise orphaned shell script does not prove execution.
-
-Required dispatchers must propagate semantic failure to a failing status.
-Governance follows the result rather than rejecting token shapes: for example,
-`|| true` may preserve captured output only when a later fail-closed check
-turns the captured failure into a failing status.
-
-### 4. Reconcile selection and one positive outcome per discovered identity
-
-The registry-derived required inventory is the union of `default` and
-`required-isolated`. Each required local and CI context emits its effective
-selected inventory before execution and reconciles it against that required
-inventory. Selection is derived from registry selectors before the runner's
-ignore-state disposition is applied. During the advisory migration, an
-ignored identity in the default complement therefore remains selected even
-though it receives a declared not-executed outcome.
-
-In governance-fixture target mode, the exact identities declared by the
-`governance-fixture` tier are that run's required inventory. The same
-selection and outcome reconciliation applies. Its inventory reconciliation
-must succeed before the audit may attribute a non-zero exit to the behavior a
-fixture is intended to certify.
-
-Each required context and governance-fixture run also emits exactly one
-positive outcome for every identity in its discovery scope from this closed
-set:
-
-- `executed-and-passed`: the identity was selected and emitted a passing
-  per-test terminal event;
-- `executed-and-failed`: the identity was selected and emitted a failing
-  per-test terminal event;
-- `declared-not-selected`: the registry declares that identity's tier out of
-  scope for this context; or
-- `declared-not-executed-with-reason`: the dispatcher or declared skip helper
-  positively records why an otherwise selected identity did not execute its
-  promised observation.
-
-Each label is valid only when every predicate in its definition holds. The
-reconciler therefore rejects an executed outcome for an unselected identity;
-an executed outcome whose pass/fail polarity lacks the matching terminal
-event; a `declared-not-selected` outcome for a selected identity or without a
-pre-run registry declaration; and a
-`declared-not-executed-with-reason` outcome for an unselected identity, without
-one of the permitted positive sources, or alongside a terminal event. An
-unknown outcome label is not an extensibility point and fails closed.
-
-Accounting an `executed-and-failed` outcome does not convert semantic failure
-into success; the dispatcher still returns a failing status.
-
-A `started` event is evidence only that an identity appeared in the stream,
-not that it executed: ignored tests emit `started` without running.
-`declared-not-selected` must come from the registry before execution.
-`declared-not-executed-with-reason` may come only from a dispatcher
-declaration made before execution or from the machine-readable skip helper; it
-is never inferred from a missing runner event.
-
-During rollout steps 3 and 4, the sole temporary authority for declaring an
-ignored default-complement identity not executed is the dispatcher's pre-run
-discovery of runner ignore state, reconciled with the runner's aggregate
-not-run count. It is not a per-test registry entry or allowlist. After step 5
-removes that migration state, the registry's context and tier policy is the
-only authority for a pre-run not-selected declaration.
-
-The dispatcher reconciles the outcome table one-to-one against nextest
-discovery, the effective selected inventory, the closed outcome definitions,
-and the runner's own run/pass/fail/not-run totals. An identity with zero or
-multiple outcomes fails the run. A selected identity with no terminal event
-and no positive declared-not-executed record fails the run. A selected identity
-carrying `declared-not-selected` fails the run. An executed outcome or reported
-terminal result outside the selected inventory fails the run. A terminal event
-for an identity declared not executed also fails the run. Selected-set equality
-is necessary but insufficient.
-
-The initial dispatcher may obtain executed outcomes from cargo-nextest 0.9.126
-with `NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1` and
-`--message-format libtest-json-plus`. Because that interface is experimental,
-the registry version-pins the recognized raw event-to-outcome mapping, and the
-dispatcher owns the environment flag and parser. Unknown events or an
-unavailable or malformed stream fail closed. The dispatcher reconciles
-explicit not-run declarations with nextest's aggregate skipped/not-run count;
-it does not translate raw event absence into an outcome.
-
-Outcome reconciliation has a governance mutation manifest derived from the
-union of the rejection rules above and every predicate in the closed outcome
-definitions. The registry declares one case per atomic mutation in the
-non-functional `governance-fixture` tier:
-
-- zero outcomes and multiple outcomes for one identity are separate cases;
-- an `executed-and-passed` or `executed-and-failed` outcome for an unselected
-  identity, without its matching terminal event, or with the opposite terminal
-  polarity is mutated separately;
-- `declared-not-selected` on a selected identity and without its pre-run
-  registry declaration, and alongside a terminal event are separate cases;
-- `declared-not-executed-with-reason` on an unselected identity, without a
-  permitted positive source, and alongside a terminal event are separate
-  cases;
-- an unknown outcome label is a separate fail-closed parser case; and
-- an otherwise valid outcome table disagreeing with the runner's aggregate
-  run/pass/fail/not-run totals is a separate case.
-
-Each fixture mutates exactly one predicate from an otherwise valid state. When
-that state also satisfies an umbrella rejection sentence above, the mutation
-manifest names the canonical diagnostic and no other diagnostic may satisfy
-the control. The audit passes only when selected-inventory reconciliation
-succeeds, the dispatcher reports that named outcome-reconciliation failure,
-attributes its non-zero status to that failure, and exits non-zero. A
-skip-helper record, semantic test failure, unrelated inventory failure, another
-reconciliation condition, or a self-reported zero receipt cannot satisfy a
-control.
-
-Governance checks the mutation manifest and the outcome-accounting rows in the
-Decision 10 receipt in both directions: every atomic invalid state has a
-specific diagnostic and receipt row, and every such receipt row is justified
-by at least one independently reddening mutation case. The steady-state
-readiness row that requires zero valid
-`declared-not-executed-with-reason` outcomes is identified separately and is
-not misrepresented as an invalid-state mutation.
-
-A context-specific difference may exist only when the registry declares it
-with a reason, owner, and expiry. It cannot be expressed as an inline
-workflow filter. A known product or dependency defect is not a permitted
-reason.
-
-The same accounting applies to external and soak tiers: a tier that is not
-scheduled in a context is accounted for by its registry execution policy,
-not by running a test that returns success without infrastructure.
-
-### 5. A selected test must account for whether it observed its property
-
-An unmet runtime precondition may not resolve to an ordinary passing test.
-The default behavior is to fail with the unmet precondition.
-
-Where Rust's test harness cannot express a native skip result, test code may
-use one declared skip-exit helper that emits a machine-readable skip record
-keyed to the discovered test identity and exits the test. The helper must be
-the exit operation itself: one macro or equivalent syntax-level construct
-performs both actions, and its call site contains no separate success return.
-`record_skip("reason"); return Ok(())` is forbidden because recognizing it
-would require the audit to infer statement domination.
-
-The one allowed helper is pinned to an exact definition rather than accepted
-by a name pattern. Governance verifies that definition emits the
-machine-readable record. The registry declares its positive-control fixture in
-the non-functional `governance-fixture` tier, outside the workspace's ordinary
-discovered test inventory. The audit invokes it through the dispatcher's
-closed fixture mode as a subprocess and passes only when all of these hold:
-the helper record maps the fixture identity to
-`declared-not-executed-with-reason`; inventory and outcome reconciliation
-otherwise succeed; the dispatcher attributes its failure to the non-zero
-skip-helper record count; and the dispatcher exits non-zero. An inventory or
-reconciliation failure cannot satisfy the control. The fixture is not an
-ordinary test and is not placed in a functional tier, because either placement
-would make the required inventory permanently red or certify the wrong
-execution context.
-
-The helper is diagnostic accounting, not an observation or a bypass. Its
-record maps to `declared-not-executed-with-reason`, never to
-`executed-and-passed`:
-
-- a required dispatcher fails if its skip-helper record count is non-zero;
-  that count includes only machine-readable records emitted by the pinned
-  helper, never dispatcher pre-run declarations;
-- a scheduled external or soak context fails if its promised infrastructure
-  is absent; and
-- a tier not scheduled in a context is accounted for by the registry, not by
-  a passing test.
-
-Within a test function's own control-flow scope, every precondition-failure or
-destructuring-failure arm must either diverge through an assertion, `panic!`,
-or `unreachable!`, or exit through the declared skip-exit helper. Direct
-success returns such as `return;`, `return Ok(())`, and
-`let ... else { return Ok(()) }` are forbidden. An assertion-dominated
-destructuring arm must use explicit divergence rather than retain an
-unreachable success return.
-
-The audit must be syntax-aware and cover integration-test functions and unit
-test modules. It distinguishes a return from the test function from a return
-inside a nested closure or async block, and recognizes only the single
-skip-exit construct as an allowed success-exit mechanism. It does not try to
-infer whether an assertion or a preceding skip-record call dominates a
-success return, and it does not grep for `return`, `Ok(())`, or a "skipping"
-message. The current brace-depth censuses may seed the implementation and
-migration, but are not the normative audit.
-
-### 6. Regeneration and validation are separate entry points
-
-An environment variable may not turn a required validation test into a green
-regeneration no-op. Artifact generation moves to an explicit non-test command
-such as an `xtask` or equivalent dispatcher action. Required tests always
-validate the committed artifact.
-
-Until those paths are separated, the required dispatcher rejects the
-regeneration environment variables and the structural audit continues to
-report the early-success paths.
-
-### 7. Known defects cannot be stored in an observation bypass
-
-No ignore, exclusion, early-success precondition, retry-only success, or
-successor mechanism may store a deterministic product or dependency defect.
-
-The two CRDT convergence cases must be triaged against intended conflict
-semantics:
-
-- if the expectation is correct, fix the product or dependency and run the
-  regression normally;
-- if the current behavior is intended, convert the test to a passing
-  characterization and track any desired semantic change separately; or
-- if intent is unresolved, remove the disputed test from the executable suite
-  rather than ignoring or tiering it, preserve the reproducer and competing
-  expectations in an issue with an owner and expiry, and do not claim the
-  property as covered until the decision produces either a normal regression
-  or an honest characterization test.
-
-`Flaky` requires measured pass/fail evidence. Even measured intermittence is
-evidence for diagnosis, not a permanent tier. The historically retry-passing
-`x0x_0041_synthetic_kill_restart` exclusion therefore requires an owner and a
-resolution rather than continued storage in a workflow filter.
-
-An environmental requirement may justify an `external` tier only when the
-registry names the infrastructure, owning context, owner, and fail-closed
-behavior.
-
-### 8. `just check` and CI use the same required dispatcher
-
-`just check` includes:
-
-- formatting;
-- lint;
-- build;
-- documentation;
-- the `default` test filter;
-- the `required-isolated` filter; and
-- the observation-completeness governance audit.
-
-Pull-request CI invokes the same registry-derived required dispatcher and
-publishes the same selected-inventory, closed-outcome, and skip-accounting
-receipt. Coverage tooling may add instrumentation, but it may not silently
-shrink the required inventory or omit an outcome.
-
-### 9. A merge gate requires proven branch enforcement
-
-A CI command is advisory until `main` has a ruleset or branch-protection rule
-requiring its exact status context. The rule covers administrators and normal
-pushes, with only a documented break-glass bypass.
-
-Enforcement requires both:
-
-1. API readback of the configured rule and exact required status context; and
-2. an intentionally red pull request that GitHub refuses to merge.
-
-Dispatcher failure propagation has its own governance negative control,
-separate from the transient red pull request. The registry declares a
-deliberately failing fixture in the non-functional `governance-fixture` tier,
-outside the workspace's ordinary discovered test inventory. Governance invokes
-it through the dispatcher's closed fixture mode as a subprocess. The audit
-passes only when the fixture receives `executed-and-failed`, inventory and
-outcome reconciliation otherwise succeed, the dispatcher attributes its
-failing status to that semantic failure, and it exits non-zero. An inventory
-or reconciliation failure cannot satisfy the control. The fixture is not an
-ordinary test and is not assigned to a functional tier, because either
-placement would make a normal required run permanently red or exercise a
-different context from the one being certified.
-
-Security Audit, Claude Code, or another context that does not produce a
-substantive pass/fail test observation cannot substitute for the required
-test context.
-
-### 10. No open-ended grandfathering
-
-The ADR may be reviewed before migration, but the comprehensive status cannot
-be required or described as complete until the final receipt is green:
-
-```text
-bare #[ignore]                              0
-non-default tests outside registry naming  0
-multi-tier matches                         0
-unreachable declared tiers                 0
-undeclared required-context divergence     0
-hand-written exclusion filtersets          0
-non-registry scheduling overrides          0
-required-tier policy not registry-derived  0
-dispatcher bypasses                        0
-silent early-success paths                 0
-regeneration-as-passing-test paths          0
-required-run skip-helper records           0
-unknown outcome labels                     0
-identities without exactly one outcome      0
-executed-outcome / terminal mismatches       0
-selected identities declared not selected   0
-outcomes without authorized declaration     0
-not-executed outcomes contradicting state    0
-reported results outside selected inventory 0
-outcome / runner-summary mismatches          0
-required-run declared-not-executed outcomes 0
-legacy baseline allowlist                  0
-```
-
-There is deliberately no `unclassified default test` metric: a discovered
-test that matches no non-default selector is default by construction.
-
-The 196 bare ignore attributes, current workflow exclusions, 31 live
-integration-test runtime-precondition paths, two further live unit-test
-self-void paths, 22 dormant self-void paths, ten already-fail-closed success
-returns that must become explicit divergence, two regeneration escape
-hatches, and fragmented legacy runners are migration work. The legacy runner
-scope includes two orphaned shell entry points and
-`tests/runners/x0x_test_runner.py`, which those scripts invoke and which owns
-retry accounting of its own. Moving a bypass from one container to another
-does not satisfy the policy. The three existing `quic-localhost` scheduling
-overrides and the default profile's slow-test termination policy are also
-migration work under the registry's single-source rule; the measured tailnet
-backpressure case matches none of those test groups and currently receives no
-declared isolation.
-
-### 11. Enforcement order is part of the decision
-
-There is no verified current substantive green baseline context. Rollout is:
-
-1. Produce substantive green CI and Build runs on `main` at a recorded SHA,
-   and record every effective test inventory at that SHA. The next approved
-   substantive merge may provide this anchor; if either workflow is red,
-   stop and diagnose that SHA.
-2. Protect those exact observed contexts, including administrators, and read
-   the rule back. This is a provisional branch-control anchor, not proof that
-   the current smaller CI inventory is complete.
-3. Introduce the registry, dispatcher, inventory reconciliation,
-   syntax-aware test-exit audit, single skip-recording helper, skip
-   reconciliation, the non-functional governance tier and its closed fixture
-   mode with the complete outcome-reconciliation mutation manifest,
-   skip-helper positive control, and semantic-failure control outside the
-   ordinary workspace inventory, and tier jobs in advisory mode; absorb the
-   three existing scheduling overrides and the default profile's termination
-   policy into the registry. At this stage the dispatcher intentionally retains
-   `--run-ignored default`. Before execution it emits a temporary
-   `declared-not-executed-with-reason` outcome for each ignored identity that
-   remains selected in that context, scoped to this advisory migration and
-   reconciled with nextest's aggregate skipped count. That declaration has an
-   owner and expires at step 5; it is derived from discovered ignore state,
-   not a per-test allowlist.
-   Outcome accounting can therefore pass honestly while the separate
-   comprehensive-readiness receipt reports the remaining migration work. The
-   dispatcher does not claim comprehensive coverage.
-4. Migrate the currently live integration-test and unit-test
-   runtime-precondition paths, convert already-fail-closed success returns to
-   explicit divergence, and move regeneration out of validation tests. Do not
-   activate ignored cohorts before this observation machinery exists.
-5. Migrate every dormant early-success path and classify all 245 ignored
-   tests. Only then switch the primary dispatcher to `--run-ignored all`,
-   activate the ignored cohorts, remove undeclared workflow exclusions, and
-   reach the comprehensive zero receipt.
-6. Require the exact comprehensive status and prove an intentionally red
-   pull request cannot merge.
-7. Only then remove the fragmented legacy runners and supersede the
-   provisional baseline context.
+5. **Enforcement is honest and staged.** The comprehensive status is not described as complete or made required while legacy bypasses remain. A CI job becomes a merge gate only after the exact status is protected, the protection is read back, and an intentionally failing pull request is refused merge.
 
 ## Consequences
 
-### Positive
+New tests fail safe into execution, and selected-but-self-voiding tests can no longer masquerade as coverage. Local and CI behavior becomes comparable because both consume one authority. Isolation and external execution remain possible, but every exception becomes visible and accountable.
 
-- New tests run by default even when their author forgets the policy
-  namespace.
-- Local and CI selection derive from one executable definition.
-- The gate proves both selection and observation; a selected-but-self-voiding
-  test can no longer masquerade as coverage.
-- Every discovered identity has a positive, closed-set outcome; raw absence
-  can no longer mean either "ignored" or "process died."
-- Isolation, external infrastructure, and soak budgets remain expressible
-  without creating a defect quarantine.
-- Required status claims become independently testable through inventory
-  receipts, protection readback, and a negative merge control.
-
-### Negative / Trade-offs
-
-- The migration covers all 245 ignores, existing workflow exclusions, silent
-  precondition paths, regeneration escape hatches, and legacy runners.
-- A syntax-aware Rust audit and machine-readable skip reconciliation add
-  tooling that must be maintained with test-language changes.
-- Executed-outcome reconciliation initially depends on cargo-nextest's
-  experimental `libtest-json-plus` interface; its adapter must fail closed and
-  be reviewed when nextest changes the format or stabilizes a replacement.
-- Required local and pull-request gates will take longer because
-  `required-isolated` remains required rather than being silently deferred.
-- Some currently green tests will become explicit failures when their
-  preconditions are unavailable.
-- External and soak jobs need declared owners, infrastructure contracts,
-  schedules, and budgets.
-
-### Neutral / Operational
-
-- `#[ignore = "..."]` remains useful metadata for cargo's ordinary runner,
-  but no longer decides routing.
-- The registry defines policies and selectors, not an exhaustive test list.
-- The registry also owns scheduling selectors currently hand-maintained as
-  nextest profile overrides.
-- Target-level namespaces classify homogeneous binaries efficiently; mixed
-  binaries pay the cost of module/test-level naming.
-- Context-specific inventory divergence is visible, owned, and expiring
-  rather than forbidden in all circumstances.
-- The measured tailnet backpressure case belongs in `required-isolated`; that
-  changes scheduling within the required set, not whether the property is
-  required.
+The migration is substantial: current bypasses must be classified or removed, and some green tests will become explicit failures. The observation adapter and audits become maintained infrastructure. Required gates may take longer because required work cannot be silently deferred.
 
 ## Validation
 
-Before the comprehensive status can become required:
+The decision is satisfied only when independent controls demonstrate all of the following.
 
-- nextest discovery plus registry evaluation shows every test in the default
-  complement or exactly one non-default tier;
-- all non-default selectors are pairwise disjoint;
-- governance-fixture namespace discovery and the registry's closed identity
-  list reconcile in both directions, and none of those identities appears in a
-  required inventory;
-- every declared tier is reachable from every context it names;
-- `just check` and pull-request CI emit and reconcile their effective
-  selected inventories against the registry-derived required inventory;
-- each context assigns exactly one declared closed-set outcome to every
-  discovered identity;
-- every executed outcome has a matching per-test terminal event, every
-  not-selected or not-executed outcome is positively declared rather than
-  inferred from absence, and outcome counts reconcile with nextest's own
-  run/pass/fail/not-run totals;
-- coverage uses the same required inventory and closed-outcome
-  reconciliation;
-- governance proves every required-tier selection, scheduling, isolation,
-  concurrency, timeout, termination, and retry policy is derived from the
-  registry, in whatever file or tool expresses it;
-- the governance-fixture mode accepts only a closed registry fixture key,
-  never a caller-supplied target or selector, selects only its
-  registry-declared identities, follows the required reconciliation path, and
-  cannot change a required context's inventory;
-- the governance-tier mutation manifest independently proves every atomic
-  invalid state derived from the outcome-reconciliation rejection rules and
-  the closed outcome definitions, including cardinality, selection,
-  per-identity terminal polarity, declaration source, and runner-aggregate
-  mismatches; the audit checks the manifest and every outcome-accounting
-  receipt row in both directions, and each control requires selected-inventory
-  reconciliation to succeed and attributes the non-zero dispatcher exit only
-  to its named condition;
-- a syntax-aware audit over integration tests and unit-test modules finds no
-  direct success return from a precondition or destructuring failure arm; the
-  only allowed success exit is the single skip-exit construct, whose call site
-  contains no separate return;
-- governance pins that skip-exit construct to one exact definition and its
-  governance-tier positive-control fixture proves that the helper record
-  caused the non-zero dispatcher exit while inventory and outcome
-  reconciliation succeeded;
-- a governance-tier deliberately failing fixture proves that its
-  `executed-and-failed` outcome caused the non-zero dispatcher exit while
-  inventory and outcome reconciliation succeeded;
-- a required run emits zero skip-helper records, zero
-  declared-not-executed outcomes, and propagates semantic failure;
-- regeneration commands and validation tests are distinct;
-- the migration receipt in Decision 10 is all zero;
-- API readback shows the exact comprehensive status required for `main`,
-  including administrators; and
-- an intentionally red pull request is refused merge.
+Each control names one condition. Run unchanged, the control passes. With an independently applied change that violates that condition, the gate fails and attributes the failure to that condition. With a change that violates a different condition instead, the gate fails without that attribution. The three runs differ only in the applied change. A failure arising from any other cause does not satisfy the control.
 
-Review triggers after acceptance:
+- a newly discovered test with no declaration enters required execution;
+- an overlap, unaccounted identity, unauthorized exclusion, selected test without its required observation, or semantic test failure makes the gate fail;
+- a self-reported empty inventory or zero receipt cannot satisfy any control;
+- required local and pull-request CI inventories derive from the same authority and reconcile with discovery;
+- the comprehensive gate is withheld until the legacy-bypass complement is empty; and
+- protection readback names the exact required status and an intentionally failing pull request cannot merge.
 
-- a new test harness, runner, retry layer, coverage tool, or workflow that can
-  change the effective inventory;
-- a new mechanism that can convert an unmet observation into success;
-- a new non-default tier or context-specific divergence;
-- a branch-protection or status-context rename; or
-- evidence that the static audit cannot recognize a Rust control-flow form
-  used by the test suite.
+A new runner, workflow, retry layer, coverage tool, or success-producing bypass requires review of this decision.
 
-## Notes for AI-assisted work
+## Grounding
 
-AI tools may help draft this ADR, but **must not mark it Accepted without
-human review**. This draft is explicitly pre-consensus until Kimi rules and
-David approves it. Accepted ADRs are immutable: create a new superseding ADR
-rather than editing an Accepted ADR.
+
+### G-001 — Required isolation remains required execution
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Supports: Decision Drivers, the requirement that legitimate isolation remain expressible without becoming an opt-out.
+
+Related repository surfaces: `justfile`, `.github/workflows/ci.yml`, `.github/workflows/integration.yml`, `.config/nextest.toml`, and `tests/**`.
+
+External source: Buzz measurement event `b1dc8e11e419913f4cba0d86f49c8e638c4ce9296fb54bb65d1ad4ea1372fe6c`.
+
+Observed result: a serial tailnet backpressure test passed four of five times under concurrent compile load and five of five times without that load; the sole loaded failure reached the substantive network body. The evidence supports required isolated scheduling, not exclusion from required execution.
+
+### G-002 — Selection and runner authority were fragmented
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Supports: Context, Decision 1, and Decision 2.
+
+Related repository surfaces: `justfile`, `.github/workflows/ci.yml`, `.github/workflows/integration.yml`, `.config/nextest.toml`, `tests/e2e_named_groups.sh`, and `tests/e2e_slow_consumer.sh`.
+
+External sources: Buzz measurement events `091570762d7bcd8f5235c7691509aa92fff98cf6214e2139e2f62e2409513bca`, `4b3f2fcf52b4de8f2ab8754ba18d91311b878422ac03c116b0452eef041d30a0`, and `eb12ce28c0907cdaa4f0adb7acc74dba695b58d2b64b0589e7b4d688f587a792`.
+
+Observed result: nextest reported 2,685 test cases across 30 binaries, including 245 ignored tests; 196 ignore attributes were bare and 49 carried a reason. Local tests, CI Test Suite, and Coverage had distinct inventories; Coverage excluded five non-ignored tests that an ignore census could not see. No CI workflow invoked `just`, two shell entry points were orphaned from tracked workflow and `justfile` reachability, and nextest scheduling policy also existed outside a common authority.
+
+### G-003 — Selection did not prove observation
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Supports: Context, Decision 3, and Decision 4.
+
+Related repository surfaces: `tests/**`, `src/exec/service.rs`, `justfile`, and `.config/nextest.toml`.
+
+External sources: Buzz measurement events `58149e7b076b8e19aa531c794d28122aea896546bb7965edf916526f6f2e18f8`, `9d9402c3b234359ae2407607c497f550eff0f93c3ff6ad9c525b23fb9cc8ec42`, and `da7d7dfcae4c375948ea20b2e5ab74247ab948ff1528cb214f917ce38a2ee885`.
+
+Observed result: a structural sweep found 33 live early-success sites across 27 non-ignored integration-test functions; 31 were runtime-precondition paths and two were regeneration paths. Source review found 22 dormant self-void sites inside ignored tests, 15 of them in `tailnet_streams_integration`, plus two further live unit-test self-void paths. Ten assertion-dominated success returns needed explicit divergence, and three separately defined build-or-skip helpers showed that silent success was a repeated convention rather than isolated accidents. Separate heuristic walks disagreed on nested-control-flow and assertion-dominance cases, which supports a syntax-aware shipping audit rather than carrying the census script forward as a gate. A measured nextest stream emitted start events for ignored tests without terminal results, so event absence could not distinguish a declared non-run from an interrupted observation.
+
+### G-004 — Defects were stored in bypass containers
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Supports: Decision 4.
+
+Related repository surfaces: `tests/crdt_convergence_concurrent.rs`, `.github/workflows/ci.yml`, and `justfile`.
+
+External source: Buzz measurement event `eb12ce28c0907cdaa4f0adb7acc74dba695b58d2b64b0589e7b4d688f587a792`.
+
+Observed result: deterministic CRDT convergence failures were labelled `Flaky`, while a historically retry-passing synthetic-kill test was excluded in CI but not in the local `justfile`. The same defect-quarantine hazard therefore existed in both test metadata and workflow selection.
+
+### G-005 — Automatic CI was not demonstrated merge enforcement
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Supports: Decision 5.
+
+Related repository surfaces: `.github/workflows/ci.yml`, `.github/workflows/build.yml`, and `.github/workflows/integration.yml`.
+
+External sources: Buzz measurement events `091570762d7bcd8f5235c7691509aa92fff98cf6214e2139e2f62e2409513bca`, `d621fda1717661c14118ab6c50ea4aebbf21b86f226cd67e3c8a24968a7c6643`, and `f9975d6926bc8cc6200476921a64c2e90fe04ad8ed81e09f265a210452dcc5d2`.
+
+Observed result: at measurement time, the GitHub branch-protection endpoint reported `main` unprotected and the repository ruleset list was empty, with administrator permission checked as a control. A separate 60-run sample contained substantive CI, Build, and Integration failures; Security Audit was green without always exercising the test suite, and Claude Code had 18 skipped conclusions. No substantive green status had therefore been verified as a protection anchor. Workflow execution reported status but had not been demonstrated capable of refusing a merge. This is an external-state observation preserved by the cited relay events, not a claim derived from the repository tree.
+
+### G-006 — The available runner interfaces constrain the adapter
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Supports: Decisions 1 through 3.
+
+Related repository surface: `.config/nextest.toml`.
+
+External sources: Buzz measurement events `4b3f2fcf52b4de8f2ab8754ba18d91311b878422ac03c116b0452eef041d30a0` and `da7d7dfcae4c375948ea20b2e5ab74247ab948ff1528cb214f917ce38a2ee885`.
+
+Observed result: cargo-nextest 0.9.126 could select binary and test filtersets and choose ignore-state behavior, but did not expose ignore-reason text or a `test_group(...)` filter predicate. Its experimental `libtest-json-plus` stream could supply per-test events, but its absence, malformation, and unknown values required a version-pinned, fail-closed adapter. The default profile could terminate slow tests after ten 60-second periods, making missing terminal output a live accounting case rather than a theoretical one.

--- a/docs/adr/0025-required-gates-prove-observation-completeness.md
+++ b/docs/adr/0025-required-gates-prove-observation-completeness.md
@@ -1,9 +1,9 @@
 # ADR 0025: Required Gates Must Prove Observation Completeness
 
-- **Status:** Proposed — pre-consensus (Kimi ruling outstanding)
+- **Status:** Accepted 2026-07-28 by the decision owner at commit `c35336a3f7044b03191b6ef270be9298d30a9373`, recorded as Buzz event `00c8063894d4070f87c5ed9ab19c337b248a043fb0a963d960b3279b2fe8cf4d`. Kimi's ruling was waived by the decision owner, not obtained.
 - **Date:** 2026-07-28
 - **Decision owners:** David Irvine
-- **Reviewers:** Dario; Kimi (required ruling outstanding); Watson
+- **Reviewers:** Sam (author); Dario; Watson. Kimi did not review; his ruling was waived (see Status).
 - **Supersedes:** none
 - **Superseded by:** none
 

--- a/docs/adr/0025-required-gates-prove-observation-completeness.md
+++ b/docs/adr/0025-required-gates-prove-observation-completeness.md
@@ -207,8 +207,14 @@ The initial tiers are:
 | `required-isolated` | `just check` and pull-request CI, after compilation with declared isolation/concurrency |
 | `external` | only in the context that supplies its declared infrastructure |
 | `soak` | on its declared schedule and budget |
+| `governance-fixture` | only in the registry-declared `fixture` context; never in a functional required inventory |
 
 There is no `flaky` or `known-defect` tier.
+
+`governance-fixture` is a non-functional control tier, not a product-test
+opt-out. It contains only the exact governance fixtures that certify the
+dispatcher itself and is unreachable through ordinary or required-tier
+selectors.
 
 A compile-contention measurement for
 `tailnet_streams_integration::backpressure_throttles_writer_with_bounded_buffering`
@@ -221,17 +227,22 @@ causation. That tier remains required locally and in pull-request CI.
 
 ### 3. One executable registry owns routing and reachability
 
-The registry enumerates tier definitions, not individual default tests. Each
-tier definition owns:
+The registry enumerates tier definitions, not individual default tests. Its
+context schema contains `local`, `pull-request`, `external`, `scheduled`, and
+`fixture`. Each functional tier definition owns:
 
 - its positive `binary(...)` / `test(...)` selector;
 - every permitted context-specific exclusion;
-- local, pull-request, external, and scheduled execution contexts;
+- the non-fixture execution contexts in which it runs;
 - scheduling, isolation, concurrency, timeout, termination, and retry policy;
 - infrastructure preconditions;
 - failure policy;
 - owner; and
 - reason and expiry for any declared context-specific divergence.
+
+The non-functional `governance-fixture` definition instead owns the exact
+fixture identities and the `fixture` context. That context has one entry point
+and is the only context permitted to select those identities.
 
 A single dispatcher consumes the registry. Any policy that affects selection,
 scheduling, isolation, concurrency, timeout, termination, or retry behavior
@@ -252,6 +263,16 @@ second source.
 `required-isolated`; `just check` invokes `run-required`. CI derives its
 required and scheduled matrices from the same registry and invokes the same
 dispatcher.
+
+The dispatcher exposes exactly one registry-declared governance-fixture target
+mode as the sole entry point for the `fixture` context. It accepts only a
+closed registry fixture key, never a caller-supplied selector or arbitrary
+target, and resolves that key only to exact identities in the
+`governance-fixture` tier. It executes the same runner adapter, outcome mapping,
+reconciliation, and semantic-failure propagation path as a required run. A
+governance audit may invoke that mode as a separate self-test, but the mode
+cannot supply, replace, narrow, or extend the inventory of any required local
+or CI context.
 
 The invariant is one execution definition per tier, reachable in every
 context that definition declares. It is not "exactly one process" or "exactly
@@ -275,8 +296,15 @@ ignore-state disposition is applied. During the advisory migration, an
 ignored identity in the default complement therefore remains selected even
 though it receives a declared not-executed outcome.
 
-Each context also emits exactly one positive outcome for every discovered test
-identity from this closed set:
+In governance-fixture target mode, the exact identities declared by the
+`governance-fixture` tier are that run's required inventory. The same
+selection and outcome reconciliation applies. Its inventory reconciliation
+must succeed before the audit may attribute a non-zero exit to the behavior a
+fixture is intended to certify.
+
+Each required context and governance-fixture run also emits exactly one
+positive outcome for every identity in its discovery scope from this closed
+set:
 
 - `executed-and-passed`: the identity was selected and emitted a passing
   per-test terminal event;
@@ -287,6 +315,15 @@ identity from this closed set:
 - `declared-not-executed-with-reason`: the dispatcher or declared skip helper
   positively records why an otherwise selected identity did not execute its
   promised observation.
+
+Each label is valid only when every predicate in its definition holds. The
+reconciler therefore rejects an executed outcome for an unselected identity;
+an executed outcome whose pass/fail polarity lacks the matching terminal
+event; a `declared-not-selected` outcome for a selected identity or without a
+pre-run registry declaration; and a
+`declared-not-executed-with-reason` outcome for an unselected identity, without
+one of the permitted positive sources, or alongside a terminal event. An
+unknown outcome label is not an extensibility point and fails closed.
 
 Accounting an `executed-and-failed` outcome does not convert semantic failure
 into success; the dispatcher still returns a failing status.
@@ -306,11 +343,13 @@ removes that migration state, the registry's context and tier policy is the
 only authority for a pre-run not-selected declaration.
 
 The dispatcher reconciles the outcome table one-to-one against nextest
-discovery, the effective selected inventory, and the runner's own
-run/pass/fail/not-run totals. An identity with zero or multiple outcomes
-fails the run. A selected identity with no terminal event and no positive
-declared-not-executed record fails the run. A terminal event for an identity
-declared unselected or not executed also fails the run. Selected-set equality
+discovery, the effective selected inventory, the closed outcome definitions,
+and the runner's own run/pass/fail/not-run totals. An identity with zero or
+multiple outcomes fails the run. A selected identity with no terminal event
+and no positive declared-not-executed record fails the run. A selected identity
+carrying `declared-not-selected` fails the run. An executed outcome or reported
+terminal result outside the selected inventory fails the run. A terminal event
+for an identity declared not executed also fails the run. Selected-set equality
 is necessary but insufficient.
 
 The initial dispatcher may obtain executed outcomes from cargo-nextest 0.9.126
@@ -321,6 +360,42 @@ dispatcher owns the environment flag and parser. Unknown events or an
 unavailable or malformed stream fail closed. The dispatcher reconciles
 explicit not-run declarations with nextest's aggregate skipped/not-run count;
 it does not translate raw event absence into an outcome.
+
+Outcome reconciliation has a governance mutation manifest derived from the
+union of the rejection rules above and every predicate in the closed outcome
+definitions. The registry declares one case per atomic mutation in the
+non-functional `governance-fixture` tier:
+
+- zero outcomes and multiple outcomes for one identity are separate cases;
+- an `executed-and-passed` or `executed-and-failed` outcome for an unselected
+  identity, without its matching terminal event, or with the opposite terminal
+  polarity is mutated separately;
+- `declared-not-selected` on a selected identity and without its pre-run
+  registry declaration, and alongside a terminal event are separate cases;
+- `declared-not-executed-with-reason` on an unselected identity, without a
+  permitted positive source, and alongside a terminal event are separate
+  cases;
+- an unknown outcome label is a separate fail-closed parser case; and
+- an otherwise valid outcome table disagreeing with the runner's aggregate
+  run/pass/fail/not-run totals is a separate case.
+
+Each fixture mutates exactly one predicate from an otherwise valid state. When
+that state also satisfies an umbrella rejection sentence above, the mutation
+manifest names the canonical diagnostic and no other diagnostic may satisfy
+the control. The audit passes only when selected-inventory reconciliation
+succeeds, the dispatcher reports that named outcome-reconciliation failure,
+attributes its non-zero status to that failure, and exits non-zero. A
+skip-helper record, semantic test failure, unrelated inventory failure, another
+reconciliation condition, or a self-reported zero receipt cannot satisfy a
+control.
+
+Governance checks the mutation manifest and the outcome-accounting rows in the
+Decision 10 receipt in both directions: every atomic invalid state has a
+specific diagnostic and receipt row, and every such receipt row is justified
+by at least one independently reddening mutation case. The steady-state
+readiness row that requires zero valid
+`declared-not-executed-with-reason` outcomes is identified separately and is
+not misrepresented as an invalid-state mutation.
 
 A context-specific difference may exist only when the registry declares it
 with a reason, owner, and expiry. It cannot be expressed as an inline
@@ -346,18 +421,26 @@ would require the audit to infer statement domination.
 
 The one allowed helper is pinned to an exact definition rather than accepted
 by a name pattern. Governance verifies that definition emits the
-machine-readable record and owns a positive-control fixture outside the
-workspace's discovered test inventory. The audit invokes that fixture through
-the required dispatcher as a subprocess and passes only when the helper fires
-and the dispatcher exits non-zero. The fixture is not an ordinary test and is
-not placed in a functional tier: either placement would make the required
-inventory permanently red or certify the wrong execution context.
+machine-readable record. The registry declares its positive-control fixture in
+the non-functional `governance-fixture` tier, outside the workspace's ordinary
+discovered test inventory. The audit invokes it through the dispatcher's
+closed fixture mode as a subprocess and passes only when all of these hold:
+the helper record maps the fixture identity to
+`declared-not-executed-with-reason`; inventory and outcome reconciliation
+otherwise succeed; the dispatcher attributes its failure to the non-zero
+skip-helper record count; and the dispatcher exits non-zero. An inventory or
+reconciliation failure cannot satisfy the control. The fixture is not an
+ordinary test and is not placed in a functional tier, because either placement
+would make the required inventory permanently red or certify the wrong
+execution context.
 
 The helper is diagnostic accounting, not an observation or a bypass. Its
 record maps to `declared-not-executed-with-reason`, never to
 `executed-and-passed`:
 
-- a required dispatcher fails if its recorded skip count is non-zero;
+- a required dispatcher fails if its skip-helper record count is non-zero;
+  that count includes only machine-readable records emitted by the pinned
+  helper, never dispatcher pre-run declarations;
 - a scheduled external or soak context fails if its promised infrastructure
   is absent; and
 - a tier not scheduled in a context is accounted for by the registry, not by
@@ -447,11 +530,15 @@ Enforcement requires both:
 2. an intentionally red pull request that GitHub refuses to merge.
 
 Dispatcher failure propagation has its own governance negative control,
-separate from the transient red pull request. Governance owns a deliberately
-failing fixture outside the workspace's discovered test inventory and invokes
-the required dispatcher over it as a subprocess. The audit passes only when
-the dispatcher reports the executed failure and exits non-zero. The fixture is
-not an ordinary test and is not assigned to a functional tier, because either
+separate from the transient red pull request. The registry declares a
+deliberately failing fixture in the non-functional `governance-fixture` tier,
+outside the workspace's ordinary discovered test inventory. Governance invokes
+it through the dispatcher's closed fixture mode as a subprocess. The audit
+passes only when the fixture receives `executed-and-failed`, inventory and
+outcome reconciliation otherwise succeed, the dispatcher attributes its
+failing status to that semantic failure, and it exits non-zero. An inventory
+or reconciliation failure cannot satisfy the control. The fixture is not an
+ordinary test and is not assigned to a functional tier, because either
 placement would make a normal required run permanently red or exercise a
 different context from the one being certified.
 
@@ -476,9 +563,14 @@ required-tier policy not registry-derived  0
 dispatcher bypasses                        0
 silent early-success paths                 0
 regeneration-as-passing-test paths          0
-required-run recorded skips                0
+required-run skip-helper records           0
+unknown outcome labels                     0
 identities without exactly one outcome      0
-executed identities without terminal event  0
+executed-outcome / terminal mismatches       0
+selected identities declared not selected   0
+outcomes without authorized declaration     0
+not-executed outcomes contradicting state    0
+reported results outside selected inventory 0
 outcome / runner-summary mismatches          0
 required-run declared-not-executed outcomes 0
 legacy baseline allowlist                  0
@@ -514,10 +606,12 @@ There is no verified current substantive green baseline context. Rollout is:
    the current smaller CI inventory is complete.
 3. Introduce the registry, dispatcher, inventory reconciliation,
    syntax-aware test-exit audit, single skip-recording helper, skip
-   reconciliation, the two governance-owned out-of-inventory control fixtures,
-   and tier jobs in advisory mode; absorb the three existing scheduling
-   overrides and the default profile's termination policy into the registry.
-   At this stage the dispatcher intentionally retains
+   reconciliation, the non-functional governance tier and its closed fixture
+   mode with the complete outcome-reconciliation mutation manifest,
+   skip-helper positive control, and semantic-failure control outside the
+   ordinary workspace inventory, and tier jobs in advisory mode; absorb the
+   three existing scheduling overrides and the default profile's termination
+   policy into the registry. At this stage the dispatcher intentionally retains
    `--run-ignored default`. Before execution it emits a temporary
    `declared-not-executed-with-reason` outcome for each ignored identity that
    remains selected in that context, scoped to this advisory migration and
@@ -608,17 +702,31 @@ Before the comprehensive status can become required:
 - governance proves every required-tier selection, scheduling, isolation,
   concurrency, timeout, termination, and retry policy is derived from the
   registry, in whatever file or tool expresses it;
+- the governance-fixture mode accepts only a closed registry fixture key,
+  never a caller-supplied target or selector, selects only its
+  registry-declared identities, follows the required reconciliation path, and
+  cannot change a required context's inventory;
+- the governance-tier mutation manifest independently proves every atomic
+  invalid state derived from the outcome-reconciliation rejection rules and
+  the closed outcome definitions, including cardinality, selection,
+  per-identity terminal polarity, declaration source, and runner-aggregate
+  mismatches; the audit checks the manifest and every outcome-accounting
+  receipt row in both directions, and each control requires selected-inventory
+  reconciliation to succeed and attributes the non-zero dispatcher exit only
+  to its named condition;
 - a syntax-aware audit over integration tests and unit-test modules finds no
   direct success return from a precondition or destructuring failure arm; the
   only allowed success exit is the single skip-exit construct, whose call site
   contains no separate return;
 - governance pins that skip-exit construct to one exact definition and its
-  out-of-inventory positive-control fixture proves that the helper records a
-  skip and makes the required dispatcher exit non-zero;
-- an out-of-inventory deliberately failing fixture proves that the required
-  dispatcher reports semantic failure and exits non-zero;
-- a required run records zero skips, zero declared-not-executed outcomes, and
-  propagates semantic failure;
+  governance-tier positive-control fixture proves that the helper record
+  caused the non-zero dispatcher exit while inventory and outcome
+  reconciliation succeeded;
+- a governance-tier deliberately failing fixture proves that its
+  `executed-and-failed` outcome caused the non-zero dispatcher exit while
+  inventory and outcome reconciliation succeeded;
+- a required run emits zero skip-helper records, zero
+  declared-not-executed outcomes, and propagates semantic failure;
 - regeneration commands and validation tests are distinct;
 - the migration receipt in Decision 10 is all zero;
 - API readback shows the exact comprehensive status required for `main`,

--- a/docs/adr/0025-required-gates-prove-observation-completeness.md
+++ b/docs/adr/0025-required-gates-prove-observation-completeness.md
@@ -188,6 +188,12 @@ Only non-default tiers carry a source-level, machine-selectable namespace:
 - use a module or test-name namespace when one binary contains multiple
   policies.
 
+`governance-fixture` uses the reserved source-level
+`governance_fixture_*` integration-target, module, or test-name namespace under
+the same rule. The registry pairs every namespace match with one exact fixture
+identity; an identity list is not an exception to selector-based
+classification.
+
 The non-default selectors must be pairwise disjoint. A missing or mistyped
 non-default namespace falls into `default` and runs.
 
@@ -207,7 +213,7 @@ The initial tiers are:
 | `required-isolated` | `just check` and pull-request CI, after compilation with declared isolation/concurrency |
 | `external` | only in the context that supplies its declared infrastructure |
 | `soak` | on its declared schedule and budget |
-| `governance-fixture` | only in the registry-declared `fixture` context; never in a functional required inventory |
+| `governance-fixture` | source namespace `governance_fixture_*`; only in the registry-declared `fixture` context; never in a functional required inventory |
 
 There is no `flaky` or `known-defect` tier.
 
@@ -240,9 +246,14 @@ context schema contains `local`, `pull-request`, `external`, `scheduled`, and
 - owner; and
 - reason and expiry for any declared context-specific divergence.
 
-The non-functional `governance-fixture` definition instead owns the exact
-fixture identities and the `fixture` context. That context has one entry point
-and is the only context permitted to select those identities.
+The non-functional `governance-fixture` definition instead owns its positive
+source-namespace selector, the exact fixture identities matched by that
+selector, and the `fixture` context. The selector classifies each fixture out
+of the `default` complement; it is not a fixture-mode selection authority. The
+closed identity list is what a fixture key resolves to. Every listed identity
+must match the selector exactly once, every discovered selector match must be
+listed, and no functional test may match it. The `fixture` context has one
+entry point and is the only context permitted to select those identities.
 
 A single dispatcher consumes the registry. Any policy that affects selection,
 scheduling, isolation, concurrency, timeout, termination, or retry behavior
@@ -688,6 +699,9 @@ Before the comprehensive status can become required:
 - nextest discovery plus registry evaluation shows every test in the default
   complement or exactly one non-default tier;
 - all non-default selectors are pairwise disjoint;
+- governance-fixture namespace discovery and the registry's closed identity
+  list reconcile in both directions, and none of those identities appears in a
+  required inventory;
 - every declared tier is reachable from every context it names;
 - `just check` and pull-request CI emit and reconcile their effective
   selected inventories against the registry-derived required inventory;

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ This directory contains architecture decision records for x0x.
 ## Proposed
 
 - [ADR 0021: DM Origin-Machine Attestation for Gossip DMs](./0021-dm-origin-machine-attestation.md) — machine-key attestation of DM origin; codec scaffolding landed (`DmOriginAttestation` in `src/dm.rs`) but enforcement not yet wired
+- [ADR 0025: Required Gates Must Prove Observation Completeness](./0025-required-gates-prove-observation-completeness.md) — pre-consensus proposal for default-run test routing, registry-derived required inventories, and proof that selected tests executed their promised observations (Dario review and Kimi ruling outstanding)
 
 ## Errata (Accepted ADRs are immutable; corrections recorded here)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,7 +33,7 @@ This directory contains architecture decision records for x0x.
 ## Proposed
 
 - [ADR 0021: DM Origin-Machine Attestation for Gossip DMs](./0021-dm-origin-machine-attestation.md) — machine-key attestation of DM origin; codec scaffolding landed (`DmOriginAttestation` in `src/dm.rs`) but enforcement not yet wired
-- [ADR 0025: Required Gates Must Prove Observation Completeness](./0025-required-gates-prove-observation-completeness.md) — pre-consensus proposal for default-run test routing, registry-derived required inventories, and proof that selected tests executed their promised observations (Dario review and Kimi ruling outstanding)
+- [ADR 0025: Required Gates Must Prove Observation Completeness](./0025-required-gates-prove-observation-completeness.md) — pre-consensus proposal for default-run test routing, registry-derived required inventories, and proof that selected tests executed their promised observations (amended-draft review and Kimi ruling outstanding)
 
 ## Errata (Accepted ADRs are immutable; corrections recorded here)
 

--- a/docs/design/required-gates-observation-completeness.md
+++ b/docs/design/required-gates-observation-completeness.md
@@ -1,0 +1,531 @@
+# Required-Gate Observation Completeness
+
+- **Status:** Draft reference implementation
+- **Governing decision:** [ADR 0025](../adr/0025-required-gates-prove-observation-completeness.md)
+- **Source migration:** ADR 0025 at
+  `102ab0e53acf35c2dcebc716d6de9127b9bb50ab`
+
+This chapter owns the mutable mechanisms that implement ADR 0025. The ADR owns
+the stable architectural decision and its Grounding appendix owns evidence.
+Changes here do not amend the ADR; a mechanism that cannot satisfy the ADR
+requires a superseding decision.
+
+The chapter declares its governing ADR. ADR-to-chapter membership must be
+computed from that field; no ADR-side chapter allowlist is maintained.
+
+## 1. Registry model
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Resolution scope: repository inputs at this commit. The registry described
+below is specified work and is not asserted to exist at that commit.
+
+The registry enumerates non-default policy definitions, never individual
+ordinary tests. Discovery computes ordinary required execution as the
+complement of those definitions.
+
+The initial functional tiers are:
+
+| Tier | Required execution |
+|---|---|
+| `default` | local `just check` and pull-request CI |
+| `required-isolated` | local `just check` and pull-request CI, after compilation and with declared isolation |
+| `external` | only in the context supplying its declared infrastructure |
+| `soak` | on its declared schedule and budget |
+
+There is no `flaky` or `known-defect` tier. A test requiring a different
+schedule may remain required; scheduling does not imply exclusion.
+
+Each functional tier definition owns:
+
+- a positive `binary(...)` or `test(...)` selector;
+- every permitted context-specific exclusion;
+- its non-fixture execution contexts;
+- scheduling, isolation, concurrency, timeout, termination, and retry policy;
+- infrastructure preconditions and failure policy;
+- an owner; and
+- a reason and expiry for every context-specific divergence.
+
+The initial contexts are `local`, `pull-request`, `external`, `scheduled`, and
+`fixture`. New contexts extend the registry schema; they do not create a
+second routing authority.
+
+### Classification algorithm
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Every discovered identity is classified mechanically:
+
+```text
+matches = registry.non_default_selectors_matching(identity)
+
+if matches.count == 0:
+    tier = default
+elif matches.count == 1:
+    tier = matches.only
+else:
+    fail("overlapping non-default declarations")
+```
+
+Only non-default tiers carry a source-level, machine-selectable namespace. A
+homogeneous integration target uses its target name. A mixed target uses a
+module or test-name namespace. A missing or mistyped namespace therefore
+falls into `default` and runs.
+
+`#[ignore = "..."]` may remain human-readable metadata for cargo's ordinary
+runner, but it is not routing authority. The steady-state dispatcher uses
+`--run-ignored all`; the temporary migration state is described in Section 10.
+
+## 2. Governance fixtures
+
+Resolves at: `102ab0e53acf35c2dcebc716d6de9127b9bb50ab`
+
+Resolution scope: the fixture governance design recorded in the source ADR.
+The mechanism remains specified rather than implemented.
+
+`governance-fixture` is a non-functional control tier. Its reserved
+`governance_fixture_*` source namespace classifies governance fixtures out of
+the default complement without making their identities a routing allowlist.
+
+The fixture definition owns:
+
+- its positive source-namespace selector;
+- a closed list of exact fixture identities;
+- the `fixture` context; and
+- a closed fixture key for each control.
+
+The following relations reconcile in both directions:
+
+- every listed identity matches the fixture selector exactly once;
+- every discovered selector match appears in the identity list;
+- no functional test matches the fixture selector; and
+- fixture identities never appear in a functional required inventory.
+
+The fixture context has one entry point. It accepts only a registry fixture
+key, never a caller-supplied selector or arbitrary test target. The key
+resolves to exact fixture identities and traverses the same runner adapter,
+outcome mapping, reconciliation, and semantic-failure propagation path as a
+required run. Fixture mode cannot alter any required run's inventory.
+
+## 3. Dispatcher ownership and reachability
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Resolution scope: fragmented runner surfaces at this commit are migration
+inputs; the dispatcher is specified work.
+
+A single dispatcher consumes the registry. Workflow files, nextest profiles,
+scripts, `justfile` recipes, and successor containers may consume generated
+policy but cannot become independent authorities.
+
+`run-required` iterates `default` and `required-isolated`. Local `just check`
+invokes `run-required`. CI derives required, external, and scheduled matrices
+from the same registry and invokes the same dispatcher.
+
+Reachability is proven from the dispatcher graph:
+
+```text
+declared tier
+  -> registry context
+  -> generated entry point
+  -> dispatcher mode
+  -> runner invocation
+```
+
+The invariant is one execution definition per tier, not one process or one
+call site. A command found in an otherwise orphaned script is not reachable.
+
+Required dispatchers propagate semantic failure to a failing status.
+Governance follows values rather than rejecting token shapes. For example,
+`|| true` may preserve output only when a later fail-closed check turns the
+captured failure into a non-zero result.
+
+## 4. Inventory and outcome accounting
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Resolution scope: nextest 0.9.126 and the repository's current runner settings
+at this commit define the initial adapter boundary.
+
+The required inventory is the union of `default` and `required-isolated`.
+Before execution, each required context emits its effective selected inventory
+and reconciles it against that required inventory. Selection is computed
+before the runner applies ignore-state behavior.
+
+Each run emits exactly one outcome per identity in its discovery scope:
+
+| Outcome | Required predicates |
+|---|---|
+| `executed-and-passed` | selected identity plus matching passing terminal event |
+| `executed-and-failed` | selected identity plus matching failing terminal event |
+| `declared-not-selected` | pre-run registry declaration that the tier is out of scope |
+| `declared-not-executed-with-reason` | selected identity plus a permitted positive dispatcher or skip-helper declaration |
+
+An executed failure remains a semantic failure. Accounting it never converts
+the dispatcher to success.
+
+A `started` event proves only presence in the stream. It is not a terminal
+observation. A missing terminal event never becomes a declared non-run by
+inference.
+
+The reconciler compares the outcome table one-to-one with:
+
+- discovery;
+- the effective selected inventory;
+- the closed outcome definitions;
+- per-identity terminal events; and
+- the runner's aggregate run, pass, fail, skipped, and not-run totals.
+
+It fails on zero or multiple outcomes, a result outside selection, a terminal
+polarity mismatch, a selected identity declared not selected, a declaration
+without its authority, a not-executed declaration alongside a terminal event,
+or a selected identity with neither a terminal event nor a positive
+not-executed declaration. Selected-set equality is necessary and insufficient.
+
+### Initial nextest adapter
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+The initial adapter may invoke cargo-nextest 0.9.126 with:
+
+```text
+NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1
+--message-format libtest-json-plus
+```
+
+The dispatcher owns the environment flag, parser, and version-pinned raw
+event-to-outcome mapping. An unavailable or malformed stream, or an unknown
+event or outcome label, fails closed. Unknown values are not extension points.
+The adapter reconciles explicit declarations with aggregate runner totals and
+does not translate event absence into an outcome.
+
+## 5. Differential controls and mutation manifest
+
+Resolves at: `102ab0e53acf35c2dcebc716d6de9127b9bb50ab`
+
+Resolution scope: this section preserves the detailed control mechanism that
+was compressed into ADR 0025 Validation.
+
+The mutation manifest is derived from every predicate in the closed outcome
+definitions and from every reconciler rejection rule. It contains a case for
+each atomic invalid state, including:
+
+- zero outcomes and multiple outcomes for one identity;
+- an executed outcome for an unselected identity;
+- a missing or opposite-polarity terminal event;
+- `declared-not-selected` on a selected identity, without its registry
+  declaration, or alongside a terminal event;
+- `declared-not-executed-with-reason` on an unselected identity, without a
+  permitted source, or alongside a terminal event;
+- an unknown outcome label; and
+- a valid-looking table that disagrees with runner aggregates.
+
+Each fixture changes one predicate from an otherwise identical state and names
+one canonical diagnostic. Governance checks the manifest and receipt rows in
+both directions: every atomic invalid state has a fixture and receipt row, and
+every mutation-backed receipt row has a fixture.
+
+For a named condition C, the control has three runs:
+
+1. unchanged, the control passes;
+2. a change violating C makes the gate fail and attribute the failure to C;
+3. a change violating another condition makes the gate fail without
+   attributing the failure to C.
+
+Only the applied change differs between runs. Compile errors, unrelated
+inventory failures, semantic failures, other reconciliation failures, and
+self-reported zero receipts cannot substitute for the named control.
+
+The steady-state requirement for zero valid not-executed outcomes is a
+readiness condition, not an invalid-state mutation, and is identified
+separately.
+
+## 6. Runtime preconditions and the skip helper
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Resolution scope: integration and unit-test control-flow shapes at this commit
+are migration inputs. The syntax-aware audit and helper are specified work.
+
+An unmet precondition fails by default. Where the test harness cannot express a
+native skip, test code may use one pinned syntax-level helper that both emits a
+machine-readable record keyed to the discovered identity and exits the test.
+The helper call is the exit operation; a separate success return is forbidden.
+
+The helper maps only to `declared-not-executed-with-reason`. It never maps to
+`executed-and-passed`.
+
+- a required dispatcher fails when any skip-helper record exists;
+- an external or soak context fails when scheduled but missing its promised
+  infrastructure; and
+- a tier not scheduled in a context is accounted for by registry policy, not
+  by a passing test.
+
+The helper's positive-control fixture runs through closed fixture mode. It
+passes its control only when the record maps to its exact identity, inventory
+and outcome reconciliation otherwise hold, the dispatcher attributes the
+non-zero result to the skip-helper count, and the dispatcher exits non-zero.
+
+### Syntax-aware exit audit
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Within a test function's own control-flow scope, a precondition-failure or
+destructuring-failure arm must:
+
+- diverge through an assertion, `panic!`, or `unreachable!`; or
+- exit through the single pinned skip construct.
+
+Direct success exits such as `return`, `return Ok(())`, and
+`let ... else { return Ok(()) }` are forbidden. An assertion-dominated arm
+still uses explicit divergence instead of retaining an unreachable success
+return.
+
+The audit parses Rust syntax across integration tests and unit-test modules. It
+distinguishes test-function exits from returns inside nested closures or async
+blocks. It does not infer assertion domination, scan for log messages, or use
+the earlier brace-depth census as its normative implementation.
+
+## 7. Regeneration and known-defect handling
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Resolution scope: regeneration escape hatches, defect-labelled tests, and
+workflow exclusions at this commit are migration inputs.
+
+Artifact generation and validation have separate entry points. An `xtask` or
+equivalent command generates an artifact; required tests always validate the
+committed artifact. Until separated, required dispatch rejects regeneration
+environment variables and the exit audit continues reporting their
+early-success paths.
+
+A deterministic product or dependency defect is not stored in an ignore,
+exclusion, early-success precondition, retry-only success, or successor
+mechanism. Triage chooses one honest state:
+
+- fix the behavior and run the regression normally;
+- record intended behavior as a passing characterization and track any desired
+  change separately; or
+- if intent is unresolved, remove the disputed executable claim, preserve the
+  reproducer and competing expectations in an owned, expiring issue, and do not
+  claim coverage.
+
+`Flaky` requires measured pass/fail evidence, and measured intermittence is
+diagnostic evidence rather than a permanent tier. An external tier is valid
+only when the registry names its infrastructure, owning context, owner, and
+fail-closed behavior.
+
+## 8. Local, CI, coverage, and protection
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Resolution scope: current `justfile` and workflow commands at this commit are
+migration inputs. No branch-protection state is inferred from this SHA.
+
+The target `just check` composition is:
+
+- formatting;
+- lint;
+- build;
+- documentation;
+- the default test filter;
+- the required-isolated filter; and
+- the observation-completeness audit.
+
+Pull-request CI invokes the same registry-derived required dispatcher and
+publishes the same selected-inventory, closed-outcome, and skip-accounting
+receipt. Coverage may add instrumentation but cannot shrink the required
+inventory or omit outcomes.
+
+A deliberately failing fixture outside the ordinary workspace inventory
+proves semantic-failure propagation. The control succeeds only when the
+fixture receives `executed-and-failed`, reconciliation otherwise holds, the
+dispatcher attributes the non-zero result to that semantic failure, and it
+exits non-zero.
+
+Branch enforcement is a separate control. It requires:
+
+1. API readback naming the exact protected comprehensive status, including
+   administrator coverage and any documented break-glass path; and
+2. an intentionally failing pull request that the platform refuses to merge.
+
+A workflow that reports green without a substantive pass/fail observation
+cannot substitute for the protected test context.
+
+## 9. Comprehensive-readiness receipt
+
+Resolves at: `102ab0e53acf35c2dcebc716d6de9127b9bb50ab`
+
+Resolution scope: this is the complete receipt schema migrated from the source
+ADR. Values are requirements, not assertions about the current tree.
+
+```text
+bare #[ignore]                              0
+non-default tests outside registry naming  0
+multi-tier matches                         0
+unreachable declared tiers                 0
+undeclared required-context divergence     0
+hand-written exclusion filtersets          0
+non-registry scheduling overrides          0
+required-tier policy not registry-derived  0
+dispatcher bypasses                        0
+silent early-success paths                 0
+regeneration-as-passing-test paths          0
+required-run skip-helper records           0
+unknown outcome labels                     0
+identities without exactly one outcome      0
+executed-outcome / terminal mismatches       0
+selected identities declared not selected   0
+outcomes without authorized declaration     0
+not-executed outcomes contradicting state    0
+reported results outside selected inventory 0
+outcome / runner-summary mismatches          0
+required-run declared-not-executed outcomes 0
+legacy baseline allowlist                  0
+```
+
+There is no `unclassified default test` row because a discovered identity
+matching no non-default selector is default by construction. Receipt
+generation computes its population; a self-reported empty population or zero
+does not satisfy a control.
+
+## 10. Rollout
+
+Resolves at: `e3013710d7ed69077de9a799dffdbeb5ac80535a`
+
+Resolution scope: source measurements at this commit define migration inputs.
+The sequence is prescribed work, not an assertion that any step has landed.
+
+1. Produce substantive green CI and Build runs on `main` at one recorded SHA
+   and record every effective test inventory there. Stop and diagnose if
+   either workflow is red.
+2. Protect those exact observed contexts, including administrators, and read
+   the rule back. This is a provisional branch-control anchor, not evidence
+   that the smaller legacy inventory is complete.
+3. Add the registry, dispatcher, inventory and outcome reconciliation,
+   syntax-aware exit audit, skip helper, governance fixtures, mutation
+   manifest, semantic-failure control, and tier jobs in advisory mode. Move
+   existing scheduling and termination policy under the registry.
+4. During this advisory stage retain `--run-ignored default`. Before
+   execution, positively declare every ignored identity still selected in the
+   context as temporarily not executed, reconcile those declarations with
+   nextest aggregates, give the declaration an owner, and expire it at step 6.
+   Do not claim comprehensive coverage.
+5. Migrate live integration and unit-test precondition paths, convert
+   already-fail-closed success returns to explicit divergence, and separate
+   regeneration from validation. Do not activate ignored cohorts first.
+6. Migrate dormant early-success paths and classify every ignored test. Then
+   switch to `--run-ignored all`, activate the cohorts, remove undeclared
+   workflow exclusions, and reach the zero receipt.
+7. Require the exact comprehensive status and prove an intentionally failing
+   pull request cannot merge.
+8. Only then remove fragmented legacy runners and supersede the provisional
+   branch-control context.
+
+Moving a bypass between an attribute, workflow, shell script, test body,
+retry layer, or environment-controlled mode does not satisfy the rollout.
+
+## 11. Implementation validation matrix
+
+Resolves at: `102ab0e53acf35c2dcebc716d6de9127b9bb50ab`
+
+Resolution scope: detailed controls migrated from source ADR Validation.
+
+Before the comprehensive status becomes required, controls prove:
+
+- discovery and registry evaluation classify every identity as default or
+  exactly one non-default tier;
+- non-default selectors are pairwise disjoint;
+- fixture namespace discovery and the closed fixture list reconcile both
+  ways, and fixtures are absent from functional inventories;
+- each declared tier is reachable from every context it names;
+- local and pull-request selected inventories reconcile with discovery and the
+  registry-derived required inventory;
+- each context assigns exactly one valid closed-set outcome per discovered
+  identity;
+- executed outcomes match terminal events, declarations are positive rather
+  than inferred from absence, and outcome totals match runner totals;
+- coverage uses the same required inventory and reconciliation;
+- every required selection, scheduling, isolation, concurrency, timeout,
+  termination, and retry policy derives from the registry;
+- fixture mode accepts only a closed key, selects only registry identities,
+  follows the required reconciliation path, and cannot change a required
+  inventory;
+- every atomic invalid outcome state has its differential control and
+  canonical attribution;
+- the syntax-aware audit finds no direct precondition or destructuring success
+  exit outside the pinned helper;
+- the helper definition and positive-control fixture are exact;
+- a deliberately failing fixture proves semantic-failure propagation;
+- a required run has zero helper records and zero not-executed outcomes;
+- regeneration and validation are distinct;
+- every readiness-receipt row is zero;
+- protection readback names the exact comprehensive status; and
+- an intentionally failing pull request is refused merge.
+
+## 12. Reference-implementation review triggers
+
+Resolves at: `102ab0e53acf35c2dcebc716d6de9127b9bb50ab`
+
+Review this chapter and ADR 0025 when:
+
+- a new test harness, runner, retry layer, coverage tool, or workflow can
+  change effective inventory;
+- a new mechanism can convert an unmet observation into success;
+- a new non-default tier or context-specific divergence is proposed;
+- a branch-protection rule or status context is renamed; or
+- evidence shows that an adapter or static audit cannot recognise a
+  control-flow or observation form the suite actually uses.
+
+The first four triggers identify policy or integration changes. The final
+trigger prevents a currently complete-looking audit from silently becoming a
+screen as test or runner syntax evolves.
+
+## 13. Source migration manifest
+
+Resolves at: `102ab0e53acf35c2dcebc716d6de9127b9bb50ab`
+
+This ledger maps every source line exactly once to its primary destination.
+The ADR carries stable decisions, its Grounding blocks carry evidence, and
+this chapter carries mutable mechanisms. Blank lines and headings travel with
+their enclosing range.
+
+| Source lines | Primary destination |
+|---:|---|
+| 1–20 | ADR register, status, and Grounding G-001 |
+| 21–46 | ADR Summary and Context |
+| 47–118 | ADR Grounding G-002, G-003, G-005, and G-006 |
+| 119–136 | ADR Decision Drivers |
+| 137–159 | ADR Considered Options |
+| 160–183 | ADR Decisions 1 and 4 |
+| 184–224 | Chapter §§1–2 |
+| 225–233 | ADR Grounding G-001 |
+| 234–287 | Chapter §§1–3 |
+| 288–299 | ADR Decisions 2 and 3 |
+| 300–407 | Chapter §§4–5 |
+| 408–420 | ADR Decision 4 |
+| 421–476 | Chapter §6 |
+| 477–483 | ADR Decision 4 |
+| 484–487 | Chapter §§7 and 10 |
+| 488–492 | ADR Decision 4 |
+| 493–514 | Chapter §7 |
+| 515–531 | Chapter §8 |
+| 532–543 | ADR Decision 5 |
+| 544–555 | Chapter §§2 and 8 |
+| 556–559 | ADR Decision 5 |
+| 560–564 | ADR Decision 5 |
+| 565–589 | Chapter §9 |
+| 590–592 | ADR Decision 1 |
+| 593–606 | ADR Grounding G-002 through G-004 |
+| 607–647 | Chapter §10 |
+| 648–663 | ADR Consequences |
+| 664–690 | Chapter §§4, 6, 7, and 8 |
+| 691–694 | ADR Grounding G-001 |
+| 695–699 | ADR Validation |
+| 700–749 | Chapter §§5 and 11 |
+| 750–759 | Chapter §12 |
+| 760–765 | ADR register and Status |
+
+The table's ranges are contiguous, non-overlapping, and cover source lines
+1–765. Future edits update this chapter in place; they do not rewrite the
+source migration or amend the Proposed decision.


### PR DESCRIPTION
Lands ADR 0025 — Accepted and immutable at `4b6570307b45e64b5f72a97037a9a272322a1ad7` — onto `main`, together with its `docs/design` chapter. Docs only: 3 files, +672/-0, no source or CI changes.

## Disclosure on the Status line, which is frozen and cannot be repaired

The ADR's Status line reads: *"Accepted 2026-07-28 by the decision owner at commit `c35336a3…`, recorded as Buzz event `00c80638…`. Kimi's ruling was waived by the decision owner, not obtained."*

Both clauses are bound to one event id, and only the first is recorded there. Event `00c80638` is the decision owner's approval and says nothing about Kimi. The waiver is real and informed, but its evidence is a different set of events:

- `11e7cfe4` and `e09d8102` — the decision owner was told twice, the second time with a measured provider balance, that Kimi's lane was down.
- `00c80638` — the approval.
- `83df428b` — the orchestrator proposed the waiver in writing, with a one-word override offered.
- `d8a2ce3e` — the decision owner replied to that message thirty-nine seconds later, on two of its subjects, without invoking the override. The flip proceeded.

**The waiver is of Kimi's ruling on this ADR, not of his participation** — he was assigned fresh work ten minutes later (`7d9f401e`).

The ADR is Accepted and immutable, so correcting the citation would cost a superseding ADR. It is disclosed here instead.

## Review

Reviewers: Sam (author), Dario, Watson. Kimi waived, as above. Decision body byte-identical to `c35336a3` — sha256 `a259f3f6…` over lines 9..EOF at both commits.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR records ADR 0025 and its reference design for proving required-test observation completeness.

- Adds the accepted architectural decision, validation requirements, and grounding evidence.
- Documents the proposed registry, dispatcher, outcome reconciliation, governance fixtures, and rollout.
- Adds ADR 0025 to the ADR index.

<h3>Confidence Score: 4/5</h3>

The documentation status mismatch should be corrected before merging so the ADR index accurately represents the accepted decision.

The ADR itself is accepted, while the newly added index entry categorizes it as proposed and states that review remains outstanding.

**Files Needing Attention:** docs/adr/README.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/adr/0025-required-gates-prove-observation-completeness.md | Adds the accepted architectural decision, its invariants, validation controls, and grounding evidence. |
| docs/adr/README.md | Adds ADR 0025 to the index but incorrectly retains its pre-acceptance status and review description. |
| docs/design/required-gates-observation-completeness.md | Adds the mutable reference design for registry-driven test routing and closed observation accounting. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  D[Discover tests] --> R[Registry classification]
  R --> I[Required inventory]
  I --> X[Dispatcher and runner]
  X --> E[Terminal events and declarations]
  E --> C[Closed outcome reconciliation]
  C -->|Complete and passing| P[Gate passes]
  C -->|Missing, unknown, or failing outcome| F[Gate fails]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/adr/README.md:34
**Accepted ADR remains proposed**

ADR 0025 is marked Accepted in the new ADR, but this entry places it under `Proposed` and says amended-draft review and Kimi's ruling remain outstanding. Readers using the ADR index therefore receive the wrong governance status and review state; move the entry to `Accepted` and update its description.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ADR 0025: Accepted — record the decision..."](https://github.com/saorsa-labs/x0x/commit/4b6570307b45e64b5f72a97037a9a272322a1ad7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48237061)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->