### PR TITLE
fix(groups): bounded resend for MemberRemoved/GroupDeleted + hermetic test plane (#333 C/D, closes the local half of #337)

### DIFF
--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -2241,12 +2241,13 @@ fn spawn_named_group_event_delivery_after(
     });
 }
 
-fn spawn_named_group_event_delivery_to_active_members(
+/// Active members plus `extra_recipients`, minus this node — the recipient set
+/// every named-group fan-out uses.
+fn named_group_event_recipients(
     state: &AppState,
     info: &x0x::groups::GroupInfo,
-    event: &NamedGroupMetadataEvent,
     extra_recipients: &[String],
-) {
+) -> HashSet<String> {
     let local_agent_hex = hex::encode(state.agent.agent_id().as_bytes());
     let mut recipients = HashSet::new();
     for member in info.active_members() {
@@ -2259,7 +2260,16 @@ fn spawn_named_group_event_delivery_to_active_members(
             recipients.insert(recipient.clone());
         }
     }
-    for recipient in recipients {
+    recipients
+}
+
+fn spawn_named_group_event_delivery_to_active_members(
+    state: &AppState,
+    info: &x0x::groups::GroupInfo,
+    event: &NamedGroupMetadataEvent,
+    extra_recipients: &[String],
+) {
+    for recipient in named_group_event_recipients(state, info, extra_recipients) {
         spawn_named_group_event_delivery(state, &recipient, event);
         spawn_named_group_event_delivery_after(
             state,
@@ -2268,6 +2278,131 @@ fn spawn_named_group_event_delivery_to_active_members(
             GROUP_BACKGROUND_PUBLISH_DELAY,
         );
     }
+}
+
+/// Attempt offsets, measured from the initial volley, for the bounded resend of
+/// terminal group-control events (`MemberRemoved`, `GroupDeleted`) — #333 slice
+/// C/D.
+///
+/// Why the schedule is blind, with no confirmation signal: unlike the join hop,
+/// where the joiner's 2s result-poll gives retries a clock to key off, the
+/// sender of a removal or a delete has nothing to poll. The recipient's whole
+/// point is that it stops participating, so it will never answer. The schedule
+/// IS the repair.
+///
+/// Why every attempt sends BOTH channels rather than just the direct message:
+/// the removed peer's metadata listener stays subscribed until it APPLIES the
+/// removal, so a republish can still reach it right up to the moment one
+/// succeeds; and the DM leg is routinely key-cold in exactly this window
+/// (`recipient key material unavailable`, proven in slice A / PR #342), so the
+/// gossip leg and the later attempts are what actually carry the notice.
+///
+/// Why it runs out to +60s: Plumtree's anti-entropy first tick lands at 30-60s,
+/// so the final attempt is the belt to that braces.
+///
+/// Deliberately NOT persisted: a daemon crash mid-schedule still loses the
+/// notice. That is the accepted trade-off of the no-ADR ruling — the ADR 0030
+/// §5 durable outbox stays `SignedPublic`-only.
+const GROUP_CONTROL_REDELIVERY_SCHEDULE: [Duration; 4] = [
+    Duration::from_secs(6),
+    Duration::from_secs(15),
+    Duration::from_secs(30),
+    Duration::from_secs(60),
+];
+
+/// Test-only replacement for [`GROUP_CONTROL_REDELIVERY_SCHEDULE`]:
+/// `X0X_TEST_GROUP_REDELIVERY_SCHEDULE_MS="500,1000,2000"` substitutes those
+/// millisecond offsets so a regression test converges in seconds instead of a
+/// minute. When set, the variable IS the schedule — a value with no parseable
+/// offsets (`""`, `"off"`) therefore means "no resends at all", which is how
+/// the negative-control tests switch the repair off. Read once per process;
+/// unset leaves the production schedule untouched.
+static GROUP_CONTROL_REDELIVERY_SCHEDULE_OVERRIDE: std::sync::LazyLock<Vec<Duration>> =
+    std::sync::LazyLock::new(|| {
+        let Ok(raw) = std::env::var("X0X_TEST_GROUP_REDELIVERY_SCHEDULE_MS") else {
+            return GROUP_CONTROL_REDELIVERY_SCHEDULE.to_vec();
+        };
+        raw.split(',')
+            .filter_map(|part| part.trim().parse::<u64>().ok())
+            .map(Duration::from_millis)
+            .collect()
+    });
+
+/// Re-send a terminal group-control event on a bounded schedule (#333 slice
+/// C/D). See [`GROUP_CONTROL_REDELIVERY_SCHEDULE`] for why this shape.
+///
+/// Callers invoke this immediately after their initial volley (the metadata
+/// publish plus [`spawn_named_group_event_delivery_to_active_members`]); the
+/// offsets are relative to that moment. Everything the schedule needs is cloned
+/// up front, so the task neither reads group state later — which for
+/// `GroupDeleted` is already gone — nor depends on the sender's own metadata
+/// listener, which `withdraw_group_state` stops before it publishes.
+fn spawn_group_control_event_redelivery(
+    state: &Arc<AppState>,
+    metadata_topic: &str,
+    info: &x0x::groups::GroupInfo,
+    event: &NamedGroupMetadataEvent,
+    extra_recipients: &[String],
+) {
+    let schedule = GROUP_CONTROL_REDELIVERY_SCHEDULE_OVERRIDE.clone();
+    if schedule.is_empty() {
+        return;
+    }
+    let recipients: Vec<String> = named_group_event_recipients(state, info, extra_recipients)
+        .into_iter()
+        .collect();
+    let state = Arc::clone(state);
+    let metadata_topic = metadata_topic.to_string();
+    let event = event.clone();
+    let kind = named_group_metadata_event_kind(&event);
+    let group_id = named_group_metadata_event_group_id(&event).to_string();
+    tokio::spawn(async move {
+        let start = tokio::time::Instant::now();
+        for (index, offset) in schedule.iter().enumerate() {
+            tokio::time::sleep_until(start + *offset).await;
+            publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+            for recipient in &recipients {
+                spawn_named_group_event_delivery(&state, recipient, &event);
+            }
+            tracing::debug!(
+                target: "treekem.trace",
+                stage = "group_control_redelivery",
+                group_id = %group_id,
+                kind,
+                attempt = index + 1,
+                attempts = schedule.len(),
+                offset_ms = offset.as_millis() as u64,
+                recipients = recipients.len(),
+            );
+        }
+    });
+}
+
+/// Test-only loss injection for #333: each `X0X_TEST_DROP_INITIAL_*` variable
+/// set to `1` makes the matching event's sender skip its ENTIRE initial volley
+/// (metadata publish plus the direct deliveries), simulating total loss so a
+/// regression test can prove the repair path alone converges.
+///
+/// All default off, and the set is read once per process, so a volley is either
+/// fully injected-lost or fully sent — never partially. These are the only
+/// production knobs this work adds and they stay `X0X_TEST_`-prefixed.
+static DROP_INITIAL_VOLLEY_KINDS: std::sync::LazyLock<HashSet<&'static str>> =
+    std::sync::LazyLock::new(|| {
+        [
+            ("X0X_TEST_DROP_INITIAL_MEMBER_JOINED", "member_joined"),
+            ("X0X_TEST_DROP_INITIAL_MEMBER_REMOVED", "member_removed"),
+            ("X0X_TEST_DROP_INITIAL_GROUP_DELETED", "group_deleted"),
+        ]
+        .into_iter()
+        .filter(|(var, _)| std::env::var(var).is_ok_and(|v| v == "1"))
+        .map(|(_, kind)| kind)
+        .collect()
+    });
+
+/// Whether this event's initial volley is being dropped for a test. Always
+/// `false` unless the matching `X0X_TEST_DROP_INITIAL_*` variable is set.
+fn drop_initial_volley(event: &NamedGroupMetadataEvent) -> bool {
+    DROP_INITIAL_VOLLEY_KINDS.contains(named_group_metadata_event_kind(event))
 }
 
 pub(in crate::server) fn signed_public_bootstrap_snapshot(
@@ -9874,17 +10009,6 @@ struct MemberJoinedResend {
     payload: Vec<u8>,
 }
 
-/// Test-only loss injection for #333: when `X0X_TEST_DROP_INITIAL_MEMBER_JOINED`
-/// is `1`, [`join_group_via_invite`] skips the entire initial `MemberJoined`
-/// send volley (gossip publish plus the direct deliveries to the inviter), so
-/// the regression test can prove the join still converges through the
-/// join-result poll's resend arm alone. Read once per process: the volley is
-/// either fully injected-lost or fully sent, never partially.
-static DROP_INITIAL_MEMBER_JOINED_VOLLEY: std::sync::LazyLock<bool> =
-    std::sync::LazyLock::new(|| {
-        std::env::var("X0X_TEST_DROP_INITIAL_MEMBER_JOINED").is_ok_and(|v| v == "1")
-    });
-
 /// POST /groups/join — join a group via invite link.
 pub(in crate::server) async fn join_group_via_invite(
     State(state): State<Arc<AppState>>,
@@ -10114,7 +10238,7 @@ pub(in crate::server) async fn join_group_via_invite(
                             "MemberJoined: failed to serialize join announcement for resend: {e}"
                         ),
                     }
-                    if *DROP_INITIAL_MEMBER_JOINED_VOLLEY {
+                    if drop_initial_volley(&event) {
                         tracing::warn!(
                             group_id = %group_id_hex,
                             member = %joiner_hex,
@@ -10868,7 +10992,9 @@ pub(in crate::server) async fn remove_named_group_member(
         )
     };
 
-    publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+    if !drop_initial_volley(&event) {
+        publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+    }
     // ADR 0030 §5: the removal is committed, so the bootstrap debt to this
     // member no longer exists.
     cancel_public_group_bootstrap_obligations_for_removal(&state, &agent_id_hex, &delivery_roster)
@@ -10884,8 +11010,19 @@ pub(in crate::server) async fn remove_named_group_member(
     // scheduling below. (Both the MemberRemoved delivery and the survivor
     // envelopes run as independent background tasks, so call order is not a
     // guaranteed recipient receipt order — no delivery barrier is claimed.)
-    spawn_named_group_event_delivery_to_active_members(
+    if !drop_initial_volley(&event) {
+        spawn_named_group_event_delivery_to_active_members(
+            &state,
+            &delivery_roster,
+            &event,
+            std::slice::from_ref(&agent_id_hex),
+        );
+    }
+    // #333 C/D: the one-shot volley above is at-most-once, and the removed
+    // member has no reason to poll for what it just lost.
+    spawn_group_control_event_redelivery(
         &state,
+        &metadata_topic,
         &delivery_roster,
         &event,
         std::slice::from_ref(&agent_id_hex),
@@ -11744,10 +11881,23 @@ async fn remove_treekem_named_group_member(
         secret_epoch: None,
         commit: Some(commit),
     };
-    publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+    if !drop_initial_volley(&event) {
+        publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+    }
     remember_treekem_membership_event(&state, &event).await;
-    spawn_named_group_event_delivery_to_active_members(
+    if !drop_initial_volley(&event) {
+        spawn_named_group_event_delivery_to_active_members(
+            &state,
+            &next,
+            &event,
+            std::slice::from_ref(&agent_id_hex),
+        );
+    }
+    // #333 C/D: without this the removed peer keeps its roster and TreeKEM key
+    // material indefinitely whenever the one-shot volley above is lost.
+    spawn_group_control_event_redelivery(
         &state,
+        &metadata_topic,
         &next,
         &event,
         std::slice::from_ref(&agent_id_hex),
@@ -12057,8 +12207,20 @@ pub(in crate::server) async fn withdraw_group_state(
     // is released; all required data was captured above.
     drop(membership_guard);
 
-    publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
-    spawn_named_group_event_delivery_to_active_members(&state, &delivery_roster, &event, &[]);
+    if !drop_initial_volley(&event) {
+        publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+        spawn_named_group_event_delivery_to_active_members(&state, &delivery_roster, &event, &[]);
+    }
+    // #333 C/D: a lost GroupDeleted leaves recipients holding a stale group and
+    // its TreeKEM snapshot forever — the withdrawn discovery card cannot wipe
+    // keyed local state. Safe to schedule here even though this handler stopped
+    // its own metadata listener above: `Agent::publish` goes straight to the
+    // gossip runtime's pubsub (src/lib.rs:8066-8082) and never consults a local
+    // subscription, while `stop_named_group_metadata_listener` only aborts this
+    // node's receive task (:2491-2496). The schedule also holds its own clones
+    // of the topic, event and roster, so it never reads the group state this
+    // handler has just torn down.
+    spawn_group_control_event_redelivery(&state, &metadata_topic, &delivery_roster, &event, &[]);
 
     (
         StatusCode::OK,

--- a/tests/harness/src/cluster.rs
+++ b/tests/harness/src/cluster.rs
@@ -355,6 +355,10 @@ pub async fn cluster() -> &'static AgentCluster {
 }
 
 /// Start a fresh two-daemon pair with Bob bootstrapping to Alice.
+///
+/// Hermetic: the pair gets its own gossip plane, so it neither sees nor is seen
+/// by other x0x daemons on the machine. See
+/// [`pair_with_extra_config_and_node_env`] for why that is not the default.
 pub async fn pair() -> AgentPair {
     pair_with_extra_config("").await
 }
@@ -401,7 +405,7 @@ pub async fn trio_with_extra_config(extra_config: &str) -> AgentCluster {
 /// Start a fresh pair with the same extra TOML appended to each daemon's
 /// generated config. Useful for test-only timing overrides.
 pub async fn pair_with_extra_config(extra_config: &str) -> AgentPair {
-    pair_with_extra_config_and_bob_env(extra_config, &[]).await
+    pair_with_extra_config_and_node_env(extra_config, &[], &[]).await
 }
 
 /// Start a fresh pair with extra environment variables set on **bob only**.
@@ -412,27 +416,64 @@ pub async fn pair_with_extra_config(extra_config: &str) -> AgentPair {
 /// initial `MemberJoined` volley while the authority behaves normally) need
 /// exactly one node configured, and bob is the harness's joiner.
 pub async fn pair_with_bob_env(env: &[(&str, &str)]) -> AgentPair {
-    pair_with_extra_config_and_bob_env("", env).await
+    pair_with_node_env(&[], env).await
 }
 
-async fn pair_with_extra_config_and_bob_env(
+/// Start a fresh pair with extra environment variables set on **alice only**.
+///
+/// The mirror of [`pair_with_bob_env`], for exchanges where alice is the
+/// sender: she is the harness's group authority, so removals and deletes
+/// originate with her (#333 slice C/D).
+pub async fn pair_with_alice_env(env: &[(&str, &str)]) -> AgentPair {
+    pair_with_node_env(env, &[]).await
+}
+
+/// Start a fresh pair with per-node environment variables. Either slice may be
+/// empty; both nodes still inherit the test process environment on top.
+pub async fn pair_with_node_env(alice_env: &[(&str, &str)], bob_env: &[(&str, &str)]) -> AgentPair {
+    pair_with_extra_config_and_node_env("", alice_env, bob_env).await
+}
+
+/// Every `pair*` constructor funnels through here, so the hermetic-plane
+/// guarantee below is stated once and cannot be forgotten by a new variant.
+async fn pair_with_extra_config_and_node_env(
     extra_config: &str,
+    alice_env: &[(&str, &str)],
     bob_env: &[(&str, &str)],
 ) -> AgentPair {
     let binary = find_x0xd_binary();
     let suffix = rand::random::<u16>();
+    // Hermetic by default: give this pair its own gossip plane.
+    //
+    // `network_id` is unset in generated test configs, and
+    // `DaemonConfig::resolved_network_id` (src/server/state.rs:568-574) maps
+    // unset to the PROD plane. The plane id is also what namespaces ant-quic's
+    // mDNS service (src/network.rs:1612-1618), so an unset value puts every
+    // test pair on the prod plane's LAN discovery: it advertises to, browses,
+    // and auto-connects to every other x0x daemon on the machine, including
+    // unrelated app daemons. `--no-hard-coded-bootstrap` does not help — that
+    // only stops this node dialling OUT, not others finding it.
+    //
+    // Measured on the two historically-flaky propagation tests (#337): 2/6
+    // passing at 39-55s each without a private plane, 6/6 at 22-25s with one.
+    // The pollution manifests as slow invite-join convergence, which is what
+    // those tests wait on.
+    let plane_config = format!("network_id = \"x0x-test-{}\"\n", rand::random::<u32>());
+    let extra_config = format!("{plane_config}{extra_config}");
+    let extra_config = extra_config.as_str();
     let alice_api = allocate_unused_tcp_port();
     let alice_bind = allocate_unused_udp_port();
     let bob_api = allocate_unused_tcp_port();
     let bob_bind = allocate_unused_udp_port();
 
-    let alice = start_instance(
+    let alice = start_instance_with_env(
         &binary,
         &format!("pair-alice-{suffix}"),
         alice_api,
         alice_bind,
         "",
         extra_config,
+        alice_env,
     )
     .await;
     // Rolling start: use the same empirically-required delay as the trio so

--- a/tests/named_group_integration.rs
+++ b/tests/named_group_integration.rs
@@ -16,7 +16,7 @@ mod cluster;
 #[path = "harness/src/daemon.rs"]
 mod daemon;
 
-use cluster::{pair, pair_with_bob_env, AgentInstance};
+use cluster::{pair, pair_with_alice_env, pair_with_bob_env, AgentInstance};
 use daemon::DaemonFixture;
 
 async fn daemon() -> DaemonFixture {
@@ -2074,4 +2074,237 @@ async fn member_joined_lost_initial_volley_recovers_via_poll_resend() {
     );
 
     let _ = alice.delete(&format!("/groups/{group_id}")).await;
+}
+
+// ===========================================================================
+// #333 C/D — terminal group-control events survive a lost initial volley
+// ===========================================================================
+
+/// Compressed stand-in for the production 6/15/30/60s resend schedule, so a
+/// regression test observes the repair in seconds rather than a minute. Four
+/// attempts, same shape.
+const FAST_REDELIVERY_SCHEDULE_MS: &str = "500,1500,4000,8000";
+
+/// Drive alice and bob to a converged two-member private_secure group and
+/// return `(alice_group_id, bob_group_id, bob_agent_id)`.
+///
+/// The #333 C/D tests all start here: the removal and delete hops can only be
+/// tested once the peer genuinely holds the group at alice's revision — a
+/// `MemberRemoved` commit applied against a stale local revision is rejected on
+/// `prev_state_hash`, so parity is load-bearing, not decorative. A join that
+/// silently failed must therefore surface as a setup failure, never as a false
+/// pass on the hop under test.
+///
+/// Setup waits use [`SETUP_CONVERGENCE_TIMEOUT`] rather than the suite's
+/// standard 30s. This is scaffolding, not the observation: the measured hop
+/// keeps the 30s bound, and giving the join room to converge stops the
+/// known-flaky invite-join wait (#333 datapoint 2 / #337) from being reported
+/// as a failure of the removal or delete path.
+const SETUP_CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(60);
+
+async fn converged_pair_group(
+    alice: &AgentInstance,
+    bob: &AgentInstance,
+    name: &str,
+) -> (String, String, String) {
+    let create: Value = alice
+        .post(
+            "/groups",
+            serde_json::json!({"name": name, "display_name": "Alice"}),
+        )
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(create["ok"], true, "create response: {create:?}");
+    let group_id = create["group_id"].as_str().unwrap().to_string();
+
+    let invite: Value = alice
+        .post(&format!("/groups/{group_id}/invite"), serde_json::json!({}))
+        .await
+        .json()
+        .await
+        .unwrap();
+    let invite_link = invite["invite_link"].as_str().unwrap().to_string();
+
+    let bob_join: Value = bob
+        .post(
+            "/groups/join",
+            serde_json::json!({"invite": invite_link, "display_name": "Bob Local"}),
+        )
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(bob_join["ok"], true, "join response: {bob_join:?}");
+    let bob_group_id = bob_join["group_id"]
+        .as_str()
+        .unwrap_or(&group_id)
+        .to_string();
+    let bob_agent_id = bob.agent_id().await;
+
+    let alice_sees_bob = wait_until(SETUP_CONVERGENCE_TIMEOUT, || async {
+        let info: Value = alice
+            .get(&format!("/groups/{group_id}/members"))
+            .await
+            .json()
+            .await
+            .unwrap_or_default();
+        info["members"]
+            .as_array()
+            .map(|members| members.iter().any(|m| m["agent_id"] == bob_agent_id))
+            .unwrap_or(false)
+    })
+    .await;
+    assert!(
+        alice_sees_bob,
+        "setup precondition failed: alice never observed bob's join, so the \
+         terminal-event hop under test was never reachable"
+    );
+
+    let alice_hash = group_state_hash(alice, &group_id)
+        .await
+        .expect("alice state hash after bob join");
+    let bob_caught_up = wait_until(SETUP_CONVERGENCE_TIMEOUT, || async {
+        group_state_hash(bob, &bob_group_id).await.as_deref() == Some(alice_hash.as_str())
+    })
+    .await;
+    assert!(
+        bob_caught_up,
+        "setup precondition failed: bob never applied alice's authoritative add"
+    );
+
+    (group_id, bob_group_id, bob_agent_id)
+}
+
+/// Why: a lost `MemberRemoved` is security-adjacent, not cosmetic — the removed
+/// peer keeps its roster entry AND its TreeKEM key material until some later
+/// event happens to trigger reactive catch-up, and nothing guarantees one ever
+/// does. The hop was one gossip publish plus two best-effort DMs, all
+/// warn-and-drop, with no recovery: unlike the join hop there is nothing the
+/// removed peer would poll, because not participating is the whole point of
+/// being removed.
+///
+/// `X0X_TEST_DROP_INITIAL_MEMBER_REMOVED` drops alice's entire initial volley,
+/// so the bounded resend schedule is the only thing that can deliver the
+/// removal. If that schedule regresses, this test fails; a wider timeout cannot
+/// rescue it.
+#[tokio::test]
+#[ignore]
+async fn member_removed_lost_initial_volley_recovers_via_bounded_resend() {
+    // Alice is the authority, so only her daemon drops the volley and only her
+    // schedule is compressed — bob must stay an ordinary recipient for this to
+    // prove delivery rather than symmetric breakage.
+    let pair = pair_with_alice_env(&[
+        ("X0X_TEST_DROP_INITIAL_MEMBER_REMOVED", "1"),
+        (
+            "X0X_TEST_GROUP_REDELIVERY_SCHEDULE_MS",
+            FAST_REDELIVERY_SCHEDULE_MS,
+        ),
+    ])
+    .await;
+    let alice = &pair.alice;
+    let bob = &pair.bob;
+
+    let (group_id, bob_group_id, bob_agent_id) =
+        converged_pair_group(alice, bob, "Lost MemberRemoved").await;
+
+    let remove: Value = alice
+        .delete(&format!("/groups/{group_id}/members/{bob_agent_id}"))
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(remove["ok"], true, "remove response: {remove:?}");
+
+    let removed_seen = wait_until(Duration::from_secs(30), || async {
+        bob.get(&format!("/groups/{bob_group_id}")).await.status() == StatusCode::NOT_FOUND
+    })
+    .await;
+    assert!(
+        removed_seen,
+        "bob never applied his own removal after alice's initial MemberRemoved \
+         volley was dropped; the bounded resend schedule did not repair the hop \
+         (#333 C). A removed member that never learns it was removed keeps its \
+         roster and TreeKEM key material indefinitely."
+    );
+
+    let _ = alice.delete(&format!("/groups/{group_id}")).await;
+}
+
+/// Why: a lost `GroupDeleted` leaves the recipient holding a live group and its
+/// TreeKEM snapshot forever. The withdrawn discovery card cannot wipe keyed
+/// local state, and the 300s card republish filters Hidden groups out, so the
+/// signed event is the only thing that terminalizes the peer's copy.
+///
+/// `X0X_TEST_DROP_INITIAL_GROUP_DELETED` drops alice's initial volley, leaving
+/// the bounded resend schedule as the sole delivery path. This also exercises
+/// the ordering hazard in `withdraw_group_state`: it stops its own metadata
+/// listener BEFORE publishing, so a repair that depended on that listener would
+/// fail here.
+#[tokio::test]
+#[ignore]
+async fn group_deleted_lost_initial_volley_recovers_via_bounded_resend() {
+    let pair = pair_with_alice_env(&[
+        ("X0X_TEST_DROP_INITIAL_GROUP_DELETED", "1"),
+        (
+            "X0X_TEST_GROUP_REDELIVERY_SCHEDULE_MS",
+            FAST_REDELIVERY_SCHEDULE_MS,
+        ),
+    ])
+    .await;
+    let alice = &pair.alice;
+    let bob = &pair.bob;
+
+    let (group_id, bob_group_id, _bob_agent_id) =
+        converged_pair_group(alice, bob, "Lost GroupDeleted").await;
+
+    let withdraw: Value = alice
+        .post(
+            &format!("/groups/{group_id}/state/withdraw"),
+            serde_json::json!({}),
+        )
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(withdraw["ok"], true, "withdraw response: {withdraw:?}");
+
+    let withdrawn_seen = wait_until(Duration::from_secs(30), || async {
+        group_state(bob, &bob_group_id)
+            .await
+            .is_some_and(|state| state["withdrawn"] == true)
+    })
+    .await;
+    assert!(
+        withdrawn_seen,
+        "bob never observed the group delete after alice's initial GroupDeleted \
+         volley was dropped; the bounded resend schedule did not repair the hop \
+         (#333 D)"
+    );
+
+    // Terminalization must be real, not just a flag: authoring is refused and
+    // the key material is gone. Without this a 'withdrawn' marker that left the
+    // snapshot on disk would pass.
+    let bob_encrypt = bob
+        .post(
+            &format!("/groups/{bob_group_id}/secure/encrypt"),
+            serde_json::json!({ "payload_b64": "aGk=" }),
+        )
+        .await;
+    assert_eq!(
+        bob_encrypt.status(),
+        StatusCode::CONFLICT,
+        "recipient authoring must be rejected after a resent GroupDeleted"
+    );
+    assert!(
+        !tokio::fs::try_exists(
+            bob.data_dir()
+                .join("treekem")
+                .join(format!("{bob_group_id}.snap"))
+        )
+        .await
+        .unwrap_or(false),
+        "recipient TreeKEM snapshot must be wiped by a resent GroupDeleted"
+    );
 }


### PR DESCRIPTION
## Status at head

Head: `0044914` — single commit on `origin/main` (8ba42b0). Diff: `src/server/routes/named_groups.rs` +184/−22, `tests/harness/src/cluster.rs` +45/−4, `tests/named_group_integration.rs` +234/−1. Built by the slice-A builder agent, final tree independently verified by the lead (numstat, fmt, both canary tests re-run green).

## Part 1: #333 slice C/D — the last two lossy control hops (per David's no-ADR ruling)

`MemberRemoved` (TreeKEM + GSS fan-outs) and `GroupDeleted` were one gossip publish + best-effort DMs, warn-and-drop. They now get a **bounded spawned redelivery schedule** (+6s/+15s/+30s/+60s from the initial volley), each attempt two-channel (metadata publish + per-recipient DM), via one shared helper (`spawn_group_control_event_redelivery`). Design rationale doc-commented on the schedule const: blind-and-bounded because the removed/deleted party has nothing to poll; the removed peer's listener stays subscribed until it applies the removal; the +60s attempt lands past Plumtree AE's first tick; the DM leg may be key-cold early (slice-A finding) so the gossip leg and later attempts carry it. **Deliberate trade-off, stated not hidden**: no persistence — a daemon crash mid-schedule loses the notice (the §5 outbox stays SignedPublic-only, per the ruling).

Scope edges, both explicit: self-leave `MemberRemoved` excluded (the leaver already knows); `MemberBanned` shares the identical gap → #344.

## Part 2: the local half of #337, root-caused and closed

Unset `network_id` in test configs resolves to the **production gossip plane** (`resolved_network_id`, state.rs:568-574), and the plane id namespaces ant-quic's mDNS (network.rs:1612-1618) — so test daemons advertised/browsed on the prod plane and auto-connected to any live x0xd on the machine; `--no-hard-coded-bootstrap` never helped because it only stops outbound dials. The harness now assigns a per-run plane (`network_id = "x0x-test-<rand>"`) at the single funnel all `pair*` constructors share. Controlled measurement: the two historically-flaky tests went **2/6 pass at 39-55s → 6/6 at 22-25s**. `cluster()`/trio and `DaemonFixture` deliberately untouched (their isolation is a separate call).

This also corrects the earlier #333 framing: those two tests fail upstream at hop B's state-hash catch-up under mesh pollution — the CI datapoints map to hops A (fixed in #342) and D (fixed here).

## Tests

Two new fault-injection tests (ignored tier, existing binary): drop the entire initial `MemberRemoved` / `GroupDeleted` volley on the sender via the generalized per-event-kind `X0X_TEST_DROP_INITIAL_*` hooks; convergence must come from the redelivery schedule alone (compressed via `X0X_TEST_GROUP_REDELIVERY_SCHEDULE_MS` so tests run in seconds). Negative controls (schedule disabled) fail with the intended assertions. Slice A's hook now flows through the same mechanism.

## Validation (final tree; builder numbers + lead spot-verification)

fmt/clippy(-D warnings)/check-panics 0 · workspace nextest **2659/2659** · full `named_group_integration` ignored suite **30/30** — first fully green local run of this binary · fault-injection tests **9/9** over 3 rounds · canaries **6/6** (lead re-ran both: green at reported timings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds bounded two-channel redelivery for `MemberRemoved` and `GroupDeleted`, isolates two-daemon test pairs onto per-run gossip planes, and adds fault-injection integration coverage.

- Snapshots terminal-event recipients and retries gossip plus direct delivery at four bounded offsets.
- Generalizes sender-specific loss-injection hooks and adds recovery tests for removal and deletion.
- Assigns every `pair*` harness instance a random private `network_id` to prevent ambient daemon discovery.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security defects identified.

Terminal retries preserve the original signed event and recipient set, while receiver-side revision and chain-link validation rejects duplicate, stale, and out-of-order deliveries; the harness isolation and new tests are consistent with the intended behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routes/named_groups.rs | Adds bounded terminal-control redelivery with snapshotted recipients; receiver commit validation safely rejects duplicate and stale attempts. |
| tests/harness/src/cluster.rs | Gives pair-based test daemons a shared per-run gossip plane and supports independent environment overrides for Alice and Bob. |
| tests/named_group_integration.rs | Adds ignored fault-injection tests proving terminal removal and deletion converge solely through scheduled redelivery. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant A as Group authority
  participant G as Gossip plane
  participant D as Direct delivery
  participant R as Recipient
  A->>G: Initial terminal event
  A->>D: Initial per-recipient delivery
  loop +6s, +15s, +30s, +60s
    A->>G: Republish cloned event
    A->>D: Redeliver to snapshotted recipients
    G-->>R: Apply if current chain head matches
    D-->>R: Apply if current chain head matches
  end
  R->>R: Reject duplicate/stale commits
```

<sub>Reviews (1): Last reviewed commit: ["fix(groups): bounded two-channel resend ..."](https://github.com/saorsa-labs/x0x/commit/0044914f1cc8bb5f53fafe7c8932c6cd4a9f0c3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54310617)</sub>

**Context used:**

- Knowledge Base — [Groups: Membership, Discovery, and State Commits](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/groups-messaging.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)

<!-- /greptile_comment -->