### PR TITLE
test(server): handler-level wiring tests for bootstrap dispatch and raw-DM history (F2)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,3 +25,7 @@ test-group = "quic-localhost"
 [[profile.default.overrides]]
 filter = "binary(threading_integration)"
 test-group = "quic-localhost"
+
+[[profile.default.overrides]]
+filter = "binary(f2_public_group_bootstrap_wiring)"
+test-group = "quic-localhost"

--- a/tests/direct_messaging_integration.rs
+++ b/tests/direct_messaging_integration.rs
@@ -7,6 +7,7 @@
 
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
+use x0x::history::{Direction, HistoryConfig, HistoryQuery, HistoryRecord, Provenance, Scope};
 use x0x::identity::{AgentId, MachineId};
 use x0x::network::NetworkConfig;
 use x0x::{Agent, DirectMessage, DiscoveredAgent};
@@ -248,6 +249,161 @@ async fn test_send_direct_loopback_delivery_between_agents(
     assert!(received.verified);
 
     Ok(())
+}
+
+/// The raw-QUIC receive loop — not just `raw_dm_history_record` in isolation —
+/// must persist an inbound history row for a verified direct message.
+///
+/// The two unit tests in `src/lib.rs` (`verified_raw_dm_builds_durable_inbound_history`
+/// and `raw_dm_history_rejects_unverified_blocked_and_plumbing_payloads`) call
+/// `raw_dm_history_record` directly and never reach the listener, so they stay
+/// green if the production call site is deleted. This test drives a real DM
+/// down the raw path and reads the receiver's durable store.
+///
+/// REVERT GUARD: delete the `if let (Some(history), Some(record)) = (...)
+/// { history.record(record); }` block from `Agent::start_direct_listener`
+/// (src/lib.rs, the ADR-0023 comment above the raw-QUIC recorder) and this
+/// test fails with "raw-QUIC receive loop must persist an inbound history
+/// row". Both `raw_dm_history_record` unit tests keep passing.
+///
+/// Why only the raw path can satisfy this assertion: the other inbound
+/// recorder is `dm_inbox::DmInboxService`, which is spawned exclusively by
+/// `Agent::start_dm_inbox` — called only by the daemon (`src/server/mod.rs`),
+/// never by `Agent::builder()`. Bob therefore has no gossip inbox at all, and
+/// the `DmPath::RawQuic` receipt asserted below confirms Alice used the raw
+/// stream rather than a gossip envelope. Alice's outbound recorder writes to
+/// *her* store, and she has history disabled.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn raw_dm_receive_loop_records_inbound_history() {
+    let temp_dir = TempDir::new().unwrap();
+
+    // Alice sends with history disabled so the only writer touching a store in
+    // this test is Bob's inbound raw-QUIC recorder.
+    let alice = Agent::builder()
+        .with_machine_key(temp_dir.path().join("alice_history_machine.key"))
+        .with_agent_key_path(temp_dir.path().join("alice_history_agent.key"))
+        .with_contact_store_path(temp_dir.path().join("alice_history_contacts.json"))
+        .with_peer_cache_disabled()
+        .with_network_config(loopback_network_config())
+        .build()
+        .await
+        .expect("alice");
+
+    let bob = Agent::builder()
+        .with_machine_key(temp_dir.path().join("bob_history_machine.key"))
+        .with_agent_key_path(temp_dir.path().join("bob_history_agent.key"))
+        .with_contact_store_path(temp_dir.path().join("bob_history_contacts.json"))
+        .with_peer_cache_disabled()
+        .with_network_config(loopback_network_config())
+        .with_history(HistoryConfig {
+            enabled: true,
+            db_path: Some(temp_dir.path().join("bob_history.db")),
+            ..HistoryConfig::default()
+        })
+        .build()
+        .await
+        .expect("bob");
+
+    alice.join_network().await.expect("alice join_network");
+    bob.join_network().await.expect("bob join_network");
+
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let alice_addr = normalize_loopback(alice_network.bound_addr().await.expect("alice bound"));
+    let bob_addr = normalize_loopback(bob_network.bound_addr().await.expect("bob bound"));
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+
+    let connected = alice_network
+        .connect_addr(bob_addr)
+        .await
+        .expect("alice must connect to bob");
+    assert_eq!(connected.0, bob.machine_id().0);
+
+    let connected_deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < connected_deadline {
+        if alice_network.is_connected(&bob_peer).await {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(alice_network.is_connected(&bob_peer).await);
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_secs();
+    // Bob's discovery cache is what makes the inbound AgentId->MachineId
+    // binding `verified`; without it `raw_dm_history_record` returns None and
+    // no row is ever built, regardless of the call site.
+    alice
+        .insert_discovered_agent_for_testing(discovered_agent(&bob, bob_addr, now_secs))
+        .await;
+    bob.insert_discovered_agent_for_testing(discovered_agent(&alice, alice_addr, now_secs))
+        .await;
+    alice
+        .direct_messaging()
+        .mark_connected(bob.agent_id(), bob.machine_id())
+        .await;
+
+    let payload = br#"{"text":"raw-history-wiring","clientId":"f2-raw-dm"}"#.to_vec();
+    let receipt = alice
+        .send_direct(&bob.agent_id(), payload.clone())
+        .await
+        .expect("send_direct must succeed");
+    assert_eq!(
+        receipt.path,
+        x0x::dm::DmPath::RawQuic,
+        "this test only guards the raw-QUIC recorder; a gossip-path receipt \
+         would mean the message never reached the listener under test"
+    );
+
+    let history = bob.history().expect("bob history enabled").clone();
+    let scope = Scope::Dm(hex::encode(alice.agent_id().as_bytes()));
+    let expected_msg_id = HistoryRecord::compute_msg_id(None, &payload);
+
+    // The history writer is a background thread, so the row lands
+    // asynchronously; poll rather than sleep a fixed interval.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let row = loop {
+        let query_handle = history.clone();
+        let query_scope = scope.clone();
+        let rows = tokio::task::spawn_blocking(move || {
+            query_handle
+                .store()
+                .query(&HistoryQuery {
+                    scope: Some(query_scope),
+                    limit: 16,
+                    ..HistoryQuery::default()
+                })
+                .expect("history query")
+        })
+        .await
+        .expect("history query task");
+
+        if let Some(row) = rows
+            .into_iter()
+            .find(|row| row.record.msg_id == expected_msg_id)
+        {
+            break row;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "raw-QUIC receive loop must persist an inbound history row for a \
+             verified DM within 5 s; if this fails, the `history.record(record)` \
+             call was removed from Agent::start_direct_listener (the two \
+             raw_dm_history_record unit tests cannot catch that)"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+
+    assert_eq!(
+        row.record.author_agent,
+        Some(hex::encode(alice.agent_id().as_bytes())),
+        "the persisted row must attribute the message to the sending agent"
+    );
+    assert_eq!(row.record.direction, Direction::Inbound);
+    assert_eq!(row.record.payload, payload);
+    assert_eq!(row.record.provenance, Provenance::VerifiedEnvelope);
 }
 
 /// Test the DirectMessageReceiver subscription mechanism.

--- a/tests/f2_public_group_bootstrap_wiring.rs
+++ b/tests/f2_public_group_bootstrap_wiring.rs
@@ -222,12 +222,17 @@ async fn serve_installs_signed_public_group_from_direct_bootstrap() {
     }
 
     // The installed group must be bob's, not a locally-created shell: the
-    // authority is the sender and alice is an active member.
+    // creator is the sending authority (alice cannot locally create a group
+    // whose creator is bob) and the roster carries both members.
     let groups = alice.get_json("/groups").await;
     let installed = group_entry(&groups, &group_name).expect("installed group entry");
-    assert!(
-        installed.to_string().contains(&bob_agent),
-        "the installed roster must carry bob as the authority: {installed:?}"
+    assert_eq!(
+        installed["creator"], bob_agent,
+        "the installed group's creator must be the sending authority: {installed:?}"
+    );
+    assert_eq!(
+        installed["member_count"], 2,
+        "the installed roster must carry both the authority and alice: {installed:?}"
     );
 }
 

--- a/tests/f2_public_group_bootstrap_wiring.rs
+++ b/tests/f2_public_group_bootstrap_wiring.rs
@@ -1,0 +1,248 @@
+//! Handler-level wiring test for the signed-public group bootstrap dispatch
+//! (review finding F2 on v0.37.0).
+//!
+//! `serve_with_options` spawns a background listener on the direct channel that
+//! deserializes a `PublicGroupBootstrap`, drops unverified senders, and calls
+//! `handle_public_group_bootstrap`. The unit tests around that handler
+//! (`signed_public_bootstrap_is_secret_free_and_commit_bound` and friends in
+//! `src/server/routes/named_groups.rs`) exercise the snapshot and the handler in
+//! isolation — deleting the dispatch block from `serve_with_options` leaves all
+//! of them green while remote bootstrap silently stops working.
+//!
+//! This test drives the real thing: two in-process daemons, a SignedPublic group
+//! created on the authority, a member add that direct-sends the snapshot, and an
+//! assertion that the group is installed on the receiver.
+//!
+//! Unlike `tests/server_inprocess.rs` (whose tests are all `#[ignore]`), this one
+//! runs in the default suite: it binds only loopback, uses ephemeral ports, and
+//! completes in a couple of seconds because it never waits on a gossip mesh.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::time::Duration;
+
+use serde_json::Value;
+use x0x::server::{serve_with_options, DaemonConfig, ServeOptions, ServerHandle};
+
+/// A running in-process daemon plus a pre-authenticated REST client.
+struct Daemon {
+    _handle: ServerHandle,
+    client: reqwest::Client,
+    base: String,
+}
+
+impl Daemon {
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base)
+    }
+
+    async fn get_json(&self, path: &str) -> Value {
+        self.client
+            .get(self.url(path))
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("GET {path}: {e}"))
+            .json()
+            .await
+            .unwrap_or_else(|e| panic!("GET {path} json: {e}"))
+    }
+
+    async fn post_json(&self, path: &str, body: Value) -> Value {
+        self.client
+            .post(self.url(path))
+            .json(&body)
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("POST {path}: {e}"))
+            .json()
+            .await
+            .unwrap_or_else(|e| panic!("POST {path} json: {e}"))
+    }
+}
+
+/// Start a hermetic daemon: loopback-only, ephemeral API and QUIC ports, all
+/// state under `dir`, and — critically for this test — an explicitly EMPTY
+/// bootstrap-peer list, so the two daemons never form a gossip mesh.
+async fn start_daemon(dir: &Path) -> Daemon {
+    let data_dir = dir.join("data");
+    tokio::fs::create_dir_all(&data_dir)
+        .await
+        .expect("create data dir");
+
+    // Pin the API token up front rather than reading it back: `serve` only
+    // generates one when `<data_dir>/api-token` is absent.
+    let token = "f2".repeat(32);
+    tokio::fs::write(data_dir.join("api-token"), &token)
+        .await
+        .expect("write api token");
+
+    let mut config = DaemonConfig::default();
+    config.api_address = SocketAddr::from(([127, 0, 0, 1], 0));
+    config.bind_address = SocketAddr::from(([127, 0, 0, 1], 0));
+    config.bootstrap_peers = Some(Vec::new());
+    config.data_dir = data_dir;
+    config.identity_dir = Some(dir.join("identity"));
+
+    let options = ServeOptions {
+        skip_update_check: true,
+        self_update_enabled: false,
+        ..ServeOptions::default()
+    };
+    let handle = serve_with_options(config, options)
+        .await
+        .expect("serve_with_options should start");
+    let base = format!("http://{}", handle.local_addr());
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_str(&format!("Bearer {token}")).expect("auth header"),
+    );
+    let client = reqwest::Client::builder()
+        .default_headers(headers)
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("client");
+
+    Daemon {
+        _handle: handle,
+        client,
+        base,
+    }
+}
+
+/// A newly-added member must receive and install the authority's SignedPublic
+/// roster snapshot over the direct channel.
+///
+/// REVERT GUARD: delete the `handle_public_group_bootstrap(&bootstrap_state,
+/// &msg.sender, bootstrap).await` call (or the whole "signed-public group
+/// bootstrap listener" block) from `serve_with_options` in `src/server/mod.rs`
+/// and this test fails with "daemon A never installed the SignedPublic group".
+/// `signed_public_bootstrap_is_secret_free_and_commit_bound` and the other
+/// named-group unit tests keep passing, because they call the snapshot builder
+/// and the handler directly and never go through the listener.
+///
+/// Why the direct dispatch is the ONLY way the group can reach daemon A here:
+/// both daemons run with `bootstrap_peers = Some(vec![])`, so neither seeds any
+/// gossip peer and no metadata topic mesh exists between them. The only link is
+/// the QUIC connection `/agents/connect` opens, and the only thing sent over it
+/// is the bootstrap snapshot `add_named_group_member` direct-sends. The
+/// named-group metadata listener cannot substitute: it applies commits to an
+/// existing local group and never creates one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn serve_installs_signed_public_group_from_direct_bootstrap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // `alice` is the receiving member, `bob` is the group authority.
+    let alice = start_daemon(&tmp.path().join("alice")).await;
+    let bob = start_daemon(&tmp.path().join("bob")).await;
+
+    // `include_local_addresses` is required for loopback: the card filters to
+    // globally-advertisable addresses otherwise, and 127.0.0.1 is not one.
+    let card_path = "/agent/card?include_local_addresses=true";
+    let alice_card = alice.get_json(card_path).await;
+    let bob_card = bob.get_json(card_path).await;
+    let alice_agent = alice_card["card"]["agent_id"]
+        .as_str()
+        .expect("alice agent_id")
+        .to_string();
+    let bob_agent = bob_card["card"]["agent_id"]
+        .as_str()
+        .expect("bob agent_id")
+        .to_string();
+    let alice_link = alice_card["link"].as_str().expect("alice card link");
+    let bob_link = bob_card["link"].as_str().expect("bob card link");
+
+    // Card import is what gives each side the other's AgentId->MachineId
+    // binding (so the inbound direct message is `verified`) and the contact
+    // trust the bootstrap consent gate requires (>= Known).
+    let imported = alice
+        .post_json(
+            "/agent/card/import",
+            serde_json::json!({ "card": bob_link, "trust_level": "trusted" }),
+        )
+        .await;
+    assert_eq!(imported["ok"], true, "alice import of bob: {imported:?}");
+    let imported = bob
+        .post_json(
+            "/agent/card/import",
+            serde_json::json!({ "card": alice_link, "trust_level": "trusted" }),
+        )
+        .await;
+    assert_eq!(imported["ok"], true, "bob import of alice: {imported:?}");
+
+    let connected = bob
+        .post_json(
+            "/agents/connect",
+            serde_json::json!({ "agent_id": alice_agent }),
+        )
+        .await;
+    assert_eq!(connected["ok"], true, "bob -> alice connect: {connected:?}");
+
+    // `public_open` is the preset whose confidentiality is SignedPublic; the
+    // bootstrap snapshot is built only for SignedPublic groups.
+    let group_name = format!("f2-bootstrap-{}", rand::random::<u32>());
+    let created = bob
+        .post_json(
+            "/groups",
+            serde_json::json!({
+                "name": group_name,
+                "description": "F2 bootstrap dispatch wiring",
+                "preset": "public_open",
+            }),
+        )
+        .await;
+    assert_eq!(created["ok"], true, "create group: {created:?}");
+    let group_id = created["group_id"].as_str().expect("group_id").to_string();
+
+    // The member add is what direct-sends the bootstrap snapshot to alice.
+    let added = bob
+        .post_json(
+            &format!("/groups/{group_id}/members"),
+            serde_json::json!({ "agent_id": alice_agent, "display_name": "alice" }),
+        )
+        .await;
+    assert_eq!(added["ok"], true, "add member: {added:?}");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let groups = alice.get_json("/groups").await;
+        if group_listing_contains(&groups, &group_name) {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "daemon A never installed the SignedPublic group within 10 s; if this \
+             fails, the PublicGroupBootstrap dispatch block was removed from \
+             serve_with_options (the named-group unit tests cannot catch that). \
+             alice /groups = {groups:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // The installed group must be bob's, not a locally-created shell: the
+    // authority is the sender and alice is an active member.
+    let groups = alice.get_json("/groups").await;
+    let installed = group_entry(&groups, &group_name).expect("installed group entry");
+    assert!(
+        installed.to_string().contains(&bob_agent),
+        "the installed roster must carry bob as the authority: {installed:?}"
+    );
+}
+
+fn group_entries(groups: &Value) -> &[Value] {
+    groups["groups"]
+        .as_array()
+        .map_or(&[][..], |entries| entries.as_slice())
+}
+
+fn group_entry<'a>(groups: &'a Value, name: &str) -> Option<&'a Value> {
+    group_entries(groups)
+        .iter()
+        .find(|entry| entry["name"].as_str() == Some(name))
+}
+
+fn group_listing_contains(groups: &Value, name: &str) -> bool {
+    group_entry(groups, name).is_some()
+}


### PR DESCRIPTION
## Purpose

Closes review finding **F2** on v0.37.0 (`c5f3208`): both headline features shipped with unit tests covering the new functions in isolation, but nothing failed if the production call sites were deleted — the house "functions tested, wiring not" failure mode. This PR is transport-layer test coverage only; **zero production changes** (the diff is two new test files, +404 lines).

## ADR alignment

- **ADR 0025** (required gates prove observation completeness): both tests are handler-level wiring tests in the style of `26d7749`, run in the default suite, no `#[ignore]`, no silent self-skip. Each carries an explicit REVERT GUARD doc comment naming the production line whose deletion makes it fail.
- **ADR 0023** (durable local history): test 1 pins the raw-QUIC receive-ACK path's history recording — the exact gap v0.37.0 filled.
- **ADR 0007/0008** (identity/trust): test 2 exercises the real consent path — agent-card import supplies both the verified AgentId→MachineId binding and the ≥ Known contact trust the bootstrap consent gate requires.

## The two tests

1. **`raw_dm_receive_loop_records_inbound_history`** (`tests/direct_messaging_integration.rs`)
   Two loopback Agents, history enabled only on the receiver, a real DM over the raw path (asserted via `DmPath::RawQuic`), polled read of the durable store. The raw recorder is provably the only writer: `DmInboxService` is spawned only by the daemon (`start_dm_inbox`), so a bare Agent has no gossip-inbox recorder.
   **Revert guard proven**: suppressing `history.record(record)` in `start_direct_listener` → test FAILS in 5.4s; the two existing unit tests stay green.

2. **`serve_installs_signed_public_group_from_direct_bootstrap`** (`tests/f2_public_group_bootstrap_wiring.rs`)
   Two in-process daemons via `serve_with_options`, mutual `/agent/card/import`, SignedPublic group created on the authority, member add direct-sends the bootstrap, poll the recipient's `GET /groups`. With `bootstrap_peers = Some(vec![])` there is no gossip mesh, and the direct bootstrap dispatch is the **only** remote install path for a SignedPublic group — no false-pass possible.
   **Revert guard proven**: suppressing the `handle_public_group_bootstrap` dispatch in `serve_with_options` → test FAILS in 10.7s with the recipient's `/groups` empty; `signed_public_bootstrap_is_secret_free_and_commit_bound` stays green.

## Mixed-version impact

None — test-only change, no wire, REST, or config surface touched.

## Gates (exact pushed tree, real exit codes)

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — exit 0
- `cargo nextest run --workspace --all-features --no-fail-fast` — **2578/2578 passed**, 260 skipped (pre-existing `#[ignore]`)

## Residual observation (filed separately)

Two pre-existing loopback tests flaked once each under full parallel load during validation (`direct_send_with_require_ack_round_trips_to_live_peer`, `suppressed_peer_inbound_redial_is_rejected`); both pass repeatedly in isolation and the final full run was green. Filed as a flaky-test issue in the style of #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds required handler-level integration coverage for raw-QUIC inbound history persistence and direct SignedPublic group bootstrap installation.
- Exercises a real raw DM and polls the receiver's durable history store.
- Starts two authenticated in-process daemons and verifies direct bootstrap installation without a gossip mesh.
- The new daemon-backed test needs the repository's localhost-QUIC serialization, and its final roster assertion does not inspect roster fields.

<h3>Confidence Score: 4/5</h3>

The test-only PR needs the new daemon-backed test serialized with other localhost QUIC tests before merging; the roster assertion should also inspect explicit member roles and states.

The new default-suite test starts two real QUIC daemons outside the repository's serialization group, exposing required runs to a known concurrent-loopback flake, while its final JSON substring assertion cannot verify the roster properties it claims.

**Files Needing Attention:** tests/f2_public_group_bootstrap_wiring.rs and .config/nextest.toml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/direct_messaging_integration.rs | Adds a well-isolated raw-QUIC receive-loop test that verifies the expected inbound durable-history record. |
| tests/f2_public_group_bootstrap_wiring.rs | Adds effective direct-bootstrap wiring coverage, but omits required QUIC test serialization and uses a summary-field substring check for its roster assertion. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Bob as Authority daemon
  participant Direct as Direct channel
  participant Alice as Member daemon
  participant API as Alice REST API
  Bob->>Bob: Create SignedPublic group
  Bob->>Bob: Add Alice as member
  Bob->>Direct: Send signed bootstrap snapshot
  Direct->>Alice: Dispatch PublicGroupBootstrap
  Alice->>Alice: Validate and install group
  API->>Alice: GET /groups
  Alice-->>API: Installed group summary
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tests/f2_public_group_bootstrap_wiring.rs:132-133
**Missing QUIC test serialization**

If the default suite runs this test alongside another localhost QUIC test, these two in-process daemons run outside the repository's single-threaded `quic-localhost` group, causing the intermittent ant-quic connection failures or hangs that the group is intended to prevent.

### Issue 2
tests/f2_public_group_bootstrap_wiring.rs:228-231
**Roster assertion checks summary field**

`GET /groups` exposes Bob's ID in the `creator` summary field but contains no member roles or states, so this substring assertion does not verify that Bob is the authority or Alice is an active member. Query the installed group or members endpoint and assert the explicit roster fields so malformed bootstrap state cannot satisfy this coverage.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(server): handler-level wiring tests..."](https://github.com/saorsa-labs/x0x/commit/7b12d3568279171bb0be075fc8245cf5e4980c0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52696553)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Required Test Gates: Observation Completeness](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/test-gate-policy.md)
- Knowledge Base — [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)
- Knowledge Base — [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)
</details>

<!-- /greptile_comment -->