### PR TITLE
fix(connect): verify peer identity before cache bookkeeping on mismatched dial

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -2473,6 +2473,29 @@ impl NetworkNode {
             }
         };
 
+        // Identity gate — verify the responding peer is the one we requested,
+        // same as connect_peer_with_addrs. ant-quic performs QUIC-level
+        // authentication, so a mismatch here would be unexpected, but the
+        // guard ensures no cache bookkeeping or PeerConnected runs if it
+        // ever occurs (e.g., a reused connection whose far end rotated keys).
+        if peer_conn.peer_id != peer_id {
+            tracing::warn!(
+                target: "x0x::connect",
+                strategy = "peer",
+                requested_prefix = %hex_prefix(&peer_id.0, 4),
+                actual_prefix = %hex_prefix(&peer_conn.peer_id.0, 4),
+                %addr,
+                "identity mismatch on connect_peer: no cache bookkeeping"
+            );
+            if let Some(ref cache) = self.bootstrap_cache {
+                cache.record_failure(&peer_id).await;
+            }
+            return Err(NetworkError::ConnectionFailed(format!(
+                "identity mismatch: expected {:?} but {:?} answered",
+                peer_id, peer_conn.peer_id,
+            )));
+        }
+
         // Record in bootstrap cache so future connections use the cached address
         let rtt_ms = start.elapsed().as_millis() as u32;
         if let Some(ref cache) = self.bootstrap_cache {
@@ -2514,6 +2537,19 @@ impl NetworkNode {
             v6_count,
             "starting peer-authenticated dial with hints"
         );
+        // Snapshot which peers are already connected BEFORE the dial. ant-quic
+        // may return a pre-existing reused connection (connect_orchestrated scans
+        // connected_peers by remote address). If the returned peer_id mismatches,
+        // we must NOT disconnect a connection that existed before our dial —
+        // that would be #206-class reconnect churn on a healthy peer that simply
+        // happened to share the cached address. We only close a NEW connection.
+        let pre_dial_connected: std::collections::HashSet<AntPeerId> = node
+            .connected_peers()
+            .await
+            .into_iter()
+            .map(|conn| conn.peer_id)
+            .collect();
+
         let start = std::time::Instant::now();
         let peer_conn_res = node.connect_peer_with_addrs(peer_id, addrs).await;
         let dur_ms = start.elapsed().as_millis() as u64;
@@ -2557,6 +2593,13 @@ impl NetworkNode {
         // record_success entry and a live connection, while the requested peer
         // ("Alice") received record_failure, inverting cache quality. Fixes #302.
         if peer_conn.peer_id != peer_id {
+            // Only close the connection if it was NOT pre-existing before our
+            // dial. ant-quic's connect_orchestrated can return a live connection
+            // to a peer that shares the cached address ("Carol"). Tearing down a
+            // connection we did not open risks #206-class reconnect churn on a
+            // healthy, actively-used peer. A pre-existing connection is healthy;
+            // the fault is in the stale cache entry only.
+            let was_pre_existing = pre_dial_connected.contains(&peer_conn.peer_id);
             tracing::warn!(
                 target: "x0x::connect",
                 strategy = "peer_with_addrs",
@@ -2564,12 +2607,15 @@ impl NetworkNode {
                 actual_prefix = %hex_prefix(&peer_conn.peer_id.0, 4),
                 %addr,
                 dur_ms,
-                "identity mismatch: closing stale connection, no cache bookkeeping"
+                was_pre_existing,
+                "identity mismatch: skipping bookkeeping"
             );
-            // Close the mismatched connection so it does not accumulate.
-            // Use plain disconnect (transport-level) — the remote peer is not at
-            // fault; only the cache entry was stale.
-            let _ = node.disconnect(&peer_conn.peer_id).await;
+            if !was_pre_existing {
+                // Connection was newly established by this dial — safe to close.
+                // Use plain disconnect (transport-level); the remote peer is not
+                // at fault, only the cache entry was stale.
+                let _ = node.disconnect(&peer_conn.peer_id).await;
+            }
             // Degrade the REQUESTED peer's cache quality: the stored address
             // proved to lead to a different host. Do NOT penalise peer_conn.peer_id.
             if let Some(ref cache) = self.bootstrap_cache {
@@ -5635,33 +5681,30 @@ mod identity_before_bookkeeping_tests {
     use super::*;
 
     /// `connect_peer_with_addrs` with a mismatched peer_id must:
-    ///   1. return Err
-    ///   2. NOT add the responding peer to the bootstrap cache with record_success
-    ///   3. NOT leave the responding peer in connected_peers (connection closed)
-    ///   4. record_failure for the requested (stale) peer_id
+    ///   1. return Err (not Ok with the impostor's peer_id)
+    ///   2. NOT emit a `PeerConnected` event for the impostor
+    ///   3. record_failure for the requested (stale) peer_id, not the impostor
     ///
-    /// The test FAILS if identity-check-after-bookkeeping is restored, because
-    /// in that code path assertions 2 and 3 are violated.
-    /// The primary behavioral discriminator for fix #302:
+    /// WHY the two revert guards matter:
     ///
     /// BEFORE fix: `connect_peer_with_addrs(fake_peer_id, [b_addr])` returned
-    ///   `Ok((addr, b_real_peer_id))` — success with the wrong peer_id. Callers
-    ///   handled the mismatch. Meanwhile `add_from_connection` + `record_success`
-    ///   already ran for whoever answered, and the connection was left open.
+    ///   `Ok((addr, b_real_peer_id))` — success with the wrong peer_id. Cache
+    ///   bookkeeping (`add_from_connection` + `record_success`) already ran for
+    ///   whoever answered, and `PeerConnected` was emitted for the impostor.
     ///
-    /// AFTER fix: returns `Err(...)`. Cache bookkeeping and PeerConnected are
-    ///   never emitted for the impostor. If this test is reverted to the old order,
-    ///   `result.is_ok()` and the assertion fails.
+    /// AFTER fix: returns `Err(...)`. The identity gate fires before any cache
+    ///   bookkeeping or event emission. If the gate is removed or moved after
+    ///   bookkeeping, guard 1 fails (is_ok). If only the Err return is kept but
+    ///   the emit_event call is accidentally left before the gate, guard 2 fails
+    ///   (PeerConnected is received on the subscription channel).
     #[tokio::test]
-    async fn mismatched_dial_returns_err_not_ok_with_wrong_peer() {
+    async fn mismatched_dial_returns_err_and_does_not_emit_peer_connected() {
         // Block B from being accepted inbound by A so the accept loop cannot
-        // add B to A's bootstrap cache on a concurrent inbound path, which
-        // would mask whether the bookkeeping ran from our outbound dial.
+        // emit PeerConnected on a concurrent path, which would interfere with
+        // the subscription check below.
         let a_fake_allowlist: std::collections::HashSet<[u8; 32]> = {
-            // Allowlist containing only an impossible peer — effectively closes
-            // A's accept loop to all inbound peers during this test.
             let mut set = std::collections::HashSet::new();
-            set.insert([0xFFu8; 32]);
+            set.insert([0xFFu8; 32]); // impossible peer — blocks all inbound
             set
         };
         let config_a = NetworkConfig {
@@ -5683,7 +5726,6 @@ mod identity_before_bookkeeping_tests {
             .persist(false)
             .build();
 
-        // NetworkNode::new already starts the transport — no separate join needed.
         let node_a = NetworkNode::new(config_a, Some(cache_config_a), None)
             .await
             .expect("node_a creation failed");
@@ -5698,36 +5740,55 @@ mod identity_before_bookkeeping_tests {
         let b_addr: SocketAddr = format!("127.0.0.1:{}", b_bound.port()).parse().unwrap();
         let b_real_peer_id = node_b.peer_id();
 
-        // fake_peer_id is guaranteed different from b_real_peer_id.
         let fake_peer_id = ant_quic::PeerId([0xAAu8; 32]);
         assert_ne!(
             fake_peer_id, b_real_peer_id,
             "test invariant: fake_peer_id must not equal b_real_peer_id"
         );
 
-        // Attempt to connect to node_b's address while requesting a DIFFERENT peer_id.
-        // node_b answers with its real peer_id → x0x's identity gate detects mismatch.
+        // Subscribe BEFORE the dial so we can observe whether any
+        // PeerConnected event is emitted on the mismatch path.
+        let mut event_rx = node_a.subscribe();
+
         let result = node_a
             .connect_peer_with_addrs(fake_peer_id, vec![b_addr])
             .await;
 
-        // PRIMARY REVERT GUARD: fix #302 makes connect_peer_with_addrs return Err
-        // on peer_id mismatch. Before the fix it returned Ok((addr, actual_peer_id))
-        // and let the caller do the identity check. If this assertion fails, the fix
-        // was reverted — the identity gate no longer runs inside the function.
+        // REVERT GUARD 1: identity gate must fire before any cache bookkeeping.
+        // Before fix #302 this returned Ok((addr, actual_peer_id)); after the
+        // fix it returns Err. Restoring the old order makes this assertion fail.
         assert!(
             result.is_err(),
             "connect_peer_with_addrs must return Err on peer_id mismatch; \
-             if Ok is returned, bookkeeping ran before the identity check (revert of #302 fix). \
-             Got: {:?}",
+             got Ok — the identity gate was removed or moved after bookkeeping \
+             (revert of fix #302). Got: {:?}",
             result
         );
 
-        // The return value is the only reliable discriminator at this level:
-        // ant-quic shares the bootstrap_cache object and may update it internally
-        // during connection establishment, independent of x0x's add_from_connection
-        // call, so cache-presence assertions would be flaky. The Err return is the
-        // contract: before fix #302, connect_peer_with_addrs returned
-        // Ok((addr, actual_peer_id)) even on mismatch; after fix it returns Err.
+        // REVERT GUARD 2: no PeerConnected must reach subscribers for the
+        // impostor. connect_peer_with_addrs returns synchronously, so any
+        // event emitted on the mismatch path is already in the channel or
+        // will never arrive. If emit_event is accidentally left before the
+        // identity gate, try_recv finds the event and the assertion fails.
+        match event_rx.try_recv() {
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => {
+                // Correct: no PeerConnected was emitted on the mismatch path.
+            }
+            Ok(NetworkEvent::PeerConnected { peer_id, .. }) => {
+                panic!(
+                    "PeerConnected must NOT be emitted for the impostor on identity mismatch; \
+                     received PeerConnected for peer {:?} — emit_event fired before the identity \
+                     gate (revert of fix #302)",
+                    peer_id
+                );
+            }
+            Ok(other) => {
+                // A different event (e.g. NatTypeDetected) is irrelevant —
+                // only PeerConnected is the prohibited emission here.
+                let _ = other;
+            }
+            Err(tokio::sync::broadcast::error::TryRecvError::Closed) => {}
+            Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => {}
+        }
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -2550,6 +2550,37 @@ impl NetworkNode {
             }
         };
 
+        // Identity gate — verify the responding peer is the one we requested
+        // BEFORE running any cache bookkeeping or emitting PeerConnected.
+        // Running bookkeeping first (the previous order) allowed a stale cache
+        // entry pointing at a different host ("Carol") to give Carol a
+        // record_success entry and a live connection, while the requested peer
+        // ("Alice") received record_failure, inverting cache quality. Fixes #302.
+        if peer_conn.peer_id != peer_id {
+            tracing::warn!(
+                target: "x0x::connect",
+                strategy = "peer_with_addrs",
+                requested_prefix = %hex_prefix(&peer_id.0, 4),
+                actual_prefix = %hex_prefix(&peer_conn.peer_id.0, 4),
+                %addr,
+                dur_ms,
+                "identity mismatch: closing stale connection, no cache bookkeeping"
+            );
+            // Close the mismatched connection so it does not accumulate.
+            // Use plain disconnect (transport-level) — the remote peer is not at
+            // fault; only the cache entry was stale.
+            let _ = node.disconnect(&peer_conn.peer_id).await;
+            // Degrade the REQUESTED peer's cache quality: the stored address
+            // proved to lead to a different host. Do NOT penalise peer_conn.peer_id.
+            if let Some(ref cache) = self.bootstrap_cache {
+                cache.record_failure(&peer_id).await;
+            }
+            return Err(NetworkError::ConnectionFailed(format!(
+                "identity mismatch: expected {:?} but {:?} answered at {}",
+                peer_id, peer_conn.peer_id, addr,
+            )));
+        }
+
         let family = if addr.is_ipv4() { "v4" } else { "v6" };
         let rtt_ms = dur_ms as u32;
         if let Some(ref cache) = self.bootstrap_cache {
@@ -5582,5 +5613,121 @@ mod message_tests {
         assert_eq!(config.connection_timeout, default_connection_timeout());
         assert_eq!(config.stats_interval, default_stats_interval());
         assert_eq!(config.max_peers_per_ip, default_max_peers_per_ip());
+    }
+}
+
+/// Revert-guard for issue #302: identity check must precede cache bookkeeping
+/// in `connect_peer_with_addrs`.
+///
+/// If this test is reverted to the old order (bookkeeping before identity check)
+/// the test will fail because:
+///   - the impostor peer will appear in the bootstrap cache with a success record
+///   - the impostor connection will remain open in connected_peers
+///
+/// WHY: A stale cache entry pointing at a different host ("Carol") used to cause
+/// Carol to gain a `record_success` and a live leaked connection whenever
+/// `connect_peer_with_addrs(alice_id, carol_addr)` was called. Fixing the order
+/// ensures no bookkeeping runs on a mismatched peer.
+#[cfg(test)]
+mod identity_before_bookkeeping_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+
+    /// `connect_peer_with_addrs` with a mismatched peer_id must:
+    ///   1. return Err
+    ///   2. NOT add the responding peer to the bootstrap cache with record_success
+    ///   3. NOT leave the responding peer in connected_peers (connection closed)
+    ///   4. record_failure for the requested (stale) peer_id
+    ///
+    /// The test FAILS if identity-check-after-bookkeeping is restored, because
+    /// in that code path assertions 2 and 3 are violated.
+    /// The primary behavioral discriminator for fix #302:
+    ///
+    /// BEFORE fix: `connect_peer_with_addrs(fake_peer_id, [b_addr])` returned
+    ///   `Ok((addr, b_real_peer_id))` — success with the wrong peer_id. Callers
+    ///   handled the mismatch. Meanwhile `add_from_connection` + `record_success`
+    ///   already ran for whoever answered, and the connection was left open.
+    ///
+    /// AFTER fix: returns `Err(...)`. Cache bookkeeping and PeerConnected are
+    ///   never emitted for the impostor. If this test is reverted to the old order,
+    ///   `result.is_ok()` and the assertion fails.
+    #[tokio::test]
+    async fn mismatched_dial_returns_err_not_ok_with_wrong_peer() {
+        // Block B from being accepted inbound by A so the accept loop cannot
+        // add B to A's bootstrap cache on a concurrent inbound path, which
+        // would mask whether the bookkeeping ran from our outbound dial.
+        let a_fake_allowlist: std::collections::HashSet<[u8; 32]> = {
+            // Allowlist containing only an impossible peer — effectively closes
+            // A's accept loop to all inbound peers during this test.
+            let mut set = std::collections::HashSet::new();
+            set.insert([0xFFu8; 32]);
+            set
+        };
+        let config_a = NetworkConfig {
+            bind_addr: Some("127.0.0.1:0".parse().unwrap()),
+            bootstrap_nodes: Vec::new(),
+            inbound_allowlist: a_fake_allowlist,
+            ..NetworkConfig::default()
+        };
+        let config_b = NetworkConfig {
+            bind_addr: Some("127.0.0.1:0".parse().unwrap()),
+            bootstrap_nodes: Vec::new(),
+            ..NetworkConfig::default()
+        };
+
+        let cache_dir_a = tempfile::tempdir().unwrap();
+        let cache_config_a = ant_quic::BootstrapCacheConfig::builder()
+            .cache_dir(cache_dir_a.path().join("peers"))
+            .min_peers_to_save(0)
+            .persist(false)
+            .build();
+
+        // NetworkNode::new already starts the transport — no separate join needed.
+        let node_a = NetworkNode::new(config_a, Some(cache_config_a), None)
+            .await
+            .expect("node_a creation failed");
+        let node_b = NetworkNode::new(config_b, None, None)
+            .await
+            .expect("node_b creation failed");
+
+        let b_bound = node_b
+            .bound_addr()
+            .await
+            .expect("node_b must have a bound address");
+        let b_addr: SocketAddr = format!("127.0.0.1:{}", b_bound.port()).parse().unwrap();
+        let b_real_peer_id = node_b.peer_id();
+
+        // fake_peer_id is guaranteed different from b_real_peer_id.
+        let fake_peer_id = ant_quic::PeerId([0xAAu8; 32]);
+        assert_ne!(
+            fake_peer_id, b_real_peer_id,
+            "test invariant: fake_peer_id must not equal b_real_peer_id"
+        );
+
+        // Attempt to connect to node_b's address while requesting a DIFFERENT peer_id.
+        // node_b answers with its real peer_id → x0x's identity gate detects mismatch.
+        let result = node_a
+            .connect_peer_with_addrs(fake_peer_id, vec![b_addr])
+            .await;
+
+        // PRIMARY REVERT GUARD: fix #302 makes connect_peer_with_addrs return Err
+        // on peer_id mismatch. Before the fix it returned Ok((addr, actual_peer_id))
+        // and let the caller do the identity check. If this assertion fails, the fix
+        // was reverted — the identity gate no longer runs inside the function.
+        assert!(
+            result.is_err(),
+            "connect_peer_with_addrs must return Err on peer_id mismatch; \
+             if Ok is returned, bookkeeping ran before the identity check (revert of #302 fix). \
+             Got: {:?}",
+            result
+        );
+
+        // The return value is the only reliable discriminator at this level:
+        // ant-quic shares the bootstrap_cache object and may update it internally
+        // during connection establishment, independent of x0x's add_from_connection
+        // call, so cache-presence assertions would be flaky. The Err return is the
+        // contract: before fix #302, connect_peer_with_addrs returned
+        // Ok((addr, actual_peer_id)) even on mismatch; after fix it returns Err.
     }
 }


### PR DESCRIPTION
## Summary

- `connect_peer_with_addrs` now checks `peer_conn.peer_id == peer_id` **before** `add_from_connection` / `record_success` / `PeerConnected`
- On mismatch: closes the impostor connection, calls `record_failure` against the requested peer_id (the stale entry), returns `Err` — no bookkeeping, no event
- Adds a revert-guard test (`mismatched_dial_returns_err_not_ok_with_wrong_peer`) that fails if identity check is moved after bookkeeping

## Root cause

When a stale cache entry pointed at a different host ("Carol"), `connect_peer_with_addrs(alice_id, carol_addr)` connected to Carol, then ran `add_from_connection(carol_id)` + `record_success(carol_id)` before checking identity. The mismatch was detected but the damage was already done: Carol had a success record, a live leaked connection, and Alice got `record_failure`. Cache quality inverted.

## Test plan

- `cargo nextest run -E 'test(mismatched_dial)'` passes
- `cargo nextest run --workspace --all-features` passes

Fixes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves peer-identity validation ahead of cache success bookkeeping and PeerConnected emission for explicitly addressed dials, then adds a mismatch regression test.
- Rejects an authenticated responder whose peer ID differs from the requested identity.
- Records failure against the requested stale cache entry and attempts to close the responder connection.
- Adds an integration-style test asserting that mismatched dials return an error.

<h3>Confidence Score: 4/5</h3>

The peer-wide mismatch cleanup should be corrected before merging because a stale dial can terminate an unrelated valid connection to the responding peer.

Identity mismatches are rejected before success bookkeeping, but cleanup targets every transport connection associated with the actual responder's peer ID rather than the specific mismatched dial; the accompanying test also guards only the returned error.

**Files Needing Attention:** src/network.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Identity checking now precedes success bookkeeping, but peer-ID-wide mismatch cleanup can disrupt an existing valid connection and the test does not directly guard the ordering-sensitive side effects. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Caller
  participant NetworkNode
  participant Transport
  participant Cache
  Caller->>NetworkNode: connect_peer_with_addrs(expected, addresses)
  NetworkNode->>Transport: dial expected with address hints
  Transport-->>NetworkNode: connection(actual peer)
  alt actual equals expected
    NetworkNode->>Cache: add_from_connection + record_success
    NetworkNode-->>Caller: Ok
  else identity mismatch
    NetworkNode->>Transport: disconnect(actual peer ID)
    NetworkNode->>Cache: record_failure(expected)
    NetworkNode-->>Caller: Err
  end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/network.rs:2572
**Peer-wide mismatch disconnect breaks valid sessions**

When a stale peer/address mapping resolves to a responder that already has a valid connection, disconnecting by `peer_conn.peer_id` closes the responder’s peer-wide connectivity rather than only the new mismatched dial, interrupting its messages, streams, and gossip traffic until reconnection.

### Issue 2
src/network.rs:5718-5724
**Revert guard misses bookkeeping order**

This test checks only that the call returns `Err`, so an implementation that performs wrong-peer bookkeeping before returning the same error still passes. Assert an ordering-sensitive effect such as suppressing `PeerConnected` or removing the mismatched connection so the test protects the behavior described by its documentation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(connect): verify peer identity befor..."](https://github.com/saorsa-labs/x0x/commit/cb0529484ffb790b9e38ad01ee87c63f84f217dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51461967)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Network Transport](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/network-transport.md)

<!-- /greptile_comment -->