### PR TITLE
fix(connect): preserve peer id during proactive redial (#295)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9620,6 +9620,10 @@ type ReconnectTracker = std::sync::Arc<
 ///   LAN/loopback) from every successful connect/accept, so Phase 2 covers
 ///   the default global-bootstrap config where `allow_local_scope=FALSE`
 ///   filters loopback out of the discovery cache (CR-HOST-1).
+/// - Dials every candidate with the **known PeerId** (`connect_peer_with_
+///   addrs`), never address-only: ant-quic's HolePunch strategy refuses to
+///   coordinate without the target's PeerId, so an address-only dial always
+///   fails when direct paths time out (issue #295).
 /// - Self-cancels when the peer reconnects (checked via `is_connected` on each
 ///   attempt) or when the shutdown token fires.
 /// - Is **single-flight** per peer: only one reconnect task runs at a time,
@@ -9750,11 +9754,11 @@ fn schedule_reconnect(
                 }
                 match tokio::time::timeout(
                     std::time::Duration::from_secs(5),
-                    network.connect_addr(*addr),
+                    network.connect_peer_with_addrs(peer_id, vec![*addr]),
                 )
                 .await
                 {
-                    Ok(Ok(connected_peer)) if connected_peer == peer_id => {
+                    Ok(Ok((_, connected_peer))) if connected_peer == peer_id => {
                         tracing::info!(
                             target: "x0x::connect",
                             peer_id_prefix = %prefix,
@@ -9765,7 +9769,7 @@ fn schedule_reconnect(
                         connected = true;
                         break;
                     }
-                    Ok(Ok(other)) => {
+                    Ok(Ok((_, other))) => {
                         tracing::warn!(
                             target: "x0x::connect",
                             peer_id_prefix = %prefix,
@@ -14014,6 +14018,60 @@ mod tests {
             .await
             .expect("DM should succeed over the recovered connection");
         assert_eq!(receipt.path, dm::DmPath::RawQuic);
+    }
+
+    /// Regression (issue #295): `connect_cached_peer` now dials with the known
+    /// PeerId (`connect_peer_with_addrs`) instead of an address-only
+    /// `connect_addr`, so ant-quic's HolePunch strategy can coordinate. The
+    /// switch must preserve the identity invariant: a stale cache entry whose
+    /// address now serves a DIFFERENT authenticated peer must not resolve as
+    /// the requested peer.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn connect_cached_peer_rejects_address_serving_a_different_peer() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("alice");
+        let carol = Agent::builder()
+            .with_machine_key(dir.path().join("carol-machine.key"))
+            .with_agent_key_path(dir.path().join("carol-agent.key"))
+            .with_contact_store_path(dir.path().join("carol-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("carol-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("carol");
+
+        let alice_network = alice.network().expect("alice network");
+        let carol_network = carol.network().expect("carol network");
+        let carol_addr =
+            normalize_loopback_addr(carol_network.bound_addr().await.expect("carol bound"));
+
+        // Poison alice's bootstrap cache: claim a victim peer lives at carol's
+        // address. The cached dial authenticates the responder and must reject
+        // it as the victim instead of reporting success for the wrong peer.
+        // ([0x42; 32] is a non-synthetic PeerId, so ant-quic retains and dials
+        // the entry normally.)
+        let victim_peer = ant_quic::PeerId([0x42; 32]);
+        alice_network
+            .bootstrap_cache()
+            .expect("alice bootstrap cache")
+            .add_from_connection(victim_peer, vec![carol_addr], None)
+            .await;
+
+        let result = alice_network.connect_cached_peer(victim_peer).await;
+        assert!(
+            result.is_err(),
+            "stale cache entry serving a different peer must not resolve \
+             as the requested peer (got {result:?})"
+        );
     }
     // ─── Reconnect-policy suppression regression tests ─────────────────────
     //

--- a/src/network.rs
+++ b/src/network.rs
@@ -2288,6 +2288,11 @@ impl NetworkNode {
     /// same authenticated peer. Stale cache entries that now point at a
     /// different peer are rejected.
     ///
+    /// Each dial is **peer-authenticated** (`connect_peer_with_addrs`), never
+    /// address-only: the HolePunch strategy refuses to coordinate without the
+    /// target's PeerId, so an address-only dial cannot traverse NAT even when
+    /// the PeerId is known (issue #295).
+    ///
     /// # Errors
     ///
     /// Returns `NetworkError` if the peer is not cached or none of its cached
@@ -2323,9 +2328,11 @@ impl NetworkNode {
 
         let candidate_addrs = cached_peer.preferred_addresses();
         for addr in &candidate_addrs {
-            match self.connect_addr(*addr).await {
-                Ok(connected_peer) if connected_peer == peer_id => return Ok(*addr),
-                Ok(connected_peer) => {
+            match self.connect_peer_with_addrs(peer_id, vec![*addr]).await {
+                Ok((selected_addr, connected_peer)) if connected_peer == peer_id => {
+                    return Ok(selected_addr)
+                }
+                Ok((_, connected_peer)) => {
                     warn!(
                         "Cached address {} for peer {:?} resolved to unexpected peer {:?}",
                         addr, peer_id, connected_peer


### PR DESCRIPTION
## Summary

- use `connect_peer_with_addrs` for every proactive reconnect candidate instead of address-only `connect_addr`
- make bootstrap-cache fallback dials peer-authenticated as well
- add a regression proving a stale cached address that resolves to a different authenticated peer is rejected

## Root cause

The proactive reconnect path knew the target `PeerId`, but dialed bare addresses. ant-quic’s HolePunch strategy refuses address-only dialing, so every reconnect degraded to direct-only and failed when the stale-connection path blocked direct dials.

## Tests

- `cargo fmt --all`
- `cargo test --lib connect_cached_peer_rejects_address_serving_a_different_peer`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`

Closes #295

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves the known peer identity when proactively reconnecting or dialing bootstrap-cache entries, enabling peer-aware hole punching while rejecting addresses that authenticate as another peer.
- Replaces address-only proactive reconnect attempts with `connect_peer_with_addrs`.
- Makes cached-peer fallback dials peer-authenticated and returns the selected transport address.
- Adds a regression test for stale cache entries that resolve to a different authenticated peer.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with peer-aware reconnect behavior and identity-mismatch rejection preserved across the changed paths.

The reconnect and bootstrap-cache paths now provide the expected PeerId to the transport, validate the authenticated result, and have no established blocking or non-blocking defect.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib.rs | Updates proactive redialing to retain the target PeerId and adds a regression test proving stale addresses cannot impersonate the requested peer. |
| src/network.rs | Changes cached-peer dialing from raw-address connections to peer-targeted connections while preserving authenticated identity validation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Reconnect candidate: PeerId and cached address] --> B[connect_peer_with_addrs]
  B --> C{Authenticated PeerId matches target?}
  C -->|Yes| D[Record connection and reconnect succeeds]
  C -->|No| E[Reject candidate]
  E --> F{More cached addresses?}
  F -->|Yes| B
  F -->|No| G[Return connection failure]
```

<sub>Reviews (1): Last reviewed commit: ["fix(connect): preserve peer id during pr..."](https://github.com/saorsa-labs/x0x/commit/b443e8d78a83ea53c8c6768d4bf9da1690bc7b74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51409783)</sub>

**Context used:**

- Knowledge Base — [Network Transport](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/network-transport.md)

<!-- /greptile_comment -->