### PR TITLE
feat(dm): durable send stage timers (#336 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ All notable changes to this project will be documented in this file.
   v1 during the migration window, so the mixed fleet upgrades with no flag
   day. This release is the fleet's first v2-capable daemon.
 
+### Added
+
+- **Durable send stage timers (#336 phase 1).** A durable gossip-inbox send
+  now records three named spans — `strict_gate_ms` (advert / capability
+  store), `publish_ms` (inbox / topic fan-out), and `ack_wait_ms` (sender
+  waiter vs receiver ACK publish-complete) — plus an independent
+  `elapsed_ms` wall. They are a partition of daemon-side send time, so a
+  slow first send can name which stage consumed the budget
+  (`budget_stage`). Exported on the existing send-timeout **504** body
+  (`error`/`detail` unchanged) and on `GET /diagnostics/dm` as
+  `last_durable_send`. The receiver also exports `last_ack_publish_ms` for
+  the durable ACK publish. Measurement only: no latency cut, no ACK-
+  semantics or HTTP-status change, no client-timeout or daemon-budget
+  change.
+
 ### Fixed
 
 - **Unsupervised self-update restart is now transactional (issue #261).**

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -438,7 +438,7 @@ Notable codes:
 | 409 | `recipient_ack_semantics_unavailable` | The send required ADR 0030 durable application-ACK semantics and the recipient advertises no current v2 capability. A peer you hold **any** contact card for lands here rather than on the 404 — including one whose advert has not converged yet, since that peer is known and may simply need upgrading. Returned after one forced targeted capability refresh, so it is fast and deterministic rather than a timeout. The caller retries, surfaces "peer needs upgrade", or resends with `require_durable_app_ack: false` — the daemon never downgrades silently. |
 | 409 | `idempotency_conflict` | The recipient already holds this `logical_id` bound to different bytes. **Retrying cannot succeed.** Either resend the original bytes under this id, or pick a new `logical_id`. |
 | 413 | `payload_too_large` | Payload exceeds the DM envelope cap. |
-| 504 | `timeout` | No application ACK within the retry budget. The DM may or may not have arrived. |
+| 504 | `timeout` | No application ACK within the retry budget. The DM may or may not have arrived. On a durable send the body also includes `strict_gate_ms`, `publish_ms`, `ack_wait_ms`, `elapsed_ms`, and `budget_stage` so the stage that consumed the budget is named. These are diagnostics, not a latency SLA. |
 
 The two 409s prescribe opposite repairs and must not be conflated in client
 code: `recipient_ack_semantics_unavailable` means *retry later or tell the user
@@ -1160,7 +1160,7 @@ All diagnostics endpoints require the normal local daemon bearer token and retur
 | GET | `/diagnostics/connectivity` | `x0x diagnostics connectivity` | ant-quic NodeStatus snapshot (UPnP, NAT, relay, mDNS) |
 | GET | `/diagnostics/ack` | `x0x diagnostics ack` | ACK-v2 per-stage latency buckets and outcome counters |
 | GET | `/diagnostics/gossip` | `x0x diagnostics gossip` | PubSub drop-detection counters (publish/deliver deltas) |
-| GET | `/diagnostics/dm` | `x0x diagnostics dm` | Direct-message send/receive counters and per-peer health |
+| GET | `/diagnostics/dm` | `x0x diagnostics dm` | Direct-message send/receive counters, per-peer health, and last durable-send stage timers (`last_durable_send`, `last_ack_publish_ms`) |
 | GET | `/diagnostics/groups` | `x0x diagnostics groups` | Per-group ingest counters, listener state, and drop buckets |
 | GET | `/diagnostics/exec` | `x0x diagnostics exec` | Remote exec counters, warnings, active sessions, and ACL summary |
 | GET | `/diagnostics/connect` | `x0x diagnostics connect` | Connect-ACL policy summary and stream allow/deny counters |

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,7 +48,7 @@ token (`Authorization: Bearer …`). The token is auto-discovered from
 | GET | `/network/bootstrap-cache` | `x0x network cache` | Bootstrap cache stats |
 | GET | `/diagnostics/connectivity` | `x0x diagnostics connectivity` | ant-quic NodeStatus (UPnP / NAT / relay / mDNS) |
 | GET | `/diagnostics/gossip` | `x0x diagnostics gossip` | PubSub drop-detection counters |
-| GET | `/diagnostics/dm` | `x0x diagnostics dm` | DM send/receive counters and per-peer health |
+| GET | `/diagnostics/dm` | `x0x diagnostics dm` | DM send/receive counters, per-peer health, and last durable-send stage timers |
 | GET | `/diagnostics/groups` | `x0x diagnostics groups` | Per-group ingest counters and drop buckets |
 | GET | `/diagnostics/exec` | `x0x diagnostics exec` | Remote-exec counters, warnings, ACL summary |
 | POST | `/peers/:peer_id/probe` | `x0x peer probe` | Active liveness + RTT probe (ant-quic) |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -87,3 +87,34 @@ points to a client that reads topic frames slowly but never fully stalls; invest
 client. Any non-zero `ws_slow_consumer_closes` indicates a client that stopped reading entirely.
 
 `GET /ws/sessions` (unchanged) lists active sessions and shared topic subscriptions.
+
+## Durable send stage timers (#336 phase 1)
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:12700/diagnostics/dm
+# {
+#   "ok": true,
+#   "stats": { ... },
+#   "last_durable_send": {
+#     "strict_gate_ms": 120,
+#     "publish_ms": 45,
+#     "ack_wait_ms": 180,
+#     "elapsed_ms": 345,
+#     "budget_stage": "ack_wait_ms"
+#   },
+#   "last_ack_publish_ms": 12
+# }
+```
+
+`last_durable_send` is the sender's last durable gossip-inbox send. The three
+named stages are a partition of `elapsed_ms` (daemon-side wall). `budget_stage`
+is the largest of the three, so a slow send names which stage consumed the
+budget. A send-timeout **504** from `POST /direct/send` exports the same
+fields on the error body; `error` remains `timeout` and `detail` stays the
+existing Display string.
+
+`last_ack_publish_ms` is the receiver's last durable (v2) ACK publish
+duration. Compare it with the sender's `ack_wait_ms` to see whether the ACK
+publish itself or the reverse path held the waiter.
+
+These fields are measurement only. They are not a latency SLA.

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -67,7 +67,7 @@
 //! ```
 
 use crate::connectivity::ObservedOrigin;
-use crate::dm::DmPath;
+use crate::dm::{DmPath, DurableSendStages};
 use crate::error::{NetworkError, NetworkResult};
 use crate::identity::{AgentId, MachineId};
 use crate::trust::TrustDecision;
@@ -601,6 +601,12 @@ pub struct DmDiagnosticsSnapshot {
     pub per_peer: BTreeMap<String, DmPeerDiagnostics>,
     pub subscriber_count: usize,
     pub subscriber_capacity: usize,
+    /// #336 phase 1: last durable gossip-inbox send's named stage timers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_durable_send: Option<DurableSendStages>,
+    /// #336 phase 1: last durable (v2) ACK publish duration on this daemon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_ack_publish_ms: Option<u64>,
 }
 
 /// Tracks connections and mappings for direct messaging.
@@ -650,6 +656,12 @@ pub struct DirectMessaging {
 
     /// Internal receiver (owned by the processing task).
     internal_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<DirectMessage>>>,
+
+    /// #336 phase 1: last durable send's named stage timers.
+    last_durable_send: Mutex<Option<DurableSendStages>>,
+
+    /// #336 phase 1: last durable ACK publish duration (receiver side).
+    last_ack_publish_ms: Mutex<Option<u64>>,
 }
 
 impl DirectMessaging {
@@ -684,6 +696,8 @@ impl DirectMessaging {
             raw_quic_ack_race_test_hook: Arc::new(Mutex::new(None)),
             internal_tx,
             internal_rx: Arc::new(tokio::sync::Mutex::new(internal_rx)),
+            last_durable_send: Mutex::new(None),
+            last_ack_publish_ms: Mutex::new(None),
         }
     }
 
@@ -990,6 +1004,26 @@ impl DirectMessaging {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    /// #336 phase 1: remember the named stages of the last durable send.
+    pub(crate) fn record_durable_send_stages(&self, stages: DurableSendStages) {
+        match self.last_durable_send.lock() {
+            Ok(mut guard) => *guard = Some(stages),
+            Err(e) => {
+                tracing::error!("durable send stage diagnostics poisoned: {e}");
+            }
+        }
+    }
+
+    /// #336 phase 1: remember how long the last durable ACK publish took.
+    pub(crate) fn record_ack_publish_ms(&self, ack_publish_ms: u64) {
+        match self.last_ack_publish_ms.lock() {
+            Ok(mut guard) => *guard = Some(ack_publish_ms),
+            Err(e) => {
+                tracing::error!("durable ACK publish diagnostics poisoned: {e}");
+            }
+        }
+    }
+
     /// Snapshot direct-message diagnostics for API surfaces.
     #[must_use]
     pub fn diagnostics_snapshot(&self) -> DmDiagnosticsSnapshot {
@@ -1099,11 +1133,28 @@ impl DirectMessaging {
             }
         };
 
+        let last_durable_send = match self.last_durable_send.lock() {
+            Ok(guard) => *guard,
+            Err(e) => {
+                tracing::error!("durable send stage diagnostics poisoned: {e}");
+                None
+            }
+        };
+        let last_ack_publish_ms = match self.last_ack_publish_ms.lock() {
+            Ok(guard) => *guard,
+            Err(e) => {
+                tracing::error!("durable ACK publish diagnostics poisoned: {e}");
+                None
+            }
+        };
+
         DmDiagnosticsSnapshot {
             stats,
             per_peer,
             subscriber_count: self.subscriber_count(),
             subscriber_capacity: self.subscriber_capacity,
+            last_durable_send,
+            last_ack_publish_ms,
         }
     }
 
@@ -1432,6 +1483,26 @@ impl Default for DirectMessaging {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn diagnostics_snapshot_includes_last_durable_send_stages() {
+        let dm = DirectMessaging::new();
+        let stages = DurableSendStages {
+            strict_gate_ms: 10,
+            publish_ms: 20,
+            ack_wait_ms: 30,
+            elapsed_ms: 60,
+        };
+        dm.record_durable_send_stages(stages);
+        dm.record_ack_publish_ms(7);
+        let snap = dm.diagnostics_snapshot();
+        assert_eq!(snap.last_durable_send, Some(stages));
+        assert_eq!(snap.last_ack_publish_ms, Some(7));
+        assert_eq!(
+            snap.last_durable_send.expect("recorded").budget_stage(),
+            "ack_wait_ms"
+        );
+    }
 
     #[test]
     fn dm_payload_digest_is_stable_and_short() {

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -526,6 +526,74 @@ where
 
 // ─── Error model ───────────────────────────────────────────────────────────
 
+/// Issue #336 phase 1: named stages of a durable gossip-inbox send.
+///
+/// These three timers are a partition of daemon-side wall time for one
+/// durable send. A slow first send must name which stage consumed the
+/// budget (`budget_stage`); warming or cutting a stage is a later phase.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DurableSendStages {
+    /// Advert lookup + optional forced targeted capability refresh
+    /// (ADR 0030 §2 strict gate).
+    pub strict_gate_ms: u64,
+    /// Inbox / topic fan-out (`publish_topic_id` + optional legacy-bus hedge)
+    /// plus the short setup that prepares that publish.
+    pub publish_ms: u64,
+    /// Sender ACK waiter after publish-complete, including inter-attempt
+    /// backoff that is still waiting for the receiver's ACK.
+    pub ack_wait_ms: u64,
+    /// Independent daemon-side wall from send start to return. The three
+    /// named stages must sum to this (millisecond truncation slack).
+    pub elapsed_ms: u64,
+}
+
+impl DurableSendStages {
+    /// Sum of the three named stages.
+    #[must_use]
+    pub fn sum_ms(&self) -> u64 {
+        self.strict_gate_ms
+            .saturating_add(self.publish_ms)
+            .saturating_add(self.ack_wait_ms)
+    }
+
+    /// Which of the three stages consumed the most time.
+    ///
+    /// Ties break in declaration order so a 17s send still names exactly
+    /// one stage. This is a diagnostic label, not an SLA.
+    #[must_use]
+    pub fn budget_stage(&self) -> &'static str {
+        let max = self
+            .strict_gate_ms
+            .max(self.publish_ms)
+            .max(self.ack_wait_ms);
+        if self.strict_gate_ms >= max {
+            "strict_gate_ms"
+        } else if self.publish_ms >= max {
+            "publish_ms"
+        } else {
+            "ack_wait_ms"
+        }
+    }
+
+    /// JSON object exported on a send-timeout 504 and on `/diagnostics/dm`.
+    #[must_use]
+    pub fn to_export_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "strict_gate_ms": self.strict_gate_ms,
+            "publish_ms": self.publish_ms,
+            "ack_wait_ms": self.ack_wait_ms,
+            "elapsed_ms": self.elapsed_ms,
+            "budget_stage": self.budget_stage(),
+        })
+    }
+}
+
+/// Elapsed milliseconds since `start`, saturating at `u64::MAX`.
+#[must_use]
+pub(crate) fn millis_since(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
 /// Errors surfaced by the gossip DM path. See design doc §"Error model".
 #[derive(Debug, thiserror::Error)]
 pub enum DmError {
@@ -2554,5 +2622,47 @@ mod tests {
             DmEnvelope::from_wire_bytes(&wire).expect("new receivers must decode old envelopes");
         assert_eq!(decoded.origin_attestation, None);
         assert_eq!(decoded.request_id, [9u8; 16]);
+    }
+
+    /// #336 phase 1: a 17s send must name which of the three stages ate the
+    /// budget. The numbers here are a fixture, not an SLA.
+    #[test]
+    fn a_seventeen_second_send_names_which_stage_ate_the_budget() {
+        let stages = DurableSendStages {
+            strict_gate_ms: 12_400,
+            publish_ms: 800,
+            ack_wait_ms: 3_800,
+            elapsed_ms: 17_000,
+        };
+        assert_eq!(stages.sum_ms(), 17_000);
+        assert_eq!(stages.budget_stage(), "strict_gate_ms");
+        assert_eq!(stages.sum_ms(), stages.elapsed_ms);
+
+        let publish_bound = DurableSendStages {
+            strict_gate_ms: 200,
+            publish_ms: 16_000,
+            ack_wait_ms: 800,
+            elapsed_ms: 17_000,
+        };
+        assert_eq!(publish_bound.budget_stage(), "publish_ms");
+
+        let ack_bound = DurableSendStages {
+            strict_gate_ms: 200,
+            publish_ms: 300,
+            ack_wait_ms: 16_500,
+            elapsed_ms: 17_000,
+        };
+        assert_eq!(ack_bound.budget_stage(), "ack_wait_ms");
+    }
+
+    /// #336 phase 1: attaching stage timers must not change the Timeout
+    /// Display string that clients already parse from `detail`.
+    #[test]
+    fn timeout_display_omits_stage_timers() {
+        let err = DmError::Timeout {
+            retries: 1,
+            elapsed: Duration::from_secs(16),
+        };
+        assert_eq!(err.to_string(), "timed out after 1 retries over 16s");
     }
 }

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -17,7 +17,7 @@ use crate::revocation::RevocationSet;
 use crate::trust::{TrustContext, TrustDecision, TrustEvaluator};
 use bytes::Bytes;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot, RwLock};
 use tokio::task::{JoinHandle, JoinSet};
 
@@ -523,7 +523,9 @@ async fn publish_durable_ack_job(
     // committed row; a second route costs one small publish and removes a
     // whole class of "committed but never acked" outcomes.
     let legacy = pubsub.publish(DM_BUS_TOPIC.to_string(), job.encoded);
+    let publish_started = Instant::now();
     let result = publish_durable_ack_routes(DURABLE_ACK_ROUTE_TIMEOUT, primary, legacy).await;
+    dm.record_ack_publish_ms(crate::dm::millis_since(publish_started));
     if let Err(error) = result {
         dm.record_ack_publish_route_failed();
         tracing::warn!(

--- a/src/dm_send.rs
+++ b/src/dm_send.rs
@@ -1,8 +1,9 @@
 //! Sender-side gossip DM path (phase 4 of `docs/design/dm-over-gossip.md`).
 
 use crate::dm::{
-    dm_inbox_topic, now_unix_ms, DmAckOutcome, DmError, DmPath, DmReceipt, DmSendConfig,
-    EnvelopeBuilder, InFlightAcks, DM_PROTOCOL_DURABLE_ACK, DM_PROTOCOL_V1, MAX_PAYLOAD_BYTES,
+    dm_inbox_topic, millis_since, now_unix_ms, DmAckOutcome, DmError, DmPath, DmReceipt,
+    DmSendConfig, DurableSendStages, EnvelopeBuilder, InFlightAcks, DM_PROTOCOL_DURABLE_ACK,
+    DM_PROTOCOL_V1, MAX_PAYLOAD_BYTES,
 };
 use crate::dm_inbox::{DmInboxService, DM_BUS_TOPIC};
 use crate::error::IdentityError;
@@ -10,7 +11,7 @@ use crate::gossip::{PubSubManager, SigningContext};
 use crate::identity::{AgentId, MachineId, MachineKeypair};
 
 use bytes::Bytes;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast::error::TryRecvError as BroadcastTryRecvError;
 use tokio::sync::oneshot::error::TryRecvError;
@@ -55,6 +56,80 @@ pub struct DmSendContext<'a> {
     pub machine_keypair: &'a MachineKeypair,
     /// Shared in-flight ACK registry.
     pub inflight: Arc<InFlightAcks>,
+    /// #336 phase 1: filled with inbox publish vs ACK-wait timings.
+    pub stages: &'a mut DurableSendStages,
+}
+
+/// #336 phase 1: partitions inbox publish vs ACK-wait so a cancelled
+/// per-attempt timeout still attributes the remainder to the stage that
+/// was running.
+struct StageTracker {
+    inner: Mutex<StageTrackerInner>,
+}
+
+struct StageTrackerInner {
+    current: u8,
+    started: Instant,
+    stages: DurableSendStages,
+}
+
+impl StageTracker {
+    const PUBLISH: u8 = 0;
+    const ACK_WAIT: u8 = 1;
+
+    fn new_publish() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(StageTrackerInner {
+                current: Self::PUBLISH,
+                started: Instant::now(),
+                stages: DurableSendStages::default(),
+            }),
+        })
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, StageTrackerInner> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn flush_locked(inner: &mut StageTrackerInner) {
+        let ms = millis_since(inner.started);
+        match inner.current {
+            Self::ACK_WAIT => {
+                inner.stages.ack_wait_ms = inner.stages.ack_wait_ms.saturating_add(ms);
+            }
+            _ => {
+                inner.stages.publish_ms = inner.stages.publish_ms.saturating_add(ms);
+            }
+        }
+        inner.started = Instant::now();
+    }
+
+    fn switch(&self, next: u8) {
+        let mut inner = self.lock();
+        Self::flush_locked(&mut inner);
+        inner.current = next;
+    }
+
+    fn take(&self) -> DurableSendStages {
+        let mut inner = self.lock();
+        Self::flush_locked(&mut inner);
+        inner.stages
+    }
+}
+
+/// Merges publish/ack-wait timings into the caller's stage bucket on every
+/// return — including `?` and timeout — so a 17s send still names a stage.
+struct PublishAckStagesGuard<'a> {
+    tracker: Arc<StageTracker>,
+    stages: &'a mut DurableSendStages,
+}
+
+impl Drop for PublishAckStagesGuard<'_> {
+    fn drop(&mut self) {
+        let taken = self.tracker.take();
+        self.stages.publish_ms = self.stages.publish_ms.saturating_add(taken.publish_ms);
+        self.stages.ack_wait_ms = self.stages.ack_wait_ms.saturating_add(taken.ack_wait_ms);
+    }
 }
 
 /// Publish a DM envelope on the recipient's gossip inbox topic and await its
@@ -80,6 +155,7 @@ pub async fn send_via_gossip(
         self_machine_id,
         machine_keypair,
         inflight,
+        stages,
     } = ctx;
     if payload.len() > MAX_PAYLOAD_BYTES {
         // 413-class rejection, not `EnvelopeConstruction`: the API layer must
@@ -95,6 +171,12 @@ pub async fn send_via_gossip(
             "recipient has no published KEM public key".to_string(),
         ));
     }
+
+    let tracker = StageTracker::new_publish();
+    let _stage_guard = PublishAckStagesGuard {
+        tracker: Arc::clone(&tracker),
+        stages,
+    };
 
     // A caller that owns a durable obligation supplies its own id so a retry
     // is the same logical request across restarts (ADR 0030 §5).
@@ -182,11 +264,13 @@ pub async fn send_via_gossip(
             }
         }
 
+        tracker.switch(StageTracker::PUBLISH);
         // The per-attempt budget covers both the local PlumTree publish and
         // the remote ACK wait.  Under PubSub back-pressure, `publish()` can be
         // the slow leg; bounding only the ACK wait let HTTP handlers exceed
         // their curl/user-visible deadline without returning a structured
         // `DmError::Timeout`.
+        let attempt_tracker = Arc::clone(&tracker);
         let attempt_result = tokio::time::timeout(config.timeout_per_attempt, async {
             let primary_publish = pubsub
                 .publish_topic_id(topic.clone(), topic_id, Bytes::from(wire.clone()))
@@ -215,6 +299,7 @@ pub async fn send_via_gossip(
                 return Ok(None);
             }
 
+            attempt_tracker.switch(StageTracker::ACK_WAIT);
             if primary_publish_ok {
                 if let Some(outcome) =
                     wait_for_ack_or_backoff(&mut rx, ACK_LEGACY_BUS_FALLBACK_DELAY).await?
@@ -232,6 +317,7 @@ pub async fn send_via_gossip(
                 primary_publish_ok,
                 bus_topic = DM_BUS_TOPIC,
             );
+            attempt_tracker.switch(StageTracker::PUBLISH);
             if let Err(e) = pubsub
                 .publish(DM_BUS_TOPIC.to_string(), Bytes::from(wire.clone()))
                 .await
@@ -250,6 +336,7 @@ pub async fn send_via_gossip(
                 }
             }
 
+            attempt_tracker.switch(StageTracker::ACK_WAIT);
             (&mut rx).await.map(Some).map_err(|_| {
                 DmError::PublishFailed("in-flight ACK registry replaced our waiter".to_string())
             })
@@ -293,6 +380,7 @@ pub async fn send_via_gossip(
             }
             Ok(Err(e)) => return Err(e),
             Err(_) => {
+                tracker.switch(StageTracker::ACK_WAIT);
                 if attempt < config.max_retries {
                     let delay = config.backoff.delay(config.timeout_per_attempt, attempt);
                     let wait_outcome = wait_for_ack_or_backoff_or_replaced(
@@ -910,5 +998,29 @@ mod tests {
     #[test]
     fn default_send_config_requires_gossip_ack() {
         assert!(DmSendConfig::default().require_gossip_ack);
+    }
+
+    /// #336 phase 1: a cancelled attempt must still attribute remaining
+    /// time to the stage that was running, so the three timers can sum to
+    /// wall time.
+    #[test]
+    fn stage_tracker_partitions_publish_and_ack_wait() {
+        let tracker = StageTracker::new_publish();
+        std::thread::sleep(Duration::from_millis(20));
+        tracker.switch(StageTracker::ACK_WAIT);
+        std::thread::sleep(Duration::from_millis(30));
+        let stages = tracker.take();
+        assert!(
+            stages.publish_ms >= 15,
+            "publish stage must capture its wall slice: {stages:?}"
+        );
+        assert!(
+            stages.ack_wait_ms >= 25,
+            "ack-wait stage must capture its wall slice: {stages:?}"
+        );
+        assert!(
+            stages.sum_ms() >= 40,
+            "named stages must cover the slept wall: {stages:?}"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4649,6 +4649,8 @@ impl Agent {
             return Ok(receipt);
         }
 
+        let send_started = std::time::Instant::now();
+        let mut stages = dm::DurableSendStages::default();
         let mut advert_binding = self.capability_store.lookup_binding(to);
         // ADR 0030 §2: one forced targeted refresh before refusing. A daemon
         // whose advert we simply have not heard yet must not be reported as
@@ -4759,15 +4761,24 @@ impl Agent {
             // every product send is strict now, so every unknown-recipient
             // send reaches this gate.
             if !recipient_is_known {
+                stages.strict_gate_ms = dm::millis_since(send_started);
+                stages.elapsed_ms = stages.strict_gate_ms;
+                self.direct_messaging.record_durable_send_stages(stages);
                 return Err(dm::DmError::RecipientKeyUnavailable(format!(
                     "recipient {} has no known DM capability advert",
                     hex::encode(to.as_bytes())
                 )));
             }
+            stages.strict_gate_ms = dm::millis_since(send_started);
+            stages.elapsed_ms = stages.strict_gate_ms;
+            self.direct_messaging.record_durable_send_stages(stages);
             return Err(dm::DmError::AckSemanticsUnavailable(format!(
                 "recipient {} has no current v2 durable-ACK capability advert",
                 hex::encode(to.as_bytes())
             )));
+        }
+        if config.require_durable_app_ack {
+            stages.strict_gate_ms = dm::millis_since(send_started);
         }
 
         // X0X-0070b: seed the relay fallback. Only retain the payload + KEM
@@ -4887,6 +4898,7 @@ impl Agent {
                             self_machine_id: self.identity.machine_id(),
                             machine_keypair: self.identity.machine_keypair(),
                             inflight: std::sync::Arc::clone(&self.dm_inflight_acks),
+                            stages: &mut stages,
                         },
                         *to,
                         cap_machine,
@@ -4921,6 +4933,19 @@ impl Agent {
                     .map_err(Self::map_raw_quic_dm_error),
             }
         };
+
+        if config.require_durable_app_ack {
+            stages.elapsed_ms = dm::millis_since(send_started);
+            // Fold the post-gate setup slice (KEM check, raw-QUIC skip) into
+            // publish_ms so the three named stages remain a partition of wall
+            // time. That slice is inbox-path preparation, not ACK wait.
+            if stages.elapsed_ms > stages.sum_ms() {
+                stages.publish_ms = stages
+                    .publish_ms
+                    .saturating_add(stages.elapsed_ms.saturating_sub(stages.sum_ms()));
+            }
+            self.direct_messaging.record_durable_send_stages(stages);
+        }
 
         match result {
             Ok(receipt) => {

--- a/src/server/routes/direct.rs
+++ b/src/server/routes/direct.rs
@@ -498,14 +498,16 @@ pub(in crate::server) async fn direct_send(
                 }
             };
             tracing::error!("direct_send failed ({err_kind}): {e}");
-            (
-                status,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": err_kind,
-                    "detail": e.to_string(),
-                })),
-            )
+            let timeout_stages = matches!(e, x0x::dm::DmError::Timeout { .. })
+                .then(|| {
+                    state
+                        .agent
+                        .direct_messaging()
+                        .diagnostics_snapshot()
+                        .last_durable_send
+                })
+                .flatten();
+            (status, Json(dm_error_body(err_kind, &e, timeout_stages)))
         }
     }
 }
@@ -545,6 +547,29 @@ pub(in crate::server) async fn direct_connections(
 // socket can modify any group. This is acceptable because x0xd listens on
 // localhost only, so all callers are implicitly the local agent.
 // ---------------------------------------------------------------------------
+
+/// Build the `/direct/send` error JSON. Timeout 504s also export the #336
+/// phase-1 stage timers so a slow send names which of the three stages
+/// consumed the budget. Status and `error`/`detail` stay unchanged.
+fn dm_error_body(
+    err_kind: &str,
+    e: &x0x::dm::DmError,
+    timeout_stages: Option<x0x::dm::DurableSendStages>,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "ok": false,
+        "error": err_kind,
+        "detail": e.to_string(),
+    });
+    if let Some(stages) = timeout_stages {
+        body["strict_gate_ms"] = serde_json::json!(stages.strict_gate_ms);
+        body["publish_ms"] = serde_json::json!(stages.publish_ms);
+        body["ack_wait_ms"] = serde_json::json!(stages.ack_wait_ms);
+        body["elapsed_ms"] = serde_json::json!(stages.elapsed_ms);
+        body["budget_stage"] = serde_json::json!(stages.budget_stage());
+    }
+    body
+}
 
 #[cfg(test)]
 mod tests {
@@ -784,6 +809,42 @@ mod tests {
             "logical_id": &"a".repeat(128)
         }))
         .is_ok());
+    }
+
+    /// #336 phase 1: a timeout 504 must keep status/`error`/`detail` and
+    /// name which of the three stages ate the budget.
+    #[test]
+    fn timeout_504_body_exports_stage_timers_without_changing_detail() {
+        let stages = x0x::dm::DurableSendStages {
+            strict_gate_ms: 12_000,
+            publish_ms: 500,
+            ack_wait_ms: 4_500,
+            elapsed_ms: 17_000,
+        };
+        let err = x0x::dm::DmError::Timeout {
+            retries: 1,
+            elapsed: Duration::from_secs(16),
+        };
+        let body = dm_error_body("timeout", &err, Some(stages));
+        assert_eq!(body["ok"], false);
+        assert_eq!(body["error"], "timeout");
+        assert_eq!(
+            body["detail"], "timed out after 1 retries over 16s",
+            "detail must stay the existing Display contract"
+        );
+        assert_eq!(body["strict_gate_ms"], 12_000);
+        assert_eq!(body["publish_ms"], 500);
+        assert_eq!(body["ack_wait_ms"], 4_500);
+        assert_eq!(body["elapsed_ms"], 17_000);
+        assert_eq!(body["budget_stage"], "strict_gate_ms");
+
+        let bare = x0x::dm::DmError::Timeout {
+            retries: 1,
+            elapsed: Duration::from_secs(16),
+        };
+        let bare_body = dm_error_body("timeout", &bare, None);
+        assert!(bare_body.get("strict_gate_ms").is_none());
+        assert_eq!(bare_body["error"], "timeout");
     }
 
     // ── ADR-0016 R2: REST pre-check (exact §3 string + status code) ─────

--- a/src/server/routes/network.rs
+++ b/src/server/routes/network.rs
@@ -679,18 +679,24 @@ pub(in crate::server) async fn dm_diagnostics(
         per_peer,
         subscriber_count,
         subscriber_capacity,
+        last_durable_send,
+        last_ack_publish_ms,
     } = state.agent.direct_messaging().diagnostics_snapshot();
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({
-            "ok": true,
-            "stats": stats,
-            "per_peer": per_peer,
-            "subscriber_count": subscriber_count,
-            "subscriber_capacity": subscriber_capacity,
-            "capability_store_entries": state.agent.capability_store().len(),
-        })),
-    )
+    let mut body = serde_json::json!({
+        "ok": true,
+        "stats": stats,
+        "per_peer": per_peer,
+        "subscriber_count": subscriber_count,
+        "subscriber_capacity": subscriber_capacity,
+        "capability_store_entries": state.agent.capability_store().len(),
+    });
+    if let Some(stages) = last_durable_send {
+        body["last_durable_send"] = stages.to_export_json();
+    }
+    if let Some(ack_publish_ms) = last_ack_publish_ms {
+        body["last_ack_publish_ms"] = serde_json::json!(ack_publish_ms);
+    }
+    (StatusCode::OK, Json(body))
 }
 
 /// Parse a hex `peer_id` path segment into an ant-quic `PeerId` (32 bytes).

--- a/tests/durable_send_stage_timers.rs
+++ b/tests/durable_send_stage_timers.rs
@@ -1,0 +1,259 @@
+//! #336 phase 1: durable-send stage timers must partition wall time.
+//!
+//! A first durable DM to a new loopback peer is slow today. This test does
+//! not cut that latency. It proves the three named stages exist, appear on
+//! the timeout 504 body and `/diagnostics/dm`, and sum to daemon wall time
+//! so a slow send can name which stage ate the budget.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use base64::Engine;
+use reqwest::StatusCode;
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+#[path = "harness/src/daemon.rs"]
+mod daemon;
+
+use daemon::DaemonFixture;
+
+/// Matches the bundled client's 30 s observer. Do not raise this.
+const DURABLE_SEND_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[tokio::test]
+async fn first_durable_send_stage_timers_sum_to_wall_time() {
+    let bob = DaemonFixture::start("dst336-bob").await;
+    let bob_client = bob.authed_client(Duration::from_secs(10));
+    let bob_status: Value = bob_client
+        .get(bob.url("/network/status"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let bob_quic = rewrite_unspecified_to_loopback(
+        bob_status["local_addr"]
+            .as_str()
+            .expect("network/status.local_addr"),
+    );
+
+    let alice = DaemonFixture::start_with_config(
+        "dst336-alice",
+        &format!("bootstrap_peers = [\"{bob_quic}\"]\n"),
+    )
+    .await;
+    let alice_client = alice.authed_client(DURABLE_SEND_CLIENT_TIMEOUT);
+
+    let alice_card: Value = alice_client
+        .get(alice.url("/agent/card"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let bob_card: Value = bob_client
+        .get(bob.url("/agent/card"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(alice_client
+        .post(alice.url("/agent/card/import"))
+        .json(&serde_json::json!({
+            "card": bob_card["link"].as_str().unwrap(),
+            "trust_level": "Trusted"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .status()
+        .is_success());
+    assert!(bob_client
+        .post(bob.url("/agent/card/import"))
+        .json(&serde_json::json!({
+            "card": alice_card["link"].as_str().unwrap(),
+            "trust_level": "Trusted"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .status()
+        .is_success());
+
+    wait_for_durable_capability(&alice, Duration::from_secs(30)).await;
+
+    let bob_agent_id = {
+        let v: Value = bob_client
+            .get(bob.url("/agent"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        v["agent_id"].as_str().unwrap().to_string()
+    };
+
+    let payload = base64::engine::general_purpose::STANDARD.encode(b"dst336-first-send");
+    let wall = Instant::now();
+    let response = alice_client
+        .post(alice.url("/direct/send"))
+        .json(&serde_json::json!({
+            "agent_id": bob_agent_id,
+            "payload": payload,
+        }))
+        .send()
+        .await
+        .unwrap();
+    let wall_ms = u64::try_from(wall.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let status = response.status();
+    let body: Value = response.json().await.unwrap();
+
+    let stages = if status == StatusCode::GATEWAY_TIMEOUT {
+        assert_eq!(
+            body["error"], "timeout",
+            "504 must keep error=timeout: {body}"
+        );
+        assert!(
+            body["detail"]
+                .as_str()
+                .is_some_and(|d| d.contains("timed out")),
+            "504 detail contract must stay: {body}"
+        );
+        stages_from_timeout_body(&body)
+    } else {
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "first durable send must be 200 or 504, got {status}: {body}"
+        );
+        let diag: Value = alice_client
+            .get(alice.url("/diagnostics/dm"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        stages_from_diagnostics(&diag)
+    };
+
+    let sum = stages.strict_gate_ms + stages.publish_ms + stages.ack_wait_ms;
+    assert!(
+        sum.abs_diff(stages.elapsed_ms) <= 25,
+        "named stages must partition daemon wall: sum={sum} elapsed={} {:?}",
+        stages.elapsed_ms,
+        stages
+    );
+    assert!(
+        wall_ms.abs_diff(stages.elapsed_ms) < 2_000,
+        "daemon elapsed must track client wall: wall={wall_ms} elapsed={} {:?}",
+        stages.elapsed_ms,
+        stages
+    );
+    assert!(
+        ["strict_gate_ms", "publish_ms", "ack_wait_ms"].contains(&stages.budget_stage.as_str()),
+        "a slow send must name one of the three stages, got {}",
+        stages.budget_stage
+    );
+
+    let bob_diag: Value = bob_client
+        .get(bob.url("/diagnostics/dm"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    if status == StatusCode::OK {
+        assert!(
+            bob_diag
+                .get("last_ack_publish_ms")
+                .and_then(Value::as_u64)
+                .is_some(),
+            "receiver must export last_ack_publish_ms after a durable ACK: {bob_diag}"
+        );
+    }
+}
+
+#[derive(Debug)]
+struct ObservedStages {
+    strict_gate_ms: u64,
+    publish_ms: u64,
+    ack_wait_ms: u64,
+    elapsed_ms: u64,
+    budget_stage: String,
+}
+
+fn stages_from_timeout_body(body: &Value) -> ObservedStages {
+    ObservedStages {
+        strict_gate_ms: required_u64(body, "strict_gate_ms"),
+        publish_ms: required_u64(body, "publish_ms"),
+        ack_wait_ms: required_u64(body, "ack_wait_ms"),
+        elapsed_ms: required_u64(body, "elapsed_ms"),
+        budget_stage: body["budget_stage"]
+            .as_str()
+            .expect("timeout 504 must name budget_stage")
+            .to_string(),
+    }
+}
+
+fn stages_from_diagnostics(diag: &Value) -> ObservedStages {
+    let last = diag
+        .get("last_durable_send")
+        .expect("successful durable send must appear on /diagnostics/dm");
+    ObservedStages {
+        strict_gate_ms: required_u64(last, "strict_gate_ms"),
+        publish_ms: required_u64(last, "publish_ms"),
+        ack_wait_ms: required_u64(last, "ack_wait_ms"),
+        elapsed_ms: required_u64(last, "elapsed_ms"),
+        budget_stage: last["budget_stage"]
+            .as_str()
+            .expect("diagnostics last_durable_send must name budget_stage")
+            .to_string(),
+    }
+}
+
+fn required_u64(value: &Value, key: &str) -> u64 {
+    value[key]
+        .as_u64()
+        .unwrap_or_else(|| panic!("{key} must be present on stage-timer export: {value}"))
+}
+
+fn rewrite_unspecified_to_loopback(addr: &str) -> String {
+    if let Some(rest) = addr.strip_prefix("0.0.0.0:") {
+        return format!("127.0.0.1:{rest}");
+    }
+    if let Some(rest) = addr.strip_prefix("[::]:") {
+        return format!("127.0.0.1:{rest}");
+    }
+    if let Some(rest) = addr.strip_prefix("[::1]:") {
+        return format!("127.0.0.1:{rest}");
+    }
+    addr.to_string()
+}
+
+async fn wait_for_durable_capability(fixture: &DaemonFixture, deadline: Duration) -> usize {
+    let client = fixture.authed_client(Duration::from_secs(5));
+    let started = tokio::time::Instant::now();
+    let mut polls = 0usize;
+    while started.elapsed() < deadline {
+        polls += 1;
+        if let Ok(resp) = client.get(fixture.url("/diagnostics/dm")).send().await {
+            if let Ok(body) = resp.json::<Value>().await {
+                if body["capability_store_entries"].as_u64().unwrap_or(0) > 0 {
+                    return polls;
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!(
+        "no peer capability advert converged within {deadline:?} ({polls} polls); \
+         a durable /direct/send would 409"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 of #336 only: **measure** the first durable DM to a new peer. This does not cut latency.

A durable gossip-inbox send now records three named stages that partition daemon-side wall time:

1. `strict_gate_ms` — advert / capability store (ADR 0030 §2 refresh)
2. `publish_ms` — inbox / topic fan-out
3. `ack_wait_ms` — sender waiter vs receiver ACK publish-complete

`budget_stage` names which of the three consumed the most time, so a slow send can say which stage ate the budget. Until that exists, no "we warmed X" merge.

Exported on:

- the existing send-timeout **504** body (`error` stays `timeout`, `detail` stays the existing Display string)
- `GET /diagnostics/dm` as `last_durable_send` (sender) and `last_ack_publish_ms` (receiver ACK publish)

## Out of scope (deliberately not in this PR)

- Phase 2 latency cuts
- Treating #338 as closing #336
- Flipping `prefer_raw_quic_if_connected` on for durable sends
- Reopening #335's ACK contract
- Client 30s timeouts, daemon 8s×2 + 8s backoff budget
- Writing 17.5s into `api-reference` as an SLA
- HTTP status or ack-semantics contract changes
- #308, #296, #310, #281

## Validation

- [x] `cargo fmt --all`
- [x] `cargo clippy --locked --all-features --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] New unit tests (stage naming, 504 body, diagnostics snapshot, tracker partition)
- [x] `cargo test --locked --all-features --test durable_send_stage_timers` (two-daemon loopback first send: stages sum to wall)

## Coverage

- Current line coverage: not collected in this revision
- Delta vs `main`: n/a
- Coverage workstream, if applicable: n/a
- Exclusions added: none

## Test Quality Checklist

- [x] Each new test has a why-named name that states the invariant or regression.
- [x] No new test is a tautology against the implementation.
- [x] Each new test checks one business invariant.
- [x] Assertion failures include enough context to diagnose the broken invariant.
- [ ] Coverage delta is reported from CI or `just coverage-summary`.
- [x] Any coverage exclusion has a `coverage-skip:` comment and a matching register entry.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5f7b02e-6b9e-4017-8099-2829932a2453?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5f7b02e-6b9e-4017-8099-2829932a2453&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds sender-side durable-DM stage timing and receiver ACK-publish timing to identify where first-send latency is spent.

- Tracks strict capability gating, gossip publishing, and ACK-wait time across retries.
- Exposes daemon-wide timing snapshots through timeout responses and `/diagnostics/dm`.
- Adds unit and two-daemon integration coverage for stage partitioning.

<h3>Confidence Score: 4/5</h3>

The timeout-stage correlation defect should be fixed before merging because concurrent sends can return another request's diagnostics.

Durable sends overwrite one daemon-wide timing slot, while a timed-out handler reads that slot later without request correlation, allowing an overlapping send to replace the measurements attached to the 504 response.

**Files Needing Attention:** src/server/routes/direct.rs, src/direct.rs, src/lib.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dm_send.rs | Adds a drop-guarded stage tracker that partitions gossip publication, ACK waiting, and retry backoff across all return paths. |
| src/lib.rs | Measures strict capability gating and total durable-send elapsed time, then records each result in daemon-wide diagnostics. |
| src/direct.rs | Adds last-write-wins sender and receiver timing snapshots shared by all requests. |
| src/server/routes/direct.rs | Adds stage fields to timeout responses, but retrieves them from an uncorrelated shared snapshot that concurrent sends can overwrite. |
| src/dm_inbox.rs | Measures completion time for each bounded, hedged durable-ACK publication job. |
| src/server/routes/network.rs | Exposes the latest sender-stage and receiver ACK-publish measurements through `/diagnostics/dm`. |
| tests/durable_send_stage_timers.rs | Validates single-send timer partitioning and API projection but does not exercise concurrent timeout attribution. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Client
  participant API as /direct/send
  participant Agent
  participant Gossip
  participant Peer
  Client->>API: durable send
  API->>Agent: send_direct_with_config
  Agent->>Agent: measure strict_gate_ms
  Agent->>Gossip: publish inbox envelope
  Note over Agent,Gossip: measure publish_ms
  Gossip->>Peer: durable DM
  Peer->>Gossip: publish durable ACK
  Gossip-->>Agent: resolve ACK waiter
  Note over Agent,Gossip: measure ack_wait_ms
  Agent->>Agent: overwrite last_durable_send
  Agent-->>API: receipt or timeout
  API->>Agent: read last_durable_send on timeout
  API-->>Client: response with stage timers
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/routes/direct.rs:501-509
**Timeout stages lose request correlation**

If two durable `/direct/send` requests overlap, each send overwrites the same daemon-wide `last_durable_send` slot before the timeout handler reads it, causing a 504 response to report another request's stage timings and `budget_stage`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dm): add durable send stage timers ..."](https://github.com/saorsa-labs/x0x/commit/e2d4e91975c604c9735c8a85a5ecdfd9c0808af2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54679257)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Direct Messaging: Send, Capability Gate, Inbox, and Forward](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/dm-messaging.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)

<!-- /greptile_comment -->