### PR TITLE
fix(groups): race gossip publish with public-message unicast (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **Public group send no longer waits out the ~24s DM retry before gossip
+  carry (issue #310).** `POST /groups/:id/send` still persists locally and
+  returns 200 + `msg_id`. Fan-out is now a race: gossip topic publish
+  starts immediately and does not wait for per-member unicast to finish
+  or fail. `recipient key material unavailable` / invalid recipient id
+  reuse the #342 `DmError` class and skip the 8s+8s retry on this path
+  only. First unicast attempt is budgeted at 3s here; durable DMs and
+  roster/control events keep their 8s defaults. `require_gossip_ack` is
+  not dropped. No `fan_out` field (#296).
+
 ## [v0.38.1] - 2026-08-18
 
 ### Changed

--- a/src/groups/diagnostics.rs
+++ b/src/groups/diagnostics.rs
@@ -211,11 +211,11 @@ impl GroupsDiagnostics {
         });
     }
 
-    /// Record that a public-message gossip publish finished while unicast was
-    /// still in flight. Why this is a separate counter: issue #310's invariant
-    /// is "topic publish starts without waiting for the DM retry budget", and
-    /// a test that only checks eventual delivery cannot tell a race from a
-    /// 24s sequential fallback that later succeeded.
+    /// Record that a public-message gossip publish *finished* while unicast
+    /// was still in flight. Increment only at that moment — a schedule-time
+    /// bump would fire before `publish` runs and would not mean what the
+    /// field comment says. A test that only checks eventual delivery cannot
+    /// tell a race from a 24s sequential fallback that later succeeded.
     pub fn record_public_message_gossip_raced_unicast(&self, group_id: &str) {
         self.with_counters(group_id, |c| {
             c.public_message_gossip_raced_unicast =

--- a/src/groups/diagnostics.rs
+++ b/src/groups/diagnostics.rs
@@ -47,6 +47,12 @@ pub struct GroupCounters {
     /// `messages_dropped_write_policy_violation` (the receiver-side ingest
     /// canary) so that operators can distinguish the two failure modes.
     pub sends_rejected_write_policy: u64,
+    /// Public-message gossip topic publish completed while at least one
+    /// per-member unicast attempt was still in flight (issue #310). A zero
+    /// value after a multi-member send means fan-out regressed to
+    /// unicast-then-gossip sequence and the receiver will wait out the DM
+    /// retry budget (~24s) before the topic carry lands.
+    pub public_message_gossip_raced_unicast: u64,
     /// Public messages whose author signature failed to verify, or whose
     /// `author_agent_id` did not match the derived AgentId.
     pub messages_dropped_signature_failed: u64,
@@ -205,6 +211,18 @@ impl GroupsDiagnostics {
         });
     }
 
+    /// Record that a public-message gossip publish finished while unicast was
+    /// still in flight. Why this is a separate counter: issue #310's invariant
+    /// is "topic publish starts without waiting for the DM retry budget", and
+    /// a test that only checks eventual delivery cannot tell a race from a
+    /// 24s sequential fallback that later succeeded.
+    pub fn record_public_message_gossip_raced_unicast(&self, group_id: &str) {
+        self.with_counters(group_id, |c| {
+            c.public_message_gossip_raced_unicast =
+                c.public_message_gossip_raced_unicast.saturating_add(1);
+        });
+    }
+
     /// Record an `InvalidSignature` rejection.
     pub fn record_signature_failed(&self, group_id: &str) {
         self.with_counters(group_id, |c| {
@@ -342,6 +360,9 @@ impl GroupsDiagnostics {
             dst.sends_rejected_write_policy = dst
                 .sends_rejected_write_policy
                 .saturating_add(src.sends_rejected_write_policy);
+            dst.public_message_gossip_raced_unicast = dst
+                .public_message_gossip_raced_unicast
+                .saturating_add(src.public_message_gossip_raced_unicast);
             dst.messages_dropped_signature_failed = dst
                 .messages_dropped_signature_failed
                 .saturating_add(src.messages_dropped_signature_failed);
@@ -535,6 +556,29 @@ mod tests {
         assert_eq!(
             g.counters.sends_rejected_write_policy, 1,
             "sender-side local rejection must be in sends_rejected_write_policy only"
+        );
+    }
+
+    /// Why: a sequential unicast-then-gossip fan-out can still deliver, so a
+    /// delivery assertion alone cannot catch issue #310. The raced counter is
+    /// the signal that topic publish finished while DM unicast was still
+    /// outstanding — if this method is wired to the wrong field, the
+    /// two-daemon <5s test would pass for the wrong reason.
+    #[test]
+    fn gossip_raced_unicast_counter_is_independent() {
+        let diag = GroupsDiagnostics::new();
+        diag.record_message_received("grp", 1);
+        diag.record_public_message_gossip_raced_unicast("grp");
+        diag.record_public_message_gossip_raced_unicast("grp");
+
+        let mut groups: HashMap<String, GroupInfo> = HashMap::new();
+        groups.insert("grp".into(), group("Grp", "grp"));
+        let snap = diag.snapshot(&groups, &HashSet::new(), &HashSet::new(), &HashMap::new());
+        let g = snap.groups.iter().find(|g| g.group_id == "grp").unwrap();
+        assert_eq!(g.counters.messages_received, 1);
+        assert_eq!(
+            g.counters.public_message_gossip_raced_unicast, 2,
+            "raced-unicast counter must not alias messages_received"
         );
     }
 

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -9562,16 +9562,6 @@ fn spawn_group_public_message_fanout_race(
 ) {
     let unicast_outstanding = Arc::new(AtomicUsize::new(recipients.len()));
 
-    // Record the race on this thread before any unicast task can finish.
-    // A `key_unavailable` inject decrements `outstanding` synchronously; if
-    // we waited for the gossip task to be scheduled the counter would miss
-    // the very failure class #310 must prove does not delay topic publish.
-    if !recipients.is_empty() {
-        state
-            .groups_diagnostics
-            .record_public_message_gossip_raced_unicast(&msg.group_id);
-    }
-
     let gossip_state = Arc::clone(&state);
     let gossip_bytes = bytes;
     let gossip_group = msg.group_id.clone();
@@ -9604,6 +9594,9 @@ fn spawn_group_public_message_fanout_race(
             );
         }
         if gossip_outstanding.load(Ordering::Relaxed) > 0 {
+            gossip_state
+                .groups_diagnostics
+                .record_public_message_gossip_raced_unicast(&gossip_group);
             tracing::info!(
                 target: "x0x::groups",
                 group_id = %LogHexId::group(&gossip_group),

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -35,7 +35,7 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::{Path as FsPath, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::Mutex as StdMutex;
@@ -9028,8 +9028,9 @@ pub(in crate::server) struct SendGroupMessageRequest {
 ///
 /// Branches on `policy.confidentiality`:
 ///
-/// - `SignedPublic` — builds a signed `GroupPublicMessage`, publishes
-///   to `x0x.groups.public.{group_id}`, and caches it locally.
+/// - `SignedPublic` — builds a signed `GroupPublicMessage`, caches it
+///   locally, returns 200 + `msg_id`, then fans out as a race: gossip
+///   topic publish and per-member direct DM start together (issue #310).
 ///   Write-access is enforced at endpoint time (same rules as
 ///   `x0x::groups::validate_public_message` applies at ingest).
 /// - `MlsEncrypted` — not supported on this endpoint yet; callers
@@ -9172,28 +9173,16 @@ pub(in crate::server) async fn send_group_public_message(
             );
         }
     };
-    if let Err(e) = state.agent.publish(&topic, bytes.clone()).await {
-        tracing::warn!(topic = %LogHexId::topic(&topic), "E: public-send publish failed: {e}");
-        return api_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("publish failed: {e}"),
-        );
-    }
-    if let Err(e) = state
-        .agent
-        .publish(GLOBAL_PUBLIC_MESSAGE_TOPIC, bytes)
-        .await
-    {
-        tracing::warn!(
-            topic = GLOBAL_PUBLIC_MESSAGE_TOPIC,
-            group_id = %msg.group_id,
-            "E: global public-send fallback publish failed: {e}"
-        );
-    }
-    // Publish succeeded, so cache locally. The listener was started before the
-    // publish above to avoid first-message topic races.
+    // Persist first. HTTP 200 is a local-commit fact (issue #310 / same
+    // contract as today); fan-out is a race and must not delay this reply.
     cache_public_message(&state, msg.clone()).await;
-    spawn_group_public_message_delivery_to_active_members(&state, direct_recipients, &msg);
+    spawn_group_public_message_fanout_race(
+        Arc::clone(&state),
+        topic.clone(),
+        bytes,
+        direct_recipients,
+        msg.clone(),
+    );
 
     let msg_id = msg.msg_id();
     (
@@ -9505,6 +9494,43 @@ fn encode_group_public_message_direct_payload(
     Ok(payload)
 }
 
+/// First unicast attempt budget on the SignedPublic send path only (issue #310).
+/// Durable DMs and roster/control events keep the 8s named-group default —
+/// do not reuse this constant there.
+const GROUP_PUBLIC_UNICAST_ATTEMPT_BUDGET: Duration = Duration::from_secs(3);
+
+/// Test-only unicast fault injection for #310. Set
+/// `X0X_TEST_GROUP_PUBLIC_UNICAST_FAIL=timeout` or `key_unavailable` on the
+/// sender daemon so a two-daemon test can prove gossip carry does not wait
+/// for the ~24s DM retry budget. Read once per process; unset is a no-op.
+enum GroupPublicUnicastInject {
+    None,
+    Timeout,
+    KeyUnavailable,
+}
+
+static GROUP_PUBLIC_UNICAST_INJECT: std::sync::LazyLock<GroupPublicUnicastInject> =
+    std::sync::LazyLock::new(
+        || match std::env::var("X0X_TEST_GROUP_PUBLIC_UNICAST_FAIL") {
+            Ok(value) if value == "timeout" => GroupPublicUnicastInject::Timeout,
+            Ok(value) if value == "key_unavailable" => GroupPublicUnicastInject::KeyUnavailable,
+            _ => GroupPublicUnicastInject::None,
+        },
+    );
+
+/// Whether a failed public-message unicast should spend another attempt.
+///
+/// Reuses the #342 `DmError` failure class — do not invent a second enum.
+/// `RecipientKeyUnavailable` (and the sibling `RecipientKeyInvalid`) cannot
+/// be healed by waiting 8s+8s; an invalid recipient id is rejected before
+/// send and is therefore also non-retryable.
+fn group_public_unicast_is_retryable(err: &x0x::dm::DmError) -> bool {
+    !matches!(
+        err,
+        x0x::dm::DmError::RecipientKeyUnavailable(_) | x0x::dm::DmError::RecipientKeyInvalid(_)
+    )
+}
+
 fn group_public_message_direct_delivery_config() -> x0x::dm::DmSendConfig {
     let mut config = named_group_direct_delivery_config();
     // User-visible community posts should use the receive-ACKed raw path when
@@ -9513,23 +9539,126 @@ fn group_public_message_direct_delivery_config() -> x0x::dm::DmSendConfig {
     // gossip overlay must not strand a post when the direct path is healthy.
     config.prefer_raw_quic_if_connected = true;
     config.require_gossip = false;
+    // Do not drop require_gossip_ack on this path to "make groups fast" —
+    // that flag is the durable-DM contract. Shorten THIS path's first-attempt
+    // budget instead (issue #310); product DMs keep the 8s default.
     config.require_gossip_ack = true;
+    config.raw_quic_receive_ack_timeout = Some(GROUP_PUBLIC_UNICAST_ATTEMPT_BUDGET);
+    config.timeout_per_attempt = GROUP_PUBLIC_UNICAST_ATTEMPT_BUDGET;
+    config.max_retries = 0;
     config
+}
+
+/// Fan-out a persisted public group message as a race: gossip topic publish
+/// starts immediately and does not wait for per-member unicast to finish or
+/// fail (issue #310). First success wins per recipient because
+/// [`cache_public_message`] no-ops on an already-cached signature.
+fn spawn_group_public_message_fanout_race(
+    state: Arc<AppState>,
+    topic: String,
+    bytes: Vec<u8>,
+    recipients: Vec<String>,
+    msg: x0x::groups::GroupPublicMessage,
+) {
+    let unicast_outstanding = Arc::new(AtomicUsize::new(recipients.len()));
+
+    // Record the race on this thread before any unicast task can finish.
+    // A `key_unavailable` inject decrements `outstanding` synchronously; if
+    // we waited for the gossip task to be scheduled the counter would miss
+    // the very failure class #310 must prove does not delay topic publish.
+    if !recipients.is_empty() {
+        state
+            .groups_diagnostics
+            .record_public_message_gossip_raced_unicast(&msg.group_id);
+    }
+
+    let gossip_state = Arc::clone(&state);
+    let gossip_bytes = bytes;
+    let gossip_group = msg.group_id.clone();
+    let gossip_outstanding = Arc::clone(&unicast_outstanding);
+    tokio::spawn(async move {
+        tracing::info!(
+            target: "x0x::groups",
+            group_id = %LogHexId::group(&gossip_group),
+            "public group message gossip publish starting (raced with unicast)"
+        );
+        if let Err(e) = gossip_state
+            .agent
+            .publish(&topic, gossip_bytes.clone())
+            .await
+        {
+            tracing::warn!(
+                topic = %LogHexId::topic(&topic),
+                "E: public-send publish failed: {e}"
+            );
+        }
+        if let Err(e) = gossip_state
+            .agent
+            .publish(GLOBAL_PUBLIC_MESSAGE_TOPIC, gossip_bytes)
+            .await
+        {
+            tracing::warn!(
+                topic = GLOBAL_PUBLIC_MESSAGE_TOPIC,
+                group_id = %gossip_group,
+                "E: global public-send fallback publish failed: {e}"
+            );
+        }
+        if gossip_outstanding.load(Ordering::Relaxed) > 0 {
+            tracing::info!(
+                target: "x0x::groups",
+                group_id = %LogHexId::group(&gossip_group),
+                "public group message gossip published before unicast returned"
+            );
+        }
+    });
+
+    for recipient in recipients {
+        spawn_group_public_message_delivery(
+            &state,
+            &recipient,
+            &msg,
+            Arc::clone(&unicast_outstanding),
+        );
+    }
 }
 
 fn spawn_group_public_message_delivery(
     state: &AppState,
     recipient_hex: &str,
     msg: &x0x::groups::GroupPublicMessage,
-    delay: Option<Duration>,
+    outstanding: Arc<AtomicUsize>,
 ) {
+    match *GROUP_PUBLIC_UNICAST_INJECT {
+        GroupPublicUnicastInject::Timeout => {
+            tracing::warn!(
+                recipient = %LogHexId::agent(recipient_hex),
+                "X0X_TEST_GROUP_PUBLIC_UNICAST_FAIL=timeout; hanging public-message unicast (test-only, #310)"
+            );
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(24)).await;
+                outstanding.fetch_sub(1, Ordering::Relaxed);
+            });
+            return;
+        }
+        GroupPublicUnicastInject::KeyUnavailable => {
+            tracing::warn!(
+                recipient = %LogHexId::agent(recipient_hex),
+                "X0X_TEST_GROUP_PUBLIC_UNICAST_FAIL=key_unavailable; skipping unicast (test-only, #310)"
+            );
+            outstanding.fetch_sub(1, Ordering::Relaxed);
+            return;
+        }
+        GroupPublicUnicastInject::None => {}
+    }
+
     let recipient = match parse_agent_id_hex(recipient_hex) {
         Ok(id) => id,
         Err(e) => {
             tracing::warn!(
-                recipient = %LogHexId::agent(&recipient_hex),
+                recipient = %LogHexId::agent(recipient_hex),
                 "cannot direct-deliver public group message: invalid recipient id: {e}"
             );
+            outstanding.fetch_sub(1, Ordering::Relaxed);
             return;
         }
     };
@@ -9537,6 +9666,7 @@ fn spawn_group_public_message_delivery(
         Ok(payload) => payload,
         Err(e) => {
             tracing::warn!("failed to serialize public group message for direct delivery: {e}");
+            outstanding.fetch_sub(1, Ordering::Relaxed);
             return;
         }
     };
@@ -9544,10 +9674,7 @@ fn spawn_group_public_message_delivery(
     let recipient_label = recipient_hex.to_string();
     let group_id = msg.group_id.clone();
     tokio::spawn(async move {
-        if let Some(delay) = delay {
-            tokio::time::sleep(delay).await;
-        }
-        if let Err(e) = agent
+        match agent
             .send_direct_with_config(
                 &recipient,
                 payload,
@@ -9555,29 +9682,24 @@ fn spawn_group_public_message_delivery(
             )
             .await
         {
-            tracing::warn!(
-                group_id = %LogHexId::group(&group_id),
-                recipient = %LogHexId::agent(&recipient_label),
-                "failed to direct-deliver public group message: {e}"
-            );
+            Ok(_) => {}
+            Err(e) if !group_public_unicast_is_retryable(&e) => {
+                tracing::info!(
+                    group_id = %LogHexId::group(&group_id),
+                    recipient = %LogHexId::agent(&recipient_label),
+                    "public group message unicast non-retryable ({e}); gossip race is the carry"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    group_id = %LogHexId::group(&group_id),
+                    recipient = %LogHexId::agent(&recipient_label),
+                    "failed to direct-deliver public group message: {e}"
+                );
+            }
         }
+        outstanding.fetch_sub(1, Ordering::Relaxed);
     });
-}
-
-fn spawn_group_public_message_delivery_to_active_members(
-    state: &AppState,
-    recipients: Vec<String>,
-    msg: &x0x::groups::GroupPublicMessage,
-) {
-    for recipient in recipients {
-        spawn_group_public_message_delivery(state, &recipient, msg, None);
-        spawn_group_public_message_delivery(
-            state,
-            &recipient,
-            msg,
-            Some(GROUP_BACKGROUND_PUBLISH_DELAY),
-        );
-    }
 }
 
 pub(in crate::server) async fn ingest_public_message(
@@ -25437,11 +25559,58 @@ pub(in crate::server) mod tests {
         assert!(config.prefer_raw_quic_if_connected);
         assert!(!config.require_gossip);
         assert!(!config.stop_fallback_on_raw_error);
+        // #310 shortens THIS path's first attempt only. Durable DMs and
+        // roster/control events still use the 8s named-group default —
+        // dropping require_gossip_ack here would be the wrong fix.
         assert!(config.require_gossip_ack);
         assert_eq!(
             config.raw_quic_receive_ack_timeout,
-            Some(Duration::from_secs(8))
+            Some(GROUP_PUBLIC_UNICAST_ATTEMPT_BUDGET)
         );
+        assert_eq!(
+            config.timeout_per_attempt,
+            GROUP_PUBLIC_UNICAST_ATTEMPT_BUDGET
+        );
+        assert_eq!(config.max_retries, 0);
+        assert!(
+            GROUP_PUBLIC_UNICAST_ATTEMPT_BUDGET >= Duration::from_secs(2)
+                && GROUP_PUBLIC_UNICAST_ATTEMPT_BUDGET <= Duration::from_secs(4),
+            "public-message unicast budget must stay in the 2–4s band, got {:?}",
+            GROUP_PUBLIC_UNICAST_ATTEMPT_BUDGET
+        );
+    }
+
+    #[test]
+    fn named_group_control_delivery_budget_is_unchanged_by_public_message_race() {
+        let config = named_group_direct_delivery_config();
+        assert_eq!(
+            config.raw_quic_receive_ack_timeout,
+            Some(Duration::from_secs(8)),
+            "roster/control events (#333 family) must keep the 8s budget"
+        );
+        assert_eq!(GROUP_BACKGROUND_PUBLISH_DELAY, Duration::from_secs(8));
+    }
+
+    #[test]
+    fn group_public_unicast_reuses_dm_error_failure_class_for_non_retryable() {
+        // Why: #310 must classify key-material misses as non-retryable so the
+        // 8s+8s delayed spawn is skipped. A second enum would drift from the
+        // #342 class that already names this failure.
+        assert!(!group_public_unicast_is_retryable(
+            &x0x::dm::DmError::RecipientKeyUnavailable("no advert".into())
+        ));
+        assert!(!group_public_unicast_is_retryable(
+            &x0x::dm::DmError::RecipientKeyInvalid("undecodable kem".into())
+        ));
+        assert!(group_public_unicast_is_retryable(
+            &x0x::dm::DmError::Timeout {
+                retries: 1,
+                elapsed: Duration::from_secs(24),
+            }
+        ));
+        assert!(group_public_unicast_is_retryable(
+            &x0x::dm::DmError::NoConnectivity("peer missing".into())
+        ));
     }
 
     #[test]

--- a/tests/named_group_public_message_race.rs
+++ b/tests/named_group_public_message_race.rs
@@ -263,13 +263,10 @@ async fn injected_key_unavailable_skips_retry_and_gossips_under_five_seconds() {
     assert_eq!(sent["ok"], true, "alice send failed: {sent:?}");
 
     assert_receiver_has_body_within(bob, &bob_group_id, &body, Duration::from_secs(5)).await;
-
-    let raced = gossip_raced_unicast_count(alice, &group_id).await;
-    assert!(
-        raced >= 1,
-        "gossip must still start when unicast is classified non-retryable; \
-         counter={raced}"
-    );
+    // Do not assert `public_message_gossip_raced_unicast` here. The
+    // key_unavailable inject decrements `outstanding` synchronously, so
+    // publish can finish with outstanding==0 and the counter stays 0.
+    // That is honest: the #342 classifier is a unit test, not this inject.
 }
 
 /// Healthy unicast is still the low-latency lane: both directions deliver

--- a/tests/named_group_public_message_race.rs
+++ b/tests/named_group_public_message_race.rs
@@ -1,0 +1,323 @@
+//! Issue #310 — public group message fan-out is a race, not a sequence.
+//!
+//! When direct-unicast fails (timeout or `recipient key material unavailable`)
+//! the sender used to burn the ~24s DM retry budget before gossip carry
+//! landed (~44s e2e). Gossip topic publish must start without waiting for
+//! unicast to finish. These tests inject that unicast failure on ONE daemon
+//! and assert the other has the row in < 5s, plus the raced-publish counter.
+//!
+//! Roster/control events (#333 family) are deliberately not exercised here.
+//!
+//! All tests are `#[ignore]` — they spawn real x0xd daemons. Run with:
+//!   cargo nextest run --test named_group_public_message_race --run-ignored all
+//!
+//! Before running: cargo build --bin x0xd
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+use cluster::{pair, pair_with_alice_env, pair_with_bob_env, AgentInstance};
+
+fn authed(d: &AgentInstance) -> reqwest::Client {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_str(&format!("Bearer {}", d.api_token))
+            .expect("auth header value"),
+    );
+    reqwest::Client::builder()
+        .default_headers(headers)
+        .timeout(Duration::from_secs(20))
+        .build()
+        .expect("authed reqwest client")
+}
+
+async fn wait_until<F, Fut>(timeout: Duration, mut check: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if check().await {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+async fn create_public_open_group(d: &AgentInstance, name: &str) -> String {
+    let resp: Value = authed(d)
+        .post(d.url("/groups"))
+        .json(&serde_json::json!({ "name": name, "preset": "public_open" }))
+        .send()
+        .await
+        .expect("POST /groups")
+        .json()
+        .await
+        .expect("create group json");
+    assert_eq!(resp["ok"], true, "create group failed: {resp:?}");
+    resp["group_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no group_id in create response: {resp:?}"))
+        .to_string()
+}
+
+async fn send_message(d: &AgentInstance, group_id: &str, body: &str) -> Value {
+    authed(d)
+        .post(d.url(&format!("/groups/{group_id}/send")))
+        .json(&serde_json::json!({ "body": body }))
+        .send()
+        .await
+        .expect("POST /groups/:id/send")
+        .json()
+        .await
+        .expect("send json")
+}
+
+async fn get_messages(d: &AgentInstance, group_id: &str) -> Vec<Value> {
+    let resp: Value = authed(d)
+        .get(d.url(&format!("/groups/{group_id}/messages")))
+        .send()
+        .await
+        .expect("GET /groups/:id/messages")
+        .json()
+        .await
+        .expect("GET messages json");
+    resp["messages"].as_array().cloned().unwrap_or_default()
+}
+
+async fn gossip_raced_unicast_count(d: &AgentInstance, group_id: &str) -> u64 {
+    let resp: Value = authed(d)
+        .get(d.url("/diagnostics/groups"))
+        .send()
+        .await
+        .expect("GET /diagnostics/groups")
+        .json()
+        .await
+        .expect("diagnostics json");
+    resp["groups"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|g| g["group_id"].as_str() == Some(group_id))
+        .and_then(|g| g["public_message_gossip_raced_unicast"].as_u64())
+        .unwrap_or(0)
+}
+
+async fn bob_joins_via_invite(
+    alice: &AgentInstance,
+    group_id: &str,
+    bob: &AgentInstance,
+) -> String {
+    let invite_resp: Value = authed(alice)
+        .post(alice.url(&format!("/groups/{group_id}/invite")))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("POST /groups/:id/invite")
+        .json()
+        .await
+        .expect("create invite json");
+    assert_eq!(
+        invite_resp["ok"], true,
+        "create invite failed: {invite_resp:?}"
+    );
+    let invite_link = invite_resp["invite_link"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no invite_link in: {invite_resp:?}"))
+        .to_string();
+
+    let join_resp: Value = authed(bob)
+        .post(bob.url("/groups/join"))
+        .json(&serde_json::json!({ "invite": invite_link }))
+        .send()
+        .await
+        .expect("POST /groups/join")
+        .json()
+        .await
+        .expect("bob join json");
+    assert_eq!(join_resp["ok"], true, "bob join failed: {join_resp:?}");
+    join_resp["group_id"]
+        .as_str()
+        .unwrap_or(group_id)
+        .to_string()
+}
+
+async fn wait_for_membership(d: &AgentInstance, group_id: &str, agent_id: &str) -> bool {
+    wait_until(Duration::from_secs(30), || async {
+        let resp: Value = authed(d)
+            .get(d.url(&format!("/groups/{group_id}/members")))
+            .send()
+            .await
+            .expect("GET /groups/:id/members")
+            .json()
+            .await
+            .expect("members json");
+        resp["members"].as_array().is_some_and(|arr| {
+            arr.iter().any(|m| {
+                m["agent_id"].as_str() == Some(agent_id) && m["state"].as_str() == Some("active")
+            })
+        })
+    })
+    .await
+}
+
+async fn settle_two_member_public_group(
+    alice: &AgentInstance,
+    bob: &AgentInstance,
+    name: &str,
+) -> (String, String) {
+    let group_id = create_public_open_group(alice, name).await;
+    let bob_group_id = bob_joins_via_invite(alice, &group_id, bob).await;
+    let bob_id = bob.agent_id().await;
+    assert!(
+        wait_for_membership(alice, &group_id, &bob_id).await,
+        "Alice never saw Bob as an active member; ingest would drop the post"
+    );
+    assert!(
+        wait_for_membership(bob, &bob_group_id, &bob_id).await,
+        "Bob's daemon never recognised Bob as active; his send would 403"
+    );
+    (group_id, bob_group_id)
+}
+
+async fn assert_receiver_has_body_within(
+    receiver: &AgentInstance,
+    group_id: &str,
+    body: &str,
+    bound: Duration,
+) {
+    let started = Instant::now();
+    let arrived = wait_until(bound, || async {
+        get_messages(receiver, group_id)
+            .await
+            .iter()
+            .any(|m| m["body"].as_str() == Some(body))
+    })
+    .await;
+    let elapsed = started.elapsed();
+    assert!(
+        arrived,
+        "receiver missing {body:?} within {bound:?} (elapsed {elapsed:?}); \
+         #310 requires gossip carry without the ~24s unicast budget. messages={:?}",
+        get_messages(receiver, group_id).await
+    );
+    assert!(
+        elapsed < bound,
+        "delivery took {elapsed:?}, which must stay under {bound:?}"
+    );
+}
+
+/// Injected unicast timeout must not delay gossip: Bob has Alice's row in < 5s
+/// and Alice's diagnostics record that gossip started while unicast was still
+/// in flight. A sequential unicast-then-gossip path would miss this bound.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "spawns real x0xd daemons"]
+async fn injected_unicast_timeout_delivers_via_gossip_under_five_seconds() {
+    let pair = pair_with_alice_env(&[("X0X_TEST_GROUP_PUBLIC_UNICAST_FAIL", "timeout")]).await;
+    let (alice, bob) = (&pair.alice, &pair.bob);
+    let (group_id, bob_group_id) =
+        settle_two_member_public_group(alice, bob, "issue-310-timeout").await;
+
+    let body = format!("timeout-inject-{}", rand::random::<u16>());
+    let sent = send_message(alice, &group_id, &body).await;
+    assert_eq!(sent["ok"], true, "alice send failed: {sent:?}");
+    assert!(
+        sent["msg_id"].as_str().is_some_and(|id| id.len() == 64),
+        "200 + msg_id contract: {sent:?}"
+    );
+
+    assert_receiver_has_body_within(bob, &bob_group_id, &body, Duration::from_secs(5)).await;
+
+    let raced = gossip_raced_unicast_count(alice, &group_id).await;
+    assert!(
+        raced >= 1,
+        "alice must record public_message_gossip_raced_unicast so the test \
+         can tell a race from a 24s sequential fallback that later succeeded; \
+         counter={raced}"
+    );
+}
+
+/// `recipient key material unavailable` is non-retryable on this path: skip
+/// the 8s+8s retry and let the already-started gossip carry land in < 5s.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "spawns real x0xd daemons"]
+async fn injected_key_unavailable_skips_retry_and_gossips_under_five_seconds() {
+    let pair =
+        pair_with_alice_env(&[("X0X_TEST_GROUP_PUBLIC_UNICAST_FAIL", "key_unavailable")]).await;
+    let (alice, bob) = (&pair.alice, &pair.bob);
+    let (group_id, bob_group_id) =
+        settle_two_member_public_group(alice, bob, "issue-310-key-unavail").await;
+
+    let body = format!("key-unavail-{}", rand::random::<u16>());
+    let sent = send_message(alice, &group_id, &body).await;
+    assert_eq!(sent["ok"], true, "alice send failed: {sent:?}");
+
+    assert_receiver_has_body_within(bob, &bob_group_id, &body, Duration::from_secs(5)).await;
+
+    let raced = gossip_raced_unicast_count(alice, &group_id).await;
+    assert!(
+        raced >= 1,
+        "gossip must still start when unicast is classified non-retryable; \
+         counter={raced}"
+    );
+}
+
+/// Healthy unicast is still the low-latency lane: both directions deliver
+/// without waiting on a gossip ACK, and we do not force `require_gossip`.
+/// This is the no-regression counterpart to the injected-failure tests.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "spawns real x0xd daemons"]
+async fn healthy_unicast_delivers_both_directions_without_gossip_ack_wait() {
+    let pair = pair().await;
+    let (alice, bob) = (&pair.alice, &pair.bob);
+    let (group_id, bob_group_id) =
+        settle_two_member_public_group(alice, bob, "issue-310-healthy").await;
+
+    let alice_body = format!("alice-healthy-{}", rand::random::<u16>());
+    let alice_sent = send_message(alice, &group_id, &alice_body).await;
+    assert_eq!(
+        alice_sent["ok"], true,
+        "alice healthy send failed: {alice_sent:?}"
+    );
+    assert_receiver_has_body_within(bob, &bob_group_id, &alice_body, Duration::from_secs(5)).await;
+
+    let bob_body = format!("bob-healthy-{}", rand::random::<u16>());
+    let bob_sent = send_message(bob, &bob_group_id, &bob_body).await;
+    assert_eq!(
+        bob_sent["ok"], true,
+        "bob healthy send failed: {bob_sent:?}"
+    );
+    assert_receiver_has_body_within(alice, &group_id, &bob_body, Duration::from_secs(5)).await;
+}
+
+/// Bob-as-sender mirror of the timeout inject: one acceptance-style reverse
+/// direction, not a soak. Proves the race is not authority-side only.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "spawns real x0xd daemons"]
+async fn injected_unicast_timeout_reverse_direction_under_five_seconds() {
+    let pair = pair_with_bob_env(&[("X0X_TEST_GROUP_PUBLIC_UNICAST_FAIL", "timeout")]).await;
+    let (alice, bob) = (&pair.alice, &pair.bob);
+    let (group_id, bob_group_id) =
+        settle_two_member_public_group(alice, bob, "issue-310-timeout-rev").await;
+
+    let body = format!("timeout-reverse-{}", rand::random::<u16>());
+    let sent = send_message(bob, &bob_group_id, &body).await;
+    assert_eq!(sent["ok"], true, "bob send failed: {sent:?}");
+    assert_receiver_has_body_within(alice, &group_id, &body, Duration::from_secs(5)).await;
+
+    let raced = gossip_raced_unicast_count(bob, &bob_group_id).await;
+    assert!(
+        raced >= 1,
+        "bob must record the raced-gossip counter on reverse send; counter={raced}"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #310: public group message fan-out is a **race**, not unicast-then-gossip.

**Problem:** when direct-unicast of a `SignedPublic` group message fails, the sender burned the full ~24s DM retry budget (plus the 8s delayed second attempt) before gossip carry landed (~44s e2e). Observed as `timed out after 1 retries over 24.00s` and `recipient key material unavailable`.

**Invariant:** gossip topic publish for a public group message starts **without** waiting for the unicast attempt to finish or fail.

### What changed

1. `POST /groups/:id/send` still persists/caches locally and returns **200 + `msg_id`** (same contract as today).
2. Fan-out is a race: (a) gossip publish on the group topic + global fallback, (b) per-member direct DM. First success wins per recipient; the loser is a no-op on the already-cached signature.
3. `recipient key material unavailable` and invalid recipient id are **non-retryable** on this path — skip the 8s+8s retry, rely on the already-started gossip. Reuses the #342 `DmError` failure class (`RecipientKeyUnavailable` / `RecipientKeyInvalid`); no second enum.
4. First unicast attempt budget is **3s on this path only**. Durable DMs and roster/control events keep the 8s named-group default. `require_gossip_ack` is **not** dropped.
5. `GET /diagnostics/groups` gains `public_message_gossip_raced_unicast`, incremented **only after both topic publishes return while unicast is still outstanding** (not at `tokio::spawn` schedule time).

Unicast remains the low-latency lane when a live QUIC binding exists (`prefer_raw_quic_if_connected = true`, `require_gossip = false`).

### Explicitly not in this PR

- No `fan_out` field / #296 200-on-zero-fan-out work
- No change to durable DM `require_gossip_ack` or #336 budgets
- No retry widening on cooled peers (X0X-0073)
- No MLS/TreeKEM apply changes
- No #308 / #336 / #281 / #349 / #333 MemberJoined reuse
- Not stacked on #353

## Validation

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features --all-targets -- -D warnings` (Rust 1.95.0, `--locked`)
- [x] `cargo check --workspace --all-targets`
- [x] Targeted lib tests:
  - `public_group_messages_prefer_receive_acked_raw_quic_with_gossip_fallback`
  - `named_group_control_delivery_budget_is_unchanged_by_public_message_race`
  - `group_public_unicast_reuses_dm_error_failure_class_for_non_retryable`
  - `gossip_raced_unicast_counter_is_independent`
- [x] Two-daemon acceptance after the post-publish increment move (`cargo test --test named_group_public_message_race -- --ignored`): **4/4 passed in 85s**
  - `injected_unicast_timeout_delivers_via_gossip_under_five_seconds` (asserts `raced >= 1`)
  - `injected_key_unavailable_skips_retry_and_gossips_under_five_seconds` (delivery &lt; 5s only; does **not** force the raced counter)
  - `healthy_unicast_delivers_both_directions_without_gossip_ack_wait`
  - `injected_unicast_timeout_reverse_direction_under_five_seconds` (asserts `raced >= 1`)

## Coverage

- Current line coverage:
- Delta vs `main`:
- Coverage workstream, if applicable:
- Exclusions added: none

## Test Quality Checklist

- [x] Each new test has a why-named name that states the invariant or regression.
- [x] No new test is a tautology against the implementation.
- [x] Each new test checks one business invariant.
- [x] Assertion failures include enough context to diagnose the broken invariant.
- [ ] Coverage delta is reported from CI or `just coverage-summary`.
- [x] Any coverage exclusion has a `coverage-skip:` comment and a matching register entry.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0498aa3b-9d34-490b-ac4a-31004449d755?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0498aa3b-9d34-490b-ac4a-31004449d755&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes signed-public group delivery so local persistence and the HTTP response no longer wait for network publication, while gossip and direct delivery proceed asynchronously.
- Adds a three-second, single-attempt public-message unicast configuration and skips retries for recipient-key errors.
- Adds a raced-unicast diagnostic counter and two-daemon acceptance coverage for timeout, unavailable-key, and healthy delivery paths.
- Preserves existing budgets for durable direct messages and group control events.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking diagnostics issue that makes the new race signal and its acceptance assertions unreliable.

The delivery paths are intentionally raced and covered by end-to-end timing checks, but the counter is incremented before gossip or unicast starts and therefore does not measure its documented event.

**Files Needing Attention:** src/server/routes/named_groups.rs, src/groups/diagnostics.rs, tests/named_group_public_message_race.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routes/named_groups.rs | Introduces asynchronous gossip/direct fan-out and a shortened unicast budget; the new diagnostic is recorded before the event it claims to measure. |
| src/groups/diagnostics.rs | Adds and aggregates the raced-unicast counter, whose documented completion semantics do not match its call site. |
| tests/named_group_public_message_race.rs | Adds ignored two-daemon acceptance tests, but the counter assertions cannot independently prove that gossip overlapped an outstanding unicast. |
| CHANGELOG.md | Documents the new local-commit response and asynchronous public-message fan-out behavior. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Client
  participant API as POST /groups/:id/send
  participant Cache
  participant Gossip
  participant DM as Direct delivery
  Client->>API: Send signed-public message
  API->>Cache: Persist locally
  API-->>Client: 200 + msg_id
  par Asynchronous gossip
    API->>Gossip: Publish group topic
    Gossip->>Gossip: Publish global fallback
  and Asynchronous unicast
    API->>DM: Send to each active member
  end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/routes/named_groups.rs:9569-9573
**Counter precedes the raced operations**

The counter increments before either gossip publishing or unicast delivery starts, so a multi-member send records a successful race even when gossip publication subsequently fails or no unicast remains outstanding. This makes the diagnostic and its acceptance assertions unable to verify the completion-and-overlap event documented for the counter.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(groups): race gossip publish with pu..."](https://github.com/saorsa-labs/x0x/commit/1a8b737088fbc3f1ed83a13279be9df8d318d6d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54686146)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Groups: Membership, Discovery, and State Commits](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/groups-messaging.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)

<!-- /greptile_comment -->