### PR TITLE
fix(deps): ant-quic 0.27.36 — InFlight underflow stall fix + mDNS plane isolation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.35"
+ant-quic = "0.27.36"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"

--- a/src/network.rs
+++ b/src/network.rs
@@ -1611,6 +1611,11 @@ impl NetworkNode {
         // isolation.
         if let Some(id) = &config.network_id {
             validate_plane_id(id).map_err(NetworkError::NodeCreation)?;
+            // Isolate LAN discovery by plane as well. Without a namespace,
+            // co-located daemons on different planes still find each other via
+            // the shared `ant-quic` mDNS service and auto-connect, so the plane
+            // gate only ever rejects them after the connection exists.
+            builder = builder.mdns_namespace(id.clone());
         }
 
         let node = Node::with_config(builder.build()).await.map_err(|e| {


### PR DESCRIPTION
Bumps ant-quic to 0.27.36, picking up the #230 InFlight-underflow silent-send-stall fix and endpoint-driver supervision, and plumbs the new `mdns_namespace` from the resolved gossip plane id so co-located daemons on different planes (prod/testnet/test) no longer auto-connect over LAN mDNS.

Part of the asymmetric-delivery investigation (x0x #295/#296/#297, ant-quic #230/#234/#235). Gate: 2561/2561 green at branch cut; trial-merged clean with #298/#299 (2563/2563).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR raises the minimum compatible ant-quic version to 0.27.36 and scopes LAN mDNS discovery using the validated gossip-plane identifier.
- Updates the ant-quic dependency requirement.
- Passes each configured network plane ID to ant-quic as its mDNS namespace.
- Leaves open-plane nodes on the default unscoped mDNS discovery namespace.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the dependency update or mDNS namespace plumbing.

Configured daemon plane IDs resolve consistently, ant-quic accepts and compares the namespace verbatim, and nodes without a plane ID intentionally retain open mDNS discovery.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Raises the ant-quic compatibility floor from 0.27.35 to 0.27.36; no lockfile prevents the requested version from resolving. |
| src/network.rs | Applies each validated network plane ID as the ant-quic mDNS namespace without changing open-plane behavior. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[Resolved NetworkConfig] --> Q{network_id set?}
  Q -->|No| D[Default open mDNS discovery]
  Q -->|Yes| V[Validate plane ID]
  V --> M[Set ant-quic mDNS namespace]
  M --> P[Discover peers advertising same namespace]
  P --> G[Plane handshake and connection gate]
```

<sub>Reviews (1): Last reviewed commit: ["Merge origin/main (post #298/#299) into ..."](https://github.com/saorsa-labs/x0x/commit/dccb9483d5be392d3806de5a2cdb53b440fa7cd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51441559)</sub>

**Context used:**

- Knowledge Base — [Network Transport](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/network-transport.md)

<!-- /greptile_comment -->