### PR TITLE
fix(dm): restore AckSemanticsUnavailable ACK outcome dropped from #328

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ All notable changes to this project will be documented in this file.
   lock, unpublishable replay completion — withholds the ACK rather than
   degrading it. `Accepted` under v2 now means what ADR 0030 §1 says it
   means: verified, durably committed, and dispatched.
+- **`DmAckOutcome::AckSemanticsUnavailable { reason }`** (ADR 0030 §2). The
+  receiver's answer when it cannot issue the durable receipt a request asked
+  for — the logical request already completed under weaker semantics, or is
+  already bound to different content. It maps to
+  `DmError::AckSemanticsUnavailable`, the same typed error the send-side
+  capability gate raises, rather than `RecipientRejected`: nothing about the
+  trust relationship failed, so callers surface "retry / peer needs upgrade",
+  not "peer blocked you". Appended last in the enum, so postcard variant
+  indices for `Accepted` and `RejectedByPolicy` are unchanged and 0.37 peers
+  keep decoding them; a v1-only sender can never be sent the new variant,
+  because it never asks for semantics above v1.
 - **History schema v4 columns gain writers.** Inbound DM rows populate
   `ingress_sender_agent` and `logical_request_id`; together they key the
   durable-history lookup that lets a restarted receiver recognise a logical

--- a/docs/design/dm-over-gossip.md
+++ b/docs/design/dm-over-gossip.md
@@ -235,7 +235,14 @@ order, per ADR 0030 §1:
    under *its own* semantics, never re-dispatched. The binding is a
    domain-separated digest over `(protocol_version, accepted bytes)`, so the
    same request id carrying different content is refused rather than
-   re-ACKed as the original delivery.
+   re-ACKed as the original delivery. Both refusals — "already completed
+   under v1 semantics" and "already bound to different content" — are
+   answered `DmAckOutcome::AckSemanticsUnavailable`, never
+   `RejectedByPolicy`: no trust decision failed, and the sender maps the
+   latter to `RecipientRejected`, which would misreport a protocol condition
+   as a blocked peer. On the sender it becomes
+   `DmError::AckSemanticsUnavailable` — the same typed error the send-side
+   capability gate raises.
 3. **Durable-history lookup** — keyed on the schema v4 columns
    `(ingress_sender_agent, logical_request_id)` via
    `Store::find_by_logical_request`. This is the check that survives restart,

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -269,6 +269,20 @@ pub enum DmAckOutcome {
     /// that prefer silent rejection can set `trust.silent_reject = true`
     /// and skip emitting this ACK entirely.
     RejectedByPolicy { reason: String },
+    /// The recipient cannot issue the durable receipt this request asked for:
+    /// the logical request already completed under weaker semantics, or is
+    /// already bound to different content (ADR 0030 §2). Distinct from
+    /// [`Self::RejectedByPolicy`] — nothing about the trust relationship
+    /// failed, so the caller should surface "retry / peer needs upgrade"
+    /// rather than "peer rejected you".
+    ///
+    /// **Wire compatibility:** appended last, so postcard's variant indices
+    /// for `Accepted` (0) and `RejectedByPolicy` (1) are unchanged and an
+    /// 0.37 peer still decodes those. A 0.37 peer can never *receive* this
+    /// variant: it is only produced when the request being answered asked for
+    /// semantics above what completed, and a v1-only sender never asks for
+    /// more than v1 (see `cached_ack_for_protocol`).
+    AckSemanticsUnavailable { reason: String },
 }
 
 // ─── Origin-machine attestation (issue #213) ──────────────────────────────

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -355,7 +355,7 @@ fn cached_ack_for_protocol(
     if cached.protocol_version >= requested_protocol {
         cached.outcome.clone()
     } else {
-        DmAckOutcome::RejectedByPolicy {
+        DmAckOutcome::AckSemanticsUnavailable {
             reason: format!(
                 "logical request already completed under v{} semantics",
                 cached.protocol_version
@@ -1007,7 +1007,7 @@ impl InboxPipeline {
                 Some(stored) if stored == binding => {
                     cached_ack_for_protocol(&cached, envelope.protocol_version)
                 }
-                Some(_) => DmAckOutcome::RejectedByPolicy {
+                Some(_) => DmAckOutcome::AckSemanticsUnavailable {
                     reason: "logical request already completed with different content".to_string(),
                 },
                 None => cached_ack_for_protocol(&cached, envelope.protocol_version),
@@ -1078,7 +1078,7 @@ impl InboxPipeline {
                     .publish_ack_for_protocol(
                         sender_agent_id,
                         request_id,
-                        DmAckOutcome::RejectedByPolicy {
+                        DmAckOutcome::AckSemanticsUnavailable {
                             reason: "logical request already committed with different content"
                                 .to_string(),
                         },
@@ -1970,14 +1970,76 @@ mod tests {
             durable_binding: None,
             first_seen: std::time::Instant::now(),
         };
+        // ADR 0030 §2 names this outcome explicitly. It must NOT be
+        // `RejectedByPolicy`: nothing about the trust relationship failed,
+        // and the sender maps that variant to `RecipientRejected`, which
+        // would tell a product UI "peer blocked you" instead of "you cannot
+        // have a durable receipt for this request".
         assert!(matches!(
             cached_ack_for_protocol(&cached, DM_PROTOCOL_DURABLE_ACK),
-            DmAckOutcome::RejectedByPolicy { .. }
+            DmAckOutcome::AckSemanticsUnavailable { .. }
         ));
         assert!(matches!(
             cached_ack_for_protocol(&cached, DM_PROTOCOL_V1),
             DmAckOutcome::Accepted
         ));
+    }
+
+    /// Wire safety for the appended `AckSemanticsUnavailable` variant: a
+    /// v1-only 0.37 peer can never be sent it, because it asks for at most v1
+    /// and any cached completion is at least v1. If this ever regresses, an
+    /// 0.37 receiver would fail to postcard-decode the ACK and the send would
+    /// degrade to a timeout.
+    #[test]
+    fn a_v1_request_is_never_answered_with_the_new_ack_variant() {
+        for cached_version in [DM_PROTOCOL_V1, DM_PROTOCOL_DURABLE_ACK] {
+            for outcome in [
+                DmAckOutcome::Accepted,
+                DmAckOutcome::RejectedByPolicy {
+                    reason: "blocked".to_string(),
+                },
+            ] {
+                let cached = crate::dm::CachedOutcome {
+                    outcome,
+                    protocol_version: cached_version,
+                    durable_binding: None,
+                    first_seen: std::time::Instant::now(),
+                };
+                assert!(
+                    !matches!(
+                        cached_ack_for_protocol(&cached, DM_PROTOCOL_V1),
+                        DmAckOutcome::AckSemanticsUnavailable { .. }
+                    ),
+                    "a v1 request must never be answered with a variant 0.37 cannot decode"
+                );
+            }
+        }
+    }
+
+    /// The two pre-existing variants must keep their postcard discriminants,
+    /// or every 0.37 peer stops decoding our ACKs.
+    #[test]
+    fn appending_the_new_ack_variant_preserves_legacy_discriminants() {
+        let accepted = postcard::to_stdvec(&DmAckOutcome::Accepted).expect("encode accepted");
+        assert_eq!(accepted.first(), Some(&0u8), "Accepted must stay variant 0");
+        let rejected = postcard::to_stdvec(&DmAckOutcome::RejectedByPolicy {
+            reason: String::new(),
+        })
+        .expect("encode rejected");
+        assert_eq!(
+            rejected.first(),
+            Some(&1u8),
+            "RejectedByPolicy must stay variant 1"
+        );
+        let unavailable = postcard::to_stdvec(&DmAckOutcome::AckSemanticsUnavailable {
+            reason: String::new(),
+        })
+        .expect("encode unavailable");
+        assert_eq!(
+            unavailable.first(),
+            Some(&2u8),
+            "AckSemanticsUnavailable must be appended last"
+        );
     }
 
     async fn assert_no_delivery(receiver: &mut crate::direct::DirectMessageReceiver) {

--- a/src/dm_send.rs
+++ b/src/dm_send.rs
@@ -493,6 +493,14 @@ fn ack_outcome_to_receipt(
             path: DmPath::GossipInbox,
         }),
         DmAckOutcome::RejectedByPolicy { reason } => Err(DmError::RecipientRejected { reason }),
+        // ADR 0030 §2: the recipient refused to issue the durable receipt,
+        // but nothing about the trust relationship failed. Surfacing this as
+        // `RecipientRejected` would tell a product UI "peer blocked you" when
+        // the actionable truth is "you cannot have a durable receipt for this
+        // logical request" — the same condition the send-side gate reports.
+        DmAckOutcome::AckSemanticsUnavailable { reason } => {
+            Err(DmError::AckSemanticsUnavailable(reason))
+        }
     }
 }
 


### PR DESCRIPTION
Follow-up to #328 (ADR 0030 slice 2). **This is not new scope — it is a commit that #328 was supposed to carry and lost.**

## What happened

I pushed slice 2 in two commits. `747f1be` (the receiver durable path) and `da87c05` (this change). #328 was squash-merged as `dc3e862` in the window between those two pushes, so main got the first commit and not the second. Verified: `git diff dc3e862 origin/feat/da-slice2-receiver-durable-path` is exactly this change — 107 insertions across 5 files — and `git branch --contains da87c05` lists only the old feature branch.

This is a clean cherry-pick of `da87c05` onto current `origin/main`, no conflicts, no edits.

## The defect currently on main

ADR 0030 §2 is explicit: *"A logical request completed under weaker semantics is answered `AckSemanticsUnavailable`, never re-ACKed as durable (`cached_ack_for_protocol`)."*

`DmAckOutcome` on main has only `Accepted` and `RejectedByPolicy`, so the durable path's refusals currently emit `RejectedByPolicy` — and `dm_send::ack_outcome_to_receipt` maps that to `DmError::RecipientRejected`.

The user-visible consequence: a v2 sender whose logical request already completed under v1 semantics, or is already bound to different content, is told **"the recipient rejected you"** when the truth is **"you cannot have a durable receipt for this request."** A product UI renders a protocol condition as a blocked peer — misreporting exactly the case the 409 contract exists to make actionable. It is also the wrong remediation: the caller should retry or surface "peer needs upgrade", not treat the relationship as refused.

## The fix

- Adds `DmAckOutcome::AckSemanticsUnavailable { reason }`, used for both refusals the durable path can make: already completed under weaker semantics, and already bound to different content.
- `dm_send` maps it to `DmError::AckSemanticsUnavailable` — the same typed error slice 1's send-side capability gate raises, so both directions of the same condition report identically.

## Wire compatibility

This variant rides on a signed, postcard-encoded ACK body, so it is proven rather than asserted:

- **Appended last**, so postcard discriminants for `Accepted` (0) and `RejectedByPolicy` (1) are unchanged and 0.37 peers keep decoding our ACKs — `appending_the_new_ack_variant_preserves_legacy_discriminants`.
- **A v1-only peer can never receive it.** It is produced only when the request asks for semantics above what completed, and a v1 sender never asks above v1 — `a_v1_request_is_never_answered_with_the_new_ack_variant`. Were this to regress, an 0.37 receiver would fail to decode the ACK and the send would silently degrade to a timeout, so the test guards a real failure mode rather than restating the code.

`cached_v1_completion_refuses_a_v2_request` is updated to assert the ADR-named outcome, with a comment recording why `RejectedByPolicy` is wrong here.

## Gates (real exit codes, run on this branch on top of merged main)

| Gate | Exit |
|---|---|
| `cargo fmt --all -- --check` | **0** |
| `cargo clippy --workspace --all-features --all-targets -- -D warnings` | **0** |
| `cargo nextest run --workspace --all-features --no-fail-fast` | **0** — 2630 passed, 260 skipped, 0 failed |

No production-code `.unwrap()`/`.expect()`/`panic!()` added. No flakes on this run; both quic-localhost serial-group tests passed first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores the distinct ACK outcome required when a durable receipt cannot be issued, preventing protocol-semantic failures from being reported as recipient trust rejection.
- Appends `AckSemanticsUnavailable` without changing legacy postcard discriminants.
- Emits the outcome for weaker cached completions and conflicting durable bindings.
- Maps it to the existing typed sender error and documents the behavior.
- Adds compatibility and protocol-routing tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or compatibility defects identified.

The new outcome is confined to v2 durable-request paths, preserves existing wire discriminants, is handled exhaustively by the sender, and reaches the intended public 409 error mapping.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dm.rs | Appends the new serialized ACK outcome while preserving the discriminants of both legacy variants. |
| src/dm_inbox.rs | Uses the new outcome on v2-only weaker-semantics and content-binding refusal paths and adds focused compatibility tests. |
| src/dm_send.rs | Exhaustively maps the new ACK outcome to the existing typed semantics-unavailable sender error. |
| docs/design/dm-over-gossip.md | Documents the distinction between receipt-semantics unavailability and recipient policy rejection. |
| CHANGELOG.md | Records the restored ACK contract, sender mapping, and rolling wire-compatibility rationale. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Sender
  participant Inbox
  participant History
  Sender->>Inbox: v2 durable DM request
  Inbox->>History: Check logical request binding
  alt Completed under weaker semantics
    Inbox-->>Sender: AckSemanticsUnavailable
  else Bound to different content
    Inbox-->>Sender: AckSemanticsUnavailable
  else Matching durable completion
    Inbox-->>Sender: Cached outcome
  end
  Sender->>Sender: Map unavailable ACK to DmError::AckSemanticsUnavailable
```

<sub>Reviews (1): Last reviewed commit: ["feat(dm): answer un-upgradable requests ..."](https://github.com/saorsa-labs/x0x/commit/269f026795685e9fd07433bc073b5aab363172e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53606512)</sub>

**Context used:**

- Knowledge Base — [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)

<!-- /greptile_comment -->