### PR TITLE
feat(dm): answer un-upgradable requests with AckSemanticsUnavailable (ADR 0030 §2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ All notable changes to this project will be documented in this file.
   lock, unpublishable replay completion — withholds the ACK rather than
   degrading it. `Accepted` under v2 now means what ADR 0030 §1 says it
   means: verified, durably committed, and dispatched.
+- **`DmAckOutcome::AckSemanticsUnavailable { reason }`** (ADR 0030 §2). The
+  receiver's answer when it cannot issue the durable receipt a request asked
+  for — the logical request already completed under weaker semantics, or is
+  already bound to different content. It maps to
+  `DmError::AckSemanticsUnavailable`, the same typed error the send-side
+  capability gate raises, rather than `RecipientRejected`: nothing about the
+  trust relationship failed, so callers surface "retry / peer needs upgrade",
+  not "peer blocked you". Appended last in the enum, so postcard variant
+  indices for `Accepted` and `RejectedByPolicy` are unchanged and 0.37 peers
+  keep decoding them; a v1-only sender can never be sent the new variant,
+  because it never asks for semantics above v1.
 - **History schema v4 columns gain writers.** Inbound DM rows populate
   `ingress_sender_agent` and `logical_request_id`; together they key the
   durable-history lookup that lets a restarted receiver recognise a logical

--- a/docs/design/dm-over-gossip.md
+++ b/docs/design/dm-over-gossip.md
@@ -235,7 +235,14 @@ order, per ADR 0030 §1:
    under *its own* semantics, never re-dispatched. The binding is a
    domain-separated digest over `(protocol_version, accepted bytes)`, so the
    same request id carrying different content is refused rather than
-   re-ACKed as the original delivery.
+   re-ACKed as the original delivery. Both refusals — "already completed
+   under v1 semantics" and "already bound to different content" — are
+   answered `DmAckOutcome::AckSemanticsUnavailable`, never
+   `RejectedByPolicy`: no trust decision failed, and the sender maps the
+   latter to `RecipientRejected`, which would misreport a protocol condition
+   as a blocked peer. On the sender it becomes
+   `DmError::AckSemanticsUnavailable` — the same typed error the send-side
+   capability gate raises.
 3. **Durable-history lookup** — keyed on the schema v4 columns
    `(ingress_sender_agent, logical_request_id)` via
    `Store::find_by_logical_request`. This is the check that survives restart,

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -269,6 +269,20 @@ pub enum DmAckOutcome {
     /// that prefer silent rejection can set `trust.silent_reject = true`
     /// and skip emitting this ACK entirely.
     RejectedByPolicy { reason: String },
+    /// The recipient cannot issue the durable receipt this request asked for:
+    /// the logical request already completed under weaker semantics, or is
+    /// already bound to different content (ADR 0030 §2). Distinct from
+    /// [`Self::RejectedByPolicy`] — nothing about the trust relationship
+    /// failed, so the caller should surface "retry / peer needs upgrade"
+    /// rather than "peer rejected you".
+    ///
+    /// **Wire compatibility:** appended last, so postcard's variant indices
+    /// for `Accepted` (0) and `RejectedByPolicy` (1) are unchanged and an
+    /// 0.37 peer still decodes those. A 0.37 peer can never *receive* this
+    /// variant: it is only produced when the request being answered asked for
+    /// semantics above what completed, and a v1-only sender never asks for
+    /// more than v1 (see `cached_ack_for_protocol`).
+    AckSemanticsUnavailable { reason: String },
 }
 
 // ─── Origin-machine attestation (issue #213) ──────────────────────────────

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -355,7 +355,7 @@ fn cached_ack_for_protocol(
     if cached.protocol_version >= requested_protocol {
         cached.outcome.clone()
     } else {
-        DmAckOutcome::RejectedByPolicy {
+        DmAckOutcome::AckSemanticsUnavailable {
             reason: format!(
                 "logical request already completed under v{} semantics",
                 cached.protocol_version
@@ -1007,7 +1007,7 @@ impl InboxPipeline {
                 Some(stored) if stored == binding => {
                     cached_ack_for_protocol(&cached, envelope.protocol_version)
                 }
-                Some(_) => DmAckOutcome::RejectedByPolicy {
+                Some(_) => DmAckOutcome::AckSemanticsUnavailable {
                     reason: "logical request already completed with different content".to_string(),
                 },
                 None => cached_ack_for_protocol(&cached, envelope.protocol_version),
@@ -1078,7 +1078,7 @@ impl InboxPipeline {
                     .publish_ack_for_protocol(
                         sender_agent_id,
                         request_id,
-                        DmAckOutcome::RejectedByPolicy {
+                        DmAckOutcome::AckSemanticsUnavailable {
                             reason: "logical request already committed with different content"
                                 .to_string(),
                         },
@@ -1970,14 +1970,76 @@ mod tests {
             durable_binding: None,
             first_seen: std::time::Instant::now(),
         };
+        // ADR 0030 §2 names this outcome explicitly. It must NOT be
+        // `RejectedByPolicy`: nothing about the trust relationship failed,
+        // and the sender maps that variant to `RecipientRejected`, which
+        // would tell a product UI "peer blocked you" instead of "you cannot
+        // have a durable receipt for this request".
         assert!(matches!(
             cached_ack_for_protocol(&cached, DM_PROTOCOL_DURABLE_ACK),
-            DmAckOutcome::RejectedByPolicy { .. }
+            DmAckOutcome::AckSemanticsUnavailable { .. }
         ));
         assert!(matches!(
             cached_ack_for_protocol(&cached, DM_PROTOCOL_V1),
             DmAckOutcome::Accepted
         ));
+    }
+
+    /// Wire safety for the appended `AckSemanticsUnavailable` variant: a
+    /// v1-only 0.37 peer can never be sent it, because it asks for at most v1
+    /// and any cached completion is at least v1. If this ever regresses, an
+    /// 0.37 receiver would fail to postcard-decode the ACK and the send would
+    /// degrade to a timeout.
+    #[test]
+    fn a_v1_request_is_never_answered_with_the_new_ack_variant() {
+        for cached_version in [DM_PROTOCOL_V1, DM_PROTOCOL_DURABLE_ACK] {
+            for outcome in [
+                DmAckOutcome::Accepted,
+                DmAckOutcome::RejectedByPolicy {
+                    reason: "blocked".to_string(),
+                },
+            ] {
+                let cached = crate::dm::CachedOutcome {
+                    outcome,
+                    protocol_version: cached_version,
+                    durable_binding: None,
+                    first_seen: std::time::Instant::now(),
+                };
+                assert!(
+                    !matches!(
+                        cached_ack_for_protocol(&cached, DM_PROTOCOL_V1),
+                        DmAckOutcome::AckSemanticsUnavailable { .. }
+                    ),
+                    "a v1 request must never be answered with a variant 0.37 cannot decode"
+                );
+            }
+        }
+    }
+
+    /// The two pre-existing variants must keep their postcard discriminants,
+    /// or every 0.37 peer stops decoding our ACKs.
+    #[test]
+    fn appending_the_new_ack_variant_preserves_legacy_discriminants() {
+        let accepted = postcard::to_stdvec(&DmAckOutcome::Accepted).expect("encode accepted");
+        assert_eq!(accepted.first(), Some(&0u8), "Accepted must stay variant 0");
+        let rejected = postcard::to_stdvec(&DmAckOutcome::RejectedByPolicy {
+            reason: String::new(),
+        })
+        .expect("encode rejected");
+        assert_eq!(
+            rejected.first(),
+            Some(&1u8),
+            "RejectedByPolicy must stay variant 1"
+        );
+        let unavailable = postcard::to_stdvec(&DmAckOutcome::AckSemanticsUnavailable {
+            reason: String::new(),
+        })
+        .expect("encode unavailable");
+        assert_eq!(
+            unavailable.first(),
+            Some(&2u8),
+            "AckSemanticsUnavailable must be appended last"
+        );
     }
 
     async fn assert_no_delivery(receiver: &mut crate::direct::DirectMessageReceiver) {

--- a/src/dm_send.rs
+++ b/src/dm_send.rs
@@ -493,6 +493,14 @@ fn ack_outcome_to_receipt(
             path: DmPath::GossipInbox,
         }),
         DmAckOutcome::RejectedByPolicy { reason } => Err(DmError::RecipientRejected { reason }),
+        // ADR 0030 §2: the recipient refused to issue the durable receipt,
+        // but nothing about the trust relationship failed. Surfacing this as
+        // `RecipientRejected` would tell a product UI "peer blocked you" when
+        // the actionable truth is "you cannot have a durable receipt for this
+        // logical request" — the same condition the send-side gate reports.
+        DmAckOutcome::AckSemanticsUnavailable { reason } => {
+            Err(DmError::AckSemanticsUnavailable(reason))
+        }
     }
 }
 


### PR DESCRIPTION
Follow-up to #328 (ADR 0030 slice 2). The receiver durable path merged as `dc3e862` carrying `747f1be` only; this is the remaining delta, re-based onto current `origin/main` so it gets its own review rather than riding in on an approval that did not cover it.

Clean cherry-pick of `da87c05` onto `dc3e862` — no conflicts, no edits. Tree verified byte-identical to the original commit.

## Why this is a correctness fix, not a naming preference

ADR 0030 §2 is explicit:

> A logical request completed under weaker semantics is answered `AckSemanticsUnavailable`, never re-ACKed as durable (`cached_ack_for_protocol`).

`DmAckOutcome` on main has only `Accepted` and `RejectedByPolicy`, so the durable path's refusals currently emit `RejectedByPolicy` — and `dm_send::ack_outcome_to_receipt` maps that variant to `DmError::RecipientRejected`.

The user-visible consequence: a v2 sender whose logical request **already completed under v1 semantics**, or is **already bound to different content**, is told *"the recipient rejected you"* when the truth is *"you cannot have a durable receipt for this request."*

That is wrong in two ways that compound:

1. **Wrong message.** A product UI renders a protocol condition as a blocked peer — misreporting precisely the case ADR 0030's 409 contract exists to make actionable.
2. **Wrong remediation.** `RecipientRejected` tells the caller the relationship is refused, so the correct responses (retry, or surface "peer needs upgrade") look inapplicable. The condition is transient and addressable; the error says it is neither.

## The fix

- Adds `DmAckOutcome::AckSemanticsUnavailable { reason }`, used for both refusals the durable path can make: already completed under weaker semantics, and already bound to different content.
- `dm_send` maps it to `DmError::AckSemanticsUnavailable` — the same typed error slice 1's send-side capability gate already raises — so both directions of the same condition report identically instead of diverging by which side noticed first.

## Wire safety

This variant rides on a **signed, postcard-encoded ACK body**, so it is proven by test rather than asserted in review:

**1. Legacy discriminants are preserved** — `appending_the_new_ack_variant_preserves_legacy_discriminants`.
Postcard encodes enum variants by declaration index. The new variant is **appended last**, so `Accepted` stays 0 and `RejectedByPolicy` stays 1, and every 0.37 peer keeps decoding our existing ACKs unchanged. The test pins all three discriminants, so a future reorder that would silently break the fleet fails here instead.

**2. A v1-only peer can never receive the new variant** — `a_v1_request_is_never_answered_with_the_new_ack_variant`.
`cached_ack_for_protocol` returns it only when the incoming request asks for semantics **above** what the cached completion made. A 0.37 peer only ever sends v1 envelopes, so it asks for at most v1, and any cached completion is at least v1 — the branch is unreachable for it. The test sweeps both cached protocol versions against both pre-existing outcomes to hold that closed.

This second property is the load-bearing one: were it to regress, an 0.37 receiver would fail to postcard-decode the ACK, drop it, and the sender would degrade to a **silent timeout** — the exact black-hole failure mode ADR 0030 §2 forbids. The test guards a real regression path, not the shape of the code.

`cached_v1_completion_refuses_a_v2_request` is updated to assert the ADR-named outcome, with a comment recording why `RejectedByPolicy` is wrong here so the substitution is not quietly reintroduced.

## Gates — re-run on this branch against the new base (`dc3e862`), not carried over

| Gate | Exit |
|---|---|
| `cargo fmt --all -- --check` | **0** |
| `cargo clippy --workspace --all-features --all-targets -- -D warnings` | **0** |
| `cargo nextest run --workspace --all-features --no-fail-fast` | **0** — 2630 passed, 260 skipped, 0 failed |

No production-code `.unwrap()` / `.expect()` / `panic!()` added; all such matches in the diff are inside `#[cfg(test)]` / `#[tokio::test]`.

## Flake encountered and cleared — plus a config gap worth a separate fix

One full-suite run failed `gossip_plane_isolation::gated_and_open_pair_converges_after_legacy_grace`. **This is not one of the two documented flakes**, so I did not assume:

- It failed in **2.4 s** at `tests/gossip_plane_isolation.rs:43`, on the very first `connect_addr` (`All connection strategies failed: DirectIPv4: Timeout; DirectIPv6: Happy Eyeballs timed out`) — transport setup, before any application logic.
- That file contains **zero** DM usage (`send_direct`, `DmAckOutcome`, `require_durable`, `/direct/send` all absent), so this change cannot reach it.
- Isolated re-runs: **4/4 passing** at ~12.4 s, matching its normal runtime. The clean full run recorded above is 2630/2630.

**Separate finding, deliberately not fixed here:** `.config/nextest.toml` serialises localhost-QUIC-endpoint tests via the `quic-localhost` group precisely because "ant-quic's dual-stack socket handling causes intermittent connection failures ... when many endpoints share the loopback interface." `gossip_plane_isolation` creates exactly that topology but is **not** in the group or in the `threads-required` reservation added for issue #316. That looks like a coverage gap in the serial-group filters. I left it alone: editing shared test-scheduling config would be unrelated scope in a cherry-pick, and it can shift timing for other suites, so it deserves its own change and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR distinguishes unavailable durable-ACK semantics from recipient policy rejection and propagates the condition through the sender as the existing typed error.
- Appends `AckSemanticsUnavailable` without changing legacy postcard discriminants.
- Emits the new outcome for weaker cached completions and conflicting durable bindings.
- Maps the outcome to `DmError::AckSemanticsUnavailable` and documents the protocol behavior.
- Adds receiver-side protocol and discriminant compatibility tests.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking test-coverage gap around the new sender-side error conversion.

The receiver paths are gated to durable-protocol requests, legacy discriminants remain stable, and current consumers handle the new outcome correctly; only the key ACK-to-error mapping lacks direct regression coverage.

**Files Needing Attention:** src/dm_send.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dm.rs | Appends the new ACK outcome while preserving the two legacy postcard discriminants. |
| src/dm_inbox.rs | Uses the new outcome for weaker cached semantics and conflicting durable bindings, with compatibility tests. |
| src/dm_send.rs | Correctly maps the new outcome to the typed semantics error, but lacks a focused regression test for that mapping. |
| docs/design/dm-over-gossip.md | Documents why durable-semantics refusals are distinct from trust-policy rejection. |
| CHANGELOG.md | Records the new outcome, sender behavior, and wire-compatibility constraints. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Sender
  participant Inbox
  participant Cache as Durable history/cache
  Sender->>Inbox: v2 durable DM request
  Inbox->>Cache: Check logical request and binding
  alt Existing completion satisfies request
    Inbox-->>Sender: Accepted / cached outcome
  else Weaker completion or conflicting content
    Inbox-->>Sender: AckSemanticsUnavailable
    Sender->>Sender: Map to DmError::AckSemanticsUnavailable
  end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/dm_send.rs:501-503
**Test the new ACK mapping**

The focused conversion tests cover `Accepted` and `RejectedByPolicy` but not this new `AckSemanticsUnavailable` arm. Add a case that pins the typed error so a future mapping regression cannot restore the incorrect recipient-rejection response unnoticed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dm): answer un-upgradable requests ..."](https://github.com/saorsa-labs/x0x/commit/269f026795685e9fd07433bc073b5aab363172e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53607022)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)

<!-- /greptile_comment -->