### PR TITLE
feat(history): schema v4 — thread and ingress/logical columns (ADR 0030 continuity)

### DIFF
--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -692,6 +692,10 @@ impl InboxPipeline {
                                 sig_context: Some("x0x-dm-v1".to_string()),
                                 provenance: crate::history::Provenance::VerifiedEnvelope,
                                 replace_key: None,
+                                thread_root: None,
+                                thread_parent: None,
+                                ingress_sender_agent: None,
+                                logical_request_id: None,
                             };
                             history.record(record);
                         }

--- a/src/history/record.rs
+++ b/src/history/record.rs
@@ -203,6 +203,31 @@ pub struct HistoryRecord {
     pub provenance: Provenance,
     /// Non-`None` marks the row replaceable, keyed by this string.
     pub replace_key: Option<String>,
+    /// Canonical 64-lowercase-hex DM/group thread root, when supplied.
+    ///
+    /// Schema v3. No writer populates this yet; the canonical-form check
+    /// lands with the DM thread-metadata parser that produces it.
+    #[serde(default)]
+    pub thread_root: Option<String>,
+    /// Canonical direct parent. Meaningful only alongside [`Self::thread_root`].
+    ///
+    /// Schema v3, dormant — see [`Self::thread_root`].
+    #[serde(default)]
+    pub thread_parent: Option<String>,
+    /// Authenticated outer transport sender for a durable typed ingress.
+    /// This is distinct from `author_agent`, which names the artifact author
+    /// and may legitimately differ when another member relays it.
+    ///
+    /// Schema v4. No writer populates this yet.
+    #[serde(default)]
+    pub ingress_sender_agent: Option<String>,
+    /// Authenticated outer logical request id for durable typed ingress.
+    /// Legacy, locally-authored, and non-typed records leave this unset.
+    ///
+    /// Schema v4, dormant — see [`Self::ingress_sender_agent`]. `validate`
+    /// enforces that the two are set together or not at all.
+    #[serde(default)]
+    pub logical_request_id: Option<[u8; 16]>,
 }
 
 impl HistoryRecord {
@@ -252,6 +277,11 @@ impl HistoryRecord {
     pub fn validate(&self) -> HistoryResult<()> {
         if self.payload.is_empty() {
             return Err(HistoryError::InvalidRecord("empty payload".into()));
+        }
+        if self.ingress_sender_agent.is_some() != self.logical_request_id.is_some() {
+            return Err(HistoryError::InvalidRecord(
+                "durable typed ingress sender and logical request id must be set together".into(),
+            ));
         }
         if self.signature.is_some() && self.signed_artifact.is_none() {
             return Err(HistoryError::InvalidRecord(

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -18,7 +18,7 @@ use crate::error::{HistoryError, HistoryResult};
 use super::record::{Direction, HistoryRecord, Provenance, Scope};
 
 /// Current schema version (forward-only migrations).
-const SCHEMA_VERSION: i64 = 2;
+const SCHEMA_VERSION: i64 = 4;
 
 /// Maximum rows a single query may return.
 pub const MAX_QUERY_LIMIT: usize = 500;
@@ -230,7 +230,8 @@ impl Store {
         let mut sql = String::from(
             "SELECT id, msg_id, scope_kind, scope_id, author_agent, author_machine, \
              author_pubkey, sent_at_ms, seen_at_ms, direction, content_type, payload, \
-             signed_artifact, signature, sig_context, provenance, replace_key \
+             signed_artifact, signature, sig_context, provenance, replace_key, \
+             thread_root, thread_parent, ingress_sender_agent, logical_request_id \
              FROM history",
         );
         let mut parts: Vec<String> = Vec::new();
@@ -253,7 +254,8 @@ impl Store {
     pub fn get_by_msg_id(&self, msg_id: [u8; 32]) -> HistoryResult<Option<StoredRecord>> {
         let sql = "SELECT id, msg_id, scope_kind, scope_id, author_agent, author_machine, \
              author_pubkey, sent_at_ms, seen_at_ms, direction, content_type, payload, \
-             signed_artifact, signature, sig_context, provenance, replace_key \
+             signed_artifact, signature, sig_context, provenance, replace_key, \
+             thread_root, thread_parent, ingress_sender_agent, logical_request_id \
              FROM history WHERE msg_id = ?1 ORDER BY id DESC LIMIT 1";
         let params = vec![rusqlite::types::Value::from(msg_id.to_vec())];
         let guard = lock_conn(&self.conn)?;
@@ -273,7 +275,8 @@ impl Store {
             "SELECT h.id, h.msg_id, h.scope_kind, h.scope_id, h.author_agent, \
              h.author_machine, h.author_pubkey, h.sent_at_ms, h.seen_at_ms, h.direction, \
              h.content_type, h.payload, h.signed_artifact, h.signature, h.sig_context, \
-             h.provenance, h.replace_key FROM history h \
+             h.provenance, h.replace_key, h.thread_root, h.thread_parent, \
+             h.ingress_sender_agent, h.logical_request_id FROM history h \
              WHERE h.id IN (SELECT rowid FROM history_fts WHERE history_fts MATCH ?)",
         );
         let mut params: Vec<rusqlite::types::Value> = vec![rusqlite::types::Value::from(fts)];
@@ -513,6 +516,10 @@ fn row_to_record(r: &rusqlite::Row<'_>) -> RowResult {
     let sig_context: Option<String> = r.get(14)?;
     let provenance: i64 = r.get(15)?;
     let replace_key: Option<String> = r.get(16)?;
+    let thread_root: Option<String> = r.get(17)?;
+    let thread_parent: Option<String> = r.get(18)?;
+    let ingress_sender_agent: Option<String> = r.get(19)?;
+    let logical_request_id_blob: Option<Vec<u8>> = r.get(20)?;
 
     let record = (|| -> HistoryResult<HistoryRecord> {
         let mut msg_id = [0u8; 32];
@@ -520,6 +527,18 @@ fn row_to_record(r: &rusqlite::Row<'_>) -> RowResult {
             return Err(HistoryError::InvalidRecord("msg_id not 32 bytes".into()));
         }
         msg_id.copy_from_slice(&msg_id_blob);
+        let logical_request_id = logical_request_id_blob
+            .map(|blob| {
+                let mut request_id = [0_u8; 16];
+                if blob.len() != request_id.len() {
+                    return Err(HistoryError::InvalidRecord(
+                        "logical_request_id not 16 bytes".into(),
+                    ));
+                }
+                request_id.copy_from_slice(&blob);
+                Ok(request_id)
+            })
+            .transpose()?;
         Ok(HistoryRecord {
             msg_id,
             scope: Scope::from_columns(scope_kind, scope_id)?,
@@ -536,6 +555,10 @@ fn row_to_record(r: &rusqlite::Row<'_>) -> RowResult {
             sig_context,
             provenance: Provenance::from_i64(provenance)?,
             replace_key,
+            thread_root,
+            thread_parent,
+            ingress_sender_agent,
+            logical_request_id,
         })
     })();
     Ok((id, record))
@@ -547,8 +570,10 @@ fn insert_row(tx: &rusqlite::Transaction<'_>, record: &HistoryRecord) -> History
     tx.execute(
         "INSERT INTO history (msg_id, scope_kind, scope_id, author_agent, author_machine, \
          author_pubkey, sent_at_ms, seen_at_ms, direction, content_type, payload, \
-         payload_text, signed_artifact, signature, sig_context, provenance, replace_key) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+         payload_text, signed_artifact, signature, sig_context, provenance, replace_key, \
+         thread_root, thread_parent, ingress_sender_agent, logical_request_id) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, \
+         ?18, ?19, ?20, ?21)",
         rusqlite::params![
             msg_id,
             record.scope.kind(),
@@ -567,6 +592,10 @@ fn insert_row(tx: &rusqlite::Transaction<'_>, record: &HistoryRecord) -> History
             record.sig_context,
             record.provenance.as_i64(),
             record.replace_key,
+            record.thread_root,
+            record.thread_parent,
+            record.ingress_sender_agent,
+            record.logical_request_id.as_ref().map(<[u8; 16]>::as_slice),
         ],
     )
     .map_err(|e| HistoryError::Database(format!("insert failed: {e}")))?;
@@ -582,16 +611,31 @@ fn migrate(conn: &Connection) -> HistoryResult<()> {
         })
         .optional()?;
     match current {
+        // A fresh database is created at v1 and then walked through the same
+        // migration steps an upgrading one takes. That costs a few no-op
+        // statements at first open but guarantees the created schema and the
+        // migrated schema cannot drift apart.
         None => {
             conn.execute_batch(SCHEMA_V1)?;
             conn.execute(
                 "INSERT INTO schema_version (version) VALUES (?1)",
-                rusqlite::params![SCHEMA_VERSION],
+                rusqlite::params![1_i64],
             )?;
-            Ok(())
+            migrate_v1_to_v2(conn)?;
+            migrate_v2_to_v3(conn)?;
+            migrate_v3_to_v4(conn)
         }
         Some(v) if v == SCHEMA_VERSION => Ok(()),
-        Some(1) => migrate_v1_to_v2(conn),
+        Some(1) => {
+            migrate_v1_to_v2(conn)?;
+            migrate_v2_to_v3(conn)?;
+            migrate_v3_to_v4(conn)
+        }
+        Some(2) => {
+            migrate_v2_to_v3(conn)?;
+            migrate_v3_to_v4(conn)
+        }
+        Some(3) => migrate_v3_to_v4(conn),
         Some(v) if v < SCHEMA_VERSION => {
             // Future migrations chain here, bumping stored version each step.
             Err(HistoryError::Database(format!(
@@ -641,7 +685,40 @@ fn migrate_v1_to_v2(conn: &Connection) -> HistoryResult<()> {
     }
     tx.execute(
         "UPDATE schema_version SET version = ?1",
-        rusqlite::params![SCHEMA_VERSION],
+        rusqlite::params![2_i64],
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Schema v3 adds first-class nullable thread ancestry to every durable row.
+/// Additive `ALTER`s only: existing rows keep their values and read back
+/// `NULL` for the new columns.
+fn migrate_v2_to_v3(conn: &Connection) -> HistoryResult<()> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute_batch(
+        "ALTER TABLE history ADD COLUMN thread_root TEXT; \
+         ALTER TABLE history ADD COLUMN thread_parent TEXT;",
+    )?;
+    tx.execute(
+        "UPDATE schema_version SET version = ?1",
+        rusqlite::params![3_i64],
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Schema v4 adds authenticated transport/logical-request binding for strict
+/// durable typed ingress. Existing rows remain intentionally unbound.
+fn migrate_v3_to_v4(conn: &Connection) -> HistoryResult<()> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute_batch(
+        "ALTER TABLE history ADD COLUMN ingress_sender_agent TEXT; \
+         ALTER TABLE history ADD COLUMN logical_request_id BLOB;",
+    )?;
+    tx.execute(
+        "UPDATE schema_version SET version = ?1",
+        rusqlite::params![4_i64],
     )?;
     tx.commit()?;
     Ok(())
@@ -801,6 +878,154 @@ mod tests {
         assert_eq!(version, SCHEMA_VERSION);
     }
 
+    /// Column names currently present on the `history` table.
+    fn history_columns(store: &Store) -> Vec<String> {
+        let guard = lock_conn(&store.conn).unwrap();
+        let mut stmt = guard.prepare("PRAGMA table_info(history)").unwrap();
+        let names = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        names
+    }
+
+    fn stored_schema_version(store: &Store) -> i64 {
+        let guard = lock_conn(&store.conn).unwrap();
+        guard
+            .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
+            .unwrap()
+    }
+
+    /// ADR 0030 schema continuity: v4 must land on top of a *released* v2
+    /// store, not replace it. A v2 database carries real user history, so the
+    /// upgrade has to be additive — every pre-existing row survives byte-for-
+    /// byte and simply reads `NULL` for the columns it predates.
+    #[test]
+    fn v2_database_migrates_to_v4_preserving_existing_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.db");
+        let payload = b"written under schema v2";
+        let scope = Scope::Dm("v2-peer".into());
+        let msg_id = HistoryRecord::compute_msg_id(None, payload);
+        {
+            // v2 is v1's table shape with the FTS backfill already applied,
+            // so the released v2 schema is SCHEMA_V1 stamped as version 2.
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE schema_version (version INTEGER NOT NULL); \
+                 INSERT INTO schema_version (version) VALUES (2);",
+            )
+            .unwrap();
+            conn.execute_batch(SCHEMA_V1).unwrap();
+            conn.execute(
+                "INSERT INTO history (msg_id, scope_kind, scope_id, author_agent, sent_at_ms, \
+                 seen_at_ms, direction, content_type, payload, payload_text, provenance) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                rusqlite::params![
+                    &msg_id[..],
+                    scope.kind(),
+                    scope.id(),
+                    "v2-author",
+                    7_000_i64,
+                    7_001_i64,
+                    Direction::Inbound.as_i64(),
+                    "text/plain",
+                    payload,
+                    "written under schema v2",
+                    Provenance::LocalAppDecrypt.as_i64(),
+                ],
+            )
+            .unwrap();
+        }
+
+        let store = Store::open(&path).unwrap();
+        assert_eq!(stored_schema_version(&store), 4);
+        let columns = history_columns(&store);
+        for added in [
+            "thread_root",
+            "thread_parent",
+            "ingress_sender_agent",
+            "logical_request_id",
+        ] {
+            assert!(
+                columns.iter().any(|c| c == added),
+                "v4 must add column {added}; found {columns:?}"
+            );
+        }
+
+        let rows = store
+            .query(&HistoryQuery {
+                scope: Some(scope),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1, "the pre-existing v2 row must survive");
+        let stored = &rows[0].record;
+        assert_eq!(stored.msg_id, msg_id);
+        assert_eq!(stored.payload, payload);
+        assert_eq!(stored.author_agent.as_deref(), Some("v2-author"));
+        assert_eq!(stored.sent_at_ms, 7_000);
+        assert_eq!(stored.seen_at_ms, 7_001);
+        // Rows that predate the columns are unbound, not defaulted.
+        assert_eq!(stored.thread_root, None);
+        assert_eq!(stored.thread_parent, None);
+        assert_eq!(stored.ingress_sender_agent, None);
+        assert_eq!(stored.logical_request_id, None);
+
+        // The v2 FTS projection still resolves after the ALTERs.
+        let hits = store.search("written", &HistoryQuery::default()).unwrap();
+        assert_eq!(hits.len(), 1, "FTS must survive the v3/v4 ALTERs");
+    }
+
+    /// A database created fresh must be indistinguishable from one migrated
+    /// up from v2 — same version, same columns. Divergence between the
+    /// `CREATE TABLE` path and the `ALTER` path is the classic migration bug.
+    #[test]
+    fn fresh_database_opens_at_v4_matching_the_migrated_shape() {
+        let (fresh, _fresh_dir) = open();
+        assert_eq!(stored_schema_version(&fresh), SCHEMA_VERSION);
+        assert_eq!(stored_schema_version(&fresh), 4);
+
+        let migrated_dir = tempfile::tempdir().unwrap();
+        let migrated_path = migrated_dir.path().join("history.db");
+        {
+            let conn = Connection::open(&migrated_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE schema_version (version INTEGER NOT NULL); \
+                 INSERT INTO schema_version (version) VALUES (2);",
+            )
+            .unwrap();
+            conn.execute_batch(SCHEMA_V1).unwrap();
+        }
+        let migrated = Store::open(&migrated_path).unwrap();
+        assert_eq!(
+            history_columns(&fresh),
+            history_columns(&migrated),
+            "fresh-create and v2->v4 migration must produce the same columns"
+        );
+    }
+
+    /// Round-trip the v3/v4 columns through SQLite. They are dormant — no
+    /// production writer sets them yet — so this is the only guard that the
+    /// insert and select column lists stay aligned.
+    #[test]
+    fn thread_and_ingress_columns_round_trip() {
+        let (store, _dir) = open();
+        let mut r = rec(b"row with schema v4 columns", Scope::Dm("peer-v4".into()));
+        r.thread_root = Some("aa".repeat(32));
+        r.thread_parent = Some("bb".repeat(32));
+        r.ingress_sender_agent = Some("cc".repeat(32));
+        r.logical_request_id = Some([0x31; 16]);
+        assert_eq!(store.insert(&r).unwrap(), InsertOutcome::Inserted);
+
+        let stored = store.get_by_msg_id(r.msg_id).unwrap().unwrap().record;
+        assert_eq!(stored.thread_root, r.thread_root);
+        assert_eq!(stored.thread_parent, r.thread_parent);
+        assert_eq!(stored.ingress_sender_agent, r.ingress_sender_agent);
+        assert_eq!(stored.logical_request_id, Some([0x31; 16]));
+    }
+
     fn rec(payload: &[u8], scope: Scope) -> HistoryRecord {
         let msg_id = HistoryRecord::compute_msg_id(None, payload);
         HistoryRecord {
@@ -819,6 +1044,10 @@ mod tests {
             sig_context: None,
             provenance: Provenance::LocalAppDecrypt,
             replace_key: None,
+            thread_root: None,
+            thread_parent: None,
+            ingress_sender_agent: None,
+            logical_request_id: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2475,6 +2475,10 @@ fn raw_dm_history_record(
         // this layer. This matches artifact-less verified pub/sub history.
         provenance: history::Provenance::VerifiedEnvelope,
         replace_key: None,
+        thread_root: None,
+        thread_parent: None,
+        ingress_sender_agent: None,
+        logical_request_id: None,
     })
 }
 
@@ -4305,6 +4309,10 @@ impl Agent {
             sig_context: None,
             provenance: history::Provenance::LocalSend,
             replace_key: None,
+            thread_root: None,
+            thread_parent: None,
+            ingress_sender_agent: None,
+            logical_request_id: None,
         });
     }
 

--- a/src/server/routes/history.rs
+++ b/src/server/routes/history.rs
@@ -62,10 +62,12 @@ fn row_json(row: &StoredRecord) -> serde_json::Value {
         .unwrap_or_else(|| hex::encode(r.msg_id));
     let thread_root = group_message
         .as_ref()
-        .and_then(|message| message.thread_root.as_deref());
+        .and_then(|message| message.thread_root.as_deref())
+        .or(r.thread_root.as_deref());
     let thread_parent = group_message
         .as_ref()
-        .and_then(|message| message.thread_parent.as_deref());
+        .and_then(|message| message.thread_parent.as_deref())
+        .or(r.thread_parent.as_deref());
     serde_json::json!({
         "id": row.id,
         "msg_id": msg_id,
@@ -400,6 +402,10 @@ mod tests {
                 sig_context: Some("x0x.group.public-message.v2".to_string()),
                 provenance: Provenance::VerifiedEnvelope,
                 replace_key: None,
+                thread_root: None,
+                thread_parent: None,
+                ingress_sender_agent: None,
+                logical_request_id: None,
             },
         };
 

--- a/src/server/routes/identity.rs
+++ b/src/server/routes/identity.rs
@@ -749,6 +749,10 @@ pub(in crate::server) async fn import_agent_card(
                 sig_context: None,
                 provenance,
                 replace_key: Some(format!("agent-card:{}", card.agent_id)),
+                thread_root: None,
+                thread_parent: None,
+                ingress_sender_agent: None,
+                logical_request_id: None,
             });
         }
     }

--- a/src/server/routes/messaging.rs
+++ b/src/server/routes/messaging.rs
@@ -58,6 +58,10 @@ fn record_topic_message(
         sig_context: None,
         provenance: x0x::history::Provenance::VerifiedEnvelope,
         replace_key: None,
+        thread_root: None,
+        thread_parent: None,
+        ingress_sender_agent: None,
+        logical_request_id: None,
     });
 }
 

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -9404,6 +9404,12 @@ fn record_group_public_history(state: &AppState, msg: &x0x::groups::GroupPublicM
             x0x::history::Provenance::VerifiedEnvelope
         },
         replace_key: None,
+        // ADR-0029 ancestry stays recomputable from the signed artifact; the
+        // schema v3 columns are reserved for the DM plane's own thread meta.
+        thread_root: None,
+        thread_parent: None,
+        ingress_sender_agent: None,
+        logical_request_id: None,
     });
 }
 
@@ -9450,6 +9456,10 @@ fn record_mls_history(
         sig_context: None,
         provenance: x0x::history::Provenance::LocalAppDecrypt,
         replace_key: None,
+        thread_root: None,
+        thread_parent: None,
+        ingress_sender_agent: None,
+        logical_request_id: None,
     });
 }
 
@@ -14788,6 +14798,10 @@ pub(in crate::server) async fn import_group_card(
                 sig_context: None,
                 provenance: x0x::history::Provenance::VerifiedEnvelope,
                 replace_key: Some(format!("group-card:{group_id}")),
+                thread_root: None,
+                thread_parent: None,
+                ingress_sender_agent: None,
+                logical_request_id: None,
             });
         }
     }
@@ -25710,6 +25724,10 @@ mod tests {
                 ),
                 provenance: Provenance::VerifiedEnvelope,
                 replace_key: None,
+                thread_root: None,
+                thread_parent: None,
+                ingress_sender_agent: None,
+                logical_request_id: None,
             };
             record.validate().expect(
                 "HistoryRecord produced by record_group_public_history must pass validate()",

--- a/tests/history_point_lookup_wiring.rs
+++ b/tests/history_point_lookup_wiring.rs
@@ -103,6 +103,94 @@ async fn start_daemon(dir: &Path) -> Daemon {
     }
 }
 
+/// Schema v4 added four columns to every history row. Readers pinned to the
+/// released response shape (tic-tac-toe 0.5.2 among them) must see no
+/// difference: rows written by today's writers leave the new columns unset,
+/// so `/history` keeps exactly the keys it served before, with `thread_root`
+/// and `thread_parent` still derived from the signed group artifact.
+///
+/// REVERT GUARD: leak a new column into `row_json` (src/server/routes/
+/// history.rs) or change the derivation and this key-set assertion fails.
+#[tokio::test]
+async fn history_row_json_shape_unchanged_by_schema_v4() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let daemon = start_daemon(dir.path()).await;
+
+    let created = daemon
+        .post_json(
+            "/groups",
+            serde_json::json!({"name": "shape-guard", "preset": "public_open"}),
+        )
+        .await;
+    assert_eq!(created["ok"], true, "create group: {created:?}");
+    let group_id = created["group_id"].as_str().expect("group_id").to_string();
+
+    let sent = daemon
+        .post_json(
+            &format!("/groups/{group_id}/send"),
+            serde_json::json!({"body": "shape guard payload"}),
+        )
+        .await;
+    assert_eq!(sent["ok"], true, "group send: {sent:?}");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let record = loop {
+        let (status, body) = daemon
+            .get_status(&format!("/history?scope=group:{group_id}&limit=10"))
+            .await;
+        if status == reqwest::StatusCode::OK {
+            if let Some(row) = body["records"].as_array().and_then(|rows| rows.first()) {
+                break row.clone();
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the group send never produced a durable history row: {body:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+
+    let mut keys: Vec<&str> = record
+        .as_object()
+        .expect("record must be a JSON object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        [
+            "author_agent",
+            "author_machine",
+            "content_type",
+            "direction",
+            "id",
+            "msg_id",
+            "payload",
+            "provenance",
+            "replace_key",
+            "scope",
+            "seen_at_ms",
+            "sent_at_ms",
+            "signed",
+            "thread_parent",
+            "thread_root",
+        ],
+        "schema v4 must not change the /history record shape: {record:?}"
+    );
+
+    // A rootless group message still reports null ancestry — the dormant
+    // columns must not turn into empty strings or defaults.
+    assert!(
+        record["thread_root"].is_null(),
+        "unthreaded row must report null thread_root: {record:?}"
+    );
+    assert!(
+        record["thread_parent"].is_null(),
+        "unthreaded row must report null thread_parent: {record:?}"
+    );
+}
+
 #[tokio::test]
 async fn history_message_point_lookup_serves_group_row_by_canonical_id() {
     let dir = tempfile::tempdir().expect("tmpdir");

--- a/tests/history_store.rs
+++ b/tests/history_store.rs
@@ -23,6 +23,10 @@ fn record(payload: &[u8], scope: Scope, seen_at_ms: i64) -> HistoryRecord {
         sig_context: None,
         provenance: Provenance::LocalAppDecrypt,
         replace_key: None,
+        thread_root: None,
+        thread_parent: None,
+        ingress_sender_agent: None,
+        logical_request_id: None,
     }
 }
 
@@ -355,6 +359,51 @@ fn config_defaults_match_adr() {
         HistoryConfig::default().max_bytes,
         x0x::history::DEFAULT_MAX_BYTES
     );
+}
+
+/// The schema v4 ingress columns are two halves of one authenticated fact:
+/// which transport peer delivered the row, and which logical request bound
+/// it. Recording a sender with no request id (or vice versa) would let a
+/// future durable-ingress writer persist a binding nothing can be checked
+/// against, so `validate` rejects the half-set pair at the store boundary.
+#[test]
+fn ingress_sender_and_logical_request_id_must_be_set_together() {
+    let scope = Scope::Dm("peer".into());
+    let base = record(b"typed ingress row", scope, 1_000);
+
+    let mut sender_only = base.clone();
+    sender_only.ingress_sender_agent = Some("aa".repeat(32));
+    let err = sender_only.validate().unwrap_err().to_string();
+    assert!(
+        err.contains("must be set together"),
+        "sender without logical request id must be rejected, got: {err}"
+    );
+
+    let mut request_only = base.clone();
+    request_only.logical_request_id = Some([0x31; 16]);
+    assert!(
+        request_only.validate().is_err(),
+        "logical request id without a sender must be rejected"
+    );
+
+    let mut both = base.clone();
+    both.ingress_sender_agent = Some("aa".repeat(32));
+    both.logical_request_id = Some([0x31; 16]);
+    both.validate().expect("a fully bound pair is valid");
+
+    // Neither set is the normal case for every row main writes today.
+    base.validate().expect("an unbound record is valid");
+}
+
+/// The store applies the same rule, so a half-set pair cannot reach SQLite
+/// even if a caller skips `validate` itself.
+#[test]
+fn insert_rejects_half_set_ingress_binding() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Store::open(&dir.path().join("history.db")).unwrap();
+    let mut r = record(b"half bound row", Scope::Dm("peer".into()), 1_000);
+    r.ingress_sender_agent = Some("aa".repeat(32));
+    assert!(store.insert(&r).is_err());
 }
 
 #[test]


### PR DESCRIPTION
The 0.37.4 schema slice: history-store migrations v2→v3→v4 extracted **schema-only** from `wip/codex-durable-app-ack`, unblocking the tic-tac-toe 0.5.2 reader dependency ahead of the durable-ACK protocol work. Per ADR 0030's continuity clause: additive ALTERs on top of the released FTS v2 store, never a drop-in replacement.

## Migrations

- v2→v3: `thread_root TEXT`, `thread_parent TEXT`
- v3→v4: `ingress_sender_agent TEXT`, `logical_request_id BLOB`
- Fresh DBs are created at v1 and walked through the same steps as upgrading ones — the CREATE path and ALTER path cannot drift. Each migration stamps its own target version (fixes a latent bug where `migrate_v1_to_v2` stamped `SCHEMA_VERSION`, which would have marked a v2 DB as v4 the moment the constant moved).
- Columns land **dormant**: every existing writer sets them `None`; `validate()` enforces only that the ingress/logical pair is set together. Writers arrive with the campaign slices.
- REST reads the new columns only as a fallback (artifact-recovered ancestry preferred) — existing rows' response shape is byte-identical.

## Deliberately NOT taken from the campaign

`record_committed`/writer commit plumbing; the duplicate-msg_id ingress rebind; `DmThreadMeta` canonical-form validation (protocol code not yet landed); the `compute_local_send_msg_id` hash change; and the campaign's **removal of `GET /history/message/:msg_id`** — that's a shipped ADR-0023 surface (#319) and it stays.

## Gates (verified independently on the pushed tree)

fmt clean · clippy `--workspace --all-features -D warnings` exit 0 · nextest **2599/2599** (+6: migration both-paths, fresh-create-at-v4, paired-field validation, and a wiring extension proving `/history` row shape is unchanged for pre-existing rows on a live daemon).

Cross-review: Grok. After merge: v0.37.4 tag (their 0.5.2 attaches to `x0x-ttt` once a released daemon has this reader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR advances the durable-history SQLite schema from v2 to v4 through additive, sequential migrations while preserving the existing REST response shape.
- Adds nullable thread ancestry and durable-ingress binding columns to history records.
- Routes fresh and existing databases through the same v1→v2→v3→v4 migration chain.
- Extends SQLite reads and writes for the new fields and validates ingress sender/request-ID pairing.
- Adds migration, round-trip, validation, and daemon-level response-compatibility coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The migration steps atomically update schema and version state, all current record constructors initialize the new dormant fields consistently, storage round-trips them correctly, and the public history projection remains compatible.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/history/store.rs | Adds atomic v2→v3→v4 migrations, extends all SQL projections and inserts, and verifies fresh and upgraded database continuity. |
| src/history/record.rs | Adds four optional durable-history fields and enforces paired ingress sender and logical request identifiers. |
| src/server/routes/history.rs | Uses stored ancestry only as a fallback while retaining signed group-artifact ancestry precedence and the existing JSON shape. |
| tests/history_store.rs | Covers paired-field validation and rejection at the store boundary. |
| tests/history_point_lookup_wiring.rs | Adds live-daemon coverage proving schema v4 does not alter the established history response shape. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Fresh[Fresh database] --> V1[Create schema v1]
  Existing1[Existing v1] --> M12[v1 → v2: FTS backfill]
  V1 --> M12
  Existing2[Existing v2] --> M23[v2 → v3: thread columns]
  M12 --> M23
  Existing3[Existing v3] --> M34[v3 → v4: ingress columns]
  M23 --> M34
  M34 --> V4[Schema v4]
```

<sub>Reviews (1): Last reviewed commit: ["feat(history): schema v4 — thread and in..."](https://github.com/saorsa-labs/x0x/commit/884769faf470ebaa9bae2de52ba9a69bb17b1902) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53131293)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)
- Knowledge Base — [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)
- Knowledge Base — [Required Test Gates: Observation Completeness](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/test-gate-policy.md)
</details>

<!-- /greptile_comment -->