### PR TITLE
fix(groups): bounded two-channel redelivery for MemberBanned (#344)

### DIFF
--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -2391,6 +2391,7 @@ static DROP_INITIAL_VOLLEY_KINDS: std::sync::LazyLock<HashSet<&'static str>> =
         [
             ("X0X_TEST_DROP_INITIAL_MEMBER_JOINED", "member_joined"),
             ("X0X_TEST_DROP_INITIAL_MEMBER_REMOVED", "member_removed"),
+            ("X0X_TEST_DROP_INITIAL_GROUP_DELETED", "group_deleted"),
             ("X0X_TEST_DROP_INITIAL_MEMBER_BANNED", "member_banned"),
         ]
         .into_iter()

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -2391,7 +2391,7 @@ static DROP_INITIAL_VOLLEY_KINDS: std::sync::LazyLock<HashSet<&'static str>> =
         [
             ("X0X_TEST_DROP_INITIAL_MEMBER_JOINED", "member_joined"),
             ("X0X_TEST_DROP_INITIAL_MEMBER_REMOVED", "member_removed"),
-            ("X0X_TEST_DROP_INITIAL_GROUP_DELETED", "group_deleted"),
+            ("X0X_TEST_DROP_INITIAL_MEMBER_BANNED", "member_banned"),
         ]
         .into_iter()
         .filter(|(var, _)| std::env::var(var).is_ok_and(|v| v == "1"))
@@ -12964,6 +12964,9 @@ pub(in crate::server) async fn ban_group_member(
         }
     };
     drop(groups);
+    // Roster snapshot for the #344 redelivery below: the persist consumes
+    // `next`, and the resend schedule must not read live group state.
+    let delivery_roster = next.clone();
     if !matches!(
         persist_named_group_info(&state, &id, next).await,
         Ok(AtomicWriteOutcome::Durable)
@@ -13035,13 +13038,25 @@ pub(in crate::server) async fn ban_group_member(
         group_id: event_group_id,
         revision,
         actor: caller_hex,
-        agent_id: agent_id_hex,
+        agent_id: agent_id_hex.clone(),
         secret_epoch: if is_encrypted { Some(new_epoch) } else { None },
         treekem_commit_b64: None,
         treekem_epoch: None,
         commit: Some(commit),
     };
-    publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+    if !drop_initial_volley(&event) {
+        publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+    }
+    // #344: a lost `MemberBanned` leaves the banned peer holding its roster
+    // entry and key material exactly like a lost removal — the banned member
+    // has no reason to poll for what it cannot see coming. Bounded resend.
+    spawn_group_control_event_redelivery(
+        &state,
+        &metadata_topic,
+        &delivery_roster,
+        &event,
+        std::slice::from_ref(&agent_id_hex),
+    );
     maybe_publish_group_card_after_state_change(&state, &id).await;
 
     (
@@ -13188,10 +13203,23 @@ async fn ban_treekem_group_member(
         treekem_epoch: Some(treekem_epoch),
         commit: Some(commit),
     };
-    publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+    if !drop_initial_volley(&event) {
+        publish_named_group_metadata_event(&state, &metadata_topic, &event).await;
+    }
     remember_treekem_membership_event(&state, &event).await;
-    spawn_named_group_event_delivery_to_active_members(
+    if !drop_initial_volley(&event) {
+        spawn_named_group_event_delivery_to_active_members(
+            &state,
+            &next,
+            &event,
+            std::slice::from_ref(&agent_id_hex),
+        );
+    }
+    // #344: same at-most-once gap as a lost removal — the banned peer keeps
+    // its roster entry and TreeKEM key material until this event lands.
+    spawn_group_control_event_redelivery(
         &state,
+        &metadata_topic,
         &next,
         &event,
         std::slice::from_ref(&agent_id_hex),

--- a/tests/named_group_integration.rs
+++ b/tests/named_group_integration.rs
@@ -2308,3 +2308,89 @@ async fn group_deleted_lost_initial_volley_recovers_via_bounded_resend() {
         "recipient TreeKEM snapshot must be wiped by a resent GroupDeleted"
     );
 }
+
+/// Why: a lost `MemberBanned` is the same security-adjacent gap as a lost
+/// removal (#344) — the banned peer keeps its roster entry and its TreeKEM
+/// key material, and unlike the removed member it was never sent a share of
+/// the post-ban epoch, so silence leaves it holding stale key material it
+/// should have been forced to surrender. The hop was a single best-effort
+/// volley (a gossip publish, plus DMs only on the TreeKEM path) with no
+/// recovery, and the banned member has nothing to poll.
+///
+/// `X0X_TEST_DROP_INITIAL_MEMBER_BANNED` drops alice's entire initial volley,
+/// so the bounded resend schedule is the only thing that can deliver the ban.
+/// If that schedule regresses, this test fails; a wider timeout cannot rescue
+/// it.
+#[tokio::test]
+#[ignore]
+async fn member_banned_lost_initial_volley_recovers_via_bounded_resend() {
+    // Alice is the authority, so only her daemon drops the volley and only her
+    // schedule is compressed — bob must stay an ordinary recipient for this to
+    // prove delivery rather than symmetric breakage.
+    let pair = pair_with_alice_env(&[
+        ("X0X_TEST_DROP_INITIAL_MEMBER_BANNED", "1"),
+        (
+            "X0X_TEST_GROUP_REDELIVERY_SCHEDULE_MS",
+            FAST_REDELIVERY_SCHEDULE_MS,
+        ),
+    ])
+    .await;
+    let alice = &pair.alice;
+    let bob = &pair.bob;
+
+    let (group_id, bob_group_id, bob_agent_id) =
+        converged_pair_group(alice, bob, "Lost MemberBanned").await;
+
+    let ban: Value = alice
+        .post(
+            &format!("/groups/{group_id}/ban/{bob_agent_id}"),
+            serde_json::json!({}),
+        )
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(ban["ok"], true, "ban response: {ban:?}");
+
+    // Delivery proof: bob's own roster can only show him banned if the event
+    // reached and was applied by bob — alice's local state says nothing about
+    // bob's copy.
+    let ban_seen = wait_until(Duration::from_secs(30), || async {
+        let members: Value = bob
+            .get(&format!("/groups/{bob_group_id}/members"))
+            .await
+            .json()
+            .await
+            .unwrap_or_default();
+        members["members"]
+            .as_array()
+            .map(|ms| {
+                ms.iter()
+                    .any(|m| m["agent_id"] == bob_agent_id && m["state"] == "banned")
+            })
+            .unwrap_or(false)
+    })
+    .await;
+    assert!(
+        ban_seen,
+        "bob never applied his own ban after alice's initial MemberBanned \
+         volley was dropped; the bounded resend schedule did not repair the hop \
+         (#344). A banned member that never learns it was banned keeps its \
+         roster entry and stale TreeKEM key material indefinitely."
+    );
+
+    // Terminalization must be real, not just a roster flag: applying your own
+    // ban tears down the local TreeKEM group and wipes its persistence.
+    assert!(
+        !tokio::fs::try_exists(
+            bob.data_dir()
+                .join("treekem")
+                .join(format!("{bob_group_id}.snap"))
+        )
+        .await
+        .unwrap_or(false),
+        "banned member's TreeKEM snapshot must be wiped by a resent MemberBanned"
+    );
+
+    let _ = alice.delete(&format!("/groups/{group_id}")).await;
+}


### PR DESCRIPTION
The ban fan-out had the same at-most-once gap as removal (#333 C/D):
a single best-effort volley — a gossip publish only on the non-TreeKEM
path, plus DMs on the TreeKEM path — with no repair. A banned peer that
misses the notice keeps its roster entry and stale TreeKEM key material
indefinitely, and it has nothing to poll.

Wire spawn_group_control_event_redelivery at both ban sites (recipients:
active members + banned peer, minus self), gate the initial volley
behind the generalized X0X_TEST_DROP_INITIAL_* fault injection, and add
the lost-volley regression test mirroring MemberRemoved: bob's own
roster showing him banned is the delivery proof; the wiped treekem
snapshot is the terminalization proof.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds bounded gossip-and-direct redelivery for `MemberBanned` events on both group-ban paths and adds a lost-initial-volley integration test. It also generalizes the test fault-injection table, but inadvertently removes the existing GroupDeleted injection mapping.

- Captures the post-ban roster for asynchronous redelivery without rereading live group state.
- Includes the banned agent alongside active members in redelivery recipients.
- Gates initial gossip and TreeKEM direct delivery behind the MemberBanned test injection.
- Adds delivery and TreeKEM-terminalization assertions for a dropped initial ban volley.

<h3>Confidence Score: 4/5</h3>

The runtime redelivery change appears safe to merge, with one non-blocking fault-injection regression that should be corrected to preserve meaningful GroupDeleted coverage.

MemberBanned redelivery includes both active members and the banned peer and applies idempotently, while the only accepted issue is that the changed injection table silently disables the existing GroupDeleted lost-volley test scenario.

**Files Needing Attention:** src/server/routes/named_groups.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routes/named_groups.rs | Adds correctly targeted MemberBanned redelivery to both ban paths, but replaces rather than preserves the GroupDeleted fault-injection mapping. |
| tests/named_group_integration.rs | Adds an ignored integration regression test proving resent MemberBanned delivery and local TreeKEM cleanup. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant A as Banning member
  participant G as Gossip topic
  participant R as Redelivery task
  participant B as Banned member
  A->>A: Persist post-ban roster
  alt Initial volley enabled
    A->>G: Publish MemberBanned
    G-->>B: Deliver event
  end
  A->>R: Spawn bounded schedule
  loop Each scheduled retry
    R->>G: Republish MemberBanned
    R->>B: Send direct MemberBanned
  end
  B->>B: Mark self banned and wipe TreeKEM snapshot
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/routes/named_groups.rs:2394
**Preserve GroupDeleted fault injection**

Replacing the `X0X_TEST_DROP_INITIAL_GROUP_DELETED` mapping makes that existing fault-injection variable a no-op, so its lost-volley regression test receives the normal initial delivery and can pass without exercising bounded redelivery.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(groups): bounded two-channel redeliv..."](https://github.com/saorsa-labs/x0x/commit/31ece8ac16ef8389ab39ba507430b3335b6ab4da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54441610)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)

<!-- /greptile_comment -->