### PR TITLE
feat(history): GET /history/message/:msg_id point lookup (#319)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,7 +27,7 @@ filter = "binary(threading_integration)"
 test-group = "quic-localhost"
 
 [[profile.default.overrides]]
-filter = "binary(f2_public_group_bootstrap_wiring)"
+filter = "binary(f2_public_group_bootstrap_wiring) | binary(history_point_lookup_wiring)"
 test-group = "quic-localhost"
 
 # Issue #316: these two loopback tests flake only under full parallel load

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -338,7 +338,7 @@ Identity types: `anonymous`, `known`, `trusted`, `pinned`
 | POST | `/machines/connect` | `x0x machines connect <machine_id>` | Establish a machine-id transport connection |
 | POST | `/direct/send` | `x0x direct send <agent_id> <message>` | Send a direct base64 payload |
 | GET | `/direct/connections` | `x0x direct connections` | List active direct connections |
-| GET | `/history/message/:msg_id` | — | Point lookup of one durable-history row by canonical `msg_id` (64 hex); 404 when absent, 400 on malformed id. Same record shape as `/history` (issue #319) |
+| GET | `/history/message/:msg_id` | `x0x history message` | Point lookup of one durable history row by exposed `msg_id` (64 hex; canonical group ids need `?scope=`); 404 when absent, 400 on malformed id. Same record shape as `/history` (issue #319) |
 | GET | `/direct/events` | `x0x direct events` | SSE stream of direct messages |
 
 ### Direct send request body

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -338,6 +338,7 @@ Identity types: `anonymous`, `known`, `trusted`, `pinned`
 | POST | `/machines/connect` | `x0x machines connect <machine_id>` | Establish a machine-id transport connection |
 | POST | `/direct/send` | `x0x direct send <agent_id> <message>` | Send a direct base64 payload |
 | GET | `/direct/connections` | `x0x direct connections` | List active direct connections |
+| GET | `/history/message/:msg_id` | — | Point lookup of one durable-history row by canonical `msg_id` (64 hex); 404 when absent, 400 on malformed id. Same record shape as `/history` (issue #319) |
 | GET | `/direct/events` | `x0x direct events` | SSE stream of direct messages |
 
 ### Direct send request body

--- a/docs/design/api-manifest.json
+++ b/docs/design/api-manifest.json
@@ -1,5 +1,5 @@
 {
-  "endpoint_count": 147,
+  "endpoint_count": 148,
   "endpoints": [
     {
       "category": "status",
@@ -210,6 +210,13 @@
       "description": "List durable history for one scope (dm:/group:/topic:), keyset-paginated",
       "method": "GET",
       "path": "/history"
+    },
+    {
+      "category": "history",
+      "cli_name": "history message",
+      "description": "Point lookup of one durable history row by exposed msg_id (canonical group ids need ?scope=)",
+      "method": "GET",
+      "path": "/history/message/:msg_id"
     },
     {
       "category": "history",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -266,6 +266,13 @@ pub const ENDPOINTS: &[EndpointDef] = &[
     },
     EndpointDef {
         method: Method::Get,
+        path: "/history/message/:msg_id",
+        cli_name: "history message",
+        description: "Point lookup of one durable history row by exposed msg_id (canonical group ids need ?scope=)",
+        category: "history",
+    },
+    EndpointDef {
+        method: Method::Get,
         path: "/history/search",
         cli_name: "history search",
         description: "Full-text search over text history payloads within a scope",

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -484,6 +484,15 @@ enum HistorySub {
         #[arg(long)]
         before_id: Option<i64>,
     },
+    /// Point lookup of one durable history row by exposed msg_id.
+    Message {
+        /// The msg_id as shown by `history list` (64 hex chars).
+        msg_id: String,
+        /// Scope hint, required to resolve canonical group-message ids:
+        /// `group:<stable_id>`, `dm:<agent_hex>`, or `topic:<name>`.
+        #[arg(long)]
+        scope: Option<String>,
+    },
     /// Full-text search over text history within a scope.
     Search {
         /// Scope: `dm:<agent_hex>`, `group:<stable_id>`, or `topic:<name>`.
@@ -1518,6 +1527,9 @@ async fn run(
                     &client, &scope, &query, since_ms, until_ms, limit, before_id,
                 )
                 .await
+            }
+            HistorySub::Message { msg_id, scope } => {
+                commands::history::message(&client, &msg_id, scope.as_deref()).await
             }
             HistorySub::Stats => commands::history::stats(&client).await,
             HistorySub::Purge { scope } => commands::history::purge(&client, &scope).await,

--- a/src/cli/commands/history.rs
+++ b/src/cli/commands/history.rs
@@ -48,6 +48,20 @@ pub async fn list(
     client.run_get_query("/history", &q).await
 }
 
+/// `x0x history message` — GET /history/message/:msg_id
+///
+/// Point lookup by any id the listing exposes; canonical group ids need
+/// the scope hint (issue #319).
+pub async fn message(client: &DaemonClient, msg_id: &str, scope: Option<&str>) -> Result<()> {
+    let mut q: Vec<(&str, &str)> = Vec::new();
+    if let Some(scope) = scope {
+        q.push(("scope", scope));
+    }
+    client
+        .run_get_query(&format!("/history/message/{msg_id}"), &q)
+        .await
+}
+
 /// `x0x history search` — GET /history/search
 ///
 /// Full-text search over text payloads within a scope.

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -247,6 +247,19 @@ impl Store {
         collect_rows(&guard, &sql, params)
     }
 
+    /// Point lookup of a single row by canonical `msg_id` (issue #319,
+    /// ADR-0023 completeness). `msg_id` is the store dedupe key, so at most
+    /// one row matches; newest wins defensively if that invariant ever bends.
+    pub fn get_by_msg_id(&self, msg_id: [u8; 32]) -> HistoryResult<Option<StoredRecord>> {
+        let sql = "SELECT id, msg_id, scope_kind, scope_id, author_agent, author_machine, \
+             author_pubkey, sent_at_ms, seen_at_ms, direction, content_type, payload, \
+             signed_artifact, signature, sig_context, provenance, replace_key \
+             FROM history WHERE msg_id = ?1 ORDER BY id DESC LIMIT 1";
+        let params = vec![rusqlite::types::Value::from(msg_id.to_vec())];
+        let guard = lock_conn(&self.conn)?;
+        Ok(collect_rows(&guard, sql, params)?.into_iter().next())
+    }
+
     /// Full-text search over searchable payload text. Tokens are quoted so
     /// user input is literal terms, never FTS operators (donor
     /// `fts_match_expr`).

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -43,20 +43,21 @@ use routes::{
     get_kv_value, get_mls_group, get_named_group, get_named_group_members, gossip_diagnostics,
     group_membership_lock, groups_diagnostics, handle_file_message, handle_join_result_message,
     handle_public_group_bootstrap, handle_treekem_catchup_request, handle_treekem_catchup_response,
-    handle_welcome_blob_message, health, history_diagnostics, history_list, history_purge,
-    history_search, history_stats, identity_revocations, identity_revoke, import_agent_card,
-    import_group_card, ingest_public_message, introduction, join_group_via_invite, join_kv_store,
-    leave_group, list_contacts, list_discovery_subscriptions, list_join_requests, list_kv_keys,
-    list_kv_stores, list_machines, list_mls_groups, list_named_groups, list_revocations,
-    list_task_lists, list_tasks, load_causal_approval_queue, load_named_groups,
-    load_predecessor_relay_outbox, load_treekem_member_key_packages, machine_for_agent_handler,
-    machines_by_user_handler, mls_decrypt, mls_encrypt, named_group_metadata_event_group_id,
-    named_group_metadata_event_kind, network_status, now_millis_u64, peer_health_handler, peers,
-    pin_machine, presence, presence_find, presence_foaf, presence_online, presence_status,
-    probe_peer_handler, publish, publish_group_card_to_discovery, put_kv_value, quick_trust,
-    recover_treekem_named_journals, reject_join_request, remove_mls_member,
-    remove_named_group_member, replay_pending_causal_approvals, restore_treekem_groups,
-    revoke_contact, run_fallback_github_poll, run_gossip_update_listener, run_startup_update_check,
+    handle_welcome_blob_message, health, history_diagnostics, history_list, history_message,
+    history_purge, history_search, history_stats, identity_revocations, identity_revoke,
+    import_agent_card, import_group_card, ingest_public_message, introduction,
+    join_group_via_invite, join_kv_store, leave_group, list_contacts, list_discovery_subscriptions,
+    list_join_requests, list_kv_keys, list_kv_stores, list_machines, list_mls_groups,
+    list_named_groups, list_revocations, list_task_lists, list_tasks, load_causal_approval_queue,
+    load_named_groups, load_predecessor_relay_outbox, load_treekem_member_key_packages,
+    machine_for_agent_handler, machines_by_user_handler, mls_decrypt, mls_encrypt,
+    named_group_metadata_event_group_id, named_group_metadata_event_kind, network_status,
+    now_millis_u64, peer_health_handler, peers, pin_machine, presence, presence_find,
+    presence_foaf, presence_online, presence_status, probe_peer_handler, publish,
+    publish_group_card_to_discovery, put_kv_value, quick_trust, recover_treekem_named_journals,
+    reject_join_request, remove_mls_member, remove_named_group_member,
+    replay_pending_causal_approvals, restore_treekem_groups, revoke_contact,
+    run_fallback_github_poll, run_gossip_update_listener, run_startup_update_check,
     save_named_groups_checked, save_named_groups_checked_unlocked,
     save_predecessor_relay_outbox_unlocked, seal_group_state, secure_group_decrypt,
     secure_group_encrypt, secure_group_reseal, secure_open_envelope_adversarial,
@@ -1510,6 +1511,7 @@ pub async fn serve_with_options(
         .route("/diagnostics/history", get(history_diagnostics))
         // ADR-0023 durable-history read surface
         .route("/history", get(history_list).delete(history_purge))
+        .route("/history/message/:msg_id", get(history_message))
         .route("/history/search", get(history_search))
         .route("/history/stats", get(history_stats))
         .route("/diagnostics/ack", get(ack_diagnostics))

--- a/src/server/routes/history.rs
+++ b/src/server/routes/history.rs
@@ -8,7 +8,7 @@
 use super::super::api_error;
 use super::super::state::AppState;
 use crate as x0x;
-use axum::extract::{Query, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
@@ -133,6 +133,111 @@ pub(in crate::server) async fn history_list(
             )
         }
         Ok(Err(e)) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("query: {e}")),
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("join: {e}")),
+    }
+}
+
+/// Optional query for `GET /history/message/:msg_id`.
+#[derive(Debug, serde::Deserialize)]
+pub(in crate::server) struct HistoryMessageParams {
+    /// Scope hint (`group:<stable_id>` | `dm:<agent_hex>` | `topic:<name>`).
+    /// Required to resolve a *canonical* group-message id (ADR 0029): the
+    /// store's `msg_id` column is the dedupe key `BLAKE3(signed_artifact)`,
+    /// not the canonical signing-domain id, so group canonical ids are found
+    /// by a bounded newest-first scan of the scope's rows.
+    scope: Option<String>,
+}
+
+/// Newest-first rows scanned per request when resolving a canonical group id
+/// within a scope. Callers holding older ids should use `GET /history` paging.
+const HISTORY_MESSAGE_SCAN_BUDGET: usize = 4096;
+const HISTORY_MESSAGE_SCAN_PAGE: usize = 256;
+
+/// GET /history/message/:msg_id — point lookup of one durable row (issue
+/// #319, ADR-0023 completeness). Accepts either the store dedupe id (DM and
+/// topic rows expose exactly that id) or a canonical ADR-0029 group-message
+/// id when `?scope=group:<stable_id>` is supplied. 400 on malformed id, 404
+/// when absent; the record uses the same JSON shape as `/history`.
+pub(in crate::server) async fn history_message(
+    State(state): State<Arc<AppState>>,
+    Path(msg_id_hex): Path<String>,
+    Query(params): Query<HistoryMessageParams>,
+) -> impl IntoResponse {
+    let Some(history) = state.agent.history() else {
+        return api_error(StatusCode::SERVICE_UNAVAILABLE, "history store disabled");
+    };
+    let requested_hex = msg_id_hex.trim().to_ascii_lowercase();
+    let msg_id: [u8; 32] = match hex::decode(&requested_hex) {
+        Ok(bytes) => match bytes.try_into() {
+            Ok(arr) => arr,
+            Err(_) => {
+                return api_error(
+                    StatusCode::BAD_REQUEST,
+                    "msg_id must be 64 hex characters (32 bytes)",
+                )
+            }
+        },
+        Err(_) => return api_error(StatusCode::BAD_REQUEST, "msg_id must be lowercase hex"),
+    };
+    let scope = match params.scope.as_deref().map(parse_scope).transpose() {
+        Ok(s) => s,
+        Err(e) => return api_error(StatusCode::BAD_REQUEST, e),
+    };
+
+    let store = Arc::clone(history.store());
+    let lookup = tokio::task::spawn_blocking(move || -> Result<Option<StoredRecord>, String> {
+        // Fast path: the store dedupe key. DM/topic rows expose exactly this
+        // id via row_json, and pre-ADR-0029 callers hold it directly.
+        if let Some(row) = store.get_by_msg_id(msg_id).map_err(|e| e.to_string())? {
+            return Ok(Some(row));
+        }
+        // Canonical group-message ids differ from the dedupe key and are
+        // recomputable only from the signed artifact; resolve them with a
+        // bounded newest-first scan inside the caller's scope.
+        let Some(scope) = scope else {
+            return Ok(None);
+        };
+        let mut before_id: Option<i64> = None;
+        let mut scanned = 0usize;
+        while scanned < HISTORY_MESSAGE_SCAN_BUDGET {
+            let q = HistoryQuery {
+                scope: Some(scope.clone()),
+                scope_kind: None,
+                since_ms: None,
+                until_ms: None,
+                limit: HISTORY_MESSAGE_SCAN_PAGE,
+                before_id,
+            };
+            let rows = store.query(&q).map_err(|e| e.to_string())?;
+            if rows.is_empty() {
+                return Ok(None);
+            }
+            scanned += rows.len();
+            before_id = rows.last().map(|r| r.id);
+            for row in rows {
+                let canonical = group_history_message(&row.record)
+                    .map(|m| m.msg_id())
+                    .unwrap_or_else(|| hex::encode(row.record.msg_id));
+                if canonical == requested_hex {
+                    return Ok(Some(row));
+                }
+            }
+        }
+        Ok(None)
+    })
+    .await;
+
+    match lookup {
+        Ok(Ok(Some(row))) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "ok": true, "record": row_json(&row) })),
+        ),
+        Ok(Ok(None)) => api_error(
+            StatusCode::NOT_FOUND,
+            "no history row for msg_id (canonical group ids require ?scope=group:<stable_id>; \
+             scan budget covers the newest 4096 rows of the scope)",
+        ),
+        Ok(Err(e)) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("lookup: {e}")),
         Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("join: {e}")),
     }
 }

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -49,7 +49,8 @@ pub(super) use groups::{
     mls_decrypt, mls_encrypt, remove_mls_member,
 };
 pub(super) use history::{
-    history_diagnostics, history_list, history_purge, history_search, history_stats,
+    history_diagnostics, history_list, history_message, history_purge, history_search,
+    history_stats,
 };
 pub(super) use identity::{
     agent_info, agent_sign, agent_user_id_handler, agent_verify, announce_identity,

--- a/tests/api_coverage.rs
+++ b/tests/api_coverage.rs
@@ -108,6 +108,11 @@ const COVERED: &[CoveredEndpoint] = &[
     ),
     covered!(
         Get,
+        "/history/message/:msg_id",
+        history_message_point_lookup_serves_group_row_by_canonical_id
+    ),
+    covered!(
+        Get,
         "/history/search",
         rest_history_list_search_stats_purge_roundtrip
     ),
@@ -471,6 +476,10 @@ const COVERAGE_MARKER_SOURCES: &[(&str, &str)] = &[
         include_str!("daemon_api_integration.rs"),
     ),
     ("tests/history_api.rs", include_str!("history_api.rs")),
+    (
+        "tests/history_point_lookup_wiring.rs",
+        include_str!("history_point_lookup_wiring.rs"),
+    ),
     (
         "tests/peer_lifecycle_integration.rs",
         include_str!("peer_lifecycle_integration.rs"),

--- a/tests/history_point_lookup_wiring.rs
+++ b/tests/history_point_lookup_wiring.rs
@@ -1,0 +1,212 @@
+//! Wiring test for `GET /history/message/:msg_id` (issue #319, ADR-0023
+//! completeness): the point-lookup route the tic-tac-toe desktop and the
+//! buzz-acp harness were already calling — and receiving 404s from — before
+//! it existed.
+//!
+//! REVERT GUARD: delete the `/history/message/{msg_id}` route registration
+//! from `serve_with_options` (src/server/mod.rs) or the
+//! `history_message` handler's `get_by_msg_id` call and this test fails:
+//! the canonical-id lookup below returns 404/500 instead of the row. The
+//! store-level unit surface cannot catch that — this is dispatch wiring.
+//!
+//! Runs in the default suite: single daemon, loopback only, ephemeral
+//! ports, sub-second.
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::time::Duration;
+use x0x::server::{serve_with_options, DaemonConfig, ServeOptions, ServerHandle};
+
+use serde_json::Value;
+
+struct Daemon {
+    _handle: ServerHandle,
+    client: reqwest::Client,
+    base: String,
+}
+
+impl Daemon {
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base)
+    }
+
+    async fn post_json(&self, path: &str, body: Value) -> Value {
+        self.client
+            .post(self.url(path))
+            .json(&body)
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("POST {path}: {e}"))
+            .json()
+            .await
+            .unwrap_or_else(|e| panic!("POST {path} json: {e}"))
+    }
+
+    async fn get_status(&self, path: &str) -> (reqwest::StatusCode, Value) {
+        let resp = self
+            .client
+            .get(self.url(path))
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("GET {path}: {e}"));
+        let status = resp.status();
+        let body = resp.json().await.unwrap_or(Value::Null);
+        (status, body)
+    }
+}
+
+/// Hermetic single daemon: loopback only, ephemeral ports, empty bootstrap
+/// list, all state under `dir`. Mirrors the F2 wiring-test harness.
+async fn start_daemon(dir: &Path) -> Daemon {
+    let data_dir = dir.join("data");
+    tokio::fs::create_dir_all(&data_dir)
+        .await
+        .expect("create data dir");
+
+    let token = "h9".repeat(32);
+    tokio::fs::write(data_dir.join("api-token"), &token)
+        .await
+        .expect("write api token");
+
+    let mut config = DaemonConfig::default();
+    config.api_address = SocketAddr::from(([127, 0, 0, 1], 0));
+    config.bind_address = SocketAddr::from(([127, 0, 0, 1], 0));
+    config.bootstrap_peers = Some(Vec::new());
+    config.data_dir = data_dir;
+    config.identity_dir = Some(dir.join("identity"));
+
+    let options = ServeOptions {
+        skip_update_check: true,
+        self_update_enabled: false,
+        ..ServeOptions::default()
+    };
+    let handle = serve_with_options(config, options)
+        .await
+        .expect("serve_with_options should start");
+    let base = format!("http://{}", handle.local_addr());
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_str(&format!("Bearer {token}")).expect("auth header"),
+    );
+    let client = reqwest::Client::builder()
+        .default_headers(headers)
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("client");
+
+    Daemon {
+        _handle: handle,
+        client,
+        base,
+    }
+}
+
+#[tokio::test]
+async fn history_message_point_lookup_serves_group_row_by_canonical_id() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let daemon = start_daemon(dir.path()).await;
+
+    // A SignedPublic group message is the simplest durable row with a
+    // canonical msg_id exposed on the send response (ADR 0029).
+    let created = daemon
+        .post_json(
+            "/groups",
+            serde_json::json!({"name": "point-lookup", "preset": "public_open"}),
+        )
+        .await;
+    assert_eq!(created["ok"], true, "create group: {created:?}");
+    let group_id = created["group_id"].as_str().expect("group_id").to_string();
+
+    let sent = daemon
+        .post_json(
+            &format!("/groups/{group_id}/send"),
+            serde_json::json!({"body": "point-lookup wiring payload"}),
+        )
+        .await;
+    assert_eq!(sent["ok"], true, "group send: {sent:?}");
+    let msg_id = sent["msg_id"].as_str().expect("send msg_id").to_string();
+
+    // The route's contract: EVERY id `/history` exposes in a record's
+    // `msg_id` field is point-resolvable. Which id a sender-side row exposes
+    // is recorder-dependent (LocalSend rows expose the store dedupe id;
+    // self-ingested rows expose the canonical ADR-0029 id, and the two race)
+    // — so the test resolves every listed id rather than asserting a
+    // relationship to the send response's `msg_id`. The store-dedupe-id case
+    // exercises the fast path; a canonical id exercises the ?scope= scan.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let listed_ids: Vec<String> = loop {
+        let (status, body) = daemon
+            .get_status(&format!("/history?scope=group:{group_id}&limit=10"))
+            .await;
+        if status == reqwest::StatusCode::OK {
+            let ids: Vec<String> = body["records"]
+                .as_array()
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|r| r["msg_id"].as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            if !ids.is_empty() {
+                break ids;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the group send never produced a durable history row: {body:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+
+    for listed_id in &listed_ids {
+        let (status, body) = daemon
+            .get_status(&format!(
+                "/history/message/{listed_id}?scope=group:{group_id}"
+            ))
+            .await;
+        assert_eq!(
+            status,
+            reqwest::StatusCode::OK,
+            "point lookup of /history-exposed id {listed_id} must succeed; \
+             if this 404s while /history lists the row, the point-lookup \
+             route or its store lookup/scan was removed (revert of issue \
+             #319). body: {body:?}"
+        );
+        assert_eq!(body["ok"], true, "lookup body: {body:?}");
+        assert_eq!(
+            body["record"]["msg_id"].as_str(),
+            Some(listed_id.as_str()),
+            "point lookup must return the row whose exposed msg_id was \
+             requested: {body:?}"
+        );
+    }
+    // Keep the send-response id in play without asserting the racy
+    // relationship: it must never produce a 5xx.
+    let (status, _) = daemon
+        .get_status(&format!("/history/message/{msg_id}?scope=group:{group_id}"))
+        .await;
+    assert!(
+        status == reqwest::StatusCode::OK || status == reqwest::StatusCode::NOT_FOUND,
+        "send-response id lookup must be 200 or 404, never an error: {status}"
+    );
+
+    // Unknown-but-well-formed id: clean 404, not 400/500.
+    let (status, _) = daemon
+        .get_status(&format!("/history/message/{}", "e".repeat(64)))
+        .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::NOT_FOUND,
+        "unknown 64-hex msg_id must 404"
+    );
+
+    // Malformed id: 400, never a store query.
+    let (status, _) = daemon.get_status("/history/message/not-hex").await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::BAD_REQUEST,
+        "malformed msg_id must 400"
+    );
+}


### PR DESCRIPTION
## Purpose

Closes #319 (ADR-0023 completeness): the point-lookup route that ttt desktop redelivery and the buzz-acp harness were already calling — and silently treating its 404 as `None` — now exists. Agreed post-0.37.2 scope on the coordination channel.

## Contract

`GET /history/message/:msg_id[?scope=…]` resolves **any id the `/history` surface exposes**:
- store dedupe ids via an indexed fast path (`HistoryStore::get_by_msg_id`);
- canonical ADR-0029 group-message ids via a bounded newest-first scan (4096 rows, 256/page) inside a caller-supplied `?scope=` — both consumers hold their scope.
400 on malformed ids; 404 (with a scope hint) when absent; record shape identical to `/history` rows.

**Explicitly not promised**: correlating a send-response canonical id to the sender's own row — LocalSend group rows nondeterministically expose either id (racing recorders). That daemon-side projection fix is #321 (Grok-agreed direction: fix the daemon, no client fallback; durable form is ADR 0030's v4 indexed canonical-id column, which also retires this PR's scan fallback).

## ADR alignment

- **ADR 0023**: read-surface completeness; store stays local-only.
- **ADR 0025**: full parity plumbing — API registry entry, regenerated `api-manifest.json`, coverage entry pointing at a real test marker, and a real CLI subcommand (`x0x history message <msg_id> --scope …`); the wiring test runs in the default suite (serialized in `quic-localhost`), no `#[ignore]`.
- **ADR 0029**: canonical-vs-dedupe id split is respected, not papered over.

## Mixed-version impact

Additive route only; no wire, send-contract, or schema change. Old daemons keep 404ing (which is exactly what consumers already handle).

## Gates (exact tree)

fmt clean · clippy `--workspace --all-features` `-D warnings` exit 0 · `cargo nextest run --workspace --all-features --no-fail-fast` — **2593/2593 passed** (the +1 is the new wiring test) · all four API-parity gates green (coverage, count, manifest, CLI reachability).

Reviewer note: axum 0.7 route params are `/:msg_id` — the 0.8-style `{msg_id}` literal-matches and router-404s with an empty body; the wiring test's `body: Null` signature is how this was caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an authenticated point-lookup API and CLI command for durable-history records, using an indexed dedupe-ID lookup with a bounded scoped scan for canonical group-message IDs.
- Registers `GET /history/message/:msg_id` across the router, endpoint manifest, documentation, and API coverage.
- Adds `Store::get_by_msg_id` and canonical group-ID recovery over the newest 4096 scoped rows.
- Adds `x0x history message` and a serialized daemon-backed wiring test.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking CLI path-construction issue for malformed message IDs.

The API and storage lookup paths are coherently wired and bounded; the remaining concern is that malformed CLI input containing path delimiters can bypass the handler's intended 400 validation and produce route-level behavior instead.

**Files Needing Attention:** src/cli/commands/history.rs, src/bin/x0x.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routes/history.rs | Adds validated point lookup, indexed fast path, bounded canonical-ID fallback, and consistent history-row projection. |
| src/history/store.rs | Adds a parameterized indexed lookup by the persisted 32-byte message dedupe key. |
| src/cli/commands/history.rs | Adds the CLI request helper, but leaves the fixed-format path argument unvalidated and unencoded. |
| src/bin/x0x.rs | Adds and dispatches the `history message` subcommand with an optional scope hint. |
| src/server/mod.rs | Registers the axum 0.7 parameterized route in the authenticated server router. |
| tests/history_point_lookup_wiring.rs | Adds default-suite daemon wiring coverage for listed IDs, malformed IDs, missing IDs, and canonical group IDs. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[CLI or HTTP client] --> R[GET /history/message/:msg_id]
  R --> V{Valid 32-byte hex ID?}
  V -- No --> B[400 Bad Request]
  V -- Yes --> F[Indexed store dedupe-ID lookup]
  F -->|Found| J[Return /history record shape]
  F -->|Absent, no scope| N[404 Not Found]
  F -->|Absent, scope supplied| S[Scan newest scoped rows]
  S --> G{Canonical group ID matches?}
  G -- Yes --> J
  G -- No within 4096 rows --> N
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/cli/commands/history.rs:61
**Unencoded message ID path**

The unconstrained `msg_id` is interpolated directly into the request path, so an input containing `/` changes route matching and returns a router 404 instead of the point-lookup endpoint's documented malformed-ID response.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(history): GET /history/message/:msg..."](https://github.com/saorsa-labs/x0x/commit/b93068bd4067523e7ecc9470277d8f96aeb56f8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52902619)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)
- Knowledge Base — [CLI and daemon startup](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/cli-daemon.md)
- Knowledge Base — [Required Test Gates: Observation Completeness](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/test-gate-policy.md)
</details>

<!-- /greptile_comment -->