### PR TITLE
fix: slice 1 — six ops-correctness fixes from the durable-app-ack campaign (no send-contract change)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -29,3 +29,23 @@ test-group = "quic-localhost"
 [[profile.default.overrides]]
 filter = "binary(f2_public_group_bootstrap_wiring)"
 test-group = "quic-localhost"
+
+# Issue #316: these two loopback tests flake only under full parallel load
+# (never in isolation). Serial-group placement alone proved insufficient —
+# the trigger is ambient suite load starving their timing windows, not
+# group-internal contention — so they also reserve scheduler slots via
+# threads-required. Not retries, not wider deadlines (ADR 0025 — a flake
+# is not an observation).
+[[profile.default.overrides]]
+filter = "test(direct_send_with_require_ack_round_trips_to_live_peer) | test(=tests::suppressed_peer_inbound_redial_is_rejected)"
+test-group = "quic-localhost"
+threads-required = 4
+
+# The slice-1 regression tests each stand up multiple loopback QUIC
+# endpoints; unserialized they add enough contention to break the
+# gossip_plane_isolation stay-down window (2-of-2 full-run repro, green
+# with these excluded, green on the v0.37.1 baseline). The plane-isolation
+# binary itself is multi-endpoint loopback and belongs in the group too.
+[[profile.default.overrides]]
+filter = "test(discovered_but_disconnected_peer_is_dialed_by_same_send) | test(identity_epoch_converges_with_linear_application_publishes) | test(non_treekem_self_leave_directly_delivers_member_removed_to_retained_owner) | binary(gossip_plane_isolation)"
+test-group = "quic-localhost"

--- a/docs/upgrade-system.md
+++ b/docs/upgrade-system.md
@@ -27,6 +27,11 @@ Manifest-based decentralized self-update with symmetric gossip propagation.
 
 Both apply paths back off versions that fail to apply: a failed version is recorded and skipped for 30 minutes before retrying (a newer release supersedes the skip immediately). This prevents a release that can never apply in a given environment from re-downloading and re-extracting on every gossip receipt.
 
+`x0xd --skip-update-check` disables self-update for that process invocation. It
+suppresses the startup GitHub check, gossip-delivered apply, manifest broadcast,
+fallback polling, and manual `/upgrade/apply`. The setting is not persisted;
+launching the daemon normally later restores the configured updater behavior.
+
 All nodes verify and rebroadcast manifests (symmetric propagation — no privileged bootstrap role).
 
 ## CI Integration

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -11,7 +11,7 @@
 //! x0xd --config /path/to/config.toml    # custom config
 //! x0xd --check                          # validate config and exit
 //! x0xd --check-updates                  # check/apply updates and exit
-//! x0xd --skip-update-check              # start daemon without startup update check
+//! x0xd --skip-update-check              # run daemon with self-update disabled
 //! x0xd --name alice                     # run a named instance (separate identity)
 //! x0xd --list                           # list running instances
 //! ```
@@ -100,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
         println!("    --connect-acl <PATH>            Override default connect ACL path");
         println!("    --check                         Check configuration and exit");
         println!("    --check-updates       Check for updates and exit");
-        println!("    --skip-update-check   Skip update check on startup");
+        println!("    --skip-update-check   Disable self-update for this process");
         println!("    --doctor              Run diagnostics");
         println!("    --version, -V         Print version and exit");
         println!("    --help, -h            Print this help and exit");
@@ -303,8 +303,9 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Phase 2 (Issue #110): start the server via the library handle. The daemon
-    // opts in to self-update (so behaviour is unchanged) and owns Ctrl-C itself
-    // — the library must not steal the host's signal.
+    // opts in to configured self-update unless this invocation supplied the
+    // process-scoped skip flag, and owns Ctrl-C itself — the library must not
+    // steal the host's signal.
     let self_update_enabled = config.update_enabled();
     let options = ServeOptions {
         skip_update_check,

--- a/src/history/record.rs
+++ b/src/history/record.rs
@@ -187,7 +187,8 @@ pub struct HistoryRecord {
     pub seen_at_ms: i64,
     /// Direction relative to this node.
     pub direction: Direction,
-    /// MIME content type of `payload`; only `text/*` rows are FTS-indexed.
+    /// MIME content type of `payload`; `text/*` rows and recognized native
+    /// channel-message JSON bodies are FTS-indexed.
     pub content_type: String,
     /// Decrypted application payload — what a UI renders and search indexes.
     pub payload: Vec<u8>,
@@ -273,7 +274,7 @@ impl HistoryRecord {
         Ok(())
     }
 
-    /// True when the payload should be FTS-indexed.
+    /// True when the complete payload should be FTS-indexed as text.
     #[must_use]
     pub fn is_text(&self) -> bool {
         self.content_type.starts_with("text/")

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -18,7 +18,7 @@ use crate::error::{HistoryError, HistoryResult};
 use super::record::{Direction, HistoryRecord, Provenance, Scope};
 
 /// Current schema version (forward-only migrations).
-const SCHEMA_VERSION: i64 = 1;
+const SCHEMA_VERSION: i64 = 2;
 
 /// Maximum rows a single query may return.
 pub const MAX_QUERY_LIMIT: usize = 500;
@@ -247,8 +247,9 @@ impl Store {
         collect_rows(&guard, &sql, params)
     }
 
-    /// Full-text search over text payloads. Tokens are quoted so user input
-    /// is literal terms, never FTS operators (donor `fts_match_expr`).
+    /// Full-text search over searchable payload text. Tokens are quoted so
+    /// user input is literal terms, never FTS operators (donor
+    /// `fts_match_expr`).
     pub fn search(&self, needle: &str, q: &HistoryQuery) -> HistoryResult<Vec<StoredRecord>> {
         let fts = fts_match_expr(needle);
         if fts.is_empty() {
@@ -528,11 +529,7 @@ fn row_to_record(r: &rusqlite::Row<'_>) -> RowResult {
 }
 
 fn insert_row(tx: &rusqlite::Transaction<'_>, record: &HistoryRecord) -> HistoryResult<()> {
-    let payload_text: Option<String> = if record.is_text() {
-        Some(String::from_utf8_lossy(&record.payload).into_owned())
-    } else {
-        None
-    };
+    let payload_text = searchable_payload_text(&record.content_type, &record.payload);
     let msg_id: &[u8] = &record.msg_id;
     tx.execute(
         "INSERT INTO history (msg_id, scope_kind, scope_id, author_agent, author_machine, \
@@ -581,6 +578,7 @@ fn migrate(conn: &Connection) -> HistoryResult<()> {
             Ok(())
         }
         Some(v) if v == SCHEMA_VERSION => Ok(()),
+        Some(1) => migrate_v1_to_v2(conn),
         Some(v) if v < SCHEMA_VERSION => {
             // Future migrations chain here, bumping stored version each step.
             Err(HistoryError::Database(format!(
@@ -591,6 +589,82 @@ fn migrate(conn: &Connection) -> HistoryResult<()> {
             "history.db schema v{v} is newer than this binary (v{SCHEMA_VERSION})"
         ))),
     }
+}
+
+/// Schema v2 adds no columns: it backfills the existing FTS projection for
+/// native channel-message JSON that schema v1 intentionally left empty. The
+/// `history_fts_au` trigger refreshes each corresponding FTS row atomically.
+fn migrate_v1_to_v2(conn: &Connection) -> HistoryResult<()> {
+    let tx = conn.unchecked_transaction()?;
+    let mut after_id = 0_i64;
+    loop {
+        let candidates = {
+            let mut stmt = tx.prepare(
+                "SELECT id, payload FROM history \
+                 WHERE content_type = 'application/json' AND payload_text IS NULL AND id > ?1 \
+                 ORDER BY id LIMIT 256",
+            )?;
+            let rows = stmt.query_map(rusqlite::params![after_id], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?))
+            })?;
+            let mut candidates = Vec::new();
+            for row in rows {
+                candidates.push(row?);
+            }
+            candidates
+        };
+        let Some((last_id, _)) = candidates.last() else {
+            break;
+        };
+        after_id = *last_id;
+        for (id, payload) in candidates {
+            if let Some(text) = searchable_payload_text("application/json", &payload) {
+                tx.execute(
+                    "UPDATE history SET payload_text = ?1 WHERE id = ?2",
+                    rusqlite::params![text, id],
+                )?;
+            }
+        }
+    }
+    tx.execute(
+        "UPDATE schema_version SET version = ?1",
+        rusqlite::params![SCHEMA_VERSION],
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Derive the text stored in the external-content FTS table without changing
+/// the original payload or its MIME type.
+///
+/// Besides ordinary `text/*`, recognize the native channel-message JSON used
+/// by current clients. Requiring its correlation fields avoids indexing
+/// unrelated JSON plumbing or metadata merely because it contains a `text`
+/// property. Only the human-authored body is indexed; `clientId`, timestamps,
+/// mentions, and any future metadata remain outside the search projection.
+fn searchable_payload_text(content_type: &str, payload: &[u8]) -> Option<String> {
+    if content_type.starts_with("text/") {
+        return Some(String::from_utf8_lossy(payload).into_owned());
+    }
+    if content_type != "application/json" {
+        return None;
+    }
+
+    let value: serde_json::Value = serde_json::from_slice(payload).ok()?;
+    let object = value.as_object()?;
+    let text = object.get("text")?.as_str()?;
+    let client_id = object.get("clientId")?.as_str()?;
+    object.get("createdAt")?.as_i64()?;
+    if client_id.is_empty() {
+        return None;
+    }
+    if let Some(mentions) = object.get("mentions") {
+        let mentions = mentions.as_array()?;
+        if !mentions.iter().all(serde_json::Value::is_string) {
+            return None;
+        }
+    }
+    Some(text.to_owned())
 }
 
 const SCHEMA_V1: &str = r#"
@@ -660,6 +734,58 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open(&dir.path().join("history.db")).unwrap();
         (store, dir)
+    }
+
+    #[test]
+    fn v1_migration_backfills_native_channel_message_search_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.db");
+        let payload = br#"{"text":"persisted-before-upgrade","createdAt":1786379111246,"clientId":"legacy-client-id"}"#;
+        let scope = Scope::Dm("legacy-peer".into());
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE schema_version (version INTEGER NOT NULL); \
+                 INSERT INTO schema_version (version) VALUES (1);",
+            )
+            .unwrap();
+            conn.execute_batch(SCHEMA_V1).unwrap();
+            let msg_id = HistoryRecord::compute_msg_id(None, payload);
+            conn.execute(
+                "INSERT INTO history (msg_id, scope_kind, scope_id, sent_at_ms, seen_at_ms, \
+                 direction, content_type, payload, payload_text, provenance) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9)",
+                rusqlite::params![
+                    &msg_id[..],
+                    scope.kind(),
+                    scope.id(),
+                    1_i64,
+                    1_i64,
+                    Direction::Inbound.as_i64(),
+                    "application/json",
+                    payload,
+                    Provenance::LocalAppDecrypt.as_i64(),
+                ],
+            )
+            .unwrap();
+        }
+
+        let store = Store::open(&path).unwrap();
+        let hits = store
+            .search(
+                "persisted-before-upgrade",
+                &HistoryQuery {
+                    scope: Some(scope),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 1, "v1 JSON row must be searchable after open");
+        let guard = lock_conn(&store.conn).unwrap();
+        let version: i64 = guard
+            .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION);
     }
 
     fn rec(payload: &[u8], scope: Scope) -> HistoryRecord {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4679,6 +4679,66 @@ impl Agent {
         self.relay_candidates.read().await.clone()
     }
 
+    /// Resolve the target's currently-live machine after a dial or transport
+    /// repair. Discovery can lag the direct-messaging registry during a
+    /// machine transition, so prefer whichever mapping ant-quic reports as
+    /// connected and reconcile the discovery entry when the registry wins.
+    async fn connected_direct_machine(
+        &self,
+        agent_id: &identity::AgentId,
+        network: &network::NetworkNode,
+    ) -> Option<identity::MachineId> {
+        let cached_machine_id = {
+            let cache = self.identity_discovery_cache.read().await;
+            cache
+                .get(agent_id)
+                .map(|entry| entry.machine_id)
+                .filter(|machine_id| machine_id.0 != [0_u8; 32])
+        };
+        if let Some(machine_id) = cached_machine_id {
+            if network.is_connected(&ant_quic::PeerId(machine_id.0)).await {
+                return Some(machine_id);
+            }
+        }
+
+        let registry_machine_id = self.direct_messaging.get_machine_id(agent_id).await;
+        if let Some(machine_id) = registry_machine_id {
+            if network.is_connected(&ant_quic::PeerId(machine_id.0)).await {
+                if cached_machine_id != Some(machine_id) {
+                    let mut cache = self.identity_discovery_cache.write().await;
+                    if let Some(entry) = cache.get_mut(agent_id) {
+                        entry.machine_id = machine_id;
+                    }
+                }
+                return Some(machine_id);
+            }
+        }
+
+        None
+    }
+
+    /// Re-run the complete identity-discovery dial after the narrow
+    /// bootstrap-cache repair path fails. A fresh presence card can contain
+    /// usable addresses even when no cached transport route exists.
+    async fn redial_direct_machine_from_discovery(
+        &self,
+        agent_id: &identity::AgentId,
+        network: &network::NetworkNode,
+    ) -> Option<identity::MachineId> {
+        if let Err(error) = self.connect_to_agent(agent_id).await {
+            tracing::debug!(
+                target: "x0x::direct",
+                stage = "send",
+                agent_prefix = %network::hex_prefix(&agent_id.0, 4),
+                error = %error,
+                "identity-discovery redial failed"
+            );
+            return None;
+        }
+
+        self.connected_direct_machine(agent_id, network).await
+    }
+
     /// Legacy raw-QUIC direct-send path. Internal fallback only.
     ///
     /// X0X-0053: `prefer_newest_grace` is the bounded post-Replaced reissue
@@ -4738,7 +4798,7 @@ impl Agent {
         };
         let registry_machine_id = self.direct_messaging.get_machine_id(agent_id).await;
 
-        let (machine_id, resolution) = match (cached_machine_id, registry_machine_id) {
+        let (mut machine_id, mut resolution) = match (cached_machine_id, registry_machine_id) {
             (Some(id), _) if network.is_connected(&ant_quic::PeerId(id.0)).await => {
                 (id, "cached_connected")
             }
@@ -4788,8 +4848,8 @@ impl Agent {
         // sends best-effort clear stale lifecycle blocks when ant-quic is live;
         // capability-first gossip sends may leave cosmetic stale diagnostics
         // until a raw probe/send path observes the live connection.
-        let ant_peer_id = ant_quic::PeerId(machine_id.0);
-        let machine_prefix = network::hex_prefix(&machine_id.0, 4);
+        let mut ant_peer_id = ant_quic::PeerId(machine_id.0);
+        let mut machine_prefix = network::hex_prefix(&machine_id.0, 4);
         let mut connected = network.is_connected(&ant_peer_id).await;
 
         // X0X-0033: when machine_id is known (resolved from cache or registry)
@@ -4824,6 +4884,23 @@ impl Agent {
                 "send-readiness repair on disconnected peer"
             );
             connected = network.is_connected(&ant_peer_id).await;
+
+            // Presence/discovery and transport readiness are deliberately
+            // separate. If the fast bootstrap-cache repair cannot recover a
+            // known machine, use the discovery card's current addresses in
+            // the same logical send instead of returning AgentNotConnected.
+            if !connected {
+                if let Some(redialed_machine_id) = self
+                    .redial_direct_machine_from_discovery(agent_id, network)
+                    .await
+                {
+                    machine_id = redialed_machine_id;
+                    ant_peer_id = ant_quic::PeerId(machine_id.0);
+                    machine_prefix = network::hex_prefix(&machine_id.0, 4);
+                    connected = true;
+                    resolution = "discovery_redial";
+                }
+            }
         }
 
         // X0X-0051 / X0X-0053: the X0X-0041 prefer-newest-grace block was

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -765,9 +765,9 @@ fn local_direct_probe_addrs(addresses: &[std::net::SocketAddr]) -> Vec<std::net:
 ///
 /// Heartbeats are anti-entropy, not a hot-path delivery mechanism. Keep the
 /// default at five minutes so bootstrap meshes do not spend their PubSub budget
-/// on repeated signed identity/machine announcements. Each fresh announcement
-/// still receives a one-shot receiver-side re-broadcast in
-/// `start_identity_listener` for epidemic convergence.
+/// on repeated signed identity/machine announcements. PlumTree forwards each
+/// locally authored announcement across the topic mesh; receivers must not
+/// re-publish the same payload as a new application message.
 pub const IDENTITY_HEARTBEAT_INTERVAL_SECS: u64 = 300;
 
 /// Default TTL for discovered agent cache entries (seconds).
@@ -778,6 +778,23 @@ pub const IDENTITY_TTL_SECS: u64 = 900;
 
 const DISCOVERY_REBROADCAST_STATE_CAP: usize = 1024;
 const DISCOVERY_REBROADCAST_STATE_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IdentityAnnouncementSource {
+    LocallyAuthored,
+    PlumtreeDelivered,
+}
+
+/// Whether x0x should create a new application-level publish on the legacy
+/// identity topic for this announcement source.
+///
+/// PlumTree already forwards a locally authored publish. Re-publishing a
+/// received payload re-signs it with a fresh message ID, bypasses PlumTree's
+/// message-ID deduplication, and turns one fleet heartbeat epoch into quadratic
+/// application traffic.
+const fn should_publish_identity_on_legacy(source: IdentityAnnouncementSource) -> bool {
+    matches!(source, IdentityAnnouncementSource::LocallyAuthored)
+}
 
 /// Interval (seconds) between runs of the background discovery cache reaper.
 /// The reaper performs TTL-based pruning using the same identity_ttl
@@ -2346,18 +2363,20 @@ impl HeartbeatContext {
                 "heartbeat: failed to serialize announcement: {e}"
             ))
         })?;
-        self.runtime
-            .pubsub()
-            .publish(
-                IDENTITY_ANNOUNCE_TOPIC.to_string(),
-                bytes::Bytes::from(encoded),
-            )
-            .await
-            .map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "heartbeat: publish failed: {e}"
-                )))
-            })?;
+        if should_publish_identity_on_legacy(IdentityAnnouncementSource::LocallyAuthored) {
+            self.runtime
+                .pubsub()
+                .publish(
+                    IDENTITY_ANNOUNCE_TOPIC.to_string(),
+                    bytes::Bytes::from(encoded),
+                )
+                .await
+                .map_err(|e| {
+                    error::IdentityError::Storage(std::io::Error::other(format!(
+                        "heartbeat: publish failed: {e}"
+                    )))
+                })?;
+        }
         let now = Agent::unix_timestamp_secs();
         upsert_discovered_machine(
             &self.machine_cache,
@@ -5747,15 +5766,17 @@ impl Agent {
             })?;
 
         // Also publish to legacy broadcast topic for backward compatibility.
-        runtime
-            .pubsub()
-            .publish(IDENTITY_ANNOUNCE_TOPIC.to_string(), payload)
-            .await
-            .map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "failed to publish identity announcement: {e}"
-                )))
-            })?;
+        if should_publish_identity_on_legacy(IdentityAnnouncementSource::LocallyAuthored) {
+            runtime
+                .pubsub()
+                .publish(IDENTITY_ANNOUNCE_TOPIC.to_string(), payload)
+                .await
+                .map_err(|e| {
+                    error::IdentityError::Storage(std::io::Error::other(format!(
+                        "failed to publish identity announcement: {e}"
+                    )))
+                })?;
+        }
 
         let now = Self::unix_timestamp_secs();
         upsert_discovered_machine(
@@ -6229,15 +6250,6 @@ impl Agent {
             let mut auto_connect_attempts =
                 std::collections::HashMap::<identity::AgentId, std::time::Instant>::new();
 
-            // One-shot dedup for re-broadcast: (agent_id, announced_at)
-            // → first-rebroadcast Instant. Bounds each fresh announcement to at
-            // most one receiver-side re-publish per daemon. Repeating the same
-            // payload every few seconds forms a PubSub feedback loop on the
-            // bootstrap mesh and delays latency-sensitive user messages.
-            let mut rebroadcast_state: std::collections::HashMap<
-                (identity::AgentId, u64),
-                std::time::Instant,
-            > = std::collections::HashMap::new();
             let mut machine_rebroadcast_state: std::collections::HashMap<
                 (identity::MachineId, u64),
                 std::time::Instant,
@@ -6778,35 +6790,23 @@ impl Agent {
                     .register_agent(announcement.agent_id, announcement.machine_id)
                     .await;
 
-                // Epidemic re-broadcast — mirrors the release-manifest
-                // re-broadcast pattern. Bootstrap-node meshes have patchy
-                // PlumTree overlap for the identity-announce topic: the
-                // origin's tree only reaches 1–2 hops reliably. Making
-                // every verified recipient re-publish guarantees flood
-                // convergence across the mesh. One-shot dedup on
-                // (agent_id, announced_at) bounds amplification. Pub/Sub
-                // v2 re-signs each publish with a new message ID so
-                // PlumTree's own dedup cannot suppress repeated forwards;
-                // therefore each daemon forwards a given announcement at most
-                // once.
-                if announcement.agent_id != own_agent_id {
-                    let key = (announcement.agent_id, announcement.announced_at);
-                    if should_rebroadcast_discovery_once(
-                        &mut rebroadcast_state,
-                        key,
-                        std::time::Instant::now(),
-                    ) {
-                        let pubsub = std::sync::Arc::clone(&rebroadcast_pubsub);
-                        let payload = raw_payload.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) = pubsub
-                                .publish(IDENTITY_ANNOUNCE_TOPIC.to_string(), payload)
-                                .await
-                            {
-                                tracing::debug!("identity announcement re-broadcast failed: {e}");
-                            }
-                        });
-                    }
+                // The message reached this listener through PlumTree, which
+                // already performs eager forwarding and anti-entropy repair.
+                // Do not turn a received announcement into a new application
+                // publish: x0x PubSub would re-sign it with a fresh message ID,
+                // defeating PlumTree deduplication across the fleet.
+                if should_publish_identity_on_legacy(
+                    IdentityAnnouncementSource::PlumtreeDelivered,
+                ) {
+                    let pubsub = std::sync::Arc::clone(&rebroadcast_pubsub);
+                    tokio::spawn(async move {
+                        if let Err(e) = pubsub
+                            .publish(IDENTITY_ANNOUNCE_TOPIC.to_string(), raw_payload)
+                            .await
+                        {
+                            tracing::debug!("identity announcement forwarding failed: {e}");
+                        }
+                    });
                 }
 
                 // Reconcile the agent-level direct-message registry if the transport peer
@@ -12412,6 +12412,95 @@ mod tests {
         s.parse().expect("valid SocketAddr literal in test")
     }
 
+    type IdentityEpochRoute =
+        tokio::sync::mpsc::UnboundedSender<(saorsa_gossip_types::PeerId, bytes::Bytes)>;
+    type IdentityEpochRoutes = std::sync::Arc<
+        std::sync::Mutex<
+            std::collections::HashMap<saorsa_gossip_types::PeerId, IdentityEpochRoute>,
+        >,
+    >;
+
+    struct IdentityEpochMeshTransport {
+        local_peer: saorsa_gossip_types::PeerId,
+        routes: IdentityEpochRoutes,
+    }
+
+    #[async_trait::async_trait]
+    impl saorsa_gossip_transport::GossipTransport for IdentityEpochMeshTransport {
+        async fn dial(
+            &self,
+            _peer: saorsa_gossip_types::PeerId,
+            _addr: std::net::SocketAddr,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn dial_bootstrap(
+            &self,
+            _addr: std::net::SocketAddr,
+        ) -> anyhow::Result<saorsa_gossip_types::PeerId> {
+            Ok(self.local_peer)
+        }
+
+        async fn listen(&self, _bind: std::net::SocketAddr) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn close(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn send_to_peer(
+            &self,
+            peer: saorsa_gossip_types::PeerId,
+            stream_type: saorsa_gossip_transport::GossipStreamType,
+            data: bytes::Bytes,
+        ) -> anyhow::Result<()> {
+            if stream_type != saorsa_gossip_transport::GossipStreamType::PubSub {
+                return Err(anyhow::anyhow!("identity epoch used a non-PubSub stream"));
+            }
+            let route = self
+                .routes
+                .lock()
+                .expect("identity mesh route lock")
+                .get(&peer)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("missing identity mesh route for {peer}"))?;
+            route
+                .send((self.local_peer, data))
+                .map_err(|_| anyhow::anyhow!("identity mesh receiver closed for {peer}"))
+        }
+
+        async fn receive_message(
+            &self,
+        ) -> anyhow::Result<(
+            saorsa_gossip_types::PeerId,
+            saorsa_gossip_transport::GossipStreamType,
+            bytes::Bytes,
+        )> {
+            Err(anyhow::anyhow!(
+                "identity epoch delivers through explicit test drivers"
+            ))
+        }
+
+        async fn connected_peer_ids(&self) -> Vec<saorsa_gossip_types::PeerId> {
+            let mut peers = self
+                .routes
+                .lock()
+                .expect("identity mesh route lock")
+                .keys()
+                .copied()
+                .filter(|peer| *peer != self.local_peer)
+                .collect::<Vec<_>>();
+            peers.sort_by_key(|peer| *peer.as_bytes());
+            peers
+        }
+
+        fn local_peer_id(&self) -> saorsa_gossip_types::PeerId {
+            self.local_peer
+        }
+    }
+
     #[test]
     fn verified_raw_dm_builds_durable_inbound_history() {
         let sender = identity::AgentId([7; 32]);
@@ -12463,7 +12552,7 @@ mod tests {
     }
 
     #[test]
-    fn discovery_rebroadcast_is_one_shot_per_announcement_key() {
+    fn non_identity_discovery_rebroadcast_is_one_shot_per_announcement_key() {
         let now = std::time::Instant::now();
         let mut state = std::collections::HashMap::new();
 
@@ -12482,6 +12571,119 @@ mod tests {
             (7_u8, 43_u64),
             now + std::time::Duration::from_secs(20),
         ));
+    }
+
+    #[test]
+    fn received_identity_announcement_does_not_request_legacy_publish() {
+        assert!(should_publish_identity_on_legacy(
+            IdentityAnnouncementSource::LocallyAuthored
+        ));
+        assert!(!should_publish_identity_on_legacy(
+            IdentityAnnouncementSource::PlumtreeDelivered
+        ));
+    }
+
+    #[tokio::test]
+    async fn identity_epoch_converges_with_linear_application_publishes() {
+        use saorsa_gossip_pubsub::{PlumtreePubSub, PubSub};
+
+        const NODE_COUNT: usize = 4;
+        let routes = std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let mut peers = Vec::with_capacity(NODE_COUNT);
+        let mut inboxes = Vec::with_capacity(NODE_COUNT);
+
+        for node_index in 0..NODE_COUNT {
+            let mut peer_bytes = [0_u8; 32];
+            peer_bytes[0] = u8::try_from(node_index + 1).expect("small test node index");
+            let peer = saorsa_gossip_types::PeerId::new(peer_bytes);
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+            routes
+                .lock()
+                .expect("identity mesh route lock")
+                .insert(peer, tx);
+            peers.push(peer);
+            inboxes.push(rx);
+        }
+
+        let mut nodes = Vec::with_capacity(NODE_COUNT);
+        for peer in &peers {
+            let transport = std::sync::Arc::new(IdentityEpochMeshTransport {
+                local_peer: *peer,
+                routes: std::sync::Arc::clone(&routes),
+            });
+            let signing_key = saorsa_gossip_identity::MlDsaKeyPair::generate()
+                .expect("identity epoch signing key");
+            nodes.push(std::sync::Arc::new(PlumtreePubSub::new(
+                *peer,
+                transport,
+                signing_key,
+            )));
+        }
+
+        let topic = saorsa_gossip_types::TopicId::from_entity(IDENTITY_ANNOUNCE_TOPIC);
+        let mut subscriptions = Vec::with_capacity(NODE_COUNT);
+        for (node_index, node) in nodes.iter().enumerate() {
+            subscriptions.push(node.subscribe(topic));
+            let connected = peers
+                .iter()
+                .copied()
+                .filter(|peer| *peer != peers[node_index])
+                .collect();
+            node.initialize_topic_peers(topic, connected).await;
+        }
+
+        let mut drivers = Vec::with_capacity(NODE_COUNT);
+        for (node, mut inbox) in nodes.iter().cloned().zip(inboxes) {
+            drivers.push(tokio::spawn(async move {
+                while let Some((from, data)) = inbox.recv().await {
+                    node.handle_message(from, data)
+                        .await
+                        .expect("identity epoch PlumTree frame");
+                }
+            }));
+        }
+
+        let mut application_publish_count = 0;
+        for origin_index in 0..NODE_COUNT {
+            for (recipient_index, node) in nodes.iter().enumerate() {
+                let source = if recipient_index == origin_index {
+                    IdentityAnnouncementSource::LocallyAuthored
+                } else {
+                    IdentityAnnouncementSource::PlumtreeDelivered
+                };
+                if should_publish_identity_on_legacy(source) {
+                    application_publish_count += 1;
+                    node.publish(
+                        topic,
+                        bytes::Bytes::from(format!("identity-epoch-{origin_index}")),
+                    )
+                    .await
+                    .expect("policy-selected identity publish");
+                }
+            }
+        }
+
+        for mut subscription in subscriptions {
+            let mut seen = std::collections::HashSet::with_capacity(NODE_COUNT);
+            while seen.len() < NODE_COUNT {
+                let (_sender, payload) =
+                    tokio::time::timeout(std::time::Duration::from_secs(2), subscription.recv())
+                        .await
+                        .expect("identity epoch convergence deadline")
+                        .expect("identity epoch subscription remains open");
+                seen.insert(payload);
+            }
+            assert_eq!(seen.len(), NODE_COUNT);
+        }
+
+        assert_eq!(
+            application_publish_count, NODE_COUNT,
+            "one application publish per origin must converge without receiver re-publish"
+        );
+
+        for driver in drivers {
+            driver.abort();
+        }
     }
 
     #[test]

--- a/src/network.rs
+++ b/src/network.rs
@@ -2799,14 +2799,28 @@ impl NetworkNode {
         }
     }
 
-    /// Connected peers eligible as gossip carriers under plane isolation
-    /// (issue #206): all connected peers when isolation is off, only
-    /// plane-cleared peers when on. Use this instead of
+    /// Peers for which ant-quic still has a routable transport winner.
+    ///
+    /// The repaired ant-quic connectivity surface filters its outer peer table
+    /// through the transport-aware send predicate: a canonical QUIC winner or
+    /// an active constrained connection. Keep that predicate authoritative
+    /// here instead of rebuilding a QUIC-only approximation from
+    /// `ConnectionHealth`.
+    pub async fn send_ready_peers(&self) -> Vec<AntPeerId> {
+        let Some(node) = self.node.read().await.as_ref().cloned() else {
+            return Vec::new();
+        };
+        send_ready_peer_ids(node.connected_peers().await)
+    }
+
+    /// Send-ready peers eligible as gossip carriers under plane isolation
+    /// (issue #206): all routable transport winners when isolation is off,
+    /// only plane-cleared winners when on. Use this instead of
     /// [`Self::connected_peers`] when seeding gossip peer sets (PlumTree
-    /// eager sets, membership keepalives) so a cross-plane or not-yet-
-    /// verified peer never enters the gossip plane.
+    /// eager sets, membership keepalives) so stale outer-table entries and
+    /// cross-plane or not-yet-verified peers never enter the gossip plane.
     pub(crate) async fn gossip_plane_peers(&self) -> Vec<AntPeerId> {
-        let connected = self.connected_peers().await;
+        let connected = self.send_ready_peers().await;
         if self.config.network_id.is_none() {
             return connected;
         }
@@ -3925,6 +3939,20 @@ fn plane_recently_cleared(
         .is_some_and(|at| at.elapsed() < PLANE_REVERIFY_TTL)
 }
 
+/// Project ant-quic's transport-filtered connection snapshot to peer IDs.
+///
+/// Filtering belongs upstream because ant-quic owns every transport-specific
+/// routability rule. In particular, constrained BLE/LoRa peers need no QUIC
+/// lifecycle winner but remain valid send and gossip carriers.
+fn send_ready_peer_ids(
+    peers: impl IntoIterator<Item = ant_quic::PeerConnection>,
+) -> Vec<AntPeerId> {
+    peers
+        .into_iter()
+        .map(|connection| connection.peer_id)
+        .collect()
+}
+
 async fn plane_note_connected(
     plane_id: &str,
     plane_peers: &Arc<Mutex<HashMap<AntPeerId, PlanePeerState>>>,
@@ -4326,6 +4354,31 @@ mod tests {
 
     fn test_ant_peer(byte: u8) -> AntPeerId {
         ant_quic::PeerId([byte; 32])
+    }
+
+    /// Boundary regression for ant-quic's transport-aware connected snapshot.
+    ///
+    /// The dependency's `constrained_peer_connectivity_surfaces_match_send_routing`
+    /// test owns the actual constrained handshake/send proof. Once that
+    /// predicate returns a BLE peer, x0x must retain it as send-ready so
+    /// `gossip_plane_peers` continues to feed both PlumTree and keepalives.
+    #[test]
+    fn constrained_transport_ready_peer_is_retained_for_gossip() {
+        let constrained = test_ant_peer(2);
+        let connection = ant_quic::PeerConnection {
+            peer_id: constrained,
+            remote_addr: ant_quic::TransportAddr::Ble {
+                device_id: [0x20; 6],
+                service_uuid: None,
+            },
+            traversal_method: ant_quic::TraversalMethod::Direct,
+            side: ant_quic::Side::Client,
+            authenticated: false,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        };
+
+        assert_eq!(send_ready_peer_ids([connection]), vec![constrained]);
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -76,11 +76,11 @@ use routes::{
     GROUP_PUBLIC_MESSAGE_DM_PREFIX, KV_STORE_DELTA_DM_PREFIX,
 };
 use sse::{direct_events_sse, events_sse, peer_events_handler, presence_events, SseEvent};
-use state::AppState;
 pub use state::{
     default_api_address, default_bind_address, default_data_dir, validate_instance_name,
     DaemonConfig, InstanceName, ServeOptions, ServerHandle, DEFAULT_QUIC_PORT,
 };
+use state::{effective_self_update_enabled, AppState};
 use ws::{serve_gui, ws_diagnostics, ws_direct_handler, ws_handler, ws_sessions, WsOutboundStats};
 
 use std::collections::HashMap;
@@ -206,6 +206,12 @@ pub async fn serve_with_options(
         connect_policy,
         self_update_enabled,
     } = options;
+    // `--skip-update-check` is process-scoped updater suppression. Compute one
+    // effective capability before any updater path is considered, then use it
+    // for startup checks, background gossip/poll workers, and `/upgrade/apply`.
+    // The config itself stays unchanged, so a later ordinary launch still
+    // participates in the normal release train.
+    let self_update_enabled = effective_self_update_enabled(self_update_enabled, skip_update_check);
     // Ensure data directory exists early so self-update has a working directory.
     tokio::fs::create_dir_all(&config.data_dir)
         .await
@@ -226,7 +232,7 @@ pub async fn serve_with_options(
     // Startup GitHub check (fallback mechanism — gossip is primary).
     // Gated on `self_update_enabled` so embedders never download/install a new
     // binary in-process; the daemon binary sets it to `config.update.enabled`.
-    if self_update_enabled && config.update.enabled && !skip_update_check {
+    if self_update_enabled && config.update.enabled {
         if let Err(e) = run_startup_update_check(&config, None).await {
             tracing::warn!(error = %e, "Startup update check failed: {e}");
         }
@@ -925,7 +931,7 @@ pub async fn serve_with_options(
     // Fix D (Issue #110 Phase 2): gated on `self_update_enabled` — this fetches a
     // GitHub release manifest and writes SKILL.md, both updater side-effects an
     // embedder with self-update off must not perform. The daemon keeps it on
-    // (self_update_enabled = config.update_enabled()), so behaviour is unchanged.
+    // Ordinary daemon launches keep it on; process-scoped skip launches do not.
     if self_update_enabled && config.update.enabled {
         let agent_for_broadcast = Arc::clone(&state.agent);
         let update_config = config.update.clone();

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -11585,6 +11585,7 @@ async fn leave_treekem_group(
         return api_error(StatusCode::CONFLICT, error);
     }
 
+    let delivery_roster = next.clone();
     next.roster_revision = next.roster_revision.saturating_add(1);
     let revision = next.roster_revision;
     next.remove_member(&local_agent_hex, Some(local_agent_hex.clone()));
@@ -11631,6 +11632,7 @@ async fn leave_treekem_group(
     };
     publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
     remember_treekem_membership_event(&state, &event).await;
+    spawn_named_group_event_delivery_to_active_members(&state, &delivery_roster, &event, &[]);
 
     (
         StatusCode::OK,
@@ -12150,6 +12152,7 @@ pub(in crate::server) async fn leave_group(
     if let Some(error) = x0x::groups::last_admin_self_leave_precheck_error(info, &local_agent_hex) {
         return api_error(StatusCode::CONFLICT, error);
     }
+    let delivery_roster = info.clone();
     let mut next = info.clone();
     next.roster_revision = next.roster_revision.saturating_add(1);
     let revision = next.roster_revision;
@@ -12185,6 +12188,7 @@ pub(in crate::server) async fn leave_group(
         );
     }
     publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+    spawn_named_group_event_delivery_to_active_members(&state, &delivery_roster, &event, &[]);
     maybe_publish_group_card_after_state_change(&state, &id).await;
 
     let cache_aliases = treekem_cache_group_aliases(&state, &id).await;
@@ -22346,6 +22350,85 @@ mod tests {
         );
         Ok(())
     }
+
+    /// A successful self-leave must deliver its signed `MemberRemoved` commit
+    /// to the members who retain the group, even when metadata gossip has no
+    /// remote fan-out. This is the exact two-daemon failure observed on the
+    /// v0.37.0 candidate: the leaver durably removed its local GSS group while
+    /// the owner remained at the pre-leave roster revision.
+    ///
+    /// Sole-catching mutation: remove the
+    /// `spawn_named_group_event_delivery_to_active_members` call from
+    /// `leave_group`. The HTTP/local-deletion assertions still pass, while the
+    /// owner disappears from both recorded delivery paths and this test fails.
+    #[tokio::test]
+    async fn non_treekem_self_leave_directly_delivers_member_removed_to_retained_owner(
+    ) -> Result<()> {
+        let (state, _dir) = secure_endpoint_test_state().await?;
+        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+        let retained_owner = crate::identity::AgentKeypair::generate()?;
+        let retained_owner_hex = hex::encode(retained_owner.agent_id().as_bytes());
+        let group_id = "self-leave-delivery-gss".to_string();
+
+        let mut info = x0x::groups::GroupInfo::with_policy(
+            "self-leave direct delivery".to_string(),
+            String::new(),
+            state.agent.agent_id(),
+            group_id.clone(),
+            x0x::groups::GroupPolicyPreset::PublicOpen.to_policy(),
+        );
+        info.secure_plane = x0x::mls::SecureGroupPlane::Gss;
+        info.add_member(
+            retained_owner_hex.clone(),
+            x0x::groups::GroupRole::Admin,
+            Some(local_hex),
+            None,
+        );
+        info.recompute_state_hash();
+        state
+            .named_groups
+            .write()
+            .await
+            .insert(group_id.clone(), info);
+
+        NAMED_GROUP_DIRECT_DELIVERIES_FOR_TEST
+            .lock()
+            .expect("delivery recorder poisoned")
+            .clear();
+
+        let (status, body) = response_json(
+            leave_group(State(Arc::clone(&state)), Path(group_id.clone()))
+                .await
+                .into_response(),
+        )
+        .await?;
+        assert_eq!(status, StatusCode::OK, "self-leave failed: {body}");
+        assert!(
+            !state.named_groups.read().await.contains_key(&group_id),
+            "successful self-leave must still remove the group locally"
+        );
+
+        let recipients_for = |kind: &str| -> Vec<String> {
+            NAMED_GROUP_DIRECT_DELIVERIES_FOR_TEST
+                .lock()
+                .expect("delivery recorder poisoned")
+                .iter()
+                .filter(|(_, gid, event_kind, path_kind)| {
+                    gid == &group_id && *event_kind == "member_removed" && *path_kind == kind
+                })
+                .map(|(recipient, _, _, _)| recipient.clone())
+                .collect()
+        };
+        let direct = recipients_for("direct");
+        let delayed = recipients_for("delayed");
+        assert!(
+            direct.contains(&retained_owner_hex) && delayed.contains(&retained_owner_hex),
+            "the retained owner must receive the signed self-leave on both direct paths; \
+             direct={direct:?} delayed={delayed:?}"
+        );
+        Ok(())
+    }
+
     // ── Non-TreeKEM JoinRequestApproved fan-out: the approval handler must
     // deliver the signed JoinRequestApproved to EVERY non-local active member
     // (the already-present witnesses) AND the new requester, on BOTH the direct

--- a/src/server/routes/status.rs
+++ b/src/server/routes/status.rs
@@ -12,6 +12,9 @@ use axum::Json;
 use serde::Serialize;
 use std::sync::Arc;
 
+const CONNECTIVITY_GRACE_SECS: u64 = 120;
+const STATUS_CONNECTING_GRACE_SECS: u64 = 45;
+
 /// Generic JSON response wrapper.
 #[derive(Debug, Serialize)]
 pub(in crate::server) struct ApiResponse<T: Serialize> {
@@ -26,6 +29,7 @@ pub(in crate::server) struct HealthData {
     status: String,
     version: String,
     peers: usize,
+    send_ready_peers: usize,
     uptime_secs: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     degraded_reason: Option<String>,
@@ -38,18 +42,50 @@ pub(in crate::server) struct HealthData {
 /// 6+ hours (wedged transport, silent socket) while fleet monitoring read
 /// `healthy` and stayed quiet. `ok` remains `true` (the process is alive and
 /// serving); `status: "degraded"` is the monitorable signal.
-fn classify_health(peers: usize, uptime_secs: u64) -> (&'static str, Option<String>) {
-    const ZERO_PEER_GRACE_SECS: u64 = 120;
-    if peers == 0 && uptime_secs >= ZERO_PEER_GRACE_SECS {
+fn classify_health(
+    peers: usize,
+    send_ready_peers: usize,
+    uptime_secs: u64,
+) -> (&'static str, Option<String>) {
+    if peers == 0 && uptime_secs >= CONNECTIVITY_GRACE_SECS {
         (
             "degraded",
             Some(format!(
-                "zero peers for the whole uptime window (>{ZERO_PEER_GRACE_SECS}s); \
+                "zero peers for the whole uptime window (>{CONNECTIVITY_GRACE_SECS}s); \
                  transport may be wedged or the network unreachable"
+            )),
+        )
+    } else if peers > 0 && send_ready_peers == 0 && uptime_secs >= CONNECTIVITY_GRACE_SECS {
+        (
+            "degraded",
+            Some(format!(
+                "{peers} peers remain in the outer connection table but none are send-ready; \
+                 ant-quic has no routable transport winner"
             )),
         )
     } else {
         ("healthy", None)
+    }
+}
+
+/// Classify the richer `/status` connectivity state from the same transport
+/// readiness predicate used by `/health` while preserving its shorter startup
+/// state transition from `connecting` to `isolated`.
+fn classify_runtime_status(
+    peers: usize,
+    send_ready_peers: usize,
+    uptime_secs: u64,
+    has_warnings: bool,
+) -> (&'static str, Option<String>) {
+    let (health, degraded_reason) = classify_health(peers, send_ready_peers, uptime_secs);
+    if has_warnings || health == "degraded" {
+        ("degraded", degraded_reason)
+    } else if send_ready_peers > 0 {
+        ("connected", None)
+    } else if uptime_secs < STATUS_CONNECTING_GRACE_SECS {
+        ("connecting", None)
+    } else {
+        ("isolated", None)
     }
 }
 
@@ -63,6 +99,7 @@ pub(in crate::server) struct StatusData {
     external_addrs: Vec<String>,
     agent_id: String,
     peers: usize,
+    send_ready_peers: usize,
     warnings: Vec<String>,
 }
 
@@ -75,8 +112,12 @@ pub(in crate::server) async fn health(
     State(state): State<Arc<AppState>>,
 ) -> Json<ApiResponse<HealthData>> {
     let peers = state.agent.peers().await.map(|p| p.len()).unwrap_or(0);
+    let send_ready_peers = match state.agent.network() {
+        Some(network) => network.send_ready_peers().await.len(),
+        None => 0,
+    };
     let uptime_secs = state.start_time.elapsed().as_secs();
-    let (status, degraded_reason) = classify_health(peers, uptime_secs);
+    let (status, degraded_reason) = classify_health(peers, send_ready_peers, uptime_secs);
 
     Json(ApiResponse {
         ok: true,
@@ -84,6 +125,7 @@ pub(in crate::server) async fn health(
             status: status.to_string(),
             version: x0x::VERSION.to_string(),
             peers,
+            send_ready_peers,
             uptime_secs,
             degraded_reason,
         },
@@ -103,6 +145,11 @@ pub(in crate::server) async fn status(
             warnings.push(format!("failed to query peers: {err}"));
             0
         }
+    };
+
+    let send_ready_peers = match state.agent.network() {
+        Some(network) => network.send_ready_peers().await.len(),
+        None => 0,
     };
 
     // Get external addresses: ant-quic observed + local IPv4/IPv6 discovery.
@@ -151,27 +198,23 @@ pub(in crate::server) async fn status(
         }
     }
 
-    let connectivity = if !warnings.is_empty() {
-        "degraded"
-    } else if peers > 0 {
-        "connected"
-    } else if uptime_secs < 45 {
-        "connecting"
-    } else {
-        "isolated"
+    let (connectivity, degraded_reason) =
+        classify_runtime_status(peers, send_ready_peers, uptime_secs, !warnings.is_empty());
+    if let Some(reason) = degraded_reason {
+        warnings.push(reason);
     }
-    .to_string();
 
     Json(ApiResponse {
         ok: true,
         data: StatusData {
-            status: connectivity,
+            status: connectivity.to_string(),
             version: x0x::VERSION.to_string(),
             uptime_secs,
             api_address: state.api_address.to_string(),
             external_addrs,
             agent_id: hex::encode(state.agent.agent_id().as_bytes()),
             peers,
+            send_ready_peers,
             warnings,
         },
     })
@@ -215,14 +258,14 @@ pub(in crate::server) async fn get_constitution_json() -> impl IntoResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::classify_health;
+    use super::{classify_health, classify_runtime_status};
 
     /// WHY (issue #262): a wedged-transport daemon — up for hours, zero
     /// peers, silent socket — must not read `healthy` to fleet monitoring.
     /// That exact state hid the NYC prod bootstrap outage for 6+ hours.
     #[test]
     fn zero_peers_past_grace_is_degraded() {
-        let (status, reason) = classify_health(0, 121);
+        let (status, reason) = classify_health(0, 0, 121);
         assert_eq!(status, "degraded");
         assert!(reason.is_some(), "degraded must carry a reason");
     }
@@ -231,7 +274,7 @@ mod tests {
     /// flagging a freshly started daemon would page on every restart.
     #[test]
     fn zero_peers_within_grace_is_still_healthy() {
-        let (status, reason) = classify_health(0, 30);
+        let (status, reason) = classify_health(0, 0, 30);
         assert_eq!(status, "healthy");
         assert!(reason.is_none());
     }
@@ -239,8 +282,62 @@ mod tests {
     /// Any live peer means the transport works — healthy regardless of age.
     #[test]
     fn connected_daemon_is_healthy() {
-        let (status, reason) = classify_health(1, 999_999);
+        let (status, reason) = classify_health(1, 1, 999_999);
         assert_eq!(status, "healthy");
+        assert!(reason.is_none());
+    }
+
+    /// An outer-table peer is not evidence that ant-quic still has a routable
+    /// transport winner. This exact split produced PeerNotFound storms while
+    /// `/health` reported healthy.
+    #[test]
+    fn outer_peers_without_transport_winner_are_degraded() {
+        let (status, reason) = classify_health(17, 0, 2_400);
+        assert_eq!(status, "degraded");
+        assert!(
+            reason
+                .as_deref()
+                .is_some_and(|value| value.contains("send-ready")),
+            "degraded response must name the cross-layer mismatch: {reason:?}"
+        );
+    }
+
+    /// A partially stale outer table still has a functioning transport when
+    /// at least one routable transport winner remains.
+    #[test]
+    fn at_least_one_transport_winner_is_healthy() {
+        let (status, reason) = classify_health(17, 1, 2_400);
+        assert_eq!(status, "healthy");
+        assert!(reason.is_none());
+    }
+
+    /// `/status` must not report `connected` for the stale-outer state which
+    /// `/health` classifies as degraded.
+    #[test]
+    fn runtime_status_degrades_without_a_transport_winner() {
+        let (status, reason) = classify_runtime_status(17, 0, 2_400, false);
+        assert_eq!(status, "degraded");
+        assert!(reason.is_some());
+    }
+
+    #[test]
+    fn runtime_status_connects_only_with_a_send_ready_peer() {
+        let (status, reason) = classify_runtime_status(17, 1, 2_400, false);
+        assert_eq!(status, "connected");
+        assert!(reason.is_none());
+    }
+
+    #[test]
+    fn runtime_status_is_connecting_during_transport_grace() {
+        let (status, reason) = classify_runtime_status(17, 0, 30, false);
+        assert_eq!(status, "connecting");
+        assert!(reason.is_none());
+    }
+
+    #[test]
+    fn runtime_status_preserves_isolated_state_before_degraded_grace() {
+        let (status, reason) = classify_runtime_status(0, 0, 60, false);
+        assert_eq!(status, "isolated");
         assert!(reason.is_none());
     }
 }

--- a/src/server/routes/upgrade.rs
+++ b/src/server/routes/upgrade.rs
@@ -701,7 +701,7 @@ pub(in crate::server) async fn apply_upgrade(
             Json(serde_json::json!({
                 "ok": true,
                 "applied": false,
-                "reason": "self-update disabled for embedded server",
+                "reason": "self-update disabled for this process",
                 "current_version": env!("CARGO_PKG_VERSION")
             })),
         );

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -93,7 +93,12 @@ impl TryFrom<String> for InstanceName {
 /// Phase 1: minimal — do not redesign config here.
 #[derive(Default)]
 pub struct ServeOptions {
-    /// Skip the startup GitHub update check.
+    /// Disable self-update for this process invocation.
+    ///
+    /// This suppresses the startup GitHub check, gossip-delivered apply,
+    /// fallback polling, manifest broadcast side effects, and manual apply.
+    /// It does not change the persisted update configuration, so later
+    /// invocations without the flag retain normal updater behavior.
     pub skip_update_check: bool,
     /// Disable ant-quic UPnP IGD port mapping for this invocation.
     pub cli_no_port_mapping: bool,
@@ -111,13 +116,20 @@ pub struct ServeOptions {
     pub connect_policy: x0x::connect::ConnectPolicy,
     /// Whether the self-update install/restart paths are allowed to run.
     ///
-    /// AND-ed with `config.update.enabled`. The daemon binary sets this to
-    /// `config.update.enabled` so its behaviour is unchanged. The public
+    /// AND-ed with `config.update.enabled` and disabled by
+    /// [`ServeOptions::skip_update_check`]. The daemon binary sets this to
+    /// `config.update.enabled`. The public
     /// [`crate::server::serve`] entrypoint defaults it to `false` — an embedded library must
-    /// never replace or restart the host application. Manifest *propagation*
-    /// (broadcast/listen for informational purposes) is unaffected; only the
-    /// paths that download + install + restart are gated.
+    /// never replace or restart the host application. Updater-owned manifest
+    /// broadcast/listener side effects are gated with the install paths.
     pub self_update_enabled: bool,
+}
+
+pub(super) const fn effective_self_update_enabled(
+    configured_for_process: bool,
+    skip_update_check: bool,
+) -> bool {
+    configured_for_process && !skip_update_check
 }
 
 /// Handle to a running, in-process x0x server.
@@ -518,8 +530,8 @@ fn default_rendezvous_validity_ms() -> u64 {
 
 impl DaemonConfig {
     /// Whether self-update is enabled in this config. The daemon binary uses
-    /// this to set [`ServeOptions::self_update_enabled`] so its behaviour is
-    /// unchanged by the embed-path default of `false`.
+    /// this to set [`ServeOptions::self_update_enabled`]; the process-scoped
+    /// skip flag is applied separately by [`crate::server::serve_with_options`].
     #[must_use]
     pub fn update_enabled(&self) -> bool {
         self.update.enabled
@@ -833,6 +845,14 @@ pub(super) struct CachedUpgradeCheck {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn skip_update_check_disables_every_process_update_path_without_changing_defaults() {
+        assert!(effective_self_update_enabled(true, false));
+        assert!(!effective_self_update_enabled(true, true));
+        assert!(!effective_self_update_enabled(false, false));
+        assert!(!effective_self_update_enabled(false, true));
+    }
 
     #[test]
     fn resolved_network_id_maps_unset_to_prod_and_empty_to_open() {

--- a/tests/convergence/convergence_soak.py
+++ b/tests/convergence/convergence_soak.py
@@ -233,11 +233,9 @@ class Node:
             # --no-hard-coded-bootstrap would now be redundant (it preserves
             # config peers), so it is not passed.
             f'bootstrap_peers = [{peers}]\n'
-            # Fully disable self-update. --skip-update-check (passed at
-            # start) only suppresses the startup GitHub check — it does NOT
-            # stop gossip-delivered auto-apply, which replaced a v0.30.1
-            # legacy participant with the latest release mid-run and
-            # invalidated the mixed-version skew gate (v0.31.1 retest).
+            # Keep the config-level disable as defense in depth for legacy
+            # x0xd binaries whose --skip-update-check only suppressed startup.
+            # Current binaries use that flag to stop every update path.
             '[update]\n'
             'enabled = false\n'
         )

--- a/tests/e2e_dogfood_local.sh
+++ b/tests/e2e_dogfood_local.sh
@@ -61,9 +61,9 @@ data_dir = "${DATA_DIRS[$node]}"
 api_address = "127.0.0.1:${API_PORTS[$node]}"
 log_level = "warn"
 
-# Fully disable self-update: --skip-update-check only suppresses the
-# startup GitHub check, not gossip-delivered auto-apply — an older
-# binary under test would otherwise replace itself and exit mid-run.
+# Keep the config-level disable as defense in depth for older x0xd binaries;
+# current binaries also suppress every process update path when launched with
+# --skip-update-check.
 [update]
 enabled = false
 TOML

--- a/tests/history_store.rs
+++ b/tests/history_store.rs
@@ -135,6 +135,41 @@ fn fts_hit_miss_and_injection_literal() {
 }
 
 #[test]
+fn native_channel_message_json_searches_only_its_text_projection() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open(&dir.path().join("history.db")).unwrap();
+    let scope = Scope::Dm("peer-agent".into());
+    let payload = br#"{"text":"e2e-ui-dm-search-marker","createdAt":1786379111246,"clientId":"metadata-must-not-be-indexed","mentions":["peer-agent"]}"#;
+    let mut channel_message = record(payload, scope.clone(), 1);
+    channel_message.content_type = "application/json".into();
+
+    assert_eq!(
+        store.insert(&channel_message).unwrap(),
+        InsertOutcome::Inserted
+    );
+
+    let hits = store
+        .search(
+            "e2e-ui-dm-search-marker",
+            &HistoryQuery {
+                scope: Some(scope),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].record.content_type, "application/json");
+    assert_eq!(hits[0].record.payload, payload);
+    assert!(
+        store
+            .search("metadata-must-not-be-indexed", &HistoryQuery::default())
+            .unwrap()
+            .is_empty(),
+        "FTS must index the human text field, not the full JSON envelope"
+    );
+}
+
+#[test]
 fn retention_evicts_oldest_and_respects_scope_limits() {
     let dir = tempfile::tempdir().unwrap();
     let store = Store::open(&dir.path().join("history.db")).unwrap();

--- a/tests/x0x_0041_synthetic_kill_restart.rs
+++ b/tests/x0x_0041_synthetic_kill_restart.rs
@@ -433,3 +433,101 @@ async fn synthetic_kill_restart_lands_on_new_connection_within_500ms() {
         "alice should have advanced bob's lifecycle generation past {pre_kill_generation}; got {final_gen:?}"
     );
 }
+
+/// Regression for the second v0.37.0 two-Mac failure shape: presence and
+/// identity discovery can be fresh while no transport connection currently
+/// exists. A raw send must use the discovered addresses to establish that
+/// connection instead of limiting repair to a bootstrap-cache lookup.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn discovered_but_disconnected_peer_is_dialed_by_same_send() {
+    let dir = TempDir::new().expect("tmpdir");
+    let alice = Arc::new(build_agent(&dir, "discovery-alice").await);
+    let bob = Arc::new(build_agent(&dir, "discovery-bob").await);
+
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let alice_addr = normalize_loopback(
+        alice_network
+            .bound_addr()
+            .await
+            .expect("alice bound to loopback"),
+    );
+    let bob_addr = normalize_loopback(
+        bob_network
+            .bound_addr()
+            .await
+            .expect("bob bound to loopback"),
+    );
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_secs();
+    let discovered = |agent: &Agent, addr| x0x::DiscoveredAgent {
+        agent_id: agent.agent_id(),
+        machine_id: agent.machine_id(),
+        user_id: None,
+        addresses: vec![addr],
+        announced_at: now_secs,
+        last_seen: now_secs,
+        machine_public_key: vec![],
+        nat_type: None,
+        can_receive_direct: Some(true),
+        is_relay: None,
+        is_coordinator: None,
+        reachable_via: Vec::new(),
+        relay_candidates: Vec::new(),
+        cert_not_after: None,
+        agent_certificate: None,
+        agent_public_key: Vec::new(),
+    };
+    alice
+        .insert_discovered_agent_for_testing(discovered(&bob, bob_addr))
+        .await;
+    bob.insert_discovered_agent_for_testing(discovered(&alice, alice_addr))
+        .await;
+
+    assert!(
+        !alice_network.is_connected(&bob_peer).await,
+        "precondition: discovery is fresh but no direct transport exists"
+    );
+
+    let mut bob_rx = bob.subscribe_direct();
+    let payload = b"same-request-connect-from-fresh-discovery".to_vec();
+    let receipt = tokio::time::timeout(
+        Duration::from_secs(8),
+        alice.send_direct_with_config(
+            &bob.agent_id(),
+            payload.clone(),
+            DmSendConfig {
+                prefer_raw_quic_if_connected: true,
+                raw_quic_receive_ack_timeout: Some(Duration::from_secs(1)),
+                stop_fallback_on_raw_error: true,
+                max_retries: 0,
+                ..DmSendConfig::default()
+            },
+        ),
+    )
+    .await
+    .expect("same logical send should dial from discovery inside eight seconds")
+    .expect("discovery redial should make the raw send succeed");
+
+    assert_eq!(receipt.path, DmPath::RawQuicAcked);
+    assert!(
+        alice_network.is_connected(&bob_peer).await,
+        "send should establish the discovered peer connection"
+    );
+    let received = tokio::time::timeout(Duration::from_secs(2), bob_rx.recv())
+        .await
+        .expect("bob receives payload")
+        .expect("bob subscriber remains open");
+    assert_eq!(received.payload, payload);
+    assert_eq!(received.sender, alice.agent_id());
+
+    alice.shutdown().await;
+    bob.shutdown().await;
+}


### PR DESCRIPTION
## Purpose

Slice 1 of the codex campaign landing plan (per the 2026-08-12 handoff): six ops-correctness cherry-picks from `codex/durable-app-ack` onto v0.37.1, **explicitly excluding durable-ACK, the bootstrap outbox, and every send-contract change**. Plus the #316 test hygiene. Ships as 0.37.2 after review.

## ADR alignment

- **ADR 0023** (durable local history): `844c000` indexes native JSON `.text` in FTS (schema v2 backfill) — unblocks the tic-tac-toe search UI shipped in ttt #8.
- **ADR 0014/0016**: `d26f669` direct self-leave fanout — owner no longer stays stale with zero gossip listeners.
- **ADR 0025** (observation completeness): flake remediation is serialization + scheduler reservation, never retries; `gossip_plane_isolation` added to the `quic-localhost` group its own comment prescribes.
- **ADR 0017**: transport-layer fixes only; nothing product-specific enters the daemon.

## The six picks (campaign order)

| Commit (original) | Here | What it fixes |
|---|---|---|
| `4aacb4d` | `2bf5dab` | process-wide `--skip-update-check` honored — bundled desktop sidecar stays pinned |
| `dfbf970` | `9f0ca0a` | send-path redial from fresh discovery — dead-but-healthy peer path after the 0.36.2 wedge |
| `d26f669` | `90695d6` | direct self-leave fanout to the retained owner |
| `844c000` | `5d6d23e` | FTS indexes native JSON `.text` (why ttt search returned `count: 0`) |
| `b9002ec` | `fe1a871` | `/health` counts send-ready peers — no healthy zombies |
| `eb68dd6` | `b7fb590` | receivers stop republishing identity announcements (mesh amplification) |

## Scope-discipline notes (conflict resolution)

- Cherry-pick conflicts were resolved by applying **each commit's own diff only** — never the campaign-branch file blob. (First attempt with `checkout --theirs` was aborted after it silently imported fragments of the excluded `ef92d5c`; redone surgically.)
- Two hunks of `dfbf970` are **deliberately omitted**: they integrate the redial into `ef92d5c`'s ACK-repair machinery, which is not in this slice. The redial applies on the send path (`resolution="discovery_redial"`); the omission is documented in the commit body. Its regression test is included and passes.

## Test hygiene (#316 + one new finding)

- The two #316 flakes are serialized **and** given `threads-required = 4` — full-suite evidence showed serial-group placement alone is insufficient (the trigger is ambient suite load starving timing windows, not group-internal contention). Updated on #316.
- The three new pick tests each stand up multiple loopback QUIC endpoints; unserialized they broke `gossip_plane_isolation`'s stay-down window (2-of-2 full-run repro; green with them excluded; green on the v0.37.1 baseline — contention, not regression). They and the plane-isolation binary join `quic-localhost`.

## Gates (exact tree, real exit codes)

- `cargo fmt --all -- --check` exit 0; `cargo clippy --workspace --all-features --all-targets -- -D warnings` exit 0
- `cargo nextest run --workspace --all-features --no-fail-fast` — **2592/2592 passed** (exit 0), 260 pre-existing skips

## Mixed-version gate (0.37.1 ↔ this build, loopback pair, no gossip mesh)

Script: two isolated daemons (`bootstrap_peers=[]`, ephemeral QUIC binds), A = v0.37.1 tag build, B = this branch; mutual `/agent/card/import` (Trusted); then:

- DM B→A: `{"ok":true,"path":"raw_quic_acked"}` — receiver history `msg_id=cb6888c3133688c1876344886851b470e121953ffd4a04e7d9c1062ddb1fce75`
- DM A→B: `{"ok":true,"path":"raw_quic_acked"}` — receiver history `msg_id=551703f38a5104b9166ea0b96a53198ec46735fc8957e1e6946373e3acf14b76`
- SignedPublic group created on A (`0d3e1308450f08…`), B added → B installed via direct bootstrap (through the F1 verified-sender gate)
- Group public A→B `msg_id=a83d03477bb998ebb8cbea73f06d73cb8a353fa887e99f3e194e41ef26dd6c06`; B→A `msg_id=f4e93300f1d51a79c20059ea64e24304cd07f27c2a2202c350fd546ea5368c5e`
- Branch `/health`: `{"peers":1,"send_ready_peers":1}`

Bonus observation: in the first run (before the pair had a live connection) the 0.37.1 daemon's first DM send failed while the branch daemon's succeeded by dialing from discovery — the exact asymmetry `dfbf970` exists to fix, demonstrated cross-version.

## Mixed-version impact

None to the send contract: both directions of both message classes work against v0.37.1, demonstrated above. `named_groups.rs` did not grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR collects six operational-correctness fixes without changing the messaging send contract.
- Makes `--skip-update-check` suppress every process-local updater path.
- Adds discovery-backed direct-send redial and direct self-leave membership fan-out.
- Backfills searchable text from recognized native JSON history records through schema v2.
- Bases health/status reporting on transport readiness and removes receiver-side identity re-publication.
- Serializes resource-intensive loopback tests and updates operational test scripts.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until discovery redial honors active reconnect-suppression decisions.

A direct send can now take an ungated discovery-redial path that reconnects an administratively or policy-disconnected peer and proceeds with delivery.

**Files Needing Attention:** src/lib.rs

<details open><summary><h3>Security Review</h3></summary>

The new discovery-redial fallback can bypass an active reconnect-suppression tombstone and re-admit a peer intentionally disconnected for administrative or policy reasons.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib.rs | Adds discovery-backed same-send redial and removes receiver-side identity re-publication; the redial bypasses active reconnect suppression. |
| src/network.rs | Adds transport send-readiness exposure used by health/status reporting. |
| src/history/store.rs | Introduces schema-v2 FTS backfill and a narrowly validated projection for native channel-message JSON. |
| src/server/mod.rs | Applies process-scoped update suppression consistently across startup, gossip, broadcast, polling, and manual update paths. |
| src/server/routes/named_groups.rs | Delivers self-leave membership events directly to retained active members in addition to metadata gossip. |
| src/server/routes/status.rs | Adds send-ready peer counts and uses them in health and runtime status classification. |
| .config/nextest.toml | Serializes additional multi-endpoint loopback tests and reserves scheduler threads for two load-sensitive tests. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  S[Direct send] --> C{Cached peer connected?}
  C -- Yes --> D[Send via raw QUIC]
  C -- No --> R[Attempt send-readiness repair]
  R --> E{Connected?}
  E -- Yes --> D
  E -- No --> X[Discovery redial]
  X --> A[connect_to_agent]
  A --> Q[Outbound QUIC dial]
  Q --> D
  T[Active reconnect-suppression tombstone] -. currently not checked .-> X
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/lib.rs:4911-4918
**Discovery redial bypasses suppression**

When a direct send targets a peer with an active reconnect-suppression tombstone that remains in the identity discovery cache, this fallback calls `connect_to_agent` without enforcing the tombstone, reconnecting the intentionally disconnected peer and allowing message delivery despite the administrative or policy decision.

**How this was verified:** The new fallback reaches outbound dial methods that do not check reconnect suppression, while disconnect handling retains the discovery entry used for the redial.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(config): serialize the two issue-31..."](https://github.com/saorsa-labs/x0x/commit/e4920d5780d938842c892f2b30d2772b422561bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52775755)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Network Transport](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/network-transport.md)
- Knowledge Base — [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)
- Knowledge Base — [CLI and daemon startup](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/cli-daemon.md)
- Knowledge Base — [Required Test Gates: Observation Completeness](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/test-gate-policy.md)
</details>

<!-- /greptile_comment -->