### PR TITLE
chore(release): v0.36.0 — ADR-0029 public-message threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.36.0] - 2026-08-06
+
+### Added
+
+- **First-class threading on signed public group messages (ADR-0029, PR #293).**
+  `GroupPublicMessage` gains optional `thread_root` / `thread_parent` fields and
+  a spec-defined identity `msg_id = BLAKE3(signable_bytes())` — deterministic,
+  recomputable by any verifier, and the direct analogue of Nostr's `event.id`
+  for NIP-10 bridge mapping. `POST /groups/:id/send` accepts the thread fields
+  and returns `msg_id`; `GET /groups/:id/messages` items carry `msg_id` and the
+  endpoint accepts a `?thread_root=` filter (400 on malformed input). CLI:
+  `x0x group send --thread-root/--reply-to`.
+
+  Wire compatibility: messages without thread fields remain **byte-identical
+  to the v1 signing encoding** under the v1 domain — full interop with
+  pre-0.36 nodes. Threaded messages sign under a new
+  `x0x.group.public-message.v2` domain and fail closed (signature reject) on
+  older nodes until they upgrade. Ingest validates thread-field format
+  (64-lowercase-hex, parent-implies-root) with cheap structural checks ordered
+  before ML-DSA-65 verification; orphan replies are accepted per ADR-0028's
+  delivery-order principle.
+
+  Verified by adversarial review (domain ambiguity, byte-identity, and
+  malleability explicitly cleared), frozen-vector compat tests, four
+  daemon-backed integration tests, and two 2-hour multi-daemon soaks — the
+  first soak caught a history-store regression (see Fixed), the second ran
+  clean (945/945 delivery, 0 history errors).
+
+### Fixed
+
+- **Group-public history writes were briefly rejected on the feature branch**
+  (never released): writing the ADR-0029 thread `msg_id` into
+  `HistoryRecord.msg_id` violated the store's `validate()` invariant and every
+  group-public history write was silently dropped. Reverted to the canonical
+  store key plus a regression test asserting the exact record the writer
+  builds passes validation (`group_public_history_record_passes_validate`).
+
+### Testing
+
+- `threading_integration` daemon tests enrolled in the serialized
+  `quic-localhost` nextest group (loopback QUIC startup contention flake).
+
 ## [v0.35.0] - 2026-07-29
 
 ### Security

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.35.0
+version: 0.36.0
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Version bump + changelog for v0.36.0. Feature landed in #293 (ADR-0029 first-class threading on signed public group messages). After merge: tag `v0.36.0` triggers the release workflow; fleet self-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release-only PR prepares v0.36.0 for the previously merged public-message threading feature.
- Bumps the crate and skill metadata from 0.35.0 to 0.36.0.
- Adds release notes covering threading behavior, wire compatibility, history-write regression prevention, and integration testing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the release metadata is synchronized and no actionable defects were identified.

The changes are limited to consistent version metadata and release documentation, with the repository’s release validation covering version alignment.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds coherent v0.36.0 release notes for the already-landed threading feature and its validation. |
| Cargo.toml | Updates the package version to 0.36.0 consistently with the release metadata. |
| SKILL.md | Updates the published skill metadata version to 0.36.0. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.36.0 — ADR-0029 publi..."](https://github.com/saorsa-labs/x0x/commit/3c19aa86b49467b89e10575bf181c7d98e6f1eda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50900060)</sub>

<!-- /greptile_comment -->