### PR TITLE
test(harness): hermetic gossip plane for trio + DaemonFixture (closes #337)

### DIFF
--- a/tests/harness/src/cluster.rs
+++ b/tests/harness/src/cluster.rs
@@ -458,9 +458,9 @@ async fn pair_with_extra_config_and_node_env(
     // passing at 39-55s each without a private plane, 6/6 at 22-25s with one.
     // The pollution manifests as slow invite-join convergence, which is what
     // those tests wait on.
-    let plane_config = format!("network_id = \"x0x-test-{}\"\n", rand::random::<u32>());
-    let extra_config = format!("{plane_config}{extra_config}");
-    let extra_config = extra_config.as_str();
+    let plane_id = format!("x0x-test-{}", rand::random::<u32>());
+    let owned_extra = with_private_plane(&plane_id, extra_config);
+    let extra_config = owned_extra.as_str();
     let alice_api = allocate_unused_tcp_port();
     let alice_bind = allocate_unused_udp_port();
     let bob_api = allocate_unused_tcp_port();
@@ -514,9 +514,33 @@ async fn create_cluster() -> AgentCluster {
     create_cluster_with_extra_config("").await
 }
 
+/// Prepend a private per-run gossip plane to `extra_config` unless the caller
+/// already set one, so every daemon this harness starts is isolated from the
+/// prod plane. See the rationale in `pair_with_extra_config_and_node_env`
+/// (#337): an unset `network_id` resolves to PROD and namespaces mDNS, so test
+/// daemons otherwise auto-connect to any live x0xd on the machine. The
+/// suppression check mirrors `daemon.rs`'s `bootstrap_peers` handling — a
+/// duplicate TOML key would be a parse error, and it lets a caller override the
+/// plane deliberately.
+fn with_private_plane(plane_id: &str, extra_config: &str) -> String {
+    let has_network_id = extra_config
+        .lines()
+        .any(|l| l.trim_start().starts_with("network_id"));
+    if has_network_id {
+        extra_config.to_string()
+    } else {
+        format!("network_id = \"{plane_id}\"\n{extra_config}")
+    }
+}
+
 async fn create_cluster_with_extra_config(extra_config: &str) -> AgentCluster {
     let binary = find_x0xd_binary();
     let suffix = rand::random::<u16>();
+    // One plane id shared by all three nodes (they must discover each other),
+    // unique to this cluster instance (no other run or ambient daemon joins).
+    let plane_id = format!("x0x-test-{}", rand::random::<u32>());
+    let owned_extra = with_private_plane(&plane_id, extra_config);
+    let extra_config = owned_extra.as_str();
     let alice_api = allocate_unused_tcp_port();
     let alice_bind = allocate_unused_udp_port();
     let bob_api = allocate_unused_tcp_port();

--- a/tests/harness/src/daemon.rs
+++ b/tests/harness/src/daemon.rs
@@ -8,8 +8,19 @@
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::LazyLock;
 use std::time::Duration;
 use tempfile::TempDir;
+
+/// A private gossip-plane id shared by every fixture in this test process
+/// (#337). Nextest runs each test in its own process, so this is effectively
+/// per-test: fixtures a single test starts share a plane and can connect, while
+/// other tests and ambient daemons are isolated. Computed once per process.
+fn process_gossip_plane_id() -> &'static str {
+    static PLANE_ID: LazyLock<String> =
+        LazyLock::new(|| format!("x0x-test-{}", rand::random::<u32>()));
+    PLANE_ID.as_str()
+}
 
 /// Per-test x0xd daemon fixture.
 pub struct DaemonFixture {
@@ -45,10 +56,33 @@ impl DaemonFixture {
         } else {
             "bootstrap_peers = []\n"
         };
+        // Hermetic gossip plane (#337): an unset `network_id` resolves to the
+        // PROD plane, which namespaces ant-quic's mDNS — so a fixture advertises
+        // on the prod plane's LAN discovery and auto-connects to any live x0xd
+        // on the machine (e.g. a running app daemon). Give fixtures a private
+        // plane unless the caller set one.
+        //
+        // The plane is per-PROCESS, not per-fixture: nextest runs each test in
+        // its own process, so all fixtures a single test starts share one plane
+        // and can still discover/connect to each other (e.g. bob as alice's
+        // bootstrap peer), while a different test process and any ambient daemon
+        // stay on different planes. A per-fixture plane would wrongly isolate the
+        // two daemons of a pairing test from each other. Same suppression shape
+        // as `bootstrap_peers` above: a duplicate TOML key is a parse error, and
+        // this lets a caller override the plane deliberately.
+        let extra_has_network_id = extra_config
+            .lines()
+            .any(|l| l.trim_start().starts_with("network_id"));
+        let network_line = if extra_has_network_id {
+            String::new()
+        } else {
+            format!("network_id = \"{}\"\n", process_gossip_plane_id())
+        };
         let mut config = format!(
-            "bind_address = \"0.0.0.0:0\"\napi_address = \"127.0.0.1:0\"\ndata_dir = \"{}\"\nlog_level = \"warn\"\n{}instance_name = \"{}\"\n",
+            "bind_address = \"0.0.0.0:0\"\napi_address = \"127.0.0.1:0\"\ndata_dir = \"{}\"\nlog_level = \"warn\"\n{}{}instance_name = \"{}\"\n",
             tempdir.path().display(),
             bootstrap_line,
+            network_line,
             name,
         );
         if !extra_config.trim().is_empty() {


### PR DESCRIPTION
## Status at head

Head: `097bd3b` — single commit on `origin/main` (17162ab, v0.38.1). Diff: `tests/harness/src/cluster.rs` +27/−3, `tests/harness/src/daemon.rs` +35/−1. Test-harness only; no production code. Built inline by the lead (the assigned agent was killed by an API outage before starting).

## What this closes

PR #345 gave every `pair*` cluster a private per-run gossip plane, closing the pair() half of #337. This extends the same isolation to the two remaining harness constructor families, closing the issue:

- **Trio (`create_cluster_with_extra_config`)**: one plane id shared by all three nodes (they must discover each other), unique per cluster instance. The plane-prepend is now a shared `with_private_plane` helper the pair funnel also uses, with a `network_id` override guard mirroring `daemon.rs`'s existing `bootstrap_peers` suppression.
- **`DaemonFixture`**: a **per-process** plane (`LazyLock`), not per-fixture. Nextest runs each test in its own process, so all fixtures one test starts share a plane and can still connect (e.g. bob as alice's bootstrap peer in `alice_and_bob_connected`), while other test processes and ambient daemons stay isolated.

## The bug my own evidence caught

A per-fixture random plane was the naive first cut. It **broke every two-`DaemonFixture` pairing test** — `peer_lifecycle_integration` went 0/4 (branch) vs 4/4 (clean main), because alice and bob landed on different planes and couldn't connect. Fixed to per-process granularity → **4/4**. This is exactly why the lane ran a controlled before/after rather than trusting the compile.

## Validation

- `peer_lifecycle_integration` ignored suite (uses two DaemonFixtures wired by bootstrap): **4/4** with the process plane (was 0/4 with per-fixture).
- fmt / clippy (`--workspace --all-features --all-targets -D warnings`) 0; `nextest --workspace --all-features` **2659/2659** (the harness change touches every binary using `cluster::pair`/`DaemonFixture`).

Mechanism reference (from #345): `resolved_network_id` (state.rs:568-574) maps unset → PROD plane; that id namespaces ant-quic mDNS (network.rs:1612-1618); `--no-hard-coded-bootstrap` only stops outbound dials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR assigns private gossip-plane identifiers to trio clusters and `DaemonFixture` instances so harness daemons avoid the production mDNS namespace.

- Extracts shared private-plane configuration handling for pair and trio cluster constructors.
- Adds a process-scoped plane identifier for `DaemonFixture` instances.
- Preserves caller-provided `network_id` overrides.

<h3>Confidence Score: 4/5</h3>

The process-scoped `DaemonFixture` plane should be corrected before merging because supported cargo-test runs can place unrelated concurrent tests on the same gossip plane.

The new `LazyLock` isolates nextest processes but not multiple tests sharing a cargo-test process, allowing cross-test mDNS discovery; explicit quoted `network_id` overrides are also mishandled by the prefix detector.

**Files Needing Attention:** tests/harness/src/daemon.rs, tests/harness/src/cluster.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/harness/src/cluster.rs | Adds shared per-cluster private-plane injection, but its textual override detector misses valid quoted TOML keys. |
| tests/harness/src/daemon.rs | Adds process-scoped fixture isolation that works with nextest but allows unrelated tests to share a plane under supported cargo-test execution. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  T[Test runner process] --> P[Process-scoped network_id]
  P --> A[Test A fixtures]
  P --> B[Test B fixtures]
  A --> M[Shared mDNS namespace]
  B --> M
  M --> X[Cross-test peer discovery under cargo test]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tests/harness/src/daemon.rs:16-17
**Process-wide plane breaks test isolation**

When a daemon-backed integration binary runs through `cargo test -- --ignored`, multiple concurrent tests share this process-wide `network_id`, so their fixtures advertise in the same mDNS namespace and can connect across test boundaries, polluting peer topology and making the supported test run flaky.

### Issue 2
tests/harness/src/cluster.rs:526-528
**Override detection ignores quoted keys**

The textual prefix check does not recognize valid quoted TOML such as `"network_id" = "custom-plane"`, so the harness prepends a second assignment and the daemon rejects the duplicate key during configuration parsing. Detect the actual TOML key, preferably through one shared helper used by both cluster and daemon configuration paths.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(harness): extend hermetic gossip-pl..."](https://github.com/saorsa-labs/x0x/commit/097bd3b70d6343201215c162c34b8e29e9310513) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54450952)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->