### PR TITLE
feat: ADR-0029 first-class threading on signed public group messages

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,3 +21,7 @@ test-group = "quic-localhost"
 [[profile.default.overrides]]
 filter = "binary(named_group_join_metadata_event) | binary(named_group_integration)"
 test-group = "quic-localhost"
+
+[[profile.default.overrides]]
+filter = "binary(threading_integration)"
+test-group = "quic-localhost"

--- a/docs/adr/0029-public-message-threading.md
+++ b/docs/adr/0029-public-message-threading.md
@@ -152,7 +152,14 @@ migrate to the first-class fields, then be removed.
 
 ### Neutral / Operational
 
-- History store, dedup keys, and retention are unchanged.
+- History store, dedup keys, and retention are unchanged. Explicitly:
+  `HistoryRecord.msg_id` remains the store-internal dedup key bound by
+  `HistoryRecord::validate()` (BLAKE3 over artifact/payload) and is NOT
+  the ADR-0029 thread `msg_id` — the thread ID is exposed at the REST
+  layer and recomputable from any stored artifact via
+  `GroupPublicMessage::msg_id()`. Writing the thread ID into
+  `HistoryRecord.msg_id` violates the validate() invariant and silently
+  rejects every write (found by soak, 2026-08-06).
 - The GUI migration is follow-up work; both schemes coexist briefly.
 
 ## Validation

--- a/docs/adr/0029-public-message-threading.md
+++ b/docs/adr/0029-public-message-threading.md
@@ -1,0 +1,177 @@
+# ADR 0029: First-Class Threading on Signed Public Group Messages
+
+- **Status:** Proposed
+- **Date:** 2026-08-06
+- **Decision owners:** David Irvine
+- **Reviewers:** (pending)
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** ADR 0023 (durable local history); ADR 0028 (delivery order is
+  not an authorization signal); `docs/design/named-groups-full-model.md`
+  §"Public groups"; x0x-nostr-bridge M1a thread-vector gate; Nostr NIP-10
+
+## Context
+
+`GroupPublicMessage` — the signed, state-bound message used by
+`POST /groups/:id/send` for `SignedPublic` groups — has no way to express
+that one message replies to another, and no spec-defined message identity
+for a reply to reference. Consumers have improvised three incompatible
+workarounds:
+
+1. The embedded GUI fakes threads with side-channel gossip topics
+   (`x0x.group.<id>.thread/<msgId>`) and a client-side parent cache. Replies
+   live outside the group's real feed: unsigned parent binding, no history
+   scope, no REST visibility, unbounded topic growth.
+2. Applications can smuggle JSON conventions into `body`. Signed, but
+   private per-app schema that pollutes FTS search and clashes with the
+   GUI's convention.
+3. The Nostr bridge carries whole Nostr events opaquely, so Buzz↔Buzz
+   threading (NIP-10 `root`/`reply` e-tags) survives *transit* — but an
+   x0x-native agent cannot author a reply into a Buzz thread, and the
+   bridge cannot project a Nostr thread onto x0x group messages, because
+   the x0x schema has no field to map the tags onto.
+
+Message identity is equally improvised: the read-path merge dedupes on the
+signature string, the ADR-0023 history store keys on `BLAKE3(signed JSON
+artifact)`, and `GET /groups/:id/messages` returns no ID at all.
+
+The hard constraint is the signature format. `signable_bytes()` is a
+fixed-order, length-prefixed canonical encoding under the domain
+`x0x.group.public-message.v1`. Any new signed field changes the bytes old
+verifiers compute. The wire form is JSON, so old receivers *parse* unknown
+fields fine (no bincode mid-struct break) and then reject the message at
+signature verification — fail-closed, never mis-verified.
+
+## Decision Drivers
+
+- Agents and the GUI need structured conversations in public groups today;
+  the side-channel topic hack fragments history and trust.
+- The Nostr bridge M1a gate requires thread vectors; NIP-10 mapping needs
+  a field to map onto and a stable message ID to translate.
+- Wire changes to a signed format must keep non-threaded traffic fully
+  interoperable with old nodes and must fail closed for new semantics.
+- Gossip delivers with gaps and reordering; per ADR 0028, missing
+  predecessors must not gate acceptance of otherwise-valid messages.
+
+## Considered Options
+
+1. **First-class optional `thread_root`/`thread_parent` fields plus a
+   defined `msg_id`, versioned signing domain (chosen).**
+2. **Body-embedded JSON convention.** Zero protocol change and fully
+   signed, but a permanent private schema: invisible to validation, breaks
+   FTS, competes with the GUI's existing different convention.
+3. **Standardize the per-thread side-topic scheme.** No signature change,
+   but replies stay outside the group feed and history scope, parent
+   binding stays unsigned, and topic count grows per-thread.
+4. **Full causal DAG references (every message cites predecessors).**
+   Strictly more general, but a much larger wire and validation change
+   than the proven need; NIP-10-shaped root/reply covers the use cases.
+
+## Decision
+
+We will add threading to `GroupPublicMessage` as follows.
+
+**Message identity.** `msg_id = BLAKE3(signable_bytes())`, lowercase hex
+(64 chars). Deterministic, recomputable by any verifier from the signed
+content, independent of JSON re-serialization. It is the direct analogue
+of Nostr's `event.id`, making bridge translation a table lookup. Hash
+references make thread cycles impossible without a hash collision. The
+ID is exposed (additively) everywhere messages appear: the
+`GET /groups/:id/messages` items, the SSE message event, and the
+`POST /groups/:id/send` response.
+
+**Thread fields.** Two new optional fields on `GroupPublicMessage`:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub thread_root: Option<String>,    // msg_id of the thread's first message
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub thread_parent: Option<String>,  // msg_id of the direct parent
+```
+
+`POST /groups/:id/send` accepts optional `thread_root` / `thread_parent`
+request fields and passes them through to signing.
+
+**Signing rule (the compatibility core).** When both fields are `None`,
+`signable_bytes()` is byte-identical to today's v1 encoding under the v1
+domain `x0x.group.public-message.v1` — non-threaded traffic interoperates
+with every existing node, forever. When either field is set, the message
+signs under a new domain `x0x.group.public-message.v2` with the two
+fields appended length-prefixed (absent field ⇒ empty string) after
+`timestamp`. Verification selects the domain by field presence. The
+explicit domain bump removes any v1/v2 byte-string ambiguity; stripping
+or injecting thread fields breaks the signature in either direction.
+
+**Ingest validation** (`validate_public_message` additions):
+
+- Each present field must be exactly 64 lowercase hex chars.
+- `thread_parent` present ⇒ `thread_root` present. A direct reply to the
+  root sets both to the root's `msg_id` (NIP-10 semantics).
+- `thread_root`/`thread_parent` must not equal the message's own `msg_id`
+  (structurally impossible to construct, cheap to check).
+- The referenced parent is **not** required to exist locally. Gossip
+  history is partial by design; per ADR 0028, delivery order and local
+  completeness are not authorization signals. Clients render orphaned
+  replies as they see fit.
+
+**Read surface.** `GET /groups/:id/messages` accepts an optional
+`thread_root=<msg_id>` query filter returning only that thread's messages
+(root included when known). No history-store schema change: rows carry
+the signed JSON artifact verbatim, so thread fields round-trip today;
+filtering parses the artifact, with an indexed column as a later
+optimization if profiling demands it.
+
+**Bridge mapping (informative, separate repo).** `thread_root` /
+`thread_parent` ↔ NIP-10 marked e-tags (`["e", <id>, "", "root"|"reply"]`)
+with a bidirectional Nostr-event-id ↔ x0x-msg-id table in the bridge's
+existing store.
+
+The GUI's side-topic thread scheme is deprecated by this ADR and should
+migrate to the first-class fields, then be removed.
+
+## Consequences
+
+### Positive
+
+- Threads become signed, validated, history-scoped, and REST-visible.
+- Non-threaded messages remain wire- and signature-identical to v1: zero
+  risk to existing traffic.
+- Old nodes fail closed on threaded messages (signature reject), never
+  mis-attribute or corrupt.
+- The bridge gains a lossless NIP-10 mapping and a stable ID to key it.
+
+### Negative / Trade-offs
+
+- Until the fleet converges (self-update handles this quickly), threaded
+  messages are invisible to old nodes — a temporary visibility partition.
+- Two signing domains must be maintained and tested against each other.
+- `msg_id` recomputation on read paths costs one BLAKE3 over signable
+  bytes per message (negligible at current volumes).
+
+### Neutral / Operational
+
+- History store, dedup keys, and retention are unchanged.
+- The GUI migration is follow-up work; both schemes coexist briefly.
+
+## Validation
+
+- **Frozen v1 vector:** a signed v1 fixture (bytes checked into the test
+  suite) must verify unchanged under the new code.
+- **Byte-identity:** a v2-built message with no thread fields must
+  serialize and sign byte-identically to v1 (assert on bytes, not just
+  round-trip).
+- **Fail-closed:** a v1-only verifier (simulated by recomputing v1
+  signable bytes) must reject a threaded message.
+- **Tamper:** stripping or adding thread fields to a signed message must
+  fail verification.
+- **Ingest rules:** property tests over hex validity, parent-implies-root,
+  and orphan acceptance.
+- **Soak:** a multi-daemon local soak on an isolated plane exchanging
+  mixed threaded/non-threaded traffic, asserting cross-daemon thread
+  reconstruction and zero regression in non-threaded delivery.
+
+## Notes for AI-assisted work
+
+AI tools may help draft this ADR, but **must not mark it Accepted without
+human review**. Accepted ADRs are immutable: create a new superseding ADR
+rather than editing an Accepted ADR.

--- a/docs/adr/0029-public-message-threading.md
+++ b/docs/adr/0029-public-message-threading.md
@@ -77,8 +77,10 @@ content, independent of JSON re-serialization. It is the direct analogue
 of Nostr's `event.id`, making bridge translation a table lookup. Hash
 references make thread cycles impossible without a hash collision. The
 ID is exposed (additively) everywhere messages appear: the
-`GET /groups/:id/messages` items, the SSE message event, and the
-`POST /groups/:id/send` response.
+`GET /groups/:id/messages` items and the `POST /groups/:id/send`
+response. (No SSE event exists for group public messages today —
+delivery is gossip-topic plus DM push; if one is added later it must
+carry `msg_id` too.)
 
 **Thread fields.** Two new optional fields on `GroupPublicMessage`:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -552,6 +552,48 @@ cached history:
 - `MlsEncrypted` — returns 400 (encrypted history belongs elsewhere).
 - Withdrawn groups return 409 and do not restart public-message listeners.
 
+#### Threading (ADR-0029)
+
+`POST /groups/:id/send` accepts two optional threading fields:
+
+```json
+{
+  "body": "text",
+  "thread_root":   "<64-char lowercase hex msg_id>",
+  "thread_parent": "<64-char lowercase hex msg_id>"
+}
+```
+
+- `thread_root` — `msg_id` of the first message in the thread.
+- `thread_parent` — `msg_id` of the direct parent reply target. Requires
+  `thread_root` to also be set. A direct reply to the root sets both fields
+  to the root's `msg_id` (NIP-10 semantics).
+- Both fields must be exactly 64 lowercase hex characters; 400 is returned
+  otherwise.
+
+The response includes `"msg_id"` — the stable BLAKE3 identity of the message:
+
+```json
+{ "ok": true, "msg_id": "<64-char hex>", "group_id": "...", "timestamp": ... }
+```
+
+Every message item returned by `GET /groups/:id/messages` also includes
+`"msg_id"`. The endpoint accepts an optional `thread_root=<msg_id>` query
+parameter that filters the result set to messages in that thread (the root
+message itself is included when present):
+
+```
+GET /groups/:id/messages?thread_root=<64-char hex>
+```
+
+**Compatibility:** messages without thread fields sign under the v1 domain
+(`x0x.group.public-message.v1`) and are byte-identical to the pre-ADR-0029
+wire format — old nodes accept them unchanged. Threaded messages sign under
+`x0x.group.public-message.v2`; old nodes reject them at signature
+verification (fail-closed, never mis-attributed). The referenced parent is
+not required to exist locally (partial gossip history is normal per
+ADR-0028).
+
 ### Phase D.3 — state-commit chain
 
 Each named group maintains a signed commit chain:

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -1080,6 +1080,13 @@ enum GroupSub {
         /// Message kind: chat (default) | announcement.
         #[arg(long)]
         kind: Option<String>,
+        /// msg_id of the thread root (64 lowercase hex). ADR-0029.
+        #[arg(long)]
+        thread_root: Option<String>,
+        /// msg_id of the direct parent reply target (64 lowercase hex). ADR-0029.
+        /// Requires --thread-root to also be set.
+        #[arg(long)]
+        reply_to: Option<String>,
     },
     /// Retrieve cached SignedPublic messages for a group.
     Messages {
@@ -1805,7 +1812,22 @@ async fn run(
                 group_id,
                 body,
                 kind,
-            }) => commands::group::send(&client, &group_id, &body, kind.as_deref()).await,
+                thread_root,
+                reply_to,
+            }) => {
+                if reply_to.is_some() && thread_root.is_none() {
+                    anyhow::bail!("--reply-to requires --thread-root to also be set");
+                }
+                commands::group::send(
+                    &client,
+                    &group_id,
+                    &body,
+                    kind.as_deref(),
+                    thread_root.as_deref(),
+                    reply_to.as_deref(),
+                )
+                .await
+            }
             Some(GroupSub::Messages { group_id }) => {
                 commands::group::messages(&client, &group_id).await
             }

--- a/src/cli/commands/group.rs
+++ b/src/cli/commands/group.rs
@@ -392,11 +392,19 @@ pub async fn send(
     group_id: &str,
     body_text: &str,
     kind: Option<&str>,
+    thread_root: Option<&str>,
+    reply_to: Option<&str>,
 ) -> Result<()> {
     client.ensure_running().await?;
     let mut req = json!({ "body": body_text });
     if let Some(k) = kind {
         req["kind"] = Value::String(k.to_string());
+    }
+    if let Some(root) = thread_root {
+        req["thread_root"] = Value::String(root.to_string());
+    }
+    if let Some(parent) = reply_to {
+        req["thread_parent"] = Value::String(parent.to_string());
     }
     let resp = client
         .post(&format!("/groups/{group_id}/send"), &req)

--- a/src/groups/public_message.rs
+++ b/src/groups/public_message.rs
@@ -327,11 +327,9 @@ pub fn validate_public_message(
         });
     }
 
-    // 4. signature + author binding
-    msg.verify_signature()
-        .map_err(|e| IngestError::InvalidSignature(format!("{e}")))?;
-
-    // 4b. threading field validation (ADR-0029)
+    // 4. threading field structural checks (cheap, no crypto — run before
+    //    signature verification so malformed gossip messages are rejected
+    //    without paying ML-DSA-65 verify cost). ADR-0029.
     if let Some(root) = &msg.thread_root {
         validate_thread_hex("thread_root", root)?;
     }
@@ -342,7 +340,11 @@ pub fn validate_public_message(
             return Err(IngestError::ThreadParentWithoutRoot);
         }
     }
-    // self-reference check (structurally impossible to construct but cheap)
+    // Self-reference: thread_root/thread_parent must not equal the message's
+    // own msg_id. Constructing a genuinely self-referential signed message
+    // requires a BLAKE3 hash fixed-point, so this check is reachable only
+    // for tampered messages whose signature would fail anyway — but it serves
+    // as a cheap early reject before the expensive ML-DSA-65 verify.
     let own_id = msg.msg_id();
     if msg.thread_root.as_deref() == Some(own_id.as_str()) {
         return Err(IngestError::ThreadSelfReference {
@@ -355,14 +357,18 @@ pub fn validate_public_message(
         });
     }
 
-    // 5. banned authors rejected
+    // 5. signature + author binding
+    msg.verify_signature()
+        .map_err(|e| IngestError::InvalidSignature(format!("{e}")))?;
+
+    // 7. banned authors rejected
     if let Some(member) = ctx.members_v2.get(&msg.author_agent_id) {
         if member.state == GroupMemberState::Banned {
             return Err(IngestError::AuthorBanned);
         }
     }
 
-    // 6. write-access policy enforcement
+    // 8. write-access policy enforcement
     let author_role = ctx
         .members_v2
         .get(&msg.author_agent_id)
@@ -904,11 +910,10 @@ mod tests {
         let kp = make_kp();
         let hex_id = hex::encode(kp.agent_id().as_bytes());
         // Build a valid v1 message then manually inject a bad thread_root.
+        // Thread structural checks now run BEFORE signature verification, so
+        // InvalidThreadField fires first (cheap reject, no crypto cost).
         let mut msg = build_signed_msg(&kp, "g1", "x", GroupPublicMessageKind::Chat);
-        // Re-sign with thread_root set to a bad value (too short).
-        // We can't produce a valid signed message with a bad thread_root (sign
-        // doesn't validate), so instead directly test the ingest validator:
-        msg.thread_root = Some("not-hex".to_string());
+        msg.thread_root = Some("not-hex".to_string()); // too short and not hex
         let policy = open_policy();
         let mut members = BTreeMap::new();
         members.insert(hex_id.clone(), active_member(&hex_id, GroupRole::Member));
@@ -919,14 +924,11 @@ mod tests {
         };
         assert!(matches!(
             validate_public_message(&ctx, &msg).unwrap_err(),
-            // Signature fails first since thread_root changes signable bytes —
-            // both InvalidSignature and InvalidThreadField are acceptable
-            // failure modes here. The key property is that the message is rejected.
-            IngestError::InvalidSignature(_) | IngestError::InvalidThreadField { .. }
+            IngestError::InvalidThreadField { .. }
         ));
     }
 
-    /// Ingest: parent-without-root rejected (validator path, not sign path).
+    /// Ingest: parent-without-root rejected (pre-signature structural check).
     #[test]
     fn ingest_rejects_parent_without_root() {
         let kp = make_kp();
@@ -956,10 +958,13 @@ mod tests {
             policy: &policy,
             members_v2: &members,
         };
-        // Signature fails first (stripping root changes bytes), which is
-        // also a valid rejection. Both InvalidSignature and
-        // ThreadParentWithoutRoot are acceptable here.
-        assert!(validate_public_message(&ctx, &msg).is_err());
+        // Thread structural checks run BEFORE signature verification.
+        // ThreadParentWithoutRoot fires as a cheap early reject; the
+        // tampered signature is never computed.
+        assert!(matches!(
+            validate_public_message(&ctx, &msg).unwrap_err(),
+            IngestError::ThreadParentWithoutRoot
+        ));
     }
 
     /// Ingest: orphan parent accepted (parent not known locally is fine).
@@ -994,20 +999,23 @@ mod tests {
         validate_public_message(&ctx, &msg).unwrap();
     }
 
-    /// Ingest: self-reference is checked by the validator.
-    /// Because sign() doesn't validate and self-reference is
-    /// structurally impossible to construct, we test the validator
-    /// path by manually constructing the condition after signing.
+    /// Ingest: self-reference check is live pre-signature (after fix 2) and
+    /// serves as a cheap early reject. Because `msg_id()` = BLAKE3(signable_bytes)
+    /// and `signable_bytes` INCLUDES `thread_root`, a genuinely self-referential
+    /// message requires a BLAKE3 fixed point (x = BLAKE3(f(x))) — computationally
+    /// infeasible. When we set `thread_root = own_id` after signing, `msg_id()`
+    /// changes (different input bytes), so the self-reference check does NOT fire;
+    /// the tampered signature is what the validator rejects. This test verifies the
+    /// end-to-end rejection and documents the hash-circularity property.
     #[test]
     fn ingest_rejects_self_reference() {
         let kp = make_kp();
         let hex_id = hex::encode(kp.agent_id().as_bytes());
-        // Sign a non-threaded message first to get a msg_id.
+        // Sign a non-threaded message first to get a stable msg_id.
         let base = build_signed_msg(&kp, "g1", "base", GroupPublicMessageKind::Chat);
         let base_id = base.msg_id();
-        // Now sign with root = base_id, then tamper root to be the
-        // threaded message's own msg_id. The signature will be invalid, but
-        // the validator should hit self-reference (or InvalidSignature) — both are correct.
+        // Sign a threaded message with root = base_id. Its own msg_id is the
+        // BLAKE3 of v2 signable bytes with thread_root=base_id.
         let mut msg = GroupPublicMessage::sign(
             "g1".into(),
             "state-hash-1".into(),
@@ -1021,8 +1029,10 @@ mod tests {
             None,
         )
         .unwrap();
+        // Capture own_id BEFORE tampering. After we set thread_root = own_id,
+        // msg_id() will recompute from the new (tampered) signable_bytes and
+        // produce a DIFFERENT value — the self-reference check passes; sig fails.
         let own_id = msg.msg_id();
-        // Tamper: set thread_root to own msg_id.
         msg.thread_root = Some(own_id);
         let policy = open_policy();
         let mut members = BTreeMap::new();
@@ -1032,7 +1042,13 @@ mod tests {
             policy: &policy,
             members_v2: &members,
         };
-        // Must fail (InvalidSignature or ThreadSelfReference).
-        assert!(validate_public_message(&ctx, &msg).is_err());
+        // Self-reference check is reachable only for messages whose signature
+        // would fail anyway (BLAKE3 fixed-point property). Tampering thread_root
+        // changes signable_bytes, so msg_id() ≠ old own_id and the self-reference
+        // check does not fire; InvalidSignature is the actual early reject here.
+        assert!(matches!(
+            validate_public_message(&ctx, &msg).unwrap_err(),
+            IngestError::InvalidSignature(_)
+        ));
     }
 }

--- a/src/groups/public_message.rs
+++ b/src/groups/public_message.rs
@@ -42,8 +42,14 @@ use ant_quic::MlDsaPublicKey;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-/// Domain-separation tag for public-message signatures.
+/// Domain-separation tag for public-message signatures (v1 — no thread fields).
 pub const PUBLIC_MESSAGE_DOMAIN: &[u8] = b"x0x.group.public-message.v1";
+
+/// Domain-separation tag for threaded public-message signatures (v2).
+///
+/// Used when `thread_root` or `thread_parent` is set. Messages without thread
+/// fields sign under `PUBLIC_MESSAGE_DOMAIN` and are byte-identical to v1.
+pub const PUBLIC_MESSAGE_DOMAIN_V2: &[u8] = b"x0x.group.public-message.v2";
 
 /// Topic-string prefix for public-group chat.
 pub const PUBLIC_GROUP_TOPIC_PREFIX: &str = "x0x.groups.public";
@@ -91,6 +97,13 @@ pub struct GroupPublicMessage {
     pub body: String,
     /// Unix milliseconds at send time.
     pub timestamp: u64,
+    /// `msg_id` of the thread's first message (hex, 64 chars). ADR-0029.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_root: Option<String>,
+    /// `msg_id` of the direct parent in the thread (hex, 64 chars). ADR-0029.
+    /// When present, `thread_root` must also be present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_parent: Option<String>,
     /// Hex ML-DSA-65 signature over `signable_bytes()`.
     pub signature: String,
 }
@@ -99,10 +112,22 @@ impl GroupPublicMessage {
     /// Canonical bytes signed by the author to produce `signature`.
     ///
     /// Includes every field except `signature` itself.
+    ///
+    /// **Compatibility rule (ADR-0029):** when both `thread_root` and
+    /// `thread_parent` are `None`, the output is byte-identical to the
+    /// pre-threading v1 encoding (same domain, no thread suffix). When
+    /// either field is `Some`, the v2 domain is used and both thread
+    /// fields are appended length-prefixed after `timestamp` (absent ⇒
+    /// empty string).
     #[must_use]
     pub fn signable_bytes(&self) -> Vec<u8> {
+        let threaded = self.thread_root.is_some() || self.thread_parent.is_some();
         let mut buf = Vec::with_capacity(512 + self.body.len());
-        buf.extend_from_slice(PUBLIC_MESSAGE_DOMAIN);
+        buf.extend_from_slice(if threaded {
+            PUBLIC_MESSAGE_DOMAIN_V2
+        } else {
+            PUBLIC_MESSAGE_DOMAIN
+        });
         push_len_prefixed(&mut buf, self.group_id.as_bytes());
         push_len_prefixed(&mut buf, self.state_hash_at_send.as_bytes());
         buf.extend_from_slice(&self.revision_at_send.to_le_bytes());
@@ -117,10 +142,32 @@ impl GroupPublicMessage {
         push_len_prefixed(&mut buf, &kind_bytes);
         push_len_prefixed(&mut buf, self.body.as_bytes());
         buf.extend_from_slice(&self.timestamp.to_le_bytes());
+        if threaded {
+            push_len_prefixed(
+                &mut buf,
+                self.thread_root.as_deref().unwrap_or("").as_bytes(),
+            );
+            push_len_prefixed(
+                &mut buf,
+                self.thread_parent.as_deref().unwrap_or("").as_bytes(),
+            );
+        }
         buf
     }
 
+    /// Stable message identity: lowercase hex of `BLAKE3(signable_bytes())`.
+    ///
+    /// 64 hex characters. Deterministic and recomputable by any verifier.
+    /// Analogous to Nostr's `event.id`. ADR-0029.
+    #[must_use]
+    pub fn msg_id(&self) -> String {
+        hex::encode(blake3::hash(&self.signable_bytes()).as_bytes())
+    }
+
     /// Build and sign a new public message.
+    ///
+    /// Pass `thread_root` / `thread_parent` to produce a v2-domain threaded
+    /// message (ADR-0029). Both `None` produces a v1-compatible message.
     #[allow(clippy::too_many_arguments)]
     pub fn sign(
         group_id: String,
@@ -131,6 +178,8 @@ impl GroupPublicMessage {
         kind: GroupPublicMessageKind,
         body: String,
         timestamp: u64,
+        thread_root: Option<String>,
+        thread_parent: Option<String>,
     ) -> Result<Self, ApplyError> {
         let author_agent_id = hex::encode(keypair.agent_id().as_bytes());
         let author_public_key = hex::encode(keypair.public_key().as_bytes());
@@ -144,6 +193,8 @@ impl GroupPublicMessage {
             kind,
             body,
             timestamp,
+            thread_root,
+            thread_parent,
             signature: String::new(),
         };
         let sig = sign_with_ml_dsa(keypair.secret_key(), &msg.signable_bytes())
@@ -185,6 +236,22 @@ fn push_len_prefixed(buf: &mut Vec<u8>, bytes: &[u8]) {
     buf.extend_from_slice(bytes);
 }
 
+/// Validate that a thread field value is exactly 64 lowercase hex characters.
+fn validate_thread_hex(field: &'static str, value: &str) -> Result<(), IngestError> {
+    if value.len() == 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
+        Ok(())
+    } else {
+        Err(IngestError::InvalidThreadField {
+            field,
+            value: value.to_string(),
+        })
+    }
+}
+
 // ────────────────────────── Ingest validator ────────────────────────────
 
 /// Errors from public-message ingest validation.
@@ -207,6 +274,18 @@ pub enum IngestError {
 
     #[error("write-policy violation under {policy:?}: author lacks required role")]
     WritePolicyViolation { policy: GroupWriteAccess },
+
+    /// A thread field value is not exactly 64 lowercase hex characters.
+    #[error("invalid thread field '{field}': must be 64 lowercase hex chars, got '{value}'")]
+    InvalidThreadField { field: &'static str, value: String },
+
+    /// `thread_parent` is set but `thread_root` is absent.
+    #[error("thread_parent requires thread_root to also be set")]
+    ThreadParentWithoutRoot,
+
+    /// A thread field references the message's own `msg_id`.
+    #[error("thread field '{field}' must not equal the message's own msg_id")]
+    ThreadSelfReference { field: &'static str },
 }
 
 /// Context passed to the ingest validator. Receivers build this from
@@ -251,6 +330,30 @@ pub fn validate_public_message(
     // 4. signature + author binding
     msg.verify_signature()
         .map_err(|e| IngestError::InvalidSignature(format!("{e}")))?;
+
+    // 4b. threading field validation (ADR-0029)
+    if let Some(root) = &msg.thread_root {
+        validate_thread_hex("thread_root", root)?;
+    }
+    if let Some(parent) = &msg.thread_parent {
+        validate_thread_hex("thread_parent", parent)?;
+        // parent requires root
+        if msg.thread_root.is_none() {
+            return Err(IngestError::ThreadParentWithoutRoot);
+        }
+    }
+    // self-reference check (structurally impossible to construct but cheap)
+    let own_id = msg.msg_id();
+    if msg.thread_root.as_deref() == Some(own_id.as_str()) {
+        return Err(IngestError::ThreadSelfReference {
+            field: "thread_root",
+        });
+    }
+    if msg.thread_parent.as_deref() == Some(own_id.as_str()) {
+        return Err(IngestError::ThreadSelfReference {
+            field: "thread_parent",
+        });
+    }
 
     // 5. banned authors rejected
     if let Some(member) = ctx.members_v2.get(&msg.author_agent_id) {
@@ -350,6 +453,8 @@ mod tests {
             kind,
             body.to_string(),
             1_000,
+            None,
+            None,
         )
         .unwrap()
     }
@@ -435,6 +540,8 @@ mod tests {
             GroupPublicMessageKind::Chat,
             "x".into(),
             1_000,
+            None,
+            None,
         )
         .unwrap();
         msg.author_user_id = Some("cafebabe".into());
@@ -645,5 +752,287 @@ mod tests {
         let p = GroupPolicyPreset::PublicAnnounce.to_policy();
         assert_eq!(p.write_access, GroupWriteAccess::AdminOnly);
         assert_eq!(p.read_access, GroupReadAccess::Public);
+    }
+
+    // ── ADR-0029 threading tests ─────────────────────────────────────────
+
+    /// v1 byte-identity: a message without thread fields must produce
+    /// signable_bytes starting with the v1 domain — no v2 suffix.
+    #[test]
+    fn v1_byte_identity_no_thread_fields() {
+        let kp = make_kp();
+        let msg = build_signed_msg(&kp, "g1", "hello", GroupPublicMessageKind::Chat);
+        assert!(msg.thread_root.is_none());
+        assert!(msg.thread_parent.is_none());
+        let bytes = msg.signable_bytes();
+        assert!(
+            bytes.starts_with(PUBLIC_MESSAGE_DOMAIN),
+            "non-threaded message must use v1 domain"
+        );
+        // Must NOT contain the v2 domain bytes anywhere in the prefix position
+        assert!(!bytes.starts_with(PUBLIC_MESSAGE_DOMAIN_V2));
+    }
+
+    /// v2 domain: a threaded message uses the v2 domain.
+    #[test]
+    fn threaded_message_uses_v2_domain() {
+        let kp = make_kp();
+        let fake_root = "a".repeat(64);
+        let msg = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "reply".into(),
+            2_000,
+            Some(fake_root.clone()),
+            Some(fake_root),
+        )
+        .unwrap();
+        let bytes = msg.signable_bytes();
+        assert!(
+            bytes.starts_with(PUBLIC_MESSAGE_DOMAIN_V2),
+            "threaded message must use v2 domain"
+        );
+        assert!(!bytes.starts_with(PUBLIC_MESSAGE_DOMAIN));
+    }
+
+    /// Fail-closed: a threaded message verified with manually constructed
+    /// v1-style bytes must fail (old-node simulation).
+    #[test]
+    fn threaded_message_fails_v1_verification() {
+        let kp = make_kp();
+        let fake_root = "b".repeat(64);
+        let mut msg = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "reply".into(),
+            3_000,
+            Some(fake_root.clone()),
+            Some(fake_root),
+        )
+        .unwrap();
+        // Simulate an old node by stripping thread fields AFTER signing —
+        // the signature was computed over v2 bytes but we now present v1 bytes.
+        msg.thread_root = None;
+        msg.thread_parent = None;
+        // verify_signature recomputes v1 bytes (both None) — should fail.
+        assert!(
+            msg.verify_signature().is_err(),
+            "stripping thread fields from a v2-signed message must fail"
+        );
+    }
+
+    /// Tamper — adding thread fields to a v1-signed message fails.
+    #[test]
+    fn adding_thread_to_v1_message_fails() {
+        let kp = make_kp();
+        let mut msg = build_signed_msg(&kp, "g1", "original", GroupPublicMessageKind::Chat);
+        msg.verify_signature().unwrap(); // baseline passes
+        msg.thread_root = Some("c".repeat(64));
+        assert!(
+            msg.verify_signature().is_err(),
+            "injecting thread_root into v1-signed message must fail"
+        );
+    }
+
+    /// Tamper — clearing thread fields from a v2-signed message fails.
+    #[test]
+    fn clearing_thread_from_v2_message_fails() {
+        let kp = make_kp();
+        let fake_root = "d".repeat(64);
+        let mut msg = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "post".into(),
+            4_000,
+            Some(fake_root.clone()),
+            Some(fake_root),
+        )
+        .unwrap();
+        msg.verify_signature().unwrap(); // baseline passes
+        msg.thread_root = None;
+        msg.thread_parent = None;
+        assert!(
+            msg.verify_signature().is_err(),
+            "stripping thread fields from v2-signed message must fail"
+        );
+    }
+
+    /// msg_id determinism: same inputs → same id.
+    #[test]
+    fn msg_id_is_deterministic() {
+        let kp = make_kp();
+        let msg = build_signed_msg(&kp, "g1", "hello", GroupPublicMessageKind::Chat);
+        assert_eq!(msg.msg_id(), msg.msg_id(), "msg_id must be deterministic");
+    }
+
+    /// msg_id differs when body differs.
+    #[test]
+    fn msg_id_differs_on_different_body() {
+        let kp = make_kp();
+        let msg1 = build_signed_msg(&kp, "g1", "hello", GroupPublicMessageKind::Chat);
+        let msg2 = build_signed_msg(&kp, "g1", "world", GroupPublicMessageKind::Chat);
+        assert_ne!(msg1.msg_id(), msg2.msg_id());
+    }
+
+    /// msg_id is exactly 64 lowercase hex chars.
+    #[test]
+    fn msg_id_format() {
+        let kp = make_kp();
+        let msg = build_signed_msg(&kp, "g1", "test", GroupPublicMessageKind::Chat);
+        let id = msg.msg_id();
+        assert_eq!(id.len(), 64);
+        assert!(id
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()));
+    }
+
+    /// Ingest: bad hex rejected.
+    #[test]
+    fn ingest_rejects_bad_thread_hex() {
+        let kp = make_kp();
+        let hex_id = hex::encode(kp.agent_id().as_bytes());
+        // Build a valid v1 message then manually inject a bad thread_root.
+        let mut msg = build_signed_msg(&kp, "g1", "x", GroupPublicMessageKind::Chat);
+        // Re-sign with thread_root set to a bad value (too short).
+        // We can't produce a valid signed message with a bad thread_root (sign
+        // doesn't validate), so instead directly test the ingest validator:
+        msg.thread_root = Some("not-hex".to_string());
+        let policy = open_policy();
+        let mut members = BTreeMap::new();
+        members.insert(hex_id.clone(), active_member(&hex_id, GroupRole::Member));
+        let ctx = PublicIngestContext {
+            group_id: "g1",
+            policy: &policy,
+            members_v2: &members,
+        };
+        assert!(matches!(
+            validate_public_message(&ctx, &msg).unwrap_err(),
+            // Signature fails first since thread_root changes signable bytes —
+            // both InvalidSignature and InvalidThreadField are acceptable
+            // failure modes here. The key property is that the message is rejected.
+            IngestError::InvalidSignature(_) | IngestError::InvalidThreadField { .. }
+        ));
+    }
+
+    /// Ingest: parent-without-root rejected (validator path, not sign path).
+    #[test]
+    fn ingest_rejects_parent_without_root() {
+        let kp = make_kp();
+        let hex_id = hex::encode(kp.agent_id().as_bytes());
+        // Sign with root+parent, then strip root after signing.
+        let fake_root = "e".repeat(64);
+        let mut msg = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "reply".into(),
+            5_000,
+            Some(fake_root.clone()),
+            Some(fake_root),
+        )
+        .unwrap();
+        // Strip root — now parent is present without root.
+        msg.thread_root = None;
+        let policy = open_policy();
+        let mut members = BTreeMap::new();
+        members.insert(hex_id.clone(), active_member(&hex_id, GroupRole::Member));
+        let ctx = PublicIngestContext {
+            group_id: "g1",
+            policy: &policy,
+            members_v2: &members,
+        };
+        // Signature fails first (stripping root changes bytes), which is
+        // also a valid rejection. Both InvalidSignature and
+        // ThreadParentWithoutRoot are acceptable here.
+        assert!(validate_public_message(&ctx, &msg).is_err());
+    }
+
+    /// Ingest: orphan parent accepted (parent not known locally is fine).
+    #[test]
+    fn ingest_accepts_orphan_parent() {
+        let kp = make_kp();
+        let hex_id = hex::encode(kp.agent_id().as_bytes());
+        let fake_root = "f".repeat(64);
+        let fake_parent = "1".repeat(64);
+        let msg = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "orphaned reply".into(),
+            6_000,
+            Some(fake_root),
+            Some(fake_parent),
+        )
+        .unwrap();
+        let policy = open_policy();
+        let mut members = BTreeMap::new();
+        members.insert(hex_id.clone(), active_member(&hex_id, GroupRole::Member));
+        let ctx = PublicIngestContext {
+            group_id: "g1",
+            policy: &policy,
+            members_v2: &members,
+        };
+        // Must succeed — the parent not being locally known is fine (ADR-0028).
+        validate_public_message(&ctx, &msg).unwrap();
+    }
+
+    /// Ingest: self-reference is checked by the validator.
+    /// Because sign() doesn't validate and self-reference is
+    /// structurally impossible to construct, we test the validator
+    /// path by manually constructing the condition after signing.
+    #[test]
+    fn ingest_rejects_self_reference() {
+        let kp = make_kp();
+        let hex_id = hex::encode(kp.agent_id().as_bytes());
+        // Sign a non-threaded message first to get a msg_id.
+        let base = build_signed_msg(&kp, "g1", "base", GroupPublicMessageKind::Chat);
+        let base_id = base.msg_id();
+        // Now sign with root = base_id, then tamper root to be the
+        // threaded message's own msg_id. The signature will be invalid, but
+        // the validator should hit self-reference (or InvalidSignature) — both are correct.
+        let mut msg = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "self ref".into(),
+            7_000,
+            Some(base_id.clone()),
+            None,
+        )
+        .unwrap();
+        let own_id = msg.msg_id();
+        // Tamper: set thread_root to own msg_id.
+        msg.thread_root = Some(own_id);
+        let policy = open_policy();
+        let mut members = BTreeMap::new();
+        members.insert(hex_id.clone(), active_member(&hex_id, GroupRole::Member));
+        let ctx = PublicIngestContext {
+            group_id: "g1",
+            policy: &policy,
+            members_v2: &members,
+        };
+        // Must fail (InvalidSignature or ThreadSelfReference).
+        assert!(validate_public_message(&ctx, &msg).is_err());
     }
 }

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -8780,6 +8780,13 @@ pub(in crate::server) struct SendGroupMessageRequest {
     /// Message kind — `"chat"` (default) or `"announcement"`.
     #[serde(default)]
     kind: Option<String>,
+    /// `msg_id` of the thread root (64 lowercase hex chars). ADR-0029.
+    #[serde(default)]
+    thread_root: Option<String>,
+    /// `msg_id` of the direct parent in the thread (64 lowercase hex chars). ADR-0029.
+    /// Requires `thread_root` to also be present.
+    #[serde(default)]
+    thread_parent: Option<String>,
 }
 
 /// POST /groups/:id/send — publish a message to the group.
@@ -8812,6 +8819,29 @@ pub(in crate::server) async fn send_group_public_message(
             StatusCode::PAYLOAD_TOO_LARGE,
             "body exceeds MAX_PUBLIC_MESSAGE_BYTES",
         );
+    }
+
+    // Validate thread fields (ADR-0029): 64 lowercase hex chars, parent ⇒ root.
+    if let Some(root) = &req.thread_root {
+        if root.len() != 64
+            || !root
+                .bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+        {
+            return bad_request("thread_root must be exactly 64 lowercase hex chars");
+        }
+    }
+    if let Some(parent) = &req.thread_parent {
+        if parent.len() != 64
+            || !parent
+                .bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+        {
+            return bad_request("thread_parent must be exactly 64 lowercase hex chars");
+        }
+        if req.thread_root.is_none() {
+            return bad_request("thread_parent requires thread_root to also be set");
+        }
     }
 
     let signing_kp = state.agent.identity().agent_keypair();
@@ -8871,6 +8901,8 @@ pub(in crate::server) async fn send_group_public_message(
             kind,
             req.body,
             now_ms,
+            req.thread_root,
+            req.thread_parent,
         ) {
             Ok(m) => (m, direct_recipients),
             Err(e) => {
@@ -8920,6 +8952,7 @@ pub(in crate::server) async fn send_group_public_message(
     cache_public_message(&state, msg.clone()).await;
     spawn_group_public_message_delivery_to_active_members(&state, direct_recipients, &msg);
 
+    let msg_id = msg.msg_id();
     (
         StatusCode::OK,
         Json(serde_json::json!({
@@ -8928,8 +8961,17 @@ pub(in crate::server) async fn send_group_public_message(
             "topic": topic,
             "fallback_topic": GLOBAL_PUBLIC_MESSAGE_TOPIC,
             "timestamp": msg.timestamp,
+            "msg_id": msg_id,
         })),
     )
+}
+
+/// Query parameters for [`get_group_public_messages`].
+#[derive(Debug, serde::Deserialize, Default)]
+pub(in crate::server) struct GetMessagesQuery {
+    /// Filter to a specific thread (64 lowercase hex chars). ADR-0029.
+    #[serde(default)]
+    thread_root: Option<String>,
 }
 
 /// GET /groups/:id/messages — retrieve cached public messages.
@@ -8938,9 +8980,13 @@ pub(in crate::server) async fn send_group_public_message(
 /// token receives the history. If `MembersOnly`, only active members
 /// receive it. For `MlsEncrypted` groups, returns 400 — encrypted
 /// history belongs in a different surface.
+///
+/// Optional query parameter: `thread_root=<msg_id>` — filters to messages
+/// in that thread (root included when present). ADR-0029.
 pub(in crate::server) async fn get_group_public_messages(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
+    Query(query): Query<GetMessagesQuery>,
 ) -> impl IntoResponse {
     let local_hex = hex::encode(state.agent.agent_id().as_bytes());
     // Resolve the stable_group_id — the public-message cache and topic
@@ -9029,9 +9075,33 @@ pub(in crate::server) async fn get_group_public_messages(
         None => cached,
     };
 
+    // Apply thread_root filter (ADR-0029): keep messages whose thread_root
+    // matches, plus the root message itself (identified by its own msg_id).
+    let msgs: Vec<_> = if let Some(filter_root) = &query.thread_root {
+        msgs.into_iter()
+            .filter(|m| {
+                m.thread_root.as_deref() == Some(filter_root.as_str()) || &m.msg_id() == filter_root
+            })
+            .collect()
+    } else {
+        msgs
+    };
+
+    // Augment each message with its computed msg_id (ADR-0029).
+    let messages_with_id: Vec<serde_json::Value> = msgs
+        .iter()
+        .filter_map(|m| {
+            let mut v = serde_json::to_value(m).ok()?;
+            if let serde_json::Value::Object(ref mut map) = v {
+                map.insert("msg_id".to_string(), serde_json::Value::String(m.msg_id()));
+            }
+            Some(v)
+        })
+        .collect();
+
     (
         StatusCode::OK,
-        Json(serde_json::json!({ "ok": true, "messages": msgs })),
+        Json(serde_json::json!({ "ok": true, "messages": messages_with_id })),
     )
 }
 
@@ -9072,8 +9142,15 @@ fn record_group_public_history(state: &AppState, msg: &x0x::groups::GroupPublicM
         payload,
         signed_artifact: Some(artifact),
         signature: hex::decode(&msg.signature).ok(),
-        // Mirrors `groups::public_message::PUBLIC_MESSAGE_DOMAIN`.
-        sig_context: Some("x0x.group.public-message.v1".to_string()),
+        // Mirrors the signing domain used for this message (ADR-0029).
+        sig_context: Some(
+            if msg.thread_root.is_some() || msg.thread_parent.is_some() {
+                "x0x.group.public-message.v2"
+            } else {
+                "x0x.group.public-message.v1"
+            }
+            .to_string(),
+        ),
         provenance: if outbound {
             x0x::history::Provenance::LocalSend
         } else {
@@ -25001,6 +25078,8 @@ mod tests {
             kind: x0x::groups::GroupPublicMessageKind::Chat,
             body: "hello".to_string(),
             timestamp: 123,
+            thread_root: None,
+            thread_parent: None,
             signature: "cc".repeat(64),
         };
 

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -9075,6 +9075,19 @@ pub(in crate::server) async fn get_group_public_messages(
         None => cached,
     };
 
+    // Validate thread_root query param format before doing any work: 64
+    // lowercase hex chars only. Garbage input would otherwise trigger O(N)
+    // BLAKE3 computations and always return an empty result set.
+    if let Some(filter_root) = &query.thread_root {
+        if filter_root.len() != 64
+            || !filter_root
+                .bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+        {
+            return bad_request("thread_root query param must be exactly 64 lowercase hex chars");
+        }
+    }
+
     // Apply thread_root filter (ADR-0029): keep messages whose thread_root
     // matches, plus the root message itself (identified by its own msg_id).
     let msgs: Vec<_> = if let Some(filter_root) = &query.thread_root {
@@ -9126,7 +9139,11 @@ fn record_group_public_history(state: &AppState, msg: &x0x::groups::GroupPublicM
     let payload = msg.body.as_bytes().to_vec();
     let now = i64::try_from(x0x::dm::now_unix_ms()).unwrap_or(i64::MAX);
     history.record(x0x::history::HistoryRecord {
-        msg_id: x0x::history::HistoryRecord::compute_msg_id(Some(&artifact), &payload),
+        // Use BLAKE3(signable_bytes()) so the history dedup key matches the
+        // thread API's msg_id (ADR-0029). Unlike compute_msg_id which hashes
+        // the JSON artifact (includes signature bytes), this is canonical-
+        // content-based: re-signed identical content now dedupes — intended.
+        msg_id: *blake3::hash(&msg.signable_bytes()).as_bytes(),
         scope: x0x::history::Scope::Group(msg.group_id.clone()),
         author_agent: Some(msg.author_agent_id.clone()),
         author_machine: None,

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -9139,11 +9139,13 @@ fn record_group_public_history(state: &AppState, msg: &x0x::groups::GroupPublicM
     let payload = msg.body.as_bytes().to_vec();
     let now = i64::try_from(x0x::dm::now_unix_ms()).unwrap_or(i64::MAX);
     history.record(x0x::history::HistoryRecord {
-        // Use BLAKE3(signable_bytes()) so the history dedup key matches the
-        // thread API's msg_id (ADR-0029). Unlike compute_msg_id which hashes
-        // the JSON artifact (includes signature bytes), this is canonical-
-        // content-based: re-signed identical content now dedupes — intended.
-        msg_id: *blake3::hash(&msg.signable_bytes()).as_bytes(),
+        // HistoryRecord.msg_id is the store-internal dedup key governed by
+        // HistoryRecord::validate(): it must equal compute_msg_id(artifact,
+        // payload), i.e. BLAKE3 of the signed JSON artifact when present.
+        // This is NOT the ADR-0029 thread msg_id (BLAKE3 of signable_bytes).
+        // The canonical thread msg_id is exposed at the REST layer and is
+        // recomputable from the stored artifact via GroupPublicMessage::msg_id().
+        msg_id: x0x::history::HistoryRecord::compute_msg_id(Some(&artifact), &payload),
         scope: x0x::history::Scope::Group(msg.group_id.clone()),
         author_agent: Some(msg.author_agent_id.clone()),
         author_machine: None,
@@ -25108,6 +25110,83 @@ mod tests {
             serde_json::from_slice(&payload[GROUP_PUBLIC_MESSAGE_DM_PREFIX.len()..])
                 .expect("payload JSON should decode");
         assert_eq!(decoded, msg);
+    }
+
+    /// Regression test: the HistoryRecord constructed by record_group_public_history
+    /// must pass HistoryRecord::validate(). Fix 1 of the ADR-0029 review broke this
+    /// by using BLAKE3(signable_bytes) instead of compute_msg_id(artifact, payload),
+    /// violating the store invariant and silently dropping every group-public message
+    /// from durable history. This test catches any future drift between the msg_id
+    /// computation and the validate() invariant.
+    #[test]
+    fn group_public_history_record_passes_validate() {
+        use x0x::history::{Direction, HistoryRecord, Provenance, Scope};
+
+        // Build a non-threaded message (v1 domain).
+        let kp = x0x::identity::AgentKeypair::generate().expect("keypair");
+        let msg_v1 = x0x::groups::GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash".into(),
+            1,
+            &kp,
+            None,
+            x0x::groups::GroupPublicMessageKind::Chat,
+            "non-threaded body".into(),
+            1_000,
+            None,
+            None,
+        )
+        .expect("sign v1");
+
+        // Build a threaded message (v2 domain).
+        let fake_root = "a".repeat(64);
+        let msg_v2 = x0x::groups::GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash".into(),
+            1,
+            &kp,
+            None,
+            x0x::groups::GroupPublicMessageKind::Chat,
+            "threaded reply".into(),
+            2_000,
+            Some(fake_root.clone()),
+            Some(fake_root),
+        )
+        .expect("sign v2");
+
+        for msg in [&msg_v1, &msg_v2] {
+            let artifact = serde_json::to_vec(msg).expect("serialize");
+            let payload = msg.body.as_bytes().to_vec();
+            let record = HistoryRecord {
+                // Must use compute_msg_id, not BLAKE3(signable_bytes) — validate()
+                // enforces this invariant and rejects rows that violate it.
+                msg_id: HistoryRecord::compute_msg_id(Some(&artifact), &payload),
+                scope: Scope::Group(msg.group_id.clone()),
+                author_agent: Some(msg.author_agent_id.clone()),
+                author_machine: None,
+                author_pubkey: hex::decode(&msg.author_public_key).ok(),
+                sent_at_ms: i64::try_from(msg.timestamp).unwrap_or(i64::MAX),
+                seen_at_ms: 0,
+                direction: Direction::Outbound,
+                content_type: "text/plain".to_string(),
+                payload,
+                signed_artifact: Some(artifact),
+                signature: hex::decode(&msg.signature).ok(),
+                sig_context: Some(
+                    if msg.thread_root.is_some() || msg.thread_parent.is_some() {
+                        "x0x.group.public-message.v2"
+                    } else {
+                        "x0x.group.public-message.v1"
+                    }
+                    .to_string(),
+                ),
+                provenance: Provenance::VerifiedEnvelope,
+                replace_key: None,
+            };
+            record.validate().expect(
+                "HistoryRecord produced by record_group_public_history must pass validate()",
+            );
+        }
     }
 
     /// Issue #205: minting a `private_secure` invite must strip per-member

--- a/tests/named_group_public_messages.rs
+++ b/tests/named_group_public_messages.rs
@@ -52,6 +52,8 @@ fn sign_msg(
         kind,
         body.into(),
         1_000,
+        None,
+        None,
     )
     .unwrap()
 }

--- a/tests/threading_integration.rs
+++ b/tests/threading_integration.rs
@@ -1,0 +1,585 @@
+//! ADR-0029 threading integration tests — signed public group messages.
+//!
+//! Daemon-backed REST-level tests covering:
+//!
+//! 1. Two-daemon threaded round-trip with cross-daemon msg_id stability.
+//! 2. Ingest validation: structurally invalid thread fields rejected with 400.
+//! 3. Orphan reply: reply to a nonexistent parent is accepted (ADR-0028).
+//! 4. Backward-compat wire: non-threaded messages carry no thread keys.
+//!
+//! All tests are `#[ignore]` — they spawn real x0xd daemons via the cluster
+//! harness. Run with:
+//!   cargo nextest run --test threading_integration -- --ignored
+//!
+//! Before running: cargo build --bin x0xd
+//!
+//! Isolation guarantees (inherited from cluster harness):
+//! - `--no-hard-coded-bootstrap` — daemons never dial prod bootstrap nodes.
+//! - `[update] enabled = false` — test binaries cannot self-replace via gossip.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use reqwest::StatusCode;
+use serde_json::Value;
+use std::time::Duration;
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+use cluster::AgentInstance;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn authed(d: &AgentInstance) -> reqwest::Client {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_str(&format!("Bearer {}", d.api_token))
+            .expect("auth header value"),
+    );
+    reqwest::Client::builder()
+        .default_headers(headers)
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("authed reqwest client")
+}
+
+/// Poll `check` every 500 ms until it returns `true` or `timeout` elapses.
+async fn wait_until<F, Fut>(timeout: Duration, mut check: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if check().await {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Create a `public_open` named group (SignedPublic confidentiality,
+/// OpenJoin admission, MembersOnly write). Returns the canonical `group_id`
+/// from the create response.
+async fn create_public_open_group(d: &AgentInstance, name: &str) -> String {
+    let resp: Value = authed(d)
+        .post(d.url("/groups"))
+        .json(&serde_json::json!({ "name": name, "preset": "public_open" }))
+        .send()
+        .await
+        .expect("POST /groups")
+        .json()
+        .await
+        .expect("create group json");
+    assert_eq!(resp["ok"], true, "create group failed: {resp:?}");
+    resp["group_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no group_id in create response: {resp:?}"))
+        .to_string()
+}
+
+/// Call `POST /groups/:id/send`. Returns the raw response so callers can
+/// inspect both success bodies and error status codes.
+async fn send_message(
+    d: &AgentInstance,
+    group_id: &str,
+    body: &str,
+    thread_root: Option<&str>,
+    thread_parent: Option<&str>,
+) -> reqwest::Response {
+    let mut payload = serde_json::json!({ "body": body });
+    if let Some(r) = thread_root {
+        payload["thread_root"] = serde_json::json!(r);
+    }
+    if let Some(p) = thread_parent {
+        payload["thread_parent"] = serde_json::json!(p);
+    }
+    authed(d)
+        .post(d.url(&format!("/groups/{group_id}/send")))
+        .json(&payload)
+        .send()
+        .await
+        .expect("POST /groups/:id/send")
+}
+
+/// GET /groups/:id/messages — returns the `messages` array or empty on error.
+async fn get_messages(d: &AgentInstance, group_id: &str) -> Vec<Value> {
+    let resp: Value = authed(d)
+        .get(d.url(&format!("/groups/{group_id}/messages")))
+        .send()
+        .await
+        .expect("GET /groups/:id/messages")
+        .json()
+        .await
+        .expect("GET messages json");
+    resp["messages"].as_array().cloned().unwrap_or_default()
+}
+
+/// GET /groups/:id/messages?thread_root=<id> — thread-scoped view.
+async fn get_thread(d: &AgentInstance, group_id: &str, thread_root: &str) -> Vec<Value> {
+    let resp: Value = authed(d)
+        .get(d.url(&format!(
+            "/groups/{group_id}/messages?thread_root={thread_root}"
+        )))
+        .send()
+        .await
+        .expect("GET /groups/:id/messages?thread_root=")
+        .json()
+        .await
+        .expect("GET thread messages json");
+    resp["messages"].as_array().cloned().unwrap_or_default()
+}
+
+/// Alice creates an invite link for `group_id`. Bob uses it to join, becoming
+/// an active member. Returns the canonical group_id Bob must use for subsequent
+/// API calls (extracted from the join response).
+///
+/// This is the correct flow for `public_open` groups (OpenJoin admission,
+/// MembersOnly write). The invite carries the base state so Bob's daemon
+/// creates its local group record without a prior card import.
+async fn bob_joins_via_invite(
+    alice: &AgentInstance,
+    group_id: &str,
+    bob: &AgentInstance,
+) -> String {
+    let invite_resp: Value = authed(alice)
+        .post(alice.url(&format!("/groups/{group_id}/invite")))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("POST /groups/:id/invite")
+        .json()
+        .await
+        .expect("create invite json");
+    assert_eq!(
+        invite_resp["ok"], true,
+        "create invite failed: {invite_resp:?}"
+    );
+    let invite_link = invite_resp["invite_link"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no invite_link in: {invite_resp:?}"))
+        .to_string();
+
+    let join_resp: Value = authed(bob)
+        .post(bob.url("/groups/join"))
+        .json(&serde_json::json!({ "invite": invite_link }))
+        .send()
+        .await
+        .expect("POST /groups/join")
+        .json()
+        .await
+        .expect("bob join json");
+    assert_eq!(join_resp["ok"], true, "bob join failed: {join_resp:?}");
+
+    // The join response contains the canonical group_id Bob must use.
+    join_resp["group_id"]
+        .as_str()
+        .unwrap_or(group_id)
+        .to_string()
+}
+
+/// Poll `d` until `agent_id` appears as an active member of `group_id`.
+async fn wait_for_membership(d: &AgentInstance, group_id: &str, agent_id: &str) -> bool {
+    wait_until(Duration::from_secs(30), || async {
+        let resp: Value = authed(d)
+            .get(d.url(&format!("/groups/{group_id}/members")))
+            .send()
+            .await
+            .expect("GET /groups/:id/members")
+            .json()
+            .await
+            .expect("members json");
+        resp["members"].as_array().is_some_and(|arr| {
+            arr.iter().any(|m| {
+                m["agent_id"].as_str() == Some(agent_id) && m["state"].as_str() == Some("active")
+            })
+        })
+    })
+    .await
+}
+
+// ── 1. Two-daemon threaded round-trip ────────────────────────────────────────
+
+/// A sends a root message; B replies with thread_root=thread_parent=root_msg_id
+/// (NIP-10 direct-reply semantics). Both daemons converge on the thread via
+/// gossip. The ?thread_root= filter returns exactly the two-message thread.
+/// Cross-daemon msg_id stability is proven: the BLAKE3(signable_bytes) the
+/// sender computes matches what the receiver re-computes from the artifact.
+///
+/// Why msg_id stability matters: ADR-0029 uses msg_id as the bridge
+/// translation key and as the thread anchor. If the id diverges after gossip
+/// delivery, thread reconstruction and Nostr bridge mapping both break.
+///
+/// Why the membership pre-condition matters: `ingest_public_message` on Alice
+/// runs `validate_public_message` which enforces MembersOnly write. If Alice
+/// does not yet know Bob is a member when his reply arrives via gossip, she
+/// drops it with WritePolicyViolation — the test would then time out on the
+/// cross-daemon poll. We wait for Alice to see Bob's membership before
+/// either party sends messages.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "spawns real x0xd daemons"]
+async fn two_daemon_threaded_round_trip() {
+    let pair = cluster::pair().await;
+    let (alice, bob) = (&pair.alice, &pair.bob);
+
+    // Alice creates a public_open group (SignedPublic, OpenJoin, MembersOnly write).
+    let group_id = create_public_open_group(alice, "adr0029-roundtrip").await;
+
+    // Bob joins via Alice's invite link. This adds Bob to the roster and
+    // publishes a MemberJoined commit that Alice's daemon will receive via gossip.
+    let bob_group_id = bob_joins_via_invite(alice, &group_id, bob).await;
+    let bob_id = bob.agent_id().await;
+
+    // Poll Alice until she knows Bob is an active member. This is a hard
+    // pre-condition: ingest_public_message drops messages from non-members
+    // under MembersOnly write policy, so we must not send until Alice's
+    // roster is current.
+    let alice_knows_bob = wait_for_membership(alice, &group_id, &bob_id).await;
+    assert!(
+        alice_knows_bob,
+        "Alice never saw Bob as active member within 30 s; \
+         subsequent cross-daemon assertions would be vacuous"
+    );
+
+    // Poll Bob's daemon until it recognises Bob himself as an active member.
+    // The join handler creates a local stub GroupInfo; Bob's `members_v2` is
+    // only marked active after Alice processes the MemberJoined event, publishes
+    // an authority-signed MemberAdded commit, and that commit propagates back to
+    // Bob via gossip. Without this gate, Bob's own POST /groups/:id/send hits
+    // the MembersOnly write check and returns a members-only error.
+    let bob_knows_himself = wait_for_membership(bob, &bob_group_id, &bob_id).await;
+    assert!(
+        bob_knows_himself,
+        "Bob's daemon never recognised Bob as active member within 30 s; \
+         Bob's send would be rejected by his own MembersOnly write check"
+    );
+
+    // Alice sends the root message and captures its msg_id from the response.
+    let root_resp: Value = send_message(alice, &group_id, "thread root", None, None)
+        .await
+        .json()
+        .await
+        .expect("root send json");
+    assert_eq!(root_resp["ok"], true, "root send failed: {root_resp:?}");
+    let root_msg_id = root_resp["msg_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("POST /send response missing msg_id: {root_resp:?}"))
+        .to_string();
+    assert_eq!(root_msg_id.len(), 64, "msg_id must be 64 chars");
+    assert!(
+        root_msg_id
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()),
+        "msg_id must be lowercase hex: {root_msg_id}"
+    );
+
+    // Bob sends a direct reply. NIP-10: direct reply to root ⇒
+    // thread_root == thread_parent == root_msg_id.
+    let reply_resp: Value = send_message(
+        bob,
+        &bob_group_id,
+        "thread reply",
+        Some(&root_msg_id),
+        Some(&root_msg_id),
+    )
+    .await
+    .json()
+    .await
+    .expect("reply send json");
+    assert_eq!(reply_resp["ok"], true, "reply send failed: {reply_resp:?}");
+    let reply_msg_id = reply_resp["msg_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("POST /send response missing msg_id for reply: {reply_resp:?}"))
+        .to_string();
+
+    // Poll Alice until Bob's reply arrives via gossip (cross-daemon delivery).
+    let alice_sees_reply = wait_until(Duration::from_secs(30), || async {
+        get_messages(alice, &group_id)
+            .await
+            .iter()
+            .any(|m| m["msg_id"].as_str() == Some(reply_msg_id.as_str()))
+    })
+    .await;
+    assert!(
+        alice_sees_reply,
+        "Alice never received Bob's threaded reply within 30 s"
+    );
+
+    // Poll Bob until Alice's root arrives via gossip (cross-daemon delivery).
+    let bob_sees_root = wait_until(Duration::from_secs(30), || async {
+        get_messages(bob, &bob_group_id)
+            .await
+            .iter()
+            .any(|m| m["msg_id"].as_str() == Some(root_msg_id.as_str()))
+    })
+    .await;
+    assert!(
+        bob_sees_root,
+        "Bob never received Alice's root message within 30 s"
+    );
+
+    // Cross-daemon msg_id stability: the root's id on Bob's read surface must
+    // be identical to what Alice's POST response reported. The id is
+    // BLAKE3(signable_bytes()) — deterministic from the signed content.
+    let bob_msgs = get_messages(bob, &bob_group_id).await;
+    let root_on_bob = bob_msgs
+        .iter()
+        .find(|m| m["msg_id"].as_str() == Some(root_msg_id.as_str()))
+        .unwrap_or_else(|| {
+            panic!(
+                "root message ({root_msg_id}) not in Bob's GET /messages surface; \
+                 got: {bob_msgs:?}"
+            )
+        });
+    assert_eq!(
+        root_on_bob["msg_id"].as_str(),
+        Some(root_msg_id.as_str()),
+        "cross-daemon msg_id mismatch: BLAKE3(signable_bytes) must be identical on both sides"
+    );
+
+    // Assert thread fields on the reply as Alice sees it after gossip delivery.
+    let alice_msgs = get_messages(alice, &group_id).await;
+    let reply_on_alice = alice_msgs
+        .iter()
+        .find(|m| m["msg_id"].as_str() == Some(reply_msg_id.as_str()))
+        .unwrap_or_else(|| {
+            panic!(
+                "reply ({reply_msg_id}) not found on Alice's GET /messages surface; \
+                 got: {alice_msgs:?}"
+            )
+        });
+    assert_eq!(
+        reply_on_alice["thread_root"].as_str(),
+        Some(root_msg_id.as_str()),
+        "reply thread_root wrong on Alice's surface"
+    );
+    assert_eq!(
+        reply_on_alice["thread_parent"].as_str(),
+        Some(root_msg_id.as_str()),
+        "reply thread_parent wrong on Alice's surface"
+    );
+
+    // Thread filter on Alice: ?thread_root=<root_msg_id> must return exactly
+    // root + reply. Any extra messages indicate filter over-inclusion.
+    let thread_alice = get_thread(alice, &group_id, &root_msg_id).await;
+    let alice_thread_ids: Vec<&str> = thread_alice
+        .iter()
+        .filter_map(|m| m["msg_id"].as_str())
+        .collect();
+    assert!(
+        alice_thread_ids.contains(&root_msg_id.as_str()),
+        "root missing from Alice's ?thread_root= result: {alice_thread_ids:?}"
+    );
+    assert!(
+        alice_thread_ids.contains(&reply_msg_id.as_str()),
+        "reply missing from Alice's ?thread_root= result: {alice_thread_ids:?}"
+    );
+    assert_eq!(
+        thread_alice.len(),
+        2,
+        "Alice's thread filter should return exactly root + reply \
+         (got {} messages): {alice_thread_ids:?}",
+        thread_alice.len()
+    );
+
+    // Same filter on Bob must agree.
+    let thread_bob = get_thread(bob, &bob_group_id, &root_msg_id).await;
+    let bob_thread_ids: Vec<&str> = thread_bob
+        .iter()
+        .filter_map(|m| m["msg_id"].as_str())
+        .collect();
+    assert!(
+        bob_thread_ids.contains(&root_msg_id.as_str()),
+        "root missing from Bob's ?thread_root= result: {bob_thread_ids:?}"
+    );
+    assert!(
+        bob_thread_ids.contains(&reply_msg_id.as_str()),
+        "reply missing from Bob's ?thread_root= result: {bob_thread_ids:?}"
+    );
+    assert_eq!(
+        thread_bob.len(),
+        2,
+        "Bob's thread filter should return exactly root + reply \
+         (got {} messages): {bob_thread_ids:?}",
+        thread_bob.len()
+    );
+}
+
+// ── 2. Endpoint validation ───────────────────────────────────────────────────
+
+/// Structurally invalid thread fields are rejected with 400 before signing.
+///
+/// Why: the server must validate thread fields before calling
+/// `GroupPublicMessage::sign` so that malformed input never produces a
+/// signed artifact with unverifiable thread references. Receivers that
+/// re-derive the signing domain from field presence would verify a different
+/// byte sequence, permanently rejecting the message.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "spawns real x0xd daemon"]
+async fn validation_bad_thread_fields_are_400() {
+    let (solo, _bind_port) = cluster::solo().await;
+    let d = &solo;
+
+    let group_id = create_public_open_group(d, "adr0029-validation").await;
+    let valid_hex_64: String = "a".repeat(64);
+
+    // thread_parent present, thread_root absent → parent-requires-root rule.
+    let resp = send_message(d, &group_id, "bad", None, Some(&valid_hex_64)).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "thread_parent without thread_root must be 400 \
+         (got {})",
+        resp.status()
+    );
+
+    // thread_root is 63 chars (one short of the required 64).
+    let short_hex: String = "a".repeat(63);
+    let resp = send_message(d, &group_id, "bad", Some(&short_hex), None).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "63-char thread_root must be 400 (got {})",
+        resp.status()
+    );
+
+    // thread_root contains uppercase hex (not lowercase).
+    let upper_hex: String = "A".repeat(64);
+    let resp = send_message(d, &group_id, "bad", Some(&upper_hex), None).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "uppercase thread_root must be 400 (got {})",
+        resp.status()
+    );
+}
+
+// ── 3. Orphan reply ──────────────────────────────────────────────────────────
+
+/// A reply referencing a well-formed but nonexistent parent msg_id is accepted.
+///
+/// Why: per ADR-0028 and ADR-0029, delivery order and local store completeness
+/// are not authorization signals. Gossip history is partial by design — a node
+/// that missed the root must still accept and cache replies so that late joiners
+/// can reconstruct threads once they receive the root. Gating acceptance on
+/// parent existence would create silent availability holes for catching-up nodes.
+///
+/// The orphan reply must appear in both the unfiltered message list AND the
+/// ?thread_root=<phantom> filtered view so clients can reconstruct threads
+/// that arrive out of order.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "spawns real x0xd daemon"]
+async fn orphan_reply_accepted_and_filterable() {
+    let (solo, _bind_port) = cluster::solo().await;
+    let d = &solo;
+
+    let group_id = create_public_open_group(d, "adr0029-orphan").await;
+
+    // A well-formed 64-char lowercase hex that references no message in the
+    // daemon's store. The daemon must not check for parent existence.
+    let phantom_root: String = "d".repeat(64);
+
+    let resp = send_message(
+        d,
+        &group_id,
+        "orphan reply",
+        Some(&phantom_root),
+        Some(&phantom_root),
+    )
+    .await;
+    let status = resp.status();
+    let body: Value = resp.json().await.expect("orphan reply json");
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "orphan reply must be accepted (parent existence is not required): \
+         got {status} — {body:?}"
+    );
+    assert_eq!(body["ok"], true, "orphan reply response not ok: {body:?}");
+    let sent_msg_id = body["msg_id"]
+        .as_str()
+        .expect("msg_id in orphan reply response");
+
+    // The reply must appear in the unfiltered message list.
+    let msgs = get_messages(d, &group_id).await;
+    assert!(
+        !msgs.is_empty(),
+        "message list is empty after successful orphan reply send"
+    );
+    assert!(
+        msgs.iter()
+            .any(|m| m["msg_id"].as_str() == Some(sent_msg_id)),
+        "orphan reply ({sent_msg_id}) not found in GET /groups/:id/messages: {msgs:?}"
+    );
+
+    // The ?thread_root=<phantom> filter must return the orphan reply even
+    // though the root itself is absent — the spec says root included "when
+    // known", so absence of the root message is acceptable here.
+    let thread = get_thread(d, &group_id, &phantom_root).await;
+    assert!(
+        !thread.is_empty(),
+        "?thread_root=<phantom> returned nothing — \
+         orphan replies must be included in the thread filter"
+    );
+    assert!(
+        thread
+            .iter()
+            .any(|m| m["msg_id"].as_str() == Some(sent_msg_id)),
+        "orphan reply ({sent_msg_id}) not found via ?thread_root=<phantom>: {thread:?}"
+    );
+}
+
+// ── 4. Backward-compat wire check ────────────────────────────────────────────
+
+/// A non-threaded message's JSON in the GET /groups/:id/messages response must
+/// contain no `thread_root` or `thread_parent` keys — not null, completely
+/// absent — because `GroupPublicMessage` uses `skip_serializing_if = "Option::is_none"`.
+///
+/// Why: ADR-0029 guarantees that non-threaded messages are wire-identical to
+/// v1. Emitting null thread fields would (a) violate that guarantee, (b) trick
+/// old consumers into thinking the message is threaded, and (c) waste bytes on
+/// every non-threaded message. Clients checking for thread membership must test
+/// for key *presence*, not `!= null`.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "spawns real x0xd daemon"]
+async fn non_threaded_message_has_no_thread_keys() {
+    let (solo, _bind_port) = cluster::solo().await;
+    let d = &solo;
+
+    let group_id = create_public_open_group(d, "adr0029-compat").await;
+
+    let send_resp: Value = send_message(d, &group_id, "plain non-threaded message", None, None)
+        .await
+        .json()
+        .await
+        .expect("send json");
+    assert_eq!(send_resp["ok"], true, "send failed: {send_resp:?}");
+    let msg_id = send_resp["msg_id"]
+        .as_str()
+        .expect("msg_id in send response");
+
+    let msgs = get_messages(d, &group_id).await;
+    let msg = msgs
+        .iter()
+        .find(|m| m["msg_id"].as_str() == Some(msg_id))
+        .unwrap_or_else(|| {
+            panic!("sent message ({msg_id}) not found in GET /groups/:id/messages: {msgs:?}")
+        });
+
+    // Keys must be completely absent (not present-as-null). This verifies
+    // that skip_serializing_if = "Option::is_none" applies end-to-end through
+    // the cache, serialisation, and the GET /messages read path.
+    let obj = msg.as_object().expect("message item is a JSON object");
+    assert!(
+        !obj.contains_key("thread_root"),
+        "non-threaded message must not carry 'thread_root' key (got: {msg:?})"
+    );
+    assert!(
+        !obj.contains_key("thread_parent"),
+        "non-threaded message must not carry 'thread_parent' key (got: {msg:?})"
+    );
+}


### PR DESCRIPTION
## Summary

Implements **ADR-0029** (Proposed — `docs/adr/0029-public-message-threading.md`): first-class threading on the SignedPublic group message surface.

- **Message identity**: `msg_id = BLAKE3(signable_bytes())` — deterministic, verifier-recomputable, exposed on `POST /groups/:id/send` responses and `GET /groups/:id/messages` items. Direct analogue of Nostr's `event.id` (bridge NIP-10 mapping becomes a table lookup).
- **Thread fields**: optional `thread_root` / `thread_parent` on `GroupPublicMessage`, accepted by the send endpoint and CLI (`--thread-root` / `--reply-to`).
- **Signing compatibility**: no-thread messages remain **byte-identical to v1** under the v1 domain — full interop with old nodes. Threaded messages sign under a new `x0x.group.public-message.v2` domain and fail closed on pre-upgrade nodes.
- **Ingest validation**: 64-lowercase-hex format, parent-implies-root, cheap structural checks ordered before ML-DSA-65 verification; orphan replies accepted per ADR-0028's delivery-order principle.
- **Read surface**: `?thread_root=` filter (400 on malformed input).

## Verification

- Adversarial review: signing-domain ambiguity, byte-identity vs pre-change encoding, and malleability all explicitly cleared; 4 findings fixed.
- Unit compat vectors: v1 byte-identity, fail-closed, tamper both directions, ingest rules.
- 4 daemon-backed integration tests (serialized via the `quic-localhost` nextest group): cross-daemon msg_id stability, thread filter, orphan replies, wire-shape.
- **Two 2-hour 3-daemon soaks**: run 1 caught a critical regression (history `msg_id` written against the `HistoryRecord::validate()` invariant → every group-public history write silently rejected → error storm → SWIM cascade → 89-min delivery outage). Fixed in `7a2862b` + regression test. Run 2: **GO** — 945/945 delivery, 0 history errors, 450 rows/daemon persisted with `write_errors=0`, 114/114 thread-filter checks, 28,585 wire checks clean.
- Full gates: fmt / clippy `-D warnings` / `cargo nextest run --all-features --workspace` 2561/2561.

## Notes

- No SSE event exists for group public messages; `msg_id` exposure is REST-only (ADR records this).
- Soak surfaced a **separate pre-existing candidate**: SWIM marks loopback peers dead in periodic waves (delivery-neutral under health, compounds under stress). Not caused by this diff; needs its own issue + main-branch control soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements ADR-0029 by adding deterministic public-message IDs and signed thread-root/parent metadata while preserving the existing non-threaded signing format.
- Adds v2-domain signing and structural ingest validation for threaded public messages.
- Exposes message IDs and thread filtering through the REST API and CLI.
- Adds compatibility, validation, persistence, and multi-daemon integration coverage.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until thread filtering can retrieve matching retained messages beyond the newest 500 group records; request-validation ordering is a separate non-blocking concern.

The signing and compatibility design is well covered, but the read endpoint filters only after an unfiltered capped query, causing older retained threads to be omitted from results.

**Files Needing Attention:** src/server/routes/named_groups.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/groups/public_message.rs | Adds optional signed threading fields, v2 domain selection, deterministic message IDs, structural validation, and comprehensive compatibility tests. |
| src/server/routes/named_groups.rs | Adds REST threading support and message-ID projection, but filters only a truncated history page and validates malformed filters after expensive stateful work. |
| src/bin/x0x.rs | Adds thread-root and reply-to CLI flags with the required parent-implies-root check. |
| src/cli/commands/group.rs | Passes the new CLI thread fields through to the send endpoint. |
| tests/threading_integration.rs | Covers cross-daemon identity stability, filtering, malformed fields, orphan replies, and non-threaded wire shape, but not histories exceeding the 500-row route limit. |
| docs/adr/0029-public-message-threading.md | Documents message identity, versioned signing, validation, filtering semantics, and the distinct durable-history dedup invariant. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Client
  participant API as Group REST API
  participant Signer as GroupPublicMessage
  participant Gossip
  participant History
  Client->>API: POST /groups/:id/send (thread_root, thread_parent)
  API->>API: Validate thread fields and authorization
  API->>Signer: Sign using v1 or v2 domain
  Signer-->>API: Signed message and deterministic msg_id
  API->>Gossip: Publish signed JSON
  API->>History: Persist signed artifact
  API-->>Client: msg_id
  Client->>API: "GET /groups/:id/messages?thread_root=id"
  API->>History: Query newest 500 group records
  History-->>API: Truncated unfiltered result
  API->>API: Apply thread filter
  API-->>Client: Matching messages with msg_id
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/routes/named_groups.rs:9093-9098
**Thread filtering truncates retained history**

When a group has more than 500 retained messages, the route loads only the newest 500 records before applying `thread_root`, causing older roots and replies to disappear from the filtered response even though they remain in durable history.

### Issue 2
src/server/routes/named_groups.rs:9081-9089
**Thread validation runs too late**

Malformed `thread_root` values are rejected only after listener creation and durable-history loading, so invalid requests perform unnecessary database and deserialization work and distinct unknown group IDs can leave long-lived topic listeners allocated until shutdown.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(history): revert Fix 1 — restore His..."](https://github.com/saorsa-labs/x0x/commit/7a2862bb2033f2eddb5347d6d237a599cec7caca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50860685)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Groups: Membership, Discovery, and State Commits](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/groups-messaging.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)
- Knowledge Base — [CLI and daemon startup](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/cli-daemon.md)
</details>

<!-- /greptile_comment -->