### PR TITLE
fix(crdt): envelope writer on TaskList merge_delta (#349 Layer A)

### DIFF
--- a/src/crdt/delta.rs
+++ b/src/crdt/delta.rs
@@ -13,6 +13,7 @@
 //! This significantly reduces bandwidth usage in collaborative scenarios.
 
 use crate::crdt::{Result, TaskId, TaskItem, TaskList, TaskListId};
+use crate::identity::AgentId;
 use saorsa_gossip_crdt_sync::{DeltaCrdt, LwwRegister};
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
@@ -194,18 +195,39 @@ impl TaskList {
     /// - Ordering uses LWW semantics
     /// - Name uses LWW semantics
     ///
+    /// # Authorship gate (issue #349, Layer A)
+    ///
+    /// Unauthenticated content fields (added tasks, metadata LWW on
+    /// TaskItem, list name, ordering, removes) apply only when `writer` —
+    /// the V2-envelope-verified sender (`AgentId`) — is `Some` AND, when
+    /// the list has an authorized-member set, is a member of it. Otherwise
+    /// they are silently rejected (Ok, KV-style) so unsigned or
+    /// non-member deltas cannot attribute create/rename/reassign/reorder/
+    /// remove to anyone. Checkbox claim/complete admission is unaffected:
+    /// it is gated by `OpAttestation`, so an attested claim on a task the
+    /// receiver already holds still converges when content is dropped.
+    ///
     /// # Arguments
     ///
     /// * `delta` - The delta to merge
+    /// * `peer_id` - OR-Set uniqueness tag source for first-seen upserts.
+    ///   NOT an identity: never compared against `writer` (invariant I3).
+    /// * `writer` - Envelope-verified sender, if any (`None` for unsigned
+    ///   legacy v1 publishes).
     ///
     /// # Returns
     ///
-    /// Ok(()) if merge succeeded.
+    /// Ok(()) if merge succeeded (including silent content rejection).
     ///
     /// # Errors
     ///
     /// Returns an error if merge operations fail.
-    pub fn merge_delta(&mut self, delta: &TaskListDelta, peer_id: PeerId) -> Result<()> {
+    pub fn merge_delta(
+        &mut self,
+        delta: &TaskListDelta,
+        peer_id: PeerId,          // tag only, not identity
+        writer: Option<&AgentId>, // envelope-verified sender
+    ) -> Result<()> {
         // Capture the resolved observable fingerprint BEFORE applying the
         // delta so the local version advances exactly once iff this merge
         // effectively changes the local snapshot. (Remote claim/complete
@@ -222,20 +244,48 @@ impl TaskList {
         // resolution. Because this fingerprint wraps the entire merge body, it
         // is computed over post-gate (authenticated) state by construction.
         let before = self.state_fingerprint();
+
+        // Layer A authorship gate (issue #349, I2 + membership): decide ONCE
+        // whether unauthenticated content fields may apply. Identity is the
+        // envelope-verified `writer` (AgentId) only; `peer_id` and every
+        // UniqueTag in the delta are OR-Set tags, never authors (I3).
+        let content_allowed = match writer {
+            None => false,
+            Some(w) => self.is_authorized_content_writer(w),
+        };
+        if !content_allowed {
+            tracing::warn!(
+                ?writer,
+                list = ?self.id(),
+                "dropping unauthenticated content in task-list delta (issue #349)"
+            );
+        }
+
         for (task_id, (task, tag)) in &delta.added_tasks {
             // If task doesn't exist, add it (admit runs inside delta_upsert_task).
             // If it exists, merge + filter (admit + membership run inside
-            // delta_merge_task).
+            // delta_merge_task / delta_merge_checkbox_only).
             if self.get_task(task_id).is_none() {
-                self.delta_upsert_task(task.clone(), tag.0, tag.1)?;
-            } else {
+                if content_allowed {
+                    self.delta_upsert_task(task.clone(), tag.0, tag.1)?;
+                }
+                // A first-seen task from an unauthenticated add is NOT
+                // created: there is no local task to run checkbox admission
+                // against, and `created_by` is self-declared payload.
+            } else if content_allowed {
                 self.delta_merge_task(task_id, task)?;
+            } else {
+                // Existing task: checkbox + attestations still merge and run
+                // the admission gate even when content is dropped.
+                self.delta_merge_checkbox_only(task_id, task)?;
             }
         }
 
         // Apply removed tasks (no version bump; deferred to commit_revision).
-        for task_id in delta.removed_tasks.keys() {
-            self.delta_remove_task(task_id);
+        if content_allowed {
+            for task_id in delta.removed_tasks.keys() {
+                self.delta_remove_task(task_id);
+            }
         }
 
         // Apply task updates (upsert: merge if exists, insert if missing).
@@ -246,8 +296,12 @@ impl TaskList {
         // inside delta_upsert_task / merge.
         for (task_id, updated_task) in &delta.task_updates {
             if self.get_task(task_id).is_some() {
-                self.delta_merge_task(task_id, updated_task)?;
-            } else {
+                if content_allowed {
+                    self.delta_merge_task(task_id, updated_task)?;
+                } else {
+                    self.delta_merge_checkbox_only(task_id, updated_task)?;
+                }
+            } else if content_allowed {
                 // Task not yet known — insert it (admit runs inside).
                 self.delta_upsert_task(updated_task.clone(), peer_id, 0)?;
             }
@@ -256,13 +310,15 @@ impl TaskList {
         // Apply ordering update via LWW (vector-clock) merge. The merged
         // ordering may reference task IDs not yet present (out-of-order
         // delivery); tasks_ordered filters those at read time.
-        if let Some(order_register) = &delta.ordering_update {
-            self.delta_merge_ordering(order_register);
-        }
+        if content_allowed {
+            if let Some(order_register) = &delta.ordering_update {
+                self.delta_merge_ordering(order_register);
+            }
 
-        // Apply name update via LWW (vector-clock) merge.
-        if let Some(name_register) = &delta.name_update {
-            self.delta_merge_name(name_register);
+            // Apply name update via LWW (vector-clock) merge.
+            if let Some(name_register) = &delta.name_update {
+                self.delta_merge_name(name_register);
+            }
         }
 
         // Advance the local revision exactly once iff the resolved observable
@@ -280,10 +336,12 @@ impl DeltaCrdt for TaskList {
     type Delta = TaskListDelta;
 
     fn merge(&mut self, delta: &Self::Delta) -> anyhow::Result<()> {
-        // Use a default peer_id for the merge
-        // In a real implementation, the peer_id would come from the sync context
+        // No writer identity here — DeltaCrdt::merge is NOT a production
+        // untrusted-apply path (issue #349). Pass `None` so no unsigned
+        // content applies; the trusted gossip route is TaskListSync, which
+        // threads the envelope-verified sender into merge_delta.
         let peer_id = PeerId::new([0u8; 32]);
-        self.merge_delta(delta, peer_id)
+        self.merge_delta(delta, peer_id, None)
             .map_err(|e| anyhow::anyhow!("Failed to merge delta: {}", e))
     }
 
@@ -417,8 +475,9 @@ mod tests {
         // Generate a full-state delta from list2
         let delta = list2.full_delta();
 
-        // Merge delta into list1
-        let result = list1.merge_delta(&delta, peer1);
+        // Merge delta into list1 (envelope-verified writer; the payload tag
+        // PeerId stays tag-only).
+        let result = list1.merge_delta(&delta, peer1, Some(&agent(2)));
         assert!(result.is_ok());
 
         // list1 should now have the task
@@ -452,7 +511,9 @@ mod tests {
         // Fresh joiner with an empty list applies only the cold-start snapshot.
         let mut joiner = TaskList::new(id, String::new(), joiner_peer);
         let snapshot = holder.full_delta();
-        joiner.merge_delta(&snapshot, holder_peer).expect("merge");
+        joiner
+            .merge_delta(&snapshot, holder_peer, Some(&agent(1)))
+            .expect("merge");
 
         assert_eq!(joiner.task_count(), 3, "all tasks transferred");
         assert_eq!(joiner.name(), "Sprint Backlog", "name transferred");
@@ -463,6 +524,10 @@ mod tests {
 
     #[test]
     fn test_delta_crdt_trait_merge() {
+        // Layer A (issue #349): DeltaCrdt::merge carries no writer identity,
+        // so it is NOT an untrusted-apply path — it passes `None` and must
+        // apply no unsigned content. The task from list2's delta must NOT
+        // land, and the version must not advance on dropped content.
         let peer1 = peer(1);
         let peer2 = peer(2);
         let id = list_id(1);
@@ -479,12 +544,17 @@ mod tests {
         let result = DeltaCrdt::merge(&mut list1, &delta);
         assert!(result.is_ok());
 
-        // Version reflects all mutations from the merge: add_task + reorder + update_name
-        assert!(
-            DeltaCrdt::version(&list1) > 0,
-            "version should be bumped after merge"
+        // Unsigned content must not apply: no task, no version advance.
+        assert_eq!(
+            list1.task_count(),
+            0,
+            "unsigned content must not apply via DeltaCrdt::merge"
         );
-        assert_eq!(list1.task_count(), 1);
+        assert_eq!(
+            DeltaCrdt::version(&list1),
+            0,
+            "dropped content must not advance the version"
+        );
     }
 
     #[test]
@@ -522,7 +592,9 @@ mod tests {
         delta.ordering_update = Some(order_register);
 
         // Merge delta
-        list.merge_delta(&delta, peer).ok().unwrap();
+        list.merge_delta(&delta, peer, Some(&agent(1)))
+            .ok()
+            .unwrap();
 
         // Verify ordering changed
         let tasks = list.tasks_ordered();
@@ -551,7 +623,9 @@ mod tests {
 
         let mut delta = TaskListDelta::new(7);
         delta.name_update = Some(stale);
-        list.merge_delta(&delta, remote).ok().unwrap();
+        list.merge_delta(&delta, remote, Some(&agent(2)))
+            .ok()
+            .unwrap();
 
         assert_eq!(list.name(), "Newest", "stale name must not clobber newer");
     }
@@ -570,7 +644,9 @@ mod tests {
         delta.name_update = Some(other.name_register().clone());
 
         // Merge delta
-        list.merge_delta(&delta, peer).ok().unwrap();
+        list.merge_delta(&delta, peer, Some(&agent(1)))
+            .ok()
+            .unwrap();
 
         // Verify name changed
         assert_eq!(list.name(), "Updated");
@@ -603,7 +679,7 @@ mod tests {
         delta.ordering_update = Some(order_register);
 
         let v0 = list.version();
-        list.merge_delta(&delta, peer).unwrap();
+        list.merge_delta(&delta, peer, Some(&agent(1))).unwrap();
         let v1 = list.version();
         assert!(
             v1 > v0,
@@ -612,7 +688,7 @@ mod tests {
 
         // Second identical merge: the ordering is already resolved identically
         // ⇒ the fingerprint is unchanged ⇒ the version MUST NOT advance again.
-        list.merge_delta(&delta, peer).unwrap();
+        list.merge_delta(&delta, peer, Some(&agent(1))).unwrap();
         assert_eq!(
             list.version(),
             v1,
@@ -620,5 +696,225 @@ mod tests {
         );
         // The two real tasks are still present (no spurious removal).
         assert_eq!(list.task_count(), 2);
+    }
+
+    // ------------------------------------------------------------------
+    // Layer A authorship gate (issue #349)
+    // ------------------------------------------------------------------
+
+    fn signing_for(_n: u8) -> (AgentId, crate::gossip::SigningContext) {
+        let kp = crate::identity::AgentKeypair::generate().expect("agent keygen");
+        (
+            kp.agent_id(),
+            crate::gossip::SigningContext::from_keypair(&kp),
+        )
+    }
+
+    /// Seed a receiver exactly like [`forged_content_delta_template`]'s base
+    /// so the delta's LWW registers causally dominate on merge.
+    fn seeded_receiver(id: TaskListId, members: Option<AgentId>) -> (TaskList, TaskId, TaskId) {
+        let mut list = TaskList::new(id, "Sprint".to_string(), peer(3));
+        if let Some(m) = members {
+            list.set_authorized_agents(HashSet::from([m]));
+        }
+        let t0 = make_task(1, peer(3));
+        let t0_id = *t0.id();
+        list.add_task(t0, peer(3), 1).expect("seed t0");
+        (list, t0_id, TaskId::from_bytes([2; 32]))
+    }
+
+    /// A delta whose every payload PeerId component equals the victim's
+    /// AgentId bytes: an attacker tries to borrow the victim's identity
+    /// through the OR-Set tag / LWW-clock namespace.
+    fn forged_content_delta(id: TaskListId, t0_id: TaskId) -> TaskListDelta {
+        let spoofed = PeerId::new(agent(1).0);
+        // Template constructed identically to seeded_receiver so registers
+        // cloned from it dominate the receiver's.
+        let mut template = TaskList::new(id, "Sprint".to_string(), peer(3));
+        template
+            .add_task(make_task(1, peer(3)), peer(3), 1)
+            .expect("seed t0");
+
+        // New task attributed to the victim (`created_by` = agent(1)).
+        let t1 = make_task(2, spoofed);
+        let t1_id = *t1.id();
+        let mut delta = TaskListDelta::new(5);
+        delta.added_tasks.insert(t1_id, (t1, (spoofed, 1)));
+
+        // Forged rename + reorder, clocked by the spoofed peer.
+        let mut name_reg = template.name_register().clone();
+        name_reg.set("Pwned".to_string(), spoofed);
+        delta.name_update = Some(name_reg);
+        let mut order_reg = template.ordering_register().clone();
+        order_reg.set(vec![t1_id, t0_id], spoofed);
+        delta.ordering_update = Some(order_reg);
+
+        // Forged remove of the existing task.
+        delta
+            .removed_tasks
+            .insert(t0_id, HashSet::from([(spoofed, 1)]));
+        delta
+    }
+
+    #[test]
+    fn merge_delta_spoofed_payload_peer_id_is_not_identity() {
+        // WHY (issue #349, invariant I3): the payload PeerId is an OR-Set
+        // uniqueness tag, never an author. A member (attacker) forging a
+        // delta whose payload PeerId EQUALS the victim's AgentId bytes must
+        // not borrow the victim's authority: content admission is gated by
+        // the envelope-verified writer (AgentId) against the
+        // authorized-agents set, never by comparing PeerId bytes to AgentId
+        // bytes.
+        let id = list_id(1);
+        let victim = agent(1);
+        let attacker = agent(99);
+        let spoofed = PeerId::new(victim.0); // same bytes — must NOT grant identity
+
+        let (mut list, t0_id, t1_id) = seeded_receiver(id, Some(victim));
+        let order_before: Vec<_> = list.tasks_ordered().iter().map(|t| *t.id()).collect();
+        let delta = forged_content_delta(id, t0_id);
+
+        // The ATTACKER is the verified envelope sender: every content field
+        // must be silently dropped (Ok, no error — KV-style reject).
+        list.merge_delta(&delta, spoofed, Some(&attacker))
+            .expect("silent reject, not an error");
+        assert_eq!(list.task_count(), 1, "spoofed add must not create a task");
+        assert!(
+            list.get_task(&t1_id).is_none(),
+            "no task attributed to the victim"
+        );
+        assert!(
+            list.get_task(&t0_id).is_some(),
+            "spoofed remove must not delete"
+        );
+        assert_eq!(list.name(), "Sprint", "spoofed rename must not apply");
+        let order_after: Vec<_> = list.tasks_ordered().iter().map(|t| *t.id()).collect();
+        assert_eq!(order_after, order_before, "spoofed reorder must not apply");
+
+        // The VICTIM as the verified writer, with a DIFFERENT payload
+        // PeerId: the same delta applies — proving the writer AgentId (not
+        // the payload PeerId) is the gate.
+        let (mut honest, t0_id, t1_id) = seeded_receiver(id, Some(victim));
+        honest
+            .merge_delta(&delta, peer(7), Some(&victim))
+            .expect("honest merge");
+        assert!(
+            honest.get_task(&t1_id).is_some(),
+            "victim's add applies regardless of payload PeerId"
+        );
+        assert!(
+            honest.get_task(&t0_id).is_none(),
+            "victim's remove applies regardless of payload PeerId"
+        );
+        assert_eq!(honest.name(), "Pwned", "victim's rename applies");
+    }
+
+    #[test]
+    fn merge_delta_anonymous_writer_drops_content_but_admits_attested_claim() {
+        // WHY (issue #349, I2): an unsigned (anonymous-sender) delta must
+        // not apply ANY unauthenticated content field — add, metadata LWW,
+        // name, order, remove — while checkbox admission (gated by
+        // OpAttestation, not by the envelope writer) still admits a validly
+        // attested claim on a task the receiver already holds.
+        let id = list_id(1);
+        let p = peer(4);
+        let (mut list, t0_id, t1_id) = seeded_receiver(id, None);
+        let order_before: Vec<_> = list.tasks_ordered().iter().map(|t| *t.id()).collect();
+
+        // A source task carrying BOTH a validly-attested claim AND a forged
+        // title change (no content attestation exists — Layer B is HOLD).
+        let (claimer, signing) = signing_for(5);
+        let mut claimed = make_task(1, p);
+        claimed.claim(id, claimer, p, 42, &signing).expect("attest");
+        claimed.update_title("Forged title".to_string(), peer(9));
+
+        let mut delta = forged_content_delta(id, t0_id);
+        delta.task_updates.insert(t0_id, claimed);
+
+        list.merge_delta(&delta, peer(9), None)
+            .expect("silent reject, not an error");
+
+        // Content dropped: no new task, no remove, no rename, no reorder,
+        // no metadata LWW.
+        assert_eq!(
+            list.task_count(),
+            1,
+            "anonymous add must not create a task (I2)"
+        );
+        assert!(list.get_task(&t1_id).is_none(), "no first-seen insert");
+        assert!(list.get_task(&t0_id).is_some(), "anonymous remove dropped");
+        assert_eq!(list.name(), "Sprint", "anonymous rename dropped");
+        let order_after: Vec<_> = list.tasks_ordered().iter().map(|t| *t.id()).collect();
+        assert_eq!(order_after, order_before, "anonymous reorder dropped");
+        assert_ne!(
+            list.get_task(&t0_id).expect("t0").title(),
+            "Forged title",
+            "anonymous metadata LWW dropped"
+        );
+
+        // Checkbox admission still ran for the existing task: the attested
+        // claim survives even though every content field was dropped.
+        assert!(
+            list.get_task(&t0_id)
+                .expect("t0")
+                .current_state()
+                .is_claimed(),
+            "attested claim must still be admitted with writer=None"
+        );
+    }
+
+    #[test]
+    fn merge_delta_honest_writer_content_applies() {
+        // WHY (issue #349): a verified envelope writer must keep today's
+        // apply path — add / name / order / remove all land when the list
+        // has no authorized set (Layer A needs no new attestations; Layer B
+        // is HOLD).
+        let id = list_id(1);
+        let (mut list, t0_id, t1_id) = seeded_receiver(id, None);
+        let delta = forged_content_delta(id, t0_id);
+
+        list.merge_delta(&delta, peer(7), Some(&agent(1)))
+            .expect("honest writer merge");
+
+        assert!(
+            list.get_task(&t1_id).is_some(),
+            "add applies for a verified writer"
+        );
+        assert!(
+            list.get_task(&t0_id).is_none(),
+            "remove applies for a verified writer"
+        );
+        assert_eq!(list.name(), "Pwned", "rename applies for a verified writer");
+        let order: Vec<_> = list.tasks_ordered().iter().map(|t| *t.id()).collect();
+        assert_eq!(order, vec![t1_id], "reorder applies for a verified writer");
+    }
+
+    #[test]
+    fn merge_delta_membership_gates_unauthorized_writer_content() {
+        // WHY (issue #349, I8): with an authorized-member set, content from
+        // a writer OUTSIDE the set is dropped — "member may edit" — while
+        // the same delta from a member applies.
+        let id = list_id(1);
+        let alice = agent(1);
+        let bob = agent(2);
+
+        let (mut list, t0_id, t1_id) = seeded_receiver(id, Some(alice));
+        let delta = forged_content_delta(id, t0_id);
+        list.merge_delta(&delta, peer(7), Some(&bob))
+            .expect("silent reject, not an error");
+        assert!(list.get_task(&t1_id).is_none(), "non-member add dropped");
+        assert!(list.get_task(&t0_id).is_some(), "non-member remove dropped");
+        assert_eq!(list.name(), "Sprint", "non-member rename dropped");
+
+        let (mut member_list, t0_id, t1_id) = seeded_receiver(id, Some(alice));
+        member_list
+            .merge_delta(&delta, peer(7), Some(&alice))
+            .expect("member merge");
+        assert!(member_list.get_task(&t1_id).is_some(), "member add applies");
+        assert!(
+            member_list.get_task(&t0_id).is_none(),
+            "member remove applies"
+        );
+        assert_eq!(member_list.name(), "Pwned", "member rename applies");
     }
 }

--- a/src/crdt/sync.rs
+++ b/src/crdt/sync.rs
@@ -16,6 +16,7 @@
 use crate::crdt::{Result, TaskList, TaskListDelta};
 use crate::gossip::wire::{decode_delta, encode_delta};
 use crate::gossip::PubSubManager;
+use crate::identity::AgentId;
 use saorsa_gossip_types::PeerId;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -359,7 +360,11 @@ impl TaskListSync {
                 match decode_delta::<TaskListDelta>(&msg.payload) {
                     Ok((peer_id, delta)) => {
                         let mut list = task_list.write().await;
-                        if let Err(e) = list.merge_delta(&delta, peer_id) {
+                        // Layer A (issue #349): the V2-envelope-verified
+                        // sender is the writer identity; the payload
+                        // `peer_id` stays an OR-Set tag only (I3).
+                        let writer = msg.sender.as_ref();
+                        if let Err(e) = list.merge_delta(&delta, peer_id, writer) {
                             tracing::warn!("Failed to merge remote delta: {}", e);
                         } else if listener_bootstrap_active
                             .load(std::sync::atomic::Ordering::Relaxed)
@@ -723,8 +728,14 @@ impl TaskListSync {
     ///
     /// # Arguments
     ///
-    /// * `peer_id` - The peer who sent this delta
+    /// * `peer_id` - The peer who sent this delta (OR-Set tag source only,
+    ///   never an identity)
     /// * `delta` - The delta to apply
+    /// * `writer` - The envelope-verified sender, if any. Content fields
+    ///   (add/metadata/name/order/remove) apply only for a `Some` writer
+    ///   authorized by the list's member set; anonymous deltas fail closed
+    ///   (issue #349, Layer A). Attested checkbox operations on existing
+    ///   tasks still converge.
     ///
     /// # Returns
     ///
@@ -733,9 +744,14 @@ impl TaskListSync {
     /// # Errors
     ///
     /// Returns an error if the merge fails.
-    pub async fn apply_remote_delta(&self, peer_id: PeerId, delta: TaskListDelta) -> Result<()> {
+    pub async fn apply_remote_delta(
+        &self,
+        peer_id: PeerId,
+        delta: TaskListDelta,
+        writer: Option<&AgentId>,
+    ) -> Result<()> {
         let mut task_list = self.task_list.write().await;
-        task_list.merge_delta(&delta, peer_id)?;
+        task_list.merge_delta(&delta, peer_id, writer)?;
         Ok(())
     }
 
@@ -851,6 +867,17 @@ mod tests {
         TaskListSync::new(list, pubsub, topic.to_string(), peer(1)).expect("task list sync")
     }
 
+    /// Shared pubsub with a SIGNING context: local publishes carry a
+    /// V2-envelope-verified sender, so the delta-merge listener's Layer A
+    /// gate (issue #349) admits their content. The convergence tests below
+    /// need this — an unsigned pubsub would fail closed on every serve.
+    async fn signed_pubsub() -> Arc<PubSubManager> {
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("agent keygen");
+        let signing = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        Arc::new(PubSubManager::new(node, Some(signing)).expect("pubsub"))
+    }
+
     /// Build a `TaskListSync` that shares its pubsub with the caller (so the
     /// caller can subscribe before the sync publishes).
     async fn make_sync_with_pubsub(topic: &str) -> (TaskListSync, Arc<PubSubManager>) {
@@ -894,7 +921,7 @@ mod tests {
         // Apply delta directly (simulating what TaskListSync::apply_remote_delta does)
         {
             let mut list = task_list_arc.write().await;
-            let result = list.merge_delta(&delta, peer2);
+            let result = list.merge_delta(&delta, peer2, Some(&agent(2)));
             assert!(result.is_ok());
         }
 
@@ -995,7 +1022,10 @@ mod tests {
         let mut delta = TaskListDelta::new(1);
         delta.added_tasks.insert(task_id, (task, (remote, 1)));
 
-        sync.apply_remote_delta(remote, delta)
+        // Layer A (issue #349): the honest path needs an envelope-verified
+        // writer for content to apply.
+        let alice = agent(1);
+        sync.apply_remote_delta(remote, delta, Some(&alice))
             .await
             .expect("apply_remote_delta");
 
@@ -1064,7 +1094,7 @@ mod tests {
         // would still pass against a no-op `Ok(())` impl. The real
         // subscribe->merge behaviour is asserted end-to-end by
         // `start_default_spawner_merges_remote_delta`, which drives
-        // `start_with_spawner(tokio::spawn)` and verifies the task lands.
+        // `start_with_spawner(tokio::spawn)` and proves Layer A I2 (unsigned add does not land).
         let sync = make_sync("tasks/E").await;
         sync.start_with_spawner(|_fut| {
             // intentionally drop the future
@@ -1079,12 +1109,15 @@ mod tests {
 
     #[tokio::test]
     async fn start_default_spawner_merges_remote_delta() {
-        // End-to-end exercise of the delta-merge listener: a delta published
-        // on the topic is received by the background loop spawned by start()
-        // and merged into the local list. TaskList::merge_delta takes no
-        // writer identity, so an unsigned (anonymous-sender) publish — what
-        // the wire delivers via a PubSubManager with no signing context —
-        // merges without any access-control consideration.
+        // End-to-end exercise of the delta-merge listener through the Layer A
+        // gate (issue #349, I2): a delta published on the topic is received
+        // by the background loop spawned by start() and merged with the
+        // V2-envelope-verified sender as the writer. A PubSubManager with no
+        // signing context publishes UNSIGNED (anonymous-sender) messages, so
+        // the listener must fail closed on content: the delta's first-seen
+        // task add must NOT land, while an attested checkbox claim on a task
+        // the receiver already holds must still converge (checkbox admission
+        // is gated by OpAttestation, not by the envelope writer).
         let sync = make_sync("tasks/F").await;
 
         sync.start().await.expect("start");
@@ -1092,18 +1125,46 @@ mod tests {
         // Let the spawned subscribe-forwarder register before we publish.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
+        // Seed an existing local task (local mutators are the trusted path —
+        // they are not the untrusted apply route this test exercises).
         let remote = peer(2);
-        let task = make_task(5, remote);
-        let task_id = *task.id();
+        let existing = make_task(5, remote);
+        let existing_id = *existing.id();
+        {
+            let mut list = sync.write().await;
+            list.add_task(existing, remote, 1).expect("seed local task");
+        }
+
+        // Unsigned delta: a first-seen add PLUS a validly-attested claim on
+        // the existing task. The claim is the positive evidence that the
+        // listener processed the message, so "add did not land" below is a
+        // real gate decision, not a dead listener.
+        let kp = crate::identity::AgentKeypair::generate().expect("agent keygen");
+        let signing = crate::gossip::SigningContext::from_keypair(&kp);
+        let claimer = kp.agent_id();
+        let mut claimed = make_task(5, remote);
+        claimed
+            .claim(list_id(1), claimer, remote, 1, &signing)
+            .expect("attest claim");
+
+        let new_task = make_task(6, remote);
+        let new_task_id = *new_task.id();
         let mut delta = TaskListDelta::new(1);
-        delta.added_tasks.insert(task_id, (task, (remote, 1)));
+        delta
+            .added_tasks
+            .insert(new_task_id, (new_task, (remote, 2)));
+        delta.task_updates.insert(existing_id, claimed);
         sync.publish_delta(remote, delta).await.expect("publish");
 
-        // The merge is asynchronous; poll the list until the task lands.
-        let landed = tokio::time::timeout(Duration::from_secs(2), async {
+        // The claim applies (checkbox path still runs for writer=None)…
+        let claim_applied = tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                let count = sync.read().await.task_count();
-                if count == 1 {
+                let claimed_landed = sync
+                    .read()
+                    .await
+                    .get_task(&existing_id)
+                    .is_some_and(|t| t.current_state().is_claimed());
+                if claimed_landed {
                     return;
                 }
                 tokio::time::sleep(Duration::from_millis(25)).await;
@@ -1111,13 +1172,19 @@ mod tests {
         })
         .await;
         assert!(
-            landed.is_ok(),
-            "remote delta was not merged by start() loop"
+            claim_applied.is_ok(),
+            "unsigned publish must still reach checkbox admission"
         );
-        // Confirm it's the right task, not just any count bump.
+
+        // …but the unsigned content must NOT land (I2).
         assert!(
-            sync.read().await.get_task(&task_id).is_some(),
-            "merged task must be retrievable by id"
+            sync.read().await.get_task(&new_task_id).is_none(),
+            "unsigned (anonymous-sender) publish must not create a task (I2)"
+        );
+        assert_eq!(
+            sync.read().await.task_count(),
+            1,
+            "only the locally seeded task is present"
         );
     }
 
@@ -1216,8 +1283,10 @@ mod tests {
     /// still gets asked.
     #[tokio::test(start_paused = true)]
     async fn single_incremental_delta_does_not_stop_recovery() {
-        let node = make_node().await;
-        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        // Signed pubsub (Layer A, issue #349): the bait delta and the late
+        // holder's serves must carry an envelope-verified writer or the
+        // listener drops their content.
+        let pubsub = signed_pubsub().await;
         let topic = "tasks-238-bait";
 
         let joiner_list = TaskList::new(list_id(1), "Test List".to_string(), peer(2));
@@ -1285,8 +1354,9 @@ mod tests {
     /// moments.
     #[tokio::test(start_paused = true)]
     async fn requester_recovers_when_holder_returns_after_old_hard_cap() {
-        let node = make_node().await;
-        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        // Signed pubsub (Layer A, issue #349): the holder's serve must carry
+        // an envelope-verified writer or the listener drops its content.
+        let pubsub = signed_pubsub().await;
         let topic = "tasks-238-zombie";
 
         // Empty joiner: subscribes and starts requesting into the void.
@@ -1473,8 +1543,10 @@ mod tests {
     /// state arrives.
     #[tokio::test(start_paused = true)]
     async fn lost_full_delta_with_surviving_marker_keeps_requester_asking() {
-        let node = make_node().await;
-        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        // Signed pubsub (Layer A, issue #349): the holder's full serve must
+        // carry an envelope-verified writer or the listener drops its
+        // content.
+        let pubsub = signed_pubsub().await;
         let topic = "tasks-240-lost-broadcast";
         let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
 
@@ -1515,7 +1587,7 @@ mod tests {
         joiner
             .write()
             .await
-            .merge_delta(&t2_only, peer(1))
+            .merge_delta(&t2_only, peer(1), Some(&agent(1)))
             .expect("seed t2");
 
         // The loss window: the marker survives, the full delta does not.
@@ -1621,7 +1693,8 @@ mod tests {
         };
         {
             let mut l = joiner.write().await;
-            l.merge_delta(&t1_only, peer(1)).expect("seed t1");
+            l.merge_delta(&t1_only, peer(1), Some(&agent(1)))
+                .expect("seed t1");
             l.add_task(make_task(9, peer(2)), peer(2), 1)
                 .expect("seed stale task");
         }
@@ -1711,8 +1784,11 @@ mod tests {
     /// v2 markers to make progress against old peers.
     #[tokio::test(start_paused = true)]
     async fn v1_marker_from_old_peer_still_converges() {
-        let node = make_node().await;
-        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        // Signed pubsub (Layer A, issue #349): the full delta on the main
+        // topic must carry an envelope-verified writer; the v1/v2 question
+        // this test exercises is the SIDE-topic marker format, which stays
+        // a raw v1 StateServed below.
+        let pubsub = signed_pubsub().await;
         let topic = "tasks-240-v1-compat";
         let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
 
@@ -1776,8 +1852,10 @@ mod tests {
     /// latest-wins).
     #[tokio::test(start_paused = true)]
     async fn tampered_digest_is_rejected_and_does_not_wedge_recovery() {
-        let node = make_node().await;
-        let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
+        // Signed pubsub (Layer A, issue #349): the genuine holder's serve
+        // must carry an envelope-verified writer; the tampered marker is
+        // still published as a raw side-topic payload.
+        let pubsub = signed_pubsub().await;
         let topic = "tasks-240-tampered";
         let side = format!("{topic}{STATE_SYNC_TOPIC_SUFFIX}");
 
@@ -1861,7 +1939,9 @@ mod tests {
         // The replica absorbs a first full serve (both tasks).
         let mut replica = TaskList::new(list_id(1), "List".to_string(), peer(2));
         let s1 = holder.full_delta();
-        replica.merge_delta(&s1, peer(1)).expect("serve 1");
+        replica
+            .merge_delta(&s1, peer(1), Some(&agent(1)))
+            .expect("serve 1");
         assert_eq!(replica.task_count(), 2);
 
         // The holder deletes the task; the next VERIFIED serve prunes it
@@ -1874,7 +1954,9 @@ mod tests {
             Some(holder.served_digest()),
             "the serve must carry the holder's declared digest"
         );
-        replica.merge_delta(&s2, peer(1)).expect("serve 2");
+        replica
+            .merge_delta(&s2, peer(1), Some(&agent(1)))
+            .expect("serve 2");
         assert_eq!(replica.prune_to_served_set(&s2), 1);
         assert!(replica.get_task(&doomed).is_none());
 
@@ -1885,7 +1967,9 @@ mod tests {
             .add_task(make_task(2, peer(1)), peer(1), 3)
             .expect("re-add");
         let s3 = holder.full_delta();
-        replica.merge_delta(&s3, peer(1)).expect("serve 3");
+        replica
+            .merge_delta(&s3, peer(1), Some(&agent(1)))
+            .expect("serve 3");
         assert!(
             replica.get_task(&doomed).is_some(),
             "a re-served task must be accepted after a prune"

--- a/src/crdt/task_item.rs
+++ b/src/crdt/task_item.rs
@@ -742,6 +742,51 @@ impl TaskItem {
         Ok(())
     }
 
+    /// Checkbox-only merge (issue #349, Layer A).
+    ///
+    /// Unions the checkbox OR-Set and the attestation map, then runs the
+    /// same provenance admission gate as [`Self::merge`] — WITHOUT merging
+    /// the title/description/assignee/priority LWW registers (their clocks
+    /// are never even considered). Used by the delta path when the
+    /// envelope-verified writer is absent or not an authorized member:
+    /// unauthenticated content fields must not land, while an attested
+    /// Claimed/Done on an existing task still converges (checkbox admission
+    /// is gated by `OpAttestation`, not by the envelope writer).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the tasks have different IDs or the checkbox
+    /// OR-Set merge fails.
+    pub fn merge_checkbox_only(&mut self, scope: TaskListId, other: &TaskItem) -> Result<()> {
+        if self.id != other.id {
+            return Err(CrdtError::Merge(format!(
+                "Cannot merge tasks with different IDs: {} != {}",
+                self.id, other.id
+            )));
+        }
+
+        self.checkbox
+            .merge_state(&other.checkbox)
+            .map_err(|e| CrdtError::Merge(format!("Failed to merge checkbox states: {}", e)))?;
+
+        for (state, att) in &other.attestations {
+            self.attestations
+                .entry(state.clone())
+                .or_insert_with(|| att.clone());
+        }
+
+        let dropped =
+            purge_unattested_elements(&scope, &self.id, &mut self.checkbox, &mut self.attestations);
+        if dropped > 0 {
+            tracing::debug!(
+                dropped,
+                "purged unauthenticated task checkbox elements during checkbox-only merge"
+            );
+        }
+
+        Ok(())
+    }
+
     /// Fail-closed admission gate: purge every checkbox element and attestation
     /// entry whose attestation is missing or fails verification for `scope`.
     ///
@@ -1843,7 +1888,11 @@ mod tests {
         delta.added_tasks.insert(task_id, (forged, (peer(1), 1)));
 
         let mut receiver = crate::crdt::TaskList::new(id, "L".to_string(), peer(2));
-        receiver.merge_delta(&delta, peer(1)).unwrap();
+        // Layer A (issue #349): a writer is required for the first-seen add
+        // itself; the forged CLAIM inside it must still be purged.
+        receiver
+            .merge_delta(&delta, peer(1), Some(&agent(1)))
+            .unwrap();
 
         let t = receiver.get_task(&task_id).expect("task admitted");
         assert!(
@@ -1866,7 +1915,9 @@ mod tests {
         delta.task_updates.insert(task_id, forged);
 
         let mut receiver = crate::crdt::TaskList::new(id, "L".to_string(), peer(2));
-        receiver.merge_delta(&delta, peer(3)).unwrap();
+        receiver
+            .merge_delta(&delta, peer(3), Some(&agent(1)))
+            .unwrap();
 
         let t = receiver
             .get_task(&task_id)
@@ -1893,7 +1944,9 @@ mod tests {
         let snapshot = holder.full_delta();
 
         let mut joiner = crate::crdt::TaskList::new(id, String::new(), peer(2));
-        joiner.merge_delta(&snapshot, peer(1)).unwrap();
+        joiner
+            .merge_delta(&snapshot, peer(1), Some(&agent(1)))
+            .unwrap();
 
         let t = joiner.get_task(&task_id).expect("task transferred");
         assert!(
@@ -1924,7 +1977,9 @@ mod tests {
             delta.added_tasks.insert(task_id, (forged, (peer(1), 1)));
 
             let mut receiver = crate::crdt::TaskList::new(id, "L".to_string(), peer(2));
-            receiver.merge_delta(&delta, peer(1)).unwrap();
+            receiver
+                .merge_delta(&delta, peer(1), Some(&agent(1)))
+                .unwrap();
 
             let t = receiver
                 .get_task(&task_id)
@@ -1961,7 +2016,7 @@ mod tests {
         delta.added_tasks.insert(task_id, (task, (p, 1)));
 
         let mut receiver = crate::crdt::TaskList::new(id, "L".to_string(), peer(2));
-        receiver.merge_delta(&delta, p).unwrap();
+        receiver.merge_delta(&delta, p, Some(&agent(1))).unwrap();
 
         let t = receiver.get_task(&task_id).expect("valid task admitted");
         assert!(

--- a/src/crdt/task_list.rs
+++ b/src/crdt/task_list.rs
@@ -181,6 +181,21 @@ impl TaskList {
         self.authorized_agents = None;
     }
 
+    /// Whether an envelope-verified writer may apply content fields
+    /// (add / metadata LWW / name / order / remove) during a delta merge.
+    ///
+    /// "Member may edit": open (any writer) when no authorized set is
+    /// configured; otherwise the writer must be a member. The payload
+    /// `PeerId` is never consulted here — it is an OR-Set uniqueness tag,
+    /// not an identity (issue #349, invariant I3).
+    #[must_use]
+    pub(crate) fn is_authorized_content_writer(&self, writer: &AgentId) -> bool {
+        match &self.authorized_agents {
+            None => true,
+            Some(members) => members.contains(writer),
+        }
+    }
+
     /// Get the current version counter.
     ///
     /// Incremented on every effective local snapshot change — local mutations
@@ -462,6 +477,30 @@ impl TaskList {
         let authorized = self.authorized_agents.clone();
         if let Some(existing) = self.task_data.get_mut(task_id) {
             existing.merge(scope, other)?;
+            if let Some(members) = &authorized {
+                let _dropped = existing.filter_unauthorized(members);
+            }
+        }
+        Ok(())
+    }
+
+    /// Checkbox-only variant of [`Self::delta_merge_task`] (issue #349,
+    /// Layer A): unions checkbox state + attestations into the EXISTING
+    /// local task, then applies the provenance and membership admission
+    /// gates, without merging any unauthenticated content field
+    /// (title/description/assignee/priority LWW). Does NOT bump version
+    /// (deferred to `commit_revision_if_changed`). No-op if the task does
+    /// not exist locally — a first-seen task is never created by this path.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn delta_merge_checkbox_only(
+        &mut self,
+        task_id: &TaskId,
+        other: &TaskItem,
+    ) -> Result<()> {
+        let scope = self.id;
+        let authorized = self.authorized_agents.clone();
+        if let Some(existing) = self.task_data.get_mut(task_id) {
+            existing.merge_checkbox_only(scope, other)?;
             if let Some(members) = &authorized {
                 let _dropped = existing.filter_unauthorized(members);
             }
@@ -1156,8 +1195,13 @@ mod tests {
             list_a.current_version(),
         );
 
-        // B applies the delta over the gossip path.
-        list_b.merge_delta(&delta, peer1).unwrap();
+        // B applies the delta over the gossip path. Writer=None is
+        // deliberate (issue #349, Layer A): the task already exists locally
+        // and the claim carries its own OpAttestation, so checkbox
+        // admission must still run and the claim must still advance the
+        // version — anonymous content fields are dropped, attested claims
+        // are not.
+        list_b.merge_delta(&delta, peer1, None).unwrap();
         assert!(
             list_b
                 .get_task(&task_id)

--- a/tests/crdt_partition_tolerance.rs
+++ b/tests/crdt_partition_tolerance.rs
@@ -97,12 +97,26 @@ fn wait_until_clock_after(timestamp: u64) {
 }
 
 fn anti_entropy_callback(
-    target: Arc<AntiEntropyManager<TaskList>>,
+    replica: Arc<RwLock<TaskList>>,
     sender: PeerId,
+    writer: AgentId,
 ) -> impl Fn(PeerId, TaskListDelta) -> AntiEntropyFuture + Send + Sync + 'static {
     move |_target_peer, delta| {
-        let target = Arc::clone(&target);
-        Box::pin(async move { target.apply_delta(sender, &delta, delta.version).await })
+        let replica = Arc::clone(&replica);
+        let writer = writer;
+        Box::pin(async move {
+            // #349 Layer A: the manager's `apply_delta` merges writer-less
+            // (`DeltaCrdt::merge` has no envelope channel), which fail-closes
+            // content. This in-memory channel stands in for the signed gossip
+            // envelope, so apply through TaskList's authorized seam with the
+            // keypair-derived writer that channel implies. Skipping the
+            // manager here is behavior-preserving: its `apply_delta` only
+            // merges writer-less plus a peer-registry `or_insert(0)` that
+            // `add_peer` already satisfied.
+            let mut list = replica.write().await;
+            list.merge_delta(&delta, sender, Some(&writer))?;
+            Ok(())
+        })
     }
 }
 
@@ -187,9 +201,12 @@ async fn test_anti_entropy_repairs_dropped_delta() -> Result<()> {
     }
 
     let delivered_delta = generated_delta(&replica_a, 0).await?;
-    anti_entropy_b
-        .apply_delta(peer_a, &delivered_delta, delivered_delta.version)
-        .await?;
+    // Authorized seam, same rationale as the callback below (#349 Layer A):
+    // the manager's writer-less apply_delta would silently drop this content.
+    {
+        let mut b = replica_b.write().await;
+        b.merge_delta(&delivered_delta, peer_a, Some(&agent_id(1)))?;
+    }
 
     {
         let mut a = replica_a.write().await;
@@ -211,12 +228,19 @@ async fn test_anti_entropy_repairs_dropped_delta() -> Result<()> {
     }
 
     anti_entropy_a
-        .start(anti_entropy_callback(Arc::clone(&anti_entropy_b), peer_a))
+        .start(anti_entropy_callback(
+            Arc::clone(&replica_b),
+            peer_a,
+            agent_id(1),
+        ))
         .await?;
     anti_entropy_b
-        .start(anti_entropy_callback(Arc::clone(&anti_entropy_a), peer_b))
+        .start(anti_entropy_callback(
+            Arc::clone(&replica_a),
+            peer_b,
+            agent_id(2),
+        ))
         .await?;
-
     let required_tasks = [task_id(1), task_id(2), task_id(3)];
     let converged = wait_for_convergence(&replica_a, &replica_b, &required_tasks).await;
 

--- a/tests/named_group_integration.rs
+++ b/tests/named_group_integration.rs
@@ -154,6 +154,25 @@ async fn group_state(d: &AgentInstance, group_id: &str) -> Option<Value> {
     Some(resp.json().await.unwrap_or_default())
 }
 
+/// Wait (bounded) for a path to be removed. The withdrawn/banned state flag
+/// can become observable through the API before the TreeKEM snapshot file
+/// delete completes, so an immediate `try_exists` assert races on slower CI
+/// disks — a flake class seen twice on CI (2026-08-19, two different tests,
+/// same assertion shape). Bounded: a file that genuinely survives fails with
+/// the caller's message after the timeout.
+async fn wait_until_gone(path: &std::path::Path, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Ok(false) = tokio::fs::try_exists(path).await {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
 // ===========================================================================
 // 1. Create Named Group
 // ===========================================================================
@@ -1865,13 +1884,13 @@ async fn named_group_admin_delete_propagates_to_peer_after_creator_delete_409() 
         "deleter authoring must be rejected after withdrawal"
     );
     assert!(
-        !tokio::fs::try_exists(
-            bob.data_dir()
+        wait_until_gone(
+            &bob.data_dir()
                 .join("treekem")
-                .join(format!("{bob_group_id}.snap"))
+                .join(format!("{bob_group_id}.snap")),
+            Duration::from_secs(10)
         )
-        .await
-        .unwrap_or(false),
+        .await,
         "deleting admin TreeKEM snapshot should be wiped"
     );
 
@@ -1897,14 +1916,14 @@ async fn named_group_admin_delete_propagates_to_peer_after_creator_delete_409() 
         "recipient authoring must be rejected after withdrawal"
     );
     assert!(
-        !tokio::fs::try_exists(
-            alice
+        wait_until_gone(
+            &alice
                 .data_dir()
                 .join("treekem")
-                .join(format!("{group_id}.snap"))
+                .join(format!("{group_id}.snap")),
+            Duration::from_secs(10)
         )
-        .await
-        .unwrap_or(false),
+        .await,
         "recipient TreeKEM snapshot should be wiped after GroupDeleted"
     );
 }
@@ -2298,13 +2317,13 @@ async fn group_deleted_lost_initial_volley_recovers_via_bounded_resend() {
         "recipient authoring must be rejected after a resent GroupDeleted"
     );
     assert!(
-        !tokio::fs::try_exists(
-            bob.data_dir()
+        wait_until_gone(
+            &bob.data_dir()
                 .join("treekem")
-                .join(format!("{bob_group_id}.snap"))
+                .join(format!("{bob_group_id}.snap")),
+            Duration::from_secs(10)
         )
-        .await
-        .unwrap_or(false),
+        .await,
         "recipient TreeKEM snapshot must be wiped by a resent GroupDeleted"
     );
 }
@@ -2382,13 +2401,13 @@ async fn member_banned_lost_initial_volley_recovers_via_bounded_resend() {
     // Terminalization must be real, not just a roster flag: applying your own
     // ban tears down the local TreeKEM group and wipes its persistence.
     assert!(
-        !tokio::fs::try_exists(
-            bob.data_dir()
+        wait_until_gone(
+            &bob.data_dir()
                 .join("treekem")
-                .join(format!("{bob_group_id}.snap"))
+                .join(format!("{bob_group_id}.snap")),
+            Duration::from_secs(10)
         )
-        .await
-        .unwrap_or(false),
+        .await,
         "banned member's TreeKEM snapshot must be wiped by a resent MemberBanned"
     );
 


### PR DESCRIPTION
## Layer A only — do not close #349

Replaces the rejected `2c95349` gate. That commit compared `sender.as_bytes() == peer_id.as_bytes()` (payload `PeerId` is an OR-Set tag, never identity), treated `writer == None` as `UnsignedAccepted` warn+merge, left `merge_delta` two-arg, and was a listener-only gate. A signed member wrapping a forgery in their own `peer_id` would have been `Authorized`. Unsigned accept-and-warn is **not** a David override; design as written is fail-closed.

This PR is **Layer A only** (clone KV). **Layer B is HOLD** (content `OpKind`s, content attestations, LWW-clock binding). **Do not close #349 on A.**

## The bug

The task-list apply path merged `added_tasks`, metadata LWW, `name_update`, `ordering_update`, and `removed_tasks` under the self-declared payload `PeerId` from `decode_delta` and never consulted the V2-envelope-verified `msg.sender` (`AgentId`). Any current member could attribute create/rename/reassign/reorder/remove to another member.

## The fix (Layer A)

```text
TaskList::merge_delta(&mut self, delta, peer_id /* tag only */, writer: Option<&AgentId>)
TaskListSync::apply_remote_delta(peer_id, delta, writer)
listener: let writer = msg.sender.as_ref(); list.merge_delta(&delta, peer_id, writer)
```

- **I3:** payload `PeerId` is never identity. Never compare `PeerId` bytes to `AgentId` bytes.
- **I2:** `writer == None` drops all unauthenticated content (add / metadata LWW / name / order / remove). KV-style silent reject (`Ok(())` + warn). Not warn-and-merge.
- **I8:** if `authorized_agents` is `Some`, `writer` must be in that set or the same content fields are dropped. Member-may-edit, not creator-only.
- Checkbox claim/complete still run via `OpAttestation` when content is dropped (existing task only; no first-seen insert from an unauthenticated add).
- `DeltaCrdt::merge` is not a production untrusted-apply path: it passes `None`.
- Production apply is KV-style: `writer = msg.sender` into merge, not a listener-only gate.

## Tests

- `merge_delta_spoofed_payload_peer_id_is_not_identity` — same-bytes payload tag does not grant identity; writer AgentId is the gate
- `merge_delta_anonymous_writer_drops_content_but_admits_attested_claim` — I2 + checkbox still converges
- `merge_delta_honest_writer_content_applies` — verified Alice applies add/name/order/remove
- `merge_delta_membership_gates_unauthorized_writer_content` — non-member dropped, member applies
- `start_default_spawner_merges_remote_delta` — unsigned publish is not a content success
- `apply_remote_delta_merges_task_into_list` — honest path passes `Some(&alice)`
- `test_delta_crdt_trait_merge` — unsigned trait merge applies no content

## Out of scope

- No new `OpKind`s, no content attestations, no LWW-clock binding (Layer B HOLD)
- No `KvStore` / KV writer-policy changes
- No `(PeerId, Delta)` wire / #240 digest-math / checkbox domain changes
- Reliability PRs and #355 left alone
- **Do not close #349**