### PR TITLE
feat(dm): DA slice 1 — capability advert + strict-send gate (ADR 0030 §2/§3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **DM protocol v2 capability advertisement + strict-send gate (ADR 0030,
+  slice 1 of 4).** `DM_PROTOCOL_VERSION` becomes the receive **ceiling** 2:
+  envelopes above it are dropped without an ACK. A daemon advertises
+  `max_protocol_version = 2` iff durable history is enabled, else 1 (ADR
+  0030 §3); agent cards now export the same runtime value instead of a
+  hardcoded v1, and card imports go through `CapabilityStore::insert_from_card`
+  so a stale card can never lower a live signed advert.
+- **`DmSendConfig::require_durable_app_ack`** (default `false`). A strict
+  send negotiates v2 on the wire and pins its ACK waiter to
+  `(protocol_version, recipient, machine)`; a recipient without a current
+  signed v2 advert yields `DmError::AckSemanticsUnavailable` → REST 409
+  `recipient_ack_semantics_unavailable`, after exactly one forced targeted
+  capability refresh. Never a silent downgrade to v1 receipt semantics,
+  never a hang (ADR 0030 §2).
+- **Targeted capability refresh protocol** on
+  `x0x/caps/v1/request/targeted-v2`, answered on
+  `x0x/caps/v1/response/targeted-v2` (both Critical admission, so a strict
+  send's convergence window is not cooled behind Bulk advert traffic).
+  Concurrent strict sends to one recipient share a single in-flight
+  request; responses are rate limited.
+
+### Notes
+
+- No send surface sets `require_durable_app_ack` yet: REST, CLI, WS and the
+  library default stay v1-defaulted, so this slice is behaviour-neutral for
+  existing callers. Product defaults flip in ADR 0030 slice 4.
+- The receiver durable path is slice 2. Until it lands this build ACKs with
+  `protocol_version = 1` — the semantics it actually honours — so a strict
+  send that clears the gate times out rather than receiving a durable
+  receipt no one made.
+
 ## [v0.37.4] - 2026-08-14
 
 History schema v4 (ADR 0030 continuity) + gossip guard v2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - **DM protocol v2 capability advertisement + strict-send gate (ADR 0030,
   slice 1 of 4).** `DM_PROTOCOL_VERSION` becomes the receive **ceiling** 2:
-  envelopes above it are dropped without an ACK. A daemon advertises
-  `max_protocol_version = 2` iff durable history is enabled, else 1 (ADR
-  0030 §3); agent cards now export the same runtime value instead of a
-  hardcoded v1, and card imports go through `CapabilityStore::insert_from_card`
+  envelopes above it are dropped without an ACK. The production advert is
+  **held at `max_protocol_version = 1`** until the slice-2 receiver durable
+  path ships in the same binary — advertising v2 without it would be a
+  false capability and hang strict senders (PR #327 review; the ADR 0030
+  §3 v2-iff-history flip lands with slice 2). Agent cards export the same
+  runtime value, and card imports go through `CapabilityStore::insert_from_card`
   so a stale card can never lower a live signed advert.
 - **`DmSendConfig::require_durable_app_ack`** (default `false`). A strict
   send negotiates v2 on the wire and pins its ACK waiter to

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -356,6 +356,19 @@ gossip inbox. **Defaults to `true` since v0.37.0** (previously `false`);
 omitting the field selects the daemon default, so clients that relied on the
 old default must now send `"prefer_raw_quic_if_connected": false` explicitly.
 
+Optional field `require_gossip_ack` (bool): when a gossip-inbox send is used,
+wait for the recipient's application ACK before returning success. `false`
+returns as soon as the publish succeeds. Omitting the field selects the daemon
+default (`true`).
+
+> **Deprecated (ADR 0030 §4), still honored.** This field is scheduled for
+> removal when the product tier moves to durable-by-default sends in ADR 0030
+> slice 4, at which point `require_gossip_ack: false` stops being expressible
+> and the route will reject the field with **400** rather than accept it as a
+> no-op. It is fully honored today — see `direct_send_config_for_request` in
+> `src/server/routes/direct.rs` and the branch on `config.require_gossip_ack`
+> in `src/dm_send.rs` — so no client needs to change yet.
+
 ### Direct send error codes
 
 `/direct/send` failures answer with `{"ok": false, "error": "<code>"}`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -356,6 +356,25 @@ gossip inbox. **Defaults to `true` since v0.37.0** (previously `false`);
 omitting the field selects the daemon default, so clients that relied on the
 old default must now send `"prefer_raw_quic_if_connected": false` explicitly.
 
+### Direct send error codes
+
+`/direct/send` failures answer with `{"ok": false, "error": "<code>"}`.
+Notable codes:
+
+| Status | `error` | Meaning |
+|---|---|---|
+| 404 | `recipient_key_unavailable` | The recipient has published no KEM key. |
+| 409 | `recipient_key_invalid` | Our view of the recipient's key material has not converged. Transient — retry. |
+| 409 | `recipient_ack_semantics_unavailable` | The send required ADR 0030 durable application-ACK semantics and the recipient advertises no current v2 capability. Returned after one forced targeted capability refresh, so it is fast and deterministic rather than a timeout. The caller retries, surfaces "peer needs upgrade", or resends without the durable requirement — the daemon never downgrades silently. |
+| 413 | `payload_too_large` | Payload exceeds the DM envelope cap. |
+| 504 | `timeout` | No application ACK within the retry budget. The DM may or may not have arrived. |
+
+**Note (as of ADR 0030 slice 1):** no REST field selects durable ACK
+semantics yet, so `recipient_ack_semantics_unavailable` is currently
+reachable only through the library (`DmSendConfig::require_durable_app_ack`).
+The product-tier default flips in ADR 0030 slice 4, at which point this
+becomes a routine response for not-yet-upgraded peers.
+
 ### `/direct/events` SSE message shape
 
 Direct messages arrive flat — no `data` envelope:

--- a/docs/design/dm-over-gossip.md
+++ b/docs/design/dm-over-gossip.md
@@ -200,6 +200,35 @@ Documented explicitly so we don't overclaim:
 `DmReceipt::delivered_at` corresponds to **level 2**. Docs and API
 names use "accepted" rather than "delivered" to avoid confusion.
 
+### Protocol v2 — durable application ACK (ADR 0030)
+
+DM protocol v2 raises `Accepted` to **level 3** for sends that ask for it.
+The envelope layout is byte-identical to v1; only ACK semantics differ, so
+`protocol_version` is a promise about the *receipt*, not a wire change.
+
+Landing in slices (ADR 0030 "Landing order"). Slice 1 ships:
+
+- `DM_PROTOCOL_VERSION = 2` as the **receive ceiling**. Envelopes above it
+  are dropped without an ACK, so the sender times out rather than being
+  handed a receipt for semantics we cannot honour.
+- A daemon advertises `max_protocol_version = 2` **iff** durable history is
+  enabled, else 1 (ADR 0030 §3). Card exports and mesh adverts carry the
+  same value.
+- `DmSendConfig::require_durable_app_ack` (default `false`). When set, the
+  send negotiates v2 on the wire and its ACK waiter is pinned to
+  `(protocol_version, recipient, machine)`. A recipient without a current
+  signed v2 advert yields `DmError::AckSemanticsUnavailable` — REST 409
+  `recipient_ack_semantics_unavailable` — after one forced targeted
+  capability refresh. Never a silent downgrade, never a hang.
+- Targeted capability refresh on `x0x/caps/v1/request/targeted-v2`, answered
+  on `x0x/caps/v1/response/targeted-v2` (both Critical). Concurrent strict
+  sends to one recipient share a single in-flight request.
+
+**Not yet in slice 1:** the receiver durable path. Until it lands, this
+build ACKs every accepted payload with `protocol_version = 1` — the
+semantics it actually honours — so a strict send that clears the capability
+gate still times out rather than receiving a durable receipt no one made.
+
 ## Capability negotiation
 
 ### Advertisement

--- a/docs/design/dm-over-gossip.md
+++ b/docs/design/dm-over-gossip.md
@@ -211,9 +211,13 @@ Landing in slices (ADR 0030 "Landing order"). Slice 1 ships:
 - `DM_PROTOCOL_VERSION = 2` as the **receive ceiling**. Envelopes above it
   are dropped without an ACK, so the sender times out rather than being
   handed a receipt for semantics we cannot honour.
-- A daemon advertises `max_protocol_version = 2` **iff** durable history is
-  enabled, else 1 (ADR 0030 §3). Card exports and mesh adverts carry the
-  same value.
+- The production advert is **held at `max_protocol_version = 1`** in this
+  slice: a binary carrying the strict-send gate but not the slice-2
+  receiver durable path must not claim v2, or a strict sender that finds
+  the advert clears its gate and hangs against a v1 ACK (exact-protocol
+  waiter). The ADR 0030 §3 rule — v2 **iff** durable history is enabled —
+  activates in the same change as slice 2. Card exports and mesh adverts
+  carry the runtime value either way.
 - `DmSendConfig::require_durable_app_ack` (default `false`). When set, the
   send negotiates v2 on the wire and its ACK waiter is pinned to
   `(protocol_version, recipient, machine)`. A recipient without a current

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -22,8 +22,18 @@ use std::time::{Duration, Instant};
 use chacha20poly1305::aead::{Aead, KeyInit, Payload};
 use chacha20poly1305::{ChaCha20Poly1305, Nonce};
 
-/// DM protocol version. Bumped on any backward-incompatible wire change.
-pub const DM_PROTOCOL_VERSION: u16 = 1;
+/// Legacy DM semantics: `Accepted` means verified and locally enqueued.
+pub const DM_PROTOCOL_V1: u16 = 1;
+
+/// Durable application-ACK semantics (ADR 0030): `Accepted` is emitted only
+/// after a verified payload commits to ADR-0023 history and local dispatch
+/// completes. The envelope layout is identical to v1; only ACK semantics
+/// differ.
+pub const DM_PROTOCOL_DURABLE_ACK: u16 = 2;
+
+/// Highest DM protocol version this build understands on the receive path.
+/// Envelopes above this ceiling are dropped without ACK (ADR 0030 §2).
+pub const DM_PROTOCOL_VERSION: u16 = DM_PROTOCOL_DURABLE_ACK;
 
 /// Maximum envelope bytes (postcard-serialised). Soft cap: receivers drop
 /// envelopes over this size without processing or ACKing.
@@ -83,13 +93,23 @@ pub struct DmCapabilities {
 }
 
 impl DmCapabilities {
+    /// Whether this live advert can satisfy a strict (`require_durable_app_ack`)
+    /// product send. Requires a usable gossip inbox *and* a v2+ receive path,
+    /// because durable ACK semantics are only produced by the gossip inbox.
+    #[must_use]
+    pub fn supports_durable_app_ack(&self) -> bool {
+        self.gossip_inbox
+            && !self.kem_public_key.is_empty()
+            && self.max_protocol_version >= DM_PROTOCOL_DURABLE_ACK
+    }
+
     /// Placeholder capability advert for agents that have not yet wired
     /// their KEM keypair. `gossip_inbox` is `false` and `kem_public_key`
     /// is empty — senders will fall back to the raw-QUIC path.
     #[must_use]
     pub fn pending() -> Self {
         Self {
-            max_protocol_version: DM_PROTOCOL_VERSION,
+            max_protocol_version: DM_PROTOCOL_V1,
             gossip_inbox: false,
             kem_algorithm: "ML-KEM-768".to_string(),
             max_envelope_bytes: MAX_ENVELOPE_BYTES,
@@ -102,7 +122,23 @@ impl DmCapabilities {
     #[must_use]
     pub fn v1_gossip_ready(kem_public_key: Vec<u8>) -> Self {
         Self {
-            max_protocol_version: DM_PROTOCOL_VERSION,
+            max_protocol_version: DM_PROTOCOL_V1,
+            gossip_inbox: true,
+            kem_algorithm: "ML-KEM-768".to_string(),
+            max_envelope_bytes: MAX_ENVELOPE_BYTES,
+            kem_public_key,
+        }
+    }
+
+    /// Fully-wired gossip DM advert whose v2 ACKs certify a committed local
+    /// history row plus completed local application dispatch.
+    ///
+    /// Published only when durable history is enabled (ADR 0030 §3): a daemon
+    /// with history off cannot honour the receipt and must advertise v1.
+    #[must_use]
+    pub fn v2_durable_gossip_ready(kem_public_key: Vec<u8>) -> Self {
+        Self {
+            max_protocol_version: DM_PROTOCOL_DURABLE_ACK,
             gossip_inbox: true,
             kem_algorithm: "ML-KEM-768".to_string(),
             max_envelope_bytes: MAX_ENVELOPE_BYTES,
@@ -472,6 +508,15 @@ pub enum DmError {
     #[error("recipient key material invalid: {0}")]
     RecipientKeyInvalid(String),
 
+    /// The caller required durable application-ACK semantics but the recipient
+    /// has no current, signed, machine-bound v2 capability advert (ADR 0030
+    /// §2). Terminal for this attempt: the daemon refuses rather than silently
+    /// downgrading to v1 receipt semantics. The caller decides whether to
+    /// retry, surface "peer needs upgrade", or resend with
+    /// `require_durable_app_ack = false`.
+    #[error("recipient does not advertise durable application ACK support: {0}")]
+    AckSemanticsUnavailable(String),
+
     /// No application-layer ACK received within the retry budget. The DM
     /// MAY or may not have been delivered; the sender cannot distinguish.
     /// Safe to retry (recipient dedupes on `request_id`).
@@ -653,6 +698,13 @@ pub struct DmSendConfig {
     /// ACK before returning success. If false, a successful gossip publish is
     /// reported as accepted-for-delivery and any later ACK is ignored.
     pub require_gossip_ack: bool,
+    /// Require ADR 0030 v2 semantics: the send negotiates DM protocol v2 and
+    /// only succeeds on a v2 ACK, which certifies a committed recipient
+    /// history row plus completed local dispatch. A recipient without a
+    /// current signed v2 capability advert yields
+    /// [`DmError::AckSemanticsUnavailable`] rather than a silent v1 downgrade.
+    /// Defaults to `false`; product surfaces opt in (ADR 0030 §4).
+    pub require_durable_app_ack: bool,
     /// X0X-0041: bounded grace window (ms) the DM path holds when ant-quic has
     /// just observed a `Replaced` event but the new `Established` has not yet
     /// fired. Mirrors iroh-gossip #43 "always prefer newest connection" — when
@@ -679,6 +731,7 @@ impl Default for DmSendConfig {
             raw_quic_receive_ack_timeout: None,
             stop_fallback_on_raw_error: false,
             require_gossip_ack: true,
+            require_durable_app_ack: false,
             // X0X-0041: 250ms is the soak-tested grace from iroh-gossip #43.
             prefer_newest_grace_ms: DEFAULT_PREFER_NEWEST_GRACE_MS,
         }
@@ -1235,6 +1288,56 @@ impl EnvelopeBuilder {
     where
         F: FnOnce(&[u8]) -> std::result::Result<Vec<u8>, String>,
     {
+        Self::build_payload_envelope_with_version(
+            DM_PROTOCOL_V1,
+            request_id,
+            self_agent_id,
+            self_machine_id,
+            machine_keypair,
+            recipient_agent_id,
+            recipient_kem_public_key,
+            created_at_unix_ms,
+            expires_at_unix_ms,
+            payload,
+            sign,
+        )
+    }
+
+    /// Build a payload envelope stamped with an explicitly negotiated protocol
+    /// version.
+    ///
+    /// The layout is identical across v1 and v2 (ADR 0030); only ACK semantics
+    /// differ, so the version is a promise about the *receipt* the sender will
+    /// accept. Senders must not stamp a version above what the recipient's
+    /// capability advert claims — the recipient drops it without ACKing.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::build_payload_envelope`], plus
+    /// [`DmError::EnvelopeConstruction`] when `protocol_version` is outside
+    /// `DM_PROTOCOL_V1..=DM_PROTOCOL_VERSION`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_payload_envelope_with_version<F>(
+        protocol_version: u16,
+        request_id: [u8; 16],
+        self_agent_id: &AgentId,
+        self_machine_id: &MachineId,
+        machine_keypair: &crate::identity::MachineKeypair,
+        recipient_agent_id: &AgentId,
+        recipient_kem_public_key: &[u8],
+        created_at_unix_ms: u64,
+        expires_at_unix_ms: u64,
+        payload: Vec<u8>,
+        sign: F,
+    ) -> std::result::Result<DmEnvelope, DmError>
+    where
+        F: FnOnce(&[u8]) -> std::result::Result<Vec<u8>, String>,
+    {
+        if !(DM_PROTOCOL_V1..=DM_PROTOCOL_VERSION).contains(&protocol_version) {
+            return Err(DmError::EnvelopeConstruction(format!(
+                "unsupported DM protocol version {protocol_version}"
+            )));
+        }
         // Classify the size cap with its dedicated variant so API layers can
         // answer 413 instead of the opaque `envelope_construction` 400
         // (issue #188). Covers the relay-fallback path, which has no earlier
@@ -1261,7 +1364,7 @@ impl EnvelopeBuilder {
         )
         .map_err(|e| DmError::EnvelopeConstruction(e.to_string()))?;
         let mut envelope = DmEnvelope {
-            protocol_version: DM_PROTOCOL_VERSION,
+            protocol_version,
             request_id,
             sender_agent_id: *self_agent_id.as_bytes(),
             sender_machine_id: *self_machine_id.as_bytes(),
@@ -1291,11 +1394,25 @@ impl EnvelopeBuilder {
 
 // ─── In-flight ACK tracking ────────────────────────────────────────────────
 
-/// Map of request_id → oneshot::Sender that the inbox handler uses to wake
-/// the sender task when an ACK arrives.
+/// Map of request_id → the pending waiter that the inbox handler wakes when an
+/// ACK arrives.
 #[derive(Default)]
 pub struct InFlightAcks {
-    inner: Arc<dashmap::DashMap<[u8; 16], tokio::sync::oneshot::Sender<DmAckOutcome>>>,
+    inner: Arc<dashmap::DashMap<[u8; 16], InFlightAck>>,
+}
+
+/// A registered waiter plus the binding an ACK must satisfy to resolve it.
+///
+/// ADR 0030 pins `(protocol_version, recipient, machine)` on the sender's
+/// waiter so a v1 ACK — or an ACK from a different machine of the same agent —
+/// can never be mistaken for the durable v2 receipt the caller asked for.
+struct InFlightAck {
+    expected_recipient: AgentId,
+    /// `None` for legacy v1 sends, which have no signed machine binding to
+    /// pin against. Strict v2 sends always supply the advert's machine.
+    expected_machine: Option<MachineId>,
+    protocol_version: u16,
+    reply: tokio::sync::oneshot::Sender<DmAckOutcome>,
 }
 
 impl Clone for InFlightAcks {
@@ -1312,31 +1429,109 @@ impl InFlightAcks {
         Self::default()
     }
 
-    /// Register a waiter for `request_id`. Returns the receiver side of the
-    /// oneshot; caller awaits it with their timeout.
+    /// Register a v1-semantics waiter for `request_id`. Returns the receiver
+    /// side of the oneshot; caller awaits it with their timeout.
     ///
     /// If a prior waiter exists for the same id (e.g. from an earlier
     /// retry that was already resolved), the existing waiter is silently
     /// replaced. This matches sender-retry semantics where only the most
     /// recent attempt's waiter is of interest.
-    pub fn register(&self, request_id: [u8; 16]) -> tokio::sync::oneshot::Receiver<DmAckOutcome> {
+    pub fn register(
+        &self,
+        request_id: [u8; 16],
+        expected_recipient: AgentId,
+        expected_machine: Option<MachineId>,
+    ) -> tokio::sync::oneshot::Receiver<DmAckOutcome> {
+        self.register_for_protocol(
+            request_id,
+            DM_PROTOCOL_V1,
+            expected_recipient,
+            expected_machine,
+        )
+    }
+
+    /// Register a waiter that only an ACK from `expected_recipient` — on
+    /// `expected_machine` when supplied — carrying exactly `protocol_version`
+    /// may resolve.
+    pub fn register_for_protocol(
+        &self,
+        request_id: [u8; 16],
+        protocol_version: u16,
+        expected_recipient: AgentId,
+        expected_machine: Option<MachineId>,
+    ) -> tokio::sync::oneshot::Receiver<DmAckOutcome> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.inner.insert(request_id, tx);
+        self.inner.insert(
+            request_id,
+            InFlightAck {
+                expected_recipient,
+                expected_machine,
+                protocol_version,
+                reply: tx,
+            },
+        );
         rx
     }
 
-    /// Resolve a waiter for `request_id`. Returns true if a waiter was
-    /// present, false otherwise (e.g. late ACK arriving after sender gave
-    /// up).
-    pub fn resolve(&self, request_id: &[u8; 16], outcome: DmAckOutcome) -> bool {
-        if let Some((_, tx)) = self.inner.remove(request_id) {
-            // If the receiver was dropped we silently swallow the send
-            // error — caller already moved on.
-            let _ = tx.send(outcome);
-            true
-        } else {
-            false
+    /// Resolve a v1-semantics waiter for `request_id`.
+    pub fn resolve(
+        &self,
+        request_id: &[u8; 16],
+        ack_sender: AgentId,
+        ack_machine: MachineId,
+        outcome: DmAckOutcome,
+    ) -> bool {
+        self.resolve_for_protocol(request_id, DM_PROTOCOL_V1, ack_sender, ack_machine, outcome)
+    }
+
+    /// Resolve a waiter only when the authenticated ACK sender agent, its
+    /// machine, and the ACK's protocol version all match the registered
+    /// binding. Returns true if a waiter was resolved, false otherwise (a late
+    /// ACK after the sender gave up, or a receipt weaker than the one the
+    /// caller is waiting for).
+    ///
+    /// The match on `protocol_version` is exact, not `>=`: a v1 ACK asserts
+    /// level-2 enqueue and must never satisfy a waiter that was promised the
+    /// v2 durable receipt (ADR 0030 §2).
+    pub fn resolve_for_protocol(
+        &self,
+        request_id: &[u8; 16],
+        protocol_version: u16,
+        ack_sender: AgentId,
+        ack_machine: MachineId,
+        outcome: DmAckOutcome,
+    ) -> bool {
+        use dashmap::mapref::entry::Entry;
+
+        match self.inner.entry(*request_id) {
+            Entry::Occupied(entry)
+                if Self::ack_binding_matches(
+                    entry.get(),
+                    protocol_version,
+                    ack_sender,
+                    ack_machine,
+                ) =>
+            {
+                // If the receiver was dropped we silently swallow the send
+                // error — caller already moved on.
+                let _ = entry.remove().reply.send(outcome);
+                true
+            }
+            Entry::Occupied(_) | Entry::Vacant(_) => false,
         }
+    }
+
+    fn ack_binding_matches(
+        pending: &InFlightAck,
+        protocol_version: u16,
+        ack_sender: AgentId,
+        ack_machine: MachineId,
+    ) -> bool {
+        pending.protocol_version == protocol_version
+            && pending.expected_recipient == ack_sender
+            && pending
+                .expected_machine
+                .is_none_or(|expected| expected == ack_machine)
     }
 
     /// Cancel a waiter (sender gave up / retry-attempt abandoned).
@@ -1715,19 +1910,177 @@ mod tests {
     #[test]
     fn in_flight_acks_resolve_and_cancel() {
         let acks = InFlightAcks::new();
+        let recipient = AgentId([9u8; 32]);
+        let machine = MachineId([8u8; 32]);
         let rid = [1u8; 16];
-        let rx = acks.register(rid);
-        assert!(acks.resolve(&rid, DmAckOutcome::Accepted));
+        let rx = acks.register(rid, recipient, Some(machine));
+        assert!(acks.resolve(&rid, recipient, machine, DmAckOutcome::Accepted));
         let received = tokio::runtime::Runtime::new().expect("rt").block_on(rx);
         assert_eq!(received.expect("ok"), DmAckOutcome::Accepted);
         // Second resolve → no-op.
-        assert!(!acks.resolve(&rid, DmAckOutcome::Accepted));
+        assert!(!acks.resolve(&rid, recipient, machine, DmAckOutcome::Accepted));
 
         // Cancellation path.
         let rid2 = [2u8; 16];
-        let _rx2 = acks.register(rid2);
+        let _rx2 = acks.register(rid2, recipient, Some(machine));
         acks.cancel(&rid2);
         assert_eq!(acks.outstanding(), 0);
+    }
+
+    /// ADR 0030 §2: a v1 ACK asserts level-2 enqueue. If it could satisfy a
+    /// waiter registered for v2 the sender would report a durable receipt the
+    /// recipient never made — the exact silent-degradation class the protocol
+    /// exists to remove. The version match is therefore exact, not `>=`.
+    #[test]
+    fn v1_ack_cannot_resolve_a_v2_waiter() {
+        let acks = InFlightAcks::new();
+        let recipient = AgentId([0x21; 32]);
+        let machine = MachineId([0x22; 32]);
+        let rid = [0x23; 16];
+        let mut rx =
+            acks.register_for_protocol(rid, DM_PROTOCOL_DURABLE_ACK, recipient, Some(machine));
+
+        assert!(
+            !acks.resolve_for_protocol(
+                &rid,
+                DM_PROTOCOL_V1,
+                recipient,
+                machine,
+                DmAckOutcome::Accepted,
+            ),
+            "a v1 ACK must not satisfy a durable v2 waiter"
+        );
+        assert!(rx.try_recv().is_err(), "the waiter must still be pending");
+        assert_eq!(acks.outstanding(), 1);
+
+        assert!(acks.resolve_for_protocol(
+            &rid,
+            DM_PROTOCOL_DURABLE_ACK,
+            recipient,
+            machine,
+            DmAckOutcome::Accepted,
+        ));
+        assert_eq!(rx.try_recv().expect("resolved"), DmAckOutcome::Accepted);
+    }
+
+    /// The waiter is bound to the exact signed-advert machine, so a second
+    /// daemon running the same agent identity cannot answer for it.
+    #[test]
+    fn ack_from_a_different_machine_cannot_resolve_a_bound_waiter() {
+        let acks = InFlightAcks::new();
+        let recipient = AgentId([0x31; 32]);
+        let bound_machine = MachineId([0x32; 32]);
+        let other_machine = MachineId([0x33; 32]);
+        let rid = [0x34; 16];
+        let mut rx = acks.register_for_protocol(
+            rid,
+            DM_PROTOCOL_DURABLE_ACK,
+            recipient,
+            Some(bound_machine),
+        );
+
+        assert!(!acks.resolve_for_protocol(
+            &rid,
+            DM_PROTOCOL_DURABLE_ACK,
+            recipient,
+            other_machine,
+            DmAckOutcome::Accepted,
+        ));
+        assert!(!acks.resolve_for_protocol(
+            &rid,
+            DM_PROTOCOL_DURABLE_ACK,
+            AgentId([0x35; 32]),
+            bound_machine,
+            DmAckOutcome::Accepted,
+        ));
+        assert!(rx.try_recv().is_err());
+        assert_eq!(acks.outstanding(), 1);
+    }
+
+    /// Legacy v1 sends have no signed machine binding to pin, so they accept
+    /// any machine of the expected recipient agent — unchanged from pre-0030
+    /// behaviour.
+    #[test]
+    fn unbound_v1_waiter_accepts_any_machine_of_the_expected_agent() {
+        let acks = InFlightAcks::new();
+        let recipient = AgentId([0x41; 32]);
+        let rid = [0x42; 16];
+        let mut rx = acks.register(rid, recipient, None);
+
+        assert!(acks.resolve(
+            &rid,
+            recipient,
+            MachineId([0x43; 32]),
+            DmAckOutcome::Accepted,
+        ));
+        assert_eq!(rx.try_recv().expect("resolved"), DmAckOutcome::Accepted);
+    }
+
+    /// A strict send must be able to negotiate v2 on the wire while the
+    /// default builder keeps stamping v1 for every existing caller — a v1/0.37
+    /// receiver's ceiling would otherwise drop all traffic from this build.
+    #[test]
+    fn payload_envelope_defaults_to_v1_and_rejects_versions_above_the_ceiling() {
+        use crate::gossip::SigningContext;
+        use crate::identity::{AgentKeypair, MachineKeypair};
+
+        let agent = AgentKeypair::generate().expect("agent keygen");
+        let machine = MachineKeypair::generate().expect("machine keygen");
+        let recipient_kem = AgentKemKeypair::generate().expect("kem keygen");
+        let signing = SigningContext::from_keypair(&agent);
+        let recipient = AgentId([0x51; 32]);
+        let now = now_unix_ms();
+
+        let build = |version: Option<u16>| {
+            let sign = |bytes: &[u8]| signing.sign(bytes).map_err(|e| e.to_string());
+            match version {
+                None => EnvelopeBuilder::build_payload_envelope(
+                    [0x52; 16],
+                    &agent.agent_id(),
+                    &machine.machine_id(),
+                    &machine,
+                    &recipient,
+                    &recipient_kem.public_bytes,
+                    now,
+                    now + 60_000,
+                    b"hello".to_vec(),
+                    sign,
+                ),
+                Some(version) => EnvelopeBuilder::build_payload_envelope_with_version(
+                    version,
+                    [0x52; 16],
+                    &agent.agent_id(),
+                    &machine.machine_id(),
+                    &machine,
+                    &recipient,
+                    &recipient_kem.public_bytes,
+                    now,
+                    now + 60_000,
+                    b"hello".to_vec(),
+                    sign,
+                ),
+            }
+        };
+
+        assert_eq!(
+            build(None).expect("default build").protocol_version,
+            DM_PROTOCOL_V1,
+            "existing callers must keep emitting v1 envelopes"
+        );
+        assert_eq!(
+            build(Some(DM_PROTOCOL_DURABLE_ACK))
+                .expect("v2 build")
+                .protocol_version,
+            DM_PROTOCOL_DURABLE_ACK
+        );
+        assert!(matches!(
+            build(Some(DM_PROTOCOL_VERSION + 1)),
+            Err(DmError::EnvelopeConstruction(_))
+        ));
+        assert!(matches!(
+            build(Some(0)),
+            Err(DmError::EnvelopeConstruction(_))
+        ));
     }
 
     // ── Issue #213: origin-machine attestation ────────────────────────

--- a/src/dm_capability.rs
+++ b/src/dm_capability.rs
@@ -30,6 +30,22 @@ use std::time::{Duration, Instant};
 /// subscribes on mesh join.
 pub const DM_CAPABILITY_TOPIC: &str = "x0x/caps/v1";
 
+/// Side-channel on which a strict (ADR 0030) sender asks one specific peer to
+/// republish its signed capability advert.
+///
+/// Adverts normally refresh only every five minutes, which is far longer than
+/// a product send can wait. Requests travel in authenticated pub/sub
+/// envelopes and responders still build and sign a fresh advert, so this
+/// channel grants no capability and cannot weaken the advert's
+/// AgentId + MachineId binding.
+pub const DM_CAPABILITY_TARGETED_REQUEST_TOPIC: &str = "x0x/caps/v1/request/targeted-v2";
+
+/// Dedicated response topic for a targeted refresh. The steady advert topic is
+/// Bulk anti-entropy traffic; a strict send has only a short convergence
+/// window, so its request and signed response use their own Critical control
+/// topics rather than being cooled behind the fleet-wide advert stream.
+pub const DM_CAPABILITY_TARGETED_RESPONSE_TOPIC: &str = "x0x/caps/v1/response/targeted-v2";
+
 /// Domain-separation prefix for the advert signature bytes.
 const ADVERT_SIGN_DOMAIN: &[u8] = b"x0x-caps-v1";
 
@@ -40,6 +56,18 @@ pub const ADVERT_PUBLISH_INTERVAL_SECS: u64 = 300;
 /// Must be > `ADVERT_PUBLISH_INTERVAL_SECS` so that a single missed
 /// publish window doesn't evict the cache entry.
 pub const ADVERT_CACHE_TTL_SECS: u64 = 900;
+
+/// Maximum tolerated sender clock lead for signed capability state. An advert
+/// dated further ahead than this is rejected rather than cached, so a skewed
+/// or hostile clock cannot mint an entry that outlives the local TTL.
+pub const MAX_CAPABILITY_FUTURE_SKEW_SECS: u64 = 300;
+
+fn timestamp_is_fresh_for_ttl(created_at_unix_ms: u64, now_unix_ms: u64, ttl_ms: u64) -> bool {
+    let skew_ms = MAX_CAPABILITY_FUTURE_SKEW_SECS.saturating_mul(1_000);
+    ttl_ms > 0
+        && created_at_unix_ms <= now_unix_ms.saturating_add(skew_ms)
+        && now_unix_ms.saturating_sub(created_at_unix_ms) < ttl_ms
+}
 
 /// Signed capability advertisement broadcast on the mesh-wide capability
 /// topic.
@@ -99,9 +127,23 @@ pub struct CapabilityStore {
 
 struct CachedAdvert {
     capabilities: DmCapabilities,
-    _machine_id: [u8; 32],
-    seen_at: Instant,
+    machine_id: [u8; 32],
+    expires_at: Instant,
     created_at_unix_ms: u64,
+}
+
+/// TTL-validated capability material together with the machine binding signed
+/// into the same advert.
+///
+/// Strict (ADR 0030) sends pin the ACK waiter to this exact machine, so the
+/// two must travel together — a capability without its machine cannot satisfy
+/// the durable gate.
+#[derive(Debug, Clone)]
+pub struct CapabilityBinding {
+    /// The advertised capabilities.
+    pub capabilities: DmCapabilities,
+    /// The machine that signed the advert carrying `capabilities`.
+    pub machine_id: MachineId,
 }
 
 impl Default for CapabilityStore {
@@ -131,7 +173,29 @@ impl CapabilityStore {
 
     /// Look up a peer's capability. Returns `None` if unknown or expired.
     pub fn lookup(&self, agent_id: &AgentId) -> Option<DmCapabilities> {
-        self.lookup_at(agent_id, Instant::now())
+        self.lookup_binding(agent_id)
+            .map(|binding| binding.capabilities)
+    }
+
+    /// Look up a peer's capability together with the machine that signed it.
+    pub fn lookup_binding(&self, agent_id: &AgentId) -> Option<CapabilityBinding> {
+        self.lookup_binding_at(agent_id, Instant::now())
+    }
+
+    /// Testable clock seam for [`Self::lookup_binding`].
+    pub fn lookup_binding_at(&self, agent_id: &AgentId, now: Instant) -> Option<CapabilityBinding> {
+        let Ok(mut inner) = self.inner.lock() else {
+            return None;
+        };
+        let entry = inner.get(agent_id.as_bytes())?;
+        if now > entry.expires_at {
+            inner.remove(agent_id.as_bytes());
+            return None;
+        }
+        Some(CapabilityBinding {
+            capabilities: entry.capabilities.clone(),
+            machine_id: MachineId(entry.machine_id),
+        })
     }
 
     /// Look up a peer's capability as of `now`.
@@ -142,15 +206,8 @@ impl CapabilityStore {
     /// deterministically instead of sleeping past a wall-clock boundary —
     /// the documented CI flake for that assertion (issue: CI de-flake).
     pub fn lookup_at(&self, agent_id: &AgentId, now: Instant) -> Option<DmCapabilities> {
-        let Ok(mut inner) = self.inner.lock() else {
-            return None;
-        };
-        let entry = inner.get(agent_id.as_bytes())?;
-        if now.duration_since(entry.seen_at) > self.ttl {
-            inner.remove(agent_id.as_bytes());
-            return None;
-        }
-        Some(entry.capabilities.clone())
+        self.lookup_binding_at(agent_id, now)
+            .map(|binding| binding.capabilities)
     }
 
     /// Insert / refresh a cache entry.
@@ -162,32 +219,133 @@ impl CapabilityStore {
     /// (gossip_inbox=false) advert can arrive *after* its upgraded
     /// gossip-ready advert and clobber it — leaving every sender on the
     /// silent raw-QUIC fallback (`advert_cache_unusable`) until the next
-    /// republish window. An equal timestamp refreshes the TTL (duplicate
-    /// delivery of the same advert).
+    /// republish window. An equal timestamp is a replay and cannot extend the
+    /// original expiry.
+    ///
+    /// Entry lifetime is derived from the *signed* timestamp, not from arrival
+    /// time: a replayed advert therefore ages out on its own schedule instead
+    /// of being renewed indefinitely by whoever rebroadcasts it.
+    ///
+    /// Returns `true` only when fresh signed state was inserted.
     pub fn insert(
         &self,
         agent_id: AgentId,
         machine_id: MachineId,
         capabilities: DmCapabilities,
         created_at_unix_ms: u64,
-    ) {
+    ) -> bool {
+        let Some(expires_at) = self.expiry_for_signed_timestamp(created_at_unix_ms, now_unix_ms())
+        else {
+            return false;
+        };
         let Ok(mut inner) = self.inner.lock() else {
-            return;
+            return false;
         };
         if let Some(existing) = inner.get(agent_id.as_bytes()) {
-            if created_at_unix_ms < existing.created_at_unix_ms {
-                return;
+            if created_at_unix_ms <= existing.created_at_unix_ms {
+                return false;
             }
         }
         inner.insert(
             *agent_id.as_bytes(),
             CachedAdvert {
                 capabilities,
-                _machine_id: *machine_id.as_bytes(),
-                seen_at: Instant::now(),
+                machine_id: *machine_id.as_bytes(),
+                expires_at,
                 created_at_unix_ms,
             },
         );
+        true
+    }
+
+    /// Insert capability material imported from an agent card, unless doing so
+    /// would lower the protocol version of a live runtime advert.
+    ///
+    /// Cards remain useful for first contact and for refreshing same-version
+    /// KEM/machine material. But a live daemon publishes its current runtime
+    /// capability on the mesh, while a legacy or statically exported card may
+    /// still claim v1 — and ADR 0030 §3 forbids an unsigned/stale source from
+    /// lowering a live binding, which would make strict sends fail until the
+    /// next mesh refresh.
+    ///
+    /// Returns `true` when the card material was inserted.
+    pub fn insert_from_card(
+        &self,
+        agent_id: AgentId,
+        machine_id: MachineId,
+        capabilities: DmCapabilities,
+        created_at_unix_ms: u64,
+    ) -> bool {
+        let now = Instant::now();
+        let Some(expires_at) =
+            self.expiry_for_signed_timestamp_at(created_at_unix_ms, now_unix_ms(), now)
+        else {
+            return false;
+        };
+        let Ok(mut inner) = self.inner.lock() else {
+            return false;
+        };
+        if let Some(existing) = inner.get(agent_id.as_bytes()) {
+            if created_at_unix_ms < existing.created_at_unix_ms {
+                return false;
+            }
+            if now <= existing.expires_at
+                && existing.capabilities.max_protocol_version > capabilities.max_protocol_version
+            {
+                return false;
+            }
+            if created_at_unix_ms == existing.created_at_unix_ms {
+                let material_is_identical = existing.machine_id == *machine_id.as_bytes()
+                    && existing.capabilities == capabilities;
+                if !material_is_identical {
+                    // Card timestamps have second precision. Two differently
+                    // signed cards from the same second cannot be ordered, so
+                    // fail closed rather than retain a possibly dead KEM key
+                    // or guess that the import is newer. A runtime advert has
+                    // millisecond precision and can install the unambiguous
+                    // current binding.
+                    inner.remove(agent_id.as_bytes());
+                }
+                return false;
+            }
+        }
+        inner.insert(
+            *agent_id.as_bytes(),
+            CachedAdvert {
+                capabilities,
+                machine_id: *machine_id.as_bytes(),
+                expires_at,
+                created_at_unix_ms,
+            },
+        );
+        true
+    }
+
+    fn expiry_for_signed_timestamp(
+        &self,
+        created_at_unix_ms: u64,
+        now_unix_ms: u64,
+    ) -> Option<Instant> {
+        self.expiry_for_signed_timestamp_at(created_at_unix_ms, now_unix_ms, Instant::now())
+    }
+
+    fn expiry_for_signed_timestamp_at(
+        &self,
+        created_at_unix_ms: u64,
+        now_unix_ms: u64,
+        now: Instant,
+    ) -> Option<Instant> {
+        let ttl_ms = u64::try_from(self.ttl.as_millis()).unwrap_or(u64::MAX);
+        if !timestamp_is_fresh_for_ttl(created_at_unix_ms, now_unix_ms, ttl_ms) {
+            return None;
+        }
+        let remaining_ms = created_at_unix_ms
+            .saturating_add(ttl_ms)
+            .saturating_sub(now_unix_ms)
+            // A tolerated future clock must not buy TTL + skew: every accepted
+            // record expires no later than one local TTL from insertion.
+            .min(ttl_ms);
+        now.checked_add(Duration::from_millis(remaining_ms))
     }
 
     /// Current cache size (diagnostic).
@@ -222,10 +380,12 @@ mod tests {
         let machine_id = MachineId([2u8; 32]);
         let caps = DmCapabilities::v1_gossip_ready(vec![0u8; 1184]);
         assert!(store.lookup(&agent_id).is_none());
-        store.insert(agent_id, machine_id, caps.clone(), 1_000);
+        assert!(store.insert(agent_id, machine_id, caps.clone(), now_unix_ms()));
         let got = store.lookup(&agent_id).expect("hit");
         assert_eq!(got.max_protocol_version, caps.max_protocol_version);
         assert_eq!(got.gossip_inbox, caps.gossip_inbox);
+        let binding = store.lookup_binding(&agent_id).expect("bound hit");
+        assert_eq!(binding.machine_id, machine_id);
     }
 
     /// Gossip delivers adverts out of order. A daemon publishes a `pending`
@@ -239,14 +399,15 @@ mod tests {
         let store = CapabilityStore::new();
         let agent_id = AgentId([5u8; 32]);
         let machine_id = MachineId([6u8; 32]);
-        store.insert(
+        let issued_at = now_unix_ms();
+        assert!(store.insert(
             agent_id,
             machine_id,
             DmCapabilities::v1_gossip_ready(vec![0u8; 1184]),
-            2_000,
-        );
+            issued_at + 1,
+        ));
         // Older pending advert delivered late: ignored.
-        store.insert(agent_id, machine_id, DmCapabilities::pending(), 1_000);
+        assert!(!store.insert(agent_id, machine_id, DmCapabilities::pending(), issued_at));
         let got = store.lookup(&agent_id).expect("hit");
         assert!(
             got.gossip_inbox && !got.kem_public_key.is_empty(),
@@ -254,7 +415,12 @@ mod tests {
         );
         // A genuinely fresher downgrade (e.g. daemon restarted pre-KEM) still
         // applies — ordering, not blanket downgrade protection.
-        store.insert(agent_id, machine_id, DmCapabilities::pending(), 3_000);
+        assert!(store.insert(
+            agent_id,
+            machine_id,
+            DmCapabilities::pending(),
+            issued_at + 2
+        ));
         let got = store.lookup(&agent_id).expect("hit");
         assert!(
             !got.gossip_inbox,
@@ -264,22 +430,23 @@ mod tests {
 
     #[test]
     fn capability_store_expires_on_ttl() {
-        // Deterministic: insert records `seen_at ≈ now`, then the test
-        // queries `lookup_at` at a synthetic future instant past the TTL.
-        // No wall-clock sleep is involved, so CI scheduling jitter can never
-        // push the "present" lookup past the TTL boundary — the prior flake.
+        // Deterministic: insert derives `expires_at` from the signed
+        // timestamp, then the test queries `lookup_at` at a synthetic future
+        // instant past the TTL. No wall-clock sleep is involved, so CI
+        // scheduling jitter can never push the "present" lookup past the TTL
+        // boundary — the prior flake.
         let ttl = Duration::from_secs(60);
         let store = CapabilityStore::with_ttl(ttl);
         let agent_id = AgentId([3u8; 32]);
         let machine_id = MachineId([4u8; 32]);
-        store.insert(
+        assert!(store.insert(
             agent_id,
             machine_id,
             DmCapabilities::v1_gossip_ready(vec![0u8; 1184]),
-            1_000,
-        );
-        // `seen_at` was captured inside `insert` just before this point, so a
-        // lookup at "now" is well within the TTL.
+            now_unix_ms(),
+        ));
+        // The signed timestamp was captured immediately before insertion, so
+        // a lookup at "now" is well within the TTL.
         let now = Instant::now();
         assert!(
             store.lookup_at(&agent_id, now).is_some(),
@@ -290,6 +457,167 @@ mod tests {
         assert!(
             store.lookup_at(&agent_id, after_ttl).is_none(),
             "entry must be evicted once the TTL elapses"
+        );
+    }
+
+    /// ADR 0030 §3: "a live binding's version is never lowered by an unsigned
+    /// source". A legacy card claiming v1 must not quarantine the live v2
+    /// advert, or every strict send to that peer 409s until the next mesh
+    /// refresh.
+    #[test]
+    fn v1_card_cannot_downgrade_a_live_v2_runtime_binding() {
+        let store = CapabilityStore::new();
+        let agent_id = AgentId([0x71; 32]);
+        let runtime_machine = MachineId([0x72; 32]);
+        let runtime_key = vec![0x73; 1184];
+        let issued_at = now_unix_ms();
+        assert!(store.insert(
+            agent_id,
+            runtime_machine,
+            DmCapabilities::v2_durable_gossip_ready(runtime_key.clone()),
+            issued_at,
+        ));
+
+        assert!(!store.insert_from_card(
+            agent_id,
+            MachineId([0x74; 32]),
+            DmCapabilities::v1_gossip_ready(vec![0x75; 1184]),
+            issued_at + 1,
+        ));
+
+        let binding = store.lookup_binding(&agent_id).expect("runtime binding");
+        assert_eq!(binding.machine_id, runtime_machine);
+        assert!(binding.capabilities.supports_durable_app_ack());
+        assert_eq!(binding.capabilities.kem_public_key, runtime_key);
+    }
+
+    /// Same-version card imports are still the first-contact path, so a newer
+    /// card must refresh the machine + KEM material it carries.
+    #[test]
+    fn newer_same_version_card_refreshes_the_binding() {
+        let store = CapabilityStore::new();
+        let agent_id = AgentId([0x81; 32]);
+        let refreshed_machine = MachineId([0x83; 32]);
+        let issued_at = now_unix_ms();
+        assert!(store.insert_from_card(
+            agent_id,
+            MachineId([0x82; 32]),
+            DmCapabilities::v1_gossip_ready(vec![0x84; 1184]),
+            issued_at,
+        ));
+        assert!(store.insert_from_card(
+            agent_id,
+            refreshed_machine,
+            DmCapabilities::v1_gossip_ready(vec![0x85; 1184]),
+            issued_at + 1,
+        ));
+
+        let binding = store
+            .lookup_binding(&agent_id)
+            .expect("refreshed card binding");
+        assert_eq!(binding.machine_id, refreshed_machine);
+        assert_eq!(binding.capabilities.max_protocol_version, 1);
+        assert_eq!(binding.capabilities.kem_public_key, vec![0x85; 1184]);
+    }
+
+    /// Card timestamps have second precision, so two differently signed cards
+    /// from the same second cannot be ordered. Retaining either one risks
+    /// pinning a dead KEM key, so the ambiguous entry is dropped and only a
+    /// millisecond-precision runtime advert can reinstate a binding.
+    #[test]
+    fn conflicting_same_timestamp_cards_quarantine_until_a_fresh_advert() {
+        let store = CapabilityStore::new();
+        let agent = AgentId([0xB1; 32]);
+        let machine_a = MachineId([0xB2; 32]);
+        let machine_b = MachineId([0xB3; 32]);
+        let kem_b = vec![0xB5; 1184];
+        let card_created_at_ms = now_unix_ms();
+
+        assert!(store.insert_from_card(
+            agent,
+            machine_a,
+            DmCapabilities::v1_gossip_ready(vec![0xB4; 1184]),
+            card_created_at_ms,
+        ));
+        assert!(!store.insert_from_card(
+            agent,
+            machine_b,
+            DmCapabilities::v1_gossip_ready(kem_b.clone()),
+            card_created_at_ms,
+        ));
+        assert!(
+            store.lookup_binding(&agent).is_none(),
+            "an ambiguous same-second restart must not retain the dead A binding"
+        );
+
+        assert!(store.insert(
+            agent,
+            machine_b,
+            DmCapabilities::v2_durable_gossip_ready(kem_b.clone()),
+            card_created_at_ms + 1,
+        ));
+        let binding = store.lookup_binding(&agent).expect("fresh B binding");
+        assert_eq!(binding.machine_id, machine_b);
+        assert_eq!(binding.capabilities.kem_public_key, kem_b);
+    }
+
+    /// Expiry follows the *signed* timestamp. A replayed advert must neither
+    /// be accepted nor renew the original entry's lifetime, and a future-dated
+    /// one must not buy more than one local TTL.
+    #[test]
+    fn signed_time_window_rejects_stale_future_and_replayed_adverts() {
+        let ttl = Duration::from_secs(60);
+        let store = CapabilityStore::with_ttl(ttl);
+        let now_ms = now_unix_ms();
+        let agent = AgentId([0x91; 32]);
+        let first_machine = MachineId([0x92; 32]);
+        let caps = DmCapabilities::v2_durable_gossip_ready(vec![0x94; 1184]);
+
+        // Older than the TTL, and further ahead than the tolerated skew.
+        assert!(!store.insert(agent, first_machine, caps.clone(), now_ms - 61_000));
+        assert!(!store.insert(
+            agent,
+            first_machine,
+            caps.clone(),
+            now_ms + MAX_CAPABILITY_FUTURE_SKEW_SECS * 1_000 + 1_000,
+        ));
+        assert!(store.lookup_binding(&agent).is_none());
+
+        let issued_at = now_ms - 59_000;
+        assert!(store.insert(agent, first_machine, caps.clone(), issued_at));
+        // Replay of the same signed advert from a different machine: rejected.
+        assert!(!store.insert(agent, MachineId([0x93; 32]), caps, issued_at));
+        let retained = store.lookup_binding(&agent).expect("original binding");
+        assert_eq!(retained.machine_id, first_machine);
+        // The replay did not extend the original expiry, which is ~1s away.
+        let after_original_expiry = Instant::now() + Duration::from_millis(1_100);
+        assert!(store
+            .lookup_binding_at(&agent, after_original_expiry)
+            .is_none());
+    }
+
+    /// A tolerated future clock must not extend an entry past one local TTL.
+    #[test]
+    fn future_dated_advert_expires_within_one_local_ttl() {
+        let ttl = Duration::from_secs(1);
+        let store = CapabilityStore::with_ttl(ttl);
+        let agent = AgentId([0xA1; 32]);
+        let future_issued_at = now_unix_ms() + MAX_CAPABILITY_FUTURE_SKEW_SECS * 1_000;
+
+        assert!(store.insert(
+            agent,
+            MachineId([0xA2; 32]),
+            DmCapabilities::v2_durable_gossip_ready(vec![0xA3; 1184]),
+            future_issued_at,
+        ));
+        assert!(
+            store.lookup_binding(&agent).is_some(),
+            "a successful insert must be immediately observable"
+        );
+        let after_local_ttl = Instant::now() + ttl + Duration::from_millis(1);
+        assert!(
+            store.lookup_binding_at(&agent, after_local_ttl).is_none(),
+            "future clock skew must not extend a one-second local TTL"
         );
     }
 

--- a/src/dm_capability_service.rs
+++ b/src/dm_capability_service.rs
@@ -5,26 +5,182 @@
 use crate::dm::DmCapabilities;
 use crate::dm_capability::{
     now_unix_ms, CapabilityAdvert, CapabilityStore, ADVERT_PUBLISH_INTERVAL_SECS,
+    DM_CAPABILITY_TARGETED_REQUEST_TOPIC, DM_CAPABILITY_TARGETED_RESPONSE_TOPIC,
     DM_CAPABILITY_TOPIC,
 };
 use crate::error::{NetworkError, NetworkResult};
-use crate::gossip::{PubSubManager, SigningContext};
+use crate::gossip::{PubSubManager, PubSubMessage, SigningContext};
 use crate::identity::{AgentId, MachineId};
 use bytes::Bytes;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinHandle;
 
 pub const ADVERT_PROTOCOL_VERSION: u16 = 1;
 
+const TARGETED_REQUEST_PROTOCOL_VERSION: u16 = 2;
+
+/// Domain prefix that lets a targeted request ride the steady advert topic
+/// without a pre-0030 subscriber mistaking it for an advert.
+const WARM_TARGETED_REQUEST_DOMAIN: &[u8] = b"x0x/caps/v1/targeted-request-v2\0";
+
 const FIRST_PUBLISH_DELAY_MS: u64 = 250;
+
+/// A verified requester can make one peer republish public data, but must not
+/// be able to amplify traffic without bound. Exactly one daemon answers a
+/// targeted request, so a short global coalescing window suffices to keep a
+/// burst of concurrent strict sends from producing an advert storm.
+const MIN_TARGETED_RESPONSE_INTERVAL_SECS: u64 = 1;
 
 /// Startup-burst schedule so late-joining peers catch our advert quickly.
 const STARTUP_BURST_INTERVALS_MS: &[u64] = &[5_000, 10_000, 20_000, 45_000];
 
+#[derive(Debug, Serialize, Deserialize)]
+struct TargetedCapabilityAdvertRequest {
+    protocol_version: u16,
+    requested_agent_id: [u8; 32],
+}
+
+// There is deliberately no request nonce. PubSub authenticates the requester,
+// and the responder answers with its independently signed current-state
+// advert rather than a challenge response. A nonce that is neither echoed nor
+// bound into the accepted advert would add bytes and security claims without
+// providing replay protection.
+
+/// Decode a targeted capability request according to its exact topic-owned
+/// wire contract.
+///
+/// On the dedicated request topic the payload is a bare postcard record. On
+/// the steady advert topic it must carry the domain prefix and be consumed
+/// exactly, so a pre-0030 subscriber sees an undecodable advert rather than
+/// mistaking the request for one.
+pub(crate) fn decode_targeted_capability_request(topic: &str, payload: &[u8]) -> Option<AgentId> {
+    let request: TargetedCapabilityAdvertRequest = match topic {
+        DM_CAPABILITY_TARGETED_REQUEST_TOPIC => postcard::from_bytes(payload).ok()?,
+        DM_CAPABILITY_TOPIC => {
+            let encoded = payload.strip_prefix(WARM_TARGETED_REQUEST_DOMAIN)?;
+            let (request, trailing) =
+                postcard::take_from_bytes::<TargetedCapabilityAdvertRequest>(encoded).ok()?;
+            if !trailing.is_empty() {
+                return None;
+            }
+            request
+        }
+        _ => return None,
+    };
+    (request.protocol_version == TARGETED_REQUEST_PROTOCOL_VERSION)
+        .then_some(AgentId(request.requested_agent_id))
+}
+
+fn encode_targeted_capability_request(requested_agent_id: AgentId) -> NetworkResult<Vec<u8>> {
+    let request = TargetedCapabilityAdvertRequest {
+        protocol_version: TARGETED_REQUEST_PROTOCOL_VERSION,
+        requested_agent_id: *requested_agent_id.as_bytes(),
+    };
+    postcard::to_stdvec(&request).map_err(|error| {
+        NetworkError::SerializationError(format!(
+            "targeted capability advert request encode: {error}"
+        ))
+    })
+}
+
+/// Publish an authenticated request asking exactly `requested_agent_id` to
+/// republish its signed capability advert (ADR 0030 §3).
+///
+/// It goes out on two carriers: the dedicated Critical request topic, and the
+/// steady advert topic behind a domain prefix. The second is not redundancy
+/// theatre — a freshly created Critical topic may have no gossip mesh peers
+/// yet, while the steady advert topic's mesh is already established, and a
+/// strict send only has a three-second window to converge. Failure on one
+/// carrier is logged; only a failure on both is an error.
+pub(crate) async fn publish_targeted_capability_request(
+    pubsub: &PubSubManager,
+    requested_agent_id: AgentId,
+) -> NetworkResult<()> {
+    let targeted = encode_targeted_capability_request(requested_agent_id)?;
+    let warm = {
+        let mut warm = Vec::with_capacity(WARM_TARGETED_REQUEST_DOMAIN.len() + targeted.len());
+        warm.extend_from_slice(WARM_TARGETED_REQUEST_DOMAIN);
+        warm.extend_from_slice(&targeted);
+        warm
+    };
+    let (targeted_result, warm_result) = tokio::join!(
+        pubsub.publish(
+            DM_CAPABILITY_TARGETED_REQUEST_TOPIC.to_string(),
+            Bytes::from(targeted),
+        ),
+        pubsub.publish(DM_CAPABILITY_TOPIC.to_string(), Bytes::from(warm)),
+    );
+    match (targeted_result, warm_result) {
+        (Ok(()), Ok(())) => {}
+        (Ok(()), Err(error)) => tracing::warn!(
+            target: "dm.trace",
+            recipient = %hex::encode(requested_agent_id.as_bytes()),
+            %error,
+            "warm capability refresh request carrier publish failed"
+        ),
+        (Err(error), Ok(())) => tracing::warn!(
+            target: "dm.trace",
+            recipient = %hex::encode(requested_agent_id.as_bytes()),
+            %error,
+            "critical capability refresh request carrier publish failed"
+        ),
+        (Err(targeted_error), Err(warm_error)) => {
+            return Err(NetworkError::ConnectionFailed(format!(
+                "both targeted capability request carriers failed: \
+                 critical={targeted_error}; warm={warm_error}"
+            )));
+        }
+    }
+    tracing::debug!(
+        target: "dm.trace",
+        stage = "capability_refresh_request_published",
+        recipient = %hex::encode(requested_agent_id.as_bytes()),
+    );
+    Ok(())
+}
+
+/// Verify and ingest one capability advert using the same checks as the live
+/// subscriber. Kept as one function so both subscriber tasks — and tests —
+/// exercise the identical authenticated-sender → advert-signature → exact
+/// AgentId/MachineId acceptance boundary.
+pub(crate) fn ingest_verified_capability_advert(
+    store: &CapabilityStore,
+    self_agent_id: AgentId,
+    message: &PubSubMessage,
+) -> bool {
+    let (pubsub_sender, sender_pubkey) =
+        match (message.sender, message.sender_public_key.as_deref()) {
+            (Some(sender), Some(public_key)) if message.verified => (sender, public_key),
+            _ => return false,
+        };
+    if pubsub_sender == self_agent_id {
+        return false;
+    }
+    let advert: CapabilityAdvert = match postcard::from_bytes(&message.payload) {
+        Ok(advert) => advert,
+        Err(_) => return false,
+    };
+    if advert.protocol_version != ADVERT_PROTOCOL_VERSION
+        || advert.agent_id != *pubsub_sender.as_bytes()
+        || !verify_advert_signature(&advert, sender_pubkey)
+    {
+        return false;
+    }
+    store.insert(
+        AgentId(advert.agent_id),
+        MachineId(advert.machine_id),
+        advert.capabilities,
+        advert.created_at_unix_ms,
+    )
+}
+
 pub struct CapabilityAdvertService {
     publisher: JoinHandle<()>,
     subscriber: JoinHandle<()>,
+    targeted_response_subscriber: JoinHandle<()>,
+    targeted_request_responder: JoinHandle<()>,
 }
 
 impl CapabilityAdvertService {
@@ -39,44 +195,92 @@ impl CapabilityAdvertService {
         publish_interval: Duration,
     ) -> NetworkResult<Self> {
         let mut subscription = pubsub.subscribe(DM_CAPABILITY_TOPIC.to_string()).await;
+        let mut targeted_response_subscription = pubsub
+            .subscribe(DM_CAPABILITY_TARGETED_RESPONSE_TOPIC.to_string())
+            .await;
+        let mut targeted_request_subscription = pubsub
+            .subscribe(DM_CAPABILITY_TARGETED_REQUEST_TOPIC.to_string())
+            .await;
         let store_sub = Arc::clone(&store);
+        let targeted_store_sub = Arc::clone(&store);
         let self_agent_for_sub = self_agent_id;
+        // Depth 16 absorbs a burst; the publisher coalesces every queued
+        // request into a single signed advert under the rate limit below.
+        let (reannounce_tx, mut reannounce_rx) = tokio::sync::mpsc::channel::<()>(16);
+        let warm_reannounce_tx = reannounce_tx.clone();
 
         let subscriber = tokio::spawn(async move {
             while let Some(message) = subscription.recv().await {
-                let (pubsub_sender, sender_pubkey) =
-                    match (message.sender, message.sender_public_key.as_deref()) {
-                        (Some(s), Some(pk)) if message.verified => (s, pk.to_vec()),
-                        _ => continue,
-                    };
-                if pubsub_sender == self_agent_for_sub {
+                let sender = message.sender;
+                // The steady advert topic doubles as the warm carrier for
+                // targeted requests, so classify before trying to ingest.
+                if message.verified
+                    && message.sender.is_some()
+                    && message.sender_public_key.is_some()
+                    && decode_targeted_capability_request(&message.topic, &message.payload)
+                        == Some(self_agent_for_sub)
+                {
+                    tracing::debug!(
+                        target: "dm.trace",
+                        stage = "capability_refresh_request_received",
+                        carrier = "warm",
+                        requester = sender.map(|agent_id| hex::encode(agent_id.as_bytes())),
+                    );
+                    let _ = warm_reannounce_tx.try_send(());
                     continue;
                 }
-                let advert: CapabilityAdvert = match postcard::from_bytes(&message.payload) {
-                    Ok(a) => a,
-                    Err(_) => continue,
-                };
-                if advert.protocol_version != ADVERT_PROTOCOL_VERSION {
-                    continue;
+                if ingest_verified_capability_advert(&store_sub, self_agent_for_sub, &message) {
+                    tracing::debug!(
+                        target: "dm.trace",
+                        stage = "capability_advert_ingested",
+                        sender = sender.map(|agent_id| hex::encode(agent_id.as_bytes())),
+                    );
                 }
-                if advert.agent_id != *pubsub_sender.as_bytes() {
-                    continue;
-                }
-                if !verify_advert_signature(&advert, &sender_pubkey) {
-                    continue;
-                }
-                store_sub.insert(
-                    AgentId(advert.agent_id),
-                    MachineId(advert.machine_id),
-                    advert.capabilities,
-                    advert.created_at_unix_ms,
-                );
-                tracing::debug!(
-                    "cached capability advert from {}",
-                    hex::encode(advert.agent_id)
-                );
             }
             tracing::debug!("capability advert subscriber exited");
+        });
+
+        let targeted_response_subscriber = tokio::spawn(async move {
+            while let Some(message) = targeted_response_subscription.recv().await {
+                let sender = message.sender;
+                if ingest_verified_capability_advert(
+                    &targeted_store_sub,
+                    self_agent_for_sub,
+                    &message,
+                ) {
+                    tracing::debug!(
+                        target: "dm.trace",
+                        stage = "capability_advert_ingested",
+                        carrier = "targeted",
+                        sender = sender.map(|agent_id| hex::encode(agent_id.as_bytes())),
+                    );
+                }
+            }
+            tracing::debug!("targeted capability advert response subscriber exited");
+        });
+
+        let targeted_request_responder = tokio::spawn(async move {
+            while let Some(message) = targeted_request_subscription.recv().await {
+                if !message.verified
+                    || message.sender.is_none()
+                    || message.sender_public_key.is_none()
+                {
+                    continue;
+                }
+                if decode_targeted_capability_request(&message.topic, &message.payload)
+                    != Some(self_agent_id)
+                {
+                    continue;
+                }
+                tracing::debug!(
+                    target: "dm.trace",
+                    stage = "capability_refresh_request_received",
+                    carrier = "critical",
+                    requester = message.sender.map(|agent_id| hex::encode(agent_id.as_bytes())),
+                );
+                let _ = reannounce_tx.try_send(());
+            }
+            tracing::debug!("targeted capability advert request responder exited");
         });
 
         let publisher_pubsub = Arc::clone(&pubsub);
@@ -85,7 +289,13 @@ impl CapabilityAdvertService {
         let publisher = tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(FIRST_PUBLISH_DELAY_MS)).await;
             let mut burst_idx: usize = 0;
+            let mut last_targeted_response_at: Option<tokio::time::Instant> = None;
+            let mut targeted_response_pending = false;
+            let mut requests_open = true;
             loop {
+                while reannounce_rx.try_recv().is_ok() {
+                    targeted_response_pending = true;
+                }
                 let caps_snapshot = publisher_caps_rx.borrow().clone();
                 // Never broadcast a not-yet-usable (pending) advert: absence
                 // already tells senders to use the raw fallback, while a
@@ -102,6 +312,16 @@ impl CapabilityAdvertService {
                                 burst_idx = 0;
                             }
                         }
+                        request = reannounce_rx.recv(), if requests_open => {
+                            // Pending capabilities cannot produce a usable
+                            // advert. A later watch upgrade publishes
+                            // immediately, so there is nothing to answer with
+                            // yet — just remember that someone asked.
+                            match request {
+                                Some(()) => targeted_response_pending = true,
+                                None => requests_open = false,
+                            }
+                        }
                     }
                     continue;
                 }
@@ -112,8 +332,34 @@ impl CapabilityAdvertService {
                     caps_snapshot,
                 ) {
                     Ok(bytes) => {
+                        let bytes = Bytes::from(bytes);
+                        // Answer the strict requester on the Critical topic
+                        // first: its convergence window is seconds long and
+                        // must not be spent waiting behind Bulk cooling on the
+                        // steady advert topic.
+                        if targeted_response_pending {
+                            match publisher_pubsub
+                                .publish(
+                                    DM_CAPABILITY_TARGETED_RESPONSE_TOPIC.to_string(),
+                                    bytes.clone(),
+                                )
+                                .await
+                            {
+                                Ok(()) => {
+                                    last_targeted_response_at = Some(tokio::time::Instant::now());
+                                    targeted_response_pending = false;
+                                    tracing::debug!(
+                                        target: "dm.trace",
+                                        stage = "capability_advert_response_published",
+                                    );
+                                }
+                                Err(e) => tracing::warn!(
+                                    "capability advert publish failed on targeted response topic: {e}"
+                                ),
+                            }
+                        }
                         if let Err(e) = publisher_pubsub
-                            .publish(DM_CAPABILITY_TOPIC.to_string(), Bytes::from(bytes))
+                            .publish(DM_CAPABILITY_TOPIC.to_string(), bytes)
                             .await
                         {
                             tracing::warn!("capability advert publish failed: {e}");
@@ -130,12 +376,47 @@ impl CapabilityAdvertService {
                 } else {
                     publish_interval
                 };
-                tokio::select! {
-                    _ = tokio::time::sleep(next_delay) => {}
-                    res = publisher_caps_rx.changed() => {
-                        if res.is_ok() {
-                            tracing::debug!("capability advert upgraded; republishing");
-                            burst_idx = 0;
+                let publish_delay = tokio::time::sleep(next_delay);
+                tokio::pin!(publish_delay);
+                loop {
+                    tokio::select! {
+                        _ = &mut publish_delay => break,
+                        res = publisher_caps_rx.changed() => {
+                            if res.is_ok() {
+                                tracing::debug!("capability advert upgraded; republishing");
+                                burst_idx = 0;
+                            }
+                            break;
+                        }
+                        request = reannounce_rx.recv(), if requests_open => {
+                            match request {
+                                None => requests_open = false,
+                                Some(()) => {
+                                    targeted_response_pending = true;
+                                    let now = tokio::time::Instant::now();
+                                    let earliest = last_targeted_response_at.map_or(now, |last| {
+                                        last + Duration::from_secs(
+                                            MIN_TARGETED_RESPONSE_INTERVAL_SECS,
+                                        )
+                                    });
+                                    if earliest <= now {
+                                        tracing::debug!(
+                                            "verified capability request received; republishing"
+                                        );
+                                        break;
+                                    }
+                                    // Bring the wake-up forward to the first
+                                    // eligible moment instead of publishing
+                                    // now — the request is answered, just rate
+                                    // limited.
+                                    if earliest < publish_delay.deadline() {
+                                        publish_delay.as_mut().reset(earliest);
+                                    }
+                                    tracing::debug!(
+                                        "verified capability request coalesced until next eligible publish"
+                                    );
+                                }
+                            }
                         }
                     }
                 }
@@ -145,6 +426,8 @@ impl CapabilityAdvertService {
         Ok(Self {
             publisher,
             subscriber,
+            targeted_response_subscriber,
+            targeted_request_responder,
         })
     }
 
@@ -171,6 +454,8 @@ impl CapabilityAdvertService {
     pub fn abort(&self) {
         self.publisher.abort();
         self.subscriber.abort();
+        self.targeted_response_subscriber.abort();
+        self.targeted_request_responder.abort();
     }
 }
 
@@ -527,6 +812,164 @@ mod tests {
         let cached = store.lookup(&agent_p).expect("cached after ingest");
         assert_eq!(cached.max_protocol_version, peer_caps.max_protocol_version);
         assert!(cached.gossip_inbox && !cached.kem_public_key.is_empty());
+
+        service.abort();
+    }
+
+    /// The request wire format is owned by its topic. Accepting a targeted
+    /// request off the wrong topic — or accepting trailing bytes on the warm
+    /// carrier — would let a request be confused with an advert on the shared
+    /// steady topic.
+    #[test]
+    fn targeted_request_decoding_is_scoped_to_its_topic() {
+        let requested = AgentId([0x33; 32]);
+        let bare = encode_targeted_capability_request(requested).expect("encode");
+        let warm = {
+            let mut warm = WARM_TARGETED_REQUEST_DOMAIN.to_vec();
+            warm.extend_from_slice(&bare);
+            warm
+        };
+
+        assert_eq!(
+            decode_targeted_capability_request(DM_CAPABILITY_TARGETED_REQUEST_TOPIC, &bare),
+            Some(requested)
+        );
+        assert_eq!(
+            decode_targeted_capability_request(DM_CAPABILITY_TOPIC, &warm),
+            Some(requested)
+        );
+
+        // The bare form is not accepted on the shared steady topic: without
+        // the domain prefix it is just an undecodable advert.
+        assert_eq!(
+            decode_targeted_capability_request(DM_CAPABILITY_TOPIC, &bare),
+            None
+        );
+        // Nor is the domain-prefixed form accepted anywhere else.
+        assert_eq!(
+            decode_targeted_capability_request(DM_CAPABILITY_TARGETED_RESPONSE_TOPIC, &warm),
+            None
+        );
+        // Trailing bytes after the record are rejected rather than ignored.
+        let mut padded = warm.clone();
+        padded.push(0);
+        assert_eq!(
+            decode_targeted_capability_request(DM_CAPABILITY_TOPIC, &padded),
+            None
+        );
+        // A future request version is not silently treated as v2.
+        let wrong_version = postcard::to_stdvec(&TargetedCapabilityAdvertRequest {
+            protocol_version: TARGETED_REQUEST_PROTOCOL_VERSION + 1,
+            requested_agent_id: *requested.as_bytes(),
+        })
+        .expect("encode");
+        assert_eq!(
+            decode_targeted_capability_request(
+                DM_CAPABILITY_TARGETED_REQUEST_TOPIC,
+                &wrong_version
+            ),
+            None
+        );
+        // And a request never decodes as an advert, so a pre-0030 subscriber
+        // sharing the steady topic drops it instead of caching garbage.
+        assert!(postcard::from_bytes::<CapabilityAdvert>(&warm).is_err());
+    }
+
+    /// ADR 0030 §3 end-to-end: a targeted request for this daemon's agent id
+    /// produces a freshly signed advert on the Critical response topic,
+    /// carrying the v2 capability the requester's strict gate needs.
+    #[tokio::test]
+    async fn targeted_request_triggers_a_signed_response_on_the_critical_topic() {
+        let kp = AgentKeypair::generate().expect("keygen");
+        let signing = Arc::new(SigningContext::from_keypair(&kp));
+        let self_agent = kp.agent_id();
+        let self_machine = MachineId([0x44; 32]);
+
+        let pubsub = Arc::new(
+            PubSubManager::new(make_node().await, Some(Arc::clone(&signing))).expect("pubsub"),
+        );
+        let store = Arc::new(CapabilityStore::new());
+        let (_caps_tx, caps_rx) =
+            tokio::sync::watch::channel(DmCapabilities::v2_durable_gossip_ready(vec![0xCC; 1184]));
+
+        let mut responses = pubsub
+            .subscribe(DM_CAPABILITY_TARGETED_RESPONSE_TOPIC.to_string())
+            .await;
+        let service = CapabilityAdvertService::spawn_default(
+            Arc::clone(&pubsub),
+            Arc::clone(&signing),
+            self_agent,
+            self_machine,
+            caps_rx,
+            Arc::clone(&store),
+        )
+        .await
+        .expect("spawn_default");
+
+        // Let the responder's subscription register before requesting.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        publish_targeted_capability_request(&pubsub, self_agent)
+            .await
+            .expect("publish targeted request");
+
+        let response = tokio::time::timeout(Duration::from_secs(5), responses.recv())
+            .await
+            .expect("targeted response within the strict convergence window")
+            .expect("subscription live");
+        let advert: CapabilityAdvert =
+            postcard::from_bytes(&response.payload).expect("decode signed response");
+
+        assert_eq!(advert.agent_id, *self_agent.as_bytes());
+        assert_eq!(advert.machine_id, *self_machine.as_bytes());
+        assert!(advert.capabilities.supports_durable_app_ack());
+        assert!(
+            verify_advert_signature(&advert, kp.public_key().as_bytes()),
+            "the response must be a freshly signed advert, not a replayed blob"
+        );
+
+        service.abort();
+    }
+
+    /// A request naming a different agent must not make this daemon republish
+    /// — otherwise any peer could use one broadcast to fan out the whole fleet.
+    #[tokio::test]
+    async fn targeted_request_for_another_agent_is_ignored() {
+        let kp = AgentKeypair::generate().expect("keygen");
+        let signing = Arc::new(SigningContext::from_keypair(&kp));
+        let self_agent = kp.agent_id();
+
+        let pubsub = Arc::new(
+            PubSubManager::new(make_node().await, Some(Arc::clone(&signing))).expect("pubsub"),
+        );
+        let store = Arc::new(CapabilityStore::new());
+        let (_caps_tx, caps_rx) =
+            tokio::sync::watch::channel(DmCapabilities::v2_durable_gossip_ready(vec![0xCD; 1184]));
+
+        let mut responses = pubsub
+            .subscribe(DM_CAPABILITY_TARGETED_RESPONSE_TOPIC.to_string())
+            .await;
+        let service = CapabilityAdvertService::spawn_default(
+            Arc::clone(&pubsub),
+            Arc::clone(&signing),
+            self_agent,
+            MachineId([0x45; 32]),
+            caps_rx,
+            Arc::clone(&store),
+        )
+        .await
+        .expect("spawn_default");
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        publish_targeted_capability_request(&pubsub, AgentId([0x46; 32]))
+            .await
+            .expect("publish targeted request");
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(2), responses.recv())
+                .await
+                .is_err(),
+            "a request for another agent must not draw a response"
+        );
 
         service.abort();
     }

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -7,7 +7,7 @@ use crate::direct::DirectMessaging;
 use crate::dm::{
     decrypt_payload, dm_inbox_topic, now_unix_ms, validate_timestamp_window, DmAckOutcome, DmBody,
     DmEnvelope, DmOriginAttestation, DmPayload, EnvelopeBuilder, InFlightAcks, RecentDeliveryCache,
-    DM_PROTOCOL_VERSION, MAX_ENVELOPE_BYTES,
+    DM_PROTOCOL_V1, DM_PROTOCOL_VERSION, MAX_ENVELOPE_BYTES,
 };
 use crate::error::{NetworkError, NetworkResult};
 use crate::gossip::{PubSubManager, PubSubMessage, SigningContext, Subscription};
@@ -374,7 +374,18 @@ impl InboxPipeline {
             }
         };
 
+        // ADR 0030 §2 receiver ceiling: an envelope above what this build
+        // understands is dropped WITHOUT an ACK, so the sender times out
+        // rather than being handed a receipt for semantics we cannot honour.
         if envelope.protocol_version > DM_PROTOCOL_VERSION {
+            tracing::info!(
+                target: "dm.trace",
+                stage = "inbound_protocol_above_ceiling_dropped",
+                sender = %hex::encode(envelope.sender_agent_id),
+                protocol_version = envelope.protocol_version,
+                ceiling = DM_PROTOCOL_VERSION,
+                "DM dropped without ACK: envelope protocol version exceeds local ceiling"
+            );
             return;
         }
 
@@ -544,9 +555,19 @@ impl InboxPipeline {
 
         match envelope.body.clone() {
             DmBody::Ack(ack) => {
-                let resolved = self.inflight.resolve(&ack.acks_request_id, ack.outcome);
+                // The ACK's own `protocol_version` names the receipt semantics
+                // the recipient is claiming; the waiter accepts it only if
+                // that matches what the send negotiated (ADR 0030 §2).
+                let resolved = self.inflight.resolve_for_protocol(
+                    &ack.acks_request_id,
+                    envelope.protocol_version,
+                    sender_agent_id,
+                    sender_machine_id,
+                    ack.outcome,
+                );
                 tracing::debug!(
                     acked = %hex::encode(ack.acks_request_id),
+                    protocol_version = envelope.protocol_version,
                     resolved,
                     "DM ACK received"
                 );
@@ -803,7 +824,12 @@ impl InboxPipeline {
         rand::thread_rng().fill_bytes(&mut ack_rid);
 
         let mut envelope = DmEnvelope {
-            protocol_version: DM_PROTOCOL_VERSION,
+            // ADR 0030: an ACK is stamped with the semantics this receiver
+            // actually honoured, not with the local ceiling. Until the
+            // receiver durable path lands (slice 2) every accepted payload is
+            // level-2 enqueue, so every ACK is v1 — a v2 waiter must time out
+            // rather than be handed a receipt no one made.
+            protocol_version: DM_PROTOCOL_V1,
             request_id: ack_rid,
             sender_agent_id: *self.self_agent_id.as_bytes(),
             sender_machine_id: *self.self_machine_id.as_bytes(),

--- a/src/dm_send.rs
+++ b/src/dm_send.rs
@@ -2,7 +2,7 @@
 
 use crate::dm::{
     dm_inbox_topic, now_unix_ms, DmAckOutcome, DmError, DmPath, DmReceipt, DmSendConfig,
-    EnvelopeBuilder, InFlightAcks, MAX_PAYLOAD_BYTES,
+    EnvelopeBuilder, InFlightAcks, DM_PROTOCOL_DURABLE_ACK, DM_PROTOCOL_V1, MAX_PAYLOAD_BYTES,
 };
 use crate::dm_inbox::{DmInboxService, DM_BUS_TOPIC};
 use crate::error::IdentityError;
@@ -57,9 +57,17 @@ pub struct DmSendContext<'a> {
     pub inflight: Arc<InFlightAcks>,
 }
 
+/// Publish a DM envelope on the recipient's gossip inbox topic and await its
+/// application ACK.
+///
+/// `recipient_machine_id` is the machine from the recipient's signed
+/// capability advert, when one is cached. Strict (ADR 0030) sends always have
+/// it — the gate in `send_direct_with_config_inner` refuses without one — and
+/// it pins the ACK waiter so only that daemon can answer.
 pub async fn send_via_gossip(
     ctx: DmSendContext<'_>,
     recipient_agent_id: AgentId,
+    recipient_machine_id: Option<MachineId>,
     recipient_kem_public_key: &[u8],
     payload: Vec<u8>,
     config: &DmSendConfig,
@@ -89,10 +97,20 @@ pub async fn send_via_gossip(
     }
 
     let request_id = fresh_request_id();
+    // The negotiated version is a promise about the receipt, not a wire-layout
+    // change: v1 and v2 envelopes are byte-identical apart from this field.
+    // Only a caller that demanded durable semantics — and therefore passed the
+    // capability gate — stamps v2.
+    let protocol_version = if config.require_durable_app_ack {
+        DM_PROTOCOL_DURABLE_ACK
+    } else {
+        DM_PROTOCOL_V1
+    };
 
     let created = now_unix_ms();
     let expires = created.saturating_add(DEFAULT_ENVELOPE_LIFETIME_MS);
-    let envelope = EnvelopeBuilder::build_payload_envelope(
+    let envelope = EnvelopeBuilder::build_payload_envelope_with_version(
+        protocol_version,
         request_id,
         &self_agent_id,
         &self_machine_id,
@@ -124,7 +142,12 @@ pub async fn send_via_gossip(
         bytes = wire.len(),
     );
 
-    let mut rx = inflight.register(request_id);
+    let mut rx = inflight.register_for_protocol(
+        request_id,
+        protocol_version,
+        recipient_agent_id,
+        recipient_machine_id,
+    );
     let mut guard = InFlightGuard::new(Arc::clone(&inflight), request_id);
 
     // X0X-0041: split the lifecycle hint into the per-peer match key and the
@@ -741,7 +764,7 @@ mod tests {
     fn inflight_guard_drop_cancels_unresolved_waiter() {
         let inflight = Arc::new(InFlightAcks::new());
         let request_id = [0x88; 16];
-        let _rx = inflight.register(request_id);
+        let _rx = inflight.register(request_id, AgentId([0x77; 32]), None);
         assert_eq!(inflight.outstanding(), 1);
         {
             let _guard = InFlightGuard::new(Arc::clone(&inflight), request_id);
@@ -753,7 +776,7 @@ mod tests {
     fn inflight_guard_mark_resolved_preserves_waiter_on_drop() {
         let inflight = Arc::new(InFlightAcks::new());
         let request_id = [0x89; 16];
-        let _rx = inflight.register(request_id);
+        let _rx = inflight.register(request_id, AgentId([0x77; 32]), None);
         let mut guard = InFlightGuard::new(Arc::clone(&inflight), request_id);
         guard.mark_resolved();
         drop(guard);

--- a/src/gossip/pubsub.rs
+++ b/src/gossip/pubsub.rs
@@ -897,6 +897,12 @@ const CRITICAL_TOPIC_PREFIXES: &[&str] = &[
     "x0x.identity.announce.v2", // Identity announce — control-plane
     "x0x.test.discover.v1", // Test orchestrator discover (X0X-0076 harness)
     "x0x.test.control.v1", // Test orchestrator control commands
+    // ADR 0030 strict-send capability refresh. These share the `x0x/caps/v1`
+    // prefix with the Bulk steady advert topic, so they rely on Critical being
+    // matched first: a strict send has a three-second convergence window and
+    // cannot wait behind Bulk cooling.
+    "x0x/caps/v1/request/targeted-v2",
+    "x0x/caps/v1/response/targeted-v2",
 ];
 
 const BULK_TOPIC_PREFIXES: &[&str] = &[
@@ -966,6 +972,14 @@ fn register_x0x_topic_priorities(
     );
     registry.register(
         TopicId::from_entity("x0x.test.control.v1".as_bytes()),
+        TopicPriority::Critical,
+    );
+    registry.register(
+        TopicId::from_entity("x0x/caps/v1/request/targeted-v2".as_bytes()),
+        TopicPriority::Critical,
+    );
+    registry.register(
+        TopicId::from_entity("x0x/caps/v1/response/targeted-v2".as_bytes()),
         TopicPriority::Critical,
     );
     // Per-recipient DM inbox topics (`x0x/dm/v1/inbox/<hash>`) are
@@ -1371,6 +1385,45 @@ mod tests {
         assert_eq!(
             classify_x0x_topic("x0x.group.cards.v1"),
             TopicPriority::Bulk
+        );
+    }
+
+    /// ADR 0030: the targeted refresh topics share the `x0x/caps/v1` prefix
+    /// with the Bulk steady advert topic, so they only land on Critical
+    /// because Critical is matched first. A reordering of the two prefix lists
+    /// would silently cool a strict send's three-second convergence window
+    /// behind Bulk admission — this pins the ordering.
+    #[test]
+    fn targeted_capability_refresh_topics_outrank_the_bulk_advert_topic() {
+        assert_eq!(
+            classify_x0x_topic(crate::dm_capability::DM_CAPABILITY_TARGETED_REQUEST_TOPIC),
+            TopicPriority::Critical
+        );
+        assert_eq!(
+            classify_x0x_topic(crate::dm_capability::DM_CAPABILITY_TARGETED_RESPONSE_TOPIC),
+            TopicPriority::Critical
+        );
+        assert_eq!(
+            classify_x0x_topic(crate::dm_capability::DM_CAPABILITY_TOPIC),
+            TopicPriority::Bulk,
+            "the steady advert topic must stay Bulk"
+        );
+
+        // The seeded registry must agree with the dynamic classifier, or the
+        // priority depends on whether the topic was pre-registered.
+        let registry = saorsa_gossip_pubsub::admission::TopicPriorityRegistry::default();
+        register_x0x_topic_priorities(&registry);
+        assert_eq!(
+            registry.priority_for(&TopicId::from_entity(
+                crate::dm_capability::DM_CAPABILITY_TARGETED_REQUEST_TOPIC.as_bytes()
+            )),
+            TopicPriority::Critical
+        );
+        assert_eq!(
+            registry.priority_for(&TopicId::from_entity(
+                crate::dm_capability::DM_CAPABILITY_TARGETED_RESPONSE_TOPIC.as_bytes()
+            )),
+            TopicPriority::Critical
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,10 @@ pub struct Agent {
     /// Capability store populated by the advert service and consulted by
     /// `send_direct` to choose between gossip and raw-QUIC paths.
     capability_store: std::sync::Arc<dm_capability::CapabilityStore>,
+    /// Single-flight registry for ADR 0030 strict capability refreshes, so
+    /// concurrent strict sends to one recipient publish a single targeted
+    /// request between them.
+    capability_refreshes: std::sync::Arc<CapabilityRefreshRegistry>,
     /// Watch channel that carries this agent's *outgoing* DM capabilities.
     /// `join_network` spawns the advert service with a placeholder (empty
     /// KEM pubkey). `start_dm_inbox` upgrades via this sender to trigger
@@ -2482,6 +2486,237 @@ fn raw_dm_history_record(
     })
 }
 
+// ─── ADR 0030: strict capability refresh ───────────────────────────────────
+
+/// Cap on concurrent refresh flights, so a burst of strict sends to distinct
+/// unknown recipients cannot grow unbounded task state.
+const MAX_INFLIGHT_CAPABILITY_REFRESHES: usize = 256;
+
+/// How long a forced refresh waits for the targeted response to arrive and be
+/// ingested before the gate gives up and returns 409. Bounded on purpose: ADR
+/// 0030 promises a fast, deterministic refusal rather than a hang.
+const CAPABILITY_REFRESH_CONVERGENCE_WAIT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Poll cadence while waiting for the subscriber task to ingest the response.
+const CAPABILITY_REFRESH_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CapabilityRefreshState {
+    Pending,
+    Finished,
+}
+
+#[derive(Debug)]
+struct CapabilityRefreshEntry {
+    flight_id: u64,
+    completion: tokio::sync::watch::Receiver<CapabilityRefreshState>,
+    worker: Option<tokio::task::JoinHandle<()>>,
+}
+
+#[derive(Debug, Default)]
+struct CapabilityRefreshRegistryState {
+    closed: bool,
+    next_flight_id: u64,
+    inflight: std::collections::HashMap<[u8; 32], CapabilityRefreshEntry>,
+}
+
+/// Bounded, recipient-keyed single-flight registry for strict capability
+/// discovery.
+///
+/// Without it, N concurrent strict sends to the same not-yet-known recipient
+/// would each publish their own targeted request — turning the gate into a
+/// gossip amplifier exactly when the mesh is already struggling to converge.
+/// The synchronous mutex is deliberate: registration and Drop cleanup are
+/// tiny non-awaiting operations, which lets an aborted worker remove its slot
+/// deterministically.
+#[derive(Debug, Default)]
+struct CapabilityRefreshRegistry {
+    state: std::sync::Mutex<CapabilityRefreshRegistryState>,
+}
+
+enum CapabilityRefreshRegistration {
+    /// Another flight for this recipient is already running; await it.
+    Joined(tokio::sync::watch::Receiver<CapabilityRefreshState>),
+    /// This caller started the flight.
+    Started(tokio::sync::watch::Receiver<CapabilityRefreshState>),
+    /// Shutting down or at the concurrency cap — proceed straight to the gate.
+    Unavailable,
+}
+
+impl CapabilityRefreshRegistry {
+    fn register_or_start<F, Fut>(
+        self: &std::sync::Arc<Self>,
+        recipient: identity::AgentId,
+        worker: F,
+    ) -> CapabilityRefreshRegistration
+    where
+        F: FnOnce(
+            CapabilityRefreshGuard,
+            tokio::sync::watch::Sender<CapabilityRefreshState>,
+        ) -> Fut,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let Ok(mut state) = self.state.lock() else {
+            return CapabilityRefreshRegistration::Unavailable;
+        };
+        let recipient_key = *recipient.as_bytes();
+        if let Some(existing) = state.inflight.get(&recipient_key) {
+            return CapabilityRefreshRegistration::Joined(existing.completion.clone());
+        }
+        if state.closed || state.inflight.len() >= MAX_INFLIGHT_CAPABILITY_REFRESHES {
+            return CapabilityRefreshRegistration::Unavailable;
+        }
+        state.next_flight_id = state.next_flight_id.wrapping_add(1);
+        let flight_id = state.next_flight_id;
+        let (completion_tx, completion) =
+            tokio::sync::watch::channel(CapabilityRefreshState::Pending);
+        state.inflight.insert(
+            recipient_key,
+            CapabilityRefreshEntry {
+                flight_id,
+                completion: completion.clone(),
+                worker: None,
+            },
+        );
+        // Spawn while holding the registry mutex, then attach the handle before
+        // releasing it. If the future finishes immediately its Drop guard waits
+        // on this mutex, so shutdown can never observe an entry without its
+        // authoritative worker handle.
+        let guard = CapabilityRefreshGuard {
+            registry: std::sync::Arc::clone(self),
+            recipient_key,
+            flight_id,
+        };
+        let handle = tokio::spawn(worker(guard, completion_tx));
+        if let Some(entry) = state.inflight.get_mut(&recipient_key) {
+            entry.worker = Some(handle);
+        }
+        CapabilityRefreshRegistration::Started(completion)
+    }
+
+    fn close(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.closed = true;
+        }
+    }
+
+    async fn shutdown_workers(&self) {
+        let handles = {
+            let Ok(mut state) = self.state.lock() else {
+                return;
+            };
+            state.closed = true;
+            state
+                .inflight
+                .drain()
+                .filter_map(|(_, mut entry)| entry.worker.take())
+                .collect::<Vec<_>>()
+        };
+        for handle in &handles {
+            handle.abort();
+        }
+        let _results = futures::future::join_all(handles).await;
+    }
+
+    fn remove(&self, recipient_key: &[u8; 32], flight_id: u64) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        if state
+            .inflight
+            .get(recipient_key)
+            .is_some_and(|entry| entry.flight_id == flight_id)
+        {
+            state.inflight.remove(recipient_key);
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.state
+            .lock()
+            .map(|state| state.inflight.len())
+            .unwrap_or_default()
+    }
+}
+
+struct CapabilityRefreshGuard {
+    registry: std::sync::Arc<CapabilityRefreshRegistry>,
+    recipient_key: [u8; 32],
+    flight_id: u64,
+}
+
+impl Drop for CapabilityRefreshGuard {
+    fn drop(&mut self) {
+        self.registry.remove(&self.recipient_key, self.flight_id);
+    }
+}
+
+/// Publish exactly one targeted capability request for `recipient`, then wait
+/// (bounded) for the signed response to be ingested.
+///
+/// ADR 0030 §2 specifies "one forced targeted capability refresh" — a single
+/// publish, not a retry loop. Returning early on a cache hit keeps a strict
+/// send that raced an in-flight advert from paying the full window.
+async fn run_strict_capability_refresh(
+    recipient: identity::AgentId,
+    capability_store: std::sync::Arc<dm_capability::CapabilityStore>,
+    shutdown_token: tokio_util::sync::CancellationToken,
+    deadline: tokio::time::Instant,
+    publish: impl std::future::Future<Output = error::NetworkResult<()>> + Send,
+) {
+    if capability_binding_supports_durable_ack(capability_store.lookup_binding(&recipient).as_ref())
+    {
+        return;
+    }
+
+    let published = tokio::select! {
+        result = publish => Some(result),
+        () = tokio::time::sleep_until(deadline) => None,
+        () = shutdown_token.cancelled() => None,
+    };
+    let Some(published) = published else {
+        return;
+    };
+    if let Err(error) = published {
+        tracing::warn!(
+            target: "dm.trace",
+            recipient = %hex::encode(recipient.as_bytes()),
+            %error,
+            "targeted capability refresh publish failed"
+        );
+    }
+
+    loop {
+        if capability_binding_supports_durable_ack(
+            capability_store.lookup_binding(&recipient).as_ref(),
+        ) {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return;
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(CAPABILITY_REFRESH_POLL_INTERVAL) => {}
+            () = tokio::time::sleep_until(deadline) => return,
+            () = shutdown_token.cancelled() => return,
+        }
+    }
+}
+
+/// Whether a cached binding can satisfy a strict send.
+///
+/// Requires both a v2 capability *and* a real machine binding: the ACK waiter
+/// is pinned to that machine, so a capability without one cannot produce the
+/// receipt the caller was promised.
+fn capability_binding_supports_durable_ack(
+    binding: Option<&dm_capability::CapabilityBinding>,
+) -> bool {
+    binding.is_some_and(|binding| {
+        binding.machine_id.0 != [0_u8; 32] && binding.capabilities.supports_durable_app_ack()
+    })
+}
+
 impl Agent {
     /// Create a new offline agent with default identity configuration.
     ///
@@ -3897,6 +4132,7 @@ impl Agent {
     /// token itself (idempotent), so calling `shutdown()` alone remains correct.
     pub fn begin_shutdown(&self) {
         self.shutdown_token.cancel();
+        self.capability_refreshes.close();
         let mut guard = match self.tracked_tasks.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
@@ -3921,6 +4157,7 @@ impl Agent {
         // 1. Signal every token-aware loop to break. Inert until now, so this
         //    is the first thing that changes steady-state behavior.
         self.shutdown_token.cancel();
+        self.capability_refreshes.shutdown_workers().await;
 
         // 2. Stop the simple Option<JoinHandle> background tasks.
         self.stop_identity_heartbeat().await;
@@ -4355,12 +4592,34 @@ impl Agent {
             return Ok(receipt);
         }
 
-        let advert_cap = self.capability_store.lookup(to);
+        let mut advert_binding = self.capability_store.lookup_binding(to);
+        // ADR 0030 §2: one forced targeted refresh before refusing. A daemon
+        // whose advert we simply have not heard yet must not be reported as
+        // incapable, but the refusal must still be bounded — the whole point
+        // of the 409 is that it is fast and deterministic, never a hang.
+        if config.require_durable_app_ack
+            && !capability_binding_supports_durable_ack(advert_binding.as_ref())
+        {
+            self.refresh_strict_dm_capability(*to).await;
+            advert_binding = self.capability_store.lookup_binding(to);
+        }
+        let advert_machine = advert_binding.as_ref().map(|binding| binding.machine_id);
+        let advert_cap = advert_binding.map(|binding| binding.capabilities);
         let advert_gossip_ready = advert_cap
             .as_ref()
             .is_some_and(|caps| caps.gossip_inbox && !caps.kem_public_key.is_empty());
-        let (cap, cap_source) = if advert_gossip_ready {
-            (advert_cap, "advert_cache")
+        let (cap, cap_machine, cap_source) = if advert_gossip_ready {
+            (advert_cap, advert_machine, "advert_cache")
+        } else if config.require_durable_app_ack {
+            // Strict semantics need a signed, machine-bound capability from
+            // the TTL-bounded runtime cache. The unbound contact-card fallback
+            // below cannot pin the ACK waiter to a machine, so it is never
+            // sufficient here.
+            (
+                advert_cap,
+                advert_machine,
+                "advert_cache_unusable_for_durable_ack",
+            )
         } else {
             let contact_cap = {
                 let contacts = self.contact_store.read().await;
@@ -4374,11 +4633,13 @@ impl Agent {
             };
             match contact_cap {
                 Some(cap) if advert_cap.is_some() => {
-                    (Some(cap), "contact_card_after_unusable_advert")
+                    (Some(cap), None, "contact_card_after_unusable_advert")
                 }
-                Some(cap) => (Some(cap), "contact_card"),
-                None if advert_cap.is_some() => (advert_cap, "advert_cache_unusable"),
-                None => (None, "none"),
+                Some(cap) => (Some(cap), None, "contact_card"),
+                None if advert_cap.is_some() => {
+                    (advert_cap, advert_machine, "advert_cache_unusable")
+                }
+                None => (None, None, "none"),
             }
         };
         let gossip_ok = cap
@@ -4395,17 +4656,49 @@ impl Agent {
             capability_store_entries = self.capability_store.len(),
         );
 
+        if config.require_durable_app_ack
+            && !capability_binding_supports_durable_ack(
+                cap.as_ref()
+                    .zip(cap_machine)
+                    .map(
+                        |(capabilities, machine_id)| dm_capability::CapabilityBinding {
+                            capabilities: capabilities.clone(),
+                            machine_id,
+                        },
+                    )
+                    .as_ref(),
+            )
+        {
+            tracing::info!(
+                target: "dm.trace",
+                stage = "strict_durable_ack_gate_refused",
+                recipient = %hex::encode(to.as_bytes()),
+                source = cap_source,
+                advertised_version = cap.as_ref().map(|c| c.max_protocol_version),
+                "refusing strict send: recipient has no current v2 capability advert"
+            );
+            return Err(dm::DmError::AckSemanticsUnavailable(format!(
+                "recipient {} has no current v2 durable-ACK capability advert",
+                hex::encode(to.as_bytes())
+            )));
+        }
+
         // X0X-0070b: seed the relay fallback. Only retain the payload + KEM
         // key clone when the engine is enabled AND we have a key to seal
         // a fresh envelope with. With the default disabled policy this
         // closure never runs - the happy path pays nothing.
-        let relay_seed: Option<(Vec<u8>, Vec<u8>)> = if self.peer_relay.policy().enabled {
-            cap.as_ref()
-                .filter(|c| !c.kem_public_key.is_empty())
-                .map(|c| (payload.clone(), c.kem_public_key.clone()))
-        } else {
-            None
-        };
+        //
+        // A strict send never seeds the relay: a relayed envelope is resealed
+        // by a third party and cannot carry the machine-bound v2 receipt the
+        // caller demanded.
+        let relay_seed: Option<(Vec<u8>, Vec<u8>)> =
+            if self.peer_relay.policy().enabled && !config.require_durable_app_ack {
+                cap.as_ref()
+                    .filter(|c| !c.kem_public_key.is_empty())
+                    .map(|c| (payload.clone(), c.kem_public_key.clone()))
+            } else {
+                None
+            };
 
         let rtt_hint_ms = self.dm_peer_rtt_ms(to).await;
         let mut config = config;
@@ -4442,7 +4735,11 @@ impl Agent {
 
         let mut preferred_raw_err = None;
         let prefer_newest_grace = std::time::Duration::from_millis(config.prefer_newest_grace_ms);
-        let preferred_raw_receipt = if config.prefer_raw_quic_if_connected && !config.require_gossip
+        // The raw-QUIC path returns a transport receipt, never an application
+        // ACK, so it can never satisfy a strict send.
+        let preferred_raw_receipt = if config.prefer_raw_quic_if_connected
+            && !config.require_gossip
+            && !config.require_durable_app_ack
         {
             match self
                 .send_direct_raw_quic(
@@ -4505,6 +4802,7 @@ impl Agent {
                             inflight: std::sync::Arc::clone(&self.dm_inflight_acks),
                         },
                         *to,
+                        cap_machine,
                         &kem_pub,
                         payload,
                         &config,
@@ -4783,6 +5081,55 @@ impl Agent {
     /// returned. This closes the X0X-0041 coverage gap surfaced by the
     /// SOTA-Borrow Phase A bisect (P1 finding; evidence in git history under
     /// `proofs/sota-borrow-phaseA-bisect-20260508T214634Z/ANALYSIS.md` §0.1).
+    /// Ask one recipient to republish its signed runtime capability and give
+    /// the local subscriber a bounded window to ingest it.
+    ///
+    /// Used only by strict (ADR 0030) sends after a TTL-bounded cache miss: a
+    /// daemon whose advert we simply have not heard yet gets one chance to
+    /// answer before the gate refuses. Concurrent strict sends to the same
+    /// recipient share a single flight.
+    async fn refresh_strict_dm_capability(&self, recipient: identity::AgentId) {
+        let Some(runtime) = self.gossip_runtime.as_ref() else {
+            return;
+        };
+        let pubsub = std::sync::Arc::clone(runtime.pubsub());
+        let capability_store = std::sync::Arc::clone(&self.capability_store);
+        let shutdown_token = self.shutdown_token.clone();
+        let deadline = tokio::time::Instant::now() + CAPABILITY_REFRESH_CONVERGENCE_WAIT;
+
+        let mut completion = match self.capability_refreshes.register_or_start(
+            recipient,
+            move |guard, completion_tx| async move {
+                run_strict_capability_refresh(
+                    recipient,
+                    capability_store,
+                    shutdown_token,
+                    deadline,
+                    dm_capability_service::publish_targeted_capability_request(&pubsub, recipient),
+                )
+                .await;
+                completion_tx.send_replace(CapabilityRefreshState::Finished);
+                drop(guard);
+            },
+        ) {
+            CapabilityRefreshRegistration::Started(completion)
+            | CapabilityRefreshRegistration::Joined(completion) => completion,
+            CapabilityRefreshRegistration::Unavailable => return,
+        };
+
+        while *completion.borrow() != CapabilityRefreshState::Finished {
+            tokio::select! {
+                changed = completion.changed() => {
+                    if changed.is_err() {
+                        return;
+                    }
+                }
+                () = tokio::time::sleep_until(deadline) => return,
+                () = self.shutdown_token.cancelled() => return,
+            }
+        }
+    }
+
     async fn send_direct_raw_quic(
         &self,
         agent_id: &identity::AgentId,
@@ -7508,8 +7855,16 @@ impl Agent {
         // Upgrade our advertised capabilities so peers stop falling back
         // to the raw-QUIC path. The capability advert service watches
         // this channel and republishes immediately on change.
-        let upgraded =
-            dm::DmCapabilities::pending().with_kem_public_key(kem_keypair.public_bytes.clone());
+        //
+        // ADR 0030 §3: advertise v2 iff durable history is enabled. Without a
+        // history handle this daemon cannot commit a message before ACKing, so
+        // claiming v2 would promise a receipt it can never honour — senders
+        // must see v1 and either downgrade explicitly or get their 409.
+        let upgraded = if self.history_handle.is_some() {
+            dm::DmCapabilities::v2_durable_gossip_ready(kem_keypair.public_bytes.clone())
+        } else {
+            dm::DmCapabilities::v1_gossip_ready(kem_keypair.public_bytes.clone())
+        };
         // send_replace stores the value even when no receiver is subscribed
         // yet; a plain send() drops the upgrade if this runs before the
         // capability advert service subscribes, leaving peers cached on
@@ -7526,6 +7881,21 @@ impl Agent {
         if let Some(service) = guard.take() {
             service.abort();
         }
+        // Withdraw the advert: with no inbox running we can honour neither v1
+        // nor v2 gossip semantics, and peers must fall back rather than send
+        // into a topic nobody is reading.
+        self.dm_capabilities_tx
+            .send_replace(dm::DmCapabilities::pending());
+    }
+
+    /// This agent's currently advertised DM capabilities.
+    ///
+    /// Mirrors what the advert service publishes and what `runtime_agent_card`
+    /// exposes, so a peer importing our card sees the same protocol version
+    /// the mesh advert claims.
+    #[must_use]
+    pub fn current_dm_capabilities(&self) -> dm::DmCapabilities {
+        self.dm_capabilities_tx.borrow().clone()
     }
 
     /// Connect to cached peers in parallel, returning (succeeded, failed) peer lists.
@@ -10767,6 +11137,7 @@ impl AgentBuilder {
             presence,
             user_identity_consented: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             capability_store: std::sync::Arc::new(dm_capability::CapabilityStore::new()),
+            capability_refreshes: std::sync::Arc::new(CapabilityRefreshRegistry::default()),
             dm_capabilities_tx: std::sync::Arc::new({
                 let (tx, _rx) = tokio::sync::watch::channel(dm::DmCapabilities::pending());
                 tx
@@ -13033,6 +13404,236 @@ mod tests {
             matches!(err, dm::DmError::LocalGossipUnavailable(_)),
             "unexpected error: {err:?}"
         );
+    }
+
+    /// ADR 0030 §2, mixed-version row 2: a strict send to a peer advertising
+    /// v1 refuses with `AckSemanticsUnavailable` instead of silently
+    /// downgrading to v1 receipt semantics. The identical non-strict send
+    /// reaching a *different* error proves the refusal came from the gate and
+    /// not from the offline harness.
+    #[tokio::test]
+    async fn strict_send_to_a_v1_peer_refuses_with_ack_semantics_unavailable() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .build()
+            .await
+            .expect("agent");
+        let target = identity::AgentId([0x61_u8; 32]);
+        let target_machine = identity::MachineId([0x62_u8; 32]);
+
+        assert!(agent.capability_store().insert(
+            target,
+            target_machine,
+            dm::DmCapabilities::v1_gossip_ready(vec![42_u8; 1184]),
+            dm_capability::now_unix_ms(),
+        ));
+
+        let strict = dm::DmSendConfig {
+            require_gossip: true,
+            require_durable_app_ack: true,
+            ..dm::DmSendConfig::default()
+        };
+        let err = agent
+            .send_direct_with_config(&target, b"strict".to_vec(), strict.clone())
+            .await
+            .expect_err("strict send to a v1 peer must refuse");
+        assert!(
+            matches!(err, dm::DmError::AckSemanticsUnavailable(_)),
+            "unexpected error: {err:?}"
+        );
+
+        let non_strict_err = agent
+            .send_direct_with_config(
+                &target,
+                b"non-strict".to_vec(),
+                dm::DmSendConfig {
+                    require_durable_app_ack: false,
+                    ..strict
+                },
+            )
+            .await
+            .expect_err("offline harness has no gossip runtime");
+        assert!(
+            matches!(non_strict_err, dm::DmError::LocalGossipUnavailable(_)),
+            "a non-strict send must be unaffected by the durable gate: {non_strict_err:?}"
+        );
+    }
+
+    /// A peer we have never heard from is indistinguishable from an
+    /// unreachable one at the gate: both refuse, neither hangs and neither
+    /// downgrades.
+    #[tokio::test]
+    async fn strict_send_to_an_unknown_peer_refuses_after_the_forced_refresh() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .build()
+            .await
+            .expect("agent");
+        let target = identity::AgentId([0x63_u8; 32]);
+
+        // A trusted contact card claiming gossip support must NOT satisfy the
+        // strict gate: a card carries no signed machine binding to pin the ACK
+        // waiter to.
+        agent.contacts().write().await.add(contacts::Contact {
+            agent_id: target,
+            trust_level: contacts::TrustLevel::Trusted,
+            label: None,
+            added_at: 0,
+            last_seen: None,
+            identity_type: contacts::IdentityType::Known,
+            dm_capabilities: Some(dm::DmCapabilities::v2_durable_gossip_ready(vec![
+                42_u8;
+                1184
+            ])),
+            machines: Vec::new(),
+        });
+
+        let err = agent
+            .send_direct_with_config(
+                &target,
+                b"strict".to_vec(),
+                dm::DmSendConfig {
+                    require_gossip: true,
+                    require_durable_app_ack: true,
+                    ..dm::DmSendConfig::default()
+                },
+            )
+            .await
+            .expect_err("strict send to an unknown peer must refuse");
+        assert!(
+            matches!(err, dm::DmError::AckSemanticsUnavailable(_)),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    /// A peer advertising v2 passes the gate. The send then fails downstream
+    /// (this harness has no gossip runtime) — asserting the *gate* moved on,
+    /// which is all slice 1 owns; end-to-end durable delivery needs the
+    /// receiver durable path.
+    #[tokio::test]
+    async fn strict_send_to_a_v2_peer_passes_the_gate() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .build()
+            .await
+            .expect("agent");
+        let target = identity::AgentId([0x64_u8; 32]);
+
+        assert!(agent.capability_store().insert(
+            target,
+            identity::MachineId([0x65_u8; 32]),
+            dm::DmCapabilities::v2_durable_gossip_ready(vec![42_u8; 1184]),
+            dm_capability::now_unix_ms(),
+        ));
+
+        let err = agent
+            .send_direct_with_config(
+                &target,
+                b"strict".to_vec(),
+                dm::DmSendConfig {
+                    require_gossip: true,
+                    require_durable_app_ack: true,
+                    ..dm::DmSendConfig::default()
+                },
+            )
+            .await
+            .expect_err("offline harness has no gossip runtime");
+        assert!(
+            matches!(err, dm::DmError::LocalGossipUnavailable(_)),
+            "a current v2 advert must clear the gate: {err:?}"
+        );
+    }
+
+    /// Concurrent strict sends to one unknown recipient must publish a single
+    /// targeted request between them. Without single-flight the gate becomes a
+    /// gossip amplifier exactly when the mesh is least able to absorb it.
+    #[tokio::test]
+    async fn capability_refresh_registry_is_single_flight_per_recipient() {
+        let registry = std::sync::Arc::new(CapabilityRefreshRegistry::default());
+        let recipient = identity::AgentId([0x71_u8; 32]);
+        let other = identity::AgentId([0x72_u8; 32]);
+        let publishes = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        // A watch latch rather than `Notify`: a worker that has not yet
+        // reached its await point would miss a notification, making the test
+        // itself the flake.
+        let (release_tx, release_rx) = tokio::sync::watch::channel(false);
+
+        let make_worker =
+            |publishes: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+             mut release: tokio::sync::watch::Receiver<bool>| {
+                move |guard: CapabilityRefreshGuard,
+                  completion_tx: tokio::sync::watch::Sender<CapabilityRefreshState>| async move {
+                publishes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                while !*release.borrow_and_update() {
+                    if release.changed().await.is_err() {
+                        break;
+                    }
+                }
+                completion_tx.send_replace(CapabilityRefreshState::Finished);
+                drop(guard);
+            }
+            };
+
+        let first = registry.register_or_start(
+            recipient,
+            make_worker(publishes.clone(), release_rx.clone()),
+        );
+        assert!(matches!(first, CapabilityRefreshRegistration::Started(_)));
+        let second = registry.register_or_start(
+            recipient,
+            make_worker(publishes.clone(), release_rx.clone()),
+        );
+        assert!(
+            matches!(second, CapabilityRefreshRegistration::Joined(_)),
+            "a second strict send for the same recipient must join the flight"
+        );
+        // A different recipient is a genuinely different question and starts
+        // its own flight.
+        let third =
+            registry.register_or_start(other, make_worker(publishes.clone(), release_rx.clone()));
+        assert!(matches!(third, CapabilityRefreshRegistration::Started(_)));
+
+        release_tx.send_replace(true);
+        // The registry drains as each worker's guard drops.
+        for _ in 0..200 {
+            if registry.len() == 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(registry.len(), 0, "every flight must release its slot");
+        assert_eq!(
+            publishes.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "two recipients means two flights, not three"
+        );
+    }
+
+    #[tokio::test]
+    async fn capability_refresh_registry_refuses_work_after_close() {
+        let registry = std::sync::Arc::new(CapabilityRefreshRegistry::default());
+        registry.close();
+        let registration = registry.register_or_start(
+            identity::AgentId([0x73_u8; 32]),
+            |guard, completion_tx| async move {
+                completion_tx.send_replace(CapabilityRefreshState::Finished);
+                drop(guard);
+            },
+        );
+        assert!(matches!(
+            registration,
+            CapabilityRefreshRegistration::Unavailable
+        ));
+        assert_eq!(registry.len(), 0);
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7856,15 +7856,16 @@ impl Agent {
         // to the raw-QUIC path. The capability advert service watches
         // this channel and republishes immediately on change.
         //
-        // ADR 0030 §3: advertise v2 iff durable history is enabled. Without a
-        // history handle this daemon cannot commit a message before ACKing, so
-        // claiming v2 would promise a receipt it can never honour — senders
-        // must see v1 and either downgrade explicitly or get their 409.
-        let upgraded = if self.history_handle.is_some() {
-            dm::DmCapabilities::v2_durable_gossip_ready(kem_keypair.public_bytes.clone())
-        } else {
-            dm::DmCapabilities::v1_gossip_ready(kem_keypair.public_bytes.clone())
-        };
+        // ADR 0030 §3 targets: advertise v2 iff durable history is enabled.
+        // HELD AT v1 FOR NOW (PR #327 review): this binary carries the
+        // sender-side gate (slice 1) but NOT the receiver durable path
+        // (slice 2), so a v2 advert would be a false capability — a strict
+        // sender clears its gate, this receiver ACKs with v1 semantics, the
+        // exact-protocol waiter never matches, and the send hangs to timeout:
+        // exactly the failure mode ADR 0030 §2 forbids. Flip to
+        // `v2_durable_gossip_ready(...)` iff `history_handle.is_some()` in
+        // the same change that lands the slice-2 receiver path.
+        let upgraded = dm::DmCapabilities::v1_gossip_ready(kem_keypair.public_bytes.clone());
         // send_replace stores the value even when no receiver is subscribed
         // yet; a plain send() drops the upgrade if this runs before the
         // capability advert service subscribes, leaving peers cached on

--- a/src/server/routes/direct.rs
+++ b/src/server/routes/direct.rs
@@ -479,5 +479,36 @@ mod tests {
         assert!(!direct_send_config_for_request(&disabled).prefer_raw_quic_if_connected);
     }
 
+    /// ADR 0030 §4 deprecates `require_gossip_ack` but objects specifically to
+    /// *silently discarding* it — the campaign branch accepted
+    /// `require_gossip_ack: false` and ignored it, so a caller asking for
+    /// fire-and-forget got a blocking send with no signal. This route honors
+    /// it, and must keep honoring it until slice 4 replaces acceptance with an
+    /// explicit 400. If a later slice makes the field a no-op, this test fails
+    /// rather than letting the silence back in.
+    #[test]
+    fn deprecated_require_gossip_ack_is_honored_not_silently_discarded() {
+        let omitted: DirectSendRequest = serde_json::from_value(serde_json::json!({
+            "agent_id": "00".repeat(32),
+            "payload": ""
+        }))
+        .expect("minimal direct-send request should deserialize");
+        assert!(
+            direct_send_config_for_request(&omitted).require_gossip_ack,
+            "omitting the field must select the daemon default (true)"
+        );
+
+        let disabled: DirectSendRequest = serde_json::from_value(serde_json::json!({
+            "agent_id": "00".repeat(32),
+            "payload": "",
+            "require_gossip_ack": false
+        }))
+        .expect("direct-send request with explicit override should deserialize");
+        assert!(
+            !direct_send_config_for_request(&disabled).require_gossip_ack,
+            "an explicit false must reach the send config, not be discarded"
+        );
+    }
+
     // ── ADR-0016 R2: REST pre-check (exact §3 string + status code) ─────
 }

--- a/src/server/routes/direct.rs
+++ b/src/server/routes/direct.rs
@@ -350,6 +350,15 @@ pub(in crate::server) async fn direct_send(
                 x0x::dm::DmError::RecipientKeyInvalid(_) => {
                     (StatusCode::CONFLICT, "recipient_key_invalid")
                 }
+                // ADR 0030 §2: the caller demanded durable application-ACK
+                // semantics and the recipient has no current v2 capability
+                // advert. 409 rather than 400 — the request was well-formed,
+                // the peer state is not what it requires — and never a silent
+                // downgrade. Callers retry, surface "peer needs upgrade", or
+                // resend with `require_durable_app_ack = false`.
+                x0x::dm::DmError::AckSemanticsUnavailable(_) => {
+                    (StatusCode::CONFLICT, "recipient_ack_semantics_unavailable")
+                }
                 x0x::dm::DmError::Timeout { .. } => (StatusCode::GATEWAY_TIMEOUT, "timeout"),
                 x0x::dm::DmError::PeerLikelyOffline { .. } => {
                     (StatusCode::BAD_GATEWAY, "peer_likely_offline")

--- a/src/server/routes/identity.rs
+++ b/src/server/routes/identity.rs
@@ -400,9 +400,16 @@ pub(in crate::server) async fn get_agent_card(
     let display_name = query.display_name.unwrap_or_default();
 
     let mut card = x0x::groups::card::AgentCard::new(display_name, &agent_id, &machine_id);
-    card.dm_capabilities = Some(x0x::dm::DmCapabilities::v1_gossip_ready(
-        state.agent_kem_keypair.public_bytes.clone(),
-    ));
+    // ADR 0030 §3: the card must carry the same protocol version the mesh
+    // advert claims. Hardcoding v1 here made an imported card contradict the
+    // live advert, and a lower-version card import would then have to be
+    // ignored by the capability store.
+    card.dm_capabilities = Some(
+        state
+            .agent
+            .current_dm_capabilities()
+            .with_kem_public_key(state.agent_kem_keypair.public_bytes.clone()),
+    );
 
     // Add user ID if available
     card.user_id = state.agent.user_id().map(|u| hex::encode(u.as_bytes()));
@@ -510,9 +517,16 @@ pub(in crate::server) async fn get_a2a_agent_card(
     let machine_id = hex::encode(state.agent.machine_id().as_bytes());
 
     let mut card = x0x::groups::card::AgentCard::new(String::new(), &agent_id, &machine_id);
-    card.dm_capabilities = Some(x0x::dm::DmCapabilities::v1_gossip_ready(
-        state.agent_kem_keypair.public_bytes.clone(),
-    ));
+    // ADR 0030 §3: the card must carry the same protocol version the mesh
+    // advert claims. Hardcoding v1 here made an imported card contradict the
+    // live advert, and a lower-version card import would then have to be
+    // ignored by the capability store.
+    card.dm_capabilities = Some(
+        state
+            .agent
+            .current_dm_capabilities()
+            .with_kem_public_key(state.agent_kem_keypair.public_bytes.clone()),
+    );
     card.user_id = state.agent.user_id().map(|u| hex::encode(u.as_bytes()));
 
     // Only globally-advertisable addresses belong in a publicly-served card.
@@ -675,13 +689,15 @@ pub(in crate::server) async fn import_agent_card(
     if machine_id_bytes != [0u8; 32] {
         if let Some(caps) = card.dm_capabilities.clone() {
             if caps.gossip_inbox && !caps.kem_public_key.is_empty() {
-                capability_store.insert(
+                // ADR 0030 §3: card imports go through `insert_from_card`, so a
+                // stale or legacy card cannot lower a live signed advert's
+                // protocol version and quarantine strict sends to that peer.
+                inserted_dm_capability = capability_store.insert_from_card(
                     agent_id,
                     x0x::identity::MachineId(machine_id_bytes),
                     caps,
                     x0x::dm_capability::now_unix_ms(),
                 );
-                inserted_dm_capability = true;
             }
         }
     }


### PR DESCRIPTION
First of four slices landing DM protocol v2 per **ADR 0030** (Accepted 2026-08-13). Sender side only; receiver durable path is slice 2.

## What lands (§ references = ADR 0030)

- **§2**: protocol constants with **ceiling `DM_PROTOCOL_VERSION = 2`** — above-ceiling envelopes dropped without ACK, with an observable trace event (ADR 0025); no v3/thread code active.
- **§3**: `v2_durable_gossip_ready` **iff durable history enabled** (the ADR's amendment over the campaign's v3-iff-history), advertised on `start_dm_inbox`/withdrawn on stop; `/agent/card` + A2A card export the live value. `CapabilityStore` never-lower rule on card import; signed-timestamp expiry with bounded skew.
- Targeted refresh protocol (request/response topics registered **Critical** so strict-send convergence isn't cooled behind the Bulk steady topic) + warm carrier on the steady topic; recipient-keyed single-flight to prevent advert storms.
- Strict gate: `require_durable_app_ack` (default **false**) → on cache miss, exactly one forced targeted refresh, bounded 3s wait, then `AckSemanticsUnavailable` → REST **409 `recipient_ack_semantics_unavailable`**. Never silent downgrade, never a hang.
- ACK-waiter binding: exact protocol match — a v1 ACK can never satisfy a v2 waiter.
- **§4 note (second commit)**: `require_gossip_ack` on `/direct/send` is *honored* on main today (the campaign's silent discard was the defect), so the hard-400 is deliberately deferred to slice 4 where product defaults change; current behavior is now documented in `api-reference.md` with the deprecation notice.

## Extraction provenance

Hunk-by-hunk from `wip/codex-durable-app-ack` (`b60b995`), never file blobs. The survey's "new files" (`dm_capability*.rs`) already existed on main — extracted as deltas. Excluded and verified absent: receiver durable path, raw-durable framing, `send_durable_raw_preferred`, outbox, product defaults, all v3/threaded code, `logical_id` derivation changes.

## Gates (verified independently on the pushed tree)

fmt clean · clippy `--workspace --all-features -D warnings` exit 0 · nextest **2617/2618** — the sole failure is the documented #316 flake (`direct_send_with_require_ack_round_trips_to_live_peer`, passes in isolation, re-verified this run). +19 new tests incl. two-daemon REST-level gate behavior (strict 409 against a v1 peer; gate passes once the receiver advertises v2), capability-store rules, single-flight, ACK binding.

Cross-review: Grok (guardrails from the channel all addressed; the 400 deferral is the one judgment call — reasoning above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces DM protocol-v2 capability advertisement, targeted capability refresh, protocol-bound ACK waiters, and a strict durable-ACK send gate.

- Advertises v2 when durable history is enabled and exposes live capability state through agent cards.
- Adds signed capability-cache expiry and card-import ordering rules.
- Adds targeted critical-topic refresh with recipient-keyed single-flight coordination.
- Pins ACK resolution to protocol, recipient, and machine and maps unavailable strict semantics to HTTP 409.
- Three correctness gaps remain around strict loopback sends, capability withdrawal, and stale card ordering.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until strict self-sends honor durable semantics, inbox withdrawal reaches remote capability stores, and card imports preserve signed capability ordering.

Strict loopback sends can report success without durable commit, stopped inboxes remain advertised remotely for the cache TTL, and stale same-version cards can replace fresher runtime KEM and machine bindings.

**Files Needing Attention:** src/lib.rs, src/dm_capability_service.rs, src/server/routes/identity.rs, src/dm_capability.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib.rs | Adds strict refresh/gating and live capability lifecycle wiring, but strict self-sends bypass the gate and inbox withdrawal is not propagated remotely. |
| src/dm_capability.rs | Adds signed-time expiry, machine bindings, and card-specific insertion, but its ordering contract is undermined by the card import call site's synthetic timestamp. |
| src/dm_capability_service.rs | Adds targeted request/response subscriptions and rate-limited publishing; pending states remain local and therefore cannot withdraw prior remote adverts. |
| src/dm_send.rs | Negotiates protocol v1/v2 per send and binds ACK waiters to the expected protocol, recipient, and optional machine. |
| src/dm_inbox.rs | Enforces the receive-version ceiling and stamps current receiver ACKs with the v1 semantics actually honored. |
| src/server/routes/identity.rs | Exports live capability values but imports card capability material using import time rather than the card's signed creation time. |
| src/server/routes/direct.rs | Adds structured mapping for AckSemanticsUnavailable while retaining existing request defaults. |
| src/gossip/pubsub.rs | Registers targeted capability topics with critical admission priority. |
| src/dm.rs | Defines v1/v2 semantic constants, strict-send configuration, versioned envelope construction, and protocol/machine-bound in-flight ACK resolution. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Caller
  participant Sender as Agent send gate
  participant Cache as CapabilityStore
  participant Refresh as Targeted refresh
  participant Peer as Recipient inbox
  Caller->>Sender: "send(require_durable_app_ack=true)"
  Sender->>Cache: lookup signed v2 binding
  alt binding missing or stale
    Sender->>Refresh: single-flight targeted request
    Refresh->>Peer: request current capability
    Peer-->>Cache: signed capability advert
  end
  alt current v2 binding available
    Sender->>Peer: publish v2 envelope
    Peer-->>Sender: protocol/machine-bound ACK
  else unavailable
    Sender-->>Caller: AckSemanticsUnavailable
  end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib.rs`, line 4562 ([link](https://github.com/saorsa-labs/x0x/blob/7f664f98d078be66345142582e7d6dcbd3234e65/src/lib.rs#L4562)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Strict loopback bypasses durability**

   When a library caller sends to its own agent with `require_durable_app_ack = true`, the loopback branch returns success before the strict gate and performs only in-memory fan-out; outbound history is then queued best-effort, so the caller can receive a durable-success receipt even when no durable record is committed.

   **Knowledge Base Used:**
   - [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)
   - [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/lib.rs
   Line: 4562
   
   Comment:
   **Strict loopback bypasses durability**
   
   When a library caller sends to its own agent with `require_durable_app_ack = true`, the loopback branch returns success before the strict gate and performs only in-memory fan-out; outbound history is then queued best-effort, so the caller can receive a durable-success receipt even when no durable record is committed.
   
   **Knowledge Base Used:**
   - [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)
   - [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/lib.rs:4562
**Strict loopback bypasses durability**

When a library caller sends to its own agent with `require_durable_app_ack = true`, the loopback branch returns success before the strict gate and performs only in-memory fan-out; outbound history is then queued best-effort, so the caller can receive a durable-success receipt even when no durable record is committed.

### Issue 2
src/lib.rs:7884-7888
**Inbox withdrawal stays local**

When `stop_dm_inbox` aborts the inbox, it sends `pending()` only through the local watch channel, while the publisher suppresses non-publishable states. Remote peers therefore retain the prior gossip-ready advert for up to the 15-minute cache TTL and continue routing non-strict messages to an inbox nobody consumes, causing timeouts or lost delivery instead of raw-QUIC fallback.

### Issue 3
src/server/routes/identity.rs:695-700
**Import time overrides card age**

When an old v1 card is imported after a fresher live v1 advert, passing `now_unix_ms()` makes the card appear newer and the never-lower check does not reject equal protocol versions. The stale card can replace the current machine and KEM binding, causing subsequent sends to encrypt for an obsolete key or pin ACKs to the wrong machine until another advert arrives.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(dm): document deprecated require\_go..."](https://github.com/saorsa-labs/x0x/commit/7f664f98d078be66345142582e7d6dcbd3234e65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53598549)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)
- Knowledge Base — [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)
- Knowledge Base — [Network Transport](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/network-transport.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)
</details>


<!-- /greptile_comment -->