### PR TITLE
fix(server): surface public message silent drops

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1027,6 +1027,17 @@ All diagnostics endpoints require the normal local daemon bearer token and retur
 | GET | `/diagnostics/connect` | `x0x diagnostics connect` | Connect-ACL policy summary and stream allow/deny counters |
 | GET | `/diagnostics/ws` | `x0x diagnostics ws` | WebSocket outbound-queue health: capacity and drop/slow-consumer-close counters |
 
+### `GET /diagnostics/groups`
+
+Per-group counters for the public-message ingest pipeline and the sender-side write-policy gate. Each row in `groups` corresponds to a locally-known group.
+
+Key counter fields (flattened into each group row):
+
+| Field | Side | Meaning |
+|---|---|---|
+| `messages_dropped_write_policy_violation` | Receiver | Inbound public messages rejected by the ingest pipeline for write-policy reasons (e.g. `MembersOnly` author not in `members_v2`). The canary for the join-roster-propagation regression: a spike here on the owner side after a joiner posts means `members_v2` is stale. |
+| `sends_rejected_write_policy` | Sender | Outgoing sends from this daemon rejected locally by a members-only write-access policy. A non-zero value means this daemon is absent from its own roster copy. Tracked separately so operators can distinguish "I cannot see joiners" from "I am missing from my own roster". |
+
 ### `GET /diagnostics/connect`
 
 Connect-ACL policy summary and allow/deny counters. Counters read `0` until the T4 forwarder (issue #132) is wired.

--- a/src/cli/commands/network.rs
+++ b/src/cli/commands/network.rs
@@ -117,11 +117,15 @@ pub async fn diagnostics_dm(client: &DaemonClient) -> Result<()> {
 /// Prints per-group ingest counters: `members_v2_size`, metadata/public
 /// listener state, accepted message count, last-message-at, and per-reason
 /// drop buckets (`decode_failed`, `author_banned`,
-/// `write_policy_violation`, `signature_failed`, `other`). The
-/// `write_policy_violation` bucket is the canary for the
-/// join-roster-propagation regression — non-zero on the owner side means
-/// joiners' messages reached the listener but the owner's `members_v2`
-/// view is missing them.
+/// `write_policy_violation`, `signature_failed`, `other`).
+///
+/// `write_policy_violation` counts two distinct events, so read it together
+/// with the WARN that accompanies each increment. On the owner side it is the
+/// canary for the join-roster-propagation regression — joiners' messages
+/// reached the listener but the owner's `members_v2` view is missing them. On
+/// the sender side it also counts this daemon's OWN outgoing sends rejected
+/// locally by a members-only policy, which instead means this daemon is
+/// absent from its own roster copy.
 pub async fn diagnostics_groups(client: &DaemonClient) -> Result<()> {
     client.run_get("/diagnostics/groups").await
 }

--- a/src/cli/commands/network.rs
+++ b/src/cli/commands/network.rs
@@ -119,13 +119,13 @@ pub async fn diagnostics_dm(client: &DaemonClient) -> Result<()> {
 /// drop buckets (`decode_failed`, `author_banned`,
 /// `write_policy_violation`, `signature_failed`, `other`).
 ///
-/// `write_policy_violation` counts two distinct events, so read it together
-/// with the WARN that accompanies each increment. On the owner side it is the
-/// canary for the join-roster-propagation regression — joiners' messages
-/// reached the listener but the owner's `members_v2` view is missing them. On
-/// the sender side it also counts this daemon's OWN outgoing sends rejected
-/// locally by a members-only policy, which instead means this daemon is
-/// absent from its own roster copy.
+/// `messages_dropped_write_policy_violation` is the receiver-side canary for
+/// the join-roster-propagation regression — joiners' messages reached the
+/// listener but the owner's `members_v2` view is missing them.
+///
+/// `sends_rejected_write_policy` is the sender-side complement: this daemon's
+/// own outgoing sends were rejected locally by a members-only policy, meaning
+/// this daemon is absent from its own roster copy.
 pub async fn diagnostics_groups(client: &DaemonClient) -> Result<()> {
     client.run_get("/diagnostics/groups").await
 }

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -346,7 +346,19 @@ impl InboxPipeline {
     async fn handle_incoming(&self, msg: PubSubMessage, ack_legacy_bus: bool) {
         let (pubsub_sender, sender_pubkey) = match (msg.sender, msg.sender_public_key.as_deref()) {
             (Some(s), Some(pk)) if msg.verified => (s, pk.to_vec()),
-            _ => return,
+            _ => {
+                // Real unverified-drop site (issue #296): count here before
+                // discarding so the server-layer typed-payload handler never
+                // sees these messages and does not need its own copy of this
+                // check.
+                self.dm.record_incoming_signature_failed();
+                tracing::debug!(
+                    target: "dm.trace",
+                    stage = "inbound_unverified_drop",
+                    "dropped unverified pubsub message before envelope decode"
+                );
+                return;
+            }
         };
 
         if msg.payload.len() > MAX_ENVELOPE_BYTES {
@@ -424,6 +436,11 @@ impl InboxPipeline {
 
         if envelope.sender_agent_id != *pubsub_sender.as_bytes() {
             self.dm.record_incoming_signature_failed();
+            tracing::debug!(
+                target: "dm.trace",
+                stage = "inbound_sender_id_mismatch",
+                "dropped DM: envelope sender_agent_id does not match gossip-layer sender"
+            );
             return;
         }
 
@@ -1918,5 +1935,42 @@ mod tests {
         let debug = format!("{:?}", config);
         assert!(debug.contains("silent_reject"));
         assert!(debug.contains("typed_payload_routes"));
+    }
+
+    // ── Unverified drop path instrumentation (issue #296) ─────────────
+
+    /// The REAL drop site for unverified pubsub messages is dm_inbox.rs, NOT
+    /// server/mod.rs. The typed-payload handler in server/mod.rs only fires
+    /// after the inbox pipeline has already verified and dispatched the message
+    /// — typed.verified is hardcoded to true there, so any !typed.verified
+    /// check in server/mod.rs is unreachable dead code. This test is the
+    /// revert-guard: if the counter call is removed from handle_incoming the
+    /// test fails even though the dead server-layer check is still in place.
+    #[tokio::test]
+    async fn unverified_pubsub_message_increments_signature_failed_counter() {
+        let sender = test_keypair();
+        let harness = make_inbox_harness(&sender, None, None).await;
+        let dm = Arc::clone(&harness.pipeline.dm);
+
+        let msg = PubSubMessage {
+            topic: "test-inbox-topic".to_string(),
+            payload: bytes::Bytes::new(),
+            sender: None,
+            sender_public_key: None,
+            verified: false,
+            trust_level: None,
+            raw_envelope: None,
+        };
+
+        let before = dm.diagnostics_snapshot().stats.incoming_signature_failed;
+        harness.pipeline.handle_incoming(msg, false).await;
+        let after = dm.diagnostics_snapshot().stats.incoming_signature_failed;
+
+        assert_eq!(
+            after - before,
+            1,
+            "unverified PubSubMessage must increment incoming_signature_failed \
+             at the real drop site in dm_inbox (issue #296)"
+        );
     }
 }

--- a/src/groups/diagnostics.rs
+++ b/src/groups/diagnostics.rs
@@ -36,7 +36,17 @@ pub struct GroupCounters {
     pub messages_dropped_author_banned: u64,
     /// Public messages rejected by `validate_public_message` for write-access
     /// policy reasons (e.g. `MembersOnly` author not in `members_v2`).
+    /// This is the ingest (receiver-side) canary for the join-roster-propagation
+    /// regression: a non-zero value means joiners' messages are reaching this
+    /// node's listener but `members_v2` is stale. See also
+    /// `sends_rejected_write_policy` for the sender-side count.
     pub messages_dropped_write_policy_violation: u64,
+    /// Outgoing public group sends that were rejected locally by a members-only
+    /// write-access policy. A non-zero value means THIS daemon is not present in
+    /// its own local roster copy. Tracked separately from
+    /// `messages_dropped_write_policy_violation` (the receiver-side ingest
+    /// canary) so that operators can distinguish the two failure modes.
+    pub sends_rejected_write_policy: u64,
     /// Public messages whose author signature failed to verify, or whose
     /// `author_agent_id` did not match the derived AgentId.
     pub messages_dropped_signature_failed: u64,
@@ -167,14 +177,31 @@ impl GroupsDiagnostics {
         });
     }
 
-    /// Record a `WritePolicyViolation` rejection — the headline counter for
-    /// the join-roster-propagation regression: a sudden jump on the owner
-    /// side immediately after a joiner posts means the owner's
+    /// Record a receiver-side `WritePolicyViolation` rejection — the headline
+    /// counter for the join-roster-propagation regression: a sudden jump on
+    /// the owner side immediately after a joiner posts means the owner's
     /// `members_v2` has not converged yet.
+    ///
+    /// Call this on the INGEST path only. For outgoing sends rejected locally
+    /// by a members-only policy, use `record_sender_write_policy_rejection`.
     pub fn record_write_policy_violation(&self, group_id: &str) {
         self.with_counters(group_id, |c| {
             c.messages_dropped_write_policy_violation =
                 c.messages_dropped_write_policy_violation.saturating_add(1);
+        });
+    }
+
+    /// Record a sender-side write-policy rejection: this daemon attempted to
+    /// send a public group message but was refused because it is not in the
+    /// local `members_v2` roster for a members-only group.
+    ///
+    /// Tracked in a separate field (`sends_rejected_write_policy`) from the
+    /// receiver-side ingest counter (`messages_dropped_write_policy_violation`)
+    /// so operators can distinguish "I cannot see joiners" from "I am missing
+    /// from my own roster".
+    pub fn record_sender_write_policy_rejection(&self, group_id: &str) {
+        self.with_counters(group_id, |c| {
+            c.sends_rejected_write_policy = c.sends_rejected_write_policy.saturating_add(1);
         });
     }
 
@@ -312,6 +339,9 @@ impl GroupsDiagnostics {
             dst.messages_dropped_write_policy_violation = dst
                 .messages_dropped_write_policy_violation
                 .saturating_add(src.messages_dropped_write_policy_violation);
+            dst.sends_rejected_write_policy = dst
+                .sends_rejected_write_policy
+                .saturating_add(src.sends_rejected_write_policy);
             dst.messages_dropped_signature_failed = dst
                 .messages_dropped_signature_failed
                 .saturating_add(src.messages_dropped_signature_failed);
@@ -468,6 +498,46 @@ mod tests {
         );
         assert!(!g2.subscribed_metadata);
         assert!(!g2.subscribed_public);
+    }
+
+    /// Verify that the receiver-side ingest counter and the sender-side
+    /// rejection counter move independently.
+    ///
+    /// Before the fix the sender-side rejection incremented
+    /// `messages_dropped_write_policy_violation` (the same field as the
+    /// receiver-side ingest counter), destroying its meaning as the
+    /// join-roster-propagation canary. After the fix the two fields are
+    /// distinct: an ingest drop bumps `messages_dropped_write_policy_violation`
+    /// while a local send rejection bumps `sends_rejected_write_policy`.
+    ///
+    /// If the sender-side call is changed back to
+    /// `record_write_policy_violation`, the `sends_rejected_write_policy`
+    /// assertion fails (stays 0) and the `messages_dropped_write_policy_violation`
+    /// assertion also fails (becomes 2 instead of 1).
+    #[test]
+    fn sender_and_receiver_write_policy_counters_are_independent() {
+        let diag = GroupsDiagnostics::new();
+
+        // Receiver-side: ingest path dropped an incoming message.
+        diag.record_write_policy_violation("grp");
+        // Sender-side: this daemon's own outgoing send was rejected locally.
+        diag.record_sender_write_policy_rejection("grp");
+
+        let mut groups: HashMap<String, GroupInfo> = HashMap::new();
+        groups.insert("grp".into(), group("Grp", "grp"));
+        let snap = diag.snapshot(&groups, &HashSet::new(), &HashSet::new(), &HashMap::new());
+
+        let g = snap.groups.iter().find(|g| g.group_id == "grp").unwrap();
+        assert_eq!(
+            g.counters.messages_dropped_write_policy_violation,
+            1,
+            "receiver-side ingest drop must be in messages_dropped_write_policy_violation only"
+        );
+        assert_eq!(
+            g.counters.sends_rejected_write_policy,
+            1,
+            "sender-side local rejection must be in sends_rejected_write_policy only"
+        );
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1190,23 +1190,7 @@ pub async fn serve_with_options(
                 else {
                     continue;
                 };
-                if !typed.verified {
-                    let group_id =
-                        serde_json::from_slice::<x0x::groups::GroupPublicMessage>(payload)
-                            .ok()
-                            .map(|msg| msg.group_id);
-                    if let Some(group_id) = group_id.as_deref() {
-                        public_dm_state
-                            .groups_diagnostics
-                            .record_signature_failed(group_id);
-                    }
-                    tracing::warn!(
-                        group_id = group_id.as_deref().unwrap_or("unknown"),
-                        sender = %hex::encode(typed.sender.as_bytes()),
-                        "dropped direct-delivered public group message with failed verification"
-                    );
-                    continue;
-                }
+
                 let Ok(msg) = serde_json::from_slice::<x0x::groups::GroupPublicMessage>(payload)
                 else {
                     tracing::debug!(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1186,13 +1186,27 @@ pub async fn serve_with_options(
         let public_dm_state = Arc::clone(&state);
         bg_tasks.push(tokio::spawn(async move {
             while let Some(typed) = group_public_dm_rx.recv().await {
-                if !typed.verified {
-                    continue;
-                }
                 let Some(payload) = typed.payload.strip_prefix(GROUP_PUBLIC_MESSAGE_DM_PREFIX)
                 else {
                     continue;
                 };
+                if !typed.verified {
+                    let group_id =
+                        serde_json::from_slice::<x0x::groups::GroupPublicMessage>(payload)
+                            .ok()
+                            .map(|msg| msg.group_id);
+                    if let Some(group_id) = group_id.as_deref() {
+                        public_dm_state
+                            .groups_diagnostics
+                            .record_signature_failed(group_id);
+                    }
+                    tracing::warn!(
+                        group_id = group_id.as_deref().unwrap_or("unknown"),
+                        sender = %hex::encode(typed.sender.as_bytes()),
+                        "dropped direct-delivered public group message with failed verification"
+                    );
+                    continue;
+                }
                 let Ok(msg) = serde_json::from_slice::<x0x::groups::GroupPublicMessage>(payload)
                 else {
                     tracing::debug!(

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -8873,6 +8873,14 @@ pub(in crate::server) async fn send_group_public_message(
         match info.policy.write_access {
             x0x::groups::GroupWriteAccess::MembersOnly => {
                 if caller_role.is_none() {
+                    state
+                        .groups_diagnostics
+                        .record_write_policy_violation(info.stable_group_id());
+                    tracing::warn!(
+                        group_id = %info.stable_group_id(),
+                        author = %local_hex,
+                        "rejected public group send: members-only write policy"
+                    );
                     return forbidden("members-only write policy");
                 }
             }

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -8875,7 +8875,7 @@ pub(in crate::server) async fn send_group_public_message(
                 if caller_role.is_none() {
                     state
                         .groups_diagnostics
-                        .record_write_policy_violation(info.stable_group_id());
+                        .record_sender_write_policy_rejection(info.stable_group_id());
                     tracing::warn!(
                         group_id = %info.stable_group_id(),
                         author = %local_hex,

--- a/src/server/routes/network.rs
+++ b/src/server/routes/network.rs
@@ -604,11 +604,16 @@ pub(in crate::server) async fn gossip_diagnostics(
 /// Mirrors `/diagnostics/dm` and `/diagnostics/exec`. For each
 /// locally-known group (or any group with non-zero counters) returns
 /// `members_v2_size`, listener-state booleans, and the per-reason
-/// drop buckets used by the public-message ingest pipeline. The
-/// `messages_dropped_write_policy_violation` bucket is the canary for
-/// the join-roster-propagation regression: a non-zero value on the
-/// owner side means joiners' messages are reaching the listener but
-/// `members_v2` is stale.
+/// drop buckets used by the public-message ingest pipeline.
+///
+/// `messages_dropped_write_policy_violation` aggregates two distinct
+/// events; the WARN emitted alongside each increment distinguishes them.
+/// Receiver side, it is the canary for the join-roster-propagation
+/// regression: a non-zero value on the owner side means joiners'
+/// messages are reaching the listener but `members_v2` is stale.
+/// Sender side, it also counts this daemon's own outgoing sends
+/// rejected locally by a members-only policy, which instead means this
+/// daemon is missing from its own roster copy.
 pub(in crate::server) async fn groups_diagnostics(
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {

--- a/src/server/routes/network.rs
+++ b/src/server/routes/network.rs
@@ -606,14 +606,14 @@ pub(in crate::server) async fn gossip_diagnostics(
 /// `members_v2_size`, listener-state booleans, and the per-reason
 /// drop buckets used by the public-message ingest pipeline.
 ///
-/// `messages_dropped_write_policy_violation` aggregates two distinct
-/// events; the WARN emitted alongside each increment distinguishes them.
-/// Receiver side, it is the canary for the join-roster-propagation
-/// regression: a non-zero value on the owner side means joiners'
-/// messages are reaching the listener but `members_v2` is stale.
-/// Sender side, it also counts this daemon's own outgoing sends
-/// rejected locally by a members-only policy, which instead means this
-/// daemon is missing from its own roster copy.
+/// `messages_dropped_write_policy_violation` is the receiver-side canary
+/// for the join-roster-propagation regression: a non-zero value on the
+/// owner side means joiners' messages are reaching the listener but
+/// `members_v2` is stale.
+///
+/// `sends_rejected_write_policy` is tracked separately and counts this
+/// daemon's own outgoing sends rejected locally by a members-only policy;
+/// a non-zero value means this daemon is absent from its own roster copy.
 pub(in crate::server) async fn groups_diagnostics(
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {


### PR DESCRIPTION
## Summary

- count and WARN on sender-side members-only write-policy rejections
- count and WARN on direct-delivered public messages dropped because transport verification failed
- preserve the existing HTTP 403 and drop behavior while making both server-side silent paths observable

## Scope

This is the independently shippable observability part of #296. The exact `fan_out: 0` REST response still needs the `publish_with_fanout` API introduced by saorsa-gossip PR #33; x0x should not pin `main` to an unmerged git branch. Once #33 merges and a saorsa-gossip release is available, the remaining x0x follow-up can return the exact fan-out count and expose it in the send response.

## Tests

- `cargo fmt --all`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`

Refs #296

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds warning logs and group diagnostic counters for rejected members-only sends and failed verification of direct-delivered public messages. The members-only instrumentation is correctly attached, but the transport-verification instrumentation is unreachable through the current typed-DM routing path.

- Count and warn when the public-message endpoint rejects a non-member under a members-only policy.
- Parse rejected direct public-message payloads to attribute verification failures to a group.
- Preserve the existing HTTP 403 and message-drop behavior.

<h3>Confidence Score: 4/5</h3>

The direct-message observability fix needs correction before merging because transport-verification drops remain silent on the actual typed routing path.

The members-only rejection instrumentation is sound, but the direct public-message warning and counter are guarded by a verification state that the receiver cannot observe as false.

**Files Needing Attention:** src/server/mod.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/mod.rs | Adds diagnostics for unverified direct public messages, but the new branch is unreachable because typed routing assigns `verified: true`. |
| src/server/routes/named_groups.rs | Adds a synchronous counter increment and warning to the existing members-only HTTP rejection without changing its response behavior. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Incoming direct public message] --> B[Typed payload router]
  B -->|constructs verified = true| C[group_public_dm_rx]
  C --> D{typed.verified?}
  D -->|true| E[Deserialize and ingest]
  D -.->|false unreachable via router| F[Increment failure counter and WARN]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/mod.rs:1193-1208
**Verification diagnostics are unreachable**

When a direct-delivered public group message fails transport verification, the typed-payload router replaces that state with `verified: true` before delivery to this receiver, so this branch never records or warns about the failure and the intended drops remain silent.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): surface public message sile..."](https://github.com/saorsa-labs/x0x/commit/feed4da496a8920e1c208b4a332cf0536ff4eb6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51411771)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)

<!-- /greptile_comment -->