### PR TITLE
chore(release): v0.35.0 — GSS rotation on admin remove (F1, ADR-0010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.35.0] - 2026-07-29
+
+### Security
+
+- **GSS group secret is now rotated on admin remove (F1, ADR-0010 conformance).**
+  `DELETE /groups/:id/members/:agent_id` removed the member from the roster but
+  never rotated the group shared secret, so a removed member retained a working
+  key and could continue decrypting content published after their removal. Only
+  the *ban* path (`POST /groups/:id/ban/:agent_id`) rotated. The remove handler
+  now derives a fresh secret, advances the epoch, and re-seals it to the
+  surviving roster; the removed member is excluded from that fan-out. Verified
+  cross-daemon on three live daemons: pre-fix the removed member decrypted
+  post-removal ciphertext at an unchanged epoch, post-fix the epoch advances,
+  survivors still decrypt, and the removed member is refused.
+
+  The rotation is **fail-closed**: unlike ban's post-save `warn + continue`, a
+  remove that cannot re-seal to a survivor (missing roster KEM key, envelope
+  build failure) is rejected rather than silently completing without rotation.
+  Callers that previously saw an unconditional success from this endpoint may
+  now receive an error — this is the reason for the minor version bump.
+
+### Added
+
+- **ADR 0024** — reference-chapter ownership, citation scoping, and break-list
+  declaration rules for accepted ADRs.
+- **ADR 0025** — required gates must prove observation completeness; governance
+  fixtures namespaced and per-test outcomes made positive.
+- `just adr-gates-f1` — runs the five `f1_` ADR gate tests with
+  `--no-fail-fast --test-threads=1` so the §7a mutation receipt's PASS/PASS/FAIL
+  split by test name is unambiguous.
+
 ## [v0.34.3] - 2026-07-23
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.34.3"
+version = "0.35.0"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.34.3
+version: 0.35.0
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
## Summary

Cuts **v0.35.0**. The substantive change is the F1 GSS-rotation fix already merged to main via #283; this release bumps the version, adds the changelog entry, and tags it.

`DELETE /groups/:id/members/:agent_id` removed a member from the roster but never rotated the group shared secret — only the *ban* path rotated. A removed member therefore retained a working key and could decrypt content published after removal (ADR-0010 violation).

Minor rather than patch because the remove-path rotation is **fail-closed**: a remove that cannot re-seal to a survivor is now rejected rather than silently completing without rotation, so a call that previously always succeeded can now return an error.

## Verification

- `just check` at the release commit: **2457/2457 passed**, 0 failures.
- `just adr-gates-f1`: **9/9 pass**.
- **Live cross-daemon proof of the remove path**, run against both this build and a pre-F1 control (v0.34.3):

  | Assertion | pre-F1 | v0.35.0 |
  |---|---|---|
  | epoch advances on admin remove | ✗ stayed 0 | ✓ 0→1 |
  | survivor decrypts post-remove content | ✓ | ✓ |
  | removed member locked out | ✗ **still decrypted** | ✓ |

- **6-node testnet** at this SHA: 30-min soak, 97 samples — 0 restarts, 0 unhealthy, 17/17 peers, RSS plateaued. Prod `x0xd`/`x0xd-443` untouched.
- **Phase-B fleet dogfood**: pass=70 fail=0 across all 6 runners.

## Note for reviewers

The F1 fix landed with unit gates only — the admin-remove path had no live cross-daemon gate, and the existing `e2e_named_groups.sh` D.2 block covers *ban*, which already rotated pre-F1. A pre-F1 control run passes D.2 identically, so D.2 could never have caught this. The live proof used here is not yet committed; worth landing as a follow-up gate under ADR-0025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Releases x0x v0.35.0 with synchronized package and skill metadata.
- Adds release notes documenting fail-closed GSS rotation on administrative group-member removal.
- Bumps the Cargo package version from 0.34.3 to 0.35.0.
- Bumps the SKILL.md version from 0.34.3 to 0.35.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the release metadata or changelog.

The package and skill versions remain synchronized, and the newly documented release features and verification recipe are present in the release commit.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds accurate v0.35.0 security, ADR, and verification-command release notes. |
| Cargo.toml | Updates the package version to 0.35.0 consistently with repository release metadata. |
| SKILL.md | Updates skill frontmatter to 0.35.0, matching Cargo.toml and release validation requirements. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.35.0 — GSS rotation o..."](https://github.com/saorsa-labs/x0x/commit/dcd40ba5f5e4e412ff364c249deba8fa997bdb03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48346658)</sub>

<!-- /greptile_comment -->