### PR TITLE
feat(dm): DA slice 3 part 1 — typed-route completion signal + carried fixes (ADR 0030 §7)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -41,11 +41,31 @@ filter = "test(direct_send_with_require_ack_round_trips_to_live_peer) | test(=te
 test-group = "quic-localhost"
 threads-required = 4
 
+# ADR 0030 slice 3: gossip_plane_isolation was ALREADY in the serial group
+# (see the block below) and still failed a full-parallel run — at the very
+# first `connect_addr`, in 2.4 s versus its normal ~12.4 s, with every dial
+# strategy timing out; 4/4 green in isolation. That is the issue-#316
+# signature exactly: group placement bounds group-internal contention, but
+# the trigger here is ambient load from the ~2600 ungrouped tests starving
+# the dial's timing window. So it needs the same remedy the two #316 tests
+# needed — a scheduler-slot reservation, not merely a group.
+#
+# This block MUST stay ahead of the broader one below: nextest applies the
+# FIRST matching override, so appending these settings after that block
+# would silently do nothing. Keeping the binary filtered separately also
+# leaves the three slice-1 tests below on their existing settings rather
+# than handing them reservations they have not been shown to need.
+[[profile.default.overrides]]
+filter = "binary(gossip_plane_isolation)"
+test-group = "quic-localhost"
+threads-required = 4
+
 # The slice-1 regression tests each stand up multiple loopback QUIC
 # endpoints; unserialized they add enough contention to break the
 # gossip_plane_isolation stay-down window (2-of-2 full-run repro, green
 # with these excluded, green on the v0.37.1 baseline). The plane-isolation
-# binary itself is multi-endpoint loopback and belongs in the group too.
+# binary itself is multi-endpoint loopback and belongs in the group too
+# (now via the more specific override above, which matches it first).
 [[profile.default.overrides]]
 filter = "test(discovered_but_disconnected_peer_is_dialed_by_same_send) | test(identity_epoch_converges_with_linear_application_publishes) | test(non_treekem_self_leave_directly_delivers_member_removed_to_retained_owner) | binary(gossip_plane_isolation)"
 test-group = "quic-localhost"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Typed-route durable completion signal (ADR 0030 §7, slice 3).** Slice 2
+  withheld every v2 ACK on a typed route because typed-prefix families
+  classify `Ephemeral` and cannot be backed by a DM-history commit. A handler
+  can now report `DmTypedPayloadCompletion::{Inserted, Duplicate}` on a
+  oneshot carried in `DmTypedPayload`, and that signal releases the ACK.
+  `DmTypedPayload` also carries the envelope `request_id` so handlers can
+  dedupe on `(sender, request_id)` across restart, and is no longer `Clone`
+  (a oneshot sender has no meaningful copy). Routes opt in via
+  `DmInboxConfig::with_durable_typed_payload_route`; routes that do not opt in
+  still get no v2 ACK, by stated policy. Every non-completion — channel
+  unavailable, handler error, dropped sender, timeout — withholds the ACK.
+- **`Store::find_by_logical_request` is now indexed.** Partial index on
+  `(ingress_sender_agent, logical_request_id)` for rows where
+  `logical_request_id IS NOT NULL`, created idempotently at open rather than
+  via a schema-version bump, so a rollback to v0.37.4 can still open the
+  database.
+
 - **DM protocol v2 receiver durable path (ADR 0030 §1, slice 2 of 4).** A v2
   envelope is answered in exactly this order: per-logical-request lock →
   replay-cache binding check → durable-history lookup → dispatch →

--- a/docs/design/dm-over-gossip.md
+++ b/docs/design/dm-over-gossip.md
@@ -284,6 +284,25 @@ already-committed envelope. The step-3 lookup holds it to exactly one
 history row. Applications needing restart-spanning exactly-once must dedupe
 on `(sender, request_id)`.
 
+Concretely, on a `DurableLogicalRequestLookup::Exact` after restart — the
+row is already committed and binds the same bytes — the receiver **still
+dispatches to the application again**, then re-commits (the store returns
+`Duplicate`, satisfying `exact_durable_history_outcome`) and re-ACKs v2.
+This is deliberate and ADR-0030-allowed, not an oversight:
+
+- The alternative, skipping dispatch on `Exact`, would silently drop the
+  message whenever the crash happened *between* the history commit and the
+  application actually finishing with it — the exact window this protocol
+  exists to close. A duplicate the application can dedupe is strictly safer
+  than a loss it cannot detect.
+- The receipt stays honest either way: the sender's `Accepted` means
+  committed **and** dispatched, and both are true on the replay.
+
+So the guarantee is precisely: **exactly one history row, at least one
+dispatch.** Anything an application does on receipt that is not idempotent
+must dedupe on `(sender, request_id)` — the same obligation §1 places on
+applications requiring restart-spanning exactly-once.
+
 ## Capability negotiation
 
 ### Advertisement

--- a/docs/design/dm-over-gossip.md
+++ b/docs/design/dm-over-gossip.md
@@ -263,19 +263,43 @@ distinguish from the durable receipt it asked for (ADR 0030 §2).
 
 #### Typed routes (ADR 0030 §7)
 
-The typed-route restart-spanning dedupe gap is **documented as a handler
-obligation, not closed in the inbox.** Typed-prefix families (group ingest,
-KV deltas, exec audit, card import, voice signalling) classify `Ephemeral`:
-their durable effect lives in their own store, not in DM history, so a
-DM-history commit could not honestly back their receipt — and they are
-handed off with a non-blocking `try_send` that may drop under backpressure,
-so a durable ACK would claim a dispatch that never completed.
+Typed-prefix families (group ingest, KV deltas, exec audit, card import,
+voice signalling) classify `Ephemeral`: their durable effect lives in their
+own store, not in DM history, so a DM-history commit could never honestly
+back their receipt. Slice 2 therefore withheld every v2 ACK on a typed route.
 
-A v2 envelope matching a typed route therefore receives **no** ACK, and each
-typed handler carries the dedupe obligation via its own durable surface (the
-bootstrap outbox handler satisfies it with `Inserted | Duplicate`
-completion). The typed-route completion signal that lets these frames earn a
-v2 ACK is slice 3.
+Slice 3 replaces that blanket refusal with a **completion signal**. The
+handler reports when the payload is durably recorded on *its* surface, and
+that report — not a history row — is what releases the ACK:
+
+```rust
+pub enum DmTypedPayloadCompletion { Inserted, Duplicate }
+pub type DmTypedPayloadCompletionResult = Result<DmTypedPayloadCompletion, String>;
+```
+
+`DmTypedPayload` carries the envelope's `request_id` (so a handler can dedupe
+on `(sender, request_id)` across restart) and a `completion` oneshot the
+inbox awaits. For a durable typed payload this replaces steps 3–5 of the
+receiver ordering: `Inserted | Duplicate` is the same "exactly one durable
+record" proof that `record_committed` gives the generic path.
+
+**Opting in is a promise.** Routes registered with
+`with_durable_typed_payload_route` may back a v2 ACK; routes registered with
+`with_typed_payload_route` may not, and a v2 envelope reaching one is
+withheld under its own trace stage. This daemon does not certify durability
+for a handler that never promised it — that withholding is **stated policy,
+not an oversight**. A route that resolves its completion optimistically,
+before its store commit, converts a durable receipt into a lie; the honest
+failure is to drop the sender, which withholds.
+
+Every non-completion withholds the ACK: channel unavailable, handler error,
+dropped sender (so a handler returning early on its own error path fails
+safe), or no answer within the completion budget. The budget is deliberately
+shorter than the sender's per-attempt budget (`DM_TIMEOUT_MAX_MS`, 30 s) —
+waiting longer than the sender will wait can only pin the receiver's serial
+inbox loop on an ACK nobody is still listening for. It is a receiver-side
+liveness bound, not a correctness one: a timeout withholds and the sender
+retries.
 
 #### At-least-once across restart
 

--- a/scripts/check-panics.sh
+++ b/scripts/check-panics.sh
@@ -70,7 +70,13 @@ scan_pattern() {
         # Found in production code
         echo "  $match"
         found_in_prod=1
-    done < <(grep -rn "$pattern" $paths 2>/dev/null || true)
+    # -a (treat binary as text) is defence in depth. GNU/BSD grep decide
+    # binary-or-not from an early read buffer, so a NUL near the top of a file
+    # would make the whole file emit no file:line matches and drop silently out
+    # of this scan. The NUL tripwire above is the primary guard; -a means the
+    # scan itself stays correct regardless of where such a byte lands or which
+    # grep implementation runs it.
+    done < <(grep -arn "$pattern" $paths 2>/dev/null || true)
 
     if [ $found_in_prod -eq 1 ]; then
         echo -e "${RED}✗ FOUND: $description in production code${NC}"
@@ -80,6 +86,46 @@ scan_pattern() {
     fi
     echo ""
 }
+
+# Tripwire: fail if any .rs file contains a raw NUL byte.
+#
+# A NUL in a source file makes text tools classify it as binary and skip it
+# silently. Which tools, and from where in the file, varies: ripgrep and ugrep
+# bail on the first NUL wherever it sits, while GNU/BSD grep decide from an
+# early read buffer and will happily scan past a NUL that lands late. So a
+# late NUL can leave this gate working while breaking every rg-based code
+# search — a split that is worse than a clean failure, because the gate looks
+# healthy.
+#
+# Testing for the defect itself (a NUL byte) rather than for "some grep thinks
+# this is binary" makes the check deterministic and independent of which tool
+# and which implementation happens to run. src/dm_inbox.rs carried four raw
+# NULs in byte-string literals where \x00 escapes were meant; this is what
+# would have caught them.
+check_no_nul_bytes() {
+    echo "Checking for: raw NUL bytes in .rs sources"
+    local binary_found=0
+    while IFS= read -r f; do
+        [ -s "$f" ] || continue
+        # Strip NULs and compare: identical means the file had none.
+        if ! LC_ALL=C tr -d '\000' < "$f" | cmp -s - "$f"; then
+            echo "  $f contains raw NUL byte(s)"
+            binary_found=1
+        fi
+    done < <(find src/ x0x/ -name '*.rs' -type f 2>/dev/null)
+
+    if [ $binary_found -eq 1 ]; then
+        echo -e "${RED}✗ FOUND: raw NUL bytes in .rs sources — text tools"
+        echo -e "  classify these files as binary and skip them silently.${NC}"
+        echo -e "  Write the byte escaped instead (\\\\x00, not a literal NUL)."
+        FOUND_ISSUES=$((FOUND_ISSUES + 1))
+    else
+        echo -e "${GREEN}✓ PASS: No raw NUL bytes in .rs sources${NC}"
+    fi
+    echo ""
+}
+
+check_no_nul_bytes
 
 # Scan for problematic patterns
 scan_pattern "\.unwrap()" ".unwrap() calls"

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -2846,9 +2846,9 @@ mod tests {
     #[test]
     fn dm_inbox_config_with_route_adds_entry() {
         let (tx, _rx) = tokio::sync::mpsc::channel::<DmTypedPayload>(8);
-        let config = DmInboxConfig::default().with_typed_payload_route(b"x0x-exec-v1 ", tx);
+        let config = DmInboxConfig::default().with_typed_payload_route(b"x0x-exec-v1\x00", tx);
         assert_eq!(config.typed_payload_routes.len(), 1);
-        assert_eq!(config.typed_payload_routes[0].prefix, b"x0x-exec-v1 ");
+        assert_eq!(config.typed_payload_routes[0].prefix, b"x0x-exec-v1\x00");
     }
 
     #[test]
@@ -2856,8 +2856,8 @@ mod tests {
         let (tx1, _rx1) = tokio::sync::mpsc::channel::<DmTypedPayload>(8);
         let (tx2, _rx2) = tokio::sync::mpsc::channel::<DmTypedPayload>(8);
         let config = DmInboxConfig::default()
-            .with_typed_payload_route(b"prefix-a ", tx1)
-            .with_typed_payload_route(b"prefix-b ", tx2);
+            .with_typed_payload_route(b"prefix-a\x00", tx1)
+            .with_typed_payload_route(b"prefix-b\x00", tx2);
         assert_eq!(config.typed_payload_routes.len(), 2);
     }
 

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -17,10 +17,24 @@ use crate::revocation::RevocationSet;
 use crate::trust::{TrustContext, TrustDecision, TrustEvaluator};
 use bytes::Bytes;
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot, RwLock};
 use tokio::task::JoinHandle;
 
 const ACK_ENVELOPE_LIFETIME_MS: u64 = 60_000;
+
+/// How long the durable path waits for a typed-route handler to report
+/// completion before withholding the ACK (ADR 0030 §7).
+///
+/// Deliberately shorter than the sender's per-attempt budget
+/// (`DM_TIMEOUT_MAX_MS`, 30 s): waiting longer than the sender will wait can
+/// only pin this receiver on an ACK nobody is still listening for. The
+/// campaign draft instead waited out the envelope's remaining lifetime — up
+/// to 120 s — inline on the serial inbox loop, which would stall every later
+/// DM and ACK behind one slow handler. The budget is a receiver-side
+/// liveness bound, not a correctness one: timing out withholds the ACK, and
+/// the sender retries.
+const DURABLE_TYPED_COMPLETION_TIMEOUT: Duration = Duration::from_secs(20);
 
 const AUTHENTICATED_MACHINE_BINDING_CAPACITY: usize = 65_536;
 
@@ -174,6 +188,9 @@ impl std::fmt::Debug for DmInboxConfig {
 impl DmInboxConfig {
     /// Add a typed-payload route. Matching payloads are delivered to `sender`
     /// and are not emitted to generic `/direct/events` consumers.
+    ///
+    /// Routes registered this way cannot satisfy a durable (v2) receipt — see
+    /// [`Self::with_durable_typed_payload_route`].
     #[must_use]
     pub fn with_typed_payload_route(
         mut self,
@@ -183,6 +200,30 @@ impl DmInboxConfig {
         self.typed_payload_routes.push(DmTypedPayloadRoute {
             prefix: prefix.into(),
             sender,
+            durable_completion: false,
+        });
+        self
+    }
+
+    /// Add a typed-payload route whose handler reports durable completion
+    /// (ADR 0030 §7).
+    ///
+    /// Opting in is a promise: the handler must resolve the payload's
+    /// [`DmTypedPayload::completion`] channel once the payload is durably
+    /// recorded in *its own* store, and only then. The inbox emits a v2 ACK
+    /// solely on that signal, so a route that resolves optimistically converts
+    /// a durable receipt into a lie. Routes that do not opt in never receive a
+    /// v2 ACK — that withholding is stated policy, not an oversight.
+    #[must_use]
+    pub fn with_durable_typed_payload_route(
+        mut self,
+        prefix: impl Into<Vec<u8>>,
+        sender: mpsc::Sender<DmTypedPayload>,
+    ) -> Self {
+        self.typed_payload_routes.push(DmTypedPayloadRoute {
+            prefix: prefix.into(),
+            sender,
+            durable_completion: true,
         });
         self
     }
@@ -193,10 +234,35 @@ impl DmInboxConfig {
 pub struct DmTypedPayloadRoute {
     pub prefix: Vec<u8>,
     pub sender: mpsc::Sender<DmTypedPayload>,
+    /// Whether this route's handler resolves [`DmTypedPayload::completion`],
+    /// and may therefore back a durable v2 ACK (ADR 0030 §7).
+    pub durable_completion: bool,
 }
 
+/// What a typed-route handler reports once it has durably recorded a payload.
+///
+/// Mirrors the history store's own vocabulary deliberately: these are the two
+/// outcomes that prove exactly one durable record exists for the request, and
+/// they are the only two that let the inbox emit a v2 ACK.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DmTypedPayloadCompletion {
+    /// Newly recorded in the handler's durable store.
+    Inserted,
+    /// Already present — an idempotent replay of the same logical request.
+    Duplicate,
+}
+
+/// Outcome a handler sends back on [`DmTypedPayload::completion`]. `Err`
+/// carries a reason for the trace; it withholds the ACK exactly like a
+/// dropped channel does.
+pub type DmTypedPayloadCompletionResult = Result<DmTypedPayloadCompletion, String>;
+
 /// A decrypted, verified DM payload routed before generic direct-message fan-out.
-#[derive(Debug, Clone)]
+///
+/// Deliberately NOT `Clone`: `completion` holds a `oneshot::Sender`, which has
+/// no meaningful copy — two clones could not both answer the receiver, and
+/// cloning would silently drop one caller's receipt.
+#[derive(Debug)]
 pub struct DmTypedPayload {
     pub sender: AgentId,
     pub machine_id: MachineId,
@@ -204,6 +270,14 @@ pub struct DmTypedPayload {
     pub verified: bool,
     pub trust_decision: Option<TrustDecision>,
     pub received_at_unix_ms: u64,
+    /// Logical request id of the envelope that carried this payload, so a
+    /// handler can dedupe on `(sender, request_id)` across restart.
+    pub request_id: [u8; 16],
+    /// Present only for a durable (v2) payload on a route that opted in.
+    /// Resolving it with `Inserted`/`Duplicate` is what releases the v2 ACK;
+    /// dropping it withholds the ACK, which is the safe default on any
+    /// handler path that returns early.
+    pub completion: Option<oneshot::Sender<DmTypedPayloadCompletionResult>>,
 }
 
 pub struct DmInboxService {
@@ -857,6 +931,7 @@ impl InboxPipeline {
             .route_typed_payload(
                 sender_agent_id,
                 sender_machine_id,
+                envelope.request_id,
                 plaintext.payload.clone(),
                 Some(decision),
             )
@@ -953,34 +1028,36 @@ impl InboxPipeline {
             return DurableAckDecision::Withheld("history_unavailable");
         };
 
-        // ADR 0030 §7 — typed-route obligation (documented, not closed here).
+        // ADR 0030 §7 — typed-route obligation, now discharged by the handler.
         //
-        // Typed-prefix families (group ingest, KV deltas, exec audit, card
-        // import, voice signalling) classify `Ephemeral`: their durable effect
+        // Typed-prefix families classify `Ephemeral`: their durable effect
         // lives in their own store, not in DM history, so a DM-history commit
-        // could not honestly back their receipt. They are also handed off with
-        // a non-blocking `try_send` that may drop under backpressure, so a
-        // durable ACK here would claim a dispatch that never completed.
+        // could never honestly back their receipt. Slice 2 therefore withheld
+        // every v2 ACK on a typed route. Slice 3 replaces that blanket refusal
+        // with a completion signal — the handler tells us when the payload is
+        // durably recorded on ITS surface, and that signal, not a history row,
+        // is what releases the ACK.
         //
-        // A v2 envelope on a typed route therefore gets NO ACK in this slice,
-        // and the handler carries the restart-spanning dedupe obligation via
-        // its own durable surface (the bootstrap outbox handler satisfies it
-        // with `Inserted | Duplicate` completion). Slice 3 adds the typed-route
-        // completion signal that lets these frames earn a v2 ACK.
-        if self
+        // Routes opt in via `with_durable_typed_payload_route`. A route that
+        // has not opted in still gets no v2 ACK: this daemon will not certify
+        // durability for a handler that has not promised it. That withholding
+        // is stated policy (see the PR/design doc), not an oversight.
+        let typed_route_durable = self
             .typed_payload_routes
             .iter()
-            .any(|route| application_payload.starts_with(&route.prefix))
-        {
+            .find(|route| application_payload.starts_with(&route.prefix))
+            .map(|route| route.durable_completion);
+        if typed_route_durable == Some(false) {
             tracing::info!(
                 target: "dm.trace",
-                stage = "inbound_durable_typed_route_unacked",
+                stage = "inbound_durable_typed_route_not_opted_in",
                 request_id = %hex::encode(request_id),
                 sender = %hex::encode(sender_agent_id.as_bytes()),
-                "v2 DM matched a typed route; ACK withheld pending typed-route completion (ADR 0030 §7)"
+                "v2 DM matched a typed route that does not report durable completion; ACK withheld by policy (ADR 0030 §7)"
             );
-            return DurableAckDecision::Withheld("typed_route");
+            return DurableAckDecision::Withheld("typed_route_not_durable");
         }
+        let is_durable_typed_route = typed_route_durable == Some(true);
 
         // 1. Per-logical-request lock. Serializes the primary inbox and the
         //    legacy-bus copy of the same envelope so neither can observe a
@@ -1038,6 +1115,61 @@ impl InboxPipeline {
             return DurableAckDecision::Acked {
                 protocol_version: ack_protocol,
                 accepted: accepted_replay,
+            };
+        }
+
+        // 3a. Durable typed route: the handler's own store is the durable
+        //     surface, so steps 3–5 are replaced by dispatch-and-await. The
+        //     handler reports `Inserted | Duplicate` only once the payload is
+        //     recorded, which is the same "exactly one durable record" proof
+        //     `record_committed` gives the generic path.
+        if is_durable_typed_route {
+            let decision = self
+                .dispatch_durable_typed_route(
+                    sender_agent_id,
+                    sender_machine_id,
+                    request_id,
+                    application_payload,
+                    Some(decision),
+                )
+                .await;
+            let completion = match decision {
+                Ok(completion) => completion,
+                Err(stage) => return DurableAckDecision::Withheld(stage),
+            };
+            tracing::info!(
+                target: "dm.trace",
+                stage = "inbound_durable_typed_completed",
+                request_id = %hex::encode(request_id),
+                ?completion,
+            );
+            if let Err(error) = self.cache.complete_durable(
+                dedupe,
+                DmAckOutcome::Accepted,
+                envelope.protocol_version,
+                binding,
+            ) {
+                tracing::warn!(
+                    target: "dm.trace",
+                    stage = "inbound_durable_typed_replay_publish_failed",
+                    request_id = %hex::encode(request_id),
+                    ?error,
+                    "v2 ACK withheld: durable typed completion could not be made replay-safe"
+                );
+                return DurableAckDecision::Withheld("replay_publish_failed");
+            }
+            let _ = self
+                .publish_ack_for_protocol(
+                    sender_agent_id,
+                    request_id,
+                    DmAckOutcome::Accepted,
+                    envelope.protocol_version,
+                    ack_legacy_bus,
+                )
+                .await;
+            return DurableAckDecision::Acked {
+                protocol_version: envelope.protocol_version,
+                accepted: true,
             };
         }
 
@@ -1187,10 +1319,102 @@ impl InboxPipeline {
         }
     }
 
+    /// Hand a durable (v2) payload to its typed route and wait for the
+    /// handler's completion signal (ADR 0030 §7).
+    ///
+    /// `Err(stage)` names the reason the ACK must be withheld. Every failure
+    /// mode lands there deliberately, because each one means the durable
+    /// receipt would be unbacked:
+    ///
+    /// - the channel is full or closed — the handler never saw the payload;
+    /// - the handler dropped the completion sender — including by returning
+    ///   early on its own error path, so "forgot to answer" fails safe;
+    /// - the handler reported an error;
+    /// - the handler did not answer inside the budget.
+    ///
+    /// Only `Inserted | Duplicate` returns `Ok`.
+    async fn dispatch_durable_typed_route(
+        &self,
+        sender_agent_id: AgentId,
+        sender_machine_id: MachineId,
+        request_id: [u8; 16],
+        payload: Vec<u8>,
+        trust_decision: Option<TrustDecision>,
+    ) -> Result<DmTypedPayloadCompletion, &'static str> {
+        let Some(route) = self
+            .typed_payload_routes
+            .iter()
+            .find(|route| payload.starts_with(&route.prefix))
+        else {
+            return Err("typed_route_vanished");
+        };
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let typed = DmTypedPayload {
+            sender: sender_agent_id,
+            machine_id: sender_machine_id,
+            payload,
+            verified: true,
+            trust_decision,
+            received_at_unix_ms: now_unix_ms(),
+            request_id,
+            completion: Some(completion_tx),
+        };
+        // Still `try_send`, still non-blocking: this runs inline on the serial
+        // inbox loop, so a full channel must not stall unrelated DMs. The
+        // difference from the v1 path is what a drop means — there it was a
+        // tolerable loss of a redundant fallback, here it withholds the ACK
+        // and the sender retries.
+        if let Err(error) = route.sender.try_send(typed) {
+            self.dm.record_incoming_typed_route_dropped();
+            tracing::warn!(
+                target: "dm.trace",
+                stage = "inbound_durable_typed_route_unavailable",
+                request_id = %hex::encode(request_id),
+                sender = %crate::logging::LogAgentId::from(&sender_agent_id),
+                "v2 ACK withheld: typed route could not accept the payload ({error})"
+            );
+            return Err("typed_route_unavailable");
+        }
+
+        match tokio::time::timeout(DURABLE_TYPED_COMPLETION_TIMEOUT, completion_rx).await {
+            Ok(Ok(Ok(completion))) => Ok(completion),
+            Ok(Ok(Err(reason))) => {
+                tracing::warn!(
+                    target: "dm.trace",
+                    stage = "inbound_durable_typed_handler_failed",
+                    request_id = %hex::encode(request_id),
+                    %reason,
+                    "v2 ACK withheld: typed-route handler reported failure"
+                );
+                Err("typed_handler_failed")
+            }
+            Ok(Err(_)) => {
+                tracing::warn!(
+                    target: "dm.trace",
+                    stage = "inbound_durable_typed_completion_dropped",
+                    request_id = %hex::encode(request_id),
+                    "v2 ACK withheld: typed-route handler dropped the completion channel"
+                );
+                Err("typed_completion_dropped")
+            }
+            Err(_) => {
+                tracing::warn!(
+                    target: "dm.trace",
+                    stage = "inbound_durable_typed_completion_timeout",
+                    request_id = %hex::encode(request_id),
+                    timeout_secs = DURABLE_TYPED_COMPLETION_TIMEOUT.as_secs(),
+                    "v2 ACK withheld: typed-route handler did not report completion in budget"
+                );
+                Err("typed_completion_timeout")
+            }
+        }
+    }
+
     async fn route_typed_payload(
         &self,
         sender_agent_id: AgentId,
         sender_machine_id: MachineId,
+        request_id: [u8; 16],
         payload: Vec<u8>,
         trust_decision: Option<TrustDecision>,
     ) -> bool {
@@ -1208,6 +1432,10 @@ impl InboxPipeline {
             verified: true,
             trust_decision,
             received_at_unix_ms: now_unix_ms(),
+            request_id,
+            // v1 payloads make no durability promise, so there is nothing for
+            // a handler to report; the ACK is level-2 enqueue either way.
+            completion: None,
         };
         // Best-effort, NON-BLOCKING hand-off. These typed routes (the
         // group-public-message and KvStore-delta gossip-DM fallbacks) are
@@ -1920,20 +2148,32 @@ mod tests {
         );
     }
 
-    /// ADR 0030 §7: typed routes are documented as carrying their own
-    /// restart-spanning dedupe obligation, and do not earn a v2 ACK in this
-    /// slice. Locking that in so slice 3 has to change this test deliberately.
-    #[tokio::test]
-    async fn durable_typed_route_withholds_ack_pending_handler_completion() {
+    /// Drive one v2 typed payload through the durable path with `route`
+    /// installed, returning the decision. `respond` receives the payload the
+    /// handler would see and decides what (if anything) to report back.
+    async fn durable_typed_decision<F>(
+        request_byte: u8,
+        durable_completion: bool,
+        respond: F,
+    ) -> DurableAckDecision
+    where
+        F: FnOnce(DmTypedPayload) + Send + 'static,
+    {
         let sender = test_keypair();
         let machine = MachineId([0xD8; 32]);
         let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
         let _service = attach_history(&mut harness);
-        let (tx, _rx) = mpsc::channel::<DmTypedPayload>(8);
+        let (tx, mut rx) = mpsc::channel::<DmTypedPayload>(8);
         harness.pipeline.typed_payload_routes = vec![DmTypedPayloadRoute {
+            durable_completion,
             prefix: b"X0X-KV-DELTA-V1\n".to_vec(),
             sender: tx,
         }];
+        let handler = tokio::spawn(async move {
+            if let Some(typed) = rx.recv().await {
+                respond(typed);
+            }
+        });
 
         let mut payload = b"X0X-KV-DELTA-V1\n".to_vec();
         payload.extend_from_slice(b"{\"k\":1}");
@@ -1941,7 +2181,7 @@ mod tests {
             &harness,
             &sender,
             machine,
-            0x58,
+            request_byte,
             DM_PROTOCOL_DURABLE_ACK,
             payload.clone(),
         );
@@ -1958,8 +2198,80 @@ mod tests {
                 false,
             )
             .await;
+        handler.abort();
+        decision
+    }
 
-        assert_eq!(decision, DurableAckDecision::Withheld("typed_route"));
+    /// ADR 0030 §7 obligation upgrade — this is the slice-2 lock, deliberately
+    /// changed. Slice 2 withheld every v2 ACK on a typed route; slice 3 lets a
+    /// handler earn one by reporting that the payload is durably recorded on
+    /// its own surface. `Inserted` and `Duplicate` are the only signals that
+    /// release the ACK, mirroring the history store's proof that exactly one
+    /// durable record exists.
+    #[tokio::test]
+    async fn durable_typed_route_acks_on_handler_completion() {
+        for completion in [
+            DmTypedPayloadCompletion::Inserted,
+            DmTypedPayloadCompletion::Duplicate,
+        ] {
+            let decision = durable_typed_decision(0x58, true, move |typed| {
+                assert_eq!(
+                    typed.request_id, [0x58; 16],
+                    "handler must receive the logical request id it dedupes on"
+                );
+                if let Some(tx) = typed.completion {
+                    let _ = tx.send(Ok(completion));
+                }
+            })
+            .await;
+            assert_eq!(
+                decision,
+                DurableAckDecision::Acked {
+                    protocol_version: DM_PROTOCOL_DURABLE_ACK,
+                    accepted: true,
+                },
+                "{completion:?} must release the durable ACK"
+            );
+        }
+    }
+
+    /// A route that has not opted in still gets no v2 ACK. This daemon will
+    /// not certify durability for a handler that never promised it — stated
+    /// policy, which is why it has its own distinct stage.
+    #[tokio::test]
+    async fn durable_typed_route_without_opt_in_is_withheld_by_policy() {
+        let decision = durable_typed_decision(0x59, false, |_typed| {}).await;
+        assert_eq!(
+            decision,
+            DurableAckDecision::Withheld("typed_route_not_durable")
+        );
+    }
+
+    /// Every way a handler can fail to confirm withholds the ACK. Each of
+    /// these would otherwise hand the sender a durable receipt for a payload
+    /// that was never durably recorded.
+    #[tokio::test]
+    async fn durable_typed_route_withholds_on_every_non_completion() {
+        // Handler reports failure.
+        assert_eq!(
+            durable_typed_decision(0x5A, true, |typed| {
+                if let Some(tx) = typed.completion {
+                    let _ = tx.send(Err("store write failed".to_string()));
+                }
+            })
+            .await,
+            DurableAckDecision::Withheld("typed_handler_failed")
+        );
+
+        // Handler drops the completion sender — the "forgot to answer" case,
+        // including any early return on the handler's own error path.
+        assert_eq!(
+            durable_typed_decision(0x5B, true, |typed| {
+                drop(typed.completion);
+            })
+            .await,
+            DurableAckDecision::Withheld("typed_completion_dropped")
+        );
     }
 
     #[test]
@@ -2816,6 +3128,7 @@ mod tests {
     fn typed_payload_route_matches_prefix() {
         let (tx, _rx) = tokio::sync::mpsc::channel::<DmTypedPayload>(1);
         let route = DmTypedPayloadRoute {
+            durable_completion: false,
             prefix: b"x0x-exec-v1\0".to_vec(),
             sender: tx,
         };
@@ -2827,6 +3140,7 @@ mod tests {
     fn typed_payload_route_no_match_for_different_prefix() {
         let (tx, _rx) = tokio::sync::mpsc::channel::<DmTypedPayload>(1);
         let route = DmTypedPayloadRoute {
+            durable_completion: false,
             prefix: b"x0x-exec-v1\0".to_vec(),
             sender: tx,
         };

--- a/src/exec/service.rs
+++ b/src/exec/service.rs
@@ -2437,6 +2437,8 @@ mod tests {
             verified,
             trust_decision,
             received_at_unix_ms: 1,
+            request_id: [0u8; 16],
+            completion: None,
         }
     }
 

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -157,6 +157,7 @@ impl Store {
             return Err(HistoryError::Locked(format!("{} ({e})", path.display())));
         }
         migrate(&conn)?;
+        ensure_indexes(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -630,6 +631,37 @@ fn insert_row(tx: &rusqlite::Transaction<'_>, record: &HistoryRecord) -> History
     Ok(())
 }
 
+/// Indexes that are pure query accelerators, created idempotently at every
+/// open rather than inside the versioned migration chain.
+///
+/// This is a deliberate departure from the migration convention, and the
+/// reason is rollback safety. An index changes no column, no row meaning, and
+/// no data: an older binary opening this database reads and writes it exactly
+/// as before, and SQLite maintains the index for those writes transparently.
+/// Adding one via a v4→v5 migration would instead bump `SCHEMA_VERSION`, and
+/// `migrate` rejects any database newer than the running binary — so a
+/// rollback from this release to v0.37.4 would leave every upgraded user with
+/// a `history.db` that refuses to open. Paying that for a performance-only
+/// change is the wrong trade. Schema changes that alter the data model still
+/// go through the versioned chain.
+///
+/// `idx_logical_request` backs `find_by_logical_request`, the ADR 0030 §1
+/// receiver durable-history lookup, which runs on every inbound v2 DM.
+/// Partial (`WHERE logical_request_id IS NOT NULL`) because only rows written
+/// by the receiver durable path populate the v4 columns — group rows and every
+/// row predating schema v4 carry NULL, and indexing those wastes space for a
+/// lookup that can never match them. Mirrors the existing `idx_replace`
+/// partial-index precedent.
+fn ensure_indexes(conn: &Connection) -> HistoryResult<()> {
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_logical_request \
+         ON history(ingress_sender_agent, logical_request_id) \
+         WHERE logical_request_id IS NOT NULL;",
+    )
+    .map_err(|e| HistoryError::Database(format!("index setup failed: {e}")))?;
+    Ok(())
+}
+
 /// Forward-only schema migration.
 fn migrate(conn: &Connection) -> HistoryResult<()> {
     conn.execute_batch("CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)")?;
@@ -923,6 +955,72 @@ mod tests {
         guard
             .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
             .unwrap()
+    }
+
+    /// The ADR 0030 §1 durable-history lookup runs on every inbound v2 DM, so
+    /// it must not degrade into a table scan as history grows. Asserting on
+    /// the query plan rather than on the index merely existing: an index that
+    /// SQLite declines to use (wrong column order, predicate mismatch) is
+    /// indistinguishable from no index at runtime, and that is the regression
+    /// worth catching.
+    #[test]
+    fn find_by_logical_request_uses_its_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&dir.path().join("history.db")).unwrap();
+        let guard = lock_conn(&store.conn).unwrap();
+        let plan: String = guard
+            .query_row(
+                "EXPLAIN QUERY PLAN SELECT id FROM history \
+                 WHERE ingress_sender_agent = ?1 AND logical_request_id = ?2 \
+                 ORDER BY id ASC",
+                rusqlite::params!["aa", vec![0x11_u8; 16]],
+                |row| row.get(3),
+            )
+            .unwrap();
+        assert!(
+            plan.contains("idx_logical_request"),
+            "durable-history lookup must use idx_logical_request, got plan: {plan}"
+        );
+        assert!(
+            !plan.contains("SCAN history"),
+            "durable-history lookup must not table-scan, got plan: {plan}"
+        );
+    }
+
+    /// The accelerator index is created outside the versioned migration chain,
+    /// so it must reach databases that were already stamped v4 by an earlier
+    /// release — those never re-run any migration step.
+    #[test]
+    fn existing_v4_database_gains_the_index_on_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.db");
+        {
+            let store = Store::open(&path).unwrap();
+            assert_eq!(stored_schema_version(&store), 4);
+        }
+        // Drop the index to simulate a database migrated to v4 before this
+        // release, then confirm reopening restores it without a version bump.
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch("DROP INDEX IF EXISTS idx_logical_request;")
+                .unwrap();
+        }
+        let store = Store::open(&path).unwrap();
+        assert_eq!(
+            stored_schema_version(&store),
+            4,
+            "adding an accelerator index must not bump the schema version, \
+             which would make the db unopenable by the previous release"
+        );
+        let guard = lock_conn(&store.conn).unwrap();
+        let count: i64 = guard
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='idx_logical_request'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "reopening a v4 database must restore the index");
     }
 
     /// ADR 0030 schema continuity: v4 must land on top of a *released* v2

--- a/src/server/routes/named_groups/tests/pr291_restart_marker_matrix.rs
+++ b/src/server/routes/named_groups/tests/pr291_restart_marker_matrix.rs
@@ -1659,6 +1659,8 @@ async fn pr291_expired_reoffer_exact_envelope_does_not_refresh_clock() {
         verified: true,
         trust_decision: None,
         received_at_unix_ms: unix_ms(),
+        request_id: [0u8; 16],
+        completion: None,
     };
     handle_predecessor_relay_typed_payload(&state, &lh, dm).await;
 
@@ -1735,6 +1737,8 @@ async fn offer_via_handler(
         verified: true,
         trust_decision: None,
         received_at_unix_ms,
+        request_id: [0u8; 16],
+        completion: None,
     };
     handle_predecessor_relay_typed_payload(state, local_hex, dm).await;
 }


### PR DESCRIPTION
ADR 0030 slice 3, **part 1 of 2**. Everything the outbox depends on, plus the carried tidies. The outbox module itself is deliberately **not** in this PR — see "Why this is split" below.

Do not merge; cross-review as usual.

## What's here

### 1. Typed-route completion signal (ADR 0030 §7) — the obligation upgrade
Slice 2 withheld every v2 ACK on a typed route, because typed-prefix families classify `Ephemeral` and no DM-history commit could honestly back their receipt. This replaces the blanket refusal with a completion contract:

```rust
pub enum DmTypedPayloadCompletion { Inserted, Duplicate }
pub type DmTypedPayloadCompletionResult = Result<DmTypedPayloadCompletion, String>;
```

`DmTypedPayload` gains `request_id` (so handlers dedupe on `(sender, request_id)` across restart) and a `completion` oneshot the inbox awaits. For a durable typed payload this replaces steps 3–5 of the receiver ordering — `Inserted | Duplicate` is the same "exactly one durable record" proof `record_committed` gives the generic path.

**`DmTypedPayload` loses `Clone`**, since a oneshot sender has no meaningful copy and cloning would silently strand one caller's receipt. Audited: nothing cloned the payload; four construction sites updated.

**Per-route policy, stated (not accidental):** routes opt in via `with_durable_typed_payload_route`. A route that has not opted in still gets no v2 ACK, under its own distinct trace stage — this daemon will not certify durability for a handler that never promised it. Optimistically resolving before the store commit would convert a durable receipt into a lie; the honest failure is to drop the sender.

**All four non-completions withhold:** channel unavailable, handler error, dropped sender (so an early return on a handler's own error path fails safe), timeout.

**Deliberate deviation from the campaign draft.** It awaited completion for the envelope's remaining lifetime — up to 120 s — inline on the serial inbox loop, while the sender's per-attempt budget is 30 s (`DM_TIMEOUT_MAX_MS`). That lets one slow handler pin the entire DM pipeline for an ACK nobody is still waiting on. Bounded here at **20 s**: a receiver-side liveness bound, not a correctness one — a timeout withholds and the sender retries.

The slice-2 lock `durable_typed_route_withholds_ack_pending_handler_completion` is replaced, which is exactly what it existed for.

### 2. `find_by_logical_request` index (reviewer non-blocking from #328)
Partial index on `(ingress_sender_agent, logical_request_id) WHERE logical_request_id IS NOT NULL` — only rows written by the receiver durable path populate the v4 columns, so indexing group rows and every pre-v4 row would cost space for entries the lookup can never match. Mirrors the existing `idx_replace` precedent.

**Created idempotently at open, not as a v4→v5 migration.** An index changes no column and no row meaning, so an older binary reads and writes the database unchanged. A version bump would instead make `migrate()` reject the db as "newer than this binary" — so a rollback to v0.37.4 would leave every upgraded user with a `history.db` that refuses to open. Wrong price for a performance-only change; data-model changes still go through the versioned chain.

Tests assert the **query plan** uses the index (an index SQLite declines to use is indistinguishable from none at runtime) and that a db already stamped v4 gains it on open without a version bump.

### 3. Restart re-dispatch documented (ADR-allowed, previously unstated)
Verified against the code first: `Missing` and `Exact` share a fall-through, so an `Exact` hit after restart re-dispatches, re-commits to `Duplicate`, and re-ACKs v2. Documented why that's correct — skipping dispatch on `Exact` would silently drop any message whose crash landed between the commit and the application finishing with it, the exact window this protocol closes. Guarantee stated as **exactly one history row, at least one dispatch**.

### 4. `gossip_plane_isolation` flake — the briefed fix would have been a no-op
`binary(gossip_plane_isolation)` was **already** in the `quic-localhost` group; adding it again would have changed nothing while carrying a fix-shaped commit message. The real gap is that its override sets `test-group` but not `threads-required` — the issue-#316 signature already documented in that file: a group bounds contention *within* the group, but the trigger is ambient load from the ~2600 ungrouped tests starving the dial's timing window. Our failure matched exactly: dead at the first `connect_addr` in 2.4 s against a ~12.4 s normal runtime, 4/4 green isolated.

Nextest applies the **first** matching override (confirmed against the nextest docs), so appending the setting to the existing later block would have silently done nothing — the same failure mode one layer down. A narrower binary-only override placed ahead of it fixes the flake without changing the three slice-1 tests that share the broader block. `nextest show-config test-groups` confirms the binding.

### 5. Raw NUL bytes escaped, with a tripwire — **scope corrected from my earlier report**
`src/dm_inbox.rs` carried four raw NUL bytes where `\x00` escapes were meant.

**Correction, stated plainly:** I earlier reported this as the Panic Scanner "failing open". **That was wrong.** My shell's `grep` is a Claude Code wrapper around `ugrep` that always passes `-I`; the scanner runs under bash with `/usr/bin/grep`, which sees all 61 matches in that file — GNU/BSD grep classify from an early read buffer and these NULs sat at byte ~114788 of 117295. The gate was never blind, and no past approval needs recalibrating on that basis.

What was real: **rg/ugrep-based code search over that file returned silent false negatives**, which is how it was found. Developer-tooling correctness, not CI integrity.

The tripwire now tests for **raw NUL bytes directly** rather than "some grep thinks this is binary" — deterministic across tools and NUL positions, and it would have caught the original. Verified by injecting a NUL (gate fails) and restoring (gate clears). `-a` stays on the scan as defence in depth, since a NUL landing early genuinely would trip real grep.

## Why this is split

The outbox depends on the completion signal — on main, `handle_payload_durable` returned before dispatch for typed routes, so a strict v2 bootstrap DM never reached the handler at all; an outbox without the signal livelocks at 60 s backoff until cap eviction. So the signal had to land first regardless.

The outbox port itself is ~430 lines of function bodies plus adaptation across 4 files, and the adaptation is the hard part rather than the copying: the campaign version calls `send_direct_with_config_and_thread(..., Option<DmThreadMeta>, Option<DmLogicalId>)` and a `DmLogicalId` type, **neither of which exists on main**, so it needs a new logical-id-carrying send entry point designed alongside it. Combined with fail-closed sidecar startup semantics (a malformed outbox file aborts daemon startup) and a hard size guardrail on `named_groups.rs`, that is work I would rather land as its own reviewable change than rush onto the end of this one. A half-ported outbox that aborts startup is worse than no outbox.

Everything in this PR is complete, tested, and independently useful; nothing here is a partial step that only makes sense once the outbox lands.

## Gates (real exit codes)

| Gate | Exit |
|---|---|
| `cargo fmt --all -- --check` | **0** |
| `cargo clippy --workspace --all-features --all-targets -- -D warnings` | **0** |
| `cargo nextest run --workspace --all-features --no-fail-fast` | **0** — 2634 passed, 260 skipped, 0 failed |
| `scripts/check-panics.sh` | **0** |

No flakes on the full run, including `gossip_plane_isolation` under its new reservation. No production `.unwrap()`/`.expect()`/`panic!()` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces handler-backed completion for durable typed DMs, adds the logical-request history index, strengthens the raw-NUL source gate, and adjusts nextest resource reservations.

- Adds request IDs and one-shot durable completion to typed payload delivery.
- Adds an idempotently created partial SQLite index for durable-request lookup.
- Documents restart redispatch semantics and updates associated tests.
- Reserves scheduler slots for `gossip_plane_isolation` and checks Rust sources for raw NUL bytes.

<h3>Confidence Score: 4/5</h3>

The durable typed-route API needs correction before merging because valid history-disabled configurations withhold every v2 request before dispatching it.

The new handler-owned durability path is placed after an unconditional generic-history availability check, making the advertised replacement path unusable for library embedders that retain the documented history-disabled default.

**Files Needing Attention:** src/dm_inbox.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/dm_inbox.rs | Adds the typed-handler completion protocol, but an early generic-history gate prevents durable typed routes from operating when history is disabled. |
| src/history/store.rs | Adds an idempotent partial index after migration; supported schema states contain the indexed columns and exclusive-open behavior remains intact. |
| scripts/check-panics.sh | Adds deterministic raw-NUL detection and forces grep to scan binary-classified inputs as text. |
| .config/nextest.toml | Adds a first-match binary-specific scheduler reservation while preserving the broader serialization override. |
| docs/design/dm-over-gossip.md | Documents typed-route completion and restart redispatch semantics consistently with the new flow, aside from the implementation's residual history dependency. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  V2[v2 typed DM] --> H{History enabled?}
  H -- No --> W[Withhold without dispatch]
  H -- Yes --> R{Durable typed route?}
  R -- No --> G[Generic history path]
  R -- Yes --> D[Dispatch to typed handler]
  D --> C{Completion}
  C -- Inserted or Duplicate --> A[Cache completion and ACK]
  C -- Error, drop, or timeout --> X[Withhold and retry]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/dm_inbox.rs`, line 1020-1029 ([link](https://github.com/saorsa-labs/x0x/blob/77e6f0c41d5bca3cb25f99b60d31ecae4dc1bb2b/src/dm_inbox.rs#L1020-L1029)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **History gate blocks typed durability**

   When a v2 payload matches a durable typed route while DM history is disabled, this early return withholds the request before route classification or handler dispatch, causing every attempt to retry or fail even though the handler’s own store is the durable surface.

   **Knowledge Base Used:**
   - [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)
   - [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/dm_inbox.rs
   Line: 1020-1029
   
   Comment:
   **History gate blocks typed durability**
   
   When a v2 payload matches a durable typed route while DM history is disabled, this early return withholds the request before route classification or handler dispatch, causing every attempt to retry or fail even though the handler’s own store is the durable surface.
   
   **Knowledge Base Used:**
   - [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)
   - [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/dm_inbox.rs:1020-1029
**History gate blocks typed durability**

When a v2 payload matches a durable typed route while DM history is disabled, this early return withholds the request before route classification or handler dispatch, causing every attempt to retry or fail even though the handler’s own store is the durable surface.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(dm): record the typed-route complet..."](https://github.com/saorsa-labs/x0x/commit/77e6f0c41d5bca3cb25f99b60d31ecae4dc1bb2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53614179)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)
- Knowledge Base — [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)
- Knowledge Base — [Required Test Gates: Observation Completeness](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/test-gate-policy.md)
</details>


<!-- /greptile_comment -->