### PR TITLE
feat(dm): DA slice 4 — product durable-by-default + logical_id + idempotency_conflict (ADR 0030 §4/§6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ All notable changes to this project will be documented in this file.
 - **`idempotency_conflict`** (`DmError::IdempotencyConflict`,
   `DmAckOutcome::IdempotencyConflict`, REST **409 `idempotency_conflict`**).
   Reusing a `logical_id` for different bytes is now its own typed error.
+- **Hedged, bounded durable-ACK publication.** A v2 ACK is now published from a
+  background worker (queue 256, ≤32 in flight) that polls the recipient's
+  targeted inbox topic and the compatibility bus concurrently, each under a
+  22 s deadline, instead of awaiting both inline on the inbox loop. A targeted
+  publish can deliver remotely yet stay pending under per-topic backpressure,
+  which previously let a receiver commit and dispatch a DM while the sender
+  burned its entire ACK budget waiting on the reverse route. Commit-before-ACK
+  ordering is unchanged — only the publication is asynchronous. Durable-by-
+  default sends make this liveness path load-bearing, which is why it lands
+  with them. **v1 ACK publication is byte-for-byte unchanged**: still inline,
+  still targeted-only unless the payload arrived on the bus.
+- **`ack_publish_route_failed` on `GET /diagnostics/dm`.** The externally
+  visible signal that a committed message's ACK never reached its sender —
+  either a route failed or timed out, or the publisher queue was saturated.
+  Those senders see `504 timeout` and retry; nothing is silently lost.
 
 - **Durable signed-public bootstrap outbox (ADR 0030 §5, slice 3b).** Adding a
   member to a SignedPublic group used to direct-send the roster snapshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,35 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+> The ADR 0030 durable-application-ACK campaign completes in this release
+> (slices 1–4). The headline behaviour change for anyone building on x0x is in
+> **Changed** below: `POST /direct/send` is now durable-by-default, so a `200`
+> means the recipient committed the message, and a peer that has not upgraded
+> answers `409` instead of accepting silently.
+
 ### Added
+
+- **Product send tiers (ADR 0030 §4, slice 4).** The two send tiers named by
+  the ADR are now real. The *product* tier — `POST /direct/send` and
+  `x0x direct send` — requires ADR 0030 durable application-ACK semantics by
+  default. The *internal* tier — the WebSocket `send_direct` frame, the library
+  `Agent::send_direct*` default config, and daemon control-plane sends (welcome
+  blobs, TreeKEM plumbing, group metadata) — keeps v1 semantics; those messages
+  deliberately race connection establishment and livelock under strict gating.
+  `api-reference.md` marks the WebSocket surface internal.
+- **`logical_id` on `POST /direct/send` and `x0x direct send --logical-id`.**
+  A caller-supplied idempotency key (1–128 chars of `[a-z0-9._:-]`) giving
+  product callers the same at-least-once retry identity the bootstrap outbox
+  uses internally. Resending the same token to the same recipient — across a
+  timeout, a reconnect, or a restart — is one logical request: the recipient
+  re-ACKs the original commit rather than storing a duplicate. The wire request
+  id is `blake3::derive_key("x0x dm logical request id v1", sender ‖ recipient
+  ‖ token)[..16]`; the token itself never goes on the wire, and binding both
+  agent ids keeps one token fanned out to two peers from colliding on the
+  sender's ACK waiter.
+- **`idempotency_conflict`** (`DmError::IdempotencyConflict`,
+  `DmAckOutcome::IdempotencyConflict`, REST **409 `idempotency_conflict`**).
+  Reusing a `logical_id` for different bytes is now its own typed error.
 
 - **Durable signed-public bootstrap outbox (ADR 0030 §5, slice 3b).** Adding a
   member to a SignedPublic group used to direct-send the roster snapshot
@@ -83,6 +111,60 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **BREAKING — `POST /direct/send` and `x0x direct send` are durable by
+  default (ADR 0030 §4, slice 4).** A `200` now means the recipient daemon
+  durably committed the message to its ADR-0023 history store and completed
+  local dispatch, not merely that it accepted the envelope. Pass
+  `require_durable_app_ack: false` (CLI: `--no-durable-ack`) for the previous
+  v1 semantics.
+
+  **What breaks:** a send to a peer running 0.37.x, or to any peer without
+  durable history enabled, now answers **409
+  `recipient_ack_semantics_unavailable`** where it previously returned `200`.
+  This is deliberate — ADR 0030 §2 forbids a silent downgrade, because a `200`
+  that sometimes means "committed" and sometimes means "enqueued" is the
+  ambiguity the whole protocol exists to remove. Handle the 409 as a
+  first-class UX state ("peer needs upgrade"), or opt out per message. The
+  refusal is fast and deterministic (one forced capability refresh), never a
+  timeout.
+
+  Durable sends also never take the raw-QUIC fast path, since a transport
+  receipt cannot certify a durable commit; `prefer_raw_quic_if_connected` is
+  ignored unless you also opt out of durable semantics.
+- **BREAKING — `require_gossip_ack` is rejected with 400 on `POST
+  /direct/send`** (ADR 0030 §4). Deprecated in the previous release, the field
+  now answers **400 `require_gossip_ack_removed`** when set in any form; an
+  explicit `null`, like omission, is still accepted. Accepting it as a silent
+  no-op was rejected in review: a client passing `require_gossip_ack: false`
+  for fire-and-forget would otherwise get a blocking durable send with no
+  signal that its request had been reinterpreted. Use
+  `require_durable_app_ack` to choose receipt semantics. Internal library
+  callers are unaffected — `DmSendConfig::require_gossip_ack` is unchanged.
+- **The strict-send gate no longer reports a stranger as a peer needing an
+  upgrade.** `AckSemanticsUnavailable` means "this peer does not advertise
+  v2", which presupposes we know the peer; an agent id with no capability
+  advert *and* no contact card now yields `RecipientKeyUnavailable` (404) as
+  it always did for non-strict sends. Without this, flipping the product
+  default would have turned every send to an undiscovered agent into a 409
+  telling the UI to chase a fleet upgrade for a peer that was never found.
+- **A rebound logical request now reports `idempotency_conflict`, not
+  `recipient_ack_semantics_unavailable`.** Both receiver-side binding-conflict
+  paths (the in-memory replay cache and the restart-spanning durable-history
+  lookup) previously reused the semantics-unavailable outcome, which told a
+  product "the peer needs upgrading" when the truth was "your client reused an
+  idempotency key". The two errors prescribe opposite repairs — retry-later
+  versus never-retry-these-bytes. `AckSemanticsUnavailable` now carries only
+  its semantics-unavailable meaning.
+- **A v2 replay is no longer re-ACKed before its binding is checked.** The
+  inbox fast path re-ACKed any envelope whose logical request was already in
+  the replay cache, which for a durable envelope meant answering `Accepted`
+  without comparing the payload against the committed binding — so a caller
+  that reused a `logical_id` for different bytes was told the new bytes were
+  stored when they were not. Durable envelopes replaying a completed request
+  now fall through to the durable path, which owns the full ADR 0030 §1 replay
+  decision. This was unreachable before slice 4 (only the bootstrap outbox set
+  a logical request id, and it derives one per payload digest); exposing
+  `logical_id` to callers is what makes it reachable.
 - **The v2 capability advert is now live and conditional (ADR 0030 §3).**
   `start_dm_inbox` advertises `max_protocol_version = 2` **iff** a durable
   history handle is present, else 1. The slice-1 hold is lifted because the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,96 +33,11 @@ All notable changes to this project will be documented in this file.
 - **`idempotency_conflict`** (`DmError::IdempotencyConflict`,
   `DmAckOutcome::IdempotencyConflict`, REST **409 `idempotency_conflict`**).
   Reusing a `logical_id` for different bytes is now its own typed error.
-- **Hedged, bounded durable-ACK publication.** A v2 ACK is now published from a
-  background worker (queue 256, ≤32 in flight) that polls the recipient's
-  targeted inbox topic and the compatibility bus concurrently, each under a
-  22 s deadline, instead of awaiting both inline on the inbox loop. A targeted
-  publish can deliver remotely yet stay pending under per-topic backpressure,
-  which previously let a receiver commit and dispatch a DM while the sender
-  burned its entire ACK budget waiting on the reverse route. Commit-before-ACK
-  ordering is unchanged — only the publication is asynchronous. Durable-by-
-  default sends make this liveness path load-bearing, which is why it lands
-  with them. **v1 ACK publication is byte-for-byte unchanged**: still inline,
-  still targeted-only unless the payload arrived on the bus.
-- **`ack_publish_route_failed` on `GET /diagnostics/dm`.** The externally
-  visible signal that a committed message's ACK never reached its sender —
-  either a route failed or timed out, or the publisher queue was saturated.
-  Those senders see `504 timeout` and retry; nothing is silently lost.
-
-- **Durable signed-public bootstrap outbox (ADR 0030 §5, slice 3b).** Adding a
-  member to a SignedPublic group used to direct-send the roster snapshot
-  fire-and-forget: an offline recipient never received it and nothing on the
-  authority remembered the debt. The send is now a durable obligation, in its
-  own module (`src/server/routes/public_group_bootstrap_outbox.rs`). It is
-  written in the same step as the roster commit, keyed by
-  `(recipient, group, frontier, payload-digest)` as one blake3 binding digest,
-  capped at 1024 entries, retried on `1s << min(attempts, 6)` clamped to 60 s,
-  and persisted to `public_group_bootstrap_outbox.json` in the data directory.
-  That sidecar is loaded **fail-closed**: an unsupported version, an over-cap
-  file, a duplicate key, or a payload that contradicts the frontier it claims
-  aborts daemon startup rather than silently dropping a promised delivery. An
-  obligation is discharged **only** by a v2 application ACK for that exact
-  frontier — released by the recipient's durable typed route after the consent
-  gate and a directory-durable install. A legacy v1 send and a failed send both
-  reschedule; neither is completion.
-- **`DmSendConfig::logical_request_id`.** An optional caller-supplied stable DM
-  request id; `None` (the default, and every existing caller) still draws a
-  fresh random one. The bootstrap outbox sets it to the head of its obligation's
-  binding digest, so obligation key and wire request id are one identity: a
-  retry after a sender restart is the *same* logical request, which is what lets
-  the recipient re-ACK instead of re-delivering and lets an ACK be matched back
-  to the obligation it discharges.
-- **Typed-route durable completion signal (ADR 0030 §7, slice 3).** Slice 2
-  withheld every v2 ACK on a typed route because typed-prefix families
-  classify `Ephemeral` and cannot be backed by a DM-history commit. A handler
-  can now report `DmTypedPayloadCompletion::{Inserted, Duplicate}` on a
-  oneshot carried in `DmTypedPayload`, and that signal releases the ACK.
-  `DmTypedPayload` also carries the envelope `request_id` so handlers can
-  dedupe on `(sender, request_id)` across restart, and is no longer `Clone`
-  (a oneshot sender has no meaningful copy). Routes opt in via
-  `DmInboxConfig::with_durable_typed_payload_route`; routes that do not opt in
-  still get no v2 ACK, by stated policy. Every non-completion — channel
-  unavailable, handler error, dropped sender, timeout — withholds the ACK.
-- **`Store::find_by_logical_request` is now indexed.** Partial index on
-  `(ingress_sender_agent, logical_request_id)` for rows where
-  `logical_request_id IS NOT NULL`, created idempotently at open rather than
-  via a schema-version bump, so a rollback to v0.37.4 can still open the
-  database.
-
-- **DM protocol v2 receiver durable path (ADR 0030 §1, slice 2 of 4).** A v2
-  envelope is answered in exactly this order: per-logical-request lock →
-  replay-cache binding check → durable-history lookup → dispatch →
-  `record_committed` awaited → ACK. A v2 ACK is emitted **only** after the
-  SQLite commit returns `Inserted | Duplicate`; every failure below that —
-  commit error, backpressured writer, unavailable history, lost delivery
-  lock, unpublishable replay completion — withholds the ACK rather than
-  degrading it. `Accepted` under v2 now means what ADR 0030 §1 says it
-  means: verified, durably committed, and dispatched.
-- **`DmAckOutcome::AckSemanticsUnavailable { reason }`** (ADR 0030 §2). The
-  receiver's answer when it cannot issue the durable receipt a request asked
-  for — the logical request already completed under weaker semantics, or is
-  already bound to different content. It maps to
-  `DmError::AckSemanticsUnavailable`, the same typed error the send-side
-  capability gate raises, rather than `RecipientRejected`: nothing about the
-  trust relationship failed, so callers surface "retry / peer needs upgrade",
-  not "peer blocked you". Appended last in the enum, so postcard variant
-  indices for `Accepted` and `RejectedByPolicy` are unchanged and 0.37 peers
-  keep decoding them; a v1-only sender can never be sent the new variant,
-  because it never asks for semantics above v1.
-- **History schema v4 columns gain writers.** Inbound DM rows populate
-  `ingress_sender_agent` and `logical_request_id`; together they key the
-  durable-history lookup that lets a restarted receiver recognise a logical
-  request it already committed, via the new
-  `Store::find_by_logical_request`.
-- **`HistoryHandle::record_committed`.** A commit-receipt write for protocol
-  surfaces whose success promises durable history. Unlike the fire-and-forget
-  `record`, it never sheds silently: a full or closed writer queue returns
-  `HistoryError::WriterBackpressured` / `WriterClosed` to the caller.
-- **DM protocol v2 capability advertisement + strict-send gate (ADR 0030,
-  slice 1 of 4).** `DM_PROTOCOL_VERSION` becomes the receive **ceiling** 2:
-  envelopes above it are dropped without an ACK. Agent cards export the same
-  runtime value, and card imports go through `CapabilityStore::insert_from_card`
-  so a stale card can never lower a live signed advert.
+- **400 `logical_id_requires_durable_ack`.** `logical_id` is only honoured by
+  the durable receiver path, so sending it with `require_durable_app_ack:
+  false` is refused rather than silently ignored — otherwise the caller holds
+  an at-least-once retry identity nothing enforces and finds out only when
+  duplicates appear. `x0x direct send` rejects the same pair at the CLI.
 
 ### Changed
 
@@ -157,11 +72,14 @@ All notable changes to this project will be documented in this file.
   callers are unaffected — `DmSendConfig::require_gossip_ack` is unchanged.
 - **The strict-send gate no longer reports a stranger as a peer needing an
   upgrade.** `AckSemanticsUnavailable` means "this peer does not advertise
-  v2", which presupposes we know the peer; an agent id with no capability
-  advert *and* no contact card now yields `RecipientKeyUnavailable` (404) as
-  it always did for non-strict sends. Without this, flipping the product
-  default would have turned every send to an undiscovered agent into a 409
-  telling the UI to chase a fleet upgrade for a peer that was never found.
+  v2", which presupposes we know the peer; an agent id with **no capability
+  advert and no contact card of any kind** now yields `RecipientKeyUnavailable`
+  (404) as it always did for non-strict sends. Without this, flipping the
+  product default would have turned every send to an undiscovered agent into a
+  409 telling the UI to chase a fleet upgrade for a peer that was never found.
+  The boundary is "do we know this agent", not "has its advert converged" — a
+  contact card whose `dm_capabilities` have not arrived yet is a known peer and
+  still gets the 409.
 - **A rebound logical request now reports `idempotency_conflict`, not
   `recipient_ack_semantics_unavailable`.** Both receiver-side binding-conflict
   paths (the in-memory replay cache and the restart-spanning durable-history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,80 @@ All notable changes to this project will be documented in this file.
   an at-least-once retry identity nothing enforces and finds out only when
   duplicates appear. `x0x direct send` rejects the same pair at the CLI.
 
+- **Durable signed-public bootstrap outbox (ADR 0030 §5, slice 3b).** Adding a
+  member to a SignedPublic group used to direct-send the roster snapshot
+  fire-and-forget: an offline recipient never received it and nothing on the
+  authority remembered the debt. The send is now a durable obligation, in its
+  own module (`src/server/routes/public_group_bootstrap_outbox.rs`). It is
+  written in the same step as the roster commit, keyed by
+  `(recipient, group, frontier, payload-digest)` as one blake3 binding digest,
+  capped at 1024 entries, retried on `1s << min(attempts, 6)` clamped to 60 s,
+  and persisted to `public_group_bootstrap_outbox.json` in the data directory.
+  That sidecar is loaded **fail-closed**: an unsupported version, an over-cap
+  file, a duplicate key, or a payload that contradicts the frontier it claims
+  aborts daemon startup rather than silently dropping a promised delivery. An
+  obligation is discharged **only** by a v2 application ACK for that exact
+  frontier — released by the recipient's durable typed route after the consent
+  gate and a directory-durable install. A legacy v1 send and a failed send both
+  reschedule; neither is completion.
+- **`DmSendConfig::logical_request_id`.** An optional caller-supplied stable DM
+  request id; `None` (the default, and every existing caller) still draws a
+  fresh random one. The bootstrap outbox sets it to the head of its obligation's
+  binding digest, so obligation key and wire request id are one identity: a
+  retry after a sender restart is the *same* logical request, which is what lets
+  the recipient re-ACK instead of re-delivering and lets an ACK be matched back
+  to the obligation it discharges.
+- **Typed-route durable completion signal (ADR 0030 §7, slice 3).** Slice 2
+  withheld every v2 ACK on a typed route because typed-prefix families
+  classify `Ephemeral` and cannot be backed by a DM-history commit. A handler
+  can now report `DmTypedPayloadCompletion::{Inserted, Duplicate}` on a
+  oneshot carried in `DmTypedPayload`, and that signal releases the ACK.
+  `DmTypedPayload` also carries the envelope `request_id` so handlers can
+  dedupe on `(sender, request_id)` across restart, and is no longer `Clone`
+  (a oneshot sender has no meaningful copy). Routes opt in via
+  `DmInboxConfig::with_durable_typed_payload_route`; routes that do not opt in
+  still get no v2 ACK, by stated policy. Every non-completion — channel
+  unavailable, handler error, dropped sender, timeout — withholds the ACK.
+- **`Store::find_by_logical_request` is now indexed.** Partial index on
+  `(ingress_sender_agent, logical_request_id)` for rows where
+  `logical_request_id IS NOT NULL`, created idempotently at open rather than
+  via a schema-version bump, so a rollback to v0.37.4 can still open the
+  database.
+
+- **DM protocol v2 receiver durable path (ADR 0030 §1, slice 2 of 4).** A v2
+  envelope is answered in exactly this order: per-logical-request lock →
+  replay-cache binding check → durable-history lookup → dispatch →
+  `record_committed` awaited → ACK. A v2 ACK is emitted **only** after the
+  SQLite commit returns `Inserted | Duplicate`; every failure below that —
+  commit error, backpressured writer, unavailable history, lost delivery
+  lock, unpublishable replay completion — withholds the ACK rather than
+  degrading it. `Accepted` under v2 now means what ADR 0030 §1 says it
+  means: verified, durably committed, and dispatched.
+- **`DmAckOutcome::AckSemanticsUnavailable { reason }`** (ADR 0030 §2). The
+  receiver's answer when it cannot issue the durable receipt a request asked
+  for — the logical request already completed under weaker semantics, or is
+  already bound to different content. It maps to
+  `DmError::AckSemanticsUnavailable`, the same typed error the send-side
+  capability gate raises, rather than `RecipientRejected`: nothing about the
+  trust relationship failed, so callers surface "retry / peer needs upgrade",
+  not "peer blocked you". Appended last in the enum, so postcard variant
+  indices for `Accepted` and `RejectedByPolicy` are unchanged and 0.37 peers
+  keep decoding them; a v1-only sender can never be sent the new variant,
+  because it never asks for semantics above v1.
+- **History schema v4 columns gain writers.** Inbound DM rows populate
+  `ingress_sender_agent` and `logical_request_id`; together they key the
+  durable-history lookup that lets a restarted receiver recognise a logical
+  request it already committed, via the new
+  `Store::find_by_logical_request`.
+- **`HistoryHandle::record_committed`.** A commit-receipt write for protocol
+  surfaces whose success promises durable history. Unlike the fire-and-forget
+  `record`, it never sheds silently: a full or closed writer queue returns
+  `HistoryError::WriterBackpressured` / `WriterClosed` to the caller.
+- **DM protocol v2 capability advertisement + strict-send gate (ADR 0030,
+  slice 1 of 4).** `DM_PROTOCOL_VERSION` becomes the receive **ceiling** 2:
+  envelopes above it are dropped without an ACK. Agent cards export the same
+  runtime value, and card imports go through `CapabilityStore::insert_from_card`
+  so a stale card can never lower a live signed advert.
 ### Changed
 
 - **BREAKING — `POST /direct/send` and `x0x direct send` are durable by
@@ -120,9 +194,13 @@ All notable changes to this project will be documented in this file.
 
 ### Notes
 
-- No send surface sets `require_durable_app_ack` yet: REST, CLI, WS and the
-  library default stay v1-defaulted, so these slices remain behaviour-neutral
-  for existing callers. Product defaults flip in ADR 0030 slice 4.
+- **Send surfaces are split into two tiers as of slice 4.** The product tier
+  (`POST /direct/send`, `x0x direct send`) defaults
+  `require_durable_app_ack = true`; the internal tier (WS `send_direct`, the
+  library default config, and daemon control-plane sends) stays v1-defaulted.
+  Existing callers of the internal tier are unaffected; product callers get
+  the stronger receipt and must handle the 409 for peers that cannot honour
+  it. See **Changed** above for the migration.
 - **v1 senders are unaffected.** A v1 envelope takes the unchanged legacy
   path and receives a v1 ACK even on a receiver with durable history enabled;
   enabling history never silently upgrades the receipt an 0.37 peer is handed.
@@ -131,16 +209,15 @@ All notable changes to this project will be documented in this file.
   without a receiver that can commit. This daemon cannot be that peer: it
   advertises v2 only when history is enabled, and withholds the ACK rather
   than downgrading if history becomes unavailable at runtime.
-- **Typed routes (ADR 0030 §7): the obligation is documented, not closed.**
-  Typed-prefix families (group ingest, KV deltas, exec audit, card import,
-  voice signalling) classify `Ephemeral` — their durable effect lives in
-  their own store, not in DM history — and are handed off with a
-  non-blocking `try_send` that may drop. A DM-history commit therefore
-  cannot honestly back their receipt, so a v2 envelope matching a typed
-  route gets **no** ACK in this slice, and each handler carries the
-  restart-spanning dedupe obligation via its own durable surface. The
-  typed-route completion signal that lets these frames earn a v2 ACK is
-  slice 3.
+- **Typed routes (ADR 0030 §7): the obligation is closed.** Typed-prefix
+  families (group ingest, KV deltas, exec audit, card import, voice
+  signalling) classify `Ephemeral` — their durable effect lives in their own
+  store, not in DM history — so a DM-history commit could never honestly back
+  their receipt. Rather than withholding every v2 ACK on these routes, the
+  handler now reports when the payload is durably recorded on *its* surface,
+  and that completion signal is what releases the ACK (see the typed-route
+  durable completion signal under **Added**). Dropping the completion, like
+  dropping the channel, still withholds the ACK.
 - Durable v2 is **at-least-once across restart**: the replay cache is
   memory-only, so a restart can re-dispatch an already-committed envelope.
   The durable-history lookup keeps it to exactly one history row, and

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -383,9 +383,20 @@ Two consequences worth planning for:
   `(sender, request_id)`.
 
 Optional field `logical_id` (string): a caller-supplied idempotency key for
-this logical send. 1–128 characters of `a`–`z`, `0`–`9`, `-`, `_`, `.`, or
-`:`; uppercase, whitespace, and non-ASCII are rejected rather than normalized,
-so two tokens that differ only in case stay two distinct requests.
+this logical send, **valid only on a durable send**. 1–128 characters of
+`a`–`z`, `0`–`9`, `-`, `_`, `.`, or `:`; uppercase, whitespace, and non-ASCII
+are rejected rather than normalized, so two tokens that differ only in case
+stay two distinct requests.
+
+The durable requirement is not a formality: everything below is a promise the
+*recipient's* durable path makes — its replay binding and its durable-history
+lookup are what recognise a retry. A v1 send would carry a derived id on the
+wire that no receiver consults, so the guarantee would not exist. Sending
+`logical_id` with `require_durable_app_ack: false` is therefore a **400
+`logical_id_requires_durable_ack`**, not a silent no-op: a caller who asked for
+retry identity and quietly got fire-and-forget would not find out until
+duplicates appeared. (`x0x direct send` rejects `--logical-id` with
+`--no-durable-ack` at the CLI, before the round trip.)
 
 Resending the same `logical_id` to the same recipient — after a timeout, a
 reconnect, or a full process restart — is *the same request*, not a second
@@ -398,13 +409,6 @@ The daemon derives the 128-bit wire request id as
 recipient_agent_id ‖ logical_id)` truncated to its leading 16 bytes. Both agent
 ids are mixed in, so the same token addressed to two different recipients
 yields two different requests. The token itself never goes on the wire.
-
-`logical_id` **requires durable delivery**. Only the durable receiver path
-consults it, so combining it with `require_durable_app_ack: false` is a **400
-`logical_id_requires_durable_ack`** rather than a silent no-op — otherwise a
-caller would be handed an at-least-once retry identity that nothing enforces,
-and would not discover it until duplicates appeared. (`x0x direct send` rejects
-`--logical-id` with `--no-durable-ack` at the CLI, before the round trip.)
 
 Reusing a `logical_id` for *different* payload bytes is a **409
 `idempotency_conflict`** — see below.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -399,6 +399,13 @@ recipient_agent_id ‖ logical_id)` truncated to its leading 16 bytes. Both agen
 ids are mixed in, so the same token addressed to two different recipients
 yields two different requests. The token itself never goes on the wire.
 
+`logical_id` **requires durable delivery**. Only the durable receiver path
+consults it, so combining it with `require_durable_app_ack: false` is a **400
+`logical_id_requires_durable_ack`** rather than a silent no-op — otherwise a
+caller would be handed an at-least-once retry identity that nothing enforces,
+and would not discover it until duplicates appeared. (`x0x direct send` rejects
+`--logical-id` with `--no-durable-ack` at the CLI, before the round trip.)
+
 Reusing a `logical_id` for *different* payload bytes is a **409
 `idempotency_conflict`** — see below.
 
@@ -421,9 +428,10 @@ Notable codes:
 |---|---|---|
 | 400 | `require_gossip_ack_removed` | The request set the removed `require_gossip_ack` field. Drop it; use `require_durable_app_ack`. |
 | 400 | `invalid_logical_id` | `logical_id` was empty, longer than 128 characters, or contained a character outside `[a-z0-9._:-]`. |
-| 404 | `recipient_key_unavailable` | The recipient has published no KEM key, or is entirely unknown to this daemon (no capability advert and no contact card). A durable send to a stranger answers this, **not** the 409 below — "does not advertise v2" presupposes we know the peer. |
+| 400 | `logical_id_requires_durable_ack` | `logical_id` was sent with `require_durable_app_ack: false`. Only the durable path honours the id; drop one or the other. |
+| 404 | `recipient_key_unavailable` | The recipient has published no KEM key, or is entirely unknown to this daemon — **no capability advert and no contact card at all**. A durable send to a stranger answers this, not the 409 below. |
 | 409 | `recipient_key_invalid` | Our view of the recipient's key material has not converged. Transient — retry. |
-| 409 | `recipient_ack_semantics_unavailable` | The send required ADR 0030 durable application-ACK semantics and the recipient advertises no current v2 capability. Returned after one forced targeted capability refresh, so it is fast and deterministic rather than a timeout. The caller retries, surfaces "peer needs upgrade", or resends with `require_durable_app_ack: false` — the daemon never downgrades silently. |
+| 409 | `recipient_ack_semantics_unavailable` | The send required ADR 0030 durable application-ACK semantics and the recipient advertises no current v2 capability. A peer you hold **any** contact card for lands here rather than on the 404 — including one whose advert has not converged yet, since that peer is known and may simply need upgrading. Returned after one forced targeted capability refresh, so it is fast and deterministic rather than a timeout. The caller retries, surfaces "peer needs upgrade", or resends with `require_durable_app_ack: false` — the daemon never downgrades silently. |
 | 409 | `idempotency_conflict` | The recipient already holds this `logical_id` bound to different bytes. **Retrying cannot succeed.** Either resend the original bytes under this id, or pick a new `logical_id`. |
 | 413 | `payload_too_large` | Payload exceeds the DM envelope cap. |
 | 504 | `timeout` | No application ACK within the retry budget. The DM may or may not have arrived. |
@@ -1153,13 +1161,6 @@ All diagnostics endpoints require the normal local daemon bearer token and retur
 | GET | `/diagnostics/exec` | `x0x diagnostics exec` | Remote exec counters, warnings, active sessions, and ACL summary |
 | GET | `/diagnostics/connect` | `x0x diagnostics connect` | Connect-ACL policy summary and stream allow/deny counters |
 | GET | `/diagnostics/ws` | `x0x diagnostics ws` | WebSocket outbound-queue health: capacity and drop/slow-consumer-close counters |
-
-`GET /diagnostics/dm` gained `ack_publish_route_failed` in v0.38.0. Durable
-(v2) ACKs publish from a bounded background worker, so this counter is the
-only externally visible signal that a receiver committed a message but its ACK
-never reached the sender — those senders see a `504 timeout` and retry. A
-persistently rising value means ACK routes are wedged or the publisher queue is
-saturating, not that messages were lost.
 
 ### `GET /diagnostics/groups`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1154,6 +1154,13 @@ All diagnostics endpoints require the normal local daemon bearer token and retur
 | GET | `/diagnostics/connect` | `x0x diagnostics connect` | Connect-ACL policy summary and stream allow/deny counters |
 | GET | `/diagnostics/ws` | `x0x diagnostics ws` | WebSocket outbound-queue health: capacity and drop/slow-consumer-close counters |
 
+`GET /diagnostics/dm` gained `ack_publish_route_failed` in v0.38.0. Durable
+(v2) ACKs publish from a bounded background worker, so this counter is the
+only externally visible signal that a receiver committed a message but its ACK
+never reached the sender — those senders see a `504 timeout` and retry. A
+persistently rising value means ACK routes are wedged or the publisher queue is
+saturating, not that messages were lost.
+
 ### `GET /diagnostics/groups`
 
 Per-group counters for the public-message ingest pipeline and the sender-side write-policy gate. Each row in `groups` corresponds to a locally-known group.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -336,7 +336,7 @@ Identity types: `anonymous`, `known`, `trusted`, `pinned`
 |---|---|---|---|
 | POST | `/agents/connect` | `x0x direct connect <agent_id>` | Establish a direct connection |
 | POST | `/machines/connect` | `x0x machines connect <machine_id>` | Establish a machine-id transport connection |
-| POST | `/direct/send` | `x0x direct send <agent_id> <message>` | Send a direct base64 payload |
+| POST | `/direct/send` | `x0x direct send <agent_id> <message> [--no-durable-ack] [--logical-id <token>]` | Send a direct base64 payload. Durable-by-default since v0.38.0 |
 | GET | `/direct/connections` | `x0x direct connections` | List active direct connections |
 | GET | `/history/message/:msg_id` | `x0x history message` | Point lookup of one durable history row by exposed `msg_id` (64 hex; canonical group ids need `?scope=`); 404 when absent, 400 on malformed id. Same record shape as `/history` (issue #319) |
 | GET | `/direct/events` | `x0x direct events` | SSE stream of direct messages |
@@ -346,9 +346,13 @@ Identity types: `anonymous`, `known`, `trusted`, `pinned`
 ```json
 {
   "agent_id": "8a3f...",
-  "payload": "aGVsbG8="
+  "payload": "aGVsbG8=",
+  "logical_id": "order-42"
 }
 ```
+
+`agent_id` and `payload` are the only required fields. Everything below is
+optional.
 
 Optional field `prefer_raw_quic_if_connected` (bool): when a live transport
 connection to the recipient exists, deliver over raw QUIC instead of the
@@ -356,42 +360,86 @@ gossip inbox. **Defaults to `true` since v0.37.0** (previously `false`);
 omitting the field selects the daemon default, so clients that relied on the
 old default must now send `"prefer_raw_quic_if_connected": false` explicitly.
 
-Optional field `require_gossip_ack` (bool): when a gossip-inbox send is used,
-wait for the recipient's application ACK before returning success. `false`
-returns as soon as the publish succeeds. Omitting the field selects the daemon
-default (`true`).
+Optional field `require_durable_app_ack` (bool): choose the receipt semantics.
+**Defaults to `true` since v0.38.0** (ADR 0030 §4) — this endpoint is a
+*product-tier* surface, so a `200` means the recipient daemon durably
+committed the message to its history store and completed local dispatch, not
+merely that it accepted the envelope.
 
-> **Deprecated (ADR 0030 §4), still honored.** This field is scheduled for
-> removal when the product tier moves to durable-by-default sends in ADR 0030
-> slice 4, at which point `require_gossip_ack: false` stops being expressible
-> and the route will reject the field with **400** rather than accept it as a
-> no-op. It is fully honored today — see `direct_send_config_for_request` in
-> `src/server/routes/direct.rs` and the branch on `config.require_gossip_ack`
-> in `src/dm_send.rs` — so no client needs to change yet.
+Pass `false` to opt out and get v1 semantics, where `200` means "accepted for
+delivery". Opting out is the right choice when reaching a peer that has not
+upgraded matters more than the stronger receipt: a durable send to a peer
+running 0.37.x — or to any peer without durable history enabled — answers
+**409 `recipient_ack_semantics_unavailable`** instead of delivering.
+
+Two consequences worth planning for:
+
+- A durable send never uses the raw-QUIC fast path, because raw QUIC yields a
+  transport receipt that cannot certify a durable commit. `prefer_raw_quic_if_connected`
+  is therefore ignored unless you also pass `require_durable_app_ack: false`.
+- Durable delivery is **at-least-once across a recipient restart** (ADR 0030
+  §1). It never implies read, and never implies exactly-once application
+  delivery. Applications needing restart-spanning exactly-once dedupe on
+  `(sender, request_id)`.
+
+Optional field `logical_id` (string): a caller-supplied idempotency key for
+this logical send. 1–128 characters of `a`–`z`, `0`–`9`, `-`, `_`, `.`, or
+`:`; uppercase, whitespace, and non-ASCII are rejected rather than normalized,
+so two tokens that differ only in case stay two distinct requests.
+
+Resending the same `logical_id` to the same recipient — after a timeout, a
+reconnect, or a full process restart — is *the same request*, not a second
+message: the recipient recognises it and re-ACKs the original commit instead of
+storing a duplicate. Omitting the field draws a fresh random id per call, which
+is correct for fire-and-forget sends.
+
+The daemon derives the 128-bit wire request id as
+`blake3::derive_key("x0x dm logical request id v1", sender_agent_id ‖
+recipient_agent_id ‖ logical_id)` truncated to its leading 16 bytes. Both agent
+ids are mixed in, so the same token addressed to two different recipients
+yields two different requests. The token itself never goes on the wire.
+
+Reusing a `logical_id` for *different* payload bytes is a **409
+`idempotency_conflict`** — see below.
+
+> **Removed (ADR 0030 §4): `require_gossip_ack`.** Setting this field in any
+> form — `true`, `false`, or a non-boolean — is now **400
+> `require_gossip_ack_removed`**. An explicit `null`, like omitting it, is
+> accepted. Accepting the field as a silent no-op was rejected in review: a
+> client that passed `require_gossip_ack: false` for fire-and-forget would
+> otherwise get a blocking durable send and no signal that its request had been
+> reinterpreted. Choose receipt semantics with `require_durable_app_ack`
+> instead.
 
 ### Direct send error codes
 
-`/direct/send` failures answer with `{"ok": false, "error": "<code>"}`.
+`/direct/send` failures answer with
+`{"ok": false, "error": "<code>", "detail": "<human-readable>"}`.
 Notable codes:
 
 | Status | `error` | Meaning |
 |---|---|---|
-| 404 | `recipient_key_unavailable` | The recipient has published no KEM key. |
+| 400 | `require_gossip_ack_removed` | The request set the removed `require_gossip_ack` field. Drop it; use `require_durable_app_ack`. |
+| 400 | `invalid_logical_id` | `logical_id` was empty, longer than 128 characters, or contained a character outside `[a-z0-9._:-]`. |
+| 404 | `recipient_key_unavailable` | The recipient has published no KEM key, or is entirely unknown to this daemon (no capability advert and no contact card). A durable send to a stranger answers this, **not** the 409 below — "does not advertise v2" presupposes we know the peer. |
 | 409 | `recipient_key_invalid` | Our view of the recipient's key material has not converged. Transient — retry. |
-| 409 | `recipient_ack_semantics_unavailable` | The send required ADR 0030 durable application-ACK semantics and the recipient advertises no current v2 capability. Returned after one forced targeted capability refresh, so it is fast and deterministic rather than a timeout. The caller retries, surfaces "peer needs upgrade", or resends without the durable requirement — the daemon never downgrades silently. |
+| 409 | `recipient_ack_semantics_unavailable` | The send required ADR 0030 durable application-ACK semantics and the recipient advertises no current v2 capability. Returned after one forced targeted capability refresh, so it is fast and deterministic rather than a timeout. The caller retries, surfaces "peer needs upgrade", or resends with `require_durable_app_ack: false` — the daemon never downgrades silently. |
+| 409 | `idempotency_conflict` | The recipient already holds this `logical_id` bound to different bytes. **Retrying cannot succeed.** Either resend the original bytes under this id, or pick a new `logical_id`. |
 | 413 | `payload_too_large` | Payload exceeds the DM envelope cap. |
 | 504 | `timeout` | No application ACK within the retry budget. The DM may or may not have arrived. |
 
-**Note (as of ADR 0030 slice 2):** no REST field selects durable ACK
-semantics yet, so `recipient_ack_semantics_unavailable` is currently
-reachable only through the library (`DmSendConfig::require_durable_app_ack`).
-The product-tier default flips in ADR 0030 slice 4, at which point this
-becomes a routine response for not-yet-upgraded peers.
+The two 409s prescribe opposite repairs and must not be conflated in client
+code: `recipient_ack_semantics_unavailable` means *retry later or tell the user
+to upgrade the peer*; `idempotency_conflict` means *these bytes will never be
+accepted under this id*. Before v0.38.0 the conflict case was reported as
+`recipient_ack_semantics_unavailable`, which sent clients down the wrong branch.
 
-Slice 2 landed the receiver durable path, so a library-level strict send now
-*succeeds* against a peer that advertises v2 — which it does only when that
-peer runs with durable history enabled. REST request and response shapes are
-unchanged by this slice.
+**Rollout note.** Because the default flipped to durable, clients that
+previously got `200` from a 0.37.x peer will now get
+`409 recipient_ack_semantics_unavailable` until that peer upgrades. This is
+deliberate (ADR 0030 §2: never a silent downgrade). Handle the 409 as a
+first-class UX state; where delivery matters more than the receipt, send
+`require_durable_app_ack: false`.
 
 ### `/direct/events` SSE message shape
 
@@ -595,6 +643,26 @@ cached history:
 - `read_access == MembersOnly` — requires active membership.
 - `MlsEncrypted` — returns 400 (encrypted history belongs elsewhere).
 - Withdrawn groups return 409 and do not restart public-message listeners.
+
+#### Bootstrap outbox sidecar (ADR 0030 §5)
+
+Adding a member to a SignedPublic group owes that member a roster snapshot.
+Since v0.38.0 the delivery is a durable obligation rather than a
+fire-and-forget send, so an offline recipient still receives it. Obligations
+are persisted to **`<data_dir>/public_group_bootstrap_outbox.json`**, capped at
+1024 entries, and retried with exponential backoff to 60 s until the recipient
+returns a durable (v2) application ACK for that exact frontier.
+
+Two operator-visible consequences:
+
+- The sidecar is loaded **fail-closed** at startup. An unsupported version, an
+  over-cap file, a duplicate key, or a payload contradicting the frontier it
+  claims **aborts daemon startup** rather than silently dropping a promised
+  delivery. If a daemon refuses to start citing this file, the file is the
+  problem — inspect it rather than deleting it blindly, since each entry is a
+  delivery someone is still waiting for.
+- Deleting the sidecar discards outstanding obligations permanently. Affected
+  members will not receive their snapshot until they are re-added.
 
 #### Threading (ADR-0029)
 
@@ -1000,6 +1068,19 @@ Client → server:
 {"type":"send_direct","agent_id":"hex64...","payload":"aGVsbG8="}
 ```
 
+> **`send_direct` over WebSocket is an internal-tier surface** (ADR 0030 §4).
+> It carries none of the product fields `POST /direct/send` accepts — no
+> `require_durable_app_ack`, no `logical_id` — and keeps v1 receipt semantics:
+> the frame is accepted for delivery, with no durable-commit guarantee and no
+> idempotency key. It shares its send configuration with the daemon's own
+> control-plane traffic (welcome blobs, TreeKEM plumbing, group metadata),
+> which must not inherit strict gating: those messages deliberately race
+> connection establishment and would livelock under it.
+>
+> Product code that needs a durable receipt or at-least-once retry identity
+> should use `POST /direct/send`, not this frame. This surface will be
+> reclassified only if it grows the product fields.
+
 Server → client:
 
 ```json
@@ -1044,6 +1125,8 @@ x0x contacts list
 x0x publish updates hello
 x0x direct connect <agent_id>
 x0x direct send <agent_id> hello
+x0x direct send <agent_id> hello --logical-id order-42   # retry-safe identity
+x0x direct send <agent_id> hello --no-durable-ack        # reach a 0.37.x peer
 x0x groups create
 x0x group create team-chat --display-name alice
 x0x tasks create inbox team.tasks

--- a/docs/design/dm-over-gossip.md
+++ b/docs/design/dm-over-gossip.md
@@ -280,7 +280,17 @@ id that two waiters contend for.
 
 This is the same mechanism the durable bootstrap outbox uses internally (§5),
 where the obligation key and the wire request id are deliberately one
-identity. The only difference is who chooses it.
+identity. The only difference is who chooses it: a product caller passes a
+token, while the outbox derives its id from the obligation's own binding
+digest so an ACK can be matched back to the exact debt it discharges.
+
+That outbox persists its obligations to
+**`<data_dir>/public_group_bootstrap_outbox.json`** (1024-entry cap,
+exponential backoff to 60 s, cleared only by a frontier-matching v2
+application ACK). The sidecar is loaded fail-closed: an unsupported version,
+an over-cap file, a duplicate key, or a payload contradicting the frontier it
+claims aborts daemon startup rather than silently dropping a promised
+delivery. Operator detail in `docs/api-reference.md`.
 
 #### Receiver ordering (normative)
 
@@ -327,6 +337,35 @@ order, per ADR 0030 §1:
    `Inserted | Duplicate`, i.e. exactly one durable row for this logical
    request.
 6. **ACK**, stamped with the semantics actually honoured.
+
+#### ACK publication — hedged, bounded, off the inbox loop
+
+Step 6 publishes; it does not block the inbox loop. A durable ACK is handed to
+a bounded background worker (queue 256, at most 32 publications in flight) that
+polls **both** routes concurrently — the recipient's targeted inbox topic and
+the compatibility bus — each under its own 22 s deadline (the pinned pubsub
+Critical contract allows 10 s at the FIFO gate plus 10 s to send, plus slack).
+
+Three properties matter, and they are separable:
+
+- **Ordering is unchanged.** The history commit is still awaited *before*
+  publication is scheduled. Only the publication became asynchronous; the
+  promise behind the ACK did not.
+- **A wedged route cannot consume the sender's ACK budget.** A targeted publish
+  can deliver remotely yet stay pending under per-topic fan-out backpressure.
+  Polling the bus hedge concurrently means the surviving route reaches the
+  sender immediately instead of after the wedged sibling's deadline, and the
+  serial inbox loop is never pinned by either.
+- **Saturation fails safe and visibly.** A full queue is reported rather than
+  awaited: the sender times out and retries, which is the documented safe
+  failure, and the drop increments `ack_publish_route_failed` on
+  `GET /diagnostics/dm`. Blocking instead would stall every later DM behind one
+  wedged ACK — trading a visible retry for an invisible stall.
+
+**v1 is untouched.** A v1 ACK still publishes to the targeted topic inline, and
+reaches the compatibility bus only when the payload itself arrived there.
+Hedging every v1 ACK onto the shared bus would add gossip traffic for every
+0.37 peer in the mesh to solve a problem only durable senders have.
 
 Steps 5→6 are the whole point: **the ACK exists only because the commit
 succeeded.** Commit error, backpressured writer, unavailable history, lost
@@ -463,10 +502,36 @@ source of truth for path selection.
 
 ### Mixed-version matrix
 
+Transport selection (0.17/0.18 era):
+
 | Sender \ Recipient | 0.17 | 0.18 |
 |---|---|---|
 | 0.17 | raw | raw (recipient accepts both, sender only sends raw) |
 | 0.18 | raw (sender sees no gossip capability) | gossip |
+
+Receipt semantics (ADR 0030 §2, normative). "0.38 product send" means a
+default `POST /direct/send` or `x0x direct send`, which is strict since
+slice 4; "0.38 opted-out" means the same surface with
+`require_durable_app_ack: false`. A 0.38 recipient advertises v2 **iff**
+durable history is enabled — it is default-on, so `history.enabled = false`
+puts a 0.38 daemon in the "advertises v1" column:
+
+| Sender \ Recipient | 0.37 / advertises v1 | 0.38 advertising v2 |
+|---|---|---|
+| **0.38 product send** (strict) | **409 `recipient_ack_semantics_unavailable`** after one forced targeted refresh — bounded, never a hang, never a silent downgrade | Durable ACK: history row committed and dispatch completed **before** the sender's 200 |
+| **0.38 opted-out** (`require_durable_app_ack: false`) | Delivered, `Ok` = level 2 | Delivered, `Ok` = level 2 — the recipient's capability does not silently upgrade the receipt |
+| **0.38 internal tier** (WS / library default / control plane) | Delivered, `Ok` = level 2 | Delivered, `Ok` = level 2 |
+| **0.37 sender** | v1, unchanged | v1, unchanged — envelope layout is identical, and a v1 envelope is answered with a v1 ACK even on a history-enabled receiver |
+
+Rows this slice owns, for the same two recipient columns:
+
+| Condition | Answer |
+|---|---|
+| Strict send, recipient unknown (no advert **and** no contact card) | **404 `recipient_key_unavailable`** — not the 409. "Does not advertise v2" presupposes we know the peer |
+| Same `logical_id`, same bytes, retried (incl. after either side restarts) | Re-ACKed from the binding or the durable-history row. Exactly one history row; re-dispatch is possible and documented |
+| Same `logical_id`, **different** bytes | **409 `idempotency_conflict`** — from the replay cache while hot, from the durable-history lookup after a receiver restart. Terminal for those bytes |
+| `require_gossip_ack` set in any form | **400 `require_gossip_ack_removed`** before any send is attempted |
+| Recipient's history commit fails mid-request | **No ACK.** The sender times out (504). A withheld ACK is the only honest answer — a v1 ACK would hand back a weaker receipt the sender cannot distinguish from the one it asked for |
 
 ## Replay protection and dedupe
 

--- a/docs/design/dm-over-gossip.md
+++ b/docs/design/dm-over-gossip.md
@@ -338,35 +338,6 @@ order, per ADR 0030 §1:
    request.
 6. **ACK**, stamped with the semantics actually honoured.
 
-#### ACK publication — hedged, bounded, off the inbox loop
-
-Step 6 publishes; it does not block the inbox loop. A durable ACK is handed to
-a bounded background worker (queue 256, at most 32 publications in flight) that
-polls **both** routes concurrently — the recipient's targeted inbox topic and
-the compatibility bus — each under its own 22 s deadline (the pinned pubsub
-Critical contract allows 10 s at the FIFO gate plus 10 s to send, plus slack).
-
-Three properties matter, and they are separable:
-
-- **Ordering is unchanged.** The history commit is still awaited *before*
-  publication is scheduled. Only the publication became asynchronous; the
-  promise behind the ACK did not.
-- **A wedged route cannot consume the sender's ACK budget.** A targeted publish
-  can deliver remotely yet stay pending under per-topic fan-out backpressure.
-  Polling the bus hedge concurrently means the surviving route reaches the
-  sender immediately instead of after the wedged sibling's deadline, and the
-  serial inbox loop is never pinned by either.
-- **Saturation fails safe and visibly.** A full queue is reported rather than
-  awaited: the sender times out and retries, which is the documented safe
-  failure, and the drop increments `ack_publish_route_failed` on
-  `GET /diagnostics/dm`. Blocking instead would stall every later DM behind one
-  wedged ACK — trading a visible retry for an invisible stall.
-
-**v1 is untouched.** A v1 ACK still publishes to the targeted topic inline, and
-reaches the compatibility bus only when the payload itself arrived there.
-Hedging every v1 ACK onto the shared bus would add gossip traffic for every
-0.37 peer in the mesh to solve a problem only durable senders have.
-
 Steps 5→6 are the whole point: **the ACK exists only because the commit
 succeeded.** Commit error, backpressured writer, unavailable history, lost
 lock, or an unpublishable replay completion each **withhold** the ACK. None
@@ -527,7 +498,9 @@ Rows this slice owns, for the same two recipient columns:
 
 | Condition | Answer |
 |---|---|
-| Strict send, recipient unknown (no advert **and** no contact card) | **404 `recipient_key_unavailable`** — not the 409. "Does not advertise v2" presupposes we know the peer |
+| Strict send, recipient unknown — no advert **and** no contact card of any kind | **404 `recipient_key_unavailable`** — not the 409. "Does not advertise v2" presupposes we know the peer |
+| Strict send, contact card present but its advert has not converged (`dm_capabilities: None`) | **409 `recipient_ack_semantics_unavailable`** — a known peer mid-convergence, plausibly one needing an upgrade. The 404/409 boundary is "do we know this agent", not "has its advert arrived" |
+| `logical_id` sent with `require_durable_app_ack: false` | **400 `logical_id_requires_durable_ack`** — only the durable path consults the id, so the combination would promise idempotency nothing enforces |
 | Same `logical_id`, same bytes, retried (incl. after either side restarts) | Re-ACKed from the binding or the durable-history row. Exactly one history row; re-dispatch is possible and documented |
 | Same `logical_id`, **different** bytes | **409 `idempotency_conflict`** — from the replay cache while hot, from the durable-history lookup after a receiver restart. Terminal for those bytes |
 | `require_gossip_ack` set in any form | **400 `require_gossip_ack_removed`** before any send is attempted |

--- a/docs/design/dm-over-gossip.md
+++ b/docs/design/dm-over-gossip.md
@@ -222,6 +222,66 @@ Landing in slices (ADR 0030 "Landing order"). Slices 1–2 ship:
   sends to one recipient share a single in-flight request.
 - The **receiver durable path** and the live v2 advert (below).
 
+#### Send surfaces and defaults (ADR 0030 §4)
+
+A product developer must not get different delivery semantics depending on
+which surface they reached for. Every send surface is classified into one of
+two named tiers, and the tier — not the caller's memory — picks the default:
+
+| Surface | Tier | `require_durable_app_ack` default | `logical_id` |
+|---|---|---|---|
+| `POST /direct/send` | Product | **`true`** (opt out with `require_durable_app_ack: false`) | accepted |
+| `x0x direct send` | Product | **`true`** (opt out with `--no-durable-ack`) | `--logical-id` |
+| WebSocket `send_direct` frame | Internal | `false` | not accepted |
+| `Agent::send_direct*` (library default config) | Internal | `false` | via `DmSendConfig::logical_request_id` |
+| Daemon control plane (welcome blobs, TreeKEM, group metadata) | Internal | `false`, per named config | per config |
+| Durable bootstrap outbox (ADR 0030 §5) | Internal, explicitly strict | `true` | obligation digest |
+
+The internal tier is not an oversight. Control-plane messages deliberately
+race connection establishment; forcing durable semantics on them causes
+livelock (v0.37.0's welcome-blob opt-out is the precedent). Conversely the
+product tier defaults *on* because the bug class this protocol exists to fix
+came precisely from products forgetting to opt in.
+
+The default flip is scoped to the request-scoped config builder in
+`src/server/routes/direct.rs`, **not** to the shared
+`direct_message_send_config()` helper — the WebSocket frame and every
+control-plane send read that helper, so flipping it there would silently make
+the whole internal tier strict.
+
+Two consequences of asking for durable semantics:
+
+- The raw-QUIC fast path is skipped. Raw QUIC returns a transport receipt,
+  which cannot certify a durable commit, so `prefer_raw_quic_if_connected` is
+  inert on a strict send.
+- No relay fallback. A relayed envelope is resealed by a third party and
+  cannot carry the machine-bound v2 receipt the caller demanded.
+
+#### Caller-supplied logical request identity (`logical_id`)
+
+The product tier accepts a stable idempotency key: 1–128 characters of
+`[a-z0-9._:-]`, rejected rather than normalized if it contains anything else,
+so tokens differing only in case stay distinct requests.
+
+The wire request id is derived, never transmitted:
+
+```
+request_id = blake3::derive_key(
+    "x0x dm logical request id v1",
+    sender_agent_id ‖ recipient_agent_id ‖ logical_id,
+)[..16]
+```
+
+Both agent ids are bound. The recipient dedupes on `(sender, request_id)`, so
+binding the sender is belt-and-braces; binding the *recipient* is
+load-bearing, because the sender's in-flight ACK waiter is keyed by
+`request_id` alone and one token fanned out to two peers must not produce one
+id that two waiters contend for.
+
+This is the same mechanism the durable bootstrap outbox uses internally (§5),
+where the obligation key and the wire request id are deliberately one
+identity. The only difference is who chooses it.
+
 #### Receiver ordering (normative)
 
 `InboxPipeline::handle_payload_durable` runs a v2 payload in exactly this
@@ -235,19 +295,33 @@ order, per ADR 0030 §1:
    under *its own* semantics, never re-dispatched. The binding is a
    domain-separated digest over `(protocol_version, accepted bytes)`, so the
    same request id carrying different content is refused rather than
-   re-ACKed as the original delivery. Both refusals — "already completed
-   under v1 semantics" and "already bound to different content" — are
-   answered `DmAckOutcome::AckSemanticsUnavailable`, never
-   `RejectedByPolicy`: no trust decision failed, and the sender maps the
-   latter to `RecipientRejected`, which would misreport a protocol condition
-   as a blocked peer. On the sender it becomes
-   `DmError::AckSemanticsUnavailable` — the same typed error the send-side
-   capability gate raises.
+   re-ACKed as the original delivery. Neither refusal is `RejectedByPolicy`:
+   no trust decision failed, and the sender maps that variant to
+   `RecipientRejected`, which would misreport a protocol condition as a
+   blocked peer. The two refusals are distinct outcomes because they
+   prescribe opposite repairs:
+   - "already completed under v1 semantics" ⇒
+     `DmAckOutcome::AckSemanticsUnavailable` ⇒
+     `DmError::AckSemanticsUnavailable` — the same typed error the send-side
+     capability gate raises. *Retry, or the peer needs upgrading.*
+   - "already bound to different content" ⇒
+     `DmAckOutcome::IdempotencyConflict` ⇒ `DmError::IdempotencyConflict` ⇒
+     REST 409 `idempotency_conflict`. *These bytes will never be accepted
+     under this id; pick a new one.* (Before ADR 0030 slice 4 this reused the
+     variant above, which sent callers down the retry branch of a condition
+     retrying cannot fix.)
+
+   The inbox's cheap pre-decrypt replay short-circuit in `handle_incoming`
+   **stands aside** for a v2 payload replaying a completion that carries a
+   durable binding: comparing bytes requires the plaintext, so the durable
+   path owns that decision end to end. Answering from the fast path would
+   report `Accepted` for content the receiver never stored.
 3. **Durable-history lookup** — keyed on the schema v4 columns
    `(ingress_sender_agent, logical_request_id)` via
    `Store::find_by_logical_request`. This is the check that survives restart,
    where the memory-only replay cache does not. A row binding different bytes
-   is a conflict and is refused.
+   is a conflict and is refused with the same `IdempotencyConflict` outcome
+   step 2 uses — the guarantee must not change because the receiver restarted.
 4. **Dispatch** to the application.
 5. **`record_committed` awaited** — the SQLite transaction must return
    `Inserted | Duplicate`, i.e. exactly one durable row for this logical
@@ -580,6 +654,14 @@ pub enum DmError {
     PublishFailed(String),
 }
 ```
+
+The block above is illustrative, not exhaustive; `src/dm.rs` is authoritative.
+ADR 0030 adds two variants that a product must distinguish, because they
+prescribe opposite repairs: `AckSemanticsUnavailable` (REST 409
+`recipient_ack_semantics_unavailable`) means *retry later, or the peer needs
+upgrading*, while `IdempotencyConflict` (REST 409 `idempotency_conflict`)
+means *this `logical_id` is already bound to different bytes and retrying
+these bytes can never succeed*.
 
 There is no `NoRoute` variant. Gossip has no routing layer — if we
 can publish, we can reach anyone subscribed to the topic; if not,

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -822,7 +822,12 @@ enum DirectSub {
         /// Stable idempotency key for this logical send (1-128 chars of
         /// [a-z0-9], '-', '_', '.', ':'). Resending the same value to the same
         /// recipient is a retry of one request, not a second message.
-        #[arg(long)]
+        ///
+        /// Requires durable delivery: only the durable receiver path consults
+        /// the id, so pairing it with --no-durable-ack would promise an
+        /// idempotency guarantee nothing enforces. Rejected here rather than
+        /// after a round trip to the daemon, which refuses the same pair.
+        #[arg(long, conflicts_with = "no_durable_ack")]
         logical_id: Option<String>,
     },
     /// List established direct connections.

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -812,6 +812,18 @@ enum DirectSub {
         /// (ant-quic 0.27.1 `probe_peer`). Response includes RTT or reason.
         #[arg(long)]
         require_ack_ms: Option<u64>,
+        /// Opt out of ADR 0030 durable delivery: succeed as soon as the
+        /// recipient accepts the envelope, instead of requiring proof it was
+        /// durably committed. Use to reach a peer that has not upgraded —
+        /// without this flag such a peer answers 409
+        /// `recipient_ack_semantics_unavailable`.
+        #[arg(long)]
+        no_durable_ack: bool,
+        /// Stable idempotency key for this logical send (1-128 chars of
+        /// [a-z0-9], '-', '_', '.', ':'). Resending the same value to the same
+        /// recipient is a retry of one request, not a second message.
+        #[arg(long)]
+        logical_id: Option<String>,
     },
     /// List established direct connections.
     Connections,
@@ -1667,7 +1679,19 @@ async fn run(
                 agent_id,
                 message,
                 require_ack_ms,
-            } => commands::direct::send(&client, &agent_id, &message, require_ack_ms).await,
+                no_durable_ack,
+                logical_id,
+            } => {
+                commands::direct::send(
+                    &client,
+                    &agent_id,
+                    &message,
+                    require_ack_ms,
+                    !no_durable_ack,
+                    logical_id.as_deref(),
+                )
+                .await
+            }
             DirectSub::Connections => commands::direct::connections(&client).await,
             DirectSub::Events => commands::direct::events(&client).await,
         },

--- a/src/cli/commands/direct.rs
+++ b/src/cli/commands/direct.rs
@@ -21,20 +21,31 @@ pub async fn connect(client: &DaemonClient, agent_id: &str) -> Result<()> {
 /// and includes the RTT (or the failure reason) in the response under
 /// `require_ack`. This does NOT prove the specific message was delivered;
 /// it proves the peer's receive pipeline is live when the call returned.
+///
+/// `require_durable_app_ack` is sent explicitly rather than left to the
+/// daemon default (ADR 0030 §4). The CLI is a product surface, so its own
+/// default is durable; sending the field means an older CLI paired with a
+/// newer daemon — or the reverse — never silently swaps receipt semantics.
 pub async fn send(
     client: &DaemonClient,
     agent_id: &str,
     message: &str,
     require_ack_ms: Option<u64>,
+    require_durable_app_ack: bool,
+    logical_id: Option<&str>,
 ) -> Result<()> {
     client.ensure_running().await?;
     let encoded = base64::engine::general_purpose::STANDARD.encode(message.as_bytes());
     let mut body = serde_json::json!({
         "agent_id": agent_id,
         "payload": encoded,
+        "require_durable_app_ack": require_durable_app_ack,
     });
     if let Some(ms) = require_ack_ms {
         body["require_ack_ms"] = serde_json::json!(ms);
+    }
+    if let Some(logical_id) = logical_id {
+        body["logical_id"] = serde_json::json!(logical_id);
     }
     let resp = client.post("/direct/send", &body).await?;
     print_value(client.format(), &resp);
@@ -106,7 +117,7 @@ mod tests {
         let mock_resp = serde_json::json!({"ok": true, "path": "gossip_inbox"});
         let (url, _shutdown) = start_mock_server(mock_resp).await;
         let client = DaemonClient::new(None, Some(&url), crate::cli::OutputFormat::Json).unwrap();
-        let result = send(&client, &"aa".repeat(32), "hello", None).await;
+        let result = send(&client, &"aa".repeat(32), "hello", None, true, None).await;
         assert!(result.is_ok(), "send should succeed: {:?}", result);
     }
 
@@ -115,8 +126,60 @@ mod tests {
         let mock_resp = serde_json::json!({"ok": true, "require_ack": {"ok": true, "rtt_ms": 12}});
         let (url, _shutdown) = start_mock_server(mock_resp).await;
         let client = DaemonClient::new(None, Some(&url), crate::cli::OutputFormat::Json).unwrap();
-        let result = send(&client, &"aa".repeat(32), "hello", Some(500)).await;
+        let result = send(&client, &"aa".repeat(32), "hello", Some(500), true, None).await;
         assert!(result.is_ok(), "send with ack should succeed: {:?}", result);
+    }
+
+    /// ADR 0030 §4 puts the CLI in the product tier. The flag names are the
+    /// negative (`--no-durable-ack`), so a plain `x0x direct send` must put
+    /// `require_durable_app_ack: true` on the wire — and must do so explicitly,
+    /// because relying on the daemon default would make the CLI's promise
+    /// depend on which daemon version answered.
+    #[tokio::test]
+    async fn send_asks_for_durable_semantics_explicitly_and_carries_the_logical_id() {
+        let (url, _shutdown, captured) =
+            crate::cli::commands::test_support::start_capturing_mock_server(
+                serde_json::json!({"ok": true}),
+            )
+            .await;
+        let client = DaemonClient::new(None, Some(&url), crate::cli::OutputFormat::Json).unwrap();
+
+        send(
+            &client,
+            &"aa".repeat(32),
+            "hello",
+            None,
+            true,
+            Some("order-7"),
+        )
+        .await
+        .unwrap();
+        send(&client, &"aa".repeat(32), "hello", None, false, None)
+            .await
+            .unwrap();
+
+        let requests: Vec<serde_json::Value> = captured
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(path, _)| path == "/direct/send")
+            .map(|(_, body)| body.clone())
+            .collect();
+        assert_eq!(requests.len(), 2, "both sends should reach /direct/send");
+        assert_eq!(
+            requests[0]["require_durable_app_ack"],
+            serde_json::json!(true)
+        );
+        assert_eq!(requests[0]["logical_id"], serde_json::json!("order-7"));
+        assert_eq!(
+            requests[1]["require_durable_app_ack"],
+            serde_json::json!(false),
+            "--no-durable-ack must reach the daemon, not be dropped"
+        );
+        assert!(
+            requests[1].get("logical_id").is_none(),
+            "an omitted logical_id must not be sent as null"
+        );
     }
 
     async fn start_sse_server(body: &'static str) -> (String, tokio::sync::oneshot::Sender<()>) {

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -498,7 +498,6 @@ struct DirectDiagnosticsCounters {
     incoming_dropped_revoked: AtomicU64,
     incoming_dropped_expired: AtomicU64,
     incoming_typed_route_dropped: AtomicU64,
-    ack_publish_route_failed: AtomicU64,
     incoming_delivered_to_subscribe: AtomicU64,
     subscriber_channel_lagged: AtomicU64,
     subscriber_events_evicted: AtomicU64,
@@ -563,11 +562,6 @@ pub struct DmDiagnosticsStats {
     /// the primary per-group/store pubsub path still delivers.
     #[serde(default)]
     pub incoming_typed_route_dropped: u64,
-    /// ACK publish operations where at least one required route returned an
-    /// explicit error or exceeded its deadline. Zero-fanout `Ok` results are
-    /// not counted here. Non-zero means some sender waited out its ACK budget.
-    #[serde(default)]
-    pub ack_publish_route_failed: u64,
     pub incoming_delivered_to_subscribe: u64,
     /// Number of oldest buffered events evicted from slow subscriber queues.
     pub subscriber_events_evicted: u64,
@@ -979,16 +973,6 @@ impl DirectMessaging {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record an ACK publication whose route returned an explicit error or
-    /// timed out. The durable path publishes in a bounded background worker,
-    /// so this counter is the only externally visible signal that an ACK the
-    /// receiver committed for never reached the sender.
-    pub(crate) fn record_ack_publish_route_failed(&self) {
-        self.diagnostics
-            .ack_publish_route_failed
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
     /// Snapshot direct-message diagnostics for API surfaces.
     #[must_use]
     pub fn diagnostics_snapshot(&self) -> DmDiagnosticsSnapshot {
@@ -1045,10 +1029,6 @@ impl DirectMessaging {
             incoming_typed_route_dropped: self
                 .diagnostics
                 .incoming_typed_route_dropped
-                .load(Ordering::Relaxed),
-            ack_publish_route_failed: self
-                .diagnostics
-                .ack_publish_route_failed
                 .load(Ordering::Relaxed),
             incoming_delivered_to_subscribe: self
                 .diagnostics

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -498,6 +498,7 @@ struct DirectDiagnosticsCounters {
     incoming_dropped_revoked: AtomicU64,
     incoming_dropped_expired: AtomicU64,
     incoming_typed_route_dropped: AtomicU64,
+    ack_publish_route_failed: AtomicU64,
     incoming_delivered_to_subscribe: AtomicU64,
     subscriber_channel_lagged: AtomicU64,
     subscriber_events_evicted: AtomicU64,
@@ -562,6 +563,11 @@ pub struct DmDiagnosticsStats {
     /// the primary per-group/store pubsub path still delivers.
     #[serde(default)]
     pub incoming_typed_route_dropped: u64,
+    /// ACK publish operations where at least one required route returned an
+    /// explicit error or exceeded its deadline. Zero-fanout `Ok` results are
+    /// not counted here. Non-zero means some sender waited out its ACK budget.
+    #[serde(default)]
+    pub ack_publish_route_failed: u64,
     pub incoming_delivered_to_subscribe: u64,
     /// Number of oldest buffered events evicted from slow subscriber queues.
     pub subscriber_events_evicted: u64,
@@ -973,6 +979,16 @@ impl DirectMessaging {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Record an ACK publication whose route returned an explicit error or
+    /// timed out. The durable path publishes in a bounded background worker,
+    /// so this counter is the only externally visible signal that an ACK the
+    /// receiver committed for never reached the sender.
+    pub(crate) fn record_ack_publish_route_failed(&self) {
+        self.diagnostics
+            .ack_publish_route_failed
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Snapshot direct-message diagnostics for API surfaces.
     #[must_use]
     pub fn diagnostics_snapshot(&self) -> DmDiagnosticsSnapshot {
@@ -1029,6 +1045,10 @@ impl DirectMessaging {
             incoming_typed_route_dropped: self
                 .diagnostics
                 .incoming_typed_route_dropped
+                .load(Ordering::Relaxed),
+            ack_publish_route_failed: self
+                .diagnostics
+                .ack_publish_route_failed
                 .load(Ordering::Relaxed),
             incoming_delivered_to_subscribe: self
                 .diagnostics

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -270,11 +270,15 @@ pub enum DmAckOutcome {
     /// and skip emitting this ACK entirely.
     RejectedByPolicy { reason: String },
     /// The recipient cannot issue the durable receipt this request asked for:
-    /// the logical request already completed under weaker semantics, or is
-    /// already bound to different content (ADR 0030 §2). Distinct from
-    /// [`Self::RejectedByPolicy`] — nothing about the trust relationship
-    /// failed, so the caller should surface "retry / peer needs upgrade"
-    /// rather than "peer rejected you".
+    /// the logical request already completed under weaker semantics (ADR 0030
+    /// §2). Distinct from [`Self::RejectedByPolicy`] — nothing about the trust
+    /// relationship failed, so the caller should surface "retry / peer needs
+    /// upgrade" rather than "peer rejected you".
+    ///
+    /// Since ADR 0030 slice 4 this variant carries *only* the
+    /// semantics-unavailable meaning. The "same logical id, different bytes"
+    /// case moved to [`Self::IdempotencyConflict`], which is a caller bug
+    /// rather than a peer-capability gap.
     ///
     /// **Wire compatibility:** appended last, so postcard's variant indices
     /// for `Accepted` (0) and `RejectedByPolicy` (1) are unchanged and an
@@ -283,6 +287,24 @@ pub enum DmAckOutcome {
     /// semantics above what completed, and a v1-only sender never asks for
     /// more than v1 (see `cached_ack_for_protocol`).
     AckSemanticsUnavailable { reason: String },
+    /// The logical request id in this envelope is already bound — in the
+    /// replay cache or in committed durable history — to *different* content.
+    /// At-least-once retry identity requires a logical id to name exactly one
+    /// payload; reusing it for new bytes would either resurrect the old bytes
+    /// or silently overwrite the binding, so the recipient refuses both
+    /// (ADR 0030 §1 / Validation "reused `logical_id` with different bytes").
+    ///
+    /// Terminal for these bytes: retrying is futile until the caller picks a
+    /// fresh logical id. That is why it is not `AckSemanticsUnavailable`,
+    /// whose actionable advice ("retry, or tell the user to upgrade the peer")
+    /// is wrong here.
+    ///
+    /// **Wire compatibility:** appended after `AckSemanticsUnavailable`
+    /// (variant 3), so every previously assigned index is unchanged. It is
+    /// only ever produced on the v2 durable receiver path answering a v2
+    /// envelope, so a v1-only peer — which never sends one — can never receive
+    /// a variant it cannot decode.
+    IdempotencyConflict { reason: String },
 }
 
 // ─── Origin-machine attestation (issue #213) ──────────────────────────────
@@ -531,6 +553,16 @@ pub enum DmError {
     #[error("recipient does not advertise durable application ACK support: {0}")]
     AckSemanticsUnavailable(String),
 
+    /// The recipient already holds this logical request id bound to different
+    /// bytes (ADR 0030 §1). Retrying cannot succeed — the caller must either
+    /// resend the *original* bytes under this id or choose a new logical id.
+    ///
+    /// Kept separate from [`Self::AckSemanticsUnavailable`]: both used to
+    /// arrive as that variant, which told a product "the peer needs
+    /// upgrading" when the truth was "your client reused an idempotency key".
+    #[error("logical request already bound to different content: {0}")]
+    IdempotencyConflict(String),
+
     /// No application-layer ACK received within the retry budget. The DM
     /// MAY or may not have been delivered; the sender cannot distinguish.
     /// Safe to retry (recipient dedupes on `request_id`).
@@ -616,6 +648,85 @@ pub enum DmError {
 impl From<IdentityError> for DmError {
     fn from(value: IdentityError) -> Self {
         Self::EnvelopeConstruction(value.to_string())
+    }
+}
+
+// ─── Caller-supplied logical request identity ──────────────────────────────
+
+/// Canonical caller-supplied idempotency key for one logical DM send
+/// (ADR 0030 §4).
+///
+/// A product that retries a send — across a network blip, a process restart,
+/// or a user mashing the button — passes the same token each time. The daemon
+/// derives a stable [`DmSendConfig::logical_request_id`] from it, so the
+/// recipient recognises the retry as *the same request* and re-ACKs instead of
+/// delivering a second copy. This is the same mechanism the durable bootstrap
+/// outbox uses internally (ADR 0030 §5); the only difference is who chooses
+/// the identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DmLogicalId(String);
+
+/// Domain separator for the logical-request-id derivation. A version suffix,
+/// so changing the derivation later breaks matching loudly rather than
+/// silently re-binding old ids to new bytes.
+const DM_LOGICAL_REQUEST_ID_CONTEXT: &str = "x0x dm logical request id v1";
+
+impl DmLogicalId {
+    /// Accept a compact lowercase token suitable for UUIDs and namespaced
+    /// client ids: 1–128 bytes of `[a-z0-9]`, `-`, `_`, `.`, or `:`.
+    ///
+    /// Whitespace, uppercase, control bytes, and non-ASCII are rejected rather
+    /// than normalized. Normalizing would let `Order-1` and `order-1` collapse
+    /// into one identity, which turns two distinct product requests into an
+    /// idempotency conflict the caller never asked for.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable reason when the token is empty, longer than
+    /// 128 bytes, or contains a byte outside the accepted set.
+    pub fn parse(value: &str) -> std::result::Result<Self, String> {
+        if value.is_empty() || value.len() > 128 {
+            return Err("logical_id must contain 1 to 128 ASCII chars".to_string());
+        }
+        if !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'-' | b'_' | b'.' | b':')
+        }) {
+            return Err(
+                "logical_id must use lowercase ASCII letters, digits, '-', '_', '.', or ':'"
+                    .to_string(),
+            );
+        }
+        Ok(Self(value.to_string()))
+    }
+
+    /// Canonical bytes used by the domain-separated request-id derivation.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Derive the 128-bit wire request id for this token on one directed pair.
+    ///
+    /// `blake3::derive_key(DM_LOGICAL_REQUEST_ID_CONTEXT, sender ‖ recipient ‖
+    /// token)`, truncated to the leading 16 bytes.
+    ///
+    /// Both agent ids are bound, not just the token. The recipient dedupes on
+    /// `(sender, request_id)` so binding the sender is belt-and-braces, but
+    /// binding the *recipient* is load-bearing: the sender's in-flight ACK
+    /// waiter is keyed by `request_id` alone, so one token fanned out to two
+    /// peers must not produce one id that two waiters fight over.
+    #[must_use]
+    pub fn request_id(&self, sender: AgentId, recipient: AgentId) -> [u8; 16] {
+        let mut hasher = blake3::Hasher::new_derive_key(DM_LOGICAL_REQUEST_ID_CONTEXT);
+        hasher.update(sender.as_bytes());
+        hasher.update(recipient.as_bytes());
+        hasher.update(self.0.as_bytes());
+        let digest = hasher.finalize();
+        let mut request_id = [0_u8; 16];
+        request_id.copy_from_slice(&digest.as_bytes()[..16]);
+        request_id
     }
 }
 

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -19,9 +19,18 @@ use bytes::Bytes;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot, RwLock};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 
 const ACK_ENVELOPE_LIFETIME_MS: u64 = 60_000;
+/// The pinned pubsub Critical-priority contract permits ten seconds waiting
+/// at its FIFO gate plus ten seconds for the send itself. Keep each durable
+/// ACK route alive for that complete healthy-congestion budget plus slack.
+const DURABLE_ACK_ROUTE_TIMEOUT: Duration = Duration::from_secs(22);
+/// ACK envelopes are small, but the queue is bounded so a disconnected mesh
+/// cannot turn sender retries into unbounded retained work.
+const DURABLE_ACK_QUEUE_CAPACITY: usize = 256;
+/// Bound the number of ACK jobs simultaneously holding pubsub fan-out work.
+const DURABLE_ACK_MAX_CONCURRENT: usize = 32;
 
 /// How long the durable path waits for a typed-route handler to report
 /// completion before withholding the ACK (ADR 0030 §7).
@@ -285,6 +294,36 @@ pub struct DmInboxService {
     topic: String,
 }
 
+/// One durable (v2) ACK envelope awaiting publication on both routes.
+struct AckPublishJob {
+    recipient: AgentId,
+    acked_request_id: [u8; 16],
+    protocol_version: u16,
+    encoded: Bytes,
+}
+
+#[derive(Clone)]
+struct AckPublisherHandle {
+    sender: mpsc::Sender<AckPublishJob>,
+}
+
+impl AckPublisherHandle {
+    /// Hand a job to the worker without ever blocking the inbox loop. A full
+    /// queue is reported, never awaited: the receiver has already committed
+    /// and the sender will time out, which is the documented safe failure —
+    /// whereas blocking here would stall every later DM behind one wedged ACK.
+    fn try_publish(&self, job: AckPublishJob) -> NetworkResult<()> {
+        self.sender.try_send(job).map_err(|error| match error {
+            mpsc::error::TrySendError::Full(_) => NetworkError::RemoteReceiveBackpressured(
+                "durable ACK publisher queue is full".to_string(),
+            ),
+            mpsc::error::TrySendError::Closed(_) => {
+                NetworkError::ChannelClosed("durable ACK publisher stopped".to_string())
+            }
+        })
+    }
+}
+
 /// Legacy shared DM transport topic. New sends use per-recipient inbox
 /// topics; this listener remains so rolling upgrades can still receive
 /// envelopes from older daemons.
@@ -323,6 +362,8 @@ impl DmInboxService {
             .subscribe_topic_id(topic.clone(), dm_inbox_topic(&self_agent_id))
             .await;
         let legacy_subscription = pubsub.subscribe(DM_BUS_TOPIC.to_string()).await;
+        let (ack_publisher, ack_worker) =
+            spawn_durable_ack_publisher(Arc::clone(&pubsub), Arc::clone(&dm));
 
         let pipeline = InboxPipeline {
             pubsub: Arc::clone(&pubsub),
@@ -340,6 +381,7 @@ impl DmInboxService {
             revocation_set,
             authenticated_machine_bindings,
             history,
+            ack_publisher,
         };
 
         let primary_handle =
@@ -352,7 +394,9 @@ impl DmInboxService {
         );
 
         Ok(Self {
-            handles: vec![primary_handle, legacy_handle],
+            // Aborting the worker drops its JoinSet, which aborts all owned
+            // route publications. A graceful channel close drains them.
+            handles: vec![primary_handle, legacy_handle, ack_worker],
             topic,
         })
     }
@@ -390,6 +434,153 @@ fn spawn_subscription_loop(
     })
 }
 
+fn spawn_durable_ack_publisher(
+    pubsub: Arc<PubSubManager>,
+    dm: Arc<DirectMessaging>,
+) -> (AckPublisherHandle, JoinHandle<()>) {
+    let (sender, receiver) = mpsc::channel(DURABLE_ACK_QUEUE_CAPACITY);
+    let worker = spawn_ack_publish_worker(receiver, move |job| {
+        let pubsub = Arc::clone(&pubsub);
+        let dm = Arc::clone(&dm);
+        async move {
+            publish_durable_ack_job(pubsub, dm, job).await;
+        }
+    });
+    (AckPublisherHandle { sender }, worker)
+}
+
+/// Generic over the publish closure so the worker's queue and concurrency
+/// behaviour can be tested without a live pubsub mesh.
+fn spawn_ack_publish_worker<Publish, PublishFuture>(
+    mut receiver: mpsc::Receiver<AckPublishJob>,
+    publish: Publish,
+) -> JoinHandle<()>
+where
+    Publish: Fn(AckPublishJob) -> PublishFuture + Send + Sync + 'static,
+    PublishFuture: std::future::Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let publish = Arc::new(publish);
+        let mut in_flight = JoinSet::new();
+
+        loop {
+            if in_flight.len() >= DURABLE_ACK_MAX_CONCURRENT {
+                if let Some(result) = in_flight.join_next().await {
+                    log_ack_publish_join_result(result);
+                }
+                continue;
+            }
+
+            tokio::select! {
+                biased;
+                Some(result) = in_flight.join_next(), if !in_flight.is_empty() => {
+                    log_ack_publish_join_result(result);
+                }
+                job = receiver.recv() => {
+                    let Some(job) = job else {
+                        break;
+                    };
+                    let publish = Arc::clone(&publish);
+                    in_flight.spawn(async move {
+                        publish(job).await;
+                    });
+                }
+            }
+        }
+
+        // Graceful closure drains accepted jobs. DmInboxService::abort aborts
+        // this owner task; dropping JoinSet then aborts every child promptly.
+        while let Some(result) = in_flight.join_next().await {
+            log_ack_publish_join_result(result);
+        }
+    })
+}
+
+fn log_ack_publish_join_result(result: Result<(), tokio::task::JoinError>) {
+    if let Err(error) = result {
+        tracing::warn!(
+            target: "dm.trace",
+            stage = "ack_publish_worker_failed",
+            %error,
+            "durable ACK publisher task failed"
+        );
+    }
+}
+
+async fn publish_durable_ack_job(
+    pubsub: Arc<PubSubManager>,
+    dm: Arc<DirectMessaging>,
+    job: AckPublishJob,
+) {
+    let topic = DmInboxService::inbox_topic_name(&job.recipient);
+    let primary = pubsub.publish_topic_id(
+        topic,
+        dm_inbox_topic(&job.recipient),
+        Bytes::clone(&job.encoded),
+    );
+    // The durable path always hedges onto the compatibility bus, even when the
+    // payload did not arrive there. A v2 sender has already been promised a
+    // committed row; a second route costs one small publish and removes a
+    // whole class of "committed but never acked" outcomes.
+    let legacy = pubsub.publish(DM_BUS_TOPIC.to_string(), job.encoded);
+    let result = publish_durable_ack_routes(DURABLE_ACK_ROUTE_TIMEOUT, primary, legacy).await;
+    if let Err(error) = result {
+        dm.record_ack_publish_route_failed();
+        tracing::warn!(
+            target: "dm.trace",
+            stage = "ack_publish_route_failed",
+            acked_request_id = %hex::encode(job.acked_request_id),
+            recipient = %hex::encode(job.recipient.as_bytes()),
+            protocol_version = job.protocol_version,
+            hedged = true,
+            %error,
+            "one or more durable ACK routes failed; another hedge may still have delivered"
+        );
+    }
+}
+
+async fn publish_durable_ack_routes<Primary, Legacy>(
+    route_timeout: Duration,
+    primary: Primary,
+    legacy: Legacy,
+) -> NetworkResult<()>
+where
+    Primary: std::future::Future<Output = NetworkResult<()>>,
+    Legacy: std::future::Future<Output = NetworkResult<()>>,
+{
+    // A targeted inbox publish can deliver remotely yet remain pending under
+    // per-topic fan-out backpressure. Poll the compatibility-bus hedge at the
+    // same time so a durable recipient does not commit and dispatch the DM
+    // while the sender exhausts its complete ACK budget waiting on the reverse
+    // targeted topic. Each independently-polled route has an explicit
+    // deadline: the successful hedge can reach the sender immediately, while
+    // a wedged sibling is cancelled at the deadline instead of pinning this
+    // serial inbox loop and blocking later DMs/ACKs forever. These futures
+    // are owned by a bounded background worker, so neither healthy congestion
+    // nor the full route deadline blocks subscription processing.
+    let (primary, legacy) = tokio::join!(
+        publish_ack_route_with_timeout("targeted", route_timeout, primary),
+        publish_ack_route_with_timeout("legacy-bus", route_timeout, legacy),
+    );
+    primary.and(legacy)
+}
+
+async fn publish_ack_route_with_timeout<Route>(
+    route: &'static str,
+    route_timeout: Duration,
+    publish: Route,
+) -> NetworkResult<()>
+where
+    Route: std::future::Future<Output = NetworkResult<()>>,
+{
+    match tokio::time::timeout(route_timeout, publish).await {
+        Ok(result) => result,
+        Err(_) => Err(NetworkError::BroadcastError(format!(
+            "ACK {route} publish timed out after {route_timeout:?}"
+        ))),
+    }
+}
+
 #[derive(Clone)]
 struct InboxPipeline {
     pubsub: Arc<PubSubManager>,
@@ -414,6 +605,8 @@ struct InboxPipeline {
     /// ADR-0023 history handle. Recording is `try_send`-only — this loop
     /// must never block (see the typed-route comment below).
     history: Option<crate::history::HistoryHandle>,
+    /// Bounded background publisher for durable (v2) ACK envelopes.
+    ack_publisher: AckPublisherHandle,
 }
 
 /// Re-ACK semantics for a logical request that already completed.
@@ -1568,19 +1761,50 @@ impl InboxPipeline {
         let encoded = envelope
             .to_wire_bytes()
             .map_err(|e| NetworkError::SerializationError(format!("ack encode: {e}")))?;
-        let topic = DmInboxService::inbox_topic_name(&to);
-        let primary = self
-            .pubsub
-            .publish_topic_id(topic, dm_inbox_topic(&to), Bytes::from(encoded.clone()))
-            .await;
-        let legacy = if ack_legacy_bus {
-            self.pubsub
-                .publish(DM_BUS_TOPIC.to_string(), Bytes::from(encoded))
-                .await
+        let result = if protocol_version >= DM_PROTOCOL_DURABLE_ACK {
+            // Durable v2 owns both publications in the bounded background
+            // worker. The inbox loop can immediately process a subsequent DM
+            // while the target and compatibility-bus routes retain their full
+            // healthy-congestion budgets. Ordering is unaffected: the history
+            // commit is already awaited before we get here, so this only makes
+            // the *publication* asynchronous, never the promise behind it.
+            self.ack_publisher.try_publish(AckPublishJob {
+                recipient: to,
+                acked_request_id: acks_request_id,
+                protocol_version,
+                encoded: Bytes::from(encoded),
+            })
         } else {
-            Ok(())
+            // Preserve v1 exactly: target first, and only publish back on the
+            // compatibility bus when this payload itself arrived there. No
+            // new deadline or background ownership changes legacy behavior.
+            let topic = DmInboxService::inbox_topic_name(&to);
+            let primary = self
+                .pubsub
+                .publish_topic_id(topic, dm_inbox_topic(&to), Bytes::from(encoded.clone()))
+                .await;
+            let legacy = if ack_legacy_bus {
+                self.pubsub
+                    .publish(DM_BUS_TOPIC.to_string(), Bytes::from(encoded))
+                    .await
+            } else {
+                Ok(())
+            };
+            primary.and(legacy)
         };
-        primary.and(legacy)
+        if let Err(error) = &result {
+            self.dm.record_ack_publish_route_failed();
+            tracing::warn!(
+                target: "dm.trace",
+                stage = "ack_publish_route_failed",
+                acked_request_id = %hex::encode(acks_request_id),
+                recipient = %hex::encode(to.as_bytes()),
+                protocol_version,
+                %error,
+                "ACK publication could not be scheduled or completed"
+            );
+        }
+        result
     }
 }
 
@@ -1679,6 +1903,10 @@ mod tests {
     }
 
     struct InboxHarness {
+        /// Keeps the durable-ACK worker alive for the harness's lifetime.
+        /// Dropping it closes the queue and every v2 ACK would fail to
+        /// schedule, which would look like a protocol bug in every test.
+        _ack_worker: JoinHandle<()>,
         pipeline: InboxPipeline,
         recipient_agent_id: AgentId,
         recipient_kem: Arc<AgentKemKeypair>,
@@ -1734,6 +1962,8 @@ mod tests {
                 .expect("insert machine revocation");
         }
 
+        let (ack_publisher, ack_worker) =
+            spawn_durable_ack_publisher(Arc::clone(&pubsub), Arc::clone(&dm));
         let pipeline = InboxPipeline {
             pubsub,
             signing: Arc::new(SigningContext::from_keypair(&recipient)),
@@ -1752,9 +1982,11 @@ mod tests {
             revocation_set: Arc::new(RwLock::new(revocation_set)),
             authenticated_machine_bindings,
             history: None,
+            ack_publisher,
         };
 
         InboxHarness {
+            _ack_worker: ack_worker,
             pipeline,
             recipient_agent_id,
             recipient_kem,
@@ -2438,6 +2670,109 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// ADR 0030 ACK liveness: the durable publisher must never make the inbox
+    /// loop wait. A saturated queue is reported to the caller rather than
+    /// awaited — the receiver has already committed, so the sender timing out
+    /// is the documented safe failure, whereas blocking here would stall every
+    /// later DM behind one wedged ACK route.
+    #[tokio::test]
+    async fn a_saturated_ack_queue_is_reported_rather_than_awaited() {
+        let (sender, mut receiver) = mpsc::channel(DURABLE_ACK_QUEUE_CAPACITY);
+        let handle = AckPublisherHandle { sender };
+        let job = || AckPublishJob {
+            recipient: AgentId([7; 32]),
+            acked_request_id: [1; 16],
+            protocol_version: DM_PROTOCOL_DURABLE_ACK,
+            encoded: Bytes::from_static(b"ack"),
+        };
+
+        for _ in 0..DURABLE_ACK_QUEUE_CAPACITY {
+            handle
+                .try_publish(job())
+                .expect("queue accepts up to its capacity");
+        }
+        assert!(
+            matches!(
+                handle.try_publish(job()),
+                Err(NetworkError::RemoteReceiveBackpressured(_))
+            ),
+            "the job past capacity must be refused, not block the inbox loop"
+        );
+
+        receiver.close();
+        while receiver.try_recv().is_ok() {}
+        assert!(
+            matches!(
+                handle.try_publish(job()),
+                Err(NetworkError::ChannelClosed(_))
+            ),
+            "a stopped worker must surface as an error, never a silent drop"
+        );
+    }
+
+    /// Both routes are polled concurrently and each carries its own deadline,
+    /// so one wedged route cannot consume the sender's whole ACK budget. If
+    /// these were awaited in sequence, a stuck targeted publish would hide a
+    /// healthy compatibility-bus hedge behind it — the exact "committed but
+    /// never acked" outcome the hedge exists to remove.
+    #[tokio::test(start_paused = true)]
+    async fn a_wedged_ack_route_is_cancelled_at_its_deadline_not_awaited_forever() {
+        let healthy = async { Ok(()) };
+        let wedged = async {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            Ok(())
+        };
+        let started = tokio::time::Instant::now();
+        let result = publish_durable_ack_routes(DURABLE_ACK_ROUTE_TIMEOUT, healthy, wedged).await;
+
+        assert!(
+            matches!(result, Err(NetworkError::BroadcastError(_))),
+            "a route that never completes must fail at its deadline: {result:?}"
+        );
+        assert_eq!(
+            started.elapsed(),
+            DURABLE_ACK_ROUTE_TIMEOUT,
+            "the deadline, not the wedged route, must bound the wait"
+        );
+    }
+
+    /// The v1 publish path must be untouched by the hedging work: a v1 ACK
+    /// still goes to the targeted topic only, and reaches the compatibility
+    /// bus only when the payload itself arrived there. Hedging every v1 ACK
+    /// onto the shared bus would add gossip traffic for every 0.37 peer in the
+    /// mesh, which is not what this change is for.
+    #[tokio::test]
+    async fn a_v1_ack_is_not_hedged_onto_the_compatibility_bus() {
+        let sender = test_keypair();
+        let machine = MachineId([0xD8; 32]);
+        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
+        let _service = attach_history(&mut harness);
+        let mut bus = harness
+            .pipeline
+            .pubsub
+            .subscribe(DM_BUS_TOPIC.to_string())
+            .await;
+
+        harness
+            .pipeline
+            .publish_ack_for_protocol(
+                sender.agent_id(),
+                [0x59; 16],
+                DmAckOutcome::Accepted,
+                DM_PROTOCOL_V1,
+                false,
+            )
+            .await
+            .expect("v1 ACK publishes");
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(300), bus.recv())
+                .await
+                .is_err(),
+            "a v1 ACK with ack_legacy_bus=false must not reach the shared bus"
+        );
     }
 
     /// The two pre-existing variants must keep their postcard discriminants,

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -438,6 +438,24 @@ fn cached_ack_for_protocol(
     }
 }
 
+/// Whether `handle_incoming`'s fast replay re-ACK must stand aside and let the
+/// durable path decide.
+///
+/// True only for a v2 payload envelope replaying a completion that carries a
+/// durable binding — the one case where the correct answer depends on bytes
+/// this stage has not decrypted yet. Everything else (v1 replays, ACK
+/// envelopes, completions with no binding) keeps the cheap path, so the cost
+/// of a signature verification and a decrypt is paid only where it buys the
+/// ADR 0030 §1 conflict check.
+fn cached_completion_needs_binding_check(
+    cached: Option<&crate::dm::CachedOutcome>,
+    envelope: &DmEnvelope,
+) -> bool {
+    matches!(envelope.body, DmBody::Payload(_))
+        && envelope.protocol_version >= DM_PROTOCOL_DURABLE_ACK
+        && cached.is_some_and(|cached| cached.durable_binding.is_some())
+}
+
 /// A commit outcome that proves exactly one durable row exists for this
 /// record. `Inserted` is the first commit; `Duplicate` is the idempotent
 /// replay of an identical record (ADR 0030 validation: "exactly one durable
@@ -625,7 +643,21 @@ impl InboxPipeline {
         );
 
         let dedupe = envelope.dedupe_key();
-        if let Some(cached) = self.cache.lookup(&dedupe) {
+        // A v2 envelope replaying a logical request that already completed
+        // durably must have its bytes compared against the committed binding
+        // before anything is re-ACKed — otherwise a caller that reused a
+        // `logical_id` for *different* content is told `Accepted` for bytes
+        // nobody stored. That comparison needs the plaintext, which this fast
+        // path does not have, so the durable path owns the whole replay
+        // decision for these envelopes (it re-ACKs from the same cache entry
+        // at step 2 without re-dispatching).
+        let needs_durable_binding_check =
+            cached_completion_needs_binding_check(self.cache.lookup(&dedupe).as_ref(), &envelope);
+        if let Some(cached) = self
+            .cache
+            .lookup(&dedupe)
+            .filter(|_| !needs_durable_binding_check)
+        {
             if matches!(envelope.body, DmBody::Payload(_)) {
                 // ADR 0030 §2: re-ACK under the semantics the completion was
                 // actually made with. A v1 completion answers a v2 request
@@ -1084,7 +1116,11 @@ impl InboxPipeline {
                 Some(stored) if stored == binding => {
                     cached_ack_for_protocol(&cached, envelope.protocol_version)
                 }
-                Some(_) => DmAckOutcome::AckSemanticsUnavailable {
+                // ADR 0030 slice 4: the id is bound to other bytes, which is a
+                // caller-side idempotency-key reuse, not a peer-capability
+                // gap. It answered `AckSemanticsUnavailable` until the typed
+                // error existed (#329 review).
+                Some(_) => DmAckOutcome::IdempotencyConflict {
                     reason: "logical request already completed with different content".to_string(),
                 },
                 None => cached_ack_for_protocol(&cached, envelope.protocol_version),
@@ -1210,7 +1246,7 @@ impl InboxPipeline {
                     .publish_ack_for_protocol(
                         sender_agent_id,
                         request_id,
-                        DmAckOutcome::AckSemanticsUnavailable {
+                        DmAckOutcome::IdempotencyConflict {
                             reason: "logical request already committed with different content"
                                 .to_string(),
                         },
@@ -2083,6 +2119,82 @@ mod tests {
         );
     }
 
+    /// Subscribe to the topic ACKs for `sender` land on, so a test can assert
+    /// the outcome the receiver actually put on the wire. `DurableAckDecision`
+    /// records only *that* a refusal was ACKed; which refusal it was is the
+    /// whole product contract, and it is only observable here.
+    async fn watch_acks_to(harness: &InboxHarness, sender: &AgentKeypair) -> Subscription {
+        harness
+            .pipeline
+            .pubsub
+            .subscribe_topic_id(
+                DmInboxService::inbox_topic_name(&sender.agent_id()),
+                dm_inbox_topic(&sender.agent_id()),
+            )
+            .await
+    }
+
+    async fn next_ack_outcome(subscription: &mut Subscription) -> DmAckOutcome {
+        let message = tokio::time::timeout(Duration::from_secs(5), subscription.recv())
+            .await
+            .expect("an ACK must be published within the timeout")
+            .expect("ACK subscription closed before an ACK arrived");
+        let envelope =
+            DmEnvelope::from_wire_bytes(&message.payload).expect("ACK envelope should decode");
+        match envelope.body {
+            DmBody::Ack(ack) => ack.outcome,
+            other => panic!("expected an ACK envelope, got {other:?}"),
+        }
+    }
+
+    /// ADR 0030 slice 4 rebind. Both binding-conflict sites answered
+    /// `AckSemanticsUnavailable` until `IdempotencyConflict` existed, which
+    /// told a product "the peer needs upgrading" when the truth was "your
+    /// client reused an idempotency key for different bytes". The two errors
+    /// prescribe opposite repairs — retry-later versus never-retry-these-bytes
+    /// — so conflating them is a user-visible defect, not a naming quibble.
+    #[tokio::test]
+    async fn a_rebound_logical_request_is_answered_idempotency_conflict() {
+        let sender = test_keypair();
+        let machine = MachineId([0xD6; 32]);
+        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
+        let _service = attach_history(&mut harness);
+        let mut acks = watch_acks_to(&harness, &sender).await;
+
+        let first = durable_payload_message(&harness, &sender, machine, 0x56, b"original bytes");
+        harness.pipeline.handle_incoming(first, false).await;
+        assert_eq!(
+            next_ack_outcome(&mut acks).await,
+            DmAckOutcome::Accepted,
+            "the first delivery is a normal durable acceptance"
+        );
+
+        // Replay-cache binding check: the id is still hot in memory.
+        let rebound = durable_payload_message(&harness, &sender, machine, 0x56, b"different bytes");
+        harness.pipeline.handle_incoming(rebound, false).await;
+        let hot = next_ack_outcome(&mut acks).await;
+        assert!(
+            matches!(hot, DmAckOutcome::IdempotencyConflict { .. }),
+            "a hot rebind must be an idempotency conflict, not a capability gap: {hot:?}"
+        );
+
+        // Restart: the replay cache is memory-only (ADR 0030 §1), so the same
+        // rebind must now be caught by the durable-history lookup instead —
+        // the site that has to reach the same verdict for the guarantee to
+        // survive a crash.
+        harness.pipeline.cache = Arc::new(RecentDeliveryCache::with_defaults());
+        let after_restart =
+            durable_payload_message(&harness, &sender, machine, 0x56, b"different bytes");
+        harness.pipeline.handle_incoming(after_restart, false).await;
+        assert!(
+            matches!(
+                next_ack_outcome(&mut acks).await,
+                DmAckOutcome::IdempotencyConflict { .. }
+            ),
+            "the durable-history conflict path must agree with the replay-cache path"
+        );
+    }
+
     /// ADR 0030 §2 mixed version: a 0.37 peer's v1 envelope keeps exactly its
     /// old behaviour on a durable-capable receiver — delivered, and ACKed with
     /// v1 semantics. Enabling durable history must not silently upgrade the
@@ -2350,7 +2462,16 @@ mod tests {
         assert_eq!(
             unavailable.first(),
             Some(&2u8),
-            "AckSemanticsUnavailable must be appended last"
+            "AckSemanticsUnavailable must keep the index slice 1 assigned it"
+        );
+        let conflict = postcard::to_stdvec(&DmAckOutcome::IdempotencyConflict {
+            reason: String::new(),
+        })
+        .expect("encode conflict");
+        assert_eq!(
+            conflict.first(),
+            Some(&3u8),
+            "IdempotencyConflict must be appended last"
         );
     }
 

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -19,18 +19,9 @@ use bytes::Bytes;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot, RwLock};
-use tokio::task::{JoinHandle, JoinSet};
+use tokio::task::JoinHandle;
 
 const ACK_ENVELOPE_LIFETIME_MS: u64 = 60_000;
-/// The pinned pubsub Critical-priority contract permits ten seconds waiting
-/// at its FIFO gate plus ten seconds for the send itself. Keep each durable
-/// ACK route alive for that complete healthy-congestion budget plus slack.
-const DURABLE_ACK_ROUTE_TIMEOUT: Duration = Duration::from_secs(22);
-/// ACK envelopes are small, but the queue is bounded so a disconnected mesh
-/// cannot turn sender retries into unbounded retained work.
-const DURABLE_ACK_QUEUE_CAPACITY: usize = 256;
-/// Bound the number of ACK jobs simultaneously holding pubsub fan-out work.
-const DURABLE_ACK_MAX_CONCURRENT: usize = 32;
 
 /// How long the durable path waits for a typed-route handler to report
 /// completion before withholding the ACK (ADR 0030 §7).
@@ -294,36 +285,6 @@ pub struct DmInboxService {
     topic: String,
 }
 
-/// One durable (v2) ACK envelope awaiting publication on both routes.
-struct AckPublishJob {
-    recipient: AgentId,
-    acked_request_id: [u8; 16],
-    protocol_version: u16,
-    encoded: Bytes,
-}
-
-#[derive(Clone)]
-struct AckPublisherHandle {
-    sender: mpsc::Sender<AckPublishJob>,
-}
-
-impl AckPublisherHandle {
-    /// Hand a job to the worker without ever blocking the inbox loop. A full
-    /// queue is reported, never awaited: the receiver has already committed
-    /// and the sender will time out, which is the documented safe failure —
-    /// whereas blocking here would stall every later DM behind one wedged ACK.
-    fn try_publish(&self, job: AckPublishJob) -> NetworkResult<()> {
-        self.sender.try_send(job).map_err(|error| match error {
-            mpsc::error::TrySendError::Full(_) => NetworkError::RemoteReceiveBackpressured(
-                "durable ACK publisher queue is full".to_string(),
-            ),
-            mpsc::error::TrySendError::Closed(_) => {
-                NetworkError::ChannelClosed("durable ACK publisher stopped".to_string())
-            }
-        })
-    }
-}
-
 /// Legacy shared DM transport topic. New sends use per-recipient inbox
 /// topics; this listener remains so rolling upgrades can still receive
 /// envelopes from older daemons.
@@ -362,8 +323,6 @@ impl DmInboxService {
             .subscribe_topic_id(topic.clone(), dm_inbox_topic(&self_agent_id))
             .await;
         let legacy_subscription = pubsub.subscribe(DM_BUS_TOPIC.to_string()).await;
-        let (ack_publisher, ack_worker) =
-            spawn_durable_ack_publisher(Arc::clone(&pubsub), Arc::clone(&dm));
 
         let pipeline = InboxPipeline {
             pubsub: Arc::clone(&pubsub),
@@ -381,7 +340,6 @@ impl DmInboxService {
             revocation_set,
             authenticated_machine_bindings,
             history,
-            ack_publisher,
         };
 
         let primary_handle =
@@ -394,9 +352,7 @@ impl DmInboxService {
         );
 
         Ok(Self {
-            // Aborting the worker drops its JoinSet, which aborts all owned
-            // route publications. A graceful channel close drains them.
-            handles: vec![primary_handle, legacy_handle, ack_worker],
+            handles: vec![primary_handle, legacy_handle],
             topic,
         })
     }
@@ -434,153 +390,6 @@ fn spawn_subscription_loop(
     })
 }
 
-fn spawn_durable_ack_publisher(
-    pubsub: Arc<PubSubManager>,
-    dm: Arc<DirectMessaging>,
-) -> (AckPublisherHandle, JoinHandle<()>) {
-    let (sender, receiver) = mpsc::channel(DURABLE_ACK_QUEUE_CAPACITY);
-    let worker = spawn_ack_publish_worker(receiver, move |job| {
-        let pubsub = Arc::clone(&pubsub);
-        let dm = Arc::clone(&dm);
-        async move {
-            publish_durable_ack_job(pubsub, dm, job).await;
-        }
-    });
-    (AckPublisherHandle { sender }, worker)
-}
-
-/// Generic over the publish closure so the worker's queue and concurrency
-/// behaviour can be tested without a live pubsub mesh.
-fn spawn_ack_publish_worker<Publish, PublishFuture>(
-    mut receiver: mpsc::Receiver<AckPublishJob>,
-    publish: Publish,
-) -> JoinHandle<()>
-where
-    Publish: Fn(AckPublishJob) -> PublishFuture + Send + Sync + 'static,
-    PublishFuture: std::future::Future<Output = ()> + Send + 'static,
-{
-    tokio::spawn(async move {
-        let publish = Arc::new(publish);
-        let mut in_flight = JoinSet::new();
-
-        loop {
-            if in_flight.len() >= DURABLE_ACK_MAX_CONCURRENT {
-                if let Some(result) = in_flight.join_next().await {
-                    log_ack_publish_join_result(result);
-                }
-                continue;
-            }
-
-            tokio::select! {
-                biased;
-                Some(result) = in_flight.join_next(), if !in_flight.is_empty() => {
-                    log_ack_publish_join_result(result);
-                }
-                job = receiver.recv() => {
-                    let Some(job) = job else {
-                        break;
-                    };
-                    let publish = Arc::clone(&publish);
-                    in_flight.spawn(async move {
-                        publish(job).await;
-                    });
-                }
-            }
-        }
-
-        // Graceful closure drains accepted jobs. DmInboxService::abort aborts
-        // this owner task; dropping JoinSet then aborts every child promptly.
-        while let Some(result) = in_flight.join_next().await {
-            log_ack_publish_join_result(result);
-        }
-    })
-}
-
-fn log_ack_publish_join_result(result: Result<(), tokio::task::JoinError>) {
-    if let Err(error) = result {
-        tracing::warn!(
-            target: "dm.trace",
-            stage = "ack_publish_worker_failed",
-            %error,
-            "durable ACK publisher task failed"
-        );
-    }
-}
-
-async fn publish_durable_ack_job(
-    pubsub: Arc<PubSubManager>,
-    dm: Arc<DirectMessaging>,
-    job: AckPublishJob,
-) {
-    let topic = DmInboxService::inbox_topic_name(&job.recipient);
-    let primary = pubsub.publish_topic_id(
-        topic,
-        dm_inbox_topic(&job.recipient),
-        Bytes::clone(&job.encoded),
-    );
-    // The durable path always hedges onto the compatibility bus, even when the
-    // payload did not arrive there. A v2 sender has already been promised a
-    // committed row; a second route costs one small publish and removes a
-    // whole class of "committed but never acked" outcomes.
-    let legacy = pubsub.publish(DM_BUS_TOPIC.to_string(), job.encoded);
-    let result = publish_durable_ack_routes(DURABLE_ACK_ROUTE_TIMEOUT, primary, legacy).await;
-    if let Err(error) = result {
-        dm.record_ack_publish_route_failed();
-        tracing::warn!(
-            target: "dm.trace",
-            stage = "ack_publish_route_failed",
-            acked_request_id = %hex::encode(job.acked_request_id),
-            recipient = %hex::encode(job.recipient.as_bytes()),
-            protocol_version = job.protocol_version,
-            hedged = true,
-            %error,
-            "one or more durable ACK routes failed; another hedge may still have delivered"
-        );
-    }
-}
-
-async fn publish_durable_ack_routes<Primary, Legacy>(
-    route_timeout: Duration,
-    primary: Primary,
-    legacy: Legacy,
-) -> NetworkResult<()>
-where
-    Primary: std::future::Future<Output = NetworkResult<()>>,
-    Legacy: std::future::Future<Output = NetworkResult<()>>,
-{
-    // A targeted inbox publish can deliver remotely yet remain pending under
-    // per-topic fan-out backpressure. Poll the compatibility-bus hedge at the
-    // same time so a durable recipient does not commit and dispatch the DM
-    // while the sender exhausts its complete ACK budget waiting on the reverse
-    // targeted topic. Each independently-polled route has an explicit
-    // deadline: the successful hedge can reach the sender immediately, while
-    // a wedged sibling is cancelled at the deadline instead of pinning this
-    // serial inbox loop and blocking later DMs/ACKs forever. These futures
-    // are owned by a bounded background worker, so neither healthy congestion
-    // nor the full route deadline blocks subscription processing.
-    let (primary, legacy) = tokio::join!(
-        publish_ack_route_with_timeout("targeted", route_timeout, primary),
-        publish_ack_route_with_timeout("legacy-bus", route_timeout, legacy),
-    );
-    primary.and(legacy)
-}
-
-async fn publish_ack_route_with_timeout<Route>(
-    route: &'static str,
-    route_timeout: Duration,
-    publish: Route,
-) -> NetworkResult<()>
-where
-    Route: std::future::Future<Output = NetworkResult<()>>,
-{
-    match tokio::time::timeout(route_timeout, publish).await {
-        Ok(result) => result,
-        Err(_) => Err(NetworkError::BroadcastError(format!(
-            "ACK {route} publish timed out after {route_timeout:?}"
-        ))),
-    }
-}
-
 #[derive(Clone)]
 struct InboxPipeline {
     pubsub: Arc<PubSubManager>,
@@ -605,8 +414,6 @@ struct InboxPipeline {
     /// ADR-0023 history handle. Recording is `try_send`-only — this loop
     /// must never block (see the typed-route comment below).
     history: Option<crate::history::HistoryHandle>,
-    /// Bounded background publisher for durable (v2) ACK envelopes.
-    ack_publisher: AckPublisherHandle,
 }
 
 /// Re-ACK semantics for a logical request that already completed.
@@ -1761,50 +1568,19 @@ impl InboxPipeline {
         let encoded = envelope
             .to_wire_bytes()
             .map_err(|e| NetworkError::SerializationError(format!("ack encode: {e}")))?;
-        let result = if protocol_version >= DM_PROTOCOL_DURABLE_ACK {
-            // Durable v2 owns both publications in the bounded background
-            // worker. The inbox loop can immediately process a subsequent DM
-            // while the target and compatibility-bus routes retain their full
-            // healthy-congestion budgets. Ordering is unaffected: the history
-            // commit is already awaited before we get here, so this only makes
-            // the *publication* asynchronous, never the promise behind it.
-            self.ack_publisher.try_publish(AckPublishJob {
-                recipient: to,
-                acked_request_id: acks_request_id,
-                protocol_version,
-                encoded: Bytes::from(encoded),
-            })
+        let topic = DmInboxService::inbox_topic_name(&to);
+        let primary = self
+            .pubsub
+            .publish_topic_id(topic, dm_inbox_topic(&to), Bytes::from(encoded.clone()))
+            .await;
+        let legacy = if ack_legacy_bus {
+            self.pubsub
+                .publish(DM_BUS_TOPIC.to_string(), Bytes::from(encoded))
+                .await
         } else {
-            // Preserve v1 exactly: target first, and only publish back on the
-            // compatibility bus when this payload itself arrived there. No
-            // new deadline or background ownership changes legacy behavior.
-            let topic = DmInboxService::inbox_topic_name(&to);
-            let primary = self
-                .pubsub
-                .publish_topic_id(topic, dm_inbox_topic(&to), Bytes::from(encoded.clone()))
-                .await;
-            let legacy = if ack_legacy_bus {
-                self.pubsub
-                    .publish(DM_BUS_TOPIC.to_string(), Bytes::from(encoded))
-                    .await
-            } else {
-                Ok(())
-            };
-            primary.and(legacy)
+            Ok(())
         };
-        if let Err(error) = &result {
-            self.dm.record_ack_publish_route_failed();
-            tracing::warn!(
-                target: "dm.trace",
-                stage = "ack_publish_route_failed",
-                acked_request_id = %hex::encode(acks_request_id),
-                recipient = %hex::encode(to.as_bytes()),
-                protocol_version,
-                %error,
-                "ACK publication could not be scheduled or completed"
-            );
-        }
-        result
+        primary.and(legacy)
     }
 }
 
@@ -1903,10 +1679,6 @@ mod tests {
     }
 
     struct InboxHarness {
-        /// Keeps the durable-ACK worker alive for the harness's lifetime.
-        /// Dropping it closes the queue and every v2 ACK would fail to
-        /// schedule, which would look like a protocol bug in every test.
-        _ack_worker: JoinHandle<()>,
         pipeline: InboxPipeline,
         recipient_agent_id: AgentId,
         recipient_kem: Arc<AgentKemKeypair>,
@@ -1962,8 +1734,6 @@ mod tests {
                 .expect("insert machine revocation");
         }
 
-        let (ack_publisher, ack_worker) =
-            spawn_durable_ack_publisher(Arc::clone(&pubsub), Arc::clone(&dm));
         let pipeline = InboxPipeline {
             pubsub,
             signing: Arc::new(SigningContext::from_keypair(&recipient)),
@@ -1982,11 +1752,9 @@ mod tests {
             revocation_set: Arc::new(RwLock::new(revocation_set)),
             authenticated_machine_bindings,
             history: None,
-            ack_publisher,
         };
 
         InboxHarness {
-            _ack_worker: ack_worker,
             pipeline,
             recipient_agent_id,
             recipient_kem,
@@ -2670,109 +2438,6 @@ mod tests {
                 );
             }
         }
-    }
-
-    /// ADR 0030 ACK liveness: the durable publisher must never make the inbox
-    /// loop wait. A saturated queue is reported to the caller rather than
-    /// awaited — the receiver has already committed, so the sender timing out
-    /// is the documented safe failure, whereas blocking here would stall every
-    /// later DM behind one wedged ACK route.
-    #[tokio::test]
-    async fn a_saturated_ack_queue_is_reported_rather_than_awaited() {
-        let (sender, mut receiver) = mpsc::channel(DURABLE_ACK_QUEUE_CAPACITY);
-        let handle = AckPublisherHandle { sender };
-        let job = || AckPublishJob {
-            recipient: AgentId([7; 32]),
-            acked_request_id: [1; 16],
-            protocol_version: DM_PROTOCOL_DURABLE_ACK,
-            encoded: Bytes::from_static(b"ack"),
-        };
-
-        for _ in 0..DURABLE_ACK_QUEUE_CAPACITY {
-            handle
-                .try_publish(job())
-                .expect("queue accepts up to its capacity");
-        }
-        assert!(
-            matches!(
-                handle.try_publish(job()),
-                Err(NetworkError::RemoteReceiveBackpressured(_))
-            ),
-            "the job past capacity must be refused, not block the inbox loop"
-        );
-
-        receiver.close();
-        while receiver.try_recv().is_ok() {}
-        assert!(
-            matches!(
-                handle.try_publish(job()),
-                Err(NetworkError::ChannelClosed(_))
-            ),
-            "a stopped worker must surface as an error, never a silent drop"
-        );
-    }
-
-    /// Both routes are polled concurrently and each carries its own deadline,
-    /// so one wedged route cannot consume the sender's whole ACK budget. If
-    /// these were awaited in sequence, a stuck targeted publish would hide a
-    /// healthy compatibility-bus hedge behind it — the exact "committed but
-    /// never acked" outcome the hedge exists to remove.
-    #[tokio::test(start_paused = true)]
-    async fn a_wedged_ack_route_is_cancelled_at_its_deadline_not_awaited_forever() {
-        let healthy = async { Ok(()) };
-        let wedged = async {
-            tokio::time::sleep(Duration::from_secs(3600)).await;
-            Ok(())
-        };
-        let started = tokio::time::Instant::now();
-        let result = publish_durable_ack_routes(DURABLE_ACK_ROUTE_TIMEOUT, healthy, wedged).await;
-
-        assert!(
-            matches!(result, Err(NetworkError::BroadcastError(_))),
-            "a route that never completes must fail at its deadline: {result:?}"
-        );
-        assert_eq!(
-            started.elapsed(),
-            DURABLE_ACK_ROUTE_TIMEOUT,
-            "the deadline, not the wedged route, must bound the wait"
-        );
-    }
-
-    /// The v1 publish path must be untouched by the hedging work: a v1 ACK
-    /// still goes to the targeted topic only, and reaches the compatibility
-    /// bus only when the payload itself arrived there. Hedging every v1 ACK
-    /// onto the shared bus would add gossip traffic for every 0.37 peer in the
-    /// mesh, which is not what this change is for.
-    #[tokio::test]
-    async fn a_v1_ack_is_not_hedged_onto_the_compatibility_bus() {
-        let sender = test_keypair();
-        let machine = MachineId([0xD8; 32]);
-        let mut harness = make_inbox_harness(&sender, Some(machine), None).await;
-        let _service = attach_history(&mut harness);
-        let mut bus = harness
-            .pipeline
-            .pubsub
-            .subscribe(DM_BUS_TOPIC.to_string())
-            .await;
-
-        harness
-            .pipeline
-            .publish_ack_for_protocol(
-                sender.agent_id(),
-                [0x59; 16],
-                DmAckOutcome::Accepted,
-                DM_PROTOCOL_V1,
-                false,
-            )
-            .await
-            .expect("v1 ACK publishes");
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(300), bus.recv())
-                .await
-                .is_err(),
-            "a v1 ACK with ack_legacy_bus=false must not reach the shared bus"
-        );
     }
 
     /// The two pre-existing variants must keep their postcard discriminants,

--- a/src/dm_send.rs
+++ b/src/dm_send.rs
@@ -503,6 +503,9 @@ fn ack_outcome_to_receipt(
         DmAckOutcome::AckSemanticsUnavailable { reason } => {
             Err(DmError::AckSemanticsUnavailable(reason))
         }
+        // ADR 0030 slice 4: distinct from the line above precisely because the
+        // caller's next move differs — a fresh logical id, not a retry.
+        DmAckOutcome::IdempotencyConflict { reason } => Err(DmError::IdempotencyConflict(reason)),
     }
 }
 

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -821,6 +821,18 @@ function trustHtml(t){const sym={Trusted:'&#10003;&#10003;',Known:'&#10003;',Unk
 function policyHtml(p){if(!p)return'';const t=typeof p==='string'?p:p.type||'Signed';const c=t.toLowerCase();return '<span class="policy policy-'+c+'">'+(c==='encrypted'?'&#128274; ':'')+t+'</span>'}
 function presenceHtml(online){return '<span class="presence '+(online?'online':'offline')+'"></span>'}
 function apiError(r){return r?(r.error||r.message||r.reason||('HTTP '+(r._http_status||'?'))):'network error'}
+// ADR 0030 §4 made /direct/send durable by default, so its refusals are now
+// routine rather than exceptional, and two of them are 409s whose repairs are
+// opposite. Showing the raw code would leave a user with "idempotency_conflict"
+// and no idea that retrying is the one thing that cannot work.
+const DM_SEND_ERRORS={
+  recipient_ack_semantics_unavailable:"Peer needs upgrading — it can't confirm durable delivery yet. Retry later, or resend without durable delivery.",
+  idempotency_conflict:"That message id was already used for different content. Retrying won't help — send it as a new message.",
+  recipient_key_unavailable:"Peer not found — no published key or contact card for that agent yet.",
+  require_gossip_ack_removed:"This client sent a field the daemon removed (require_gossip_ack). Update the app.",
+  invalid_logical_id:"Invalid message id: use 1-128 characters from a-z, 0-9, '-', '_', '.', ':'."
+};
+function dmSendError(r){return (r&&DM_SEND_ERRORS[r.error])||apiError(r)}
 function agentCardPath(displayName,includeGroups){
   const params=new URLSearchParams();
   if(displayName)params.set('display_name',displayName);
@@ -2849,10 +2861,15 @@ async function sendDm(){
   const payload=u8encode(JSON.stringify({text:t,sender_name:name,ts:Date.now()}));
   const ackBox=document.getElementById('dm-require-ack');
   const body={agent_id:target,payload};
-  if(ackBox&&ackBox.checked){body.require_ack_ms=5000;body.require_gossip_ack=true}
+  // ADR 0030 §4: require_gossip_ack was removed from /direct/send and now
+  // answers 400. Nothing replaces it here — the product default is durable
+  // delivery, which is a strictly stronger confirmation than the gossip ACK
+  // this used to request. The checkbox keeps its remaining job, the
+  // post-send liveness probe.
+  if(ackBox&&ackBox.checked){body.require_ack_ms=5000}
   const resp=await api('/direct/send',{method:'POST',body:JSON.stringify(body)});
   if(!resp||resp._http_ok===false||resp.ok===false){
-    toast('Send failed: '+apiError(resp),'error');
+    toast('Send failed: '+dmSendError(resp),'error');
     inp.focus();
     return;
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4674,11 +4674,16 @@ impl Agent {
             // withholds the contact-card fallback from strict sends (a card
             // pins no machine), so a peer we know only by card arrives here
             // with `cap == None`. Ask what we actually know instead.
+            //
+            // *Any* contact card counts, including one with no
+            // `dm_capabilities` yet. Such a card is a known peer whose advert
+            // has not converged — plausibly one that needs upgrading, which is
+            // exactly what the 409 tells the caller. Requiring capabilities on
+            // the card would misfile it as "no such agent" and send a product
+            // UI looking for a typo instead of waiting for convergence.
             let recipient_is_known = cap.is_some() || {
                 let contacts = self.contact_store.read().await;
-                contacts
-                    .get(to)
-                    .is_some_and(|contact| contact.dm_capabilities.is_some())
+                contacts.get(to).is_some()
             };
             tracing::info!(
                 target: "dm.trace",
@@ -13537,6 +13542,54 @@ mod tests {
         assert!(
             matches!(err, dm::DmError::AckSemanticsUnavailable(_)),
             "unexpected error: {err:?}"
+        );
+    }
+
+    /// The 404/409 boundary sits at "do we know this agent at all", not at
+    /// "has its advert converged". A contact card with no `dm_capabilities`
+    /// yet is a *known* peer mid-convergence — plausibly one that needs
+    /// upgrading — so it gets the 409 that says so. Classifying it as a
+    /// stranger would tell a product UI to go looking for a typo in an agent
+    /// id that is demonstrably in the contact store.
+    #[tokio::test]
+    async fn a_known_contact_without_capabilities_is_a_409_not_a_404() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .build()
+            .await
+            .expect("agent");
+        let target = identity::AgentId([0x65_u8; 32]);
+
+        agent.contacts().write().await.add(contacts::Contact {
+            agent_id: target,
+            trust_level: contacts::TrustLevel::Trusted,
+            label: None,
+            added_at: 0,
+            last_seen: None,
+            identity_type: contacts::IdentityType::Known,
+            // The distinguishing detail: known agent, no advert yet.
+            dm_capabilities: None,
+            machines: Vec::new(),
+        });
+
+        let err = agent
+            .send_direct_with_config(
+                &target,
+                b"strict".to_vec(),
+                dm::DmSendConfig {
+                    require_gossip: true,
+                    require_durable_app_ack: true,
+                    ..dm::DmSendConfig::default()
+                },
+            )
+            .await
+            .expect_err("strict send must refuse without a v2 advert");
+        assert!(
+            matches!(err, dm::DmError::AckSemanticsUnavailable(_)),
+            "a known contact must not be reported as an unknown agent: {err:?}"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4669,14 +4669,39 @@ impl Agent {
                     .as_ref(),
             )
         {
+            // "This peer does not advertise v2" presupposes we know the peer.
+            // `cap` cannot answer that on its own: the branch above deliberately
+            // withholds the contact-card fallback from strict sends (a card
+            // pins no machine), so a peer we know only by card arrives here
+            // with `cap == None`. Ask what we actually know instead.
+            let recipient_is_known = cap.is_some() || {
+                let contacts = self.contact_store.read().await;
+                contacts
+                    .get(to)
+                    .is_some_and(|contact| contact.dm_capabilities.is_some())
+            };
             tracing::info!(
                 target: "dm.trace",
                 stage = "strict_durable_ack_gate_refused",
                 recipient = %hex::encode(to.as_bytes()),
                 source = cap_source,
                 advertised_version = cap.as_ref().map(|c| c.max_protocol_version),
+                recipient_is_known,
                 "refusing strict send: recipient has no current v2 capability advert"
             );
+            // A stranger gets the same 404 a non-strict send gives. Answering
+            // 409 "peer needs upgrade" for an agent id that was never
+            // discovered would send a product UI chasing a fleet-upgrade
+            // problem it does not have — the misdiagnosis ADR 0030 §2's typed
+            // errors exist to prevent. Slice 4 makes this the common failure:
+            // every product send is strict now, so every unknown-recipient
+            // send reaches this gate.
+            if !recipient_is_known {
+                return Err(dm::DmError::RecipientKeyUnavailable(format!(
+                    "recipient {} has no known DM capability advert",
+                    hex::encode(to.as_bytes())
+                )));
+            }
             return Err(dm::DmError::AckSemanticsUnavailable(format!(
                 "recipient {} has no current v2 durable-ACK capability advert",
                 hex::encode(to.as_bytes())
@@ -13512,6 +13537,44 @@ mod tests {
         assert!(
             matches!(err, dm::DmError::AckSemanticsUnavailable(_)),
             "unexpected error: {err:?}"
+        );
+    }
+
+    /// ADR 0030 slice 4 precedence. `AckSemanticsUnavailable` means "this peer
+    /// does not advertise v2", which presupposes we know the peer at all. For
+    /// an agent id we hold no capability record for — no advert, no contact
+    /// card — the honest answer stays the 404 a non-strict send gives, not a
+    /// 409 that sends a product UI chasing a fleet upgrade for a peer that was
+    /// never discovered. Slice 4 makes this the common failure: every product
+    /// send is strict now, so unknown recipients all arrive at this gate.
+    #[tokio::test]
+    async fn a_strict_send_to_a_wholly_unknown_peer_reports_missing_key_not_missing_v2() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .build()
+            .await
+            .expect("agent");
+        // No capability-store entry and no contact card: this id is a stranger.
+        let target = identity::AgentId([0x64_u8; 32]);
+
+        let err = agent
+            .send_direct_with_config(
+                &target,
+                b"strict".to_vec(),
+                dm::DmSendConfig {
+                    require_gossip: true,
+                    require_durable_app_ack: true,
+                    ..dm::DmSendConfig::default()
+                },
+            )
+            .await
+            .expect_err("strict send to a stranger must refuse");
+        assert!(
+            matches!(err, dm::DmError::RecipientKeyUnavailable(_)),
+            "a stranger must not be reported as a peer needing an upgrade: {err:?}"
         );
     }
 

--- a/src/server/routes/direct.rs
+++ b/src/server/routes/direct.rs
@@ -169,6 +169,23 @@ fn direct_send_config_for_request(
                 detail,
             }
         })?;
+        // `logical_id` only means something under durable semantics: the
+        // recipient's binding and durable-history checks are what recognise a
+        // retry and answer `idempotency_conflict`. A v1 send carries the
+        // derived id on the wire but nothing on the receiver consults it, so
+        // accepting the combination would hand back an idempotency guarantee
+        // that does not exist. Refuse instead of documenting a silent no-op —
+        // a caller who asked for at-least-once retry identity and got
+        // fire-and-forget has no way to notice.
+        if !config.require_durable_app_ack {
+            return Err(DirectSendRequestRejection {
+                status: StatusCode::BAD_REQUEST,
+                code: "logical_id_requires_durable_ack",
+                detail: "logical_id has no effect without durable delivery; \
+                         remove require_durable_app_ack: false or drop logical_id"
+                    .to_string(),
+            });
+        }
         config.logical_request_id = Some(logical_id.request_id(self_agent_id, recipient));
     }
     Ok(config)
@@ -703,6 +720,42 @@ mod tests {
                 .is_none(),
             "omitting logical_id must keep the fresh-random-id behaviour"
         );
+    }
+
+    /// ADR 0030 slice 4 review: `logical_id` is only honoured by the durable
+    /// receiver path, so pairing it with the opt-out would hand back an
+    /// at-least-once retry identity that nothing enforces. Refused rather than
+    /// documented as a no-op — a caller who asked for idempotency and silently
+    /// got fire-and-forget has no way to discover it until duplicates appear.
+    #[test]
+    fn a_logical_id_without_durable_delivery_is_refused_not_ignored() {
+        let rejection = direct_send_config_for_request(
+            &parse_request(serde_json::json!({
+                "agent_id": "00".repeat(32),
+                "payload": "",
+                "logical_id": "order-42",
+                "require_durable_app_ack": false
+            })),
+            test_agent_id(1),
+            test_agent_id(2),
+        )
+        .expect_err("logical_id with the durable opt-out must be refused");
+        assert_eq!(rejection.status, StatusCode::BAD_REQUEST);
+        assert_eq!(rejection.code, "logical_id_requires_durable_ack");
+
+        // Each half alone stays valid — the refusal is about the combination.
+        assert!(config_for(serde_json::json!({
+            "agent_id": "00".repeat(32),
+            "payload": "",
+            "logical_id": "order-42"
+        }))
+        .is_ok());
+        assert!(config_for(serde_json::json!({
+            "agent_id": "00".repeat(32),
+            "payload": "",
+            "require_durable_app_ack": false
+        }))
+        .is_ok());
     }
 
     /// A rejected token must not reach the send path at all: silently dropping

--- a/src/server/routes/direct.rs
+++ b/src/server/routes/direct.rs
@@ -59,6 +59,10 @@ pub(in crate::server) struct DirectSendRequest {
     /// Base64-encoded payload.
     pub(in crate::server) payload: String,
     /// Prefer the raw-QUIC path when a live direct connection exists.
+    ///
+    /// Ignored by a durable send: raw QUIC yields a transport receipt, which
+    /// can never certify the recipient's durable commit (see
+    /// `require_durable_app_ack`).
     #[serde(default)]
     pub(in crate::server) prefer_raw_quic_if_connected: Option<bool>,
     /// Optional raw-QUIC receive-pipeline ACK timeout for the message itself.
@@ -72,34 +76,102 @@ pub(in crate::server) struct DirectSendRequest {
     /// gossip DM capability.
     #[serde(default)]
     pub(in crate::server) require_gossip: bool,
-    /// If set, override whether gossip-inbox sends wait for the recipient's
-    /// inbox ACK before returning success. When omitted, the daemon default is
-    /// used.
+    /// **Removed** (ADR 0030 §4). Setting this field in any form is a 400.
+    ///
+    /// Typed as a raw value rather than `Option<bool>` deliberately: the
+    /// contract is "this field is gone", so `"require_gossip_ack": "maybe"`
+    /// must answer the same documented 400 as `false` does, not an opaque
+    /// deserialization rejection from the JSON extractor.
     #[serde(default)]
-    pub(in crate::server) require_gossip_ack: Option<bool>,
+    pub(in crate::server) require_gossip_ack: Option<serde_json::Value>,
     /// Optional opt-in: after the DM path accepts the message, probe the
     /// recipient's ant-quic receive pipeline for liveness with this timeout.
     /// This does not force the message itself onto raw-QUIC receive-ACK.
     #[serde(default)]
     pub(in crate::server) require_ack_ms: Option<u64>,
+    /// ADR 0030 §4 opt-out. This product surface is durable-by-default:
+    /// omitting the field selects `true`, so `ok: true` means the recipient
+    /// durably committed the message and completed local dispatch. Pass
+    /// `false` for v1 semantics (`ok: true` means "accepted for delivery"),
+    /// which is what a caller does when reaching a peer that has not upgraded
+    /// matters more than the stronger receipt.
+    #[serde(default)]
+    pub(in crate::server) require_durable_app_ack: Option<bool>,
+    /// Caller-supplied idempotency key for this logical send (ADR 0030 §4).
+    ///
+    /// 1–128 chars of `[a-z0-9]`, `-`, `_`, `.`, `:`. Resending the same token
+    /// to the same recipient is *the same request*: the recipient re-ACKs the
+    /// original commit instead of storing a second copy. Reusing it for
+    /// different bytes is a 409 `idempotency_conflict`.
+    #[serde(default)]
+    pub(in crate::server) logical_id: Option<String>,
 }
 
-fn direct_send_config_for_request(req: &DirectSendRequest) -> x0x::dm::DmSendConfig {
+/// A request the route refuses before any send is attempted, carrying the
+/// exact wire contract (`error` code + `detail`) the caller sees.
+#[derive(Debug)]
+struct DirectSendRequestRejection {
+    status: StatusCode,
+    code: &'static str,
+    detail: String,
+}
+
+impl DirectSendRequestRejection {
+    fn into_response(self) -> (StatusCode, Json<serde_json::Value>) {
+        (
+            self.status,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": self.code,
+                "detail": self.detail,
+            })),
+        )
+    }
+}
+
+fn direct_send_config_for_request(
+    req: &DirectSendRequest,
+    self_agent_id: x0x::identity::AgentId,
+    recipient: x0x::identity::AgentId,
+) -> Result<x0x::dm::DmSendConfig, DirectSendRequestRejection> {
+    // ADR 0030 §4: `require_gossip_ack` is removed from the product surface,
+    // and removal is announced, not silent. Accepting it as a no-op would let
+    // a caller keep believing it selected fire-and-forget while every send
+    // blocked on an ACK — the exact silent-degradation class ADR 0025 forbids.
+    if req.require_gossip_ack.is_some() {
+        return Err(DirectSendRequestRejection {
+            status: StatusCode::BAD_REQUEST,
+            code: "require_gossip_ack_removed",
+            detail: "require_gossip_ack was removed in ADR 0030 §4; use \
+                     require_durable_app_ack to choose receipt semantics"
+                .to_string(),
+        });
+    }
+
     let mut config = direct_message_send_config();
     if let Some(prefer_raw_quic_if_connected) = req.prefer_raw_quic_if_connected {
         config.prefer_raw_quic_if_connected = prefer_raw_quic_if_connected;
     }
     config.stop_fallback_on_raw_error = req.stop_fallback_on_raw_error;
     config.require_gossip = req.require_gossip;
-    if let Some(require_gossip_ack) = req.require_gossip_ack {
-        config.require_gossip_ack = require_gossip_ack;
-    }
+    // ADR 0030 §4 product tier: durable unless the caller opts out.
+    config.require_durable_app_ack = req.require_durable_app_ack.unwrap_or(true);
     if let Some(raw_ack_ms) = req.raw_quic_receive_ack_ms {
         config.raw_quic_receive_ack_timeout = Some(std::time::Duration::from_millis(
             raw_ack_ms.clamp(100, 30_000),
         ));
     }
-    config
+    if let Some(raw_logical_id) = &req.logical_id {
+        let logical_id = x0x::dm::DmLogicalId::parse(raw_logical_id).map_err(|detail| {
+            DirectSendRequestRejection {
+                status: StatusCode::BAD_REQUEST,
+                code: "invalid_logical_id",
+                detail,
+            }
+        })?;
+        config.logical_request_id = Some(logical_id.request_id(self_agent_id, recipient));
+    }
+    Ok(config)
 }
 
 /// POST /agents/connect — connect to a discovered agent.
@@ -244,6 +316,14 @@ pub(in crate::server) async fn direct_send(
         }
     };
 
+    // Request-shape validation precedes trust and payload handling: a removed
+    // or malformed field is refused unconditionally, so a caller debugging the
+    // 400 never has to wonder whether trust state changed the answer.
+    let send_config = match direct_send_config_for_request(&req, state.agent.agent_id(), agent_id) {
+        Ok(config) => config,
+        Err(rejection) => return rejection.into_response(),
+    };
+
     // Check trust level before sending — reject blocked agents
     {
         let contacts = state.contacts.read().await;
@@ -258,8 +338,6 @@ pub(in crate::server) async fn direct_send(
         Ok(p) => p,
         Err(resp) => return resp,
     };
-
-    let send_config = direct_send_config_for_request(&req);
 
     match state
         .agent
@@ -358,6 +436,14 @@ pub(in crate::server) async fn direct_send(
                 // resend with `require_durable_app_ack = false`.
                 x0x::dm::DmError::AckSemanticsUnavailable(_) => {
                     (StatusCode::CONFLICT, "recipient_ack_semantics_unavailable")
+                }
+                // ADR 0030 §1: the recipient holds this `logical_id` bound to
+                // different bytes. 409 like the line above, but the caller's
+                // repair is the opposite — not "retry / upgrade the peer" but
+                // "you reused an idempotency key; pick a new one or resend the
+                // original bytes". Retrying this one is guaranteed to fail.
+                x0x::dm::DmError::IdempotencyConflict(_) => {
+                    (StatusCode::CONFLICT, "idempotency_conflict")
                 }
                 x0x::dm::DmError::Timeout { .. } => (StatusCode::GATEWAY_TIMEOUT, "timeout"),
                 x0x::dm::DmError::PeerLikelyOffline { .. } => {
@@ -461,53 +547,190 @@ mod tests {
         );
     }
 
-    #[test]
-    fn direct_send_request_preserves_raw_quic_default_unless_explicitly_overridden() {
-        let omitted: DirectSendRequest = serde_json::from_value(serde_json::json!({
-            "agent_id": "00".repeat(32),
-            "payload": ""
-        }))
-        .expect("minimal direct-send request should deserialize");
-        assert!(direct_send_config_for_request(&omitted).prefer_raw_quic_if_connected);
-
-        let disabled: DirectSendRequest = serde_json::from_value(serde_json::json!({
-            "agent_id": "00".repeat(32),
-            "payload": "",
-            "prefer_raw_quic_if_connected": false
-        }))
-        .expect("direct-send request with explicit override should deserialize");
-        assert!(!direct_send_config_for_request(&disabled).prefer_raw_quic_if_connected);
+    fn test_agent_id(byte: u8) -> x0x::identity::AgentId {
+        x0x::identity::AgentId([byte; 32])
     }
 
-    /// ADR 0030 §4 deprecates `require_gossip_ack` but objects specifically to
-    /// *silently discarding* it — the campaign branch accepted
-    /// `require_gossip_ack: false` and ignored it, so a caller asking for
-    /// fire-and-forget got a blocking send with no signal. This route honors
-    /// it, and must keep honoring it until slice 4 replaces acceptance with an
-    /// explicit 400. If a later slice makes the field a no-op, this test fails
-    /// rather than letting the silence back in.
-    #[test]
-    fn deprecated_require_gossip_ack_is_honored_not_silently_discarded() {
-        let omitted: DirectSendRequest = serde_json::from_value(serde_json::json!({
-            "agent_id": "00".repeat(32),
-            "payload": ""
-        }))
-        .expect("minimal direct-send request should deserialize");
-        assert!(
-            direct_send_config_for_request(&omitted).require_gossip_ack,
-            "omitting the field must select the daemon default (true)"
-        );
+    fn parse_request(value: serde_json::Value) -> DirectSendRequest {
+        serde_json::from_value(value).expect("direct-send request should deserialize")
+    }
 
-        let disabled: DirectSendRequest = serde_json::from_value(serde_json::json!({
+    fn config_for(value: serde_json::Value) -> Result<x0x::dm::DmSendConfig, StatusCode> {
+        direct_send_config_for_request(&parse_request(value), test_agent_id(1), test_agent_id(2))
+            .map_err(|rejection| rejection.status)
+    }
+
+    fn config_ok(value: serde_json::Value) -> x0x::dm::DmSendConfig {
+        config_for(value).expect("request should be accepted")
+    }
+
+    #[test]
+    fn direct_send_request_preserves_raw_quic_default_unless_explicitly_overridden() {
+        assert!(
+            config_ok(serde_json::json!({ "agent_id": "00".repeat(32), "payload": "" }))
+                .prefer_raw_quic_if_connected
+        );
+        assert!(
+            !config_ok(serde_json::json!({
+                "agent_id": "00".repeat(32),
+                "payload": "",
+                "prefer_raw_quic_if_connected": false
+            }))
+            .prefer_raw_quic_if_connected
+        );
+    }
+
+    /// ADR 0030 §4: this product surface promises a durable receipt unless the
+    /// caller says otherwise. The whole bug class this ADR exists to kill is a
+    /// product believing `ok: true` meant "committed" when it meant "enqueued";
+    /// defaulting to `false` here would restore it while the docs claimed
+    /// otherwise.
+    #[test]
+    fn product_rest_sends_are_durable_unless_the_caller_opts_out() {
+        assert!(
+            config_ok(serde_json::json!({ "agent_id": "00".repeat(32), "payload": "" }))
+                .require_durable_app_ack,
+            "omitting require_durable_app_ack must select the product default (true)"
+        );
+        assert!(
+            !config_ok(serde_json::json!({
+                "agent_id": "00".repeat(32),
+                "payload": "",
+                "require_durable_app_ack": false
+            }))
+            .require_durable_app_ack,
+            "an explicit false is the documented opt-out and must reach the config"
+        );
+    }
+
+    /// ADR 0030 §4 classifies WS and daemon control-plane sends as the internal
+    /// tier. They share `direct_message_send_config` with this route, so the
+    /// product default must live in the request-scoped builder — flipping it in
+    /// the shared helper would silently make every welcome blob and TreeKEM
+    /// message a strict send, which v0.37.0 already showed causes livelock.
+    #[test]
+    fn the_shared_internal_send_config_stays_v1() {
+        assert!(!direct_message_send_config().require_durable_app_ack);
+    }
+
+    /// ADR 0030 §4 requires the removal of `require_gossip_ack` to be
+    /// *announced*. Accepting it as a no-op is the failure mode the ADR names
+    /// explicitly: a caller asking for fire-and-forget would get a blocking
+    /// durable send and no signal that its request was reinterpreted.
+    #[test]
+    fn require_gossip_ack_is_rejected_in_any_form_not_silently_accepted() {
+        for value in [
+            serde_json::json!(false),
+            serde_json::json!(true),
+            serde_json::json!("maybe"),
+        ] {
+            let rejection = direct_send_config_for_request(
+                &parse_request(serde_json::json!({
+                    "agent_id": "00".repeat(32),
+                    "payload": "",
+                    "require_gossip_ack": value
+                })),
+                test_agent_id(1),
+                test_agent_id(2),
+            )
+            .expect_err("setting the removed field must be refused");
+            assert_eq!(rejection.status, StatusCode::BAD_REQUEST);
+            assert_eq!(rejection.code, "require_gossip_ack_removed");
+        }
+
+        assert!(
+            config_for(serde_json::json!({ "agent_id": "00".repeat(32), "payload": "" })).is_ok(),
+            "omitting the field is the correct way to send and must stay accepted"
+        );
+        // An explicit JSON null asks for nothing, exactly like omission, and
+        // serde treats it that way for every other optional field on this
+        // body. Rejecting it would punish clients that serialize their whole
+        // struct with nulls rather than clients that still want the old
+        // behaviour.
+        assert!(config_for(serde_json::json!({
             "agent_id": "00".repeat(32),
             "payload": "",
-            "require_gossip_ack": false
+            "require_gossip_ack": null
         }))
-        .expect("direct-send request with explicit override should deserialize");
-        assert!(
-            !direct_send_config_for_request(&disabled).require_gossip_ack,
-            "an explicit false must reach the send config, not be discarded"
+        .is_ok());
+    }
+
+    /// The point of `logical_id` is that a retry — including one issued by a
+    /// different process after a restart — resolves to the *same* wire request
+    /// id, so the recipient re-ACKs rather than storing a second copy. A
+    /// derivation that mixed in time, randomness, or payload bytes would look
+    /// fine in a single-shot test and silently deliver duplicates in the field.
+    #[test]
+    fn logical_id_derives_a_stable_request_id_bound_to_the_directed_pair() {
+        let request = |logical_id: &str, payload: &str| {
+            parse_request(serde_json::json!({
+                "agent_id": "00".repeat(32),
+                "payload": payload,
+                "logical_id": logical_id
+            }))
+        };
+        let derive = |logical_id: &str, payload: &str, recipient: u8| {
+            direct_send_config_for_request(
+                &request(logical_id, payload),
+                test_agent_id(1),
+                test_agent_id(recipient),
+            )
+            .expect("valid logical_id should be accepted")
+            .logical_request_id
+            .expect("a logical_id must populate logical_request_id")
+        };
+
+        let first = derive("order-42", "", 2);
+        assert_eq!(
+            first,
+            derive("order-42", "aGVsbG8=", 2),
+            "the same token to the same peer is one logical request whatever the bytes"
         );
+        assert_ne!(
+            first,
+            derive("order-43", "", 2),
+            "distinct tokens must not collide"
+        );
+        assert_ne!(
+            first,
+            derive("order-42", "", 3),
+            "one token fanned out to two peers must not share a sender-side ACK waiter"
+        );
+
+        assert!(
+            config_ok(serde_json::json!({ "agent_id": "00".repeat(32), "payload": "" }))
+                .logical_request_id
+                .is_none(),
+            "omitting logical_id must keep the fresh-random-id behaviour"
+        );
+    }
+
+    /// A rejected token must not reach the send path at all: silently dropping
+    /// an unusable `logical_id` would hand the caller a fresh random id and the
+    /// at-least-once retry identity they asked for would not exist.
+    #[test]
+    fn a_malformed_logical_id_is_refused_rather_than_ignored() {
+        for bad in ["", "Order-42", "order 42", "order/42", &"a".repeat(129)] {
+            let rejection = direct_send_config_for_request(
+                &parse_request(serde_json::json!({
+                    "agent_id": "00".repeat(32),
+                    "payload": "",
+                    "logical_id": bad
+                })),
+                test_agent_id(1),
+                test_agent_id(2),
+            )
+            .err()
+            .unwrap_or_else(|| panic!("logical_id {bad:?} must be refused"));
+            assert_eq!(rejection.status, StatusCode::BAD_REQUEST);
+            assert_eq!(rejection.code, "invalid_logical_id");
+        }
+        assert!(config_for(serde_json::json!({
+            "agent_id": "00".repeat(32),
+            "payload": "",
+            "logical_id": &"a".repeat(128)
+        }))
+        .is_ok());
     }
 
     // ── ADR-0016 R2: REST pre-check (exact §3 string + status code) ─────

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -27362,6 +27362,11 @@ pub(in crate::server) mod tests {
             require_gossip: false,
             require_gossip_ack: None,
             require_ack_ms: None,
+            // These #188 malformed-request cases predate ADR 0030 and assert
+            // on shapes the durable tier does not change; keeping them on v1
+            // semantics keeps them testing what they were written to test.
+            require_durable_app_ack: Some(false),
+            logical_id: None,
         }
     }
 

--- a/tests/harness/src/cluster.rs
+++ b/tests/harness/src/cluster.rs
@@ -204,6 +204,45 @@ impl AgentInstance {
             .expect("GET request failed")
     }
 
+    /// Wait until this daemon holds a peer's signed v2 capability advert.
+    ///
+    /// Since ADR 0030 slice 4 a bare `POST /direct/send` is a *durable* send:
+    /// it refuses with 409 `recipient_ack_semantics_unavailable` until the
+    /// recipient's advert has converged into this daemon's capability store.
+    /// A test whose subject is something else — history persistence, response
+    /// shape — must not race that convergence, or it fails intermittently for
+    /// a reason unrelated to what it asserts.
+    ///
+    /// `capability_store_entries` is the available signal: in a two-daemon
+    /// fixture the only advert this daemon can hold is its counterpart's, and
+    /// the harness leaves `[history]` at the daemon default (enabled), so that
+    /// peer advertises the v2 ceiling. A non-zero count therefore means
+    /// exactly "we hold the other side's v2 advert".
+    ///
+    /// # Panics
+    ///
+    /// Panics if no advert converges within `deadline` — a durable send would
+    /// 409, so failing here names the real cause instead of surfacing it as a
+    /// confusing assertion on the send's status code.
+    pub async fn wait_for_durable_capability(&self, deadline: std::time::Duration) {
+        let started = std::time::Instant::now();
+        let mut polls = 0_usize;
+        while started.elapsed() < deadline {
+            polls += 1;
+            let resp = self.get("/diagnostics/dm").await;
+            if let Ok(body) = resp.json::<serde_json::Value>().await {
+                if body["capability_store_entries"].as_u64().unwrap_or(0) > 0 {
+                    return;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
+        panic!(
+            "no peer capability advert converged within {deadline:?} ({polls} polls); \
+             a durable /direct/send would 409"
+        );
+    }
+
     /// Authenticated POST request with JSON body.
     pub async fn post(&self, path: &str, body: serde_json::Value) -> reqwest::Response {
         reqwest::Client::new()

--- a/tests/harness/src/cluster.rs
+++ b/tests/harness/src/cluster.rs
@@ -204,26 +204,24 @@ impl AgentInstance {
             .expect("GET request failed")
     }
 
-    /// Wait until this daemon holds a peer's signed v2 capability advert.
+    /// Wait until this daemon has *an* advert in its capability store.
     ///
-    /// Since ADR 0030 slice 4 a bare `POST /direct/send` is a *durable* send:
-    /// it refuses with 409 `recipient_ack_semantics_unavailable` until the
-    /// recipient's advert has converged into this daemon's capability store.
-    /// A test whose subject is something else — history persistence, response
-    /// shape — must not race that convergence, or it fails intermittently for
-    /// a reason unrelated to what it asserts.
+    /// Since ADR 0030 slice 4 a bare `POST /direct/send` is a durable send, so it
+    /// depends on the recipient's advert having converged. This shortens that
+    /// window but does **not** close it: `capability_store_entries` is the only
+    /// REST-visible signal, and it is a count — it cannot say whether the entry is
+    /// the signed, machine-bound v2 binding the strict gate actually requires.
     ///
-    /// `capability_store_entries` is the available signal: in a two-daemon
-    /// fixture the only advert this daemon can hold is its counterpart's, and
-    /// the harness leaves `[history]` at the daemon default (enabled), so that
-    /// peer advertises the v2 ceiling. A non-zero count therefore means
-    /// exactly "we hold the other side's v2 advert".
+    /// Measured on this fixture: the first durable send to a peer takes ~17.5 s
+    /// even after this wait returns (subsequent sends ~200-450 ms), because the
+    /// send itself still performs the ADR 0030 §2 forced targeted refresh and
+    /// waits for the gossip ACK. A caller whose HTTP timeout is below that will
+    /// still fail. Closing the gap properly needs either a REST surface exposing
+    /// per-peer advert state, or a product change to the cold-start path.
     ///
     /// # Panics
     ///
-    /// Panics if no advert converges within `deadline` — a durable send would
-    /// 409, so failing here names the real cause instead of surfacing it as a
-    /// confusing assertion on the send's status code.
+    /// Panics if no advert appears within `deadline`.
     pub async fn wait_for_durable_capability(&self, deadline: std::time::Duration) {
         let started = std::time::Instant::now();
         let mut polls = 0_usize;

--- a/tests/history_api.rs
+++ b/tests/history_api.rs
@@ -312,6 +312,13 @@ async fn history_backpressure_smoke() {
         let v: serde_json::Value = bob.get("/agent").await.json().await.expect("agent");
         v["agent_id"].as_str().expect("agent_id").to_string()
     };
+    // A bare /direct/send is durable since ADR 0030 slice 4; wait for Bob's v2
+    // advert so the latency assertion below measures the burst, not advert
+    // convergence. (This suite has a separate pre-existing failure on main.)
+    alice
+        .wait_for_durable_capability(Duration::from_secs(30))
+        .await;
+
     let mut worst = Duration::ZERO;
     for i in 0..5 {
         let start = std::time::Instant::now();

--- a/tests/history_wiring.rs
+++ b/tests/history_wiring.rs
@@ -160,6 +160,12 @@ async fn dm_history_survives_daemon_kill() {
     let alice_id = mesh.alice.agent_id().await;
     let bob_id = mesh.bob.agent_id().await;
 
+    // A bare /direct/send is durable since ADR 0030 slice 4; wait for Bob's v2
+    // advert so this test fails only on the history persistence it is about.
+    mesh.alice
+        .wait_for_durable_capability(std::time::Duration::from_secs(30))
+        .await;
+
     let message = b"history restart-survival probe";
     let payload_b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, message);
     let resp = mesh

--- a/tests/peer_lifecycle_integration.rs
+++ b/tests/peer_lifecycle_integration.rs
@@ -241,24 +241,20 @@ async fn wait_for_peer(fixture: &DaemonFixture, peer_machine: &str, deadline: Du
     );
 }
 
-/// Wait until this daemon holds a peer's signed v2 capability advert.
+/// Wait until this daemon has *an* advert in its capability store.
 ///
-/// Since ADR 0030 slice 4 a bare `POST /direct/send` is a *durable* send, so
-/// it refuses with 409 `recipient_ack_semantics_unavailable` until the
-/// recipient's advert has converged into the sender's capability store. Tests
-/// that are about something else — the `require_ack` probe block, the response
-/// shape — must not race that convergence, or they fail intermittently for a
-/// reason unrelated to what they assert.
+/// Since ADR 0030 slice 4 a bare `POST /direct/send` is a durable send, so it
+/// depends on the recipient's advert having converged. This shortens that
+/// window but does **not** close it: `capability_store_entries` is the only
+/// REST-visible signal, and it is a count — it cannot say whether the entry is
+/// the signed, machine-bound v2 binding the strict gate actually requires.
 ///
-/// `capability_store_entries` is the available signal: in a two-daemon fixture
-/// the only advert this daemon can hold is its counterpart's, and the fixture
-/// leaves `[history]` at the daemon default (enabled), so that peer advertises
-/// the v2 ceiling. A non-zero count therefore means exactly "we hold the other
-/// side's v2 advert".
-///
-/// Deliberately a wait, not a longer timeout and not an opt-out: the strict
-/// path is what these tests should exercise, since it is now the product
-/// default.
+/// Measured on this fixture: the first durable send to a peer takes ~17.5 s
+/// even after this wait returns (subsequent sends ~200-450 ms), because the
+/// send itself still performs the ADR 0030 §2 forced targeted refresh and
+/// waits for the gossip ACK. A caller whose HTTP timeout is below that will
+/// still fail. Closing the gap properly needs either a REST surface exposing
+/// per-peer advert state, or a product change to the cold-start path.
 async fn wait_for_durable_capability(fixture: &DaemonFixture, deadline: Duration) -> usize {
     let client = fixture.authed_client(Duration::from_secs(5));
     let started = tokio::time::Instant::now();

--- a/tests/peer_lifecycle_integration.rs
+++ b/tests/peer_lifecycle_integration.rs
@@ -27,6 +27,20 @@ use daemon::DaemonFixture;
 
 const STARTUP_SETTLE: Duration = Duration::from_secs(5);
 
+/// HTTP client timeout for the two tests that issue a bare — and therefore,
+/// since ADR 0030 slice 4, durable — `POST /direct/send`.
+///
+/// This aligns the test's observer with the daemon's own send budget rather
+/// than widening a race: `direct_message_send_config` allows 8 s per attempt
+/// with one retry and an 8 s backoff, so a legitimate durable send can occupy
+/// ~24 s before the daemon itself gives up. A 10 s client abandons work the
+/// daemon is still correctly doing and reports it as a test failure. The
+/// bundled tic-tac-toe client already uses 30 s for exactly this reason.
+///
+/// The cold-path latency this exposes is tracked in issue #336; it is
+/// deliberately not frozen into a documented contract here.
+const DURABLE_SEND_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
+
 #[cfg(unix)]
 struct PeerLifecycleLock(std::fs::File);
 
@@ -520,7 +534,7 @@ async fn direct_send_with_require_ack_round_trips_to_live_peer() {
     wait_for_durable_capability(&alice, Duration::from_secs(30)).await;
 
     let payload = base64::engine::general_purpose::STANDARD.encode(b"plc-ack-test");
-    let alice_client = alice.authed_client(Duration::from_secs(10));
+    let alice_client = alice.authed_client(DURABLE_SEND_CLIENT_TIMEOUT);
     let r = alice_client
         .post(alice.url("/direct/send"))
         .json(&serde_json::json!({
@@ -531,8 +545,12 @@ async fn direct_send_with_require_ack_round_trips_to_live_peer() {
         .send()
         .await
         .unwrap();
-    assert_eq!(r.status(), StatusCode::OK);
+    let status = r.status();
     let body: Value = r.json().await.unwrap();
+    // Carry status *and* body: a durable send's refusals are typed (409
+    // recipient_ack_semantics_unavailable when the advert has not converged),
+    // and a bare status code cannot distinguish that from a real regression.
+    assert_eq!(status, StatusCode::OK, "direct/send {status}: {body}");
     assert_eq!(body["ok"], true, "direct/send body: {body}");
     let ack = &body["require_ack"];
     assert_eq!(ack["ok"], true, "require_ack absent or failed: {body}");
@@ -567,7 +585,7 @@ async fn direct_send_without_require_ack_omits_ack_block() {
     wait_for_durable_capability(&alice, Duration::from_secs(30)).await;
 
     let payload = base64::engine::general_purpose::STANDARD.encode(b"plc-no-ack-test");
-    let alice_client = alice.authed_client(Duration::from_secs(10));
+    let alice_client = alice.authed_client(DURABLE_SEND_CLIENT_TIMEOUT);
     // Retry the direct-send POST: same transient-connection rationale as above.
     let r = retry_post_json(
         &alice_client,
@@ -579,9 +597,10 @@ async fn direct_send_without_require_ack_omits_ack_block() {
         5,
     )
     .await;
-    assert_eq!(r.status(), StatusCode::OK);
+    let status = r.status();
     let body: Value = r.json().await.unwrap();
-    assert_eq!(body["ok"], true);
+    assert_eq!(status, StatusCode::OK, "direct/send {status}: {body}");
+    assert_eq!(body["ok"], true, "direct/send body: {body}");
     assert!(
         body.get("require_ack").is_none() || body["require_ack"].is_null(),
         "require_ack should be absent when not requested, got: {body}"

--- a/tests/peer_lifecycle_integration.rs
+++ b/tests/peer_lifecycle_integration.rs
@@ -241,6 +241,45 @@ async fn wait_for_peer(fixture: &DaemonFixture, peer_machine: &str, deadline: Du
     );
 }
 
+/// Wait until this daemon holds a peer's signed v2 capability advert.
+///
+/// Since ADR 0030 slice 4 a bare `POST /direct/send` is a *durable* send, so
+/// it refuses with 409 `recipient_ack_semantics_unavailable` until the
+/// recipient's advert has converged into the sender's capability store. Tests
+/// that are about something else — the `require_ack` probe block, the response
+/// shape — must not race that convergence, or they fail intermittently for a
+/// reason unrelated to what they assert.
+///
+/// `capability_store_entries` is the available signal: in a two-daemon fixture
+/// the only advert this daemon can hold is its counterpart's, and the fixture
+/// leaves `[history]` at the daemon default (enabled), so that peer advertises
+/// the v2 ceiling. A non-zero count therefore means exactly "we hold the other
+/// side's v2 advert".
+///
+/// Deliberately a wait, not a longer timeout and not an opt-out: the strict
+/// path is what these tests should exercise, since it is now the product
+/// default.
+async fn wait_for_durable_capability(fixture: &DaemonFixture, deadline: Duration) -> usize {
+    let client = fixture.authed_client(Duration::from_secs(5));
+    let started = tokio::time::Instant::now();
+    let mut polls = 0usize;
+    while started.elapsed() < deadline {
+        polls += 1;
+        if let Ok(resp) = client.get(fixture.url("/diagnostics/dm")).send().await {
+            if let Ok(body) = resp.json::<Value>().await {
+                if body["capability_store_entries"].as_u64().unwrap_or(0) > 0 {
+                    return polls;
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!(
+        "no peer capability advert converged within {deadline:?} ({polls} polls); \
+         a durable /direct/send would 409"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // /peers/:peer_id/probe — active liveness with finite RTT
 // ---------------------------------------------------------------------------
@@ -480,6 +519,10 @@ async fn direct_send_with_require_ack_round_trips_to_live_peer() {
         v["agent_id"].as_str().unwrap().to_string()
     };
 
+    // A bare /direct/send is durable since ADR 0030 slice 4; wait for Bob's v2
+    // advert so this test fails only on the probe behaviour it is about.
+    wait_for_durable_capability(&alice, Duration::from_secs(30)).await;
+
     let payload = base64::engine::general_purpose::STANDARD.encode(b"plc-ack-test");
     let alice_client = alice.authed_client(Duration::from_secs(10));
     let r = alice_client
@@ -523,6 +566,9 @@ async fn direct_send_without_require_ack_omits_ack_block() {
         let v: Value = r.json().await.unwrap();
         v["agent_id"].as_str().unwrap().to_string()
     };
+
+    // Same durable-send convergence wait as the sibling test above.
+    wait_for_durable_capability(&alice, Duration::from_secs(30)).await;
 
     let payload = base64::engine::general_purpose::STANDARD.encode(b"plc-no-ack-test");
     let alice_client = alice.authed_client(Duration::from_secs(10));


### PR DESCRIPTION
> ### Status at head `8a23f47` — read this before reviewing an older SHA
>
> This branch moved several times during review. Verify against the head SHA;
> `c54d22e`, `3ff374a`, and `b291448` are all stale.
>
> | Pre-merge item | State at `8a23f47` |
> |---|---|
> | 1. Restore main's slice 1–3 Unreleased bullets | **Done.** main's entire Unreleased `Added` block (5175 chars, all 9 bullets) present verbatim, slice-4 bullets on top. Nothing condensed. |
> | 2. Two stale Notes | **Done.** Zero occurrences on head. |
> | 3. Calibrate the two durable-send test clients 10s → 30s | **Done**, per ruling (b'). No `~20s` sentence added to api-reference, per the same ruling. |
>
> **One residual, and it is a product finding rather than a test issue —
> see "Gate results".** Production code is unchanged since the approved
> `3ff374a` (`git diff --stat 3ff374a HEAD -- src/` is empty), so this stays
> in glance scope.

Completes the ADR 0030 durable-application-ACK campaign (slices 1–4). Precedes
the 0.38.0 release; **no version or tag changes here**.

## Scope

**1. Product send tier defaults (ADR §4).** `POST /direct/send` and
`x0x direct send` default `require_durable_app_ack = true`, with an explicit
opt-out (`require_durable_app_ack: false` / `--no-durable-ack`). The flip lives
in the request-scoped builder `direct_send_config_for_request`, **not** in the
shared `direct_message_send_config()` helper — the WS frame and every
control-plane send read that helper, so flipping it there would have made the
whole internal tier strict and reintroduced v0.37.0's welcome-blob livelock.
A test (`the_shared_internal_send_config_stays_v1`) pins that boundary.

**2. `require_gossip_ack` → hard 400.** Setting the field in any form answers
`400 require_gossip_ack_removed`. It is typed as `Option<serde_json::Value>`
rather than `Option<bool>` on purpose: `"require_gossip_ack": "maybe"` must get
the same documented 400 as `false`, not an opaque JSON-extractor rejection. An
explicit `null` is treated as omission, like every other optional field on this
body. `DmSendConfig::require_gossip_ack` is untouched for library callers.

**3. REST `logical_id`.** Validation ported from the campaign branch's
`DmLogicalId` (1–128 bytes of `[a-z0-9._:-]`, rejected rather than normalized).
Rejection happens before any send: silently dropping an unusable token would
hand the caller a fresh random id and the retry identity they asked for would
not exist.

**4. `idempotency_conflict`.** New `DmError::IdempotencyConflict` /
`DmAckOutcome::IdempotencyConflict` (postcard index 3, appended last — a
discriminant test pins 0/1/2/3). Both receiver binding-conflict sites — the
in-memory replay cache and the restart-spanning durable-history lookup — now
report it instead of reusing `AckSemanticsUnavailable`, which is the reuse the
#329 review flagged as "least-wrong until this error lands".
`AckSemanticsUnavailable` keeps only its semantics-unavailable meaning.

## Review round (head is `3ff374a`)

Three requested changes, all in:

1. **GUI migration** (below) — the ship-blocker.
2. **404/409 boundary widened.** Was `contacts.get(to).is_some_and(|c|
   c.dm_capabilities.is_some())`, which still filed a pre-capability card as a
   stranger. Now `contacts.get(to).is_some()`: any known card ⇒ 409, only a
   wholly unknown id ⇒ 404. Pinned by
   `a_known_contact_without_capabilities_is_a_409_not_a_404`.
3. **`logical_id` + durable opt-out ⇒ 400 `logical_id_requires_durable_ack`.**
   Only the durable receiver path consults the id, so the pair would hand back
   an at-least-once retry identity nothing enforces — discoverable only once
   duplicates appear. `x0x direct send` rejects `--logical-id` with
   `--no-durable-ack` via clap, before the round trip. The docs were also
   re-ordered per review: the restart-spanning promise was stated four lines
   *before* the durable precondition that makes it true, so the constraint now
   opens the field definition and the reason is given — every guarantee in that
   section is made by the recipient's durable path.

Also reverted the hedged ACK publisher back out (see deferred families) — this
PR's `src/dm_inbox.rs` and `src/direct.rs` are byte-identical to their state
before that port attempt.

## Migration: the hard-400's blast radius

The 400 is a ship-blocker for any caller that sets the field, so I grepped the
whole tree for producers before enforcing — and found one:

`src/gui/x0x-gui.html` set `body.require_gossip_ack=true` on `/direct/send`
whenever the DM "ACK" checkbox was ticked. **Note the shape**: a quoted-key
search (`"require_gossip_ack"`) does **not** find it, because the GUI assigns
via dot notation. `git grep` for the bare identifier does. Migrated by removing
the field — nothing replaces it, because the product default is now durable
delivery, which is strictly stronger than the gossip ACK the checkbox was
requesting. The checkbox keeps its remaining job, the post-send liveness probe.

Every other hit in the tree is a Rust `DmSendConfig` field assignment
(`stores.rs`, `named_groups.rs`, `exec/service.rs`) — library-internal config,
not a REST body, and explicitly unaffected: `DmSendConfig::require_gossip_ack`
is unchanged.

While in the GUI I added a `/direct/send` error map, because ADR 0030 calls the
409 UX "load-bearing, not transitional" and the GUI is a product surface. It
renders `recipient_ack_semantics_unavailable` as "Peer needs upgrading… retry
later, or resend without durable delivery" and `idempotency_conflict` as
"Retrying won't help — send it as a new message", instead of showing the raw
code for a condition where retrying is the one thing that cannot work.

`gui_smoke` (11/11) passes.

## Interop sanity check

Durable-by-default is only safe if two stock daemons interoperate.
`[history].enabled` is **default-on** in the daemon (`server/state.rs`), and the
advert is v2-iff-history, so two stock 0.38 daemons negotiate durable ACKs. The
409 is reached by genuinely not-yet-upgraded peers and by daemons that
explicitly set `history.enabled = false` — documented in api-reference.

## Defaults matrix

| Surface | Tier | `require_durable_app_ack` | `logical_id` |
|---|---|---|---|
| `POST /direct/send` | Product | **`true`** (opt out with the field) | accepted |
| `x0x direct send` | Product | **`true`** (opt out with `--no-durable-ack`) | `--logical-id` |
| WS `send_direct` frame | Internal | `false` | not accepted |
| `Agent::send_direct*` default config | Internal | `false` | via `DmSendConfig` |
| Daemon control plane (welcome/TreeKEM/metadata) | Internal | `false` | per named config |
| Bootstrap outbox (§5) | Internal, explicitly strict | `true` | obligation digest |

The CLI sends `require_durable_app_ack` **explicitly** rather than relying on
the daemon default, so a version-skewed CLI/daemon pair can never silently swap
receipt semantics.

## logical_id derivation

```
request_id = blake3::derive_key(
    "x0x dm logical request id v1",
    sender_agent_id ‖ recipient_agent_id ‖ logical_id,
)[..16]
```

Ported from the campaign's `dm_send::logical_request_id` rather than the
simpler blake3-of-token the brief allowed. Both agent ids are bound. The
recipient dedupes on `(sender, request_id)`, so binding the sender is
belt-and-braces; binding the **recipient** is load-bearing — the sender's
in-flight ACK waiter is keyed by `request_id` alone, so one token fanned out to
two peers must not produce one id that two waiters contend for. The token never
goes on the wire.

## Two fixes the default flip forced

Both were found by the gates, not by inspection, and neither is cosmetic.

**The conflict check was unreachable through real ingress.** `handle_incoming`
re-ACKed any envelope already in the replay cache *before* comparing its
durable binding — so a v2 caller reusing a `logical_id` for different bytes was
told `Accepted` for content the receiver never stored, and the §1 binding check
at `dm_inbox.rs` was dead code on that path. Durable envelopes replaying a
completed request now fall through to the durable path, which owns the whole
replay decision. Narrowly scoped via `cached_completion_needs_binding_check`:
only a v2 payload replaying a completion that *has* a durable binding pays the
signature-verify + decrypt; v1 replays and ACK envelopes keep the cheap path.
This was latent before slice 4 — only the bootstrap outbox set a logical
request id, and it derives one per payload digest, so a rebind was impossible
by construction. Exposing `logical_id` to callers is what makes it reachable.

**A stranger was reported as a peer needing an upgrade.** The strict gate fired
before any key-availability check, so with every product send now strict, a
send to an undiscovered agent id would have returned `409
recipient_ack_semantics_unavailable` instead of `404`. That tells a product UI
to chase a fleet-upgrade problem it does not have. `AckSemanticsUnavailable`
now requires that we actually know the peer — an advert **or any contact card**
(`cap` alone cannot answer this, because the strict path deliberately withholds
the card fallback). Per review, the boundary is "do we know this agent", not
"has its advert converged": a card with `dm_capabilities: None` is a known peer
mid-convergence, plausibly one needing an upgrade, so it gets the 409. Caught by
`daemon_api_direct_send_not_found`, an Integration-only ignored test that a
`--workspace` run never executes.

## Two port items evaluated and declined, with evidence

**`HistoryCommitFailed` → `503 history_commit_failed`: not ported.** On the
campaign branch every raise site (`lib.rs:5108-5136`) is inside a **sender-side
durable-loopback history write** that main does not implement, and that code
also carries `thread_root`/`thread_parent` — v3 fields explicitly out of scope.
Main's loopback path (`send_direct_with_config_inner`) writes no history and
cannot fail this way, and a *receiver's* commit failure withholds the ACK by
design (§1), so the sender sees a 504 timeout, never a typed error. Adding the
variant would create an error nothing can construct and document a REST code
the daemon can never emit. Flagging rather than silently skipping.

**Product timeouts: no change, and the reason is not laziness.**
`PRODUCT_DM_ATTEMPT_TIMEOUT = 8s` already matches main's
`direct_message_send_config()`. `PRODUCT_DM_TOTAL_TIMEOUT = 30s` has no
equivalent field in main's `DmSendConfig`, and it is not needed: `max_retries:
1` with `ExponentialFromTimeout { factor: 2 }` gives 8 s + 8 s backoff + 8 s ≈
24 s worst case, already inside 30 s. Adding a total-timeout field would be new
machinery ADR §4/§6 does not ask for. Raising
`raw_quic_receive_ack_timeout` from 8 s to 30 s would be an active regression:
raw QUIC is skipped entirely for durable sends, so it only affects opted-out
sends — where it would make a dead raw path hang 30 s instead of failing at 8 s
and falling back — and it lives in the **shared** helper, so it would hit WS and
every control-plane send too.

## Deferred families — decisions

**(a) Hedged multi-route ACK publisher — DEFERRED to #335.** This briefly
landed and has been reverted out of this PR at the reviewer's direction, which
I agree with: mixing a change to *when the ACK reaches the wire* with a
product-default flip is exactly what a release rider should not do, and the
saturated-queue drop interacts with the commit-before-ACK promise in a way that
deserves its own review and validation-matrix run.

The evidence for deferring, for the record: cherry-picking each commit onto
`origin/main` in an isolated worktree conflicts every time (`21387d2` in
`dm_inbox.rs`; `bde4d28` in `dm_inbox.rs`, `direct.rs`, and the design doc;
`fa538eb` in `dm_inbox.rs`) — ~+670/−160 restructuring `DmInboxService`,
`InboxPipeline`, and `spawn_subscription_loop`, the code slices 2/3/4 rewrote.

The gap it addresses is real and tracked in **#335**: main awaits
`publish_ack_for_protocol` inline at 8 call sites in the inbox loop with no
timeout, and durable-by-default increases v2 ACK traffic. `src/dm_inbox.rs` and
`src/direct.rs` in this PR are byte-identical to their `c219e4b` state.

The ported implementation and its three behavioural tests are preserved on
`wip/335-hedged-ack-publisher`, with a take-this/skip-that porting note on #335
so the work becomes a ready-made PR there rather than being redone.

**(b) Raw durable DM frame transport — DEFER.** `handle_raw_frame` is
inseparable from the `AckRoute` / `handle_incoming_routed` refactor — one hunk
of `6a58d81` (+1866/−174), the same refactor the survey says to avoid taking.
Independently, `RAW_DURABLE_DM_MAGIC` is a **new wire framing**, and ADR 0030
states the entire compatibility surface is "ACK semantics + capability adverts"
with envelope layout unchanged. Post-0.38.

**(c) Successor-suffix admission — DEFER.** The two validators are liftable
pure functions (~110 lines), but every call site is entangled with the
`4880a9f` full-file rewrite, and the 26 call-site references live in
`named_groups.rs` — the 33.7k-line file whose size ADR 0030 §5 explicitly
constrains ("must not grow past its pre-branch size"). Hand-porting the two
validators plus their call sites is the path for post-0.38; doing it here would
grow exactly the file the ADR forbids growing.

## Docs (ADR §6)

- `docs/api-reference.md` — request body, `logical_id`, the durable default and
  its rollout consequences, the hard 400, all new error codes, the 404-vs-409
  precedence, CLI flags, WS-is-internal note, and the bootstrap outbox sidecar
  (`<data_dir>/public_group_bootstrap_outbox.json`, fail-closed startup).
- `docs/design/dm-over-gossip.md` — send-surface tier table, `logical_id`
  derivation, corrected receiver-ordering step 2/3 with the two distinct
  outcomes, and the fast-path stand-aside rule.
- `CHANGELOG.md` — Unreleased, 0.38.0 framing, both breaking changes called out
  as BREAKING with the migration, plus the hedged publisher and the new
  diagnostics counter.
- **Mixed-version matrix rows this slice owns** (`dm-over-gossip.md`): a
  receipt-semantics matrix (0.38 strict / 0.38 opted-out / internal tier / 0.37
  sender × v1-advertising vs v2-advertising recipient) and a precedence table
  covering the unknown-recipient 404, same-id-same-bytes vs same-id-different-bytes,
  the `require_gossip_ack` 400, and the withheld ACK on commit failure.
- The bootstrap outbox sidecar is now **named** in `dm-over-gossip.md`
  (`<data_dir>/public_group_bootstrap_outbox.json`), not only in api-reference.

**ADR §6 item with nothing to do:** the daemon config keys
`dm_capability_cache_ttl_secs` and `dm_capability_test_controls` do not exist
in the tree (`grep` over `src/` finds zero hits) — slice 1 did not port them,
so there is no key to document. Flagging rather than silently skipping.

## Gate results

All run locally with real exit codes on `8a23f47`.

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-features --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace --all-features` | **2655 passed**, 0 failed, 260 skipped |
| `scripts/check-panics.sh` | exit 0 — zero panic/todo/unimplemented in production |

**Ignored / CI-Integration-only suites** (the slice-3b lesson — a `--workspace`
run does not execute these):

| Suite | Result |
|---|---|
| `--test api_manifest` | 3/3 passed |
| `--test api_coverage --run-ignored all` | 16/16 passed |
| `--test daemon_api_integration --run-ignored ignored-only` | **100/100 passed** — includes `daemon_api_direct_send_not_found`, which the precedence fix above was required for |
| `--test history_wiring --run-ignored all` | 4/4 passed |
| `--test peer_lifecycle_integration --run-ignored all` | 6/6 (see the finding below — one failure in seven runs total) |
| `--test x0x_0041_prefer_newest_test --run-ignored all` | 4/4 passed |
| `--test x0x_0041_synthetic_kill_restart --run-ignored all` | 2/2 passed |
| `--test gui_smoke --run-ignored all` | 11/11 passed — covers the migrated GUI |
| `--test named_group_integration --run-ignored ignored-only` | 25/27 passed, **2 failed — pre-existing** |
| `--test history_api --run-ignored all` | 1/3 passed, **2 failed — pre-existing** |

**Both failing suites verified against a clean `origin/main` (f16448f)
checkout, not assumed:**

- `named_group_integration`: `named_group_admin_delete_propagates_to_peer_after_creator_delete_409`
  and `named_group_creator_removal_propagates_to_removed_peer` fail identically
  on `origin/main` with the same message ("bob never applied alice's
  authoritative member add before removal"). Known flaky family, issue #333.
  Both propagate over `named_group_direct_delivery_config()` — internal tier,
  untouched by this diff.
- `history_api`: `history_backpressure_smoke` fails on `origin/main` and on
  every run here. The *second* failure moves between runs — `ws_backfill_then_live_no_gap_no_dup`
  on the main baseline and on the latest run here, `rest_history_list_search_stats_purge_roundtrip`
  on an earlier run — which is itself the flakiness signature. This suite drives
  **topic publish** ingest, not DM sends; nothing in this diff touches that path.

### One residual — a product finding, not a test flake

`peer_lifecycle_integration` fails roughly **1 run in 6**. Raising the client
timeout to 30 s (ruling b') removed the *client-side* timeouts, which finally
let the daemon's own answer be observed. It is not a 409, and not a harness
artifact:

```
direct/send 504 Gateway Timeout:
{"detail":"timed out after 1 retries over 24.002880959s","error":"timeout","ok":false}
```

- **Not** `409 recipient_ack_semantics_unavailable` ⇒ the advert had converged
  and the strict gate passed. This is not the convergence race we assumed, so
  no `wait_until` can close it.
- **504 after 24.0028 s** ⇒ the daemon exhausted its whole budget (8 s + 8 s
  backoff + 8 s) waiting for the **v2 application ACK**, against a live peer on
  loopback.

The receiver plausibly committed and dispatched and the ACK never got back —
the "committed but never acked" outcome, which is precisely what the hedged
multi-route ACK publisher deferred to **#335** exists to remove. Filed with
full detail on **#336**, including the note that #335 may be more load-bearing
than "ACK liveness, nice to have": durable-by-default is what makes this
reachable, and it reproduces on loopback with two healthy daemons.

Both status assertions now print status + body, so the next occurrence is
self-diagnosing. I have deliberately not masked this with a retry loop or a
further timeout widen.

No API-manifest regeneration was needed: routes, `cli_name`s, and descriptions
are unchanged, and the manifest carries no request-field schema. `route_set_matches_registry`
and `manifest_matches_registry` both pass.

## Omitted hunks

Nothing v3 — no `DmThreadMeta`, no `DM_PROTOCOL_THREADED`. The receive ceiling
stays `DM_PROTOCOL_DURABLE_ACK` (2). All campaign material was taken
hunk-by-hunk from individual commits; no file blobs, no `checkout --theirs`.

## Tooling note

`grep` in this shell is a ugrep wrapper (verified: `ugrep 7.5.0`, skips binary
files, different glob handling from `/usr/bin/grep`). All campaign-branch
surveys used real `git grep` / `git show` against explicit revisions, and the
portability claims above come from actual `git cherry-pick` runs in a throwaway
worktree, not from reading diffs.

Do not merge — review first.
