### PR TITLE
fix(kv): reserve Encrypted policy fail-closed (#341 Phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **The reserved `Encrypted` KV-store policy now fails closed instead of
+  accepting every writer (issue #341, Phase A).** `AccessPolicy::Encrypted`
+  promised group confidentiality while the sync path gossips plaintext
+  deltas and the store layer authorized everyone — including anonymous
+  unsigned deltas. Phase A makes the name stop lying: `KvStore::new` and
+  the Agent/handle create paths return the new
+  `KvError::EncryptedPolicyReserved { group_id }` (WARN-logged at target
+  `x0x::kv`) instead of constructing a live replica; a replica that
+  reaches the policy anyway (e.g. a snapshot from an older binary)
+  authorizes nobody, refuses local writes with the same error, and merges
+  nothing — anonymous or attributed. The variant itself is untouched:
+  discriminant 2 is pinned, `Display` stays `"encrypted"`, and REST
+  `POST /stores` / manifest rehydration keep rejecting the string. In-tree
+  tests that used `Encrypted` as an anonymous-merge crutch
+  (`DeltaCrdt::merge(None)` and friends) now use real writers. **Phase A
+  only — no encryption yet**: `SecureContext`, the sealed wire format, and
+  `POST /groups/:id/stores` remain Phase B; do not close #341 until that
+  lands.
+
 - **Public group send no longer waits out the ~24s DM retry before gossip
   carry (issue #310).** `POST /groups/:id/send` still persists locally and
   returns 200 + `msg_id`. Fan-out is now a race: gossip topic publish

--- a/src/kv/delta.rs
+++ b/src/kv/delta.rs
@@ -136,10 +136,13 @@ impl DeltaCrdt for KvStore {
 
     fn merge(&mut self, delta: &Self::Delta) -> anyhow::Result<()> {
         let peer_id = PeerId::new([0u8; 32]);
-        // Anti-entropy merges don't carry writer identity. Signed/Allowlisted
-        // stores rely on the main sync path in KvStoreSync to provide the
-        // writer identity; Encrypted is currently a reserved policy shape, not
-        // transport confidentiality for KvStore deltas.
+        // Anti-entropy merges don't carry writer identity, and every policy
+        // now rejects an anonymous apply (#341 Phase A): Signed/Allowlisted/
+        // AppendOnly rely on the KvStoreSync path to thread the verified
+        // writer, and the reserved Encrypted policy applies nothing at all.
+        // This trait impl is therefore NOT an untrusted-apply path — it
+        // deliberately applies nothing and exists only so KvStore can plug
+        // into saorsa-gossip's delta-sync infrastructure.
         self.merge_delta(delta, peer_id, None)
             .map_err(|e| anyhow::anyhow!("KvStore delta merge failed: {e}"))
     }
@@ -205,7 +208,8 @@ mod tests {
         let id = store_id(1);
 
         // Allowlisted store so both agents can write
-        let mut store = KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Allowlisted);
+        let mut store = KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Allowlisted)
+            .expect("kv store");
         store.allow_writer(writer, &owner).expect("allow");
 
         let entry = KvEntry::new(
@@ -226,11 +230,13 @@ mod tests {
     fn test_merge_delta_with_name_update() {
         let owner = agent(1);
         let id = store_id(1);
-        let mut store = KvStore::new(id, "Original".to_string(), owner, AccessPolicy::Signed);
+        let mut store = KvStore::new(id, "Original".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
 
         // A peer renames the store on top of the shared initial state; its
         // name register causally dominates ours, so the LWW merge adopts it.
-        let mut other = KvStore::new(id, "Original".to_string(), owner, AccessPolicy::Signed);
+        let mut other = KvStore::new(id, "Original".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         other.update_name("Updated".to_string(), peer(1));
 
         let mut delta = KvStoreDelta::new(1);
@@ -244,26 +250,20 @@ mod tests {
 
     #[test]
     fn test_delta_crdt_trait() {
+        // #341 Phase A (I3): this test used to construct Encrypted stores so
+        // the writer-less `DeltaCrdt::merge` would apply. That crutch is
+        // gone: anonymous applies are rejected for EVERY policy now, and
+        // `DeltaCrdt::merge` is not a production untrusted-apply path. The
+        // trait's delta()/version() halves stay exercised; applying goes
+        // through `merge_delta` with a real writer, which is the path
+        // KvStoreSync uses.
         let owner = agent(1);
         let id = store_id(1);
 
-        // DeltaCrdt trait uses merge(None) — use Encrypted policy to allow it
-        let mut s1 = KvStore::new(
-            id,
-            "Store".to_string(),
-            owner,
-            AccessPolicy::Encrypted {
-                group_id: vec![1, 2, 3],
-            },
-        );
-        let mut s2 = KvStore::new(
-            id,
-            "Store".to_string(),
-            owner,
-            AccessPolicy::Encrypted {
-                group_id: vec![1, 2, 3],
-            },
-        );
+        let mut s1 =
+            KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed).expect("kv store");
+        let mut s2 =
+            KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed).expect("kv store");
 
         s2.put(
             "key".to_string(),
@@ -274,9 +274,25 @@ mod tests {
         .expect("put");
 
         let delta = DeltaCrdt::delta(&s2, 0).expect("delta");
-        DeltaCrdt::merge(&mut s1, &delta).expect("merge");
 
+        // The writer-less trait merge applies nothing — fail closed, no
+        // Encrypted escape hatch.
+        DeltaCrdt::merge(&mut s1, &delta).expect("merge");
+        assert!(
+            s1.get("key").is_none(),
+            "anonymous DeltaCrdt::merge must not apply a delta"
+        );
+        assert_eq!(
+            DeltaCrdt::version(&s1),
+            0,
+            "a rejected anonymous merge must not bump the version"
+        );
+
+        // The writer-authenticated production path applies.
+        s1.merge_delta(&delta, peer(2), Some(&owner))
+            .expect("merge as owner");
         assert!(DeltaCrdt::version(&s1) > 0);
+        assert!(s1.get("key").is_some());
     }
 
     #[test]

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -88,6 +88,24 @@ pub enum KvError {
     /// an idempotent no-op and never raises this error.)
     #[error("immutable key: {0} — append-only store; existing keys cannot be updated or deleted")]
     ImmutableKey(String),
+
+    /// Construction or write attempted on the reserved `Encrypted` policy
+    /// (issue #341, Phase A).
+    ///
+    /// `AccessPolicy::Encrypted` is a reserved discriminant: the KvStore sync
+    /// path still publishes plaintext deltas and does not enforce group
+    /// membership, so no live `Encrypted` replica may be constructed and any
+    /// replica that reaches the policy (e.g. deserialized from an older
+    /// snapshot) refuses every write and merge. Fail closed until the secure
+    /// sync path (Phase B) makes the policy constructible again.
+    #[error(
+        "encrypted policy is reserved (no secure sync path yet): group_id {}",
+        hex::encode(group_id)
+    )]
+    EncryptedPolicyReserved {
+        /// The MLS group id the policy wanted to bind.
+        group_id: Vec<u8>,
+    },
 }
 
 #[cfg(test)]
@@ -131,6 +149,19 @@ mod tests {
         assert!(display.contains("immutable key"));
         assert!(display.contains("evt-0001"));
         assert!(display.contains("append-only"));
+    }
+
+    #[test]
+    fn test_error_display_encrypted_policy_reserved() {
+        // WHY: the reserved-policy rejection is the Phase A guard for #341 —
+        // callers (and logs) must be able to tell it apart from a plain
+        // Unauthorized, and the group id must be visible in the message.
+        let error = KvError::EncryptedPolicyReserved {
+            group_id: vec![0xde, 0xad],
+        };
+        let display = format!("{error}");
+        assert!(display.contains("encrypted policy is reserved"));
+        assert!(display.contains("dead"));
     }
 
     #[test]

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -9,9 +9,11 @@
 //!   from non-owners are rejected. Use for app stores, agent skill registries.
 //! - **Allowlisted**: Only explicitly allowed writers can write. The owner
 //!   manages the allowlist. Use for team workspaces, private swarms.
-//! - **Encrypted**: Reserved for group-scoped encrypted stores. The current
-//!   KvStore sync path does not encrypt deltas; do not rely on this policy for
-//!   confidentiality until encrypted sync is wired.
+//! - **Encrypted**: Reserved for group-scoped encrypted stores — REJECTED at
+//!   construction and fail-closed everywhere else (issue #341 Phase A). The
+//!   sync path still publishes plaintext deltas, so no live `Encrypted`
+//!   replica may be created; one that is reached anyway (e.g. deserialized
+//!   from an older snapshot) authorizes nobody and applies no delta.
 //! - **AppendOnly**: Like `Signed` (owner-only writes), but existing keys are
 //!   immutable — no update, no delete, even by the owner. Use for
 //!   tamper-evident event logs where the author must not be able to rewrite
@@ -37,11 +39,17 @@ pub enum AccessPolicy {
     /// The owner manages the allowlist.
     Allowlisted,
 
-    /// Reserved for group-scoped encrypted stores.
+    /// Reserved for group-scoped encrypted stores — RESERVED, FAIL-CLOSED
+    /// (issue #341 Phase A).
     ///
     /// The current KvStore sync path still publishes plaintext deltas and does
-    /// not enforce group membership by itself. Do not rely on this variant for
-    /// confidentiality until encrypted sync is wired.
+    /// not enforce group membership by itself, so this variant is rejected at
+    /// construction ([`KvStore::new`](KvStore::new) returns
+    /// [`KvError::EncryptedPolicyReserved`]) and any replica that reaches the
+    /// policy refuses every write and merge. Do not rely on this variant for
+    /// confidentiality until encrypted sync is wired. The discriminant (2) is
+    /// pinned by `access_policy_bincode_discriminants_are_pinned`: reservation
+    /// is fail-closed behavior, not a removed variant.
     Encrypted {
         /// MLS group ID for this store.
         group_id: Vec<u8>,
@@ -645,14 +653,32 @@ impl KvStore {
     /// This is the **creator** path: ownership is anchored on `owner` at
     /// construction (channel [`AnchorChannel::Creator`]) and is immutable for
     /// the life of the store.
-    #[must_use]
-    pub fn new(id: KvStoreId, name: String, owner: AgentId, policy: AccessPolicy) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KvError::EncryptedPolicyReserved`] when `policy` is
+    /// [`AccessPolicy::Encrypted`] (issue #341 Phase A): with no secure sync
+    /// path wired, an "encrypted" store would gossip plaintext deltas while
+    /// the name promises confidentiality — so construction fails closed
+    /// until Phase B supplies a `SecureContext`.
+    pub fn new(id: KvStoreId, name: String, owner: AgentId, policy: AccessPolicy) -> Result<Self> {
+        if let AccessPolicy::Encrypted { group_id } = &policy {
+            tracing::warn!(
+                target: "x0x::kv",
+                group_id = %hex::encode(group_id),
+                store_id = %id,
+                "refused to create store with reserved Encrypted policy: no secure sync path is wired (issue #341 Phase A)"
+            );
+            return Err(KvError::EncryptedPolicyReserved {
+                group_id: group_id.clone(),
+            });
+        }
         let mut name_reg = LwwRegister::new(name.clone());
         // Stamp the creator-set name with a non-empty clock so it wins LWW
         // merge against replicas initialized with empty names and empty
         // clocks (which would otherwise be concurrent and hash-tiebroken).
         name_reg.set(name, PeerId::new(owner.0));
-        Self {
+        Ok(Self {
             id,
             keys: OrSet::new(),
             entries: HashMap::new(),
@@ -667,7 +693,7 @@ impl KvStore {
             allowed_writers: HashSet::new(),
             version: 0,
             seq_counter: Arc::new(AtomicU64::new(0)),
-        }
+        })
     }
 
     /// Create a joined replica of a store, anchoring ownership from trusted
@@ -844,10 +870,12 @@ impl KvStore {
                     || self.allowed_writers.contains(agent_id)
             }
             AccessPolicy::Encrypted { .. } => {
-                // Reserved for encrypted sync. The store layer currently treats
-                // this as permissive; group membership enforcement belongs in
-                // the secure sync path once wired.
-                true
+                // Reserved (#341 Phase A): no secure sync context exists, so a
+                // reachable (deserialized / test-built) Encrypted replica
+                // authorizes NOBODY. Fail closed instead of accepting
+                // anonymous plaintext writes under a confidential-sounding
+                // name.
+                false
             }
             AccessPolicy::AppendOnly => {
                 // Owner-only writes, exactly like Signed. Immutability of
@@ -869,16 +897,29 @@ impl KvStore {
     ///
     /// # Errors
     ///
+    /// - [`KvError::EncryptedPolicyReserved`] if the store carries the
+    ///   reserved [`AccessPolicy::Encrypted`] policy (issue #341 Phase A): a
+    ///   reachable Encrypted replica is read-only because no secure sync
+    ///   context exists to authorize through.
     /// - [`KvError::OwnerUnknown`] if the store has a policy-restricted
     ///   (`Signed`/`Allowlisted`) policy but its authoritative owner has not
     ///   been learned yet (a freshly joined replica). Fail closed.
     /// - [`KvError::Unauthorized`] if `writer` is not authorized under the
     ///   store's policy.
     pub fn authorize_local_write(&self, writer: &AgentId) -> Result<()> {
-        if matches!(self.policy, AccessPolicy::Encrypted { .. }) {
+        if let AccessPolicy::Encrypted { group_id } = &self.policy {
             // Matches the inbound path: the reserved Encrypted policy is
-            // currently permissive at the store layer.
-            return Ok(());
+            // fail-closed at the store layer (#341 Phase A).
+            tracing::warn!(
+                target: "x0x::kv",
+                group_id = %hex::encode(group_id),
+                writer = %hex::encode(writer.as_bytes()),
+                store_id = %self.id,
+                "refused local write on reserved Encrypted policy: no secure sync path is wired (issue #341 Phase A)"
+            );
+            return Err(KvError::EncryptedPolicyReserved {
+                group_id: group_id.clone(),
+            });
         }
         let Some(owner) = self.owner.as_ref() else {
             return Err(KvError::OwnerUnknown);
@@ -1148,15 +1189,36 @@ impl KvStore {
 
     /// Merge a delta into this store.
     ///
-    /// Enforces access control: if the store has a Signed or Allowlisted
-    /// policy, the `writer` must be authorized. Unauthorized deltas are
-    /// silently rejected (returns Ok but does not apply changes).
+    /// Enforces access control: unauthorized deltas are silently rejected
+    /// (returns Ok but does not apply changes). A delta whose writer is
+    /// unknown (`None`) is rejected for every policy, and a store carrying
+    /// the reserved [`AccessPolicy::Encrypted`] policy applies nothing at all
+    /// — anonymous or attributed (issue #341 Phase A).
     pub fn merge_delta(
         &mut self,
         delta: &KvStoreDelta,
         peer_id: PeerId,
         writer: Option<&AgentId>,
     ) -> Result<()> {
+        // Reserved Encrypted policy is fail-closed on EVERY apply path
+        // (#341 Phase A): no secure sync context exists, so nothing may be
+        // applied — anonymous or attributed, checkpoint-carrying or not. A
+        // deserialized replica that reaches this policy must not become a
+        // plaintext-accepting back door.
+        if let AccessPolicy::Encrypted { group_id } = &self.policy {
+            let writer_desc = match writer {
+                Some(w) => hex::encode(w.as_bytes()),
+                None => "anonymous".to_string(),
+            };
+            tracing::warn!(
+                target: "x0x::kv",
+                group_id = %hex::encode(group_id),
+                store_id = %self.id,
+                writer = %writer_desc,
+                "rejected delta merge on reserved Encrypted policy: no secure sync path is wired (issue #341 Phase A)"
+            );
+            return Ok(()); // rejection, not an error — mirrors the sender-auth path
+        }
         // Authoritative full-snapshot checkpoint adoption (cold-recovery path):
         // if the checkpoint's content root matches the relayed entry set, adopt
         // as owner-proven independent of the relayer. An incremental delta's
@@ -1198,19 +1260,12 @@ impl KvStore {
                 return Ok(()); // Silent rejection — don't propagate errors for spam
             }
         } else {
-            // No writer identity is only tolerated for the reserved Encrypted
-            // policy. KvStoreSync does not decrypt or verify group membership
-            // here today.
-            match &self.policy {
-                AccessPolicy::Encrypted { .. } => {} // OK
-                _ => {
-                    tracing::warn!(
-                        "rejected anonymous delta for non-encrypted store {}",
-                        self.id
-                    );
-                    return Ok(());
-                }
-            }
+            // No writer identity is rejected for EVERY policy (#341 Phase A):
+            // KvStoreSync threads the transport-authenticated sender, and the
+            // reserved Encrypted policy was rejected before this point —
+            // anonymous applies have no production path.
+            tracing::warn!("rejected anonymous delta for store {}", self.id);
+            return Ok(());
         }
 
         // Canonical-map gate, ALL policies: a delta carrying the same key in
@@ -1790,7 +1845,8 @@ mod tests {
     #[test]
     fn test_new_store() {
         let owner = agent(1);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         assert_eq!(store.name(), "Test");
         assert_eq!(store.len(), 0);
         assert!(store.is_empty());
@@ -1806,7 +1862,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
 
         store
             .put(
@@ -1830,7 +1887,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
 
         store
             .put(
@@ -1861,7 +1919,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
 
         store
             .put(
@@ -1882,7 +1941,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         assert!(store.remove("nope").is_err());
     }
 
@@ -1894,7 +1954,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         let big = vec![0u8; 100_000];
         let result = store.put(
             "big".to_string(),
@@ -1913,7 +1974,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
 
         store
             .put("a".to_string(), b"1".to_vec(), "text/plain".to_string(), p)
@@ -1935,8 +1997,10 @@ mod tests {
         let id = store_id(1);
         let owner = agent(1);
 
-        let mut s1 = KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed);
-        let mut s2 = KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed);
+        let mut s1 =
+            KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed).expect("kv store");
+        let mut s2 =
+            KvStore::new(id, "Store".to_string(), owner, AccessPolicy::Signed).expect("kv store");
 
         s1.put("a".to_string(), b"1".to_vec(), "text/plain".to_string(), p1)
             .expect("put");
@@ -1950,8 +2014,10 @@ mod tests {
     #[test]
     fn test_merge_different_ids_fails() {
         let owner = agent(1);
-        let mut s1 = KvStore::new(store_id(1), "A".to_string(), owner, AccessPolicy::Signed);
-        let s2 = KvStore::new(store_id(2), "B".to_string(), owner, AccessPolicy::Signed);
+        let mut s1 = KvStore::new(store_id(1), "A".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
+        let s2 = KvStore::new(store_id(2), "B".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         assert!(s1.merge(&s2).is_err());
     }
 
@@ -1963,7 +2029,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         assert_eq!(store.current_version(), 0);
 
         store
@@ -1994,7 +2061,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "key1".to_string(),
@@ -2041,7 +2109,8 @@ mod tests {
             "Legacy".to_string(),
             owner,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "k".to_string(),
@@ -2094,7 +2163,8 @@ mod tests {
             "Test".to_string(),
             agent(1),
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         let s1 = store.next_seq();
         let s2 = store.next_seq();
         assert!(s2 > s1);
@@ -2105,7 +2175,8 @@ mod tests {
     #[test]
     fn test_signed_policy_owner_authorized() {
         let owner = agent(1);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         assert!(store.is_authorized(&owner));
     }
 
@@ -2113,7 +2184,8 @@ mod tests {
     fn test_signed_policy_non_owner_rejected() {
         let owner = agent(1);
         let other = agent(2);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         assert!(!store.is_authorized(&other));
     }
 
@@ -2121,7 +2193,8 @@ mod tests {
     fn test_signed_policy_rejects_unauthorized_delta() {
         let owner = agent(1);
         let attacker = agent(99);
-        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
 
         let entry = KvEntry::new(
             "spam".to_string(),
@@ -2140,7 +2213,8 @@ mod tests {
     #[test]
     fn test_signed_policy_accepts_owner_delta() {
         let owner = agent(1);
-        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
 
         let entry = KvEntry::new(
             "legit".to_string(),
@@ -2166,7 +2240,8 @@ mod tests {
             "Team".to_string(),
             owner,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
 
         // Owner can add writers
         store.allow_writer(writer, &owner).expect("allow");
@@ -2186,7 +2261,8 @@ mod tests {
             "Team".to_string(),
             owner,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
 
         let result = store.allow_writer(agent(3), &other);
         assert!(result.is_err());
@@ -2202,7 +2278,8 @@ mod tests {
             "Team".to_string(),
             owner,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
 
         store.allow_writer(writer, &owner).expect("allow");
         assert!(store.is_authorized(&writer));
@@ -2221,7 +2298,8 @@ mod tests {
             "Team".to_string(),
             owner,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
         store.allow_writer(writer, &owner).expect("allow");
 
         // Full delta should include the allowlist
@@ -2236,7 +2314,8 @@ mod tests {
     #[test]
     fn test_anonymous_delta_rejected_for_signed_store() {
         let owner = agent(1);
-        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let mut store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
 
         let entry = KvEntry::new(
             "anon".to_string(),
@@ -2261,7 +2340,8 @@ mod tests {
     #[test]
     fn test_local_write_owner_authorized_on_signed_store() {
         let owner = agent(1);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         store
             .authorize_local_write(&owner)
             .expect("owner must be able to write locally");
@@ -2271,7 +2351,8 @@ mod tests {
     fn test_local_write_non_owner_rejected_on_signed_store() {
         let owner = agent(1);
         let joiner = agent(2);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         let err = store
             .authorize_local_write(&joiner)
             .expect_err("non-owner local write must be rejected, not silently applied");
@@ -2528,7 +2609,8 @@ mod tests {
         // (exactly what a holder — including a v0.30.1 owner — sends on a
         // StateRequest).
         let mut owner_store =
-            KvStore::new(store_id(1), "S".to_string(), owner, AccessPolicy::Signed);
+            KvStore::new(store_id(1), "S".to_string(), owner, AccessPolicy::Signed)
+                .expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -2568,18 +2650,97 @@ mod tests {
     }
 
     #[test]
-    fn test_local_write_encrypted_policy_stays_permissive() {
-        // The reserved Encrypted policy is permissive at the store layer on
-        // the inbound path; the local path must match it, not diverge.
-        let store = KvStore::new(
+    fn encrypted_new_is_reserved() {
+        // I0 (#341 Phase A): constructing an Encrypted store must fail with
+        // the dedicated reserved-policy error — never `OwnerUnknown`, never a
+        // live replica that would accept anonymous plaintext writes while the
+        // name promises confidentiality. `new_replica` cannot take a policy
+        // (it is Signed by construction), so there is no other in-crate
+        // constructor left to guard.
+        let owner = agent(1);
+        let err = KvStore::new(
             store_id(1),
-            "Test".to_string(),
-            agent(1),
-            AccessPolicy::Encrypted { group_id: vec![1] },
+            "Enc".to_string(),
+            owner,
+            AccessPolicy::Encrypted {
+                group_id: vec![7, 7, 7],
+            },
+        )
+        .expect_err("Encrypted policy must be reserved at construction");
+        match err {
+            KvError::EncryptedPolicyReserved { group_id } => {
+                assert_eq!(group_id, vec![7, 7, 7], "error carries the group id");
+            }
+            other => panic!("expected EncryptedPolicyReserved, got {other:?}"),
+        }
+        // The same reject fires for every group id, not just this one.
+        assert!(matches!(
+            KvStore::new(
+                store_id(2),
+                "Enc".to_string(),
+                owner,
+                AccessPolicy::Encrypted {
+                    group_id: Vec::new()
+                },
+            ),
+            Err(KvError::EncryptedPolicyReserved { .. })
+        ));
+    }
+
+    #[test]
+    fn encrypted_fail_closed_if_forced() {
+        // I1 (#341 Phase A): the Encrypted variant stays deserializable
+        // (discriminant 2 is pinned), so a replica can still reach the policy
+        // — e.g. a snapshot written before this guard. Such a replica must
+        // fail closed: nobody is authorized, local writes error with the
+        // reserved-policy error, and merge_delta applies NOTHING, anonymous
+        // or attributed.
+        let owner = agent(1);
+        let mut store = KvStore::new(
+            store_id(1),
+            "Forced".to_string(),
+            owner,
+            AccessPolicy::Signed,
+        )
+        .expect("signed store");
+        // Test-only forced flip (a deserialized replica reaches the same
+        // state through the persisted policy field).
+        store.policy = AccessPolicy::Encrypted {
+            group_id: vec![9, 9],
+        };
+
+        assert!(
+            !store.is_authorized(&owner),
+            "even the owner is not authorized on a reserved-policy replica"
         );
+        assert!(matches!(
+            store.authorize_local_write(&owner),
+            Err(KvError::EncryptedPolicyReserved { .. })
+        ));
+
+        let entry = KvEntry::new("k".to_string(), b"v".to_vec(), "text/plain".to_string());
+        let mut delta = KvStoreDelta::new(1);
+        delta.added.insert("k".to_string(), (entry, (peer(2), 1)));
+        let version_before = store.current_version();
+
         store
-            .authorize_local_write(&agent(9))
-            .expect("encrypted policy is permissive at the store layer");
+            .merge_delta(&delta, peer(2), None)
+            .expect("anonymous merge is a silent reject, not an error");
+        assert!(store.get("k").is_none(), "anonymous delta applied nothing");
+
+        store
+            .merge_delta(&delta, peer(2), Some(&owner))
+            .expect("attributed merge is a silent reject, not an error");
+        assert!(store.get("k").is_none(), "attributed delta applied nothing");
+        assert!(
+            !store.active_keys().iter().any(|k| k.as_str() == "k"),
+            "no OR-Set membership leaked from the rejected delta"
+        );
+        assert_eq!(
+            store.current_version(),
+            version_before,
+            "a rejected delta must not even bump the version"
+        );
     }
 
     #[test]
@@ -2633,7 +2794,8 @@ mod tests {
         let topic = "store/cold";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -2666,7 +2828,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/inject";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -2710,7 +2873,8 @@ mod tests {
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
         // Owner at time 1: state {k1}; the broadcast delta carries cp seq 1.
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -2770,7 +2934,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/delrec";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -2822,7 +2987,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/tamper";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -2858,7 +3024,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/replay";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         let cp_old = checkpoint_for(&owner_store, topic, &kp, 1);
         let mut joiner =
             KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
@@ -2877,7 +3044,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/unanchored";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         let cp = checkpoint_for(&owner_store, topic, &kp, 1);
         let mut delta = KvStoreDelta::new(0);
         delta.owner_checkpoint = Some(cp);
@@ -2899,7 +3067,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic_a = "store/A";
         let id_a = KvStoreId::for_topic_owner(topic_a, &owner);
-        let owner_store = KvStore::new(id_a, "A".to_string(), owner, AccessPolicy::Signed);
+        let owner_store =
+            KvStore::new(id_a, "A".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         let cp = checkpoint_for(&owner_store, topic_a, &kp, 1);
         // Replay onto a different store B (different topic -> different id).
         let id_b = KvStoreId::for_topic_owner("store/B", &owner);
@@ -2951,7 +3120,8 @@ mod tests {
         let owner = kp.agent_id();
         let topic = "store/return";
         let id = KvStoreId::for_topic_owner(topic, &owner);
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -3087,7 +3257,8 @@ mod tests {
         let topic = "store/forgery";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "Legit".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "Legit".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put(
                 "k".to_string(),
@@ -3229,7 +3400,8 @@ mod tests {
         let id = KvStoreId::for_topic_owner(topic, &owner);
         let p = peer(1);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         let mut relay =
             KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
 
@@ -3329,7 +3501,8 @@ mod tests {
         let id = KvStoreId::for_topic_owner(topic, &owner);
         let p = peer(1);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         let mut relay =
             KvStore::new_replica(id, String::new(), Some(owner), AnchorChannel::RestParam);
 
@@ -3392,7 +3565,8 @@ mod tests {
         let id = KvStoreId::for_topic_owner(topic, &owner);
         let p = peer(1);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         owner_store
             .put("k".to_string(), b"v".to_vec(), "text/plain".to_string(), p)
             .expect("owner put");
@@ -3471,7 +3645,8 @@ mod tests {
             "log".to_string(),
             owner,
             AccessPolicy::AppendOnly,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "k1".to_string(),
@@ -3642,7 +3817,8 @@ mod tests {
         let topic = "store/ao-cold";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -3683,7 +3859,8 @@ mod tests {
         entries: &[(&str, &[u8])],
         seq: u64,
     ) -> KvStoreDelta {
-        let mut forged = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut forged =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         for (k, v) in entries {
             forged
                 .put(
@@ -3711,7 +3888,8 @@ mod tests {
         let topic = "store/ao-shrink";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         for (k, v) in [("k1", b"v1".as_slice()), ("k2", b"v2".as_slice())] {
             owner_store
                 .put(k.to_string(), v.to_vec(), "text/plain".to_string(), peer(1))
@@ -3750,7 +3928,8 @@ mod tests {
         let topic = "store/ao-rewrite";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -3792,7 +3971,8 @@ mod tests {
             "plain".to_string(),
             owner,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "k".to_string(),
@@ -3864,7 +4044,8 @@ mod tests {
         let topic = "store/ao-downgrade";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -3886,7 +4067,8 @@ mod tests {
 
         // Forge: identical content, policy flipped to Signed, newer seq +
         // newer policy_version.
-        let mut forged = KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed);
+        let mut forged =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::Signed).expect("kv store");
         forged
             .put(
                 "k1".to_string(),
@@ -3921,7 +4103,8 @@ mod tests {
         let topic = "store/ao-dup";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -4006,7 +4189,8 @@ mod tests {
             "log".to_string(),
             owner,
             AccessPolicy::AppendOnly,
-        );
+        )
+        .expect("kv store");
         hostile
             .put(
                 "k1".to_string(),
@@ -4048,7 +4232,8 @@ mod tests {
             "log".to_string(),
             owner,
             AccessPolicy::AppendOnly,
-        );
+        )
+        .expect("kv store");
         additive
             .put(
                 "k2".to_string(),
@@ -4151,7 +4336,8 @@ mod tests {
         let topic = "store/ao-truncate";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         for (k, v) in [("k1", b"v1".as_slice()), ("k2", b"v2".as_slice())] {
             owner_store
                 .put(k.to_string(), v.to_vec(), "text/plain".to_string(), peer(1))
@@ -4217,7 +4403,8 @@ mod tests {
         let topic = "store/ao-skiponly";
         let id = KvStoreId::for_topic_owner(topic, &owner);
 
-        let mut owner_store = KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly);
+        let mut owner_store =
+            KvStore::new(id, "S".to_string(), owner, AccessPolicy::AppendOnly).expect("kv store");
         owner_store
             .put(
                 "k1".to_string(),
@@ -4307,7 +4494,8 @@ mod tests {
             "plain".to_string(),
             owner,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "k".to_string(),
@@ -4358,6 +4546,9 @@ mod tests {
         // stores, checkpoints (wire + signing bytes), and deltas. If anyone
         // reorders or inserts a variant mid-enum, every existing store
         // corrupts. This test pins the exact on-wire indices 0..=3.
+        // #341 Phase A note: Encrypted stays index 2 — reserving the policy
+        // (fail-closed construction) must NOT remove or move the variant,
+        // because persisted Encrypted stores/deltas still decode to it.
         let cases: [(AccessPolicy, u32); 4] = [
             (AccessPolicy::Signed, 0),
             (AccessPolicy::Allowlisted, 1),

--- a/src/kv/sync.rs
+++ b/src/kv/sync.rs
@@ -1335,7 +1335,8 @@ mod tests {
             "log".to_string(),
             agent(1),
             AccessPolicy::AppendOnly,
-        );
+        )
+        .expect("kv store");
         store
             .put(
                 "k1".to_string(),
@@ -1410,7 +1411,8 @@ mod tests {
     async fn make_sync(topic: &str, policy: AccessPolicy) -> KvStoreSync {
         let node = make_node().await;
         let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
-        let store = KvStore::new(store_id(1), "Test".to_string(), agent(1), policy);
+        let store =
+            KvStore::new(store_id(1), "Test".to_string(), agent(1), policy).expect("kv store");
         KvStoreSync::new(store, pubsub, topic.to_string(), peer(1), Some(agent(1)))
             .expect("kv sync")
     }
@@ -1423,7 +1425,8 @@ mod tests {
     ) -> (KvStoreSync, Arc<PubSubManager>) {
         let node = make_node().await;
         let pubsub = Arc::new(PubSubManager::new(node, None).expect("pubsub"));
-        let store = KvStore::new(store_id(1), "Test".to_string(), agent(1), policy);
+        let store =
+            KvStore::new(store_id(1), "Test".to_string(), agent(1), policy).expect("kv store");
         let sync = KvStoreSync::new(
             store,
             Arc::clone(&pubsub),
@@ -1438,7 +1441,8 @@ mod tests {
     #[tokio::test]
     async fn test_kv_store_sync_creation() {
         let owner = agent(1);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         let _store_for_sync = store;
     }
 
@@ -1453,7 +1457,8 @@ mod tests {
             "Test".to_string(),
             owner,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
         store.allow_writer(writer, &owner).expect("allow");
         let store_arc = Arc::new(RwLock::new(store));
 
@@ -1479,7 +1484,8 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_reads() {
         let owner = agent(1);
-        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed);
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         let store_arc = Arc::new(RwLock::new(store));
 
         let s1 = store_arc.read().await;
@@ -1625,17 +1631,25 @@ mod tests {
     async fn start_default_spawner_merges_remote_delta() {
         // End-to-end exercise of the delta-merge listener: a delta published
         // on the topic is received by the background loop spawned by start()
-        // and merged into the local store. We use an Encrypted policy so an
-        // unsigned (anonymous-sender) delta is accepted by the store's
-        // access control — matching what the wire delivers for an unsigned
-        // publish via a PubSubManager with no signing context.
-        let sync = make_sync(
-            "store/E",
-            AccessPolicy::Encrypted {
-                group_id: vec![1, 2, 3],
-            },
-        )
-        .await;
+        // and merged into the local store. #341 Phase A removed the
+        // permissive Encrypted crutch this test used to rely on, so the
+        // store is Signed and the publish is SIGNED as the owner: the wire
+        // then delivers msg.sender = Some(owner) exactly like production
+        // gossip, and an unsigned (anonymous-sender) delta is rejected.
+        let kp = crate::identity::AgentKeypair::generate().expect("agent keypair");
+        let owner = kp.agent_id();
+        let node = make_node().await;
+        let pubsub = Arc::new(
+            PubSubManager::new(
+                node,
+                Some(Arc::new(crate::gossip::SigningContext::from_keypair(&kp))),
+            )
+            .expect("pubsub"),
+        );
+        let store = KvStore::new(store_id(1), "Test".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
+        let sync = KvStoreSync::new(store, pubsub, "store/E".to_string(), peer(1), Some(owner))
+            .expect("kv sync");
 
         sync.start().await.expect("start");
 
@@ -1915,7 +1929,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k_old".to_string(),
@@ -1981,7 +1996,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         let (pub_bytes, sec_bytes) = kp.to_bytes();
         let public_key =
             ant_quic::MlDsaPublicKey::from_bytes(&pub_bytes).expect("public key bytes");
@@ -2102,7 +2118,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k_old".to_string(),
@@ -2231,7 +2248,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::AppendOnly,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k1".to_string(),
@@ -2323,8 +2341,10 @@ mod tests {
             "alpha".to_string(),
             owner,
             AccessPolicy::Signed,
-        );
-        let mut b = KvStore::new(store_id(1), "beta".to_string(), owner, AccessPolicy::Signed);
+        )
+        .expect("kv store");
+        let mut b = KvStore::new(store_id(1), "beta".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         // Empty stores: same id ⇒ same digest; the name is not content.
         assert_eq!(a.served_digest(), b.served_digest());
         let c = KvStore::new(
@@ -2332,7 +2352,8 @@ mod tests {
             "alpha".to_string(),
             owner,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         assert_ne!(
             a.served_digest(),
             c.served_digest(),
@@ -2389,7 +2410,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k1".to_string(),
@@ -2529,7 +2551,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k_live".to_string(),
@@ -2724,7 +2747,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k1".to_string(),
@@ -2841,7 +2865,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k1".to_string(),
@@ -2897,7 +2922,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Signed,
-        );
+        )
+        .expect("kv store");
         owned
             .put(
                 "k".to_string(),
@@ -3005,7 +3031,8 @@ mod tests {
             "log".to_string(),
             owner_id,
             AccessPolicy::Allowlisted,
-        );
+        )
+        .expect("kv store");
         owned.allow_writer(writer, &owner_id).expect("allow writer");
         owned
             .put(
@@ -3122,7 +3149,8 @@ mod tests {
     #[test]
     fn pruned_key_is_accepted_when_re_served_with_fresh_tags() {
         let owner = agent(1);
-        let mut holder = KvStore::new(store_id(1), "log".to_string(), owner, AccessPolicy::Signed);
+        let mut holder = KvStore::new(store_id(1), "log".to_string(), owner, AccessPolicy::Signed)
+            .expect("kv store");
         holder
             .put(
                 "k_live".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11786,6 +11786,25 @@ impl Agent {
         policy: kv::AccessPolicy,
         state_dir: Option<&std::path::Path>,
     ) -> error::Result<KvStoreHandle> {
+        // #341 Phase A: the reserved Encrypted policy is unconstructible.
+        // Gate BEFORE any state is reserved or a snapshot is loaded, so no
+        // live replica that would accept anonymous plaintext writes under a
+        // confidentiality-promising name can be spawned through the Agent
+        // create paths either.
+        if let kv::AccessPolicy::Encrypted { group_id } = &policy {
+            tracing::warn!(
+                target: "x0x::kv",
+                group_id = %hex::encode(group_id),
+                topic = %topic,
+                "refused agent create of store with reserved Encrypted policy: no secure sync path is wired (issue #341 Phase A)"
+            );
+            return Err(error::IdentityError::Unauthorized(
+                kv::KvError::EncryptedPolicyReserved {
+                    group_id: group_id.clone(),
+                }
+                .to_string(),
+            ));
+        }
         let store_id = kv::KvStoreId::for_topic_owner(topic, &self.agent_id());
         let persist_path = state_dir.map(|d| kv_snapshot_path(d, &store_id));
         let store = match persist_path.as_deref().map(kv::sync::load_snapshot) {
@@ -11818,10 +11837,26 @@ impl Agent {
                         "kv store {topic}: snapshot policy is terminal append_only; ignoring requested policy {policy}"
                     );
                 }
+                if let kv::AccessPolicy::Encrypted { group_id } = snap.policy() {
+                    // #341 Phase A: a snapshot written before the
+                    // reservation guard may carry the reserved Encrypted
+                    // policy. Do not open it as a live (inert-but-publishing)
+                    // replica — fail closed, loudly, same as the constructor.
+                    tracing::warn!(
+                        target: "x0x::kv",
+                        group_id = %hex::encode(group_id),
+                        topic = %topic,
+                        "refused to open kv snapshot with reserved Encrypted policy: no secure sync path is wired (issue #341 Phase A)"
+                    );
+                    return Err(kv_storage_err(format!(
+                        "kv snapshot for topic {topic} carries the reserved encrypted policy; no secure sync path is wired yet (issue #341 Phase A) — remove the snapshot or wait for encrypted store support"
+                    )));
+                }
                 snap
             }
             Some(Ok(None)) | None => {
                 kv::KvStore::new(store_id, name.to_string(), self.agent_id(), policy)
+                    .map_err(|e| error::IdentityError::Unauthorized(e.to_string()))?
             }
             Some(Err(e)) => {
                 // Corrupt snapshot: fail closed, loudly. Starting an empty
@@ -14009,6 +14044,54 @@ mod tests {
         agent.shutdown().await;
         assert!(agent.heartbeat_handle.lock().await.is_none());
         assert!(dropped.load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    /// #341 Phase A (I0): the Agent create paths must refuse the reserved
+    /// Encrypted policy exactly like `KvStore::new` does — a handle created
+    /// with it would gossip plaintext deltas under a confidentiality-
+    /// promising name. The reject must happen BEFORE any snapshot state is
+    /// consulted, so both the plain and persistent create paths fail the
+    /// same way.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn agent_create_kv_store_with_encrypted_policy_is_reserved() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let agent = Agent::builder()
+            .with_machine_key(dir.path().join("machine.key"))
+            .with_agent_key_path(dir.path().join("agent.key"))
+            .with_contact_store_path(dir.path().join("contacts.json"))
+            .with_peer_cache_disabled()
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("agent");
+
+        let policy = kv::AccessPolicy::Encrypted {
+            group_id: vec![4, 1],
+        };
+        let err = agent
+            .create_kv_store_with_policy("reserved", "reserved-topic", policy.clone())
+            .await
+            .expect_err("agent create must refuse the reserved Encrypted policy");
+        assert!(
+            format!("{err}").contains("encrypted policy is reserved"),
+            "error must name the reserved policy, got: {err}"
+        );
+
+        let err = agent
+            .create_kv_store_persistent(
+                "reserved",
+                "reserved-topic",
+                policy,
+                &dir.path().join("kv-stores"),
+            )
+            .await
+            .expect_err("persistent agent create must refuse it too");
+        assert!(
+            format!("{err}").contains("encrypted policy is reserved"),
+            "error must name the reserved policy, got: {err}"
+        );
+
+        agent.shutdown().await;
     }
 
     /// Issue #126 / WS1.5: the delta-merge + state-request subscription loops

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -823,6 +823,19 @@ mod tests {
             serde_json::Value::String("immutable".into()),
         );
         assert_eq!(manifest_policy(&extra), None, "garbage fails closed");
+        extra.insert(
+            "policy".into(),
+            serde_json::Value::String("encrypted".into()),
+        );
+        // WHY (#341 Phase A): "encrypted" is a real policy variant but a
+        // RESERVED one — there is no create path for it, so a manifest can
+        // never legitimately carry it. It must fail closed like garbage,
+        // never silently rehydrate as Signed.
+        assert_eq!(
+            manifest_policy(&extra),
+            None,
+            "reserved encrypted policy fails closed on rehydration"
+        );
         extra.insert("policy".into(), serde_json::Value::Bool(true));
         assert_eq!(manifest_policy(&extra), None, "non-string fails closed");
     }

--- a/src/server/routes/stores.rs
+++ b/src/server/routes/stores.rs
@@ -251,6 +251,21 @@ pub(in crate::server) async fn list_kv_stores(
     Json(serde_json::json!({ "ok": true, "stores": entries }))
 }
 
+/// Resolve a POST /stores policy string to an [`AccessPolicy`].
+///
+/// `None` (absent) and `"signed"` → Signed; `"append_only"` → AppendOnly.
+/// Anything else — including the reserved `"encrypted"` — returns `None` so
+/// the caller can 400: the flat `/stores` route must fail closed on policies
+/// it cannot create (encrypted group stores arrive with the Phase B
+/// `POST /groups/:id/stores` route, not here).
+fn parse_create_policy(policy: Option<&str>) -> Option<x0x::kv::AccessPolicy> {
+    match policy {
+        None | Some("signed") => Some(x0x::kv::AccessPolicy::Signed),
+        Some("append_only") => Some(x0x::kv::AccessPolicy::AppendOnly),
+        _ => None,
+    }
+}
+
 /// POST /stores
 pub(in crate::server) async fn create_kv_store(
     State(state): State<Arc<AppState>>,
@@ -258,14 +273,11 @@ pub(in crate::server) async fn create_kv_store(
 ) -> impl IntoResponse {
     let id = req.topic.clone();
     // Resolve the requested access policy before any state is reserved.
-    let policy = match req.policy.as_deref() {
-        None | Some("signed") => x0x::kv::AccessPolicy::Signed,
-        Some("append_only") => x0x::kv::AccessPolicy::AppendOnly,
-        Some(other) => {
-            return bad_request(format!(
-                "unsupported policy {other:?}: expected \"signed\" or \"append_only\""
-            ))
-        }
+    let Some(policy) = parse_create_policy(req.policy.as_deref()) else {
+        return bad_request(format!(
+            "unsupported policy {:?}: expected \"signed\" or \"append_only\"",
+            req.policy
+        ));
     };
     // Reserve the entire handle+manifest transaction for this (kind,id) so
     // a concurrent create/rehydrate for the same id cannot interleave handle
@@ -592,6 +604,35 @@ pub(in crate::server) async fn delete_kv_value(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn create_policy_parsing_rejects_encrypted_and_garbage() {
+        // WHY (#341 Phase A): the flat /stores route must keep failing
+        // closed on the reserved "encrypted" policy string — an "encrypted"
+        // store here would gossip plaintext deltas under a confidentiality-
+        // promising name. It stays rejected until Phase B wires the
+        // group-scoped POST /groups/:id/stores route.
+        assert!(matches!(
+            parse_create_policy(None),
+            Some(x0x::kv::AccessPolicy::Signed)
+        ));
+        assert!(matches!(
+            parse_create_policy(Some("signed")),
+            Some(x0x::kv::AccessPolicy::Signed)
+        ));
+        assert!(matches!(
+            parse_create_policy(Some("append_only")),
+            Some(x0x::kv::AccessPolicy::AppendOnly)
+        ));
+        assert!(
+            parse_create_policy(Some("encrypted")).is_none(),
+            "reserved \"encrypted\" policy must not be creatable via flat /stores"
+        );
+        assert!(
+            parse_create_policy(Some("allowlisted")).is_none(),
+            "garbage must fail closed, not silently become Signed"
+        );
+    }
 
     #[test]
     fn kv_store_delta_direct_payload_is_prefixed_json() {

--- a/tests/kv_store_integration.rs
+++ b/tests/kv_store_integration.rs
@@ -41,6 +41,7 @@ fn make_store(id_byte: u8, name: &str, owner_byte: u8) -> KvStore {
         test_agent(owner_byte),
         AccessPolicy::Signed,
     )
+    .expect("kv store")
 }
 
 // ---------------------------------------------------------------------------
@@ -55,7 +56,8 @@ fn test_create_kv_store() {
         "My Store".to_string(),
         owner,
         AccessPolicy::Signed,
-    );
+    )
+    .expect("kv store");
 
     assert_eq!(store.name(), "My Store");
     assert_eq!(store.owner(), Some(&owner));
@@ -92,6 +94,7 @@ fn test_create_multiple_stores() {
                 owner,
                 AccessPolicy::Signed,
             )
+            .expect("kv store")
         })
         .collect();
 
@@ -549,23 +552,14 @@ async fn test_concurrent_writes_converge() {
     let peer_a = test_peer(1);
     let peer_b = test_peer(2);
 
-    // Use Encrypted policy so both peers can write without allowlist.
-    let mut store_a = KvStore::new(
-        store_id,
-        "Shared".to_string(),
-        owner,
-        AccessPolicy::Encrypted {
-            group_id: vec![1, 2, 3],
-        },
-    );
-    let mut store_b = KvStore::new(
-        store_id,
-        "Shared".to_string(),
-        owner,
-        AccessPolicy::Encrypted {
-            group_id: vec![1, 2, 3],
-        },
-    );
+    // Both replicas are owned by `owner`; local puts and the full-state
+    // merge are policy-independent, so plain Signed replicas exercise the
+    // same convergence (the Encrypted "anyone may write" crutch is gone —
+    // #341 Phase A).
+    let mut store_a = KvStore::new(store_id, "Shared".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
+    let mut store_b = KvStore::new(store_id, "Shared".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
 
     // Agent A writes keys.
     store_a
@@ -628,22 +622,10 @@ async fn test_concurrent_writes_same_key_lww() {
     let peer_a = test_peer(1);
     let peer_b = test_peer(2);
 
-    let mut store_a = KvStore::new(
-        store_id,
-        "Shared".to_string(),
-        owner,
-        AccessPolicy::Encrypted {
-            group_id: vec![1, 2, 3],
-        },
-    );
-    let mut store_b = KvStore::new(
-        store_id,
-        "Shared".to_string(),
-        owner,
-        AccessPolicy::Encrypted {
-            group_id: vec![1, 2, 3],
-        },
-    );
+    let mut store_a = KvStore::new(store_id, "Shared".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
+    let mut store_b = KvStore::new(store_id, "Shared".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
 
     // Both write to the same key with controlled timestamps.
     let mut entry_a = KvEntry::new(
@@ -664,8 +646,14 @@ async fn test_concurrent_writes_same_key_lww() {
     entry_b.updated_at = 200;
     let delta_b = KvStoreDelta::for_put("shared".to_string(), entry_b, (peer_b, 1), 1);
 
-    store_a.merge_delta(&delta_a, peer_a, None).expect("put A");
-    store_b.merge_delta(&delta_b, peer_b, None).expect("put B");
+    // #341 Phase A: anonymous merge_delta(None) is rejected for every
+    // policy — apply as the owner, the writer-authenticated production path.
+    store_a
+        .merge_delta(&delta_a, peer_a, Some(&owner))
+        .expect("put A");
+    store_b
+        .merge_delta(&delta_b, peer_b, Some(&owner))
+        .expect("put B");
 
     // Merge both ways.
     store_a.merge(&store_b).expect("merge B->A");
@@ -687,10 +675,9 @@ async fn test_concurrent_writes_via_arc_rwlock() {
         store_id,
         "Concurrent".to_string(),
         owner,
-        AccessPolicy::Encrypted {
-            group_id: vec![7, 8, 9],
-        },
-    );
+        AccessPolicy::Signed,
+    )
+    .expect("kv store");
     let store_arc = Arc::new(RwLock::new(store));
 
     // Spawn multiple writers.
@@ -733,7 +720,8 @@ fn test_delta_roundtrip_put() {
     let owner = test_agent(1);
     let store_id = test_store_id(1);
 
-    let mut source = KvStore::new(store_id, "Source".to_string(), owner, AccessPolicy::Signed);
+    let mut source = KvStore::new(store_id, "Source".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
 
     source
         .put(
@@ -757,7 +745,8 @@ fn test_delta_roundtrip_put() {
     assert!(!delta.is_empty());
 
     // Apply delta to a fresh target store.
-    let mut target = KvStore::new(store_id, "Target".to_string(), owner, AccessPolicy::Signed);
+    let mut target = KvStore::new(store_id, "Target".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
 
     target
         .merge_delta(&delta, peer, Some(&owner))
@@ -778,8 +767,9 @@ fn test_delta_crdt_trait_integration() {
         store_id,
         "DeltaCRDT".to_string(),
         owner,
-        AccessPolicy::Encrypted { group_id: vec![1] },
-    );
+        AccessPolicy::Signed,
+    )
+    .expect("kv store");
 
     assert_eq!(DeltaCrdt::version(&store), 0);
     assert!(DeltaCrdt::delta(&store, 0).is_none());
@@ -796,14 +786,22 @@ fn test_delta_crdt_trait_integration() {
     assert!(DeltaCrdt::version(&store) > 0);
     let delta = DeltaCrdt::delta(&store, 0).expect("delta should exist");
 
-    // Apply to fresh store.
-    let mut replica = KvStore::new(
-        store_id,
-        "Replica".to_string(),
-        owner,
-        AccessPolicy::Encrypted { group_id: vec![1] },
-    );
+    // #341 Phase A: the writer-less `DeltaCrdt::merge` used to ride the
+    // permissive Encrypted policy; it now applies nothing for every policy.
+    // Assert that fail-closed behavior, then apply through the real
+    // writer-authenticated path.
+    let mut replica = KvStore::new(store_id, "Replica".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
     DeltaCrdt::merge(&mut replica, &delta).expect("merge");
+    assert!(
+        replica.get("x").is_none(),
+        "anonymous DeltaCrdt::merge must not apply"
+    );
+    assert_eq!(DeltaCrdt::version(&replica), 0);
+
+    replica
+        .merge_delta(&delta, peer, Some(&owner))
+        .expect("merge as owner");
     assert!(replica.get("x").is_some());
 }
 
@@ -899,7 +897,8 @@ fn test_signed_policy_rejects_non_owner_delta() {
     let peer = test_peer(99);
     let store_id = test_store_id(1);
 
-    let mut store = KvStore::new(store_id, "Signed".to_string(), owner, AccessPolicy::Signed);
+    let mut store = KvStore::new(store_id, "Signed".to_string(), owner, AccessPolicy::Signed)
+        .expect("kv store");
 
     let entry = KvEntry::new(
         "spam".to_string(),
@@ -930,7 +929,8 @@ fn test_allowlisted_policy_workflow() {
         "Team".to_string(),
         owner,
         AccessPolicy::Allowlisted,
-    );
+    )
+    .expect("kv store");
 
     // Initially only the owner is authorized.
     assert!(store.is_authorized(&owner));
@@ -972,10 +972,12 @@ fn test_merge_propagates_allowlist() {
     let writer = test_agent(2);
     let store_id = test_store_id(1);
 
-    let mut store_a = KvStore::new(store_id, "A".to_string(), owner, AccessPolicy::Allowlisted);
+    let mut store_a = KvStore::new(store_id, "A".to_string(), owner, AccessPolicy::Allowlisted)
+        .expect("kv store");
     store_a.allow_writer(writer, &owner).expect("allow");
 
-    let mut store_b = KvStore::new(store_id, "B".to_string(), owner, AccessPolicy::Allowlisted);
+    let mut store_b = KvStore::new(store_id, "B".to_string(), owner, AccessPolicy::Allowlisted)
+        .expect("kv store");
 
     // Merge A into B — allowlist should propagate.
     store_b.merge(&store_a).expect("merge");
@@ -993,7 +995,8 @@ fn test_full_delta_includes_allowlist() {
         "Delta".to_string(),
         owner,
         AccessPolicy::Allowlisted,
-    );
+    )
+    .expect("kv store");
     store.allow_writer(writer, &owner).expect("allow");
 
     let delta = store.full_delta();

--- a/tests/proptest_kv.rs
+++ b/tests/proptest_kv.rs
@@ -42,6 +42,7 @@ fn make_store(owner: AgentId, policy: AccessPolicy) -> KvStore {
         owner,
         policy,
     )
+    .expect("kv store")
 }
 
 proptest! {


### PR DESCRIPTION
## Summary
- Phase A only: `AccessPolicy::Encrypted` is unconstructible via `KvStore::new` / Agent create (`KvError::EncryptedPolicyReserved { group_id }`).
- Forced/deserialized Encrypted replicas fail closed: `is_authorized` is false; `authorize_local_write` returns the reserved error; `merge_delta` applies nothing for `writer` None or Some. WARN at `x0x::kv` includes `group_id`.
- Encrypted stays discriminant 2. REST `POST /stores` and `manifest_policy` still reject `"encrypted"`. Tests no longer use Encrypted as a writer=None fixture.

## Out of scope
No Phase B (`SecureContext`, encryption, `POST /groups/:id/stores`). No #340 SelfKeyed. No #349. Do not close #341 on Phase A alone.

## Test plan
- [x] `encrypted_new_is_reserved`
- [x] `encrypted_fail_closed_if_forced`
- [x] `access_policy_bincode_discriminants_are_pinned` (Encrypted == 2)
- [x] `create_policy_parsing_rejects_encrypted_and_garbage` / `manifest_policy_parses_and_fails_closed`
- [x] `agent_create_kv_store_with_encrypted_policy_is_reserved`
- [x] rewritten `test_delta_crdt_trait` + `kv_store_integration` (35 passed)
- [x] `cargo fmt`, `clippy --all-targets -D warnings`, `cargo check --workspace --all-targets`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reserves the Encrypted KV policy by rejecting new construction and making forced or deserialized replicas reject local writes and delta merges. It also updates Agent creation, persistent restoration, REST/manifest parsing, and tests for the new fallible constructor and pinned wire discriminant.
- Adds a dedicated EncryptedPolicyReserved error and warning diagnostics.
- Rejects Encrypted stores across constructor and Agent create paths.
- Makes authorization and writer-authenticated delta application fail closed.
- Keeps Encrypted’s bincode discriminant stable and updates integration/property tests.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking consistency gap in the public full-state merge API for deserialized Encrypted replicas.

The live synchronization and creation paths fail closed as intended, but direct users of the retained public KvStore::merge method can still mutate a replica carrying the reserved policy.

**Files Needing Attention:** src/kv/store.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/kv/store.rs | Adds the core reserved-policy checks, but the public full-state merge method remains outside the fail-closed guard. |
| src/lib.rs | Rejects Encrypted Agent creation and refuses legacy Encrypted snapshots before starting synchronization. |
| src/kv/error.rs | Adds the dedicated EncryptedPolicyReserved error carrying the group identifier. |
| src/server/crdt_subscriptions.rs | Confirms reserved encrypted manifest policies are skipped rather than downgraded. |
| src/server/routes/stores.rs | Keeps the flat store-creation API restricted to signed and append-only policies. |
| src/kv/delta.rs | Updates DeltaCrdt tests and documentation to reflect anonymous merges applying nothing. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Encrypted policy input] --> B{Entry path}
  B -->|KvStore::new / Agent create| C[Return reserved-policy error]
  B -->|Legacy deserialization| D[Reachable Encrypted replica]
  D -->|Local write| E[Reject with reserved-policy error]
  D -->|merge_delta| F[Apply nothing]
  D -->|Public merge| G[Full-state merge remains possible]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/kv/store.rs`, line 1721 ([link](https://github.com/saorsa-labs/x0x/blob/fb592640f666bb0086d22ecc4e801fbf0a7c896c/src/kv/store.rs#L1721)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Encrypted full-state merge bypass**

   The public `KvStore::merge` path invokes `merge_unchecked` without rejecting a destination carrying `AccessPolicy::Encrypted`, so direct callers can mutate keys, entries, allowlisted writers, the name, and the version of a forced or deserialized Encrypted replica despite the new fail-closed contract.

   **Knowledge Base Used:** [KV Store](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/kv.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/kv/store.rs
   Line: 1721
   
   Comment:
   **Encrypted full-state merge bypass**
   
   The public `KvStore::merge` path invokes `merge_unchecked` without rejecting a destination carrying `AccessPolicy::Encrypted`, so direct callers can mutate keys, entries, allowlisted writers, the name, and the version of a forced or deserialized Encrypted replica despite the new fail-closed contract.
   
   **Knowledge Base Used:** [KV Store](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/kv.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/kv/store.rs:1721
**Encrypted full-state merge bypass**

The public `KvStore::merge` path invokes `merge_unchecked` without rejecting a destination carrying `AccessPolicy::Encrypted`, so direct callers can mutate keys, entries, allowlisted writers, the name, and the version of a forced or deserialized Encrypted replica despite the new fail-closed contract.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(kv): reserve Encrypted policy fail-c..."](https://github.com/saorsa-labs/x0x/commit/fb592640f666bb0086d22ecc4e801fbf0a7c896c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54709090)</sub>

**Context used:**

- Knowledge Base — [KV Store](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/kv.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)

<!-- /greptile_comment -->