### PR TITLE
chore(release): v0.37.0 — raw-preferred delivery, raw-DM history, consent-gated bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.37.0] - 2026-08-10
+
+Delivery-path follow-up to the v0.36.2 transport wedge fix: raw-QUIC direct
+delivery becomes the preferred path, gains durable history, and signed-public
+groups get a consent-gated cold-start bootstrap.
+
+### Added
+
+- **SignedPublic group bootstrap over the direct channel.** When an admin adds
+  a member to a SignedPublic group, the authority direct-sends a
+  secret-stripped, commit-bound roster snapshot so a cold-start member can
+  install the group without waiting for gossip anti-entropy. The receiver
+  validates genesis, roster root, policy hash, and the sealed head commit
+  (ML-DSA) before installing; existing local state is never overwritten.
+- **Consent gate + capacity cap on bootstrap install.** Bootstraps are only
+  accepted from senders the local agent already knows (contact trust ≥ Known),
+  and `MAX_BOOTSTRAP_INSTALLED_GROUPS = 256` bounds remote-triggered group
+  state and listener-task growth. The roster inside a bootstrap is
+  sender-controlled and cannot carry the consent decision.
+- **Durable ADR-0023 history for raw-QUIC DMs.** Direct messages arriving on
+  the raw-QUIC receive-ACK path previously bypassed the gossip-inbox recorder
+  and left no history row; they are now recorded (gated on transport
+  verification, trust decision, and payload classification).
+- **ADR-0029 thread metadata in `GET /history`.** Group rows now expose the
+  canonical `msg_id` and recovered `thread_root`/`thread_parent`.
+
+### Changed
+
+- **`prefer_raw_quic_if_connected` now defaults ON** for direct sends and
+  group public messages. The REST field is now `Option<bool>`: omitting it
+  selects the daemon default (previously `false`). Clients that relied on the
+  old default must send `"prefer_raw_quic_if_connected": false` explicitly.
+  Welcome-blob control messages explicitly keep gossip preference — a welcome
+  fetch races the very connection raw delivery depends on.
+- Named-group metadata events from `add_named_group_member` are now also
+  direct-delivered to active members, matching the existing convention on
+  remove/update/join.
+
 ## [v0.36.2] - 2026-08-09
 
 **This release fixes the asymmetric group-message delivery bug that v0.36.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.36.2"
+version = "0.37.0"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.36.2
+version: 0.37.0
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Version bump 0.36.2 → 0.37.0 + CHANGELOG for the delivery-path follow-up merged in #313.

Highlights: raw-QUIC becomes the preferred direct path (REST default flip, documented), raw-path DMs gain durable ADR-0023 history, SignedPublic groups get a consent-gated (trust ≥ Known, 256-group cap) cold-start bootstrap, /history exposes ADR-0029 thread fields.

Tag v0.37.0 after merge triggers release.yml (artifacts + self-update manifest; prod fleet converges via self-update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the project release metadata and documentation for v0.37.0.

- Bumps the Rust package and skill metadata from 0.36.2 to 0.37.0.
- Documents raw-QUIC preference, durable raw-DM history, consent-gated SignedPublic bootstrap, and history thread metadata.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The release version is synchronized across the repository’s version-bearing files, and the changelog-only additions do not alter executable behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds the v0.37.0 release notes describing the delivery, history, bootstrap, and API changes already merged. |
| Cargo.toml | Bumps the crate version to 0.37.0 consistently with the repository’s release metadata. |
| SKILL.md | Bumps the published skill version to 0.37.0, matching Cargo.toml. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.37.0 — raw-preferred ..."](https://github.com/saorsa-labs/x0x/commit/573c1ef594a4f22995b54b0dd86591a6b2f5a284) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51735911)</sub>

<!-- /greptile_comment -->