### PR TITLE
chore(release): v0.36.1 — transport and join-path hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.36.1] - 2026-08-08
+
+Hardening-only release. **It does not fix the asymmetric group-message delivery
+bug** that is currently under investigation (x0x #296, #302): Stage-1 acceptance
+for a candidate fix failed, and the investigation remains open. What ships here
+is transport and join-path hardening that was verified on its own terms — see
+*Known issues* below for what is still broken.
+
+### Fixed
+
+- **ant-quic 0.27.35 → 0.27.36 — silent permanent send-stall (ant-quic #230).**
+  When a path was abandoned, its in-flight packets were debited from the
+  surviving paths, underflowing the `InFlight` counter. The congestion
+  controller then believed the window was permanently full and never sent
+  again — a connection that looked healthy but could no longer transmit. The
+  underflow wraps silently in every prior release build, so this affects all
+  x0x versions up to and including v0.36.0. The same bump brings endpoint-driver
+  supervision and respawn instead of a terminal latched `driver_lost`
+  (ant-quic #220), a synthetic peer-ID leak fix (ant-quic #221), and session-cap
+  hardening (ant-quic #215).
+
+- **mDNS plane isolation.** `x0xd` now sets ant-quic's `mdns_namespace` from the
+  resolved gossip plane id. Previously, co-located daemons on different planes
+  (prod / testnet / test) still found each other over the shared ant-quic mDNS
+  service and auto-connected on the LAN, so the plane gate only rejected the
+  peer *after* the connection already existed. Prod (`x0x.prod`) and testnet now
+  occupy distinct namespaces; the explicit open-plane opt-out
+  (`network_id = ""`) still maps to ant-quic's default of no namespace.
+  Verified in live testing.
+
+- **Proactive reconnect keeps the peer's identity (#295, PR #298).** The
+  proactive redial path knew the target `PeerId` but dialled bare addresses.
+  ant-quic's hole-punch strategy refuses address-only dialling, so every
+  reconnect silently degraded to direct-only and failed whenever the stale
+  connection blocked direct dials. Proactive reconnect and bootstrap-cache
+  fallback now both use peer-authenticated `connect_peer_with_addrs`, and a
+  stale cached address that authenticates as a *different* peer is rejected.
+  Verified in live testing; recovery in degraded topologies is still limited —
+  tracked in the open investigation below.
+
+- **Non-TreeKEM group joins repair their own roster (#297, PR #299).** Only
+  TreeKEM joins entered the post-join result polling path. A non-TreeKEM joiner
+  that missed the authoritative `MemberAdded` commit had no retry mechanism and
+  stayed absent from its own roster indefinitely, so every send failed with 403.
+  Non-TreeKEM joins now poll the authority until roster membership is confirmed
+  or the 10-minute staged-result retention window expires; TreeKEM joins keep
+  their existing 120-second Welcome convergence path. This is groundwork — its
+  full effectiveness depends on transport fixes still in progress.
+
+### Known issues
+
+- The asymmetric group-delivery investigation is **still open**: x0x #296 and
+  #302, ant-quic #234, #235 and #238, and saorsa-gossip #32. Nothing in this
+  release should be read as closing them.
+
 ## [v0.36.0] - 2026-08-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.36.0
+version: 0.36.1
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
## Summary

Hardening-only patch release. Bumps `Cargo.toml` / `SKILL.md` to 0.36.1 and adds the `## [v0.36.1]` CHANGELOG section. No source changes — the code shipped here is what merged in #298, #299 and #301.

## What this release does NOT do

**It does not fix the asymmetric group-message delivery bug.** Stage-1 acceptance for a candidate fix failed and the investigation stays open (x0x #296, #302; ant-quic #234, #235, #238; saorsa-gossip #32). The CHANGELOG says this explicitly, in the release preamble and again under *Known issues*.

## What it does ship

- **ant-quic 0.27.35 → 0.27.36** — silent permanent send-stall (ant-quic #230): an abandoned path debited its in-flight packets from surviving paths, underflowing `InFlight` so the congestion controller thought the window was permanently full and never sent again. The underflow wraps silently in every prior release build, so this affects all x0x versions through v0.36.0. Also brings endpoint-driver supervision/respawn (#220), a synthetic peer-ID leak fix (#221), and session-cap hardening (#215).
- **mDNS plane isolation** — `x0xd` sets ant-quic's `mdns_namespace` from the resolved gossip plane id, so co-located daemons on different planes no longer auto-connect over LAN mDNS before the plane gate can reject them. Verified in live testing.
- **#295 / PR #298** — proactive reconnect retains the peer's identity and uses peer-authenticated, hole-punch-capable dials. Verified in live testing; recovery in degraded topologies is still limited.
- **#297 / PR #299** — non-TreeKEM group joins poll the authority until roster membership is confirmed or staging expires. Groundwork; full effectiveness depends on transport fixes still in progress.

## Gate

`just check` run against a clean worktree of this commit (tracked files only):

| Phase | Result |
|---|---|
| `fmt-check` | pass |
| `deploy-check` | pass |
| `lint` (clippy `-D warnings`) | pass, zero warnings |
| `build --all-features` | pass |
| `test` | 2555/2555 passed, 256 skipped |
| `doc` | pass |

One retry was used. The first run hit `admin_revocation_shutdown_disconnect_suppresses_proactive_reconnect` failing with `DirectIPv4: Timeout` on a **loopback** dial after 19s — a saturation signature, not a logic failure, under a 2563-test parallel run on a box also hosting live investigation daemons. CI is green on the identical source (b5b8574), and the full `--no-fail-fast` retry passed 2555/2555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch prepares the v0.36.1 release without changing source code.
- Bumps the package and skill metadata from 0.36.0 to 0.36.1.
- Documents the transport and group-join hardening included in the release.
- Explicitly preserves the asymmetric group-delivery problem as a known issue.

<h3>Confidence Score: 5/5</h3>

The release-only changes appear safe to merge.

The package and skill versions are synchronized, and the new changelog accurately describes the hardening present at the head commit while clearly retaining the unresolved delivery bug as a known issue.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds release notes whose concrete behavioral claims and timeout values agree with the shipped implementation. |
| Cargo.toml | Advances the package version to 0.36.1 consistently with the repository's release metadata policy. |
| SKILL.md | Keeps the skill metadata version synchronized with Cargo.toml. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.36.1 — transport and ..."](https://github.com/saorsa-labs/x0x/commit/f4f32aa5a31f42b54f08b402768920ec8042d846) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51446563)</sub>

<!-- /greptile_comment -->