### PR TITLE
fix(history): salt MLS epoch msg_id with group scope (#276)

### DIFF
--- a/src/history/record.rs
+++ b/src/history/record.rs
@@ -170,8 +170,12 @@ impl Direction {
 /// One durable (or replaceable) history row (ADR-0023 §3).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryRecord {
-    /// BLAKE3 of `signed_artifact` when present, else of `payload`.
     /// Dedupe key across redundant delivery channels.
+    ///
+    /// BLAKE3 of `signed_artifact` when present; otherwise a producer-chosen
+    /// id (`compute_local_send_msg_id`, `compute_epoch_msg_id`, or BLAKE3 of
+    /// `payload`). Unsigned MLS rows use the epoch helper — not an ADR-0029
+    /// thread id.
     pub msg_id: [u8; 32],
     /// Conversation scope.
     pub scope: Scope,
@@ -257,17 +261,22 @@ impl HistoryRecord {
         *hasher.finalize().as_bytes()
     }
 
-    /// Dedupe id for an unsigned row salted by an epoch (MLS plaintext).
+    /// Dedupe id for an unsigned MLS-plaintext row salted by group and epoch.
     ///
-    /// `BLAKE3(salt-domain ‖ epoch ‖ payload)`: ciphertext replays within an
-    /// epoch still dedupe, while identical plaintext sent in different
-    /// epochs survives as distinct rows. Identical plaintext *within* one
-    /// epoch still collapses — per-message MLS identity is a future
-    /// wire-format change (ADR-0023 §3).
+    /// `BLAKE3("x0x-history-mls-epoch-v2" ‖ u32_le(len(stable_id)) ‖
+    /// stable_id ‖ u64_le(epoch) ‖ payload)`: identical plaintext in two
+    /// groups whose epochs coincide no longer collapses (#276). Ciphertext
+    /// replays within one group+epoch still dedupe. Epoch is a hash salt
+    /// only — it is not persisted, and this is a new domain rather than an
+    /// extension of v1.
     #[must_use]
-    pub fn compute_epoch_msg_id(epoch: u64, payload: &[u8]) -> [u8; 32] {
+    pub fn compute_epoch_msg_id(stable_id: &str, epoch: u64, payload: &[u8]) -> [u8; 32] {
         let mut hasher = blake3::Hasher::new();
-        hasher.update(b"x0x-history-mls-epoch-v1");
+        hasher.update(b"x0x-history-mls-epoch-v2");
+        let id_bytes = stable_id.as_bytes();
+        let id_len = u32::try_from(id_bytes.len()).unwrap_or(u32::MAX);
+        hasher.update(&id_len.to_le_bytes());
+        hasher.update(id_bytes);
         hasher.update(&epoch.to_le_bytes());
         hasher.update(payload);
         *hasher.finalize().as_bytes()
@@ -290,10 +299,16 @@ impl HistoryRecord {
         }
         // Artifact-less local sends carry a nonce-derived msg_id (see
         // `compute_local_send_msg_id`) that cannot be recomputed from the
-        // row alone; every other row must match the canonical computation.
-        let nonce_keyed_local_send =
-            self.provenance == Provenance::LocalSend && self.signed_artifact.is_none();
-        if !nonce_keyed_local_send {
+        // row alone. Unsigned MLS `LocalAppDecrypt` rows similarly carry an
+        // epoch+group-salted msg_id (`compute_epoch_msg_id`) that cannot be
+        // recomputed because epoch is not a stored column. Every other row
+        // must match the canonical computation.
+        let opaque_unsigned = self.signed_artifact.is_none()
+            && matches!(
+                self.provenance,
+                Provenance::LocalSend | Provenance::LocalAppDecrypt
+            );
+        if !opaque_unsigned {
             let expected = Self::compute_msg_id(self.signed_artifact.as_deref(), &self.payload);
             if expected != self.msg_id {
                 return Err(HistoryError::InvalidRecord(
@@ -308,5 +323,82 @@ impl HistoryRecord {
     #[must_use]
     pub fn is_text(&self) -> bool {
         self.content_type.starts_with("text/")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn epoch_msg_id_is_stable_for_the_same_triple() {
+        let a = HistoryRecord::compute_epoch_msg_id("group-a", 7, b"payload");
+        let b = HistoryRecord::compute_epoch_msg_id("group-a", 7, b"payload");
+        assert_eq!(
+            a, b,
+            "same group+epoch+payload must produce the same v2 msg_id"
+        );
+    }
+
+    #[test]
+    fn epoch_msg_id_differs_across_epochs() {
+        let a = HistoryRecord::compute_epoch_msg_id("group-a", 1, b"same-payload");
+        let b = HistoryRecord::compute_epoch_msg_id("group-a", 2, b"same-payload");
+        assert_ne!(
+            a, b,
+            "same group+payload in different epochs must be distinct ids"
+        );
+    }
+
+    #[test]
+    fn epoch_msg_id_differs_across_groups_and_payloads() {
+        let base = HistoryRecord::compute_epoch_msg_id("group-a", 3, b"payload");
+        let other_group = HistoryRecord::compute_epoch_msg_id("group-b", 3, b"payload");
+        let other_payload = HistoryRecord::compute_epoch_msg_id("group-a", 3, b"other");
+        assert_ne!(
+            base, other_group,
+            "same epoch+payload in different groups must be distinct ids"
+        );
+        assert_ne!(
+            base, other_payload,
+            "same group+epoch with a different payload must be distinct ids"
+        );
+    }
+
+    /// Without `u32_le(len(stable_id))`, these two encodings concatenate to
+    /// the same byte string after the domain:
+    /// ` "xy" ‖ u64_le(1) ‖ (u64_le(2) ‖ "hello") `
+    /// vs ` ("xy" ‖ u64_le(1)) ‖ u64_le(2) ‖ "hello" `.
+    /// The length prefix is what keeps them apart.
+    #[test]
+    fn epoch_msg_id_length_prefix_prevents_stable_id_glue() {
+        let mut glued_payload = Vec::new();
+        glued_payload.extend_from_slice(&2u64.to_le_bytes());
+        glued_payload.extend_from_slice(b"hello");
+
+        let epoch1 = 1u64.to_le_bytes();
+        let mut glued_id = String::from("xy");
+        glued_id.push_str(std::str::from_utf8(&epoch1).expect("le64(1) is valid UTF-8"));
+
+        let mut unprefixed_a = Vec::new();
+        unprefixed_a.extend_from_slice(b"xy");
+        unprefixed_a.extend_from_slice(&1u64.to_le_bytes());
+        unprefixed_a.extend_from_slice(&glued_payload);
+        let mut unprefixed_b = Vec::new();
+        unprefixed_b.extend_from_slice(glued_id.as_bytes());
+        unprefixed_b.extend_from_slice(&2u64.to_le_bytes());
+        unprefixed_b.extend_from_slice(b"hello");
+        assert_eq!(
+            unprefixed_a, unprefixed_b,
+            "precondition: the two triples are a glue pair without the length prefix"
+        );
+
+        let a = HistoryRecord::compute_epoch_msg_id("xy", 1, &glued_payload);
+        let b = HistoryRecord::compute_epoch_msg_id(&glued_id, 2, b"hello");
+        assert_ne!(
+            a, b,
+            "v2 length-prefix must keep glued stable_id encodings distinct"
+        );
     }
 }

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -1177,6 +1177,100 @@ mod tests {
         }
     }
 
+    fn mls_rec(stable_id: &str, epoch: u64, payload: &[u8]) -> HistoryRecord {
+        HistoryRecord {
+            msg_id: HistoryRecord::compute_epoch_msg_id(stable_id, epoch, payload),
+            scope: Scope::Group(stable_id.into()),
+            author_agent: None,
+            author_machine: None,
+            author_pubkey: None,
+            sent_at_ms: 1_000,
+            seen_at_ms: 1_000,
+            direction: Direction::Inbound,
+            content_type: "text/plain".into(),
+            payload: payload.to_vec(),
+            signed_artifact: None,
+            signature: None,
+            sig_context: None,
+            provenance: Provenance::LocalAppDecrypt,
+            replace_key: None,
+            thread_root: None,
+            thread_parent: None,
+            ingress_sender_agent: None,
+            logical_request_id: None,
+        }
+    }
+
+    /// #276: identical plaintext + coinciding MLS epochs in two groups
+    /// must not collide on the global UNIQUE(msg_id).
+    #[test]
+    fn epoch_msg_id_two_groups_same_payload_and_epoch_both_insert() {
+        let (store, _dir) = open();
+        let a = mls_rec("group-a", 3, b"identical-plaintext");
+        let b = mls_rec("group-b", 3, b"identical-plaintext");
+        assert_ne!(
+            a.msg_id, b.msg_id,
+            "v2 helper must mix stable_id so two groups cannot share an id"
+        );
+        assert_eq!(store.insert(&a).unwrap(), InsertOutcome::Inserted);
+        assert_eq!(store.insert(&b).unwrap(), InsertOutcome::Inserted);
+        assert_eq!(store.query(&HistoryQuery::default()).unwrap().len(), 2);
+    }
+
+    /// Same group+epoch+payload is a replay and must keep UNIQUE(msg_id).
+    #[test]
+    fn epoch_msg_id_same_triple_is_duplicate() {
+        let (store, _dir) = open();
+        let first = mls_rec("group-a", 3, b"plaintext");
+        let again = mls_rec("group-a", 3, b"plaintext");
+        assert_eq!(first.msg_id, again.msg_id);
+        assert_eq!(store.insert(&first).unwrap(), InsertOutcome::Inserted);
+        assert_eq!(store.insert(&again).unwrap(), InsertOutcome::Duplicate);
+        assert_eq!(store.query(&HistoryQuery::default()).unwrap().len(), 1);
+    }
+
+    /// I4: unsigned LocalAppDecrypt carries a v2 id that is not
+    /// BLAKE3(payload) and cannot be recomputed (epoch is not stored).
+    /// validate() must treat it as opaque, same as unsigned LocalSend.
+    #[test]
+    fn unsigned_local_app_decrypt_with_v2_id_validates_and_inserts() {
+        let (store, _dir) = open();
+        let r = mls_rec("group-a", 9, b"mls-plaintext");
+        assert_ne!(
+            r.msg_id,
+            HistoryRecord::compute_msg_id(None, &r.payload),
+            "v2 id must not collapse to BLAKE3(payload)"
+        );
+        r.validate()
+            .expect("unsigned LocalAppDecrypt with v2 id must be opaque to validate");
+        assert_eq!(store.insert(&r).unwrap(), InsertOutcome::Inserted);
+    }
+
+    /// A signed artifact whose msg_id does not match the artifact is still
+    /// rejected — I4 only skips the check when there is no artifact.
+    #[test]
+    fn artifact_msg_id_mismatch_is_still_rejected() {
+        let (store, _dir) = open();
+        let mut r = rec(b"payload", Scope::Group("g".into()));
+        r.signed_artifact = Some(b"signed-bytes".to_vec());
+        r.provenance = Provenance::VerifiedEnvelope;
+        r.msg_id = HistoryRecord::compute_epoch_msg_id("g", 1, b"payload");
+        let err = r
+            .validate()
+            .expect_err("mismatched artifact id must fail validate");
+        assert!(
+            err.to_string().contains("msg_id does not match"),
+            "validate must name the artifact mismatch; got: {err}"
+        );
+        let insert_err = store
+            .insert(&r)
+            .expect_err("insert must refuse artifact mismatch");
+        assert!(
+            insert_err.to_string().contains("msg_id does not match"),
+            "insert must surface the same mismatch; got: {insert_err}"
+        );
+    }
+
     /// ADR-0023 §3: rows re-verify offline from signed_artifact +
     /// author_pubkey. Store a real ML-DSA-65-signed artifact, reload it
     /// from SQLite, and re-run verification over the stored bytes.

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -9431,7 +9431,8 @@ fn record_group_public_history(state: &AppState, msg: &x0x::groups::GroupPublicM
 /// Record MLS-group plaintext obtained via a local secure-surface call
 /// (ADR-0023 §3/§4): unsigned, `provenance = LocalAppDecrypt`, author
 /// unattributed — no per-message author signature exists on this plane.
-/// `msg_id = BLAKE3(plaintext)` dedupes replays of the same ciphertext.
+/// `msg_id` is the v2 group+epoch helper so identical plaintext in two
+/// groups whose epochs coincide does not collide (#276).
 fn record_mls_history(
     state: &AppState,
     stable_group_id: &str,
@@ -9451,12 +9452,16 @@ fn record_mls_history(
         "application/octet-stream"
     };
     let now = i64::try_from(x0x::dm::now_unix_ms()).unwrap_or(i64::MAX);
-    // Epoch-salted id: ciphertext replays within an epoch dedupe, identical
-    // plaintext across epochs survives. Identical plaintext *within* one
-    // epoch still collapses — per-message MLS identity is a future
-    // wire-format change (ADR-0023 §3).
+    // Group+epoch-salted id: ciphertext replays within one group+epoch
+    // dedupe; identical plaintext across groups or epochs survives.
+    // Identical plaintext *within* one group+epoch still collapses —
+    // per-message MLS identity is a future wire-format change (ADR-0023 §3).
     history.record(x0x::history::HistoryRecord {
-        msg_id: x0x::history::HistoryRecord::compute_epoch_msg_id(epoch, plaintext),
+        msg_id: x0x::history::HistoryRecord::compute_epoch_msg_id(
+            stable_group_id,
+            epoch,
+            plaintext,
+        ),
         scope: x0x::history::Scope::Group(stable_group_id.to_string()),
         author_agent: None,
         author_machine: None,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Mix group `stable_id` into the MLS history dedupe id so identical plaintext in two groups whose epochs coincide is no longer silently dropped as `Duplicate` (#276).
- New helper domain, not an extension of v1: `msg_id = BLAKE3("x0x-history-mls-epoch-v2" ‖ u32_le(len(stable_id)) ‖ stable_id ‖ u64_le(epoch) ‖ payload)`.
- `UNIQUE(msg_id)` stays global. Epoch is a hash salt only — not persisted, no `SCHEMA_VERSION` bump, no TreeKEM/MLS wire change, no ADR-0029 thread id written into `msg_id`.
- Unsigned `LocalAppDecrypt` is opaque to `validate()` the same way unsigned `LocalSend` already is (the v2 id cannot be recomputed from the row). Artifact `msg_id` mismatch is still rejected.

Signature: `HistoryRecord::compute_epoch_msg_id(stable_id: &str, epoch: u64, payload: &[u8]) -> [u8; 32]`.

This PR is #276 only. It does not bundle #321.

## Validation

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] 8 new history unit tests (`epoch_msg_id_*`, unsigned LocalAppDecrypt insert, artifact mismatch)
- [x] `tests/history_store.rs` (13 tests)

## Coverage

- Current line coverage: not measured locally
- Delta vs `main`: not measured locally
- Coverage workstream, if applicable:
- Exclusions added: none

## Test Quality Checklist

- [x] Each new test has a why-named name that states the invariant or regression.
- [x] No new test is a tautology against the implementation.
- [x] Each new test checks one business invariant.
- [x] Assertion failures include enough context to diagnose the broken invariant.
- [ ] Coverage delta is reported from CI or `just coverage-summary`.
- [x] Any coverage exclusion has a `coverage-skip:` comment and a matching register entry.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a59b0ef-c34a-4d9e-a385-c4934d985f9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a59b0ef-c34a-4d9e-a385-c4934d985f9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes MLS history deduplication IDs by stable group ID and relaxes validation for unsigned `LocalAppDecrypt` rows whose epoch cannot be reconstructed. It also adds focused unit and store tests.

- Introduces a length-prefixed, group-scoped v2 epoch message-ID helper.
- Uses the helper when recording named-group MLS plaintext.
- Treats unsigned `LocalAppDecrypt` IDs as opaque during validation.
- Adds cross-group deduplication and validation regression coverage.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until deduplication remains compatible with persisted v1 history IDs during post-upgrade message replay.

Persisted v1 IDs are not migrated, and insertion deduplicates only by exact msg_id, so a successfully reprocessed pre-upgrade MLS message is inserted again under its new v2 ID.

**Files Needing Attention:** src/history/record.rs, src/history/store.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/history/record.rs | Adds the group-scoped v2 ID and opaque LocalAppDecrypt validation, but the new domain breaks deduplication continuity with persisted v1 rows. |
| src/history/store.rs | Adds useful regression tests for v2 IDs, though no test covers replay against a pre-existing v1 row. |
| src/server/routes/named_groups.rs | Correctly supplies stable group scope to the helper across MLS history writes, while making post-upgrade writes use the incompatible v2 key. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/history/record.rs:276
**V2 IDs break replay deduplication**

When an MLS ciphertext recorded before upgrade is successfully decrypted again afterward, the new domain generates a v2 ID that cannot match its persisted v1 ID, so `Store::insert` treats the replay as a new message and users see duplicate history.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(history): salt MLS epoch msg\_id with..."](https://github.com/saorsa-labs/x0x/commit/b62e690ca388b17ace55f568b39fd3fabb9500a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54692540)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Durable local history (ADR-0023)](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/history.md)

<!-- /greptile_comment -->