### PR TITLE
fix(groups): resend lost MemberJoined from the join-result poll (#333 slice A)

### DIFF
--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -9858,6 +9858,33 @@ fn invite_join_group_info(
     info
 }
 
+/// Everything the join-result poll needs to re-send the joiner's signed
+/// `MemberJoined` if the initial volley was lost (#333).
+///
+/// Both channels of the initial volley are carried, because they fail
+/// independently: the metadata topic needs no per-recipient key material but
+/// depends on mesh coverage, while the direct message is the order-sensitive
+/// trigger for the authority's add commit but is unusable until the joiner has
+/// resolved the authority's DM key material — which, right after a join,
+/// routinely takes longer than the repair window.
+struct MemberJoinedResend {
+    metadata_topic: String,
+    event: NamedGroupMetadataEvent,
+    /// The exact bytes the volley's direct deliveries send, serialized once.
+    payload: Vec<u8>,
+}
+
+/// Test-only loss injection for #333: when `X0X_TEST_DROP_INITIAL_MEMBER_JOINED`
+/// is `1`, [`join_group_via_invite`] skips the entire initial `MemberJoined`
+/// send volley (gossip publish plus the direct deliveries to the inviter), so
+/// the regression test can prove the join still converges through the
+/// join-result poll's resend arm alone. Read once per process: the volley is
+/// either fully injected-lost or fully sent, never partially.
+static DROP_INITIAL_MEMBER_JOINED_VOLLEY: std::sync::LazyLock<bool> =
+    std::sync::LazyLock::new(|| {
+        std::env::var("X0X_TEST_DROP_INITIAL_MEMBER_JOINED").is_ok_and(|v| v == "1")
+    });
+
 /// POST /groups/join — join a group via invite link.
 pub(in crate::server) async fn join_group_via_invite(
     State(state): State<Arc<AppState>>,
@@ -10046,6 +10073,10 @@ pub(in crate::server) async fn join_group_via_invite(
                 now_ms,
                 treekem_key_package_b64.as_deref(),
             );
+            // Copy of the signed event, handed to the join-result poll so it
+            // can re-send the initial volley if that volley was lost (#333).
+            // `None` means there is nothing to resend.
+            let mut member_joined_resend: Option<MemberJoinedResend> = None;
             match ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
                 signing_kp.secret_key(),
                 &canonical,
@@ -10070,49 +10101,72 @@ pub(in crate::server) async fn join_group_via_invite(
                         recovery_authority_commit: None,
                         signature_b64,
                     };
-                    tracing::info!(
-                        group_id = %group_id_hex,
-                        topic = %info.metadata_topic,
-                        member = %joiner_hex,
-                        inviter = %invite.inviter,
-                        "MemberJoined: publishing joiner-authored membership event to metadata topic"
-                    );
-                    // Publish twice: once immediately so the inviter gets it
-                    // as soon as the metadata mesh covers them, then again
-                    // after `GROUP_BACKGROUND_PUBLISH_DELAY` so members
-                    // whose Plumtree links formed late still pick it up.
-                    // The applier is idempotent (re-applying the same
-                    // event for an already-active member is a no-op), so
-                    // double-publish is safe.
-                    publish_named_group_metadata_event(&state, &info.metadata_topic, &event).await;
-                    // TreeKEM membership is order-sensitive: gossip remains the
-                    // broadcast path, but the join trigger must reach the inviter
-                    // reliably so they can produce the authoritative add commit.
-                    spawn_named_group_event_delivery(&state, &invite.inviter, &event);
-                    spawn_named_group_event_delivery_after(
-                        &state,
-                        &invite.inviter,
-                        &event,
-                        GROUP_BACKGROUND_PUBLISH_DELAY,
-                    );
-                    let state_for_replay = Arc::clone(&state);
-                    let topic_for_replay = info.metadata_topic.clone();
-                    let inviter_for_replay = invite.inviter.clone();
-                    let event_for_replay = event;
-                    tokio::spawn(async move {
-                        tokio::time::sleep(GROUP_BACKGROUND_PUBLISH_DELAY).await;
-                        publish_named_group_metadata_event(
-                            &state_for_replay,
-                            &topic_for_replay,
-                            &event_for_replay,
-                        )
-                        .await;
-                        spawn_named_group_event_delivery(
-                            &state_for_replay,
-                            &inviter_for_replay,
-                            &event_for_replay,
+                    match serde_json::to_vec(&event) {
+                        Ok(payload) => {
+                            member_joined_resend = Some(MemberJoinedResend {
+                                metadata_topic: info.metadata_topic.clone(),
+                                event: event.clone(),
+                                payload,
+                            })
+                        }
+                        Err(e) => tracing::warn!(
+                            group_id = %group_id_hex,
+                            "MemberJoined: failed to serialize join announcement for resend: {e}"
+                        ),
+                    }
+                    if *DROP_INITIAL_MEMBER_JOINED_VOLLEY {
+                        tracing::warn!(
+                            group_id = %group_id_hex,
+                            member = %joiner_hex,
+                            inviter = %invite.inviter,
+                            "MemberJoined: X0X_TEST_DROP_INITIAL_MEMBER_JOINED is set; dropping the initial send volley (test-only loss injection, #333)"
                         );
-                    });
+                    } else {
+                        tracing::info!(
+                            group_id = %group_id_hex,
+                            topic = %info.metadata_topic,
+                            member = %joiner_hex,
+                            inviter = %invite.inviter,
+                            "MemberJoined: publishing joiner-authored membership event to metadata topic"
+                        );
+                        // Publish twice: once immediately so the inviter gets it
+                        // as soon as the metadata mesh covers them, then again
+                        // after `GROUP_BACKGROUND_PUBLISH_DELAY` so members
+                        // whose Plumtree links formed late still pick it up.
+                        // The applier is idempotent (re-applying the same
+                        // event for an already-active member is a no-op), so
+                        // double-publish is safe.
+                        publish_named_group_metadata_event(&state, &info.metadata_topic, &event)
+                            .await;
+                        // TreeKEM membership is order-sensitive: gossip remains the
+                        // broadcast path, but the join trigger must reach the inviter
+                        // reliably so they can produce the authoritative add commit.
+                        spawn_named_group_event_delivery(&state, &invite.inviter, &event);
+                        spawn_named_group_event_delivery_after(
+                            &state,
+                            &invite.inviter,
+                            &event,
+                            GROUP_BACKGROUND_PUBLISH_DELAY,
+                        );
+                        let state_for_replay = Arc::clone(&state);
+                        let topic_for_replay = info.metadata_topic.clone();
+                        let inviter_for_replay = invite.inviter.clone();
+                        let event_for_replay = event;
+                        tokio::spawn(async move {
+                            tokio::time::sleep(GROUP_BACKGROUND_PUBLISH_DELAY).await;
+                            publish_named_group_metadata_event(
+                                &state_for_replay,
+                                &topic_for_replay,
+                                &event_for_replay,
+                            )
+                            .await;
+                            spawn_named_group_event_delivery(
+                                &state_for_replay,
+                                &inviter_for_replay,
+                                &event_for_replay,
+                            );
+                        });
+                    }
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -10138,6 +10192,7 @@ pub(in crate::server) async fn join_group_via_invite(
                     inviter,
                     member_for_poll,
                     invite_is_treekem,
+                    member_joined_resend,
                 )
                 .await;
             });
@@ -18337,6 +18392,13 @@ const EXPECTED_JOIN_RESULT_INVITER_TTL: Duration = NON_TREEKEM_JOIN_RESULT_POLL_
 
 const JOIN_RESULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
+/// How many unconfirmed join-result polls pass between `MemberJoined` resends
+/// to the authority (#333). At `JOIN_RESULT_POLL_INTERVAL` that is roughly one
+/// resend every 6s — slow enough that a merely slow authority is not spammed,
+/// fast enough that a lost join volley is repaired well inside the 30s the
+/// propagation tests allow.
+const MEMBER_JOINED_RESEND_POLL_INTERVALS: u32 = 3;
+
 const PENDING_WELCOME_TTL: Duration = Duration::from_secs(10 * 60);
 
 const WELCOME_FETCH_TIMEOUT: Duration = Duration::from_secs(90);
@@ -18635,6 +18697,14 @@ pub(in crate::server) async fn handle_join_result_message(
 /// during the join window (e.g. a gossip connection dropping right after the
 /// join was accepted) is repaired instead of leaving the joiner permanently
 /// absent from its own roster and write-locked with a 403 (#297).
+///
+/// The poll also repairs the *outbound* leg. `member_joined` carries the
+/// signed `MemberJoined` event the join volley sent; if that volley was lost
+/// outright the authority never stages a result, so nothing this loop fetches
+/// can ever succeed. Every `MEMBER_JOINED_RESEND_POLL_INTERVALS` unconfirmed
+/// polls the volley is re-sent (#333). Re-application is a documented no-op
+/// for an already-active member, and once the authority applies it the staged
+/// result satisfies the next poll — so resends stop on their own.
 async fn poll_join_result_until_membership_confirmed(
     state: Arc<AppState>,
     group_id: String,
@@ -18642,6 +18712,7 @@ async fn poll_join_result_until_membership_confirmed(
     inviter: AgentId,
     member_agent_id: String,
     await_treekem: bool,
+    member_joined: Option<MemberJoinedResend>,
 ) {
     let timeout = if await_treekem {
         JOIN_RESULT_POLL_TIMEOUT
@@ -18651,6 +18722,7 @@ async fn poll_join_result_until_membership_confirmed(
     let deadline = tokio::time::Instant::now() + timeout;
     let expected_key = join_result_key(&event_group_id, &member_agent_id);
     let mut timed_out = true;
+    let mut unconfirmed_polls: u32 = 0;
     while tokio::time::Instant::now() < deadline {
         let confirmed = if await_treekem {
             state.treekem_groups.read().await.contains_key(&group_id)
@@ -18666,6 +18738,7 @@ async fn poll_join_result_until_membership_confirmed(
             timed_out = false;
             break;
         }
+        unconfirmed_polls = unconfirmed_polls.saturating_add(1);
         let request = JoinResultMessage::FetchRequest {
             group_id: event_group_id.clone(),
             member_agent_id: member_agent_id.clone(),
@@ -18714,6 +18787,60 @@ async fn poll_join_result_until_membership_confirmed(
                 payload_len,
                 payload_hash = %payload_hash,
             );
+        }
+        // Outbound-leg repair (#333): the authority can only stage a result
+        // for a `MemberJoined` it actually received, so a lost join volley
+        // makes every fetch above answer "nothing staged" until the deadline.
+        //
+        // Both volley channels are retried, because either one alone leaves a
+        // hole: the direct message is unusable until the joiner has resolved
+        // the authority's DM key material (routinely still pending here, and
+        // the reason a DM-only retry cannot repair the very window it
+        // targets), while the metadata publish needs no key material but only
+        // reaches an authority the mesh already covers.
+        //
+        // Spawned, not awaited, for the same reason every other named-group
+        // delivery is spawned: a send can block for the full ack timeout, and
+        // blocking here would stretch the fetch cadence this loop exists to
+        // maintain. Individual attempts are expected to fail; the repair is
+        // the repetition, not any single send.
+        if let Some(member_joined) = member_joined.as_ref() {
+            if unconfirmed_polls.is_multiple_of(MEMBER_JOINED_RESEND_POLL_INTERVALS) {
+                let resend_state = Arc::clone(&state);
+                let recipient = inviter;
+                let topic = member_joined.metadata_topic.clone();
+                let event = member_joined.event.clone();
+                let payload = member_joined.payload.clone();
+                let resend_len = payload.len();
+                let resend_hash = hex::encode(blake3::hash(&payload).as_bytes());
+                let attempt = unconfirmed_polls / MEMBER_JOINED_RESEND_POLL_INTERVALS;
+                let resend_group_id = group_id.clone();
+                let resend_event_group_id = event_group_id.clone();
+                let resend_member = member_agent_id.clone();
+                tokio::spawn(async move {
+                    publish_named_group_metadata_event(&resend_state, &topic, &event).await;
+                    let error = resend_state
+                        .agent
+                        .send_direct_with_config(
+                            &recipient,
+                            payload,
+                            named_group_direct_delivery_config(),
+                        )
+                        .await
+                        .err();
+                    tracing::debug!(
+                        target: "treekem.trace",
+                        stage = "member_joined_resend",
+                        group_id = %resend_group_id,
+                        event_group_id = %resend_event_group_id,
+                        member = %resend_member,
+                        attempt,
+                        payload_len = resend_len,
+                        payload_hash = %resend_hash,
+                        direct_error = error.as_ref().map(|e| e.to_string()),
+                    );
+                });
+            }
         }
         tokio::time::sleep(JOIN_RESULT_POLL_INTERVAL).await;
     }
@@ -20085,6 +20212,9 @@ pub(in crate::server) mod tests {
                 inviter,
                 poll_member,
                 false,
+                // No `MemberJoined` payload: this test pins the loop's exit
+                // conditions, which the #333 resend arm must leave unchanged.
+                None,
             )
             .await;
         });

--- a/tests/harness/src/cluster.rs
+++ b/tests/harness/src/cluster.rs
@@ -401,6 +401,24 @@ pub async fn trio_with_extra_config(extra_config: &str) -> AgentCluster {
 /// Start a fresh pair with the same extra TOML appended to each daemon's
 /// generated config. Useful for test-only timing overrides.
 pub async fn pair_with_extra_config(extra_config: &str) -> AgentPair {
+    pair_with_extra_config_and_bob_env(extra_config, &[]).await
+}
+
+/// Start a fresh pair with extra environment variables set on **bob only**.
+///
+/// Daemons otherwise inherit the test process environment, which is shared —
+/// so a fault-injection hook set that way would fire on both nodes. Tests that
+/// must break one side of a two-party exchange (e.g. #333: drop the joiner's
+/// initial `MemberJoined` volley while the authority behaves normally) need
+/// exactly one node configured, and bob is the harness's joiner.
+pub async fn pair_with_bob_env(env: &[(&str, &str)]) -> AgentPair {
+    pair_with_extra_config_and_bob_env("", env).await
+}
+
+async fn pair_with_extra_config_and_bob_env(
+    extra_config: &str,
+    bob_env: &[(&str, &str)],
+) -> AgentPair {
     let binary = find_x0xd_binary();
     let suffix = rand::random::<u16>();
     let alice_api = allocate_unused_tcp_port();
@@ -421,13 +439,14 @@ pub async fn pair_with_extra_config(extra_config: &str) -> AgentPair {
     // bob has a stable alice to bootstrap against. The previous 5s was too
     // short and let propagation-dependent tests race mesh formation.
     tokio::time::sleep(ROLLING_START_DELAY).await;
-    let bob = start_instance(
+    let bob = start_instance_with_env(
         &binary,
         &format!("pair-bob-{suffix}"),
         bob_api,
         bob_bind,
         &format!("bootstrap_peers = [\"127.0.0.1:{alice_bind}\"]"),
         extra_config,
+        bob_env,
     )
     .await;
     tokio::time::sleep(MESH_SETTLE_TIME).await;
@@ -672,6 +691,29 @@ async fn start_instance(
     bootstrap: &str,
     extra_config: &str,
 ) -> AgentInstance {
+    start_instance_with_env(
+        binary,
+        name,
+        api_port,
+        bind_port,
+        bootstrap,
+        extra_config,
+        &[],
+    )
+    .await
+}
+
+/// As [`start_instance`], plus environment variables applied to this daemon
+/// process only (on top of the inherited test environment).
+async fn start_instance_with_env(
+    binary: &PathBuf,
+    name: &str,
+    api_port: u16,
+    bind_port: u16,
+    bootstrap: &str,
+    extra_config: &str,
+    env: &[(&str, &str)],
+) -> AgentInstance {
     let config_dir = std::env::temp_dir().join(format!("x0x-test-{name}"));
     let _ = std::fs::remove_dir_all(&config_dir);
     let _ = std::fs::create_dir_all(&config_dir);
@@ -719,14 +761,19 @@ async fn start_instance(
         }
     };
 
-    let process = Command::new(binary)
+    let mut command = Command::new(binary);
+    command
         .arg("--config")
         .arg(&config_path)
         .arg("--name")
         .arg(name)
         .arg("--no-hard-coded-bootstrap")
         .stdout(stdout)
-        .stderr(stderr)
+        .stderr(stderr);
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let process = command
         .spawn()
         .unwrap_or_else(|e| panic!("Failed to start x0xd {name}: {e}"));
 

--- a/tests/named_group_integration.rs
+++ b/tests/named_group_integration.rs
@@ -16,7 +16,7 @@ mod cluster;
 #[path = "harness/src/daemon.rs"]
 mod daemon;
 
-use cluster::{pair, AgentInstance};
+use cluster::{pair, pair_with_bob_env, AgentInstance};
 use daemon::DaemonFixture;
 
 async fn daemon() -> DaemonFixture {
@@ -1976,4 +1976,102 @@ async fn last_admin_rest_self_demote_returns_409_exact_string() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// ===========================================================================
+// #333 — MemberJoined delivery is at-least-once, not at-most-once
+// ===========================================================================
+
+/// Why: the joiner's signed `MemberJoined` is what authorizes the group
+/// authority to publish the `MemberAdded` commit. It used to be sent exactly
+/// once (a gossip publish plus a handful of best-effort DMs, all warn-and-drop)
+/// with no repair path, so losing that volley meant the join silently never
+/// completed — the authority had nothing to stage, and the joiner's 2s
+/// result-poll could only ever fetch a result that was never going to exist.
+///
+/// `X0X_TEST_DROP_INITIAL_MEMBER_JOINED` drops bob's entire initial volley, so
+/// the only way alice can ever learn of the join is the poll loop's resend arm.
+/// If that arm regresses, this test fails; a wider timeout cannot rescue it.
+#[tokio::test]
+#[ignore]
+async fn member_joined_lost_initial_volley_recovers_via_poll_resend() {
+    // Bob is the joiner, so only bob's daemon drops the volley — alice must
+    // stay a normal authority for this to prove recovery rather than
+    // symmetric breakage.
+    let pair = pair_with_bob_env(&[("X0X_TEST_DROP_INITIAL_MEMBER_JOINED", "1")]).await;
+    let alice = &pair.alice;
+    let bob = &pair.bob;
+
+    let alice_create: Value = alice
+        .post(
+            "/groups",
+            serde_json::json!({"name":"Lost MemberJoined","display_name":"Alice"}),
+        )
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        alice_create["ok"], true,
+        "create response: {alice_create:?}"
+    );
+    let group_id = alice_create["group_id"].as_str().unwrap().to_string();
+
+    // The gap is worst on the secure default preset, where the authority's
+    // commit also carries TreeKEM key material; pin that we exercise it.
+    let alice_state = group_state(alice, &group_id).await;
+    assert!(
+        alice_state.is_some(),
+        "alice state missing after default private_secure create"
+    );
+    let Some(alice_state) = alice_state else {
+        return;
+    };
+    assert!(
+        alice_state["security_binding"]
+            .as_str()
+            .is_some_and(|binding| binding.starts_with("treekem:")),
+        "resend regression must exercise a private_secure TreeKEM group: {alice_state:?}"
+    );
+
+    let invite: Value = alice
+        .post(&format!("/groups/{group_id}/invite"), serde_json::json!({}))
+        .await
+        .json()
+        .await
+        .unwrap();
+    let invite_link = invite["invite_link"].as_str().unwrap().to_string();
+
+    let bob_join: Value = bob
+        .post(
+            "/groups/join",
+            serde_json::json!({"invite": invite_link, "display_name": "Bob Local"}),
+        )
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(bob_join["ok"], true, "join response: {bob_join:?}");
+
+    let bob_agent_id = bob.agent_id().await;
+    let alice_sees_bob = wait_until(Duration::from_secs(30), || async {
+        let info: Value = alice
+            .get(&format!("/groups/{group_id}/members"))
+            .await
+            .json()
+            .await
+            .unwrap_or_default();
+        info["members"]
+            .as_array()
+            .map(|members| members.iter().any(|m| m["agent_id"] == bob_agent_id))
+            .unwrap_or(false)
+    })
+    .await;
+    assert!(
+        alice_sees_bob,
+        "alice never observed bob's join after the initial MemberJoined volley was dropped; \
+         the join-result poll's resend arm did not repair the outbound leg (#333)"
+    );
+
+    let _ = alice.delete(&format!("/groups/{group_id}")).await;
 }


### PR DESCRIPTION
## Status at head

Head: `b517705` — single commit on `origin/main` (617790c, the v0.38.0 release commit). Diff: `src/server/routes/named_groups.rs` +172/−42, `tests/harness/src/cluster.rs` +50/−3, `tests/named_group_integration.rs` +99/−1. Built by a dispatched agent, independently verified by the lead (tree self-diff, fmt, regression test re-run).

## What this fixes (slice A of #333)

Root cause (full trace in the #333 comment, 2026-08-17): the joiner's signed `MemberJoined` to the group authority was **at-most-once** — one gossip publish (5s timeout, warn-and-drop) plus best-effort v1 DMs (~24s ceiling, warn-and-drop). A lost volley meant the join never completed: the joiner's 2s result-poll can only fetch a result the authority staged, so it repaired the return leg but never the outbound leg. This was CI failure datapoint 2 ("alice never observed bob's invite join").

**Fix:** the poll loop now carries the signed event and re-sends it every 3rd unconfirmed poll (~6s cadence). Safety is by existing contract: re-application is a documented no-op for an already-active member (`named_groups.rs` apply-arm contract item 7), and once the authority applies, the staged result satisfies the next poll — resends terminate naturally.

## Two deviations from the original sketch, both evidence-driven

1. **The resend uses both volley channels (gossip publish + DM), not DM-only.** DM-only was implemented first and failed 3/3 regression runs: instrumentation showed every resend failing instantly with `recipient key material unavailable` — the joiner routinely has not resolved the authority's DM key material in exactly the window the resend targets. The metadata-topic publish needs no per-recipient key material. Two-channel: 3/3, converging in ~5s.
2. **The resend is spawned, not awaited** — an inline send was observed stalling a poll iteration by 9s, stretching the fetch cadence the loop exists to maintain. Matches how every other named-group delivery in the file is dispatched.

Deviation 1 is also a **finding for slice C/D**: sender-driven obligations (MemberRemoved/GroupDeleted) planned over the DM path may hit the same cold-key window; the §5 extension ADR should account for it.

## Test

`member_joined_lost_initial_volley_recovers_via_poll_resend` (ignored tier, existing binary — stays inside the `quic-localhost` nextest group): the new check-once `X0X_TEST_DROP_INITIAL_MEMBER_JOINED` hook drops the joiner's **entire** initial volley, so convergence can only come from the resend arm. Verified genuine: with the resend disabled (call site passes `None`), the test fails. Injection confirmed firing on the joiner only. Harness grows `cluster::pair_with_bob_env` for per-daemon env injection; existing callers delegate with an empty slice and are behavior-identical.

## Validation

Builder gates at this tree: fmt clean, clippy `--workspace --all-features --all-targets -D warnings` zero, check-panics zero, nextest `--workspace --all-features` 2659/2659. Regression test 4/4 (3 by-name + 1 in-suite) + 1 independent lead re-run. Full ignored-only suite: 26/28 — the 2 failures are the pre-existing #333 hops C/D tests, shown by clean-baseline rebuild (617790c, no changes) to fail without this change present, in the known #337-polluted local environment (live x0xd on the machine); CI is authoritative for those.

Slice C/D (MemberRemoved/GroupDeleted durable obligations) is deliberately NOT in this PR — it needs the ADR scope decision. This PR narrows #333 to those two hops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs named-group joins when the initial signed `MemberJoined` volley is lost.
- Retains the signed join event and periodically resends it over metadata gossip and direct delivery while the join-result poll remains unconfirmed.
- Adds a process-scoped loss-injection hook and a harness helper for configuring only Bob’s daemon.
- Adds an ignored integration regression test proving a TreeKEM join converges after the complete initial volley is dropped.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The resend reuses the established signed payload and delivery paths, while existing per-group serialization, active-member rejection, and invite-consumption checks prevent duplicate state transitions.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routes/named_groups.rs | Adds bounded periodic retransmission of the original signed `MemberJoined` event while preserving existing serialization, delivery configuration, locking, and idempotency behavior. |
| tests/harness/src/cluster.rs | Refactors pair startup to support daemon-specific environment variables while keeping existing callers behaviorally unchanged. |
| tests/named_group_integration.rs | Adds an ignored two-daemon regression test that drops Bob’s initial join volley and verifies authority-side convergence through polling resends. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant J as Joiner
  participant G as Metadata Gossip
  participant A as Group Authority
  J-xG: Initial MemberJoined volley lost
  J-xA: Initial direct delivery lost
  loop Until membership confirmed
    J->>A: Fetch staged join result
    alt Every third unconfirmed poll
      J->>G: Republish signed MemberJoined
      G->>A: Deliver MemberJoined
      J->>A: Resend signed MemberJoined directly
    end
  end
  A->>A: Validate invite and stage MemberAdded
  A-->>J: Return authoritative join result
  J->>J: Apply result and confirm membership
```

<sub>Reviews (1): Last reviewed commit: ["fix(groups): resend lost MemberJoined fr..."](https://github.com/saorsa-labs/x0x/commit/b51770554bc402befe382779ceee9696be869132) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54007230)</sub>

**Context used:**

- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)

<!-- /greptile_comment -->