### PR TITLE
fix(history): name resolved db path on pragma setup (#281 leftover)

### DIFF
--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -150,7 +150,9 @@ impl Store {
         conn.execute_batch(
             "PRAGMA auto_vacuum = INCREMENTAL;\n             PRAGMA locking_mode = EXCLUSIVE;\n             PRAGMA journal_mode = WAL;\n             PRAGMA synchronous = NORMAL;",
         )
-        .map_err(|e| HistoryError::Database(format!("pragma setup failed: {e}")))?;
+        .map_err(|e| {
+            HistoryError::Database(format!("pragma setup history db {}: {e}", path.display()))
+        })?;
         // Acquire the exclusive lock NOW so a second process fails at open,
         // not at first write.
         if let Err(e) = conn.execute_batch("BEGIN IMMEDIATE; COMMIT;") {
@@ -1258,6 +1260,30 @@ mod tests {
         assert!(
             msg.contains(&bad_path.display().to_string()),
             "history init error must name the resolved db path; got: {msg}"
+        );
+    }
+
+    /// Item (b) leftover (#281): pragma setup used to say only
+    /// `pragma setup failed: …`, which sent operators down a lock-contention
+    /// path when the real cause was the resolved db path. A non-SQLite file
+    /// at that path fails at the first PRAGMA (SQLite opens lazily), so the
+    /// error must name the path actually attempted — same wording style as
+    /// `open history db {path}: …`.
+    #[test]
+    fn pragma_setup_error_names_the_resolved_db_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.db");
+        std::fs::write(&path, b"not a sqlite database").unwrap();
+        let err = Store::open(&path).unwrap_err();
+        let msg = err.to_string();
+        let resolved = path.display().to_string();
+        assert!(
+            msg.contains(&resolved),
+            "pragma setup error must name the resolved db path; got: {msg}"
+        );
+        assert!(
+            msg.contains("pragma setup"),
+            "must be the pragma-setup path, not open/lock/create; got: {msg}"
         );
     }
 }

--- a/tests/daemon_config_section_placement.rs
+++ b/tests/daemon_config_section_placement.rs
@@ -177,6 +177,37 @@ fn warn_section_misplacements_emits_one_warn_per_finding() {
     );
 }
 
+/// Fleet case (issue #281): `data_dir` nested under `[gossip]` is the
+/// production misplacement that made two daemons on one box collide on the
+/// derived default `history.db`. `[gossip]` has no `data_dir` field, so
+/// serde drops it silently. The diagnostic must flag exactly that one
+/// finding — not reject, and not require a real `[gossip].data_dir`.
+fn data_dir_under_gossip() -> String {
+    r#"
+[gossip]
+data_dir = "/var/lib/x0x-443"
+"#
+    .to_string()
+}
+
+/// Prove the fleet case, not just the `[history]` fixture: a TOML with
+/// only `data_dir` under `[gossip]` yields exactly one
+/// `SectionMisplacement { key: data_dir, found_under: gossip }`.
+#[test]
+fn diagnose_section_placement_finds_data_dir_under_gossip() {
+    let parsed: toml::Table = toml::from_str(&data_dir_under_gossip()).expect("fixture parses");
+    let findings = diagnose_section_placement(&parsed);
+    assert_eq!(
+        findings,
+        vec![SectionMisplacement {
+            key: "data_dir".to_string(),
+            found_under: "gossip".to_string(),
+            expected_section: "top level".to_string(),
+        }],
+        "fleet case: data_dir under [gossip] is exactly one finding"
+    );
+}
+
 /// Clean fixture — a TOML with the correct section placement for every
 /// key (no root-owned keys under any sub-section) produces an empty
 /// findings vec, and `warn_section_misplacements` on that vec emits


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Leftovers from #281 only. Most of that issue already landed (section-placement warn, `[history]` fixture, path-named open/create/lock errors). This PR does **not** rebuild config, reject on misplace, change default `data_dir` derivation, give `[gossip]` a real `data_dir` field, enable `deny_unknown_fields`, or share/drop exclusive-open.

1. **Pragma setup names the resolved db path.** `Store::open` now reports `pragma setup history db {path}: …`, matching `open history db {path}: …`. The previous `pragma setup failed: …` sent operators down a lock-contention path when the real cause was path resolution (the fleet `data_dir` under `[gossip]` case).
2. **Fleet fixture.** `data_dir` under `[gossip]` yields exactly one `SectionMisplacement { key: data_dir, found_under: gossip }`. Warn-and-continue is unchanged.

Does **not** implement #308, #296, #310, or #336.

## Validation

Run on Rust 1.95.0 (CI pin). `cargo +stable clippy` (1.97) fails on pre-existing `for_kv_map` in `src/server/routes/identity.rs` — not in this diff.

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features --all-targets -- -D warnings` (1.95.0)
- [x] `cargo check --workspace --all-targets`
- [x] `pragma_setup_error_names_the_resolved_db_path`
- [x] `open_error_names_the_resolved_db_path` (existing)
- [x] `diagnose_section_placement_finds_data_dir_under_gossip`
- [x] Existing `[history]` two-key fixture and clean-config tests stay green (integration + `server::config` unit suite 5/5)

## Coverage

- Current line coverage: n/a (leftover path-in-error + one diagnostic fixture)
- Delta vs `main`: n/a
- Coverage workstream, if applicable:
- Exclusions added: none

## Test Quality Checklist

- [x] Each new test has a why-named name that states the invariant or regression.
- [x] No new test is a tautology against the implementation.
- [x] Each new test checks one business invariant.
- [x] Assertion failures include enough context to diagnose the broken invariant.
- [ ] Coverage delta is reported from CI or `just coverage-summary`.
- [x] Any coverage exclusion has a `coverage-skip:` comment and a matching register entry.

Closes the remaining #281 leftovers (pragma path + fleet `[gossip]` fixture). Does not close #281 if other tracking remains.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-114aaa3c-bc90-4624-8ab2-88a787fee352?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-114aaa3c-bc90-4624-8ab2-88a787fee352&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves history database startup diagnostics and adds coverage for a known daemon configuration misplacement.
- Includes the attempted history database path in SQLite pragma-setup errors.
- Verifies that `data_dir` nested under `[gossip]` produces exactly the expected section-misplacement finding.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code defects identified.

The production change only enriches an existing error with the exact path passed to SQLite, while the new configuration fixture matches the production diagnostic parsing and expected finding shape.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/history/store.rs | Adds the database path to pragma-setup failures using the same formatting convention as adjacent open, directory-creation, and lock errors, with focused regression coverage. |
| tests/daemon_config_section_placement.rs | Adds a representative `[gossip].data_dir` fixture that exercises the same TOML diagnostic function used by production configuration loading. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(history): name resolved db path on p..."](https://github.com/saorsa-labs/x0x/commit/acdf98dcc9403a934762f9694a21c5889f4582f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54677695)</sub>

**Context used:**

- Knowledge Base — [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)

<!-- /greptile_comment -->