### PR TITLE
feat(dm): DA slice 2 — receiver durable path (ADR 0030)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,38 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **DM protocol v2 receiver durable path (ADR 0030 §1, slice 2 of 4).** A v2
+  envelope is answered in exactly this order: per-logical-request lock →
+  replay-cache binding check → durable-history lookup → dispatch →
+  `record_committed` awaited → ACK. A v2 ACK is emitted **only** after the
+  SQLite commit returns `Inserted | Duplicate`; every failure below that —
+  commit error, backpressured writer, unavailable history, lost delivery
+  lock, unpublishable replay completion — withholds the ACK rather than
+  degrading it. `Accepted` under v2 now means what ADR 0030 §1 says it
+  means: verified, durably committed, and dispatched.
+- **History schema v4 columns gain writers.** Inbound DM rows populate
+  `ingress_sender_agent` and `logical_request_id`; together they key the
+  durable-history lookup that lets a restarted receiver recognise a logical
+  request it already committed, via the new
+  `Store::find_by_logical_request`.
+- **`HistoryHandle::record_committed`.** A commit-receipt write for protocol
+  surfaces whose success promises durable history. Unlike the fire-and-forget
+  `record`, it never sheds silently: a full or closed writer queue returns
+  `HistoryError::WriterBackpressured` / `WriterClosed` to the caller.
 - **DM protocol v2 capability advertisement + strict-send gate (ADR 0030,
   slice 1 of 4).** `DM_PROTOCOL_VERSION` becomes the receive **ceiling** 2:
-  envelopes above it are dropped without an ACK. The production advert is
-  **held at `max_protocol_version = 1`** until the slice-2 receiver durable
-  path ships in the same binary — advertising v2 without it would be a
-  false capability and hang strict senders (PR #327 review; the ADR 0030
-  §3 v2-iff-history flip lands with slice 2). Agent cards export the same
+  envelopes above it are dropped without an ACK. Agent cards export the same
   runtime value, and card imports go through `CapabilityStore::insert_from_card`
   so a stale card can never lower a live signed advert.
+
+### Changed
+
+- **The v2 capability advert is now live and conditional (ADR 0030 §3).**
+  `start_dm_inbox` advertises `max_protocol_version = 2` **iff** a durable
+  history handle is present, else 1. The slice-1 hold is lifted because the
+  receiver path in this release is what makes the v2 claim true. Daemons
+  without history keep advertising v1, so a strict sender gets the typed 409
+  instead of clearing its gate against a receiver that could never commit.
 - **`DmSendConfig::require_durable_app_ack`** (default `false`). A strict
   send negotiates v2 on the wire and pins its ACK waiter to
   `(protocol_version, recipient, machine)`; a recipient without a current
@@ -32,12 +55,31 @@ All notable changes to this project will be documented in this file.
 ### Notes
 
 - No send surface sets `require_durable_app_ack` yet: REST, CLI, WS and the
-  library default stay v1-defaulted, so this slice is behaviour-neutral for
-  existing callers. Product defaults flip in ADR 0030 slice 4.
-- The receiver durable path is slice 2. Until it lands this build ACKs with
-  `protocol_version = 1` — the semantics it actually honours — so a strict
-  send that clears the gate times out rather than receiving a durable
-  receipt no one made.
+  library default stay v1-defaulted, so these slices remain behaviour-neutral
+  for existing callers. Product defaults flip in ADR 0030 slice 4.
+- **v1 senders are unaffected.** A v1 envelope takes the unchanged legacy
+  path and receives a v1 ACK even on a receiver with durable history enabled;
+  enabling history never silently upgrades the receipt an 0.37 peer is handed.
+- A strict v2 send can still end in a timeout, but now only against a peer
+  advertising a **false** v2 capability — one claiming the durable ceiling
+  without a receiver that can commit. This daemon cannot be that peer: it
+  advertises v2 only when history is enabled, and withholds the ACK rather
+  than downgrading if history becomes unavailable at runtime.
+- **Typed routes (ADR 0030 §7): the obligation is documented, not closed.**
+  Typed-prefix families (group ingest, KV deltas, exec audit, card import,
+  voice signalling) classify `Ephemeral` — their durable effect lives in
+  their own store, not in DM history — and are handed off with a
+  non-blocking `try_send` that may drop. A DM-history commit therefore
+  cannot honestly back their receipt, so a v2 envelope matching a typed
+  route gets **no** ACK in this slice, and each handler carries the
+  restart-spanning dedupe obligation via its own durable surface. The
+  typed-route completion signal that lets these frames earn a v2 ACK is
+  slice 3.
+- Durable v2 is **at-least-once across restart**: the replay cache is
+  memory-only, so a restart can re-dispatch an already-committed envelope.
+  The durable-history lookup keeps it to exactly one history row, and
+  applications needing restart-spanning exactly-once dedupe on
+  `(sender, request_id)`.
 
 ## [v0.37.4] - 2026-08-14
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -382,11 +382,16 @@ Notable codes:
 | 413 | `payload_too_large` | Payload exceeds the DM envelope cap. |
 | 504 | `timeout` | No application ACK within the retry budget. The DM may or may not have arrived. |
 
-**Note (as of ADR 0030 slice 1):** no REST field selects durable ACK
+**Note (as of ADR 0030 slice 2):** no REST field selects durable ACK
 semantics yet, so `recipient_ack_semantics_unavailable` is currently
 reachable only through the library (`DmSendConfig::require_durable_app_ack`).
 The product-tier default flips in ADR 0030 slice 4, at which point this
 becomes a routine response for not-yet-upgraded peers.
+
+Slice 2 landed the receiver durable path, so a library-level strict send now
+*succeeds* against a peer that advertises v2 — which it does only when that
+peer runs with durable history enabled. REST request and response shapes are
+unchanged by this slice.
 
 ### `/direct/events` SSE message shape
 

--- a/docs/design/dm-over-gossip.md
+++ b/docs/design/dm-over-gossip.md
@@ -194,7 +194,7 @@ Documented explicitly so we don't overclaim:
 |---|---|---|---|
 | 1 | Transport accepted | — | Gossip `publish()` returned Ok. We don't expose this as a receipt. |
 | 2 | **Recipient agent accepted** | **YES** | Recipient's process decrypted, verified, passed policy, enqueued to the DM handler. This is what `send_direct` returns on success. |
-| 3 | Durable locally stored | future | Recipient wrote the DM to a persistent inbox. Not in v1. |
+| 3 | Durable locally stored | v2 | Recipient committed the DM to ADR-0023 history (SQLite transaction awaited) and completed dispatch, before ACKing. Reached only by a v2 send to a v2-advertising receiver; at-least-once across restart. |
 | 4 | User read | future/never | Human read the DM in a UI. Out of scope. |
 
 `DmReceipt::delivered_at` corresponds to **level 2**. Docs and API
@@ -206,18 +206,11 @@ DM protocol v2 raises `Accepted` to **level 3** for sends that ask for it.
 The envelope layout is byte-identical to v1; only ACK semantics differ, so
 `protocol_version` is a promise about the *receipt*, not a wire change.
 
-Landing in slices (ADR 0030 "Landing order"). Slice 1 ships:
+Landing in slices (ADR 0030 "Landing order"). Slices 1–2 ship:
 
 - `DM_PROTOCOL_VERSION = 2` as the **receive ceiling**. Envelopes above it
   are dropped without an ACK, so the sender times out rather than being
   handed a receipt for semantics we cannot honour.
-- The production advert is **held at `max_protocol_version = 1`** in this
-  slice: a binary carrying the strict-send gate but not the slice-2
-  receiver durable path must not claim v2, or a strict sender that finds
-  the advert clears its gate and hangs against a v1 ACK (exact-protocol
-  waiter). The ADR 0030 §3 rule — v2 **iff** durable history is enabled —
-  activates in the same change as slice 2. Card exports and mesh adverts
-  carry the runtime value either way.
 - `DmSendConfig::require_durable_app_ack` (default `false`). When set, the
   send negotiates v2 on the wire and its ACK waiter is pinned to
   `(protocol_version, recipient, machine)`. A recipient without a current
@@ -227,11 +220,62 @@ Landing in slices (ADR 0030 "Landing order"). Slice 1 ships:
 - Targeted capability refresh on `x0x/caps/v1/request/targeted-v2`, answered
   on `x0x/caps/v1/response/targeted-v2` (both Critical). Concurrent strict
   sends to one recipient share a single in-flight request.
+- The **receiver durable path** and the live v2 advert (below).
 
-**Not yet in slice 1:** the receiver durable path. Until it lands, this
-build ACKs every accepted payload with `protocol_version = 1` — the
-semantics it actually honours — so a strict send that clears the capability
-gate still times out rather than receiving a durable receipt no one made.
+#### Receiver ordering (normative)
+
+`InboxPipeline::handle_payload_durable` runs a v2 payload in exactly this
+order, per ADR 0030 §1:
+
+1. **Per-logical-request lock** (`RecentDeliveryCache::delivery_lock`) —
+   serializes the primary-inbox and legacy-bus copies of one envelope so
+   neither observes the other's provisional success. No free slot ⇒ ACK
+   withheld; evicting an in-flight lock would permit duplicate dispatch.
+2. **Replay-cache binding check** — a completion already present is re-ACKed
+   under *its own* semantics, never re-dispatched. The binding is a
+   domain-separated digest over `(protocol_version, accepted bytes)`, so the
+   same request id carrying different content is refused rather than
+   re-ACKed as the original delivery.
+3. **Durable-history lookup** — keyed on the schema v4 columns
+   `(ingress_sender_agent, logical_request_id)` via
+   `Store::find_by_logical_request`. This is the check that survives restart,
+   where the memory-only replay cache does not. A row binding different bytes
+   is a conflict and is refused.
+4. **Dispatch** to the application.
+5. **`record_committed` awaited** — the SQLite transaction must return
+   `Inserted | Duplicate`, i.e. exactly one durable row for this logical
+   request.
+6. **ACK**, stamped with the semantics actually honoured.
+
+Steps 5→6 are the whole point: **the ACK exists only because the commit
+succeeded.** Commit error, backpressured writer, unavailable history, lost
+lock, or an unpublishable replay completion each **withhold** the ACK. None
+of them may fall back to a v1 ACK — a withheld ACK costs the sender a
+timeout, whereas a downgraded one hands it a weaker receipt it cannot
+distinguish from the durable receipt it asked for (ADR 0030 §2).
+
+#### Typed routes (ADR 0030 §7)
+
+The typed-route restart-spanning dedupe gap is **documented as a handler
+obligation, not closed in the inbox.** Typed-prefix families (group ingest,
+KV deltas, exec audit, card import, voice signalling) classify `Ephemeral`:
+their durable effect lives in their own store, not in DM history, so a
+DM-history commit could not honestly back their receipt — and they are
+handed off with a non-blocking `try_send` that may drop under backpressure,
+so a durable ACK would claim a dispatch that never completed.
+
+A v2 envelope matching a typed route therefore receives **no** ACK, and each
+typed handler carries the dedupe obligation via its own durable surface (the
+bootstrap outbox handler satisfies it with `Inserted | Duplicate`
+completion). The typed-route completion signal that lets these frames earn a
+v2 ACK is slice 3.
+
+#### At-least-once across restart
+
+The replay cache is memory-only, so a restart can re-dispatch an
+already-committed envelope. The step-3 lookup holds it to exactly one
+history row. Applications needing restart-spanning exactly-once must dedupe
+on `(sender, request_id)`.
 
 ## Capability negotiation
 
@@ -258,6 +302,24 @@ pub struct DmCapabilities {
 `dm_capabilities` is signed as part of the AgentCard's existing
 signature (AgentCard version bump required — see *Identity evolution*
 below).
+
+#### `max_protocol_version` is v2 **iff** durable history is enabled
+
+ADR 0030 §3. `start_dm_inbox` advertises `max_protocol_version = 2` when the
+agent holds a durable history handle, and `1` otherwise. The advert is a
+promise about *this receiver*, so it tracks the only thing that can make the
+promise true: without history there is nothing for the durable path to
+commit to, and it would withhold every v2 ACK.
+
+Advertising v2 without the receiver path would be a false capability — a
+strict sender clears its gate, the receiver never produces a matching v2
+ACK, and the exact-protocol waiter hangs to timeout, exactly the failure
+ADR 0030 §2 forbids. Advertising v1 instead routes that sender to a typed
+409 it can act on. Card exports and mesh adverts carry the runtime value
+either way, and a card import can never lower a live signed advert.
+
+A strict v2 send can therefore still time out, but only against a peer
+advertising a **false** v2 capability — never against this daemon.
 
 ### Sender path selection
 

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -818,13 +818,58 @@ struct RecentDeliveryCacheInner {
     entries: HashMap<DedupeKey, CachedOutcome>,
     ttl: Duration,
     max_size: usize,
+    /// Per-logical-message serialization used by v2 so concurrent primary
+    /// inbox and legacy-bus copies cannot observe a provisional success.
+    delivery_locks: HashMap<DedupeKey, Arc<tokio::sync::Mutex<()>>>,
+    delivery_lock_order: VecDeque<DedupeKey>,
+}
+
+/// Exact authenticated application binding for one completed durable request.
+///
+/// Sender and request id are carried by [`DedupeKey`]; the recipient is scoped
+/// by the per-inbox cache. This digest binds every remaining application-level
+/// input which must be identical before a durable completion may be replayed,
+/// so a replay carrying the same `(sender, request_id)` but different accepted
+/// bytes is detected instead of being re-ACKed as the original.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DmDurableBindingDigest([u8; 32]);
+
+impl DmDurableBindingDigest {
+    /// Bind the negotiated protocol and the exact decrypted application bytes
+    /// into one domain-separated digest.
+    #[must_use]
+    pub fn accepted(protocol_version: u16, application_payload: &[u8]) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"x0x-dm-durable-accepted-binding-v1");
+        hasher.update(&protocol_version.to_be_bytes());
+        let payload_len = u64::try_from(application_payload.len()).unwrap_or(u64::MAX);
+        hasher.update(&payload_len.to_be_bytes());
+        hasher.update(application_payload);
+        Self(*hasher.finalize().as_bytes())
+    }
 }
 
 /// A cached per-DM outcome.
 #[derive(Debug, Clone)]
 pub struct CachedOutcome {
     pub outcome: DmAckOutcome,
+    /// Semantics under which the outcome completed. This is metadata, not
+    /// part of the logical dedupe key: changing protocol versions must never
+    /// make one request dispatch twice.
+    pub protocol_version: u16,
+    /// Exact accepted application binding for durable completions. Legacy and
+    /// policy-rejection entries do not have one.
+    pub durable_binding: Option<DmDurableBindingDigest>,
     pub first_seen: Instant,
+}
+
+/// Failure to durably publish a completed v2 outcome into the replay cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DurableCacheError {
+    /// The cache mutex was poisoned; callers must withhold the ACK.
+    Poisoned,
+    /// A completion already exists for this logical request.
+    AlreadyCompleted,
 }
 
 impl RecentDeliveryCache {
@@ -858,6 +903,8 @@ impl RecentDeliveryCache {
                 entries: HashMap::new(),
                 ttl,
                 max_size,
+                delivery_locks: HashMap::new(),
+                delivery_lock_order: VecDeque::new(),
             }),
         }
     }
@@ -894,6 +941,16 @@ impl RecentDeliveryCache {
     /// (proceed) so a poisoned cache degrades to possible double-delivery
     /// rather than silent message loss.
     pub fn insert(&self, key: DedupeKey, outcome: DmAckOutcome) -> bool {
+        self.insert_for_protocol(key, outcome, DM_PROTOCOL_V1)
+    }
+
+    /// Insert an outcome and record which protocol semantics produced it.
+    pub fn insert_for_protocol(
+        &self,
+        key: DedupeKey,
+        outcome: DmAckOutcome,
+        protocol_version: u16,
+    ) -> bool {
         let Ok(mut inner) = self.inner.lock() else {
             return true;
         };
@@ -904,6 +961,8 @@ impl RecentDeliveryCache {
             key,
             CachedOutcome {
                 outcome,
+                protocol_version,
+                durable_binding: None,
                 first_seen: Instant::now(),
             },
         );
@@ -917,6 +976,77 @@ impl RecentDeliveryCache {
             inner.entries.remove(&oldest);
         }
         true
+    }
+
+    /// Publish a completed durable delivery into the replay cache.
+    ///
+    /// Unlike the legacy insertion path, mutex poisoning and a competing
+    /// completion are explicit failures. The receiver must withhold its ACK
+    /// unless this succeeds, so it can never acknowledge a completion that
+    /// was not made replay-safe.
+    pub fn complete_durable(
+        &self,
+        key: DedupeKey,
+        outcome: DmAckOutcome,
+        protocol_version: u16,
+        durable_binding: DmDurableBindingDigest,
+    ) -> std::result::Result<(), DurableCacheError> {
+        let mut inner = self.inner.lock().map_err(|_| DurableCacheError::Poisoned)?;
+        if inner.entries.contains_key(&key) {
+            return Err(DurableCacheError::AlreadyCompleted);
+        }
+        inner.entries.insert(
+            key,
+            CachedOutcome {
+                outcome,
+                protocol_version,
+                durable_binding: Some(durable_binding),
+                first_seen: Instant::now(),
+            },
+        );
+        inner.order.push_back(key);
+        while inner.entries.len() > inner.max_size {
+            let Some(oldest) = inner.order.pop_front() else {
+                break;
+            };
+            inner.entries.remove(&oldest);
+        }
+        Ok(())
+    }
+
+    /// Return the shared per-logical-request lock used by the durable v2
+    /// pipeline (ADR 0030 §1, first ordering step). Locks are bounded by the
+    /// same capacity as cached outcomes.
+    ///
+    /// Returns `None` when every slot has a live owner or waiter: the caller
+    /// must then withhold its ACK rather than proceed unserialized, because
+    /// evicting an in-flight lock would permit duplicate durable dispatch.
+    pub fn delivery_lock(&self, key: DedupeKey) -> Option<Arc<tokio::sync::Mutex<()>>> {
+        let Ok(mut inner) = self.inner.lock() else {
+            return None;
+        };
+        if let Some(lock) = inner.delivery_locks.get(&key) {
+            return Some(Arc::clone(lock));
+        }
+        while inner.delivery_locks.len() >= inner.max_size {
+            let removable = inner.delivery_lock_order.iter().position(|candidate| {
+                inner
+                    .delivery_locks
+                    .get(candidate)
+                    .is_some_and(|lock| Arc::strong_count(lock) == 1)
+            });
+            // `None` here means every slot has a live owner or waiter. Fail
+            // closed: evicting an in-flight lock would let a second copy of
+            // the same envelope dispatch concurrently.
+            let position = removable?;
+            if let Some(oldest_idle) = inner.delivery_lock_order.remove(position) {
+                inner.delivery_locks.remove(&oldest_idle);
+            }
+        }
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        inner.delivery_locks.insert(key, Arc::clone(&lock));
+        inner.delivery_lock_order.push_back(key);
+        Some(lock)
     }
 
     /// Current cache size (diagnostic).

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -7,7 +7,7 @@ use crate::direct::DirectMessaging;
 use crate::dm::{
     decrypt_payload, dm_inbox_topic, now_unix_ms, validate_timestamp_window, DmAckOutcome, DmBody,
     DmEnvelope, DmOriginAttestation, DmPayload, EnvelopeBuilder, InFlightAcks, RecentDeliveryCache,
-    DM_PROTOCOL_V1, DM_PROTOCOL_VERSION, MAX_ENVELOPE_BYTES,
+    DM_PROTOCOL_DURABLE_ACK, DM_PROTOCOL_V1, DM_PROTOCOL_VERSION, MAX_ENVELOPE_BYTES,
 };
 use crate::error::{NetworkError, NetworkResult};
 use crate::gossip::{PubSubManager, PubSubMessage, SigningContext, Subscription};
@@ -342,6 +342,144 @@ struct InboxPipeline {
     history: Option<crate::history::HistoryHandle>,
 }
 
+/// Re-ACK semantics for a logical request that already completed.
+///
+/// ADR 0030 §2: a request completed under weaker semantics is answered
+/// `AckSemanticsUnavailable`, never re-ACKed as durable — otherwise a v2
+/// sender racing a v1 delivery of the same request would be handed a durable
+/// receipt nobody made.
+fn cached_ack_for_protocol(
+    cached: &crate::dm::CachedOutcome,
+    requested_protocol: u16,
+) -> DmAckOutcome {
+    if cached.protocol_version >= requested_protocol {
+        cached.outcome.clone()
+    } else {
+        DmAckOutcome::RejectedByPolicy {
+            reason: format!(
+                "logical request already completed under v{} semantics",
+                cached.protocol_version
+            ),
+        }
+    }
+}
+
+/// A commit outcome that proves exactly one durable row exists for this
+/// record. `Inserted` is the first commit; `Duplicate` is the idempotent
+/// replay of an identical record (ADR 0030 validation: "exactly one durable
+/// history row (`Duplicate` re-ACK)"). Anything else means the row we
+/// promised is not the row that is there, so the ACK must be withheld.
+fn exact_durable_history_outcome(outcome: crate::history::InsertOutcome) -> bool {
+    matches!(
+        outcome,
+        crate::history::InsertOutcome::Inserted | crate::history::InsertOutcome::Duplicate
+    )
+}
+
+/// Build the ADR-0023 history row for a verified inbound DM.
+///
+/// `Ok(None)` means the payload classifies `Ephemeral` — protocol plumbing
+/// whose durable effect lives in its own store, never in DM history.
+///
+/// Schema v4 (`ingress_sender_agent`, `logical_request_id`) is populated here:
+/// together they key the ADR 0030 §1 durable-history lookup, which is what
+/// lets a receiver recognise a logical request it has already committed.
+fn inbound_dm_history_record(
+    envelope: &DmEnvelope,
+    application_payload: &[u8],
+    sender_machine_id: MachineId,
+    sender_pubkey: &[u8],
+) -> Result<Option<crate::history::HistoryRecord>, String> {
+    let crate::history::classify::DmPayloadClass::Durable(content_type) =
+        crate::history::classify::classify_dm_payload(application_payload)
+    else {
+        return Ok(None);
+    };
+    let artifact = envelope.to_wire_bytes().map_err(|e| e.to_string())?;
+    Ok(Some(crate::history::HistoryRecord {
+        msg_id: crate::history::HistoryRecord::compute_msg_id(Some(&artifact), application_payload),
+        scope: crate::history::Scope::Dm(hex::encode(envelope.sender_agent_id)),
+        author_agent: Some(hex::encode(envelope.sender_agent_id)),
+        author_machine: Some(hex::encode(sender_machine_id.as_bytes())),
+        author_pubkey: Some(sender_pubkey.to_vec()),
+        sent_at_ms: i64::try_from(envelope.created_at_unix_ms).unwrap_or(i64::MAX),
+        seen_at_ms: i64::try_from(now_unix_ms()).unwrap_or(i64::MAX),
+        direction: crate::history::Direction::Inbound,
+        content_type: content_type.to_string(),
+        payload: application_payload.to_vec(),
+        signed_artifact: Some(artifact),
+        signature: Some(envelope.signature.clone()),
+        // Mirrors `DM_SIGN_DOMAIN` in `dm.rs`.
+        sig_context: Some("x0x-dm-v1".to_string()),
+        provenance: crate::history::Provenance::VerifiedEnvelope,
+        replace_key: None,
+        thread_root: None,
+        thread_parent: None,
+        ingress_sender_agent: Some(hex::encode(envelope.sender_agent_id)),
+        logical_request_id: Some(envelope.request_id),
+    }))
+}
+
+/// What the receiver durable path decided for one v2 envelope.
+///
+/// Returned rather than inferred from side effects so the commit-before-ACK
+/// ordering is directly assertable: "no ACK when the commit fails" is the
+/// central promise of ADR 0030 §1 and must not be tested by proxy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DurableAckDecision {
+    /// An ACK was emitted with these semantics. `accepted` distinguishes a
+    /// delivery receipt from a refusal; a refusal never claims durability.
+    Acked {
+        protocol_version: u16,
+        accepted: bool,
+    },
+    /// No ACK was emitted — the sender times out. The stage names why.
+    Withheld(&'static str),
+}
+
+/// Result of the ADR 0030 §1 durable-history lookup for one logical request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DurableLogicalRequestLookup {
+    /// No durable row for this `(sender, request_id)` yet.
+    Missing,
+    /// A durable row exists and binds exactly the bytes now being accepted.
+    Exact,
+    /// A durable row exists under this logical request but binds different
+    /// bytes — the sender reused a request id for different content.
+    Conflict,
+}
+
+/// Durable-history lookup keyed on the schema v4 columns this path writes.
+///
+/// Runs on `spawn_blocking`: `Store` is synchronous SQLite and this is called
+/// from the inbox task.
+async fn durable_history_logical_request(
+    history: &crate::history::HistoryHandle,
+    sender: AgentId,
+    request_id: [u8; 16],
+    accepted_payload: Vec<u8>,
+) -> crate::error::HistoryResult<DurableLogicalRequestLookup> {
+    let store = Arc::clone(history.store());
+    let ingress = hex::encode(sender.as_bytes());
+    tokio::task::spawn_blocking(move || {
+        let rows = store.find_by_logical_request(&ingress, request_id)?;
+        if rows.is_empty() {
+            return Ok(DurableLogicalRequestLookup::Missing);
+        }
+        if rows
+            .iter()
+            .any(|row| row.record.payload != accepted_payload)
+        {
+            return Ok(DurableLogicalRequestLookup::Conflict);
+        }
+        Ok(DurableLogicalRequestLookup::Exact)
+    })
+    .await
+    .map_err(|error| {
+        crate::error::HistoryError::Database(format!("logical request lookup task failed: {error}"))
+    })?
+}
+
 impl InboxPipeline {
     async fn handle_incoming(&self, msg: PubSubMessage, ack_legacy_bus: bool) {
         let (pubsub_sender, sender_pubkey) = match (msg.sender, msg.sender_public_key.as_deref()) {
@@ -415,11 +553,27 @@ impl InboxPipeline {
         let dedupe = envelope.dedupe_key();
         if let Some(cached) = self.cache.lookup(&dedupe) {
             if matches!(envelope.body, DmBody::Payload(_)) {
+                // ADR 0030 §2: re-ACK under the semantics the completion was
+                // actually made with. A v1 completion answers a v2 request
+                // with a refusal, never with a durable-looking receipt.
+                let outcome = cached_ack_for_protocol(&cached, envelope.protocol_version);
+                // Accepted re-ACKs carry the semantics actually honoured;
+                // refusals carry the requested version so they reach the
+                // sender's exact-protocol waiter instead of timing out.
+                let ack_protocol = if matches!(outcome, DmAckOutcome::Accepted) {
+                    cached
+                        .protocol_version
+                        .min(envelope.protocol_version)
+                        .max(DM_PROTOCOL_V1)
+                } else {
+                    envelope.protocol_version
+                };
                 let _ = self
-                    .publish_ack(
+                    .publish_ack_for_protocol(
                         AgentId(envelope.sender_agent_id),
                         envelope.request_id,
-                        cached.outcome,
+                        outcome,
+                        ack_protocol,
                         ack_legacy_bus,
                     )
                     .await;
@@ -616,13 +770,23 @@ impl InboxPipeline {
                 let outcome = DmAckOutcome::RejectedByPolicy {
                     reason: decision.to_string(),
                 };
-                self.cache.insert(envelope.dedupe_key(), outcome.clone());
+                self.cache.insert_for_protocol(
+                    envelope.dedupe_key(),
+                    outcome.clone(),
+                    envelope.protocol_version,
+                );
                 if !self.silent_reject {
+                    // A refusal makes no durability claim, so it is stamped
+                    // with the requested version rather than downgraded to v1:
+                    // a strict v2 sender must learn it was rejected instead of
+                    // waiting out its ACK budget on a receipt it would ignore
+                    // (ADR 0030 drivers — no black hole, bounded latency).
                     let _ = self
-                        .publish_ack(
+                        .publish_ack_for_protocol(
                             sender_agent_id,
                             envelope.request_id,
                             outcome,
+                            envelope.protocol_version,
                             ack_legacy_bus,
                         )
                         .await;
@@ -642,6 +806,25 @@ impl InboxPipeline {
         };
         if plaintext.request_id != envelope.request_id {
             self.dm.record_incoming_decode_failed();
+            return;
+        }
+
+        // ADR 0030 §1/§2: a v2 envelope is answered by the durable path or not
+        // at all. There is no silent v1 downgrade of a v2 request — if durable
+        // history is unavailable the ACK is withheld and the sender times out,
+        // which can only happen against a peer that believed a false v2
+        // capability advert (this daemon advertises v2 iff history is on).
+        if envelope.protocol_version >= DM_PROTOCOL_DURABLE_ACK {
+            let _decision = self
+                .handle_payload_durable(
+                    envelope,
+                    plaintext.payload,
+                    decision,
+                    sender_machine_id,
+                    sender_pubkey,
+                    ack_legacy_bus,
+                )
+                .await;
             return;
         }
 
@@ -684,47 +867,23 @@ impl InboxPipeline {
             // signature/trust/revocation gate has passed. Non-blocking
             // (`HistoryHandle::record` is try_send); plumbing payload
             // families classify Ephemeral and are skipped.
-            if let Some(history) = self.history.as_ref() {
-                if let crate::history::classify::DmPayloadClass::Durable(content_type) =
-                    crate::history::classify::classify_dm_payload(&plaintext.payload)
-                {
-                    match envelope.to_wire_bytes() {
-                        Ok(artifact) => {
-                            let record = crate::history::HistoryRecord {
-                                msg_id: crate::history::HistoryRecord::compute_msg_id(
-                                    Some(&artifact),
-                                    &plaintext.payload,
-                                ),
-                                scope: crate::history::Scope::Dm(hex::encode(
-                                    envelope.sender_agent_id,
-                                )),
-                                author_agent: Some(hex::encode(envelope.sender_agent_id)),
-                                author_machine: Some(hex::encode(sender_machine_id.as_bytes())),
-                                author_pubkey: Some(sender_pubkey.clone()),
-                                sent_at_ms: i64::try_from(envelope.created_at_unix_ms)
-                                    .unwrap_or(i64::MAX),
-                                seen_at_ms: i64::try_from(now_unix_ms()).unwrap_or(i64::MAX),
-                                direction: crate::history::Direction::Inbound,
-                                content_type: content_type.to_string(),
-                                payload: plaintext.payload.clone(),
-                                signed_artifact: Some(artifact),
-                                signature: Some(envelope.signature.clone()),
-                                // Mirrors `DM_SIGN_DOMAIN` in `dm.rs`.
-                                sig_context: Some("x0x-dm-v1".to_string()),
-                                provenance: crate::history::Provenance::VerifiedEnvelope,
-                                replace_key: None,
-                                thread_root: None,
-                                thread_parent: None,
-                                ingress_sender_agent: None,
-                                logical_request_id: None,
-                            };
+            if self.history.is_some() {
+                match inbound_dm_history_record(
+                    &envelope,
+                    &plaintext.payload,
+                    sender_machine_id,
+                    &sender_pubkey,
+                ) {
+                    Ok(Some(record)) => {
+                        if let Some(history) = self.history.as_ref() {
                             history.record(record);
                         }
-                        Err(e) => {
-                            tracing::debug!(
-                                "history: DM envelope wire encode failed, row skipped: {e}"
-                            );
-                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::debug!(
+                            "history: DM envelope wire encode failed, row skipped: {e}"
+                        );
                     }
                 }
             }
@@ -757,6 +916,275 @@ impl InboxPipeline {
                 ack_legacy_bus,
             )
             .await;
+    }
+
+    /// Receiver durable path for a v2 envelope (ADR 0030 §1).
+    ///
+    /// Ordering is normative and implemented in exactly this order:
+    /// per-logical-request lock → replay-cache binding check →
+    /// durable-history lookup → dispatch → `record_committed` awaited → ACK.
+    ///
+    /// Every failure below withholds the ACK. A withheld ACK costs the sender
+    /// a timeout; a premature ACK costs it a lost message it was told had
+    /// arrived, which is the defect this protocol exists to remove. No branch
+    /// here may fall back to a v1 ACK: that would answer a durable request
+    /// with a weaker receipt the sender cannot distinguish (ADR 0030 §2).
+    async fn handle_payload_durable(
+        &self,
+        envelope: DmEnvelope,
+        application_payload: Vec<u8>,
+        decision: TrustDecision,
+        sender_machine_id: MachineId,
+        sender_pubkey: Vec<u8>,
+        ack_legacy_bus: bool,
+    ) -> DurableAckDecision {
+        let sender_agent_id = AgentId(envelope.sender_agent_id);
+        let request_id = envelope.request_id;
+        let dedupe = envelope.dedupe_key();
+
+        let Some(history) = self.history.clone() else {
+            tracing::warn!(
+                target: "dm.trace",
+                stage = "inbound_durable_history_unavailable",
+                request_id = %hex::encode(request_id),
+                sender = %hex::encode(sender_agent_id.as_bytes()),
+                "v2 DM withheld: durable history is not enabled on this daemon"
+            );
+            return DurableAckDecision::Withheld("history_unavailable");
+        };
+
+        // ADR 0030 §7 — typed-route obligation (documented, not closed here).
+        //
+        // Typed-prefix families (group ingest, KV deltas, exec audit, card
+        // import, voice signalling) classify `Ephemeral`: their durable effect
+        // lives in their own store, not in DM history, so a DM-history commit
+        // could not honestly back their receipt. They are also handed off with
+        // a non-blocking `try_send` that may drop under backpressure, so a
+        // durable ACK here would claim a dispatch that never completed.
+        //
+        // A v2 envelope on a typed route therefore gets NO ACK in this slice,
+        // and the handler carries the restart-spanning dedupe obligation via
+        // its own durable surface (the bootstrap outbox handler satisfies it
+        // with `Inserted | Duplicate` completion). Slice 3 adds the typed-route
+        // completion signal that lets these frames earn a v2 ACK.
+        if self
+            .typed_payload_routes
+            .iter()
+            .any(|route| application_payload.starts_with(&route.prefix))
+        {
+            tracing::info!(
+                target: "dm.trace",
+                stage = "inbound_durable_typed_route_unacked",
+                request_id = %hex::encode(request_id),
+                sender = %hex::encode(sender_agent_id.as_bytes()),
+                "v2 DM matched a typed route; ACK withheld pending typed-route completion (ADR 0030 §7)"
+            );
+            return DurableAckDecision::Withheld("typed_route");
+        }
+
+        // 1. Per-logical-request lock. Serializes the primary inbox and the
+        //    legacy-bus copy of the same envelope so neither can observe a
+        //    provisional success from the other.
+        let Some(lock) = self.cache.delivery_lock(dedupe) else {
+            tracing::warn!(
+                target: "dm.trace",
+                stage = "inbound_durable_lock_unavailable",
+                request_id = %hex::encode(request_id),
+                "v2 DM withheld: no durable delivery lock slot available"
+            );
+            return DurableAckDecision::Withheld("lock_unavailable");
+        };
+        let _guard = lock.lock().await;
+
+        // 2. Replay-cache binding check. A completion already exists ⇒ re-ACK
+        //    it under its own semantics, never re-dispatch.
+        let binding = crate::dm::DmDurableBindingDigest::accepted(
+            envelope.protocol_version,
+            &application_payload,
+        );
+        if let Some(cached) = self.cache.lookup(&dedupe) {
+            let outcome = match cached.durable_binding {
+                Some(stored) if stored == binding => {
+                    cached_ack_for_protocol(&cached, envelope.protocol_version)
+                }
+                Some(_) => DmAckOutcome::RejectedByPolicy {
+                    reason: "logical request already completed with different content".to_string(),
+                },
+                None => cached_ack_for_protocol(&cached, envelope.protocol_version),
+            };
+            let accepted_replay = matches!(outcome, DmAckOutcome::Accepted);
+            // An accepted re-ACK is stamped with the semantics actually
+            // honoured (never above what this request asked for). A refusal
+            // makes no durability claim and is stamped with the requested
+            // version instead, so it reaches the sender's exact-protocol
+            // waiter and is answered rather than waited out.
+            let ack_protocol = if accepted_replay {
+                cached
+                    .protocol_version
+                    .min(envelope.protocol_version)
+                    .max(DM_PROTOCOL_V1)
+            } else {
+                envelope.protocol_version
+            };
+            let _ = self
+                .publish_ack_for_protocol(
+                    sender_agent_id,
+                    request_id,
+                    outcome,
+                    ack_protocol,
+                    ack_legacy_bus,
+                )
+                .await;
+            return DurableAckDecision::Acked {
+                protocol_version: ack_protocol,
+                accepted: accepted_replay,
+            };
+        }
+
+        // 3. Durable-history lookup. Survives restart, where the in-memory
+        //    replay cache above does not.
+        let Ok(Some(record)) = inbound_dm_history_record(
+            &envelope,
+            &application_payload,
+            sender_machine_id,
+            &sender_pubkey,
+        ) else {
+            tracing::warn!(
+                target: "dm.trace",
+                stage = "inbound_durable_record_unbuildable",
+                request_id = %hex::encode(request_id),
+                "v2 DM withheld: payload has no durable history representation"
+            );
+            return DurableAckDecision::Withheld("no_durable_representation");
+        };
+        match durable_history_logical_request(
+            &history,
+            sender_agent_id,
+            request_id,
+            application_payload.clone(),
+        )
+        .await
+        {
+            Ok(DurableLogicalRequestLookup::Missing | DurableLogicalRequestLookup::Exact) => {}
+            Ok(DurableLogicalRequestLookup::Conflict) => {
+                tracing::warn!(
+                    target: "dm.trace",
+                    stage = "inbound_durable_logical_request_conflict",
+                    request_id = %hex::encode(request_id),
+                    sender = %hex::encode(sender_agent_id.as_bytes()),
+                    "v2 DM rejected: logical request already committed with different content"
+                );
+                let _ = self
+                    .publish_ack_for_protocol(
+                        sender_agent_id,
+                        request_id,
+                        DmAckOutcome::RejectedByPolicy {
+                            reason: "logical request already committed with different content"
+                                .to_string(),
+                        },
+                        envelope.protocol_version,
+                        ack_legacy_bus,
+                    )
+                    .await;
+                return DurableAckDecision::Acked {
+                    protocol_version: envelope.protocol_version,
+                    accepted: false,
+                };
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "dm.trace",
+                    stage = "inbound_durable_history_lookup_failed",
+                    request_id = %hex::encode(request_id),
+                    %error,
+                    "v2 DM withheld: durable history lookup failed"
+                );
+                return DurableAckDecision::Withheld("history_lookup_failed");
+            }
+        }
+
+        // 4. Dispatch.
+        self.dm
+            .handle_incoming(
+                sender_machine_id,
+                sender_agent_id,
+                application_payload.clone(),
+                true,
+                Some(decision),
+                // Gossip-inbox deliveries carry no point-to-point transport
+                // observation (issue #120).
+                None,
+            )
+            .await;
+
+        // 5. Commit awaited. This is the step the v2 receipt is actually
+        //    about: the ACK below may not exist unless this returned.
+        match history.record_committed(record).await {
+            Ok(outcome) if exact_durable_history_outcome(outcome) => {}
+            Ok(outcome) => {
+                tracing::warn!(
+                    target: "dm.trace",
+                    stage = "inbound_durable_commit_inexact",
+                    request_id = %hex::encode(request_id),
+                    ?outcome,
+                    "v2 ACK withheld: history commit did not yield exactly one durable row"
+                );
+                return DurableAckDecision::Withheld("commit_inexact");
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "dm.trace",
+                    stage = "inbound_durable_commit_failed",
+                    request_id = %hex::encode(request_id),
+                    %error,
+                    "v2 ACK withheld: durable history commit failed"
+                );
+                return DurableAckDecision::Withheld("commit_failed");
+            }
+        }
+
+        // Publish the completion into the replay cache before acknowledging,
+        // so a concurrent copy of this envelope can never be dispatched twice
+        // by a peer that has already been told the request completed.
+        if let Err(error) = self.cache.complete_durable(
+            dedupe,
+            DmAckOutcome::Accepted,
+            envelope.protocol_version,
+            binding,
+        ) {
+            tracing::warn!(
+                target: "dm.trace",
+                stage = "inbound_durable_replay_publish_failed",
+                request_id = %hex::encode(request_id),
+                ?error,
+                "v2 ACK withheld: durable completion could not be made replay-safe"
+            );
+            return DurableAckDecision::Withheld("replay_publish_failed");
+        }
+
+        // 6. ACK, stamped with the semantics actually honoured.
+        let _ = self
+            .publish_ack_for_protocol(
+                sender_agent_id,
+                request_id,
+                DmAckOutcome::Accepted,
+                envelope.protocol_version,
+                ack_legacy_bus,
+            )
+            .await;
+
+        tracing::info!(
+            target: "dm.trace",
+            stage = "inbound_durable_ack_published",
+            request_id = %hex::encode(request_id),
+            sender = %hex::encode(sender_agent_id.as_bytes()),
+            protocol_version = envelope.protocol_version,
+        );
+
+        DurableAckDecision::Acked {
+            protocol_version: envelope.protocol_version,
+            accepted: true,
+        }
     }
 
     async fn route_typed_payload(
@@ -809,11 +1237,30 @@ impl InboxPipeline {
         true
     }
 
+    /// Emit a v1 ACK: verified and locally enqueued (receipt level 2).
     async fn publish_ack(
         &self,
         to: AgentId,
         acks_request_id: [u8; 16],
         outcome: DmAckOutcome,
+        ack_legacy_bus: bool,
+    ) -> NetworkResult<()> {
+        self.publish_ack_for_protocol(to, acks_request_id, outcome, DM_PROTOCOL_V1, ack_legacy_bus)
+            .await
+    }
+
+    /// Emit an ACK stamped with the semantics this receiver actually honoured.
+    ///
+    /// ADR 0030: `protocol_version` names the receipt the recipient is
+    /// claiming, and the sender's waiter matches it exactly. Callers must pass
+    /// [`DM_PROTOCOL_DURABLE_ACK`] only from the durable path, after
+    /// `record_committed` has returned — never as an optimistic stamp.
+    async fn publish_ack_for_protocol(
+        &self,
+        to: AgentId,
+        acks_request_id: [u8; 16],
+        outcome: DmAckOutcome,
+        protocol_version: u16,
         ack_legacy_bus: bool,
     ) -> NetworkResult<()> {
         let body = EnvelopeBuilder::build_ack_body(acks_request_id, outcome);
@@ -825,11 +1272,11 @@ impl InboxPipeline {
 
         let mut envelope = DmEnvelope {
             // ADR 0030: an ACK is stamped with the semantics this receiver
-            // actually honoured, not with the local ceiling. Until the
-            // receiver durable path lands (slice 2) every accepted payload is
-            // level-2 enqueue, so every ACK is v1 — a v2 waiter must time out
-            // rather than be handed a receipt no one made.
-            protocol_version: DM_PROTOCOL_V1,
+            // actually honoured, not with the local ceiling. Only the durable
+            // path passes v2, and only once the history commit has returned;
+            // everything else stays v1 so a v2 waiter times out rather than
+            // being handed a receipt no one made.
+            protocol_version,
             request_id: ack_rid,
             sender_agent_id: *self.self_agent_id.as_bytes(),
             sender_machine_id: *self.self_machine_id.as_bytes(),
@@ -1054,11 +1501,34 @@ mod tests {
 
     /// Build a signed-but-unattested payload envelope, simulating a
     /// pre-#213 (legacy) sender: agent signature only, no origin attestation.
+    /// The trust/origin/revocation regression suite below is about the gates
+    /// that run before any protocol version matters, so it builds v1
+    /// envelopes: these tests predate DM v2 and only became v2 incidentally
+    /// when slice 1 raised `DM_PROTOCOL_VERSION` to the durable-ACK ceiling.
+    /// The durable path has its own envelopes via `durable_payload_message`.
     fn craft_unsigned_payload_envelope(
         harness: &InboxHarness,
         sender: &AgentKeypair,
         claimed_machine: MachineId,
         request_byte: u8,
+    ) -> DmEnvelope {
+        craft_unsigned_payload_envelope_versioned(
+            harness,
+            sender,
+            claimed_machine,
+            request_byte,
+            DM_PROTOCOL_V1,
+            b"security regression payload".to_vec(),
+        )
+    }
+
+    fn craft_unsigned_payload_envelope_versioned(
+        harness: &InboxHarness,
+        sender: &AgentKeypair,
+        claimed_machine: MachineId,
+        request_byte: u8,
+        protocol_version: u16,
+        application_payload: Vec<u8>,
     ) -> DmEnvelope {
         let created_at = now_unix_ms();
         let body = EnvelopeBuilder::build_payload_body(
@@ -1066,13 +1536,13 @@ mod tests {
             sender.agent_id().as_bytes(),
             harness.recipient_agent_id.as_bytes(),
             created_at,
-            b"security regression payload".to_vec(),
+            application_payload,
             None,
             &harness.recipient_kem.public_bytes,
         )
         .expect("build payload body");
         DmEnvelope {
-            protocol_version: DM_PROTOCOL_VERSION,
+            protocol_version,
             request_id: [request_byte; 16],
             sender_agent_id: *sender.agent_id().as_bytes(),
             sender_machine_id: *claimed_machine.as_bytes(),
@@ -1138,6 +1608,376 @@ mod tests {
         attestation.sign(machine).expect("machine attest");
         envelope.origin_attestation = Some(attestation);
         wrap_in_pubsub(harness, sender, &envelope)
+    }
+
+    // ── ADR 0030 §1 receiver durable path ─────────────────────────────
+
+    /// Start a real history service in the harness tempdir and attach its
+    /// handle to the pipeline. The service is returned so a test can shut the
+    /// writer down mid-flight to force a commit failure.
+    fn attach_history(harness: &mut InboxHarness) -> crate::history::HistoryService {
+        let config = crate::history::HistoryConfig {
+            db_path: Some(harness._tempdir.path().join("history.db")),
+            ..crate::history::HistoryConfig::daemon_default()
+        };
+        let service = crate::history::HistoryService::start(&config, harness._tempdir.path())
+            .expect("history service");
+        harness.pipeline.history = Some(service.handle());
+        service
+    }
+
+    /// A signed v2 (durable) payload envelope carrying `application_payload`.
+    fn durable_payload_message(
+        harness: &InboxHarness,
+        sender: &AgentKeypair,
+        claimed_machine: MachineId,
+        request_byte: u8,
+        application_payload: &[u8],
+    ) -> PubSubMessage {
+        let mut envelope = craft_unsigned_payload_envelope_versioned(
+            harness,
+            sender,
+            claimed_machine,
+            request_byte,
+            DM_PROTOCOL_DURABLE_ACK,
+            application_payload.to_vec(),
+        );
+        sign_envelope_with_agent(&mut envelope, sender);
+        wrap_in_pubsub(harness, sender, &envelope)
+    }
+
+    fn committed_rows(
+        history: &crate::history::HistoryHandle,
+        sender: &AgentKeypair,
+        request_byte: u8,
+    ) -> Vec<crate::history::StoredRecord> {
+        history
+            .store()
+            .find_by_logical_request(
+                &hex::encode(sender.agent_id().as_bytes()),
+                [request_byte; 16],
+            )
+            .expect("logical request lookup")
+    }
+
+    /// ADR 0030 §1: the ACK exists only because the commit succeeded. With the
+    /// writer stopped the commit cannot succeed, so no ACK may be emitted —
+    /// and crucially it must NOT degrade to a v1 ACK, which would hand the
+    /// sender a weaker receipt it cannot tell apart from the durable one.
+    #[tokio::test]
+    async fn durable_ack_is_withheld_when_history_commit_fails() {
+        let sender = test_keypair();
+        let machine = MachineId([0xD1; 32]);
+        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
+        let service = attach_history(&mut harness);
+        let history = harness.pipeline.history.clone().expect("history handle");
+
+        // Stop the writer thread; the retained handle now fails every commit.
+        service.shutdown().await;
+
+        let message = durable_payload_message(&harness, &sender, machine, 0x51, b"durable hello");
+        harness.pipeline.handle_incoming(message, false).await;
+
+        assert!(
+            committed_rows(&history, &sender, 0x51).is_empty(),
+            "a failed commit must leave no durable row"
+        );
+        assert!(
+            harness
+                .pipeline
+                .cache
+                .lookup(&crate::dm::DedupeKey::new(
+                    *sender.agent_id().as_bytes(),
+                    [0x51; 16]
+                ))
+                .is_none(),
+            "a withheld ACK must not publish a completion into the replay cache"
+        );
+    }
+
+    /// The same ordering asserted directly on the durable path's decision, so
+    /// "no ACK" is a checked outcome rather than an absence inferred from
+    /// side effects.
+    #[tokio::test]
+    async fn durable_path_reports_withheld_ack_on_commit_failure() {
+        let sender = test_keypair();
+        let machine = MachineId([0xD2; 32]);
+        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
+        let service = attach_history(&mut harness);
+        service.shutdown().await;
+
+        let mut envelope = craft_unsigned_payload_envelope_versioned(
+            &harness,
+            &sender,
+            machine,
+            0x52,
+            DM_PROTOCOL_DURABLE_ACK,
+            b"durable hello".to_vec(),
+        );
+        sign_envelope_with_agent(&mut envelope, &sender);
+
+        let decision = harness
+            .pipeline
+            .handle_payload_durable(
+                envelope,
+                b"durable hello".to_vec(),
+                TrustDecision::Accept,
+                machine,
+                sender.public_key().as_bytes().to_vec(),
+                false,
+            )
+            .await;
+
+        assert_eq!(decision, DurableAckDecision::Withheld("commit_failed"));
+    }
+
+    /// Happy path: commit lands first, then a v2-stamped ACK, and the schema
+    /// v4 columns are populated — they are what makes the restart-spanning
+    /// lookup in step 3 possible at all.
+    #[tokio::test]
+    async fn durable_path_commits_before_acking_and_stamps_v2() {
+        let sender = test_keypair();
+        let machine = MachineId([0xD3; 32]);
+        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
+        let _service = attach_history(&mut harness);
+        let history = harness.pipeline.history.clone().expect("history handle");
+
+        let mut envelope = craft_unsigned_payload_envelope_versioned(
+            &harness,
+            &sender,
+            machine,
+            0x53,
+            DM_PROTOCOL_DURABLE_ACK,
+            b"durable hello".to_vec(),
+        );
+        sign_envelope_with_agent(&mut envelope, &sender);
+
+        let decision = harness
+            .pipeline
+            .handle_payload_durable(
+                envelope,
+                b"durable hello".to_vec(),
+                TrustDecision::Accept,
+                machine,
+                sender.public_key().as_bytes().to_vec(),
+                false,
+            )
+            .await;
+
+        assert_eq!(
+            decision,
+            DurableAckDecision::Acked {
+                protocol_version: DM_PROTOCOL_DURABLE_ACK,
+                accepted: true,
+            }
+        );
+
+        let rows = committed_rows(&history, &sender, 0x53);
+        assert_eq!(rows.len(), 1, "exactly one durable row per logical request");
+        assert_eq!(rows[0].record.payload, b"durable hello".to_vec());
+        assert_eq!(
+            rows[0].record.ingress_sender_agent.as_deref(),
+            Some(hex::encode(sender.agent_id().as_bytes()).as_str()),
+            "schema v4 ingress_sender_agent must be written"
+        );
+        assert_eq!(
+            rows[0].record.logical_request_id,
+            Some([0x53; 16]),
+            "schema v4 logical_request_id must be written"
+        );
+    }
+
+    /// ADR 0030 §1 step 2: a replayed logical request is re-ACKed from the
+    /// binding, never dispatched or committed a second time.
+    #[tokio::test]
+    async fn durable_replay_rebinds_instead_of_committing_twice() {
+        let sender = test_keypair();
+        let machine = MachineId([0xD4; 32]);
+        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
+        let _service = attach_history(&mut harness);
+        let history = harness.pipeline.history.clone().expect("history handle");
+
+        for _ in 0..2 {
+            let message =
+                durable_payload_message(&harness, &sender, machine, 0x54, b"durable hello");
+            harness.pipeline.handle_incoming(message, false).await;
+        }
+
+        let rows = committed_rows(&history, &sender, 0x54);
+        assert_eq!(
+            rows.len(),
+            1,
+            "a replayed logical request must not commit a second durable row"
+        );
+    }
+
+    /// ADR 0030 §1 step 2: the binding is over the accepted bytes, so the
+    /// same request id carrying different content is refused rather than
+    /// re-ACKed as the original delivery.
+    #[tokio::test]
+    async fn durable_replay_with_different_bytes_is_refused() {
+        let sender = test_keypair();
+        let machine = MachineId([0xD5; 32]);
+        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
+        let _service = attach_history(&mut harness);
+
+        let first = durable_payload_message(&harness, &sender, machine, 0x55, b"original bytes");
+        harness.pipeline.handle_incoming(first, false).await;
+
+        let mut envelope = craft_unsigned_payload_envelope_versioned(
+            &harness,
+            &sender,
+            machine,
+            0x55,
+            DM_PROTOCOL_DURABLE_ACK,
+            b"different bytes".to_vec(),
+        );
+        sign_envelope_with_agent(&mut envelope, &sender);
+        let decision = harness
+            .pipeline
+            .handle_payload_durable(
+                envelope,
+                b"different bytes".to_vec(),
+                TrustDecision::Accept,
+                machine,
+                sender.public_key().as_bytes().to_vec(),
+                false,
+            )
+            .await;
+
+        assert_eq!(
+            decision,
+            DurableAckDecision::Acked {
+                protocol_version: DM_PROTOCOL_DURABLE_ACK,
+                accepted: false,
+            },
+            "a rebound logical request must be refused, not accepted"
+        );
+    }
+
+    /// ADR 0030 §2 mixed version: a 0.37 peer's v1 envelope keeps exactly its
+    /// old behaviour on a durable-capable receiver — delivered, and ACKed with
+    /// v1 semantics. Enabling durable history must not silently upgrade the
+    /// receipt an old sender is handed.
+    #[tokio::test]
+    async fn v1_envelope_receives_v1_ack_even_with_durable_history_enabled() {
+        let sender = test_keypair();
+        let machine = MachineId([0xD6; 32]);
+        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
+        let _service = attach_history(&mut harness);
+
+        let message = payload_message(&harness, &sender, machine, 0x56);
+        harness.pipeline.handle_incoming(message, false).await;
+
+        let delivered = tokio::time::timeout(Duration::from_secs(2), harness.receiver.recv())
+            .await
+            .expect("v1 delivery timeout")
+            .expect("v1 delivery stream closed");
+        assert_eq!(delivered.sender, sender.agent_id());
+
+        let cached = harness
+            .pipeline
+            .cache
+            .lookup(&crate::dm::DedupeKey::new(
+                *sender.agent_id().as_bytes(),
+                [0x56; 16],
+            ))
+            .expect("v1 completion is cached");
+        assert_eq!(
+            cached.protocol_version, DM_PROTOCOL_V1,
+            "a v1 envelope must complete under v1 semantics"
+        );
+        assert!(
+            cached.durable_binding.is_none(),
+            "the v1 path must not publish a durable binding"
+        );
+    }
+
+    /// ADR 0030 §2: a v2 request is never silently downgraded. Without a
+    /// history handle there is nothing to commit to, so the ACK is withheld
+    /// rather than answered at v1.
+    #[tokio::test]
+    async fn v2_envelope_without_history_is_never_downgraded_to_v1() {
+        let sender = test_keypair();
+        let machine = MachineId([0xD7; 32]);
+        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
+        assert!(harness.pipeline.history.is_none());
+
+        let message = durable_payload_message(&harness, &sender, machine, 0x57, b"durable hello");
+        harness.pipeline.handle_incoming(message, false).await;
+
+        assert_no_delivery(&mut harness.receiver).await;
+        assert!(
+            harness
+                .pipeline
+                .cache
+                .lookup(&crate::dm::DedupeKey::new(
+                    *sender.agent_id().as_bytes(),
+                    [0x57; 16]
+                ))
+                .is_none(),
+            "a withheld v2 request must leave no completion behind"
+        );
+    }
+
+    /// ADR 0030 §7: typed routes are documented as carrying their own
+    /// restart-spanning dedupe obligation, and do not earn a v2 ACK in this
+    /// slice. Locking that in so slice 3 has to change this test deliberately.
+    #[tokio::test]
+    async fn durable_typed_route_withholds_ack_pending_handler_completion() {
+        let sender = test_keypair();
+        let machine = MachineId([0xD8; 32]);
+        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
+        let _service = attach_history(&mut harness);
+        let (tx, _rx) = mpsc::channel::<DmTypedPayload>(8);
+        harness.pipeline.typed_payload_routes = vec![DmTypedPayloadRoute {
+            prefix: b"X0X-KV-DELTA-V1\n".to_vec(),
+            sender: tx,
+        }];
+
+        let mut payload = b"X0X-KV-DELTA-V1\n".to_vec();
+        payload.extend_from_slice(b"{\"k\":1}");
+        let mut envelope = craft_unsigned_payload_envelope_versioned(
+            &harness,
+            &sender,
+            machine,
+            0x58,
+            DM_PROTOCOL_DURABLE_ACK,
+            payload.clone(),
+        );
+        sign_envelope_with_agent(&mut envelope, &sender);
+
+        let decision = harness
+            .pipeline
+            .handle_payload_durable(
+                envelope,
+                payload,
+                TrustDecision::Accept,
+                machine,
+                sender.public_key().as_bytes().to_vec(),
+                false,
+            )
+            .await;
+
+        assert_eq!(decision, DurableAckDecision::Withheld("typed_route"));
+    }
+
+    #[test]
+    fn cached_v1_completion_refuses_a_v2_request() {
+        let cached = crate::dm::CachedOutcome {
+            outcome: DmAckOutcome::Accepted,
+            protocol_version: DM_PROTOCOL_V1,
+            durable_binding: None,
+            first_seen: std::time::Instant::now(),
+        };
+        assert!(matches!(
+            cached_ack_for_protocol(&cached, DM_PROTOCOL_DURABLE_ACK),
+            DmAckOutcome::RejectedByPolicy { .. }
+        ));
+        assert!(matches!(
+            cached_ack_for_protocol(&cached, DM_PROTOCOL_V1),
+            DmAckOutcome::Accepted
+        ));
     }
 
     async fn assert_no_delivery(receiver: &mut crate::direct::DirectMessageReceiver) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -475,6 +475,11 @@ pub enum HistoryError {
     #[error("history writer is shut down")]
     WriterClosed,
 
+    /// The bounded history writer queue is full. Callers that require a
+    /// commit receipt must retry instead of silently shedding the record.
+    #[error("history writer is backpressured")]
+    WriterBackpressured,
+
     /// Filesystem error touching the database path.
     #[error("history io error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -115,6 +115,14 @@ impl HistoryHandle {
         self.writer.record(record);
     }
 
+    /// Enqueue a record and wait for its SQLite transaction to commit.
+    ///
+    /// This is reserved for protocol surfaces whose success receipt promises
+    /// durable local history. Hot paths should continue using [`Self::record`].
+    pub async fn record_committed(&self, record: HistoryRecord) -> HistoryResult<InsertOutcome> {
+        self.writer.record_committed(record).await
+    }
+
     /// Read access to the store. Synchronous — call from `spawn_blocking`
     /// on async paths.
     #[must_use]

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -262,6 +262,34 @@ impl Store {
         Ok(collect_rows(&guard, sql, params)?.into_iter().next())
     }
 
+    /// Look up the durable rows a logical request has already committed.
+    ///
+    /// Keyed on the schema v4 columns the DM inbox writes
+    /// (`ingress_sender_agent`, `logical_request_id`), so the receiver durable
+    /// path can answer "did this logical request already commit, and with
+    /// which bytes?" without scanning and decoding an entire DM scope
+    /// (ADR 0030 §1). Ordinarily at most one row matches; the query returns
+    /// all of them so a caller can detect a binding conflict rather than
+    /// silently trusting the newest.
+    pub fn find_by_logical_request(
+        &self,
+        ingress_sender_agent: &str,
+        logical_request_id: [u8; 16],
+    ) -> HistoryResult<Vec<StoredRecord>> {
+        let sql = "SELECT id, msg_id, scope_kind, scope_id, author_agent, author_machine, \
+             author_pubkey, sent_at_ms, seen_at_ms, direction, content_type, payload, \
+             signed_artifact, signature, sig_context, provenance, replace_key, \
+             thread_root, thread_parent, ingress_sender_agent, logical_request_id \
+             FROM history WHERE ingress_sender_agent = ?1 AND logical_request_id = ?2 \
+             ORDER BY id ASC";
+        let params = vec![
+            rusqlite::types::Value::from(ingress_sender_agent.to_string()),
+            rusqlite::types::Value::from(logical_request_id.to_vec()),
+        ];
+        let guard = lock_conn(&self.conn)?;
+        collect_rows(&guard, sql, params)
+    }
+
     /// Full-text search over searchable payload text. Tokens are quoted so
     /// user input is literal terms, never FTS operators (donor
     /// `fts_match_expr`).

--- a/src/history/writer.rs
+++ b/src/history/writer.rs
@@ -13,7 +13,16 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::record::HistoryRecord;
-use super::store::Store;
+use super::store::{InsertOutcome, Store};
+use crate::error::{HistoryError, HistoryResult};
+
+enum WriteCommand {
+    BestEffort(HistoryRecord),
+    Commit {
+        record: HistoryRecord,
+        reply: tokio::sync::oneshot::Sender<HistoryResult<InsertOutcome>>,
+    },
+}
 
 /// Channel capacity (records) between producers and the writer thread.
 pub const WRITER_QUEUE_CAPACITY: usize = 4096;
@@ -47,7 +56,7 @@ pub struct HistoryCounters {
 /// Producer-side handle: cheap to clone, never blocks.
 #[derive(Clone, Debug)]
 pub struct WriterHandle {
-    tx: mpsc::SyncSender<HistoryRecord>,
+    tx: mpsc::SyncSender<WriteCommand>,
     counters: Arc<HistoryCounters>,
 }
 
@@ -55,11 +64,29 @@ impl WriterHandle {
     /// Enqueue a record; drops (and counts) when the queue is full or the
     /// writer has shut down. Never blocks.
     pub fn record(&self, record: HistoryRecord) {
-        match self.tx.try_send(record) {
+        match self.tx.try_send(WriteCommand::BestEffort(record)) {
             Ok(()) => {}
             Err(mpsc::TrySendError::Full(_)) | Err(mpsc::TrySendError::Disconnected(_)) => {
                 self.counters.dropped_full.fetch_add(1, Ordering::Relaxed);
             }
+        }
+    }
+
+    /// Enqueue a record and wait until its SQLite transaction has committed.
+    ///
+    /// Unlike [`Self::record`], this never sheds silently: a full or closed
+    /// writer queue is returned to the caller so an application-level ACK
+    /// cannot get ahead of durable history.
+    pub async fn record_committed(&self, record: HistoryRecord) -> HistoryResult<InsertOutcome> {
+        let (reply, receipt) = tokio::sync::oneshot::channel();
+        match self.tx.try_send(WriteCommand::Commit { record, reply }) {
+            Ok(()) => {}
+            Err(mpsc::TrySendError::Full(_)) => return Err(HistoryError::WriterBackpressured),
+            Err(mpsc::TrySendError::Disconnected(_)) => return Err(HistoryError::WriterClosed),
+        }
+        match receipt.await {
+            Ok(result) => result,
+            Err(_) => Err(HistoryError::WriterClosed),
         }
     }
 
@@ -87,7 +114,7 @@ impl Writer {
     /// Spawn the writer thread over `store`.
     #[must_use]
     pub fn spawn(store: Arc<Store>) -> Self {
-        let (tx, rx) = mpsc::sync_channel::<HistoryRecord>(WRITER_QUEUE_CAPACITY);
+        let (tx, rx) = mpsc::sync_channel::<WriteCommand>(WRITER_QUEUE_CAPACITY);
         let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
         let counters = Arc::new(HistoryCounters::default());
         let thread_counters = Arc::clone(&counters);
@@ -126,7 +153,7 @@ impl Writer {
 
 fn writer_loop(
     store: &Store,
-    rx: &mpsc::Receiver<HistoryRecord>,
+    rx: &mpsc::Receiver<WriteCommand>,
     shutdown_rx: &mpsc::Receiver<()>,
     counters: &HistoryCounters,
 ) {
@@ -137,11 +164,15 @@ fn writer_loop(
         // Fill a batch: block briefly for the first record, then drain
         // whatever is immediately available up to BATCH_MAX.
         match rx.recv_timeout(BATCH_WINDOW) {
-            Ok(rec) => {
-                batch.push(rec);
-                while batch.len() < BATCH_MAX {
+            Ok(command) => {
+                process_command(store, command, &mut batch, counters);
+                let mut commands_processed = 1;
+                while commands_processed < BATCH_MAX {
                     match rx.try_recv() {
-                        Ok(r) => batch.push(r),
+                        Ok(command) => {
+                            process_command(store, command, &mut batch, counters);
+                            commands_processed += 1;
+                        }
                         Err(_) => break,
                     }
                 }
@@ -162,18 +193,15 @@ fn writer_loop(
     }
 }
 
-fn drain_at_shutdown(
-    store: &Store,
-    rx: &mpsc::Receiver<HistoryRecord>,
-    counters: &HistoryCounters,
-) {
+fn drain_at_shutdown(store: &Store, rx: &mpsc::Receiver<WriteCommand>, counters: &HistoryCounters) {
     let deadline = std::time::Instant::now() + SHUTDOWN_DRAIN_GRACE;
     let mut batch: Vec<HistoryRecord> = Vec::with_capacity(BATCH_MAX);
     loop {
         if std::time::Instant::now() >= deadline {
             // Count what we are abandoning, then stop.
             let mut abandoned = 0u64;
-            while rx.try_recv().is_ok() {
+            while let Ok(command) = rx.try_recv() {
+                abandon_command(command);
                 abandoned += 1;
             }
             if abandoned > 0 {
@@ -188,17 +216,55 @@ fn drain_at_shutdown(
             return;
         }
         match rx.try_recv() {
-            Ok(rec) => {
-                batch.push(rec);
-                if batch.len() >= BATCH_MAX {
-                    flush(store, &mut batch, counters);
-                }
+            Ok(command) => {
+                process_command(store, command, &mut batch, counters);
             }
             Err(_) => {
                 flush(store, &mut batch, counters);
                 return;
             }
         }
+    }
+}
+
+fn process_command(
+    store: &Store,
+    command: WriteCommand,
+    batch: &mut Vec<HistoryRecord>,
+    counters: &HistoryCounters,
+) {
+    match command {
+        WriteCommand::BestEffort(record) => {
+            batch.push(record);
+            if batch.len() >= BATCH_MAX {
+                flush(store, batch, counters);
+            }
+        }
+        WriteCommand::Commit { record, reply } => {
+            // Preserve producer order: everything queued before this receipt
+            // is committed before the receipt-bearing record.
+            flush(store, batch, counters);
+            let result = store.insert(&record);
+            match &result {
+                Ok(InsertOutcome::Inserted | InsertOutcome::Replaced) => {
+                    counters.written_total.fetch_add(1, Ordering::Relaxed);
+                }
+                Ok(InsertOutcome::Duplicate | InsertOutcome::StaleRejected) => {
+                    counters.dedup_hits.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(error) => {
+                    counters.write_errors.fetch_add(1, Ordering::Relaxed);
+                    tracing::error!(%error, "[history] receipt-bearing write failed");
+                }
+            }
+            let _ = reply.send(result);
+        }
+    }
+}
+
+fn abandon_command(command: WriteCommand) {
+    if let WriteCommand::Commit { reply, .. } = command {
+        let _ = reply.send(Err(HistoryError::WriterClosed));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7856,16 +7856,18 @@ impl Agent {
         // to the raw-QUIC path. The capability advert service watches
         // this channel and republishes immediately on change.
         //
-        // ADR 0030 §3 targets: advertise v2 iff durable history is enabled.
-        // HELD AT v1 FOR NOW (PR #327 review): this binary carries the
-        // sender-side gate (slice 1) but NOT the receiver durable path
-        // (slice 2), so a v2 advert would be a false capability — a strict
-        // sender clears its gate, this receiver ACKs with v1 semantics, the
-        // exact-protocol waiter never matches, and the send hangs to timeout:
-        // exactly the failure mode ADR 0030 §2 forbids. Flip to
-        // `v2_durable_gossip_ready(...)` iff `history_handle.is_some()` in
-        // the same change that lands the slice-2 receiver path.
-        let upgraded = dm::DmCapabilities::v1_gossip_ready(kem_keypair.public_bytes.clone());
+        // ADR 0030 §3: advertise v2 iff durable history is enabled. The
+        // receiver durable path (slice 2) is what makes that claim true — it
+        // only emits a v2 ACK after `record_committed` returns, and withholds
+        // the ACK entirely when history is unavailable. Without a history
+        // handle there is nothing to commit to, so the honest advert is v1:
+        // a strict sender then gets a typed 409 rather than clearing its gate
+        // and hanging on a waiter this daemon can never satisfy.
+        let upgraded = if self.history_handle.is_some() {
+            dm::DmCapabilities::v2_durable_gossip_ready(kem_keypair.public_bytes.clone())
+        } else {
+            dm::DmCapabilities::v1_gossip_ready(kem_keypair.public_bytes.clone())
+        };
         // send_replace stores the value even when no receiver is subscribed
         // yet; a plain send() drops the upgrade if this runs before the
         // capability advert service subscribes, leaving peers cached on
@@ -17552,6 +17554,58 @@ fn sort_discovered_machine_sorts_fields() {
     assert_eq!(machine.agent_ids[1], identity::AgentId([2u8; 32]));
     assert_eq!(machine.user_ids[0], identity::UserId([1u8; 32]));
     assert_eq!(machine.user_ids[1], identity::UserId([2u8; 32]));
+}
+
+/// ADR 0030 §3: the advertised ceiling is a promise about this receiver, so
+/// it must track the thing that makes the promise true. Durable history on ⇒
+/// advertise 2 (the receiver durable path can commit before it ACKs);
+/// history off ⇒ advertise 1, so a strict sender gets a typed 409 instead of
+/// clearing its gate and hanging on a v2 waiter nothing will ever satisfy.
+#[tokio::test]
+async fn dm_capability_advert_tracks_durable_history_presence() {
+    async fn advertised_ceiling(with_history: bool) -> u16 {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let mut builder = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_peer_cache_dir(dir.path().join("peers"))
+            .with_network_config(network::NetworkConfig::default());
+        if with_history {
+            builder = builder.with_history(history::HistoryConfig {
+                db_path: Some(dir.path().join("history.db")),
+                ..history::HistoryConfig::daemon_default()
+            });
+        }
+        let agent = builder.build().await.expect("agent");
+        assert_eq!(
+            agent.history_handle.is_some(),
+            with_history,
+            "test setup: history handle presence must match the requested mode"
+        );
+
+        let kem = std::sync::Arc::new(
+            groups::kem_envelope::AgentKemKeypair::generate().expect("kem keypair"),
+        );
+        agent
+            .start_dm_inbox(kem, dm_inbox::DmInboxConfig::default())
+            .await
+            .expect("start dm inbox");
+        let caps = agent.dm_capabilities_tx.subscribe().borrow().clone();
+        agent.stop_dm_inbox().await;
+        assert!(caps.gossip_inbox, "inbox must be advertised in both modes");
+        caps.max_protocol_version
+    }
+
+    assert_eq!(
+        advertised_ceiling(true).await,
+        dm::DM_PROTOCOL_DURABLE_ACK,
+        "durable history enabled must advertise the v2 ceiling"
+    );
+    assert_eq!(
+        advertised_ceiling(false).await,
+        dm::DM_PROTOCOL_V1,
+        "without durable history the advert must stay at v1"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
DA slice 2 of 4 per [ADR 0030](docs/adr/0030-dm-durable-application-ack-v2.md) (Accepted). Follows slice 1 (`d1bcc85`, #327). **Not for merge without cross-review.**

## Scope

### 1. Receiver durable path (ADR 0030 §1)

`InboxPipeline::handle_payload_durable` runs a v2 payload in exactly the normative order:

1. **Per-logical-request lock** — `RecentDeliveryCache::delivery_lock`, serializing the primary-inbox and legacy-bus copies of one envelope. No free slot ⇒ ACK withheld; evicting an in-flight lock would permit duplicate dispatch.
2. **Replay-cache binding check** — an existing completion is re-ACKed under *its own* semantics, never re-dispatched. The binding is a domain-separated blake3 digest over `(protocol_version, accepted bytes)`, so the same request id carrying different content is refused rather than re-ACKed as the original.
3. **Durable-history lookup** — keyed on the schema v4 columns via the new `Store::find_by_logical_request`. This is the check that survives restart, where the memory-only replay cache does not.
4. **Dispatch.**
5. **`record_committed` awaited** — must return `Inserted | Duplicate`.
6. **ACK**, stamped with the semantics actually honoured.

**The ACK exists only because the commit succeeded.** Commit error, backpressured/closed writer, unavailable history, lost lock, or an unpublishable replay completion each *withhold* the ACK. No branch falls back to a v1 ACK: a withheld ACK costs the sender a timeout, whereas a downgraded one hands it a weaker receipt it cannot distinguish from the durable one it asked for (§2).

### 2. ACK version stamping

`publish_ack_for_protocol` replaces the hardcoded v1 stamp. v2 is passed **only** from the durable path, after `record_committed` returns. The v1 receive path is untouched: a v1 envelope takes the legacy path and gets a v1 ACK even with durable history enabled — test `v1_envelope_receives_v1_ack_even_with_durable_history_enabled`.

One deliberate refinement: a *refusal* (policy rejection, binding conflict) is stamped with the **requested** version rather than downgraded, because a refusal makes no durability claim and must reach the sender's exact-protocol waiter. Downgrading it would turn an actionable "no" into a timeout, which §2's drivers forbid. Only `Accepted` is constrained to the semantics actually honoured.

### 2b. `AckSemanticsUnavailable` as an ACK outcome (ADR 0030 §2)

ADR 0030 §2 names this outcome explicitly: *"A logical request completed under weaker semantics is answered `AckSemanticsUnavailable`, never re-ACKed as durable (`cached_ack_for_protocol`)."*

Adds `DmAckOutcome::AckSemanticsUnavailable { reason }`, used for both refusals the durable path can make — already completed under weaker semantics, and already bound to different content. `dm_send::ack_outcome_to_receipt` maps it to `DmError::AckSemanticsUnavailable`, the same typed error the slice-1 send-side capability gate raises.

This matters beyond naming: the alternative (`RejectedByPolicy`) is mapped by the sender to `DmError::RecipientRejected`, so a product UI would render a protocol condition as *"peer blocked you"* instead of *"retry / peer needs upgrade"* — misreporting the one thing the 409 contract exists to make actionable.

**Wire compatibility**, covered by two tests:
- The variant is **appended last**, so postcard discriminants for `Accepted` (0) and `RejectedByPolicy` (1) are unchanged — 0.37 peers keep decoding our ACKs. Asserted by `appending_the_new_ack_variant_preserves_legacy_discriminants`.
- A v1-only 0.37 peer can never *receive* it: it is produced only when the request asks for semantics above what completed, and a v1 sender never asks for more than v1. Asserted by `a_v1_request_is_never_answered_with_the_new_ack_variant`. Were this to regress, an 0.37 receiver would fail to decode the ACK and the send would degrade to a timeout.

### 3. ADR §7 typed-route dedupe gap — **DOCUMENTED AS A HANDLER OBLIGATION, NOT CLOSED**

I chose to **own the obligation**, not extend the lookup. Rationale — extending it is not merely more expensive, it would be *wrong*:

- Typed-prefix families (group ingest, KV deltas, exec audit, card import, voice signalling) classify **`Ephemeral`** in `history::classify` **by design**: their durable effect lives in their own store (group state chain, KV store, exec log), not in DM history. Committing them to DM history would duplicate the authoritative durable surface and grow history with plumbing traffic.
- Typed routes are handed off with a **non-blocking `try_send` that may drop** under backpressure. A durable ACK would claim a dispatch that never completed.

So a v2 envelope matching a typed route gets **no ACK** in this slice, and each typed handler carries the restart-spanning dedupe obligation via its own durable surface — the bootstrap outbox handler satisfies it with `Inserted | Duplicate` completion, exactly as the ADR anticipates. The typed-route completion signal (`DmTypedPayloadCompletion` on the campaign branch) that lets these frames earn a v2 ACK is **slice 3**. Locked in by `durable_typed_route_withholds_ack_pending_handler_completion`, so slice 3 has to change it deliberately.

### 4. Schema v4 columns gain writers

Inbound DM rows now populate `ingress_sender_agent` and `logical_request_id` (both paths, via the factored `inbound_dm_history_record`). New `Store::find_by_logical_request` reads them. No migration change — main is on the released v4 schema.

Also adds `HistoryHandle::record_committed` / `WriterHandle::record_committed` (a `WriteCommand::Commit` variant that flushes the pending batch first, preserving producer order) and `HistoryError::WriterBackpressured`. Unlike `record`, it never sheds silently.

### 5. Capability advert flip (ADR §3)

`start_dm_inbox` now advertises `v2_durable_gossip_ready(...)` **iff `history_handle.is_some()`**, else `v1_gossip_ready`. The slice-1 hold comment is replaced with the reason the flip is now correct. Protocol ceiling stays 2; no v3 anything.

### 6. Docs in the same PR (ADR §6)

- `CHANGELOG.md` — Unreleased entries for the durable path, v4 writers, `record_committed`, and a `### Changed` entry for the advert flip.
- `docs/design/dm-over-gossip.md` — normative receiver ordering, the §7 typed-route position, at-least-once-across-restart, the v2-iff-history advert rule, and delivery level 3 moved from "future" to "v2".
- `docs/api-reference.md` — note updated to slice 2. **No REST-visible shape change in this slice**; no new routes, so no manifest regeneration, no `api_coverage.rs` entry, no CLI subcommand needed.
- **CHANGELOG Notes tidy (reviewer nit from #327):** the interim-timeout caveat no longer reads as a general condition. It now states that a strict v2 send can time out *only against a peer advertising a false v2 capability*, and that this daemon cannot be that peer.

## Extraction method and omitted hunks

Extracted hunk-by-hunk from individual commit diffs on `wip/codex-durable-app-ack` (`b60b995`) with `git apply --reject`; no `git checkout --theirs`, no whole-file blobs. `src/history/writer.rs`, `src/error.rs` and `src/history/mod.rs` are touched on that branch **only** by `3d714db` (a durable-ACK commit, no contamination) and applied cleanly with zero rejects. Everything in `dm.rs`/`dm_inbox.rs` was hand-placed.

**Deliberately omitted:**

- **All campaign `src/history/store.rs` hunks.** They are the v2→v3→v4 migration work, which main already shipped in better form in v0.37.4 over the released FTS v2 schema. Dropping the campaign `store.rs` would have regressed the released schema — the explicit failure mode ADR 0030 "Neutral/Operational" warns about. The only store change here is the additive `find_by_logical_request` reader.
- **v3 threading.** `DmThreadMeta` does not exist on main and the ADR defers v3, so `DmDurableBindingDigest::accepted` and the logical-request binding drop the campaign's `thread_meta` parameter. Ceiling stays 2.
- **Hedged/multi-route ACK publisher** (`AckPublisherHandle`, `spawn_durable_ack_publisher`, `publish_durable_ack_routes`, `publish_raw_and_gossip_ack_routes`, `DURABLE_ACK_ROUTE_TIMEOUT` — from `bde4d28`, `fa538eb`, `ed04a23`, `21387d2`, `b60b995`). ACK *delivery* robustness, orthogonal to commit-before-ACK ordering.
- **Raw durable DM frame transport** (`RAW_DURABLE_DM_MAGIC`, `DmInboxIngress::handle_raw_frame`, `encode_raw_durable_frame`) — tied to the outbox slice.
- **`DmTypedPayloadCompletion`** — slice 3, per the §7 decision above.
- The campaign's `durable_history_logical_request` paginated 500-row scan that decodes every stored envelope in Rust, replaced by a single indexed-shape SQL lookup on the v4 columns. Same semantics (Missing/Exact/Conflict), far cheaper.

Legacy trust/origin/revocation tests in `dm_inbox.rs` were pinned to `DM_PROTOCOL_V1` via `craft_unsigned_payload_envelope`. They predate v2 and became v2 only incidentally when slice 1 raised `DM_PROTOCOL_VERSION`; they exercise gates that run before protocol version matters.

## Tests

New, all plain `#[tokio::test]` / `#[test]`:

- `durable_ack_is_withheld_when_history_commit_fails` — writer shut down mid-flight; no durable row, no replay completion.
- `durable_path_reports_withheld_ack_on_commit_failure` — asserts `Withheld("commit_failed")` **directly**. The durable path returns a `DurableAckDecision` so "no ACK when the commit fails" is a checked outcome, not an absence inferred from side effects.
- `durable_path_commits_before_acking_and_stamps_v2` — v2 stamp, exactly one row, both v4 columns populated.
- `durable_replay_rebinds_instead_of_committing_twice` — replay commits no second row.
- `durable_replay_with_different_bytes_is_refused` — binding conflict refused, not accepted.
- `v1_envelope_receives_v1_ack_even_with_durable_history_enabled` — mixed-version case.
- `v2_envelope_without_history_is_never_downgraded_to_v1` — withheld, no completion.
- `durable_typed_route_withholds_ack_pending_handler_completion` — §7 position.
- `cached_v1_completion_refuses_a_v2_request` — `cached_ack_for_protocol` returns `AckSemanticsUnavailable`, not `RejectedByPolicy`.
- `a_v1_request_is_never_answered_with_the_new_ack_variant` and `appending_the_new_ack_variant_preserves_legacy_discriminants` — wire safety for the appended ACK variant.
- `dm_capability_advert_tracks_durable_history_presence` (lib.rs) — asserts the advert in **both** directions, history on ⇒ 2 and off ⇒ 1.

## Gate results (real exit codes, no `| tail` on the gates)

| Gate | Exit |
|---|---|
| `cargo fmt --all -- --check` | **0** |
| `cargo clippy --workspace --all-features --all-targets -- -D warnings` | **0** |
| `cargo nextest run --workspace --all-features --no-fail-fast` | **0** — 2630 passed, 260 skipped, 0 failed |

No `.unwrap()` / `.expect()` / `panic!()` added to production code (all such matches in the diff are inside `#[cfg(test)]` / `#[tokio::test]`).

**Known flake, verified:** on one full run `direct_send_with_require_ack_round_trips_to_live_peer` failed with a client-side `reqwest ... TimedOut` on the localhost `/direct/send` call — a transport timeout, not an assertion. Re-run in isolation **3/3 passing**, and the clean `--no-fail-fast` full run above is 2630/2630. It is unreachable from this change's new code: that test sends with `require_durable_app_ack = false`, so the envelope is v1 and never enters the durable path or the new ACK variant. `suppressed_peer_inbound_redial_is_rejected` passed every run.

## Incidental finding (not fixed here)

`src/dm_inbox.rs` contains a literal NUL byte at line ~1947 — a test writes `b"x0x-exec-v1\0"` as a raw byte rather than the `\x00` escape. Harmless to `rustc`, but it makes `grep`/`rg` treat the whole file as binary and silently suppress matches past that offset, which is a real hazard when reviewing this file. Left alone to keep this PR surgical; worth a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
