### PR TITLE
release: v0.36.2 — transport wedge fix (asymmetric delivery root cause)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,78 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.36.2] - 2026-08-09
+
+**This release fixes the asymmetric group-message delivery bug that v0.36.1
+could not.** The root cause was in the transport, one layer below everything
+previously investigated, and the fix is live-verified rather than inferred.
+
+### Fixed
+
+- **ant-quic 0.27.36 → 0.27.37 — a transient UDP send error permanently killed
+  the connection driver.** In `State::drive_transmit`, a `Poll::Ready(Err(e))`
+  from `udp_sender.poll_send` was propagated as fatal, ending the per-connection
+  driver task. Once that task was gone the connection state machine was never
+  driven again: no ACKs, no PTO probes, no idle timeout and therefore no
+  `CONNECTION_CLOSE`. `Connection::is_closed()` stayed `false`, so the daemon
+  kept reporting `connected_peers=1, direct_connections=1` while transmitting
+  nothing at all — a silent, permanent, one-way black-hole that looked healthy
+  from every API surface.
+
+  The trigger in the field is `EHOSTUNREACH` (os error 65), raised synchronously
+  by `sendto`. ant-quic already had an `is_transient_socket_error` classifier
+  listing errno 65, added by x0x#262 — but it guarded only the endpoint *receive*
+  path, and the helper was private to `endpoint.rs`. The transmit path in the
+  connection driver was never covered. 0.27.37 makes the classifier
+  `pub(crate)` and applies it in `drive_transmit`: transient errors now drop the
+  single datagram, log at debug, and let QUIC loss recovery retransmit over a
+  working path. Non-transient errors keep the previous fatal behaviour.
+
+  This is the root cause of the asymmetric delivery reported in #296 and #302.
+  Root-cause writeup and packet-level correlation:
+  `.planning/investigations/20260807-120832/wedge-rootcause-20260808.md`.
+
+- **saorsa-gossip 0.5.67 → 0.5.68** — zero-fanout diagnostics and cooling-floor
+  rescue.
+
+- **Machine-discovery cache and connection bookkeeping (#296, PR #300;
+  #302, PR #305; #304, PR #307)** — identity is now established before
+  bookkeeping, disconnect is guarded on a pre-existing connection, and
+  candidate retention no longer discards addresses still needed for redial.
+
+### Verified
+
+Live two-node acceptance run on 2026-08-09 (laptop ↔ Mac Studio over LAN,
+isolated gossip plane, release-profile binaries with default features):
+
+- Roster converged to 2 Active members on both nodes within 60 s.
+- All four messages — top-level and threaded, in both directions — were
+  delivered, with identical `msg_id`s present in both nodes' `history.db` and
+  correct direction flags. Every ingest drop counter stayed at 0.
+- The joining node logged **87** `ignoring transient socket send error` events.
+  Under v0.36.1 the *first* such error terminated its connection driver; here
+  the driver absorbed all 87 and the fatal `background I/O path ended` line
+  appears zero times.
+- A genuine environmental UDP black-hole opened mid-run (an independent probe
+  recorded a 100 %-loss window). Delivery completed through it.
+- Zero panics, zero `ERROR` lines on either node.
+
+### Known issues
+
+- **Group message delivery is correct but slow (~44 s end-to-end).** The
+  direct-unicast delivery path fails before gossip carries the message — the
+  sender burns a ~24 s direct-delivery timeout plus a retry, and the receiver
+  reports `recipient key material unavailable`. Messages arrive intact and in
+  order, but latency is far higher than it should be. This is a distinct defect
+  from the driver wedge and was previously masked, because before this release
+  the affected pair delivered nothing at all. Newly observed; no healthy
+  baseline exists to compare against.
+
+- **The studio1 `EHOSTUNREACH` window itself is unexplained and remains an open
+  ops item.** This release stops that condition from being fatal; it does not
+  stop it from occurring. The leading (unproven) hypothesis is a dual-stack
+  socket selecting an `IPV6_V6ONLY` socket for an IPv4-mapped destination.
+
 ## [v0.36.1] - 2026-08-08
 
 Hardening-only release. **It does not fix the asymmetric group-message delivery

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.36"
+ant-quic = "0.27.37"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"
@@ -40,17 +40,17 @@ hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 rand = "0.8"
-saorsa-gossip-coordinator = "0.5.67"
-saorsa-gossip-crdt-sync = "0.5.67"
-saorsa-gossip-groups = "0.5.67"
-saorsa-gossip-identity = "0.5.67"
-saorsa-gossip-membership = "0.5.67"
-saorsa-gossip-presence = "0.5.67"
-saorsa-gossip-pubsub = "0.5.67"
-saorsa-gossip-rendezvous = "0.5.67"
-saorsa-gossip-runtime = "0.5.67"
-saorsa-gossip-transport = "0.5.67"
-saorsa-gossip-types = "0.5.67"
+saorsa-gossip-coordinator = "0.5.68"
+saorsa-gossip-crdt-sync = "0.5.68"
+saorsa-gossip-groups = "0.5.68"
+saorsa-gossip-identity = "0.5.68"
+saorsa-gossip-membership = "0.5.68"
+saorsa-gossip-presence = "0.5.68"
+saorsa-gossip-pubsub = "0.5.68"
+saorsa-gossip-rendezvous = "0.5.68"
+saorsa-gossip-runtime = "0.5.68"
+saorsa-gossip-transport = "0.5.68"
+saorsa-gossip-types = "0.5.68"
 saorsa-pqc = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.36.1"
+version = "0.36.2"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.36.1
+version: 0.36.2
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com

--- a/src/groups/diagnostics.rs
+++ b/src/groups/diagnostics.rs
@@ -529,13 +529,11 @@ mod tests {
 
         let g = snap.groups.iter().find(|g| g.group_id == "grp").unwrap();
         assert_eq!(
-            g.counters.messages_dropped_write_policy_violation,
-            1,
+            g.counters.messages_dropped_write_policy_violation, 1,
             "receiver-side ingest drop must be in messages_dropped_write_policy_violation only"
         );
         assert_eq!(
-            g.counters.sends_rejected_write_policy,
-            1,
+            g.counters.sends_rejected_write_policy, 1,
             "sender-side local rejection must be in sends_rejected_write_policy only"
         );
     }


### PR DESCRIPTION
Cuts **v0.36.2**. Contains the dependency bumps *and* the release commit in one PR — see "Why one PR" below.

## What this fixes

v0.36.1 shipped with an explicit note that it did **not** fix the asymmetric group-message delivery bug (#296, #302). This release does, and the fix is live-verified rather than inferred.

Root cause was one layer below everything previously investigated. In ant-quic's `State::drive_transmit`, a `Poll::Ready(Err(e))` from `udp_sender.poll_send` was propagated as fatal, ending the per-connection driver task. The connection state machine then stopped being driven entirely — no ACKs, no PTO probes, no idle timeout and therefore no `CONNECTION_CLOSE`. `Connection::is_closed()` stayed `false`, so the daemon kept reporting `connected_peers=1, direct_connections=1` while transmitting nothing: a silent, permanent, one-way black-hole that looked healthy from every API surface.

The field trigger is `EHOSTUNREACH` (os error 65) from `sendto`. ant-quic already had an `is_transient_socket_error` classifier listing errno 65 — added by x0x#262 — but it guarded only the endpoint *receive* path and was private to `endpoint.rs`. The transmit path was never covered. **ant-quic 0.27.37** makes the classifier `pub(crate)` and applies it in `drive_transmit`.

## Changes

- `ant-quic` 0.27.36 → **0.27.37** (the wedge fix above)
- `saorsa-gossip-*` (11 crates) 0.5.67 → **0.5.68** — zero-fanout diagnostics, cooling-floor rescue
- version 0.36.1 → 0.36.2 (`Cargo.toml`, `SKILL.md`), CHANGELOG entry
- Reflows two `assert_eq!` calls in `src/groups/diagnostics.rs` that landed unformatted on `main` — `cargo fmt --all -- --check` was already failing on `origin/main` before this branch
- Carries the already-merged #300 / #305 / #307 machine-discovery and bookkeeping fixes

## Live acceptance run (2026-08-09)

Two nodes, laptop ↔ Mac Studio over LAN, isolated gossip plane, release-profile binaries with **default** features (matching the release workflow). Gated on a mandatory bidirectional UDP probe that ran clean (20/20 each way) before any daemon started.

- Roster converged to 2 Active on **both** nodes within 60 s
- All four messages — top-level and threaded, **both** directions — delivered, with identical `msg_id`s in both nodes' `history.db` and correct direction flags. Every ingest drop counter 0.
- The joining node logged **87** `ignoring transient socket send error` events. Under v0.36.1 the *first* such error killed its connection driver; here the driver absorbed all 87 and the fatal `background I/O path ended` line appears **zero** times on both nodes.
- A genuine environmental UDP black-hole opened mid-run (independent probe recorded a 100 %-loss window) and **delivery completed through it**.
- Zero panics, zero `ERROR` lines either side.

Artifacts in `.planning/investigations/20260807-120832/`: `results-v0362-acceptance-20260809-101531.txt`, `x0xd-accept-a.log`, `x0xd-accept-b.log`, `probe-during-*.log`.

## Known issues — stated, not glossed

- **Delivery is correct but slow (~44 s end-to-end).** The direct-unicast path fails before gossip carries the message: sender burns a ~24 s direct-delivery timeout plus retry, receiver reports `recipient key material unavailable`. Distinct from the driver wedge, and previously masked because the affected pair delivered nothing at all. Newly observed; no healthy baseline to compare against.
- **The studio1 `EHOSTUNREACH` window is unexplained and stays an open ops item.** This release stops it being fatal; it does not stop it occurring.

## Gate

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace --all-features --no-fail-fast --retries 2` — 2570/2570 passed, 256 skipped, zero retries consumed (on the dependency-bump commit; re-running on the release commit)

Disclosure: one initial fail-fast run hit `a2a_binding_integration::unary_round_trip_over_dm` (`address-only dial: hole-punch requires the target's PeerId`); it passed first-try on the clean re-run without consuming a retry, and CI's Test Suite is green. Not on the project's known-flake list, so noting it — it sits in the #296/#302 problem area.

## Why one PR

The plan was two PRs (bump, then release). `gh pr merge` is not available to the agent, so the bump PR could not be landed before cutting the release. Splitting would have produced a release PR that still contained the bump commits, so both are collapsed here: **one merge lands v0.36.2**.

After merging, tag `v0.36.2` on the merge commit and push the tag to trigger the Release workflow and fleet self-update.