### PR TITLE
fix(kv): fail-closed reserved Encrypted policy (#341 Phase A)

### DIFF
--- a/src/kv/delta.rs
+++ b/src/kv/delta.rs
@@ -136,10 +136,11 @@ impl DeltaCrdt for KvStore {
 
     fn merge(&mut self, delta: &Self::Delta) -> anyhow::Result<()> {
         let peer_id = PeerId::new([0u8; 32]);
-        // Anti-entropy merges don't carry writer identity. Signed/Allowlisted
-        // stores rely on the main sync path in KvStoreSync to provide the
-        // writer identity; Encrypted is currently a reserved policy shape, not
-        // transport confidentiality for KvStore deltas.
+        // Anti-entropy merges don't carry writer identity, so they apply NO
+        // content under any policy (including the reserved Encrypted one —
+        // #341 Phase A): Signed/Allowlisted/AppendOnly stores rely on the
+        // main sync path in KvStoreSync, which threads the verified gossip
+        // envelope sender as the writer.
         self.merge_delta(delta, peer_id, None)
             .map_err(|e| anyhow::anyhow!("KvStore delta merge failed: {e}"))
     }
@@ -205,7 +206,8 @@ mod tests {
         let id = store_id(1);
 
         // Allowlisted store so both agents can write
-        let mut store = KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Allowlisted);
+        let mut store = KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Allowlisted)
+            .expect("kv store");
         store.allow_writer(writer, &owner).expect("allow");
 
         let entry = KvEntry::new(
@@ -226,11 +228,13 @@ mod tests {
     fn test_merge_delta_with_name_update() {
         let owner = agent(1);
         let id = store_id(1);
-        let mut store = KvStore::new(id, "Original".to_string(), owner, AccessPolicy::Signed);
+        let mut store = KvStore::new(id, "Original".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
 
         // A peer renames the store on top of the shared initial state; its
         // name register causally dominates ours, so the LWW merge adopts it.
-        let mut other = KvStore::new(id, "Original".to_string(), owner, AccessPolicy::Signed);
+        let mut other = KvStore::new(id, "Original".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         other.update_name("Updated".to_string(), peer(1));
 
         let mut delta = KvStoreDelta::new(1);
@@ -244,26 +248,19 @@ mod tests {
 
     #[test]
     fn test_delta_crdt_trait() {
+        // #341 Phase A (I3): this test used to construct Encrypted stores so
+        // the trait's writer-less merge would apply content. Encrypted is
+        // reserved now — no policy is an anonymous-merge escape hatch. The
+        // trait merge must apply NOTHING unsigned; applying real content
+        // goes through merge_delta with the verified writer, exactly like
+        // the production sync path.
         let owner = agent(1);
         let id = store_id(1);
 
-        // DeltaCrdt trait uses merge(None) — use Encrypted policy to allow it
-        let mut s1 = KvStore::new(
-            id,
-            "Store".to_string(),
-            owner,
-            AccessPolicy::Encrypted {
-                group_id: vec![1, 2, 3],
-            },
-        );
-        let mut s2 = KvStore::new(
-            id,
-            "Store".to_string(),
-            owner,
-            AccessPolicy::Encrypted {
-                group_id: vec![1, 2, 3],
-            },
-        );
+        let mut s1 =
+            KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed).expect("kv store");
+        let mut s2 =
+            KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed).expect("kv store");
 
         s2.put(
             "key".to_string(),
@@ -274,8 +271,20 @@ mod tests {
         .expect("put");
 
         let delta = DeltaCrdt::delta(&s2, 0).expect("delta");
-        DeltaCrdt::merge(&mut s1, &delta).expect("merge");
 
+        // Anonymous trait merge: returns Ok but applies no content.
+        DeltaCrdt::merge(&mut s1, &delta).expect("merge");
+        assert!(
+            s1.get("key").is_none(),
+            "writer-less DeltaCrdt::merge must not apply content"
+        );
+        assert_eq!(DeltaCrdt::version(&s1), 0, "no state change");
+
+        // The same delta applies once the writer is supplied — this is the
+        // path KvStoreSync uses (envelope sender as writer).
+        s1.merge_delta(&delta, peer(2), Some(&owner))
+            .expect("owner merge");
+        assert!(s1.get("key").is_some());
         assert!(DeltaCrdt::version(&s1) > 0);
     }
 

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -88,6 +88,21 @@ pub enum KvError {
     /// an idempotent no-op and never raises this error.)
     #[error("immutable key: {0} — append-only store; existing keys cannot be updated or deleted")]
     ImmutableKey(String),
+
+    /// Construction or local write on the reserved `Encrypted` policy.
+    ///
+    /// `AccessPolicy::Encrypted` names a group-scoped confidential store,
+    /// but the secure sync path (seal/open, group membership) is not wired
+    /// yet — a live replica would gossip plaintext deltas while authorizing
+    /// every writer. Until that lands (#341 Phase B), the policy is
+    /// unconstructible via ordinary constructors and fail-closed on any
+    /// replica that already carries it. Never mapped to `OwnerUnknown`:
+    /// this is a reserved-policy rejection, not a missing ownership anchor.
+    #[error("encrypted policy reserved: group_id={group_id:?} — AccessPolicy::Encrypted is not constructible until secure sync is wired")]
+    EncryptedPolicyReserved {
+        /// The group id the reserved policy carried.
+        group_id: Vec<u8>,
+    },
 }
 
 #[cfg(test)]
@@ -131,6 +146,22 @@ mod tests {
         assert!(display.contains("immutable key"));
         assert!(display.contains("evt-0001"));
         assert!(display.contains("append-only"));
+    }
+
+    #[test]
+    fn test_error_display_encrypted_policy_reserved() {
+        // WHY: the reserved-policy rejection must be self-explanatory at the
+        // call site — the variant name alone is invisible to logs and API
+        // clients. The display carries the group id and the reason Encrypted
+        // refuses to construct.
+        let error = KvError::EncryptedPolicyReserved {
+            group_id: vec![1, 2, 3],
+        };
+        let display = format!("{error}");
+        assert!(display.contains("encrypted policy reserved"));
+        assert!(display.contains("[1, 2, 3]"));
+        assert!(display.contains("not constructible"));
+        assert!(display.contains("secure sync"));
     }
 
     #[test]

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -43,7 +43,7 @@ pub enum AccessPolicy {
     /// Reserved for group-scoped encrypted stores.
     ///
     /// The variant is **unconstructible** through ordinary constructors
-    /// ([`KvStore::new`](Self::new) returns
+    /// ([`KvStore::new`] returns
     /// [`KvError::EncryptedPolicyReserved`]) and **fail-closed** on any
     /// replica that already carries it: the sync path still publishes
     /// plaintext deltas and enforces no group membership, so until encrypted
@@ -1413,16 +1413,31 @@ impl KvStore {
     /// cold-recover a Signed store from a non-owner replica while the owner is
     /// offline.
     ///
-    /// Returns `false` otherwise (unanchored, bad sig/owner, stale seq,
-    /// cross-store, entry integrity failure, root mismatch / incremental
-    /// delta / tamper), in which case [`merge_delta`] falls through to the
-    /// normal sender-auth path. Never establishes ownership (anchor gate).
+    /// Returns `false` otherwise (unanchored, reserved Encrypted policy,
+    /// bad sig/owner, stale seq, cross-store, entry integrity failure,
+    /// root mismatch / incremental delta / tamper), in which case
+    /// [`merge_delta`] falls through to the normal sender-auth path. Never
+    /// establishes ownership (anchor gate).
     fn try_adopt_full_snapshot(
         &mut self,
         delta: &KvStoreDelta,
         peer_id: PeerId,
         cp: &OwnerCheckpoint,
     ) -> bool {
+        // 0. Reserved Encrypted policy is fail-closed (#341 Phase A, I1):
+        //    this path runs in merge_delta BEFORE the sender-auth check, so
+        //    without this gate a genuine owner checkpoint would apply its
+        //    plaintext entries and refresh the policy in step 10 — flipping
+        //    the replica Encrypted→Signed and re-opening every write path.
+        if let AccessPolicy::Encrypted { group_id } = &self.policy {
+            tracing::warn!(
+                target: "x0x::kv",
+                "rejected owner checkpoint for encrypted store {} (group_id {}) — secure sync is not wired",
+                self.id,
+                hex::encode(group_id)
+            );
+            return false;
+        }
         // 1. Anchor gate: never learn the owner from a relay.
         let Some(expected_owner) = self.owner else {
             tracing::warn!("rejected owner checkpoint for unanchored store {}", self.id);
@@ -2760,6 +2775,59 @@ mod tests {
 
         assert_eq!(dest.current_version(), v_before, "no state change at all");
         assert!(dest.is_empty(), "forced Encrypted replica stays empty");
+    }
+
+    #[test]
+    fn encrypted_replica_rejects_owner_checkpoint_adoption() {
+        // WHY (#341 Phase A, I1): checkpoint adoption runs in merge_delta
+        // BEFORE the sender-auth check, so `try_adopt_full_snapshot` is the
+        // one write path the is_authorized fail-closed arm never sees. A
+        // forced Encrypted replica (legacy/deserialized state) receiving a
+        // delta with a GENUINE owner checkpoint must not adopt: adoption
+        // would apply the plaintext entries and refresh the policy in
+        // step 10 — silently flipping Encrypted→Signed and re-opening
+        // every write path the reservation closed.
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let topic = "store/enc-adopt";
+        let id = KvStoreId::for_topic_owner(topic, &owner);
+
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
+        owner_store
+            .put(
+                "k".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+        let cp = checkpoint_for(&owner_store, topic, &kp, 1);
+        let mut delta = owner_store.full_delta();
+        delta.owner_checkpoint = Some(cp);
+
+        let mut dest = KvStore::new_encrypted_unchecked(id, String::new(), owner, vec![1, 2, 3]);
+        let v_before = dest.current_version();
+        dest.merge_delta(&delta, peer(9), Some(&owner))
+            .expect("silent reject, not an error");
+        assert!(
+            dest.get("k").is_none(),
+            "owner checkpoint must not apply its plaintext entries"
+        );
+        assert!(dest.is_empty(), "forced Encrypted replica stays empty");
+        assert!(
+            matches!(dest.policy, AccessPolicy::Encrypted { .. }),
+            "policy must stay Encrypted, not flip to Signed"
+        );
+        assert!(
+            dest.latest_checkpoint.is_none(),
+            "checkpoint must not be cached"
+        );
+        assert_eq!(
+            dest.highest_checkpoint_seq, 0,
+            "high-water mark must stay untouched"
+        );
+        assert_eq!(dest.current_version(), v_before, "no state change at all");
     }
 
     #[test]

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -9,9 +9,12 @@
 //!   from non-owners are rejected. Use for app stores, agent skill registries.
 //! - **Allowlisted**: Only explicitly allowed writers can write. The owner
 //!   manages the allowlist. Use for team workspaces, private swarms.
-//! - **Encrypted**: Reserved for group-scoped encrypted stores. The current
-//!   KvStore sync path does not encrypt deltas; do not rely on this policy for
-//!   confidentiality until encrypted sync is wired.
+//! - **Encrypted**: Reserved for group-scoped encrypted stores. Reserved
+//!   means reserved: [`KvStore::new`] refuses to construct one (returning
+//!   [`KvError::EncryptedPolicyReserved`]), and a replica that already
+//!   carries the policy (e.g. deserialized legacy state) fails closed — no
+//!   authorized writer, no local writes, no delta application — until
+//!   encrypted sync is wired.
 //! - **AppendOnly**: Like `Signed` (owner-only writes), but existing keys are
 //!   immutable — no update, no delete, even by the owner. Use for
 //!   tamper-evident event logs where the author must not be able to rewrite
@@ -39,9 +42,14 @@ pub enum AccessPolicy {
 
     /// Reserved for group-scoped encrypted stores.
     ///
-    /// The current KvStore sync path still publishes plaintext deltas and does
-    /// not enforce group membership by itself. Do not rely on this variant for
-    /// confidentiality until encrypted sync is wired.
+    /// The variant is **unconstructible** through ordinary constructors
+    /// ([`KvStore::new`](Self::new) returns
+    /// [`KvError::EncryptedPolicyReserved`]) and **fail-closed** on any
+    /// replica that already carries it: the sync path still publishes
+    /// plaintext deltas and enforces no group membership, so until encrypted
+    /// sync is wired the name must not promise confidentiality. The variant
+    /// itself stays (bincode discriminant 2 is pinned on disk and on the
+    /// wire).
     Encrypted {
         /// MLS group ID for this store.
         group_id: Vec<u8>,
@@ -645,14 +653,32 @@ impl KvStore {
     /// This is the **creator** path: ownership is anchored on `owner` at
     /// construction (channel [`AnchorChannel::Creator`]) and is immutable for
     /// the life of the store.
-    #[must_use]
-    pub fn new(id: KvStoreId, name: String, owner: AgentId, policy: AccessPolicy) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// [`KvError::EncryptedPolicyReserved`] if `policy` is
+    /// [`AccessPolicy::Encrypted`]: the secure sync path is not wired yet,
+    /// so an Encrypted replica would gossip plaintext while authorizing
+    /// every writer. The name must not over-promise — the variant stays
+    /// reserved (and deserialized replicas fail closed) until that lands.
+    pub fn new(id: KvStoreId, name: String, owner: AgentId, policy: AccessPolicy) -> Result<Self> {
+        if let AccessPolicy::Encrypted { group_id } = &policy {
+            tracing::warn!(
+                target: "x0x::kv",
+                "refused to construct store {} with reserved encrypted policy (group_id {}) — secure sync is not wired; use a Signed/Allowlisted/AppendOnly store until then",
+                id,
+                hex::encode(group_id)
+            );
+            return Err(KvError::EncryptedPolicyReserved {
+                group_id: group_id.clone(),
+            });
+        }
         let mut name_reg = LwwRegister::new(name.clone());
         // Stamp the creator-set name with a non-empty clock so it wins LWW
         // merge against replicas initialized with empty names and empty
         // clocks (which would otherwise be concurrent and hash-tiebroken).
         name_reg.set(name, PeerId::new(owner.0));
-        Self {
+        Ok(Self {
             id,
             keys: OrSet::new(),
             entries: HashMap::new(),
@@ -667,7 +693,30 @@ impl KvStore {
             allowed_writers: HashSet::new(),
             version: 0,
             seq_counter: Arc::new(AtomicU64::new(0)),
-        }
+        })
+    }
+
+    /// Force-build a live replica carrying the reserved
+    /// [`AccessPolicy::Encrypted`] policy, bypassing the [`new`](Self::new)
+    /// reservation guard.
+    ///
+    /// **Test-only by design** (`#[cfg(test)]`, #341 Phase A): it exists
+    /// solely so the fail-closed arms (`is_authorized`,
+    /// `authorize_local_write`, `merge_delta`) can be proven against a
+    /// replica that no ordinary constructor will build anymore. The only
+    /// production-shaped way such a replica can exist is deserializing
+    /// legacy state (snapshot/wire), which hits the same fail-closed paths.
+    #[cfg(test)]
+    pub(crate) fn new_encrypted_unchecked(
+        id: KvStoreId,
+        name: String,
+        owner: AgentId,
+        group_id: Vec<u8>,
+    ) -> Self {
+        let mut store = Self::new(id, name, owner, AccessPolicy::Signed)
+            .expect("Signed policy is always constructible");
+        store.policy = AccessPolicy::Encrypted { group_id };
+        store
     }
 
     /// Create a joined replica of a store, anchoring ownership from trusted
@@ -844,10 +893,11 @@ impl KvStore {
                     || self.allowed_writers.contains(agent_id)
             }
             AccessPolicy::Encrypted { .. } => {
-                // Reserved for encrypted sync. The store layer currently treats
-                // this as permissive; group membership enforcement belongs in
-                // the secure sync path once wired.
-                true
+                // Reserved for encrypted sync — fail closed (#341 Phase A):
+                // the sync path still carries plaintext deltas and no group
+                // membership check exists, so nobody is authorized on an
+                // Encrypted replica until the secure sync path is wired.
+                false
             }
             AccessPolicy::AppendOnly => {
                 // Owner-only writes, exactly like Signed. Immutability of
@@ -869,16 +919,29 @@ impl KvStore {
     ///
     /// # Errors
     ///
+    /// - [`KvError::EncryptedPolicyReserved`] if the store carries the
+    ///   reserved [`AccessPolicy::Encrypted`] policy: secure sync is not
+    ///   wired, so no local write may mutate such a replica (fail closed).
     /// - [`KvError::OwnerUnknown`] if the store has a policy-restricted
     ///   (`Signed`/`Allowlisted`) policy but its authoritative owner has not
     ///   been learned yet (a freshly joined replica). Fail closed.
     /// - [`KvError::Unauthorized`] if `writer` is not authorized under the
     ///   store's policy.
     pub fn authorize_local_write(&self, writer: &AgentId) -> Result<()> {
-        if matches!(self.policy, AccessPolicy::Encrypted { .. }) {
-            // Matches the inbound path: the reserved Encrypted policy is
-            // currently permissive at the store layer.
-            return Ok(());
+        if let AccessPolicy::Encrypted { group_id } = &self.policy {
+            // Matches the inbound path: the reserved Encrypted policy
+            // authorizes nobody until secure sync is wired. Fail closed,
+            // loudly — never `OwnerUnknown`, this is not an ownership issue.
+            tracing::warn!(
+                target: "x0x::kv",
+                "refused local write by {} on reserved encrypted store {} (group_id {}) — secure sync is not wired",
+                hex::encode(writer.as_bytes()),
+                self.id,
+                hex::encode(group_id)
+            );
+            return Err(KvError::EncryptedPolicyReserved {
+                group_id: group_id.clone(),
+            });
         }
         let Some(owner) = self.owner.as_ref() else {
             return Err(KvError::OwnerUnknown);
@@ -1198,19 +1261,14 @@ impl KvStore {
                 return Ok(()); // Silent rejection — don't propagate errors for spam
             }
         } else {
-            // No writer identity is only tolerated for the reserved Encrypted
-            // policy. KvStoreSync does not decrypt or verify group membership
-            // here today.
-            match &self.policy {
-                AccessPolicy::Encrypted { .. } => {} // OK
-                _ => {
-                    tracing::warn!(
-                        "rejected anonymous delta for non-encrypted store {}",
-                        self.id
-                    );
-                    return Ok(());
-                }
-            }
+            // No writer identity applies nothing under ANY policy: the
+            // gossip V2 envelope supplies the verified sender for
+            // Signed/Allowlisted/AppendOnly merges, and the reserved
+            // Encrypted policy is fail-closed (#341 Phase A) until secure
+            // sync is wired — it is no longer an anonymous-merge escape
+            // hatch.
+            tracing::warn!("rejected anonymous delta for store {}", self.id);
+            return Ok(());
         }
 
         // Canonical-map gate, ALL policies: a delta carrying the same key in
@@ -1790,7 +1848,8 @@ mod tests {
     #[test]
     fn test_new_store() {
         let owner = agent(1);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         assert_eq!(store.name(), "Test");
         assert_eq!(store.len(), 0);
         assert!(store.is_empty());
@@ -1806,7 +1865,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
 
         store
             .put(
@@ -1830,7 +1890,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
 
         store
             .put(
@@ -1861,7 +1922,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
 
         store
             .put(
@@ -1882,7 +1944,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         assert!(store.remove("nope").is_err());
     }
 
@@ -1894,7 +1957,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         let big = vec![0u8; 100_000];
         let result = store.put(
             "big".to_string(),
@@ -1913,7 +1977,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
 
         store
             .put("a".to_string(), b"1".to_vec(), "text/plain".to_string(), p)
@@ -1935,8 +2000,10 @@ mod tests {
         let id = store_id(1);
         let owner = agent(1);
 
-        let mut s1 = KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed);
-        let mut s2 = KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed);
+        let mut s1 =
+            KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed).expect("kv store");
+        let mut s2 =
+            KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed).expect("kv store");
 
         s1.put("a".to_string(), b"1".to_vec(), "text/plain".to_string(), p1)
             .expect("put");
@@ -1950,8 +2017,10 @@ mod tests {
     #[test]
     fn test_merge_different_ids_fails() {
         let owner = agent(1);
-        let mut s1 = KvStore::new(store_id(1), "A".to_string(), owner, AccessPolicy::Signed);
-        let s2 = KvStore::new(store_id(2), "B".to_string(), owner, AccessPolicy::Signed);
+        let mut s1 = KvStore::new(store_id(1), "A".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
+        let s2 = KvStore::new(store_id(2), "B".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         assert!(s1.merge(&s2).is_err());
     }
 
@@ -1963,7 +2032,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         assert_eq!(store.current_version(), 0);
 
         store
@@ -1994,7 +2064,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "key1".to_string(),
@@ -2041,7 +2112,8 @@ mod tests {
             "Legacy".to_string(),
             owner,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "k".to_string(),
@@ -2094,7 +2166,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         let s1 = store.next_seq();
         let s2 = store.next_seq();
         assert!(s2 > s1);
@@ -2105,7 +2178,8 @@ mod tests {
     #[test]
     fn test_signed_policy_owner_authorized() {
         let owner = agent(1);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         assert!(store.is_authorized(&owner));
     }
 
@@ -2113,7 +2187,8 @@ mod tests {
     fn test_signed_policy_non_owner_rejected() {
         let owner = agent(1);
         let other = agent(2);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         assert!(!store.is_authorized(&other));
     }
 
@@ -2121,7 +2196,8 @@ mod tests {
     fn test_signed_policy_rejects_unauthorized_delta() {
         let owner = agent(1);
         let attacker = agent(99);
-        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
 
         let entry = KvEntry::new(
             "spam".to_string(),
@@ -2140,7 +2216,8 @@ mod tests {
     #[test]
     fn test_signed_policy_accepts_owner_delta() {
         let owner = agent(1);
-        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
 
         let entry = KvEntry::new(
             "legit".to_string(),
@@ -2166,7 +2243,8 @@ mod tests {
             "Team".to_string(),
             owner,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
 
         // Owner can add writers
         store.allow_writer(writer, &owner).expect("allow");
@@ -2186,7 +2264,8 @@ mod tests {
             "Team".to_string(),
             owner,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
 
         let result = store.allow_writer(agent(3), &other);
         assert!(result.is_err());
@@ -2202,7 +2281,8 @@ mod tests {
             "Team".to_string(),
             owner,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
 
         store.allow_writer(writer, &owner).expect("allow");
         assert!(store.is_authorized(&writer));
@@ -2221,7 +2301,8 @@ mod tests {
             "Team".to_string(),
             owner,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
         store.allow_writer(writer, &owner).expect("allow");
 
         // Full delta should include the allowlist
@@ -2236,7 +2317,8 @@ mod tests {
     #[test]
     fn test_anonymous_delta_rejected_for_signed_store() {
         let owner = agent(1);
-        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
 
         let entry = KvEntry::new(
             "anon".to_string(),
@@ -2261,7 +2343,8 @@ mod tests {
     #[test]
     fn test_local_write_owner_authorized_on_signed_store() {
         let owner = agent(1);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         store
             .authorize_local_write(&owner)
             .expect("owner must be able to write locally");
@@ -2271,7 +2354,8 @@ mod tests {
     fn test_local_write_non_owner_rejected_on_signed_store() {
         let owner = agent(1);
         let joiner = agent(2);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         let err = store
             .authorize_local_write(&joiner)
             .expect_err("non-owner local write must be rejected, not silently applied");
@@ -2528,7 +2612,8 @@ mod tests {
         // (exactly what a holder — including a v0.30.1 owner — sends on a
         // StateRequest).
         let mut owner_store =
-            KvStore::new(store_id(1), "S".to_string(), owner, AccessPolicy::Signed);
+            KvStore::new(store_id(1), "S".to_string(), owner, AccessPolicy::Signed)
+                .expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -2568,18 +2653,113 @@ mod tests {
     }
 
     #[test]
-    fn test_local_write_encrypted_policy_stays_permissive() {
-        // The reserved Encrypted policy is permissive at the store layer on
-        // the inbound path; the local path must match it, not diverge.
-        let store = KvStore::new(
+    fn encrypted_new_is_reserved() {
+        // WHY (#341 Phase A, I0): the Encrypted policy names group-scoped
+        // confidentiality, but secure sync is not wired — a constructible
+        // replica would gossip plaintext while authorizing every writer.
+        // The constructor must refuse it with the DEDICATED reserved error,
+        // never OwnerUnknown (this is not an ownership problem) and never
+        // a live store.
+        let err = KvStore::new(
             store_id(1),
             "Test".to_string(),
             agent(1),
-            AccessPolicy::Encrypted { group_id: vec![1] },
+            AccessPolicy::Encrypted {
+                group_id: vec![1, 2, 3],
+            },
+        )
+        .expect_err("Encrypted policy must not be constructible");
+        assert!(
+            matches!(
+                &err,
+                KvError::EncryptedPolicyReserved { group_id } if group_id == &vec![1, 2, 3]
+            ),
+            "expected EncryptedPolicyReserved, got {err:?}"
         );
-        store
-            .authorize_local_write(&agent(9))
-            .expect("encrypted policy is permissive at the store layer");
+        assert!(
+            !matches!(err, KvError::OwnerUnknown),
+            "the reserved-policy reject must never surface as OwnerUnknown"
+        );
+
+        // Every wired policy still constructs.
+        for policy in [
+            AccessPolicy::Signed,
+            AccessPolicy::Allowlisted,
+            AccessPolicy::AppendOnly,
+        ] {
+            assert!(
+                KvStore::new(store_id(1), "Test".to_string(), agent(1), policy.clone()).is_ok(),
+                "{policy} must stay constructible"
+            );
+        }
+    }
+
+    #[test]
+    fn encrypted_fail_closed_if_forced() {
+        // WHY (#341 Phase A, I1): a legacy/deserialized replica CAN carry
+        // the reserved Encrypted policy even though no constructor builds
+        // one anymore. Such a replica must fail closed: nobody authorized,
+        // no local writes, and no delta application — anonymous or signed —
+        // until secure sync is wired. `new_encrypted_unchecked` is the
+        // test-only bypass that proves these arms.
+        let owner = agent(1);
+        let anyone = agent(9);
+        let id = store_id(1);
+
+        let mut dest =
+            KvStore::new_encrypted_unchecked(id, "Test".to_string(), owner, vec![1, 2, 3]);
+
+        // is_authorized: false for everyone, the anchored owner included.
+        assert!(!dest.is_authorized(&owner), "owner is not authorized");
+        assert!(!dest.is_authorized(&anyone), "stranger is not authorized");
+
+        // authorize_local_write: dedicated reserved error, not Ok, not
+        // Unauthorized, not OwnerUnknown.
+        for writer in [&owner, &anyone] {
+            let err = dest
+                .authorize_local_write(writer)
+                .expect_err("local writes must fail on a forced Encrypted replica");
+            assert!(
+                matches!(
+                    &err,
+                    KvError::EncryptedPolicyReserved { group_id } if group_id == &vec![1, 2, 3]
+                ),
+                "expected EncryptedPolicyReserved, got {err:?}"
+            );
+        }
+
+        // merge_delta: a real delta from a source store applies NOTHING —
+        // neither anonymously (writer == None) nor with a named writer
+        // (even the owner). Silent-for-spam Ok, but nothing lands.
+        let mut source =
+            KvStore::new(id, "Test".to_string(), owner, AccessPolicy::Signed).expect("kv store");
+        source
+            .put(
+                "k".to_string(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("source put");
+        let delta = source.full_delta();
+        let v_before = dest.current_version();
+
+        dest.merge_delta(&delta, peer(2), None)
+            .expect("anonymous merge is a silent reject, not an error");
+        assert!(dest.get("k").is_none(), "anonymous delta applied nothing");
+
+        dest.merge_delta(&delta, peer(2), Some(&owner))
+            .expect("signed merge is a silent reject, not an error");
+        assert!(
+            dest.get("k").is_none(),
+            "owner-signed delta applied nothing"
+        );
+        dest.merge_delta(&delta, peer(2), Some(&anyone))
+            .expect("signed merge is a silent reject, not an error");
+        assert!(dest.get("k").is_none(), "stranger delta applied nothing");
+
+        assert_eq!(dest.current_version(), v_before, "no state change at all");
+        assert!(dest.is_empty(), "forced Encrypted replica stays empty");
     }
 
     #[test]
@@ -2633,7 +2813,8 @@ mod tests {
         let topic = "store/cold";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -2666,7 +2847,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/inject";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -2710,7 +2892,8 @@ mod tests {
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
         // Owner at time 1: state {k1}; the broadcast delta carries cp seq 1.
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -2770,7 +2953,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/delrec";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -2822,7 +3006,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/tamper";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -2858,7 +3043,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/replay";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         let cp_old = checkpoint_for(&owner_store, topic, &kp, 1);
         let mut joiner =
             KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
@@ -2877,7 +3063,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/unanchored";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         let cp = checkpoint_for(&owner_store, topic, &kp, 1);
         let mut delta = KvStoreDelta::new(0);
         delta.owner_checkpoint = Some(cp);
@@ -2899,7 +3086,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic_a = "store/A";
         let id_a = KvStoreId::for_topic_owner(topic_a, &owner);
-        let owner_store = KvStore::new(id_a, "A".to_string(), owner, AccessPolicy::Signed);
+        let owner_store =
+            KvStore::new(id_a, "A".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         let cp = checkpoint_for(&owner_store, topic_a, &kp, 1);
         // Replay onto a different store B (different topic -> different id).
         let id_b = KvStoreId::for_topic_owner("store/B", &owner);
@@ -2951,7 +3139,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/return";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -3087,7 +3276,8 @@ mod tests {
         let topic = "store/forgery";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "Legit".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "Legit".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -3229,7 +3419,8 @@ mod tests {
         let id = KvStoreId::for_topic_owner(topic, &owner);
         let p = peer(1);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         let mut relay =
             KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
 
@@ -3329,7 +3520,8 @@ mod tests {
         let id = KvStoreId::for_topic_owner(topic, &owner);
         let p = peer(1);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         let mut relay =
             KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
 
@@ -3392,7 +3584,8 @@ mod tests {
         let id = KvStoreId::for_topic_owner(topic, &owner);
         let p = peer(1);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put("k".to_string(), b"v".to_vec(), "text/plain".to_string(), p)
             .expect("owner put");
@@ -3471,7 +3664,8 @@ mod tests {
             "log".to_string(),
             owner,
             AccessPolicy::AppendOnly,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "k1".to_string(),
@@ -3642,7 +3836,8 @@ mod tests {
         let topic = "store/ao-cold";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -3683,7 +3878,8 @@ mod tests {
         entries: &[(&str, &[u8])],
         seq: u64,
     ) -> KvStoreDelta {
-        let mut forged = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut forged =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         for (k, v) in entries {
             forged
                 .put(
@@ -3711,7 +3907,8 @@ mod tests {
         let topic = "store/ao-shrink";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         for (k, v) in [("k1", b"v1".as_slice()), ("k2", b"v2".as_slice())] {
             owner_store
                 .put(k.to_string(), v.to_vec(), "text/plain".to_string(), peer(1))
@@ -3750,7 +3947,8 @@ mod tests {
         let topic = "store/ao-rewrite";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -3792,7 +3990,8 @@ mod tests {
             "plain".to_string(),
             owner,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "k".to_string(),
@@ -3864,7 +4063,8 @@ mod tests {
         let topic = "store/ao-downgrade";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -3886,7 +4086,8 @@ mod tests {
 
         // Forge: identical content, policy flipped to Signed, newer seq +
         // newer policy_version.
-        let mut forged = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut forged =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         forged
             .put(
                 "k1".to_string(),
@@ -3921,7 +4122,8 @@ mod tests {
         let topic = "store/ao-dup";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -4006,7 +4208,8 @@ mod tests {
             "log".to_string(),
             owner,
             AccessPolicy::AppendOnly,
-        );
+        )
+        .expect("kv store");
         hostile
             .put(
                 "k1".to_string(),
@@ -4048,7 +4251,8 @@ mod tests {
             "log".to_string(),
             owner,
             AccessPolicy::AppendOnly,
-        );
+        )
+        .expect("kv store");
         additive
             .put(
                 "k2".to_string(),
@@ -4151,7 +4355,8 @@ mod tests {
         let topic = "store/ao-truncate";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         for (k, v) in [("k1", b"v1".as_slice()), ("k2", b"v2".as_slice())] {
             owner_store
                 .put(k.to_string(), v.to_vec(), "text/plain".to_string(), peer(1))
@@ -4217,7 +4422,8 @@ mod tests {
         let topic = "store/ao-skiponly";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -4307,7 +4513,8 @@ mod tests {
             "plain".to_string(),
             owner,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "k".to_string(),

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -1290,6 +1290,19 @@ pub fn load_snapshot(path: &Path) -> Result<Option<KvStore>> {
     };
     let body: SnapshotBody = bincode::deserialize(body_bytes)?;
     let store = body.store;
+    // #341 Phase A: a snapshot written before the reservation guard can
+    // still carry the reserved Encrypted policy. The replica opens
+    // fail-closed (no authorized writer, no local writes, no delta
+    // application) — surface that loudly at open time, not only on first
+    // rejected use.
+    if let AccessPolicy::Encrypted { group_id } = store.policy() {
+        tracing::warn!(
+            target: "x0x::kv",
+            "opened snapshot of reserved encrypted store {} (group_id {}) — replica is fail-closed until secure sync is wired",
+            store.id(),
+            hex::encode(group_id)
+        );
+    }
     store.restore_seq_counter(body.seq_counter.max(store.current_version()));
     Ok(Some(store))
 }
@@ -1335,7 +1348,8 @@ mod tests {
             "log".to_string(),
             agent(1),
             AccessPolicy::AppendOnly,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "k1".to_string(),
@@ -1394,6 +1408,35 @@ mod tests {
         );
     }
 
+    #[test]
+    fn snapshot_with_reserved_encrypted_policy_opens_fail_closed() {
+        // WHY (#341 Phase A): a snapshot written before the reservation
+        // guard can carry the reserved Encrypted policy. Restoring it must
+        // neither error (that would lose the data) nor silently downgrade
+        // to Signed (that would invent write authority): the replica
+        // restores as-is and the store's fail-closed arms apply.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("kv").join("enc.bin");
+        let store = KvStore::new_encrypted_unchecked(
+            store_id(7),
+            "enc".to_string(),
+            agent(1),
+            vec![1, 2, 3],
+        );
+        let bytes = encode_snapshot(&store).expect("encode");
+        write_snapshot_atomic(&path, &bytes).expect("write");
+
+        let restored = load_snapshot(&path).expect("load").expect("present");
+        assert!(
+            matches!(restored.policy(), AccessPolicy::Encrypted { .. }),
+            "policy restores verbatim — never silently downgraded"
+        );
+        assert!(
+            !restored.is_authorized(&agent(1)),
+            "restored reserved replica is fail-closed, even for its owner"
+        );
+    }
+
     /// Construct an isolated network node (mirrors the helper in
     /// `src/gossip/pubsub.rs` tests). `PubSubManager` is fully constructable
     /// in tests, so `KvStoreSync` is testable end-to-end without a live mesh.
@@ -1410,7 +1453,8 @@ mod tests {
     async fn make_sync(topic: &str, policy: AccessPolicy) -> KvStoreSync {
         let node = make_node().await;
         let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
-        let store = KvStore::new(store_id(1), "Test".to_string(), agent(1), policy);
+        let store =
+            KvStore::new(store_id(1), "Test".to_string(), agent(1), policy).expect("kv store");
         KvStoreSync::new(store, pubsub, topic.to_string(), peer(1), Some(agent(1)))
             .expect("kv sync")
     }
@@ -1423,7 +1467,8 @@ mod tests {
     ) -> (KvStoreSync, Arc<PubSubManager>) {
         let node = make_node().await;
         let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
-        let store = KvStore::new(store_id(1), "Test".to_string(), agent(1), policy);
+        let store =
+            KvStore::new(store_id(1), "Test".to_string(), agent(1), policy).expect("kv store");
         let sync = KvStoreSync::new(
             store,
             Arc::clone(&pubsub),
@@ -1438,7 +1483,8 @@ mod tests {
     #[tokio::test]
     async fn test_kv_store_sync_creation() {
         let owner = agent(1);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         let _store_for_sync = store;
     }
 
@@ -1453,7 +1499,8 @@ mod tests {
             "Test".to_string(),
             owner,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
         store.allow_writer(writer, &owner).expect("allow");
         let store_arc = Arc::new(RwLock::new(store));
 
@@ -1479,7 +1526,8 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_reads() {
         let owner = agent(1);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         let store_arc = Arc::new(RwLock::new(store));
 
         let s1 = store_arc.read().await;
@@ -1625,17 +1673,21 @@ mod tests {
     async fn start_default_spawner_merges_remote_delta() {
         // End-to-end exercise of the delta-merge listener: a delta published
         // on the topic is received by the background loop spawned by start()
-        // and merged into the local store. We use an Encrypted policy so an
-        // unsigned (anonymous-sender) delta is accepted by the store's
-        // access control — matching what the wire delivers for an unsigned
-        // publish via a PubSubManager with no signing context.
-        let sync = make_sync(
-            "store/E",
-            AccessPolicy::Encrypted {
-                group_id: vec![1, 2, 3],
-            },
-        )
-        .await;
+        // and merged into the local store. The publish goes out through a
+        // SigningContext for the store owner so the delivered v2 message
+        // carries a verified sender — the only writer a Signed store accepts.
+        // (#341 Phase A: anonymous deltas apply nothing under every policy;
+        // the reserved Encrypted policy is no longer an unsigned-publish
+        // escape hatch.)
+        let node = make_node().await;
+        let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+        let owner = kp.agent_id();
+        let ctx = Arc::new(crate::gossip::SigningContext::from_keypair(&kp));
+        let pubsub = Arc::new(PubSubManager::new(node, Some(ctx)).expect("pubsub"));
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
+        let sync = KvStoreSync::new(store, pubsub, "store/E".to_string(), peer(1), Some(owner))
+            .expect("kv sync");
 
         sync.start().await.expect("start");
 
@@ -1915,7 +1967,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k_old".to_string(),
@@ -1981,7 +2034,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         let (pub_bytes, sec_bytes) = kp.to_bytes();
         let public_key =
             ant_quic::MlDsaPublicKey::from_bytes(&pub_bytes).expect("public key bytes");
@@ -2102,7 +2156,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k_old".to_string(),
@@ -2231,7 +2286,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::AppendOnly,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k1".to_string(),
@@ -2323,8 +2379,10 @@ mod tests {
             "alpha".to_string(),
             owner,
             AccessPolicy::Signed,
-        );
-        let mut b = KvStore::new(store_id(1), "beta".to_string(), owner, AccessPolicy::Signed);
+        )
+        .expect("kv store");
+        let mut b = KvStore::new(store_id(1), "beta".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         // Empty stores: same id ⇒ same digest; the name is not content.
         assert_eq!(a.served_digest(), b.served_digest());
         let c = KvStore::new(
@@ -2332,7 +2390,8 @@ mod tests {
             "alpha".to_string(),
             owner,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         assert_ne!(
             a.served_digest(),
             c.served_digest(),
@@ -2389,7 +2448,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k1".to_string(),
@@ -2529,7 +2589,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k_live".to_string(),
@@ -2724,7 +2785,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k1".to_string(),
@@ -2841,7 +2903,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k1".to_string(),
@@ -2897,7 +2960,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k".to_string(),
@@ -3005,7 +3069,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
         owned.allow_writer(writer, &owner_id).expect("allow writer");
         owned
             .put(
@@ -3122,7 +3187,8 @@ mod tests {
     #[test]
     fn pruned_key_is_accepted_when_re_served_with_fresh_tags() {
         let owner = agent(1);
-        let mut holder = KvStore::new(store_id(1), "log".to_string(), owner, AccessPolicy::Signed);
+        let mut holder = KvStore::new(store_id(1), "log".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         holder
             .put(
                 "k_live".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11739,7 +11739,10 @@ impl Agent {
     ///
     /// # Errors
     ///
-    /// Returns an error if the gossip runtime is not initialized.
+    /// - Returns an error if the gossip runtime is not initialized.
+    /// - [`kv::AccessPolicy::Encrypted`] is refused
+    ///   ([`kv::KvError::EncryptedPolicyReserved`] at the store layer):
+    ///   secure sync is not wired, so the policy stays reserved.
     pub async fn create_kv_store_with_policy(
         &self,
         name: &str,
@@ -11821,7 +11824,14 @@ impl Agent {
                 snap
             }
             Some(Ok(None)) | None => {
-                kv::KvStore::new(store_id, name.to_string(), self.agent_id(), policy)
+                kv::KvStore::new(store_id, name.to_string(), self.agent_id(), policy).map_err(
+                    |e| {
+                        // Encrypted is reserved (#341): the store layer has
+                        // already logged the WARN; surface its message intact
+                        // rather than a generic create failure.
+                        kv_storage_err(format!("kv store creation failed: {e}"))
+                    },
+                )?
             }
             Some(Err(e)) => {
                 // Corrupt snapshot: fail closed, loudly. Starting an empty

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -827,6 +827,27 @@ mod tests {
         assert_eq!(manifest_policy(&extra), None, "non-string fails closed");
     }
 
+    #[test]
+    fn rest_and_manifest_still_reject_encrypted() {
+        // WHY (#341 Phase A): `AccessPolicy::Encrypted` is reserved — the
+        // store layer refuses to construct it, and the daemon surfaces must
+        // keep refusing it too, so a restart can never resurrect a live
+        // plaintext-gossiping "encrypted" store from the manifest. The REST
+        // create route mirrors this: it accepts only "signed"/"append_only"
+        // (see routes/stores.rs). "encrypted" must resolve to None here —
+        // the caller skips rehydration loudly instead of guessing a policy.
+        let mut extra = serde_json::Map::new();
+        extra.insert(
+            "policy".into(),
+            serde_json::Value::String("encrypted".into()),
+        );
+        assert_eq!(
+            manifest_policy(&extra),
+            None,
+            "encrypted policy must fail closed on manifest rehydration"
+        );
+    }
+
     fn entry(kind: &str, id: &str, role: &str) -> CrdtSubscriptionEntry {
         CrdtSubscriptionEntry {
             kind: kind.to_string(),

--- a/tests/kv_store_integration.rs
+++ b/tests/kv_store_integration.rs
@@ -41,6 +41,7 @@ fn make_store(id_byte: u8, name: &str, owner_byte: u8) -> KvStore {
         test_agent(owner_byte),
         AccessPolicy::Signed,
     )
+    .expect("kv store")
 }
 
 // ---------------------------------------------------------------------------
@@ -55,7 +56,8 @@ fn test_create_kv_store() {
         "My Store".to_string(),
         owner,
         AccessPolicy::Signed,
-    );
+    )
+    .expect("kv store");
 
     assert_eq!(store.name(), "My Store");
     assert_eq!(store.owner(), Some(&owner));
@@ -92,6 +94,7 @@ fn test_create_multiple_stores() {
                 owner,
                 AccessPolicy::Signed,
             )
+            .expect("kv store")
         })
         .collect();
 
@@ -549,23 +552,13 @@ async fn test_concurrent_writes_converge() {
     let peer_a = test_peer(1);
     let peer_b = test_peer(2);
 
-    // Use Encrypted policy so both peers can write without allowlist.
-    let mut store_a = KvStore::new(
-        store_id,
-        "Shared".to_string(),
-        owner,
-        AccessPolicy::Encrypted {
-            group_id: vec![1, 2, 3],
-        },
-    );
-    let mut store_b = KvStore::new(
-        store_id,
-        "Shared".to_string(),
-        owner,
-        AccessPolicy::Encrypted {
-            group_id: vec![1, 2, 3],
-        },
-    );
+    // Signed: both replicas share the same owner, so each side's writes are
+    // owner-written. (#341 Phase A: Encrypted is reserved — it is no longer
+    // a both-peers-can-write shortcut.)
+    let mut store_a = KvStore::new(store_id, "Shared".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
+    let mut store_b = KvStore::new(store_id, "Shared".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
 
     // Agent A writes keys.
     store_a
@@ -628,24 +621,14 @@ async fn test_concurrent_writes_same_key_lww() {
     let peer_a = test_peer(1);
     let peer_b = test_peer(2);
 
-    let mut store_a = KvStore::new(
-        store_id,
-        "Shared".to_string(),
-        owner,
-        AccessPolicy::Encrypted {
-            group_id: vec![1, 2, 3],
-        },
-    );
-    let mut store_b = KvStore::new(
-        store_id,
-        "Shared".to_string(),
-        owner,
-        AccessPolicy::Encrypted {
-            group_id: vec![1, 2, 3],
-        },
-    );
+    let mut store_a = KvStore::new(store_id, "Shared".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
+    let mut store_b = KvStore::new(store_id, "Shared".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
 
-    // Both write to the same key with controlled timestamps.
+    // Both write to the same key with controlled timestamps. The deltas are
+    // applied as owner-written merges (#341 Phase A: no policy accepts a
+    // writer-less merge anymore, so the LWW exercise threads the owner).
     let mut entry_a = KvEntry::new(
         "shared".to_string(),
         b"from-A".to_vec(),
@@ -664,8 +647,12 @@ async fn test_concurrent_writes_same_key_lww() {
     entry_b.updated_at = 200;
     let delta_b = KvStoreDelta::for_put("shared".to_string(), entry_b, (peer_b, 1), 1);
 
-    store_a.merge_delta(&delta_a, peer_a, None).expect("put A");
-    store_b.merge_delta(&delta_b, peer_b, None).expect("put B");
+    store_a
+        .merge_delta(&delta_a, peer_a, Some(&owner))
+        .expect("put A");
+    store_b
+        .merge_delta(&delta_b, peer_b, Some(&owner))
+        .expect("put B");
 
     // Merge both ways.
     store_a.merge(&store_b).expect("merge B->A");
@@ -687,10 +674,9 @@ async fn test_concurrent_writes_via_arc_rwlock() {
         store_id,
         "Concurrent".to_string(),
         owner,
-        AccessPolicy::Encrypted {
-            group_id: vec![7, 8, 9],
-        },
-    );
+        AccessPolicy::Signed,
+    )
+    .expect("kv store");
     let store_arc = Arc::new(RwLock::new(store));
 
     // Spawn multiple writers.
@@ -733,7 +719,8 @@ fn test_delta_roundtrip_put() {
     let owner = test_agent(1);
     let store_id = test_store_id(1);
 
-    let mut source = KvStore::new(store_id, "Source".to_string(), owner, AccessPolicy::Signed);
+    let mut source = KvStore::new(store_id, "Source".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
 
     source
         .put(
@@ -757,7 +744,8 @@ fn test_delta_roundtrip_put() {
     assert!(!delta.is_empty());
 
     // Apply delta to a fresh target store.
-    let mut target = KvStore::new(store_id, "Target".to_string(), owner, AccessPolicy::Signed);
+    let mut target = KvStore::new(store_id, "Target".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
 
     target
         .merge_delta(&delta, peer, Some(&owner))
@@ -770,6 +758,11 @@ fn test_delta_roundtrip_put() {
 
 #[test]
 fn test_delta_crdt_trait_integration() {
+    // #341 Phase A (I3): this test used to construct Encrypted stores so the
+    // writer-less DeltaCrdt::merge would apply content. No policy is an
+    // anonymous-merge escape hatch anymore: the trait merge must apply
+    // NOTHING unsigned, and real application goes through merge_delta with
+    // the verified writer (what KvStoreSync does).
     let peer = test_peer(1);
     let owner = test_agent(1);
     let store_id = test_store_id(1);
@@ -778,8 +771,9 @@ fn test_delta_crdt_trait_integration() {
         store_id,
         "DeltaCRDT".to_string(),
         owner,
-        AccessPolicy::Encrypted { group_id: vec![1] },
-    );
+        AccessPolicy::Signed,
+    )
+    .expect("kv store");
 
     assert_eq!(DeltaCrdt::version(&store), 0);
     assert!(DeltaCrdt::delta(&store, 0).is_none());
@@ -796,14 +790,17 @@ fn test_delta_crdt_trait_integration() {
     assert!(DeltaCrdt::version(&store) > 0);
     let delta = DeltaCrdt::delta(&store, 0).expect("delta should exist");
 
-    // Apply to fresh store.
-    let mut replica = KvStore::new(
-        store_id,
-        "Replica".to_string(),
-        owner,
-        AccessPolicy::Encrypted { group_id: vec![1] },
-    );
+    // Writer-less trait merge: Ok, but applies no content.
+    let mut replica = KvStore::new(store_id, "Replica".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
     DeltaCrdt::merge(&mut replica, &delta).expect("merge");
+    assert!(replica.get("x").is_none(), "unsigned merge applies nothing");
+    assert_eq!(DeltaCrdt::version(&replica), 0, "no state change");
+
+    // The same delta applies once the writer is supplied.
+    replica
+        .merge_delta(&delta, peer, Some(&owner))
+        .expect("owner merge");
     assert!(replica.get("x").is_some());
 }
 
@@ -899,7 +896,8 @@ fn test_signed_policy_rejects_non_owner_delta() {
     let peer = test_peer(99);
     let store_id = test_store_id(1);
 
-    let mut store = KvStore::new(store_id, "Signed".to_string(), owner, AccessPolicy::Signed);
+    let mut store = KvStore::new(store_id, "Signed".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
 
     let entry = KvEntry::new(
         "spam".to_string(),
@@ -930,7 +928,8 @@ fn test_allowlisted_policy_workflow() {
         "Team".to_string(),
         owner,
         AccessPolicy::Allowlisted,
-    );
+    )
+    .expect("kv store");
 
     // Initially only the owner is authorized.
     assert!(store.is_authorized(&owner));
@@ -972,10 +971,12 @@ fn test_merge_propagates_allowlist() {
     let writer = test_agent(2);
     let store_id = test_store_id(1);
 
-    let mut store_a = KvStore::new(store_id, "A".to_string(), owner, AccessPolicy::Allowlisted);
+    let mut store_a = KvStore::new(store_id, "A".to_string(), owner, AccessPolicy::Allowlisted)
+        .expect("kv store");
     store_a.allow_writer(writer, &owner).expect("allow");
 
-    let mut store_b = KvStore::new(store_id, "B".to_string(), owner, AccessPolicy::Allowlisted);
+    let mut store_b = KvStore::new(store_id, "B".to_string(), owner, AccessPolicy::Allowlisted)
+        .expect("kv store");
 
     // Merge A into B — allowlist should propagate.
     store_b.merge(&store_a).expect("merge");
@@ -993,7 +994,8 @@ fn test_full_delta_includes_allowlist() {
         "Delta".to_string(),
         owner,
         AccessPolicy::Allowlisted,
-    );
+    )
+    .expect("kv store");
     store.allow_writer(writer, &owner).expect("allow");
 
     let delta = store.full_delta();

--- a/tests/proptest_kv.rs
+++ b/tests/proptest_kv.rs
@@ -42,6 +42,7 @@ fn make_store(owner: AgentId, policy: AccessPolicy) -> KvStore {
         owner,
         policy,
     )
+    .expect("kv store")
 }
 
 proptest! {


### PR DESCRIPTION
## Phase A only — do not close #341

This PR is **Phase A only** (Encrypted unconstructible + fail-closed). **Phase B is HOLD** (`SecureContext`, sealed records, `POST /groups/:id/stores`). **Do not close #341 on A.**

No mix with #340 (SelfKeyed) or #349 (task-list CRDT). Encrypted stays discriminant **2**. AppendOnly stays 3. Display stays `"encrypted"`.

## The bug

`AccessPolicy::Encrypted` constructed and then authorized every writer — including anonymous unsigned deltas — while gossiping plaintext `KvStoreDelta`s. The name promised group confidentiality and was strictly weaker than `Signed`.

## The fix (Phase A)

- **I0:** `KvStore::new` returns `Result<Self>` and refuses Encrypted with `KvError::EncryptedPolicyReserved { group_id }` (never `OwnerUnknown`). WARN at `x0x::kv` including `group_id`. Agent `create_kv_store_with_policy` propagates the same reject. REST / `manifest_policy` keep rejecting `"encrypted"`.
- **I1:** a forced/deserialized Encrypted replica is fail-closed: `is_authorized` is false; `authorize_local_write` returns `EncryptedPolicyReserved`; `merge_delta` applies nothing for both `writer=None` and `writer=Some` (WARN, KV-style `Ok`). Snapshot open of a legacy Encrypted replica WARNs and does not silently downgrade to Signed.
- **I2:** discriminant frozen — Encrypted == 2, AppendOnly == 3.
- **I3:** `test_delta_crdt_trait` no longer uses Encrypted as a `writer=None` escape hatch. `DeltaCrdt::merge` is not a production untrusted-apply path.

Test-only `new_encrypted_unchecked` exists solely to prove the fail-closed arms.

## Update (follow-up commit) — I1 adopt reject + rustdoc fix

- **I1 hole closed:** `try_adopt_full_snapshot` runs in `merge_delta` BEFORE the sender-auth check, so a forced/deserialized Encrypted replica receiving a delta with a genuine owner checkpoint could apply the plaintext entries and refresh `self.policy` (Encrypted → Signed). Gate 0 at the top of `try_adopt_full_snapshot`: if `self.policy` is Encrypted, WARN (target `x0x::kv`, includes `group_id`) and return `false` — no entries applied, no policy refresh, no checkpoint cached. Owned-store (Signed/Allowlisted/AppendOnly) checkpoint verify/adopt behavior is unchanged.
- **rustdoc CI:** `AccessPolicy::Encrypted` docs said `[KvStore::new](Self::new)` — `Self` resolves to `AccessPolicy` there, so the intra-doc link was broken under `-D warnings`. Fixed to `[KvStore::new]`; verified `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` passes and the generated link anchors to `KvStore::new`.

## Tests

- `encrypted_new_is_reserved`
- `encrypted_fail_closed_if_forced`
- `encrypted_replica_rejects_owner_checkpoint_adoption` **(new)** — forced Encrypted replica + owner-checkpoint delta: stays Encrypted, stays empty, policy does not flip to Signed, checkpoint not cached, high-water mark untouched
- `access_policy_bincode_discriminants_are_pinned`
- `snapshot_with_reserved_encrypted_policy_opens_fail_closed`
- `test_error_display_encrypted_policy_reserved`
- rewritten `test_delta_crdt_trait`

## Out of scope

- No Phase B (`SecureContext`, envelope, group stores route)
- No `SelfKeyed` / disc 4 (#340)
- No `src/crdt/` / #349
- Reliability PRs and #355 left alone
- **Do not close #341**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reserves `AccessPolicy::Encrypted`, rejects new construction, and makes ordinary local and remote writes fail closed while retaining legacy snapshots. It also updates constructor callers and tests, but checkpoint adoption still bypasses the new fail-closed authorization.

- Adds a dedicated `EncryptedPolicyReserved` error and fallible `KvStore::new`.
- Rejects ordinary signed and anonymous deltas on Encrypted replicas.
- Preserves and warns on legacy Encrypted snapshots.
- Pins policy discriminants and updates KV synchronization tests.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until checkpoint adoption is made to honor the fail-closed Encrypted policy.

Ordinary delta authorization now rejects Encrypted replicas, but the production checkpoint path executes first and can replace their content and policy.

**Files Needing Attention:** src/kv/store.rs

<details open><summary><h3>Security Review</h3></summary>

Legacy Encrypted replicas can still adopt owner-signed full-state checkpoints because checkpoint adoption precedes the new authorization check. This violates the intended no-delta fail-closed boundary and can replace plaintext content or policy on a reserved replica.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/kv/store.rs | Adds fail-closed Encrypted authorization and constructor rejection, but checkpoint adoption still mutates Encrypted replicas before authorization. |
| src/kv/sync.rs | Restores legacy Encrypted snapshots verbatim with a warning, making complete merge-path enforcement essential. |
| src/lib.rs | Propagates constructor rejection for new stores while intentionally permitting legacy snapshots to open fail closed. |
| src/kv/error.rs | Adds the dedicated reserved-policy error and display coverage. |
| src/kv/delta.rs | Makes writer-less DeltaCrdt merges no-op through the ordinary merge_delta authorization path. |
| tests/kv_store_integration.rs | Updates constructor handling and removes Encrypted as an anonymous merge test shortcut. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Load legacy Encrypted snapshot] --> B[Live KvStoreSync replica]
  B --> C[Receive delta with owner checkpoint]
  C --> D[merge_delta]
  D --> E[try_adopt_full_snapshot]
  E --> F[Replace entries and refresh policy]
  D -. ordinary path .-> G[is_authorized returns false]
  G --> H[Reject delta]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/kv/store.rs:893-901
**Checkpoint adoption bypasses fail-closed policy**

When a legacy Encrypted replica receives a valid owner-signed full-state checkpoint, `merge_delta` adopts the checkpoint before reaching this authorization check, replacing entries and potentially changing the policy despite the no-delta fail-closed contract.

**How this was verified:** The snapshot restoration and production sync path feed Encrypted replicas into `merge_delta`, where `try_adopt_full_snapshot` executes before sender authorization and mutates state without an Encrypted guard.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(kv): fail-closed reserved Encrypted ..."](https://github.com/saorsa-labs/x0x/commit/987cffb5cdde01418f41b9a80bc888572eb3ae36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54704452)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [KV Store](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/kv.md)

<!-- /greptile_comment -->
