### PR TITLE
chore(deps): bump ant-quic 0.27.38 → 0.27.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **ant-quic 0.27.38 → 0.27.39.** Dropping a QUIC send stream without an
+  explicit `finish()` now resets it (ant-quic #244/#248) instead of
+  gracefully FINning at the current offset — a cancelled or timed-out
+  in-flight write can no longer arrive at a peer as a plausible short
+  message. This is the transport-level root fix for the
+  "Failed to deserialize PubSub message: Hit the end of buffer" family of
+  receiver errors observed whenever a sender's publish timeout cancelled a
+  stalled write.
+
 - **ant-quic 0.27.37 → 0.27.38.** Picks up the transport fixes released
   after the durable-ACK campaign: idle timers now reset on peer-delivered
   application payload (ant-quic #241 — removes the permanent half-open

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.38"
+ant-quic = "0.27.39"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
## Status at head

Single commit on origin/main: Cargo.toml pin 0.27.38→0.27.39 + CHANGELOG Unreleased bullet. Gates at head: fmt 0, clippy (workspace, all features/targets, -D warnings) 0, nextest --workspace --all-features **2659/2659**.

## Why

ant-quic v0.27.39 (released today, verified: 13 assets + crates.io) carries exactly one change: **#244/#248** — `SendStream` drop resets unfinished streams (`DROPPED_UNFINISHED_ERROR_CODE = 0xA17C_0244`) instead of gracefully FINning at the current write offset, with all implicit-finish call sites remediated (disposition table in ant-quic #248). For x0x this is the transport-level root fix for the `Failed to deserialize PubSub message: Hit the end of buffer` family — a cancelled/timed-out in-flight write can no longer arrive as a plausible short message.

Review queue: with #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the workspace ant-quic dependency from 0.27.38 to 0.27.39 and documents the transport fix for truncated messages caused by cancelled or timed-out writes.
- Raises the ant-quic dependency requirement to 0.27.39.
- Adds an Unreleased changelog entry explaining the send-stream reset behavior and its effect on PubSub deserialization errors.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code defect identified.

The dependency requirement advances to the intended fixed release, no stale lockfile or conflicting override prevents resolution, and the accompanying changelog accurately describes the purpose of the update based on the provided release context.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates ant-quic from 0.27.38 to 0.27.39 without introducing a conflicting workspace override or stale committed lockfile. |
| CHANGELOG.md | Documents the dependency update and the intended transport-level correction for unfinished send streams. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump ant-quic 0.27.38 -&gt; 0...."](https://github.com/saorsa-labs/x0x/commit/548d4c29b20bc240a339c8e24b0ad59ecfcaa16e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54327879)</sub>

<!-- /greptile_comment -->