### PR TITLE
chore(deps): bump ant-quic 0.27.37 → 0.27.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **ant-quic 0.27.37 → 0.27.38.** Picks up the transport fixes released
+  after the durable-ACK campaign: idle timers now reset on peer-delivered
+  application payload (ant-quic #241 — removes the permanent half-open
+  links of ant-quic #234 while preserving x0x #278 zombie reaping), atomic
+  connection lifecycle (ant-quic #229), and the assembler `Bytes`-aliasing
+  torn-read fix (ant-quic #209).
+
 ## [v0.38.0] - 2026-08-16
 
 > The ADR 0030 durable-application-ACK campaign completes in this release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.37"
+ant-quic = "0.27.38"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
## Status at head

Single commit on origin/main (617790c): Cargo.toml pin 0.27.37→0.27.38 + CHANGELOG Unreleased bullet. Gates at head: fmt 0, clippy (workspace, all features/targets, -D warnings) 0, nextest --workspace --all-features **2659/2659**.

## Why

ant-quic v0.27.38 (released by the GLM lane, verified tag + assets) carries:
- **#241** — idle timers reset on peer-delivered application payload: removes the #234 permanent half-open links while preserving x0x #278 zombie reaping. Directly relevant to the wedged-targeted-route/504 family (#335/#336).
- **#229** — atomic connection lifecycle.
- **#209** — assembler `Bytes`-aliasing torn-read fix.

Review queue: behind #342 for omp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the workspace’s ant-quic dependency from 0.27.37 to 0.27.38 and documents the transport and lifecycle fixes included in that release.
- Bumps the ant-quic dependency requirement to 0.27.38.
- Adds an Unreleased changelog entry describing the upstream fixes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the dependency bump or changelog update.

The change is limited to a patch-level ant-quic update and corresponding release documentation, and the available evidence does not show an incompatible dependency constraint, API break, or behavioral regression.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps ant-quic by one patch release; no concrete compatibility or resolution defect was identified. |
| CHANGELOG.md | Adds an Unreleased entry accurately scoped to the dependency update and its stated upstream fixes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump ant-quic 0.27.37 -&gt; 0...."](https://github.com/saorsa-labs/x0x/commit/72a831d0d86b7cd5d850383061f88ab1cd7f7630) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54094051)</sub>

<!-- /greptile_comment -->