### PR TITLE
feat(kv): AccessPolicy::SelfKeyed lowest-N quota (#340)

### DIFF
--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -1188,8 +1188,10 @@ enum StoreSub {
         name: String,
         /// Gossip topic for sync.
         topic: String,
-        /// Access policy: "signed" (default) or "append_only" (existing keys
-        /// are immutable — no update, no delete, even by the owner).
+        /// Access policy: "signed" (default), "append_only" (existing keys
+        /// are immutable — no update, no delete, even by the owner), or
+        /// "self_keyed" (owner-free directory; writers are bound to their
+        /// AgentId key prefix).
         #[arg(long)]
         policy: Option<String>,
     },

--- a/src/cli/commands/store.rs
+++ b/src/cli/commands/store.rs
@@ -10,8 +10,10 @@ pub async fn list(client: &DaemonClient) -> Result<()> {
 
 /// `x0x store create` — POST /stores.
 ///
-/// `policy` is the optional access policy: `"signed"` (default) or
-/// `"append_only"` (existing keys immutable, even to the owner).
+/// `policy` is the optional access policy: `"signed"` (default),
+/// `"append_only"` (existing keys immutable, even to the owner), or
+/// `"self_keyed"` (owner-free directory: joiners write only keys prefixed
+/// by their own AgentId).
 pub async fn create(
     client: &DaemonClient,
     name: &str,

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -103,6 +103,29 @@ pub enum KvError {
         /// The group id the reserved policy carried.
         group_id: Vec<u8>,
     },
+
+    /// A `SelfKeyed` writer's per-agent quota would be exceeded (issue #340).
+    ///
+    /// The quota is a deterministic admission rule (lowest-N in lexicographic
+    /// key order), not spam resistance: it caps how much of a shared
+    /// directory topic one agent's namespace can occupy so every replica
+    /// admits the same subset. `keys`/`bytes` are the counts the writer's
+    /// candidate live set reached; `max_keys`/`max_bytes` are the protocol
+    /// constants. Raising them is a coordinated protocol change — divergent
+    /// constants would split-brain on which keys exist.
+    #[error("self_keyed quota exceeded for agent {agent:?}: candidates {keys} keys / {bytes} bytes exceed max {max_keys} keys / {max_bytes} bytes (lowest-N admission)")]
+    AgentQuotaExceeded {
+        /// The writer whose candidate live set exceeded the cap.
+        agent: AgentId,
+        /// Candidate live key count (existing survivors plus this write).
+        keys: usize,
+        /// Candidate live byte total (`Σ value.len()`).
+        bytes: u64,
+        /// Protocol constant `MAX_SELFKEYED_KEYS_PER_AGENT`.
+        max_keys: usize,
+        /// Protocol constant `MAX_SELFKEYED_BYTES_PER_AGENT`.
+        max_bytes: u64,
+    },
 }
 
 #[cfg(test)]

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -32,6 +32,7 @@ pub use delta::KvStoreDelta;
 pub use entry::KvEntry;
 pub use error::{KvError, Result};
 pub use store::{
-    AccessPolicy, AnchorChannel, KvStore, KvStoreId, OwnershipSource, OwnershipStatus,
+    key_agent_prefix, AccessPolicy, AnchorChannel, KvStore, KvStoreId, OwnershipSource,
+    OwnershipStatus, MAX_SELFKEYED_BYTES_PER_AGENT, MAX_SELFKEYED_KEYS_PER_AGENT,
 };
 pub use sync::KvStoreSync;

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -19,6 +19,14 @@
 //!   immutable — no update, no delete, even by the owner. Use for
 //!   tamper-evident event logs where the author must not be able to rewrite
 //!   history retroactively.
+//! - **SelfKeyed**: No owner. Any agent may join knowing only the topic and
+//!   write exclusively under its own namespace: keys whose first 64
+//!   characters are the lowercase-hex `AgentId` (an optional `/suffix`
+//!   follows). Write authority is bound by the key prefix, not a store owner,
+//!   and each agent is capped by a deterministic per-agent quota
+//!   ([`MAX_SELFKEYED_KEYS_PER_AGENT`] keys / [`MAX_SELFKEYED_BYTES_PER_AGENT`]
+//!   bytes, admitted lowest-N in lexicographic order). Use for open
+//!   directories with many mutually-unknown publishers.
 
 use crate::identity::AgentId;
 use crate::kv::{KvEntry, KvError, KvStoreDelta, Result};
@@ -83,12 +91,29 @@ pub enum AccessPolicy {
     /// numbers + previous-entry hashes, as x0x-symphony's tracker-integrity-v2
     /// does — see saorsa-labs/x0x-symphony#10); witnesses/transparency logs
     /// are out of scope here.
+    AppendOnly,
+
+    /// Owner-free open directory: any agent that knows the topic may join,
+    /// and each writer owns exactly the keys whose first 64 characters are
+    /// the lowercase-hex encoding of its `AgentId` (optionally followed by
+    /// `/suffix`). See [`key_agent_prefix`] for the grammar and the binding
+    /// invariant (I1: write/tombstone iff `key_agent_prefix(key) ==
+    /// Some(writer)`).
+    ///
+    /// The store has **no owner for its entire life** (`owner = None`;
+    /// `OwnerUnknown` never fires) — ownership paths (announces, allowlists,
+    /// owner-signed checkpoints) are no-ops. A hard per-agent quota
+    /// ([`MAX_SELFKEYED_KEYS_PER_AGENT`] / [`MAX_SELFKEYED_BYTES_PER_AGENT`])
+    /// admits writes deterministically (lowest-N lexicographic) so every
+    /// replica converges on the same subset. Raising those constants is a
+    /// coordinated protocol change; document next to the discriminant pin
+    /// (`access_policy_bincode_discriminants_are_pinned`).
     ///
     /// NOTE: this variant MUST stay last — bincode encodes enum variants
     /// positionally, and stores/checkpoints/deltas carrying `AccessPolicy`
     /// are bincode-serialized on disk and on the wire. Inserting a variant
     /// mid-enum would corrupt every existing store.
-    AppendOnly,
+    SelfKeyed,
 }
 
 impl std::fmt::Display for AccessPolicy {
@@ -98,8 +123,63 @@ impl std::fmt::Display for AccessPolicy {
             Self::Allowlisted => write!(f, "allowlisted"),
             Self::Encrypted { .. } => write!(f, "encrypted"),
             Self::AppendOnly => write!(f, "append_only"),
+            Self::SelfKeyed => write!(f, "self_keyed"),
         }
     }
+}
+
+/// Maximum number of active (OR-Set-live) keys one agent may hold in a
+/// [`AccessPolicy::SelfKeyed`] store (issue #340).
+///
+/// Protocol constant, NOT a create-time knob: every joiner must admit the
+/// same subset (lowest-N) or replicas split-brain on which keys exist.
+/// Raising it is a coordinated protocol change.
+pub const MAX_SELFKEYED_KEYS_PER_AGENT: usize = 64;
+
+/// Maximum total value bytes one agent may hold in a
+/// [`AccessPolicy::SelfKeyed`] store (issue #340).
+///
+/// Protocol constant, NOT a create-time knob — see
+/// [`MAX_SELFKEYED_KEYS_PER_AGENT`]. Tombstones do not count (they free
+/// budget); this is a deterministic admission bound, not spam resistance.
+pub const MAX_SELFKEYED_BYTES_PER_AGENT: u64 = 256 * 1024;
+
+/// Parse the writer-binding prefix of a `SelfKeyed` store key (issue #340).
+///
+/// Grammar: `key := lowercase_hex(AgentId, 64 chars) [ "/" suffix ]`.
+///
+/// - The first 64 characters must be lowercase hex (`0-9`, `a-f`) decoding to
+///   exactly the 32-byte `AgentId`.
+/// - If the key is longer than 64 characters, character 65 MUST be `/` — any
+///   other separator (`.` `:` `_` …) is rejected, so one agent's namespace is
+///   never a prefix of another's.
+/// - A bare 64-character key (no suffix) is valid: the agent's root record.
+///
+/// A key that fails this parse is writable by **no one**.
+#[must_use]
+pub fn key_agent_prefix(key: &str) -> Option<AgentId> {
+    let bytes = key.as_bytes();
+    if bytes.len() < 64 {
+        return None;
+    }
+    if bytes.len() > 64 && bytes[64] != b'/' {
+        return None;
+    }
+    let mut id = [0u8; 32];
+    for (i, &b) in bytes[..64].iter().enumerate() {
+        let v = match b {
+            b'0'..=b'9' => b - b'0',
+            b'a'..=b'f' => b - b'a' + 10,
+            // Uppercase and non-hex characters are rejected.
+            _ => return None,
+        };
+        if i % 2 == 0 {
+            id[i / 2] = v << 4;
+        } else {
+            id[i / 2] |= v;
+        }
+    }
+    Some(AgentId(id))
 }
 
 /// Unique identifier for a KvStore (32 bytes).
@@ -146,6 +226,22 @@ impl KvStoreId {
         hasher.update(b"x0x.store.v2");
         hasher.update(topic.as_bytes());
         hasher.update(owner.as_bytes());
+        Self(*hasher.finalize().as_bytes())
+    }
+
+    /// Derive an owner-free store ID for a [`AccessPolicy::SelfKeyed`]
+    /// directory topic (issue #340).
+    ///
+    /// Every joiner who knows only the topic computes the same id — there is
+    /// no owner to bind. The domain tag (`x0x.store.selfkeyed.v1`) is
+    /// distinct from both `x0x.store` and `x0x.store.v2`, so the same topic
+    /// string under `Signed` (via [`for_topic_owner`](Self::for_topic_owner))
+    /// never collides with its self-keyed directory.
+    #[must_use]
+    pub fn for_self_keyed_topic(topic: &str) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"x0x.store.selfkeyed.v1");
+        hasher.update(topic.as_bytes());
         Self(*hasher.finalize().as_bytes())
     }
 }
@@ -760,6 +856,43 @@ impl KvStore {
         }
     }
 
+    /// Create a new owner-free [`AccessPolicy::SelfKeyed`] directory store.
+    ///
+    /// `owner` is `None` for life: write authority is the key-prefix binding
+    /// ([`key_agent_prefix`]), not an owner anchor, so `OwnerUnknown` never
+    /// fires on this store. Named separately from
+    /// [`new_replica`](Self::new_replica) so that path cannot drift into an
+    /// owner-free writable mode.
+    #[must_use]
+    pub fn new_self_keyed(id: KvStoreId, name: String) -> Self {
+        Self {
+            id,
+            keys: OrSet::new(),
+            entries: HashMap::new(),
+            name: LwwRegister::new(name),
+            policy: AccessPolicy::SelfKeyed,
+            owner: None,
+            anchor_channel: AnchorChannel::Persistence,
+            policy_version: 0,
+            ownership_conflict: None,
+            latest_checkpoint: None,
+            highest_checkpoint_seq: 0,
+            allowed_writers: HashSet::new(),
+            version: 0,
+            seq_counter: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Create a joined replica of an owner-free
+    /// [`AccessPolicy::SelfKeyed`] directory store.
+    ///
+    /// Same shape as [`new_self_keyed`](Self::new_self_keyed); named
+    /// separately so a future edit to one cannot silently change the other.
+    #[must_use]
+    pub fn join_self_keyed(id: KvStoreId, name: String) -> Self {
+        Self::new_self_keyed(id, name)
+    }
+
     /// Get the next monotonically-increasing sequence number.
     pub fn next_seq(&self) -> u64 {
         self.seq_counter.fetch_add(1, Ordering::Relaxed) + 1
@@ -905,7 +1038,108 @@ impl KvStore {
                 // (put/remove/merge_delta/checkpoint adoption).
                 self.owner.as_ref().is_some_and(|o| o == agent_id)
             }
+            AccessPolicy::SelfKeyed => {
+                // Fail-closed for the key-less store-wide predicate: a
+                // SelfKeyed store has no owner and authority is per key
+                // (I1/I3). Callers that forgot the key get `false`; the
+                // mutation paths use `authorize_write` / `is_authorized_for_key`.
+                false
+            }
         }
+    }
+
+    /// Check that `writer` may write `key` under this store's policy.
+    ///
+    /// This is the key-aware authority predicate for
+    /// [`AccessPolicy::SelfKeyed`] (I1: the key's agent prefix must equal
+    /// `writer`); the owner-anchored policies ignore the key and apply their
+    /// store-wide rule; the reserved [`AccessPolicy::Encrypted`] is
+    /// fail-closed (#341 Phase A / #358).
+    #[must_use]
+    pub fn is_authorized_for_key(&self, writer: &AgentId, key: &str) -> bool {
+        match &self.policy {
+            AccessPolicy::SelfKeyed => key_agent_prefix(key) == Some(*writer),
+            // Owner-anchored and reserved policies: key-independent.
+            _ => self.is_authorized(writer),
+        }
+    }
+
+    /// Enforce the store's access policy for a mutation of `key` by
+    /// `writer`.
+    ///
+    /// The key-aware successor of [`authorize_local_write`](Self::authorize_local_write)
+    /// and the local-write counterpart of the inbound check in
+    /// [`merge_delta`](Self::merge_delta): the same rule is applied before a
+    /// local put/remove mutates the replica, so an unauthorized local write
+    /// can never fork the replica away from what authorized peers accept.
+    ///
+    /// # Errors
+    ///
+    /// - [`KvError::OwnerUnknown`] if an owner-anchored policy
+    ///   (`Signed`/`Allowlisted`/`AppendOnly`) has no anchored owner.
+    ///   Never returned for `SelfKeyed` (I3: it has no owner for life).
+    /// - [`KvError::Unauthorized`] if `writer` is not authorized for `key`.
+    pub fn authorize_write(&self, writer: &AgentId, key: &str) -> Result<()> {
+        match &self.policy {
+            AccessPolicy::Encrypted { .. } => {
+                // Matches the inbound path: the reserved Encrypted policy is
+                // currently permissive at the store layer (#341).
+                Ok(())
+            }
+            AccessPolicy::SelfKeyed => {
+                if self.is_authorized_for_key(writer, key) {
+                    Ok(())
+                } else {
+                    Err(KvError::Unauthorized(format!(
+                        "self_keyed store: key {key:?} is not bound to writer {}",
+                        hex::encode(writer.as_bytes())
+                    )))
+                }
+            }
+            AccessPolicy::Signed | AccessPolicy::Allowlisted | AccessPolicy::AppendOnly => {
+                let Some(owner) = self.owner.as_ref() else {
+                    return Err(KvError::OwnerUnknown);
+                };
+                if !self.is_authorized_for_key(writer, key) {
+                    return Err(KvError::Unauthorized(format!(
+                        "store policy is {}; owner is {}",
+                        self.policy,
+                        hex::encode(owner.as_bytes())
+                    )));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Enforce authority AND the `SelfKeyed` per-agent quota for a local put
+    /// of `value` under `key`.
+    ///
+    /// Applies the SAME deterministic lowest-N admission predicate as the
+    /// remote merge path (`merge_delta`), so a local write that peers would
+    /// drop never mutates this replica. Authority is checked first
+    /// (`Unauthorized` wins over the quota); `MAX_INLINE_SIZE` is checked
+    /// before the quota so a single oversized value still surfaces as
+    /// [`KvError::ValueTooLarge`].
+    ///
+    /// # Errors
+    ///
+    /// As [`authorize_write`](Self::authorize_write), plus
+    /// [`KvError::AgentQuotaExceeded`] when the put would fall outside the
+    /// writer's admitted lowest-N set, and [`KvError::ValueTooLarge`] for a
+    /// single value above the inline maximum.
+    pub fn authorize_put(&self, writer: &AgentId, key: &str, value: &[u8]) -> Result<()> {
+        self.authorize_write(writer, key)?;
+        if matches!(self.policy, AccessPolicy::SelfKeyed) {
+            if value.len() > crate::kv::entry::MAX_INLINE_SIZE {
+                return Err(KvError::ValueTooLarge {
+                    size: value.len(),
+                    max: crate::kv::entry::MAX_INLINE_SIZE,
+                });
+            }
+            self.check_self_keyed_admission(writer, key, value.len())?;
+        }
+        Ok(())
     }
 
     /// Check that `writer` may perform a local mutation on this store.
@@ -942,6 +1176,16 @@ impl KvStore {
             return Err(KvError::EncryptedPolicyReserved {
                 group_id: group_id.clone(),
             });
+        }
+        if matches!(self.policy, AccessPolicy::SelfKeyed) {
+            // Legacy key-less check: a SelfKeyed store cannot validate the
+            // prefix binding without a key. Fail closed WITHOUT OwnerUnknown
+            // (I3 — the store deliberately has no owner); the mutation paths
+            // use the key-aware `authorize_write` / `authorize_put`.
+            return Err(KvError::Unauthorized(
+                "self_keyed store: authorization is per key — use authorize_write(writer, key)"
+                    .to_string(),
+            ));
         }
         let Some(owner) = self.owner.as_ref() else {
             return Err(KvError::OwnerUnknown);
@@ -1209,6 +1453,199 @@ impl KvStore {
         self.version += 1;
     }
 
+    // -----------------------------------------------------------------
+    // SelfKeyed quota (issue #340) — deterministic lowest-N admission.
+    // -----------------------------------------------------------------
+
+    /// Candidate live `(key, value_len)` pairs for `writer`, overlaid with
+    /// pending puts (`key -> NEW value_len`; an update of a live key counts
+    /// the replacement value). Lexicographically sorted; foreign keys are
+    /// never included.
+    fn self_keyed_candidates(
+        &self,
+        writer: &AgentId,
+        puts: &HashMap<String, u64>,
+    ) -> Vec<(String, u64)> {
+        let mut lens: HashMap<String, u64> = self
+            .keys
+            .elements()
+            .into_iter()
+            .filter(|k| key_agent_prefix(k) == Some(*writer))
+            .map(|k| {
+                (
+                    k.clone(),
+                    self.entries.get(k).map_or(0u64, |e| e.value.len() as u64),
+                )
+            })
+            .collect();
+        for (key, len) in puts {
+            lens.insert(key.clone(), *len);
+        }
+        let mut candidates: Vec<(String, u64)> = lens.into_iter().collect();
+        candidates.sort_by(|a, b| a.0.cmp(&b.0));
+        candidates
+    }
+
+    /// Deterministic lowest-N admission (I7): admit candidates from the
+    /// lexicographic front until the key-count or byte-total cap would be
+    /// exceeded; everything from there on (the tail) is dropped. A pure
+    /// function of the candidate set, so any two replicas with the same live
+    /// set admit the same subset.
+    fn self_keyed_admitted(candidates: &[(String, u64)]) -> HashSet<&str> {
+        let mut admitted: HashSet<&str> = HashSet::new();
+        let mut bytes = 0u64;
+        for (key, len) in candidates {
+            if admitted.len() >= MAX_SELFKEYED_KEYS_PER_AGENT
+                || bytes.saturating_add(*len) > MAX_SELFKEYED_BYTES_PER_AGENT
+            {
+                break; // drop this candidate and the whole lexicographic tail
+            }
+            admitted.insert(key.as_str());
+            bytes = bytes.saturating_add(*len);
+        }
+        admitted
+    }
+
+    /// Local-put quota predicate — the SAME rule the remote merge applies,
+    /// so a local write that peers would drop never mutates this replica.
+    fn check_self_keyed_admission(
+        &self,
+        writer: &AgentId,
+        key: &str,
+        value_len: usize,
+    ) -> Result<()> {
+        let mut puts = HashMap::new();
+        puts.insert(key.to_string(), value_len as u64);
+        let candidates = self.self_keyed_candidates(writer, &puts);
+        let admitted = Self::self_keyed_admitted(&candidates);
+        if admitted.contains(key) {
+            return Ok(());
+        }
+        let bytes = candidates.iter().map(|(_, len)| len).sum();
+        Err(KvError::AgentQuotaExceeded {
+            agent: *writer,
+            keys: candidates.len(),
+            bytes,
+            max_keys: MAX_SELFKEYED_KEYS_PER_AGENT,
+            max_bytes: MAX_SELFKEYED_BYTES_PER_AGENT,
+        })
+    }
+
+    /// `AccessPolicy::SelfKeyed` merge path (issue #340).
+    ///
+    /// Per-key authority instead of a whole-delta owner gate: the gossip
+    /// envelope's verified `msg.sender` (passed as `writer`) is the only
+    /// identity, and a writer can only touch keys bound to its own prefix
+    /// (I1). Anonymous deltas apply NOTHING (I5). Encrypted is independently
+    /// fail-closed (#358); SelfKeyed does not share that path.
+    ///
+    /// Order: the writer's own tombstones first (they free quota budget),
+    /// then own adds/updates admitted by the deterministic lowest-N rule,
+    /// then eviction of the writer's live keys outside the admitted set (the
+    /// quota is a hard cap on the live set, so replicas fed in different
+    /// orders converge on the same subset — I7). Foreign keys in
+    /// `added`/`updated`/`removed` are skipped (I6). Allowlist mutations and
+    /// any carried owner checkpoint are ignored (I8 — this store has no
+    /// owner and never publishes or adopts checkpoints).
+    fn merge_delta_self_keyed(
+        &mut self,
+        delta: &KvStoreDelta,
+        peer_id: PeerId,
+        writer: Option<&AgentId>,
+    ) -> Result<()> {
+        let Some(w) = writer else {
+            tracing::warn!("rejected anonymous self_keyed delta for store {}", self.id);
+            return Ok(()); // silent whole-delta reject — applies nothing
+        };
+        // Ambiguity gate (mirrors the sender-auth path): a delta carrying the
+        // same key in both `added` and `updated` is ambiguous by
+        // construction — drop the whole delta.
+        for key in delta.updated.keys() {
+            if delta.added.contains_key(key) {
+                tracing::warn!(
+                    "rejected ambiguous self_keyed delta for store {}: key {key:?} appears in both added and updated",
+                    self.id
+                );
+                return Ok(());
+            }
+        }
+        // 1. The writer's own tombstones first — a single delta can free
+        //    budget and spend it (apply-order guarantee).
+        for key in delta.removed.keys() {
+            if key_agent_prefix(key) != Some(*w) {
+                continue; // foreign tombstone: skipped (I6)
+            }
+            let _ = self.keys.remove(key);
+            self.entries.remove(key);
+        }
+        // 2. Collect the writer's otherwise-admissible puts (prefix-bound
+        //    keys only; foreign keys are skipped).
+        let mut puts: HashMap<String, u64> = HashMap::new();
+        for (key, (entry, _tag)) in &delta.added {
+            if key_agent_prefix(key) == Some(*w) {
+                puts.insert(key.clone(), entry.value.len() as u64);
+            }
+        }
+        for (key, entry) in &delta.updated {
+            if key_agent_prefix(key) == Some(*w) {
+                puts.insert(key.clone(), entry.value.len() as u64);
+            }
+        }
+        // 3. Deterministic lowest-N admission over survivors ∪ own puts.
+        //    `admitted` contains only the writer's own keys, so foreign puts
+        //    fail the membership check below and are skipped.
+        let candidates = self.self_keyed_candidates(w, &puts);
+        let admitted = Self::self_keyed_admitted(&candidates);
+        for (key, (entry, tag)) in &delta.added {
+            if !admitted.contains(key.as_str()) {
+                continue; // foreign key or over-quota tail: skipped
+            }
+            self.keys
+                .add(key.clone(), *tag)
+                .map_err(|e| KvError::Merge(format!("OR-Set add failed: {e}")))?;
+            if let Some(existing) = self.entries.get_mut(key) {
+                existing.merge(entry);
+            } else {
+                self.entries.insert(key.clone(), entry.clone());
+            }
+        }
+        for (key, entry) in &delta.updated {
+            if !admitted.contains(key.as_str()) {
+                continue;
+            }
+            if let Some(existing) = self.entries.get_mut(key) {
+                existing.merge(entry);
+            } else {
+                self.keys
+                    .add(key.clone(), (peer_id, 0))
+                    .map_err(|e| KvError::Merge(format!("OR-Set add failed: {e}")))?;
+                self.entries.insert(key.clone(), entry.clone());
+            }
+        }
+        // 4. Evict the writer's live keys outside the admitted set: the
+        //    admitted set is a pure function of the candidate live set, so
+        //    every replica converges to exactly that subset regardless of
+        //    delivery order (I7).
+        let stale: Vec<String> = self
+            .keys
+            .elements()
+            .into_iter()
+            .filter(|k| key_agent_prefix(k) == Some(*w) && !admitted.contains(k.as_str()))
+            .cloned()
+            .collect();
+        for key in stale {
+            let _ = self.keys.remove(&key);
+            self.entries.remove(&key);
+        }
+        // The name is LWW metadata, not directory content — merge it like
+        // every other policy so replicas converge on the creator's name.
+        if let Some(name_register) = &delta.name_update {
+            self.name.merge(name_register);
+        }
+        self.version += 1;
+        Ok(())
+    }
+
     /// Merge a delta into this store.
     ///
     /// Enforces access control: if the store has a Signed or Allowlisted
@@ -1220,6 +1657,12 @@ impl KvStore {
         peer_id: PeerId,
         writer: Option<&AgentId>,
     ) -> Result<()> {
+        // SelfKeyed directories take the per-key path: no owner gate, no
+        // checkpoint adoption — the store has no owner for life (I3/I8), so
+        // both owner-anchored blocks below would no-op anyway.
+        if matches!(self.policy, AccessPolicy::SelfKeyed) {
+            return self.merge_delta_self_keyed(delta, peer_id, writer);
+        }
         // Authoritative full-snapshot checkpoint adoption (cold-recovery path):
         // if the checkpoint's content root matches the relayed entry set, adopt
         // as owner-proven independent of the relayer. An incremental delta's
@@ -1824,7 +2267,15 @@ impl KvStore {
     /// declared digest (and its sender authorization) first — without that
     /// binding, any holder could truncate local state at will.
     pub(crate) fn prune_to_served_set(&mut self, delta: &KvStoreDelta) -> usize {
-        if matches!(self.policy, AccessPolicy::AppendOnly) {
+        if matches!(
+            self.policy,
+            AccessPolicy::AppendOnly | AccessPolicy::SelfKeyed
+        ) {
+            // SelfKeyed is prune-free for the same reason Allowlisted is:
+            // a peer's serve can legitimately omit co-writers' keys (the
+            // listener's sole-author gate already restricts pruning to
+            // Signed; this guard keeps any future caller from truncating a
+            // directory).
             return 0;
         }
         let stale: Vec<String> = self
@@ -4632,8 +5083,8 @@ mod tests {
         // WHY: AccessPolicy is bincode-encoded positionally in persisted
         // stores, checkpoints (wire + signing bytes), and deltas. If anyone
         // reorders or inserts a variant mid-enum, every existing store
-        // corrupts. This test pins the exact on-wire indices 0..=3.
-        let cases: [(AccessPolicy, u32); 4] = [
+        // corrupts. This test pins the exact on-wire indices 0..=4.
+        let cases: [(AccessPolicy, u32); 5] = [
             (AccessPolicy::Signed, 0),
             (AccessPolicy::Allowlisted, 1),
             (
@@ -4643,6 +5094,7 @@ mod tests {
                 2,
             ),
             (AccessPolicy::AppendOnly, 3),
+            (AccessPolicy::SelfKeyed, 4),
         ];
         for (policy, index) in cases {
             let bytes = bincode::serialize(&policy).expect("serialize");
@@ -4653,5 +5105,481 @@ mod tests {
                 "bincode discriminant for {policy} moved — this BREAKS every existing store/checkpoint"
             );
         }
+    }
+
+    // -----------------------------------------------------------------
+    // AccessPolicy::SelfKeyed (issue #340) — owner-free open directories.
+    // -----------------------------------------------------------------
+
+    fn hex_key(agent: &AgentId, suffix: Option<&str>) -> String {
+        match suffix {
+            Some(s) => format!("{}/{}", hex::encode(agent.as_bytes()), s),
+            None => hex::encode(agent.as_bytes()),
+        }
+    }
+
+    fn self_keyed_store() -> KvStore {
+        KvStore::new_self_keyed(store_id(9), "directory".to_string())
+    }
+
+    fn kv_entry(key: &str, val: &[u8]) -> KvEntry {
+        KvEntry::new(key.to_string(), val.to_vec(), "text/plain".to_string())
+    }
+
+    #[test]
+    fn key_agent_prefix_grammar() {
+        // WHY (I1): the key prefix IS the write-authority binding. If the
+        // grammar admitted ambiguous forms (uppercase, foreign separators,
+        // short prefixes), one agent's namespace could collide with or be a
+        // prefix of another's and the binding would be forgeable.
+        let w = AgentId([0xab; 32]); // hex form contains letters a-f
+        let hex_w = hex::encode(w.as_bytes());
+        assert_eq!(hex_w.len(), 64);
+        // Bare 64-hex key: the agent's root record.
+        assert_eq!(key_agent_prefix(&hex_w), Some(w));
+        // hex/suffix, including nested suffixes.
+        assert_eq!(key_agent_prefix(&format!("{hex_w}/profile")), Some(w));
+        assert_eq!(key_agent_prefix(&format!("{hex_w}/a/b")), Some(w));
+        // Uppercase hex rejected.
+        assert_eq!(key_agent_prefix(&hex_w.to_uppercase()), None);
+        // Length < 64 rejected.
+        assert_eq!(key_agent_prefix(&hex_w[..63]), None);
+        assert_eq!(key_agent_prefix(""), None);
+        // Length > 64 without the mandatory `/` at position 65 rejected.
+        assert_eq!(key_agent_prefix(&format!("{hex_w}x")), None);
+        // Any other separator rejected: one namespace is never a prefix of
+        // another's.
+        for sep in ['.', ':', '_', '-'] {
+            assert_eq!(
+                key_agent_prefix(&format!("{hex_w}{sep}x")),
+                None,
+                "separator {sep:?} must be rejected"
+            );
+        }
+        // Non-hex characters rejected.
+        let mut non_hex = hex_w.clone();
+        non_hex.replace_range(0..1, "z");
+        assert_eq!(key_agent_prefix(&non_hex), None);
+    }
+
+    #[test]
+    fn selfkeyed_local_put_requires_own_prefix() {
+        let me = agent(7);
+        let other = agent(9);
+        let mut store = self_keyed_store();
+
+        // Own prefixed key and bare own root record are both writable.
+        store
+            .authorize_put(&me, &hex_key(&me, Some("profile")), b"v")
+            .expect("own prefix writable");
+        store
+            .authorize_put(&me, &hex_key(&me, None), b"v")
+            .expect("bare own root record writable");
+
+        // Foreign prefix: Unauthorized — and never OwnerUnknown (I3: the
+        // store deliberately has no owner for life).
+        let err = store
+            .authorize_put(&me, &hex_key(&other, Some("x")), b"v")
+            .unwrap_err();
+        assert!(matches!(err, KvError::Unauthorized(_)), "got {err:?}");
+
+        // Malformed key: writable by no one.
+        let err = store
+            .authorize_put(&me, "not-a-bound-key", b"v")
+            .unwrap_err();
+        assert!(matches!(err, KvError::Unauthorized(_)), "got {err:?}");
+
+        // The legacy key-less predicate fails closed for SelfKeyed.
+        assert!(!store.is_authorized(&me));
+        assert!(!store.is_authorized_for_key(&me, "anything"));
+        assert!(store.is_authorized_for_key(&me, &hex_key(&me, None)));
+        let err = store.authorize_local_write(&me).unwrap_err();
+        assert!(
+            matches!(err, KvError::Unauthorized(_)),
+            "never OwnerUnknown: {err:?}"
+        );
+
+        // An authorized own-prefix put applies and reads back.
+        let key = hex_key(&me, Some("profile"));
+        store
+            .put(
+                key.clone(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+        assert_eq!(store.get(&key).expect("entry").value, b"v");
+        assert_eq!(store.owner(), None, "owner stays None for life (I3)");
+        assert_eq!(*store.policy(), AccessPolicy::SelfKeyed);
+    }
+
+    #[test]
+    fn selfkeyed_anonymous_delta_rejected() {
+        // WHY (I5): a SelfKeyed directory binds writes to the verified
+        // envelope sender; an anonymous delta has no identity to bind, so it
+        // must apply NOTHING. Encrypted is independently fail-closed (#358).
+        let w = agent(7);
+        let mut store = self_keyed_store();
+        let key = hex_key(&w, None);
+        let mut delta = KvStoreDelta::new(1);
+        delta
+            .added
+            .insert(key.clone(), (kv_entry(&key, b"v"), (peer(1), 1)));
+        store
+            .merge_delta(&delta, peer(1), None)
+            .expect("silent whole-delta reject is not an error");
+        assert!(
+            store.get(&key).is_none(),
+            "anonymous self_keyed delta applies nothing (I5)"
+        );
+        assert_eq!(store.current_version(), 0, "no state change");
+        // Encrypted contrast omitted: #358 made Encrypted unconstructible
+        // and fail-closed. Do not reopen construction here.
+    }
+
+    #[test]
+    fn selfkeyed_merge_delta_applies_only_own_keys() {
+        // WHY (I6): the envelope's verified sender is the only identity; a
+        // writer cannot forge another agent's namespace, and keys outside
+        // its prefix are dropped rather than applied.
+        let w = agent(7);
+        let other = agent(9);
+        let mut store = self_keyed_store();
+        let own = hex_key(&w, Some("a"));
+        let foreign = hex_key(&other, Some("b"));
+        let mut delta = KvStoreDelta::new(1);
+        delta
+            .added
+            .insert(own.clone(), (kv_entry(&own, b"own"), (peer(1), 1)));
+        delta.added.insert(
+            foreign.clone(),
+            (kv_entry(&foreign, b"foreign"), (peer(2), 1)),
+        );
+        // Allowlist mutations in the delta are ignored (I8).
+        delta.allowlist_additions = Some(vec![other]);
+        store.merge_delta(&delta, peer(1), Some(&w)).expect("merge");
+        assert_eq!(store.get(&own).expect("own key applied").value, b"own");
+        assert!(store.get(&foreign).is_none(), "foreign keys dropped (I6)");
+        assert!(
+            store.allowed_writers().is_empty(),
+            "allowlist mutations are ignored"
+        );
+    }
+
+    #[test]
+    fn selfkeyed_foreign_tombstone_dropped() {
+        let w = agent(7);
+        let other = agent(9);
+        let mut store = self_keyed_store();
+        // Seed the other agent's key via its own legitimate delta.
+        let other_key = hex_key(&other, Some("k"));
+        let mut seed = KvStoreDelta::new(1);
+        seed.added.insert(
+            other_key.clone(),
+            (kv_entry(&other_key, b"v"), (peer(2), 1)),
+        );
+        store
+            .merge_delta(&seed, peer(2), Some(&other))
+            .expect("seed");
+        assert!(store.get(&other_key).is_some());
+
+        // w attempts to tombstone other's key remotely: skipped.
+        let mut delta = KvStoreDelta::new(2);
+        delta.removed.insert(other_key.clone(), HashSet::new());
+        store.merge_delta(&delta, peer(1), Some(&w)).expect("merge");
+        assert!(
+            store.get(&other_key).is_some(),
+            "remote tombstone of a foreign key is dropped (I1)"
+        );
+
+        // Local counterpart: authorize_write refuses the foreign key.
+        let err = store.authorize_write(&w, &other_key).unwrap_err();
+        assert!(matches!(err, KvError::Unauthorized(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn selfkeyed_quota_enforced_local() {
+        // WHY (I7): the quota is a deterministic admission rule, and the
+        // local write path must use the SAME predicate as the remote merge
+        // or a local write could diverge from what peers keep.
+        let w = agent(7);
+        let mut store = self_keyed_store();
+        for i in 0..MAX_SELFKEYED_KEYS_PER_AGENT {
+            let key = hex_key(&w, Some(&format!("{i:03}")));
+            store
+                .authorize_put(&w, &key, b"v")
+                .expect("within the key cap");
+            store
+                .put(key, b"v".to_vec(), "text/plain".to_string(), peer(1))
+                .expect("put");
+        }
+        // The 65th active key: AgentQuotaExceeded with key-count fields.
+        let err = store
+            .authorize_put(&w, &hex_key(&w, Some("065")), b"v")
+            .unwrap_err();
+        match &err {
+            KvError::AgentQuotaExceeded {
+                keys,
+                bytes,
+                max_keys,
+                max_bytes,
+                ..
+            } => {
+                assert_eq!(*keys, MAX_SELFKEYED_KEYS_PER_AGENT + 1);
+                assert_eq!(*bytes, (MAX_SELFKEYED_KEYS_PER_AGENT + 1) as u64);
+                assert_eq!(*max_keys, MAX_SELFKEYED_KEYS_PER_AGENT);
+                assert_eq!(*max_bytes, MAX_SELFKEYED_BYTES_PER_AGENT);
+            }
+            other => panic!("expected AgentQuotaExceeded, got {other:?}"),
+        }
+        // The quota is per agent: a different agent's first key is unaffected.
+        let other = agent(9);
+        store
+            .authorize_put(&other, &hex_key(&other, Some("a")), b"v")
+            .expect("other agent unaffected");
+
+        // Byte growth past 256 KiB trips the byte fields (4 max-size values
+        // hit the cap exactly; a 5th exceeds it).
+        let mut byte_store = self_keyed_store();
+        let v = vec![0u8; crate::kv::entry::MAX_INLINE_SIZE];
+        for i in 0..4 {
+            let key = hex_key(&w, Some(&format!("{i}")));
+            byte_store
+                .authorize_put(&w, &key, &v)
+                .expect("within the byte cap");
+            byte_store
+                .put(key, v.clone(), "text/plain".to_string(), peer(1))
+                .expect("put");
+        }
+        let err = byte_store
+            .authorize_put(&w, &hex_key(&w, Some("4")), b"x")
+            .unwrap_err();
+        match &err {
+            KvError::AgentQuotaExceeded { keys, bytes, .. } => {
+                assert_eq!(*keys, 5);
+                assert_eq!(*bytes, MAX_SELFKEYED_BYTES_PER_AGENT + 1);
+            }
+            other => panic!("expected AgentQuotaExceeded, got {other:?}"),
+        }
+
+        // MAX_INLINE_SIZE still wins on a single oversized value.
+        let err = store
+            .authorize_put(
+                &w,
+                &hex_key(&w, Some("big")),
+                &vec![0u8; crate::kv::entry::MAX_INLINE_SIZE + 1],
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::ValueTooLarge { .. }),
+            "inline cap precedes the quota: {err:?}"
+        );
+    }
+
+    #[test]
+    fn selfkeyed_quota_lowest_n_converges() {
+        // WHY (I7): "drop until under cap" is replica-order-dependent and
+        // would split the directory. Lowest-N in lexicographic order is a
+        // pure function of the live set, so two replicas fed the SAME 80
+        // keys in DIFFERENT delivery orders must end with exactly the same
+        // 64 lexicographically-lowest keys.
+        let w = agent(7);
+        let total = MAX_SELFKEYED_KEYS_PER_AGENT + 16; // 80
+        let keys: Vec<String> = (0..total)
+            .map(|i| hex_key(&w, Some(&format!("{i:03}"))))
+            .collect();
+        let deltas: Vec<KvStoreDelta> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| {
+                let mut d = KvStoreDelta::new((i + 1) as u64);
+                d.added
+                    .insert(k.clone(), (kv_entry(k, b"v"), (peer(1), i as u64 + 1)));
+                d
+            })
+            .collect();
+
+        let mut forward = self_keyed_store();
+        let mut reverse = self_keyed_store();
+        for d in &deltas {
+            forward
+                .merge_delta(d, peer(1), Some(&w))
+                .expect("forward merge");
+        }
+        for d in deltas.iter().rev() {
+            reverse
+                .merge_delta(d, peer(1), Some(&w))
+                .expect("reverse merge");
+        }
+
+        let expected: Vec<String> = keys[..MAX_SELFKEYED_KEYS_PER_AGENT].to_vec();
+        for (label, store) in [("forward", &forward), ("reverse", &reverse)] {
+            let mut live: Vec<String> = store.active_keys().into_iter().cloned().collect();
+            live.sort();
+            assert_eq!(
+                live, expected,
+                "{label} replica must hold exactly the 64 lex-lowest keys"
+            );
+        }
+    }
+
+    #[test]
+    fn selfkeyed_quota_freed_by_remove() {
+        // WHY: tombstones must free budget — and a single delta must be able
+        // to free and spend in one message (tombstones apply before puts).
+        let w = agent(7);
+        let mut store = self_keyed_store();
+        for i in 0..MAX_SELFKEYED_KEYS_PER_AGENT {
+            store
+                .put(
+                    hex_key(&w, Some(&format!("{i:03}"))),
+                    b"v".to_vec(),
+                    "text/plain".to_string(),
+                    peer(1),
+                )
+                .expect("put");
+        }
+        // At the cap: a 65th key is refused.
+        store
+            .authorize_put(&w, &hex_key(&w, Some("999")), b"v")
+            .unwrap_err();
+        // An own tombstone frees count and bytes.
+        store
+            .remove(&hex_key(&w, Some("000")))
+            .expect("own remove frees budget");
+        store
+            .authorize_put(&w, &hex_key(&w, Some("999")), b"v")
+            .expect("quota freed by own tombstone");
+
+        // Remote apply-order: bring a replica to the cap, then one delta
+        // tombstones a key AND adds a fresh key.
+        let mut replica = self_keyed_store();
+        for i in 0..MAX_SELFKEYED_KEYS_PER_AGENT {
+            let key = hex_key(&w, Some(&format!("{i:03}")));
+            let mut d = KvStoreDelta::new(i as u64 + 1);
+            d.added
+                .insert(key.clone(), (kv_entry(&key, b"v"), (peer(1), i as u64 + 1)));
+            replica
+                .merge_delta(&d, peer(1), Some(&w))
+                .expect("seed replica");
+        }
+        let mut d = KvStoreDelta::new(99);
+        d.removed.insert(hex_key(&w, Some("000")), HashSet::new());
+        d.added.insert(
+            hex_key(&w, Some("999")),
+            (kv_entry(&hex_key(&w, Some("999")), b"v"), (peer(1), 99)),
+        );
+        replica
+            .merge_delta(&d, peer(1), Some(&w))
+            .expect("tombstone frees budget within one delta");
+        assert!(replica.get(&hex_key(&w, Some("000"))).is_none());
+        assert!(replica.get(&hex_key(&w, Some("999"))).is_some());
+    }
+
+    #[test]
+    fn selfkeyed_store_id_deterministic_and_domain_separated() {
+        // WHY (I2): joiners know only the topic; the id must be derivable
+        // from the topic alone, identical on every peer, and never collide
+        // with an owner-anchored derivation of the same topic string.
+        let owner = agent(1);
+        let a = KvStoreId::for_self_keyed_topic("directory/topic");
+        let b = KvStoreId::for_self_keyed_topic("directory/topic");
+        assert_eq!(a, b, "same topic ⇒ same id on every peer (I2)");
+        assert_ne!(a, KvStoreId::for_self_keyed_topic("other"));
+        assert_ne!(
+            a,
+            KvStoreId::for_topic_owner("directory/topic", &owner),
+            "domain-separated from the owner-anchored derivation"
+        );
+        assert_ne!(
+            a,
+            KvStoreId::from_content("directory/topic", &owner),
+            "domain-separated from the legacy derivation"
+        );
+    }
+
+    #[test]
+    fn selfkeyed_no_owner_checkpoint_and_no_prune() {
+        // WHY (I8): the store has no owner, so no checkpoint can be adopted
+        // and no peer's full serve may truncate a co-writer's key — a serve
+        // can legitimately omit keys this replica holds from another writer.
+        let w1 = agent(7);
+        let w2 = agent(9);
+        let mut store = self_keyed_store();
+        for (writer, suffix) in [(&w1, "a"), (&w2, "b")] {
+            let key = hex_key(writer, Some(suffix));
+            let mut d = KvStoreDelta::new(1);
+            d.added
+                .insert(key.clone(), (kv_entry(&key, b"v"), (peer(1), 1)));
+            store.merge_delta(&d, peer(1), Some(writer)).expect("merge");
+            assert!(store.get(&key).is_some());
+        }
+        // A delta carrying an (unverifiable) owner checkpoint is ignored:
+        // no owner exists to verify against, nothing adopted.
+        let mut cp_delta = KvStoreDelta::new(2);
+        cp_delta.owner_checkpoint = Some(OwnerCheckpoint {
+            topic: "directory".to_string(),
+            store_id: store_id(9),
+            owner_pubkey: Vec::new(),
+            policy: AccessPolicy::Signed,
+            policy_version: 9,
+            checkpoint_seq: 9,
+            content_root: [0u8; 32],
+            timestamp: 0,
+            signature: Vec::new(),
+        });
+        store
+            .merge_delta(&cp_delta, peer(1), Some(&w1))
+            .expect("checkpoint ignored");
+        assert!(
+            store.latest_checkpoint.is_none(),
+            "no OwnerCheckpoint is ever adopted (I8)"
+        );
+        assert_eq!(store.highest_checkpoint_seq, 0);
+        assert_eq!(store.owner(), None);
+
+        // A digest-verified-style full serve from w1 must NOT truncate w2's
+        // key: prune_to_served_set is a no-op on SelfKeyed (mirrors the
+        // Allowlisted sole-author rule — a peer's serve can omit
+        // co-writers' keys).
+        let w1_key = hex_key(&w1, Some("a"));
+        let mut serve = KvStoreDelta::new(3);
+        serve
+            .added
+            .insert(w1_key.clone(), (kv_entry(&w1_key, b"v"), (peer(1), 2)));
+        assert_eq!(
+            store.prune_to_served_set(&serve),
+            0,
+            "prune is a no-op for self_keyed"
+        );
+        assert!(
+            store.get(&hex_key(&w2, Some("b"))).is_some(),
+            "a co-writer's key survives another writer's full serve"
+        );
+    }
+
+    #[test]
+    fn selfkeyed_owner_announce_and_allowlist_ignored() {
+        // WHY (I8): ownership and the allowlist are owner-anchored concepts;
+        // a SelfKeyed store has no owner for life, so every such path must
+        // fail closed without mutating policy, owner, or the allowlist.
+        let mut store = self_keyed_store();
+        let claimant = agent(7);
+        // A self-announced ownership claim is rejected — ownership is
+        // construction-only and this store deliberately has none.
+        let err = store
+            .learn_ownership(claimant, AccessPolicy::Signed, 99, &claimant)
+            .unwrap_err();
+        assert!(matches!(err, KvError::OwnerTokenInvalid(_)));
+        assert_eq!(store.owner(), None);
+        assert_eq!(*store.policy(), AccessPolicy::SelfKeyed, "policy immutable");
+
+        // Allowlist mutations are owner-only and this store has no owner.
+        let err = store.allow_writer(claimant, &claimant).unwrap_err();
+        assert!(matches!(err, KvError::Unauthorized(_)), "got {err:?}");
+        let err = store.deny_writer(&claimant, &claimant).unwrap_err();
+        assert!(matches!(err, KvError::Unauthorized(_)), "got {err:?}");
+        assert!(store.allowed_writers().is_empty());
     }
 }

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -1122,6 +1122,10 @@ impl KvStore {
     /// before the quota so a single oversized value still surfaces as
     /// [`KvError::ValueTooLarge`].
     ///
+    /// This gates only the INCOMING key: `put` additionally trims the
+    /// writer's live set down to the admitted subset (same predicate), so a
+    /// local put can evict the writer's existing lex-high keys.
+    ///
     /// # Errors
     ///
     /// As [`authorize_write`](Self::authorize_write), plus
@@ -1337,6 +1341,11 @@ impl KvStore {
     /// immutable: a re-put of byte-identical content (same value AND
     /// content type) is accepted as an idempotent no-op so retries are safe,
     /// and anything else returns [`KvError::ImmutableKey`].
+    ///
+    /// Under [`AccessPolicy::SelfKeyed`], the writer's live set is trimmed to
+    /// the admitted lowest-N subset after the entry lands — the same rule
+    /// the remote merge applies — so a local put can evict the writer's
+    /// lex-highest keys.
     pub fn put(
         &mut self,
         key: String,
@@ -1361,6 +1370,14 @@ impl KvStore {
             }
         }
 
+        // Captured before `key` is consumed below: the SelfKeyed live-set cap
+        // is enforced after the entry lands.
+        let self_keyed_writer = if matches!(self.policy, AccessPolicy::SelfKeyed) {
+            key_agent_prefix(&key)
+        } else {
+            None
+        };
+
         let seq = self.next_seq();
 
         // Add key to OR-Set
@@ -1374,6 +1391,14 @@ impl KvStore {
         } else {
             self.entries
                 .insert(key.clone(), KvEntry::new(key, value, content_type));
+        }
+
+        // SelfKeyed live-set cap (I7): the quota bounds the live set, not
+        // just the write. `authorize_put` gates only the incoming key, so
+        // without this the local replica would keep the writer's over-cap
+        // lex-high keys that every remote evicts at step 4.
+        if let Some(writer) = self_keyed_writer {
+            self.enforce_self_keyed_live_set(&writer);
         }
 
         self.version += 1;
@@ -1531,6 +1556,36 @@ impl KvStore {
         })
     }
 
+    /// Shared live-set enforcement (I7): evict `writer`'s live keys outside
+    /// `admitted`. Both the remote merge (step 4 of
+    /// [`merge_delta_self_keyed`](Self::merge_delta_self_keyed)) and the
+    /// local put path call this, so neither side can hold keys the other
+    /// drops.
+    fn evict_outside_admitted(&mut self, writer: &AgentId, admitted: &HashSet<&str>) {
+        let stale: Vec<String> = self
+            .keys
+            .elements()
+            .into_iter()
+            .filter(|k| key_agent_prefix(k) == Some(*writer) && !admitted.contains(k.as_str()))
+            .cloned()
+            .collect();
+        for key in &stale {
+            let _ = self.keys.remove(key);
+            self.entries.remove(key);
+        }
+    }
+
+    /// Enforce the `SelfKeyed` live-set cap after a LOCAL put of a key bound
+    /// to `writer` — the same predicate as the remote merge's step 4,
+    /// recomputed over the post-put live set. [`authorize_put`](Self::authorize_put)
+    /// only gates the incoming key; without this the local replica could
+    /// hold 65 keys while every remote holds the admitted 64.
+    fn enforce_self_keyed_live_set(&mut self, writer: &AgentId) {
+        let candidates = self.self_keyed_candidates(writer, &HashMap::new());
+        let admitted = Self::self_keyed_admitted(&candidates);
+        self.evict_outside_admitted(writer, &admitted);
+    }
+
     /// `AccessPolicy::SelfKeyed` merge path (issue #340).
     ///
     /// Per-key authority instead of a whole-delta owner gate: the gossip
@@ -1625,18 +1680,10 @@ impl KvStore {
         // 4. Evict the writer's live keys outside the admitted set: the
         //    admitted set is a pure function of the candidate live set, so
         //    every replica converges to exactly that subset regardless of
-        //    delivery order (I7).
-        let stale: Vec<String> = self
-            .keys
-            .elements()
-            .into_iter()
-            .filter(|k| key_agent_prefix(k) == Some(*w) && !admitted.contains(k.as_str()))
-            .cloned()
-            .collect();
-        for key in stale {
-            let _ = self.keys.remove(&key);
-            self.entries.remove(&key);
-        }
+        //    delivery order (I7). Shared with the local put path
+        //    (`enforce_self_keyed_live_set`) so neither side can hold keys
+        //    the other drops.
+        self.evict_outside_admitted(w, &admitted);
         // The name is LWW metadata, not directory content — merge it like
         // every other policy so replicas converge on the creator's name.
         if let Some(name_register) = &delta.name_update {
@@ -5422,6 +5469,68 @@ mod tests {
                 "{label} replica must hold exactly the 64 lex-lowest keys"
             );
         }
+
+        // Local-put counterpart (I7): `authorize_put` only gates the incoming
+        // key, so `KvStore::put` must apply the same step-4 eviction or a
+        // writer filling 64 lex-high keys and then putting a lex-low key
+        // keeps 65 locally while every remote holds 64 — a local fork.
+        let high: Vec<String> = (0..MAX_SELFKEYED_KEYS_PER_AGENT)
+            .map(|i| hex_key(&w, Some(&format!("1{i:02}"))))
+            .collect();
+        let low = hex_key(&w, Some("050"));
+        let mut local = self_keyed_store();
+        for key in &high {
+            local
+                .authorize_put(&w, key, b"v")
+                .expect("lex-high key within the key cap");
+            local
+                .put(
+                    key.clone(),
+                    b"v".to_vec(),
+                    "text/plain".to_string(),
+                    peer(1),
+                )
+                .expect("put");
+        }
+        local
+            .authorize_put(&w, &low, b"v")
+            .expect("lex-low key sorts into the admitted set");
+        local
+            .put(
+                low.clone(),
+                b"v".to_vec(),
+                "text/plain".to_string(),
+                peer(1),
+            )
+            .expect("put");
+
+        // Second replica fed the SAME 65 keys through merge_delta, in the
+        // opposite order (low first), must land on the identical 64.
+        let mut remote = self_keyed_store();
+        for (i, key) in std::iter::once(&low).chain(high.iter()).enumerate() {
+            let mut d = KvStoreDelta::new((i + 1) as u64);
+            d.added
+                .insert(key.clone(), (kv_entry(key, b"v"), (peer(1), i as u64 + 1)));
+            remote.merge_delta(&d, peer(1), Some(&w)).expect("merge");
+        }
+
+        let mut admitted: Vec<String> = high.clone();
+        admitted.push(low.clone());
+        admitted.sort();
+        admitted.truncate(MAX_SELFKEYED_KEYS_PER_AGENT); // the lex-highest is evicted
+        for (label, store) in [("local", &local), ("remote", &remote)] {
+            let mut live: Vec<String> = store.active_keys().into_iter().cloned().collect();
+            live.sort();
+            assert_eq!(
+                live, admitted,
+                "{label} replica must hold exactly the admitted 64 after the local/remote split"
+            );
+        }
+        assert!(local.get(&low).is_some(), "the new lex-low key stays");
+        assert!(
+            local.get(high.last().expect("64 high keys")).is_none(),
+            "the lex-highest key is evicted locally, not only on remotes"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11789,7 +11789,15 @@ impl Agent {
         policy: kv::AccessPolicy,
         state_dir: Option<&std::path::Path>,
     ) -> error::Result<KvStoreHandle> {
-        let store_id = kv::KvStoreId::for_topic_owner(topic, &self.agent_id());
+        // SelfKeyed directories are owner-free: every joiner who knows the
+        // topic derives the same id (I2/I4). Owner-anchored policies keep
+        // the topic→owner binding.
+        let is_self_keyed = matches!(policy, kv::AccessPolicy::SelfKeyed);
+        let store_id = if is_self_keyed {
+            kv::KvStoreId::for_self_keyed_topic(topic)
+        } else {
+            kv::KvStoreId::for_topic_owner(topic, &self.agent_id())
+        };
         let persist_path = state_dir.map(|d| kv_snapshot_path(d, &store_id));
         let store = match persist_path.as_deref().map(kv::sync::load_snapshot) {
             Some(Ok(Some(snap))) => {
@@ -11798,7 +11806,16 @@ impl Agent {
                         "kv snapshot store-id mismatch for topic {topic}"
                     )));
                 }
-                if snap.owner() != Some(&self.agent_id()) {
+                if is_self_keyed {
+                    // A SelfKeyed snapshot is owner-free for life: an owner
+                    // or a non-SelfKeyed policy on the same (domain-separated)
+                    // id means the snapshot is not this store — fail closed.
+                    if snap.owner().is_some() || *snap.policy() != kv::AccessPolicy::SelfKeyed {
+                        return Err(kv_storage_err(format!(
+                            "kv snapshot for topic {topic} is not an owner-free self_keyed store; refusing to load"
+                        )));
+                    }
+                } else if snap.owner() != Some(&self.agent_id()) {
                     return Err(kv_storage_err(format!(
                         "kv snapshot for topic {topic} is owned by a different agent"
                     )));
@@ -11824,14 +11841,18 @@ impl Agent {
                 snap
             }
             Some(Ok(None)) | None => {
-                kv::KvStore::new(store_id, name.to_string(), self.agent_id(), policy).map_err(
-                    |e| {
-                        // Encrypted is reserved (#341): the store layer has
-                        // already logged the WARN; surface its message intact
-                        // rather than a generic create failure.
-                        kv_storage_err(format!("kv store creation failed: {e}"))
-                    },
-                )?
+                if is_self_keyed {
+                    kv::KvStore::new_self_keyed(store_id, name.to_string())
+                } else {
+                    kv::KvStore::new(store_id, name.to_string(), self.agent_id(), policy).map_err(
+                        |e| {
+                            // Encrypted is reserved (#341): the store layer has
+                            // already logged the WARN; surface its message intact
+                            // rather than a generic create failure.
+                            kv_storage_err(format!("kv store creation failed: {e}"))
+                        },
+                    )?
+                }
             }
             Some(Err(e)) => {
                 // Corrupt snapshot: fail closed, loudly. Starting an empty
@@ -11846,15 +11867,21 @@ impl Agent {
 
         // The creator is the owner: capture signing material so each write
         // produces an owner-signed content checkpoint (cold-recovery provenance).
-        let (pk_bytes, sk_bytes) = self.identity().agent_keypair().to_bytes();
+        // SelfKeyed stores have no owner and never produce checkpoints.
+        let owner_signing = if is_self_keyed {
+            None
+        } else {
+            let (pk_bytes, sk_bytes) = self.identity().agent_keypair().to_bytes();
+            Some(std::sync::Arc::new(OwnerSigningMaterial {
+                public_key_bytes: pk_bytes,
+                secret_key_bytes: sk_bytes,
+            }))
+        };
         Ok(KvStoreHandle {
             sync,
             agent_id: self.agent_id(),
             peer_id,
-            owner_signing: Some(std::sync::Arc::new(OwnerSigningMaterial {
-                public_key_bytes: pk_bytes,
-                secret_key_bytes: sk_bytes,
-            })),
+            owner_signing,
         })
     }
 
@@ -11955,6 +11982,64 @@ impl Agent {
     ) -> error::Result<KvStoreHandle> {
         self.join_kv_store_inner(topic, owner, channel, Some(state_dir))
             .await
+    }
+
+    /// Join (or restore) an owner-free [`kv::AccessPolicy::SelfKeyed`]
+    /// directory store by topic alone (issue #340).
+    ///
+    /// Knowing only the topic is enough to create, join, write, and
+    /// rehydrate (I4): the store id is `KvStoreId::for_self_keyed_topic`
+    /// (domain-separated from the owner-anchored derivations, I2) and write
+    /// authority is the key-prefix binding, so there is no `expected_owner`
+    /// to supply. Deliberately NOT an overload of
+    /// [`join_kv_store_persistent`](Self::join_kv_store_persistent): a
+    /// missing owner on that path is a dead Signed replica by design, and
+    /// this path must not blur that fail-closed boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the gossip runtime is not initialized, or
+    /// fail-closed snapshot errors (corrupt file, store-id mismatch, or a
+    /// snapshot that is not an owner-free self_keyed store).
+    pub async fn join_self_keyed_kv_store_persistent(
+        &self,
+        topic: &str,
+        state_dir: &std::path::Path,
+    ) -> error::Result<KvStoreHandle> {
+        let store_id = kv::KvStoreId::for_self_keyed_topic(topic);
+        let persist_path = Some(kv_snapshot_path(state_dir, &store_id));
+        let store = match persist_path.as_deref().map(kv::sync::load_snapshot) {
+            Some(Ok(Some(snap))) => {
+                if snap.id() != &store_id {
+                    return Err(kv_storage_err(format!(
+                        "kv snapshot store-id mismatch for topic {topic}"
+                    )));
+                }
+                if snap.owner().is_some() || *snap.policy() != kv::AccessPolicy::SelfKeyed {
+                    return Err(kv_storage_err(format!(
+                        "kv snapshot for topic {topic} is not an owner-free self_keyed store; refusing to load"
+                    )));
+                }
+                snap
+            }
+            Some(Ok(None)) | None => kv::KvStore::join_self_keyed(store_id, String::new()),
+            Some(Err(e)) => {
+                return Err(kv_storage_err(format!(
+                    "kv snapshot for topic {topic} is unreadable ({e}); refusing to start with amnesia — repair or remove the snapshot file explicitly"
+                )));
+            }
+        };
+
+        let (sync, peer_id) = self.spawn_kv_sync(store, topic, persist_path).await?;
+
+        Ok(KvStoreHandle {
+            sync,
+            agent_id: self.agent_id(),
+            peer_id,
+            // No owner exists on a SelfKeyed store; nobody produces
+            // checkpoints.
+            owner_signing: None,
+        })
     }
 
     async fn join_kv_store_inner(
@@ -12148,13 +12233,33 @@ impl KvStoreHandle {
         Some(cp)
     }
 
-    /// Enforce the store's access policy for a local mutation.
+    /// Enforce the store's access policy for a local put of `key`.
     ///
-    /// Applies the same authorization rule as the inbound delta path
-    /// (`KvStore::merge_delta`), so a local write that peers would reject
-    /// never mutates this replica (no local fork).
-    fn check_local_write(store: &kv::KvStore, writer: &identity::AgentId) -> error::Result<()> {
-        store.authorize_local_write(writer).map_err(|e| match e {
+    /// Applies the same authorization and (for `SelfKeyed`) the same
+    /// lowest-N quota rule as the inbound delta path
+    /// (`KvStore::merge_delta`), so a local write that peers would drop or
+    /// evict never mutates this replica (no local fork).
+    fn check_local_put(
+        store: &kv::KvStore,
+        writer: &identity::AgentId,
+        key: &str,
+        value: &[u8],
+    ) -> error::Result<()> {
+        store
+            .authorize_put(writer, key, value)
+            .map_err(|e| match e {
+                kv::KvError::Unauthorized(msg) => error::IdentityError::Unauthorized(msg),
+                other => error::IdentityError::Unauthorized(other.to_string()),
+            })
+    }
+
+    /// Enforce the store's access policy for a local remove of `key`.
+    fn check_local_remove(
+        store: &kv::KvStore,
+        writer: &identity::AgentId,
+        key: &str,
+    ) -> error::Result<()> {
+        store.authorize_write(writer, key).map_err(|e| match e {
             kv::KvError::Unauthorized(msg) => error::IdentityError::Unauthorized(msg),
             other => error::IdentityError::Unauthorized(other.to_string()),
         })
@@ -12207,7 +12312,7 @@ impl KvStoreHandle {
         })?;
         let delta = {
             let mut store = self.sync.write().await;
-            Self::check_local_write(&store, &self.agent_id)?;
+            Self::check_local_put(&store, &self.agent_id, &key, &value)?;
             let version_before = store.current_version();
             store
                 .put(
@@ -12338,7 +12443,7 @@ impl KvStoreHandle {
         })?;
         let delta = {
             let mut store = self.sync.write().await;
-            Self::check_local_write(&store, &self.agent_id)?;
+            Self::check_local_remove(&store, &self.agent_id, key)?;
             store.remove(key).map_err(|e| match e {
                 // AppendOnly immutability violation — surfaced distinctly
                 // so the API layer can map it to HTTP 409 Conflict.
@@ -12464,7 +12569,7 @@ pub struct KvStoreOwnershipInfo {
     /// (read-only by design).
     pub owner: Option<String>,
     /// Access policy (`"signed"` / `"allowlisted"` / `"encrypted"` /
-    /// `"append_only"`).
+    /// `"append_only"` / `"self_keyed"`).
     pub policy: String,
     /// Store version (monotonic, bumped on every mutation).
     pub version: u64,
@@ -14256,6 +14361,122 @@ mod tests {
             "append_only requested over a Signed snapshot must fail closed"
         );
         agent3.shutdown().await;
+    }
+
+    /// SelfKeyed directories end-to-end at the handle layer (issue #340):
+    /// knowing only the topic is enough to create, write (own prefix only),
+    /// join, and rehydrate from the snapshot — no `expected_owner` exists to
+    /// supply (I4), `owner` stays `None` (I3), and the id is the
+    /// domain-separated topic derivation (I2).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn self_keyed_join_persistence_and_prefix_gating() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let creator_state = dir.path().join("kv-creator");
+        let joiner_state = dir.path().join("kv-joiner");
+        let build_agent = |prefix: &'static str| {
+            let base = dir.path().to_path_buf();
+            async move {
+                Agent::builder()
+                    .with_machine_key(base.join(format!("{prefix}.machine.key")))
+                    .with_agent_key_path(base.join(format!("{prefix}.agent.key")))
+                    .with_contact_store_path(base.join(format!("{prefix}.contacts.json")))
+                    .with_peer_cache_disabled()
+                    .with_network_config(loopback_network_config())
+                    .build()
+                    .await
+                    .expect("agent")
+            }
+        };
+
+        // Creator: owner-free store, id derived from the topic alone.
+        let creator = build_agent("creator").await;
+        let creator_id = creator.agent_id();
+        let creator_key = format!("{}/profile", hex::encode(creator_id.as_bytes()));
+        let store = creator
+            .create_kv_store_persistent(
+                "directory",
+                "sk-persist-topic",
+                kv::AccessPolicy::SelfKeyed,
+                &creator_state,
+            )
+            .await
+            .expect("create self_keyed store");
+        {
+            let s = store.sync.read().await;
+            assert_eq!(*s.policy(), kv::AccessPolicy::SelfKeyed);
+            assert_eq!(s.owner(), None, "owner stays None for life (I3)");
+            assert_eq!(
+                *s.id(),
+                kv::KvStoreId::for_self_keyed_topic("sk-persist-topic"),
+                "id is the domain-separated topic derivation (I2)"
+            );
+        }
+        store
+            .put(creator_key.clone(), b"v".to_vec(), "text/plain".to_string())
+            .await
+            .expect("own-prefix put");
+        // A foreign prefix through the handle: Unauthorized, never a silent
+        // local-only write.
+        let foreign_key = format!("{}/x", "0f".repeat(32));
+        let err = store
+            .put(foreign_key.clone(), b"v".to_vec(), "text/plain".to_string())
+            .await
+            .expect_err("foreign prefix rejected");
+        assert!(matches!(err, error::IdentityError::Unauthorized(_)));
+
+        // A second agent joins knowing ONLY the topic — no owner anchor.
+        let joiner = build_agent("joiner").await;
+        let joiner_id = joiner.agent_id();
+        let joined = joiner
+            .join_self_keyed_kv_store_persistent("sk-persist-topic", &joiner_state)
+            .await
+            .expect("join by topic alone");
+        {
+            let s = joined.sync.read().await;
+            assert_eq!(*s.policy(), kv::AccessPolicy::SelfKeyed);
+            assert_eq!(s.owner(), None, "joined replica has no owner");
+        }
+        let joiner_key = format!("{}/card", hex::encode(joiner_id.as_bytes()));
+        joined
+            .put(joiner_key.clone(), b"j".to_vec(), "text/plain".to_string())
+            .await
+            .expect("joiner writes its own namespace");
+        let err = joined
+            .put(
+                creator_key.clone(),
+                b"hijack".to_vec(),
+                "text/plain".to_string(),
+            )
+            .await
+            .expect_err("cannot write the creator's namespace");
+        assert!(matches!(err, error::IdentityError::Unauthorized(_)));
+        joined.cancel_sync();
+        joiner.shutdown().await;
+
+        // Restart the joiner: rehydrate requires no expected_owner and
+        // restores its own key from the snapshot.
+        let joiner2 = build_agent("joiner").await;
+        let restored = joiner2
+            .join_self_keyed_kv_store_persistent("sk-persist-topic", &joiner_state)
+            .await
+            .expect("rehydrate without an owner anchor");
+        {
+            let s = restored.sync.read().await;
+            assert_eq!(
+                *s.policy(),
+                kv::AccessPolicy::SelfKeyed,
+                "policy survives restart"
+            );
+            assert_eq!(s.owner(), None);
+            assert!(
+                s.get(&joiner_key).is_some(),
+                "the joiner's own key survives restart from its snapshot"
+            );
+        }
+        restored.cancel_sync();
+        joiner2.shutdown().await;
+        store.cancel_sync();
+        creator.shutdown().await;
     }
 
     /// Durability blockers (round-3 review): (1) the direct-delivery path

--- a/src/server/crdt_subscriptions.rs
+++ b/src/server/crdt_subscriptions.rs
@@ -530,7 +530,8 @@ pub(super) async fn handle_reservation(state: &AppState, kind: &str, id: &str) -
 /// exactly 32 bytes — the caller treats that as migration-required.
 /// Resolve the persisted access policy from a manifest entry's `extra` map.
 ///
-/// - `"append_only"` → `AppendOnly`; `"signed"` → `Signed`.
+/// - `"append_only"` → `AppendOnly`; `"signed"` → `Signed`;
+///   `"self_keyed"` → `SelfKeyed`.
 /// - Absent key → `Signed` (legacy entries predate the policy field and were
 ///   all created Signed — this is a documented compatibility default, not a
 ///   downgrade).
@@ -547,6 +548,9 @@ fn manifest_policy(
         }
         Some(serde_json::Value::String(s)) if s == "append_only" => {
             Some(crate::kv::AccessPolicy::AppendOnly)
+        }
+        Some(serde_json::Value::String(s)) if s == "self_keyed" => {
+            Some(crate::kv::AccessPolicy::SelfKeyed)
         }
         Some(_) => None,
     }
@@ -683,43 +687,58 @@ async fn rehydrate_one(state: Arc<AppState>, entry: CrdtSubscriptionEntry) -> Re
             }
             let result = match entry.role.as_str() {
                 ROLE_JOINED => {
-                    // The owner anchor is REQUIRED: a join without it is a
-                    // dead replica, not a successful rehydration. A legacy
-                    // entry with no stored anchor, or a malformed one, is
-                    // migration-required — skip it loudly rather than
-                    // creating a read-only handle that can never accept
-                    // Signed state.
-                    let owner = match entry.extra.get("expected_owner").and_then(|v| v.as_str()) {
-                        Some(hex_str) => match parse_owner_hex(hex_str) {
-                            Some(id) => id,
+                    // The `self_keyed` directory policy is the one owner-free
+                    // join: knowing only the topic is enough (I4), so no
+                    // stored anchor is required — the persisted policy field
+                    // routes here.
+                    if manifest_policy(&entry.extra) == Some(crate::kv::AccessPolicy::SelfKeyed) {
+                        state
+                            .agent
+                            .join_self_keyed_kv_store_persistent(
+                                &entry.topic,
+                                &state.kv_store_state_dir,
+                            )
+                            .await
+                    } else {
+                        // The owner anchor is REQUIRED: a join without it is
+                        // a dead replica, not a successful rehydration. A
+                        // legacy entry with no stored anchor, or a malformed
+                        // one, is migration-required — skip it loudly rather
+                        // than creating a read-only handle that can never
+                        // accept Signed state.
+                        let owner = match entry.extra.get("expected_owner").and_then(|v| v.as_str())
+                        {
+                            Some(hex_str) => match parse_owner_hex(hex_str) {
+                                Some(id) => id,
+                                None => {
+                                    tracing::warn!(
+                                        id = %entry.id,
+                                        "stored expected_owner is malformed; \
+                                         skipping rehydration (migration_required)"
+                                    );
+                                    return RehydrateOutcome::Skipped;
+                                }
+                            },
                             None => {
                                 tracing::warn!(
                                     id = %entry.id,
-                                    "stored expected_owner is malformed; \
-                                     skipping rehydration (migration_required)"
+                                    "no stored expected_owner for joined store; \
+                                     skipping rehydration (migration_required). \
+                                     Re-join with an owner anchor to recover."
                                 );
                                 return RehydrateOutcome::Skipped;
                             }
-                        },
-                        None => {
-                            tracing::warn!(
-                                id = %entry.id,
-                                "no stored expected_owner for joined store; \
-                                 skipping rehydration (migration_required). \
-                                 Re-join with an owner anchor to recover."
-                            );
-                            return RehydrateOutcome::Skipped;
-                        }
-                    };
-                    state
-                        .agent
-                        .join_kv_store_persistent(
-                            &entry.topic,
-                            owner,
-                            crate::kv::store::AnchorChannel::Persistence,
-                            &state.kv_store_state_dir,
-                        )
-                        .await
+                        };
+                        state
+                            .agent
+                            .join_kv_store_persistent(
+                                &entry.topic,
+                                owner,
+                                crate::kv::store::AnchorChannel::Persistence,
+                                &state.kv_store_state_dir,
+                            )
+                            .await
+                    }
                 }
                 ROLE_CREATED => {
                     // Restore the persisted policy: an append-only store must
@@ -817,6 +836,15 @@ mod tests {
         assert_eq!(
             manifest_policy(&extra),
             Some(crate::kv::AccessPolicy::AppendOnly)
+        );
+        extra.insert(
+            "policy".into(),
+            serde_json::Value::String("self_keyed".into()),
+        );
+        assert_eq!(
+            manifest_policy(&extra),
+            Some(crate::kv::AccessPolicy::SelfKeyed),
+            "self_keyed must parse — otherwise a joined directory replica could never rehydrate"
         );
         extra.insert(
             "policy".into(),

--- a/src/server/routes/stores.rs
+++ b/src/server/routes/stores.rs
@@ -175,8 +175,9 @@ pub(in crate::server) async fn apply_direct_kv_store_delta(
 /// Request body for POST /stores.
 ///
 /// `policy` selects the access policy: `"signed"` (default — owner-only
-/// writes) or `"append_only"` (owner-only writes AND existing keys are
-/// immutable, even to the owner).
+/// writes), `"append_only"` (owner-only writes AND existing keys are
+/// immutable, even to the owner), or `"self_keyed"` (owner-free open
+/// directory: any joiner writes only keys prefixed by its own AgentId).
 #[derive(Debug, Deserialize)]
 pub(in crate::server) struct CreateStoreRequest {
     name: String,
@@ -195,10 +196,16 @@ pub(in crate::server) struct PutValueRequest {
 ///
 /// `expected_owner` is the optional hex-encoded AgentId of the authoritative
 /// owner, supplied out-of-band (the local user/operator is the trust root).
-/// Omitting it yields a permanently read-only replica (no permissive fallback).
+/// Omitting it yields a permanently read-only replica (no permissive
+/// fallback) — EXCEPT under `policy: "self_keyed"`, the owner-free directory
+/// policy, which requires joining WITHOUT an owner.
 #[derive(Debug, Default, Deserialize)]
 pub(in crate::server) struct JoinStoreRequest {
     expected_owner: Option<String>,
+    /// Optional policy discriminator for the join. `"self_keyed"` selects
+    /// the owner-free directory join (no `expected_owner` allowed); any
+    /// other value is ignored in favor of the owner-anchored path.
+    policy: Option<String>,
 }
 
 /// Response entry for GET /stores.
@@ -261,10 +268,11 @@ pub(in crate::server) async fn create_kv_store(
     let policy = match req.policy.as_deref() {
         None | Some("signed") => x0x::kv::AccessPolicy::Signed,
         Some("append_only") => x0x::kv::AccessPolicy::AppendOnly,
+        Some("self_keyed") => x0x::kv::AccessPolicy::SelfKeyed,
         Some(other) => {
             return bad_request(format!(
-                "unsupported policy {other:?}: expected \"signed\" or \"append_only\""
-            ))
+            "unsupported policy {other:?}: expected \"signed\", \"append_only\", or \"self_keyed\""
+        ))
         }
     };
     // Reserve the entire handle+manifest transaction for this (kind,id) so
@@ -281,6 +289,9 @@ pub(in crate::server) async fn create_kv_store(
         return api_error(StatusCode::CONFLICT, "store already exists");
     }
     let policy_str = policy.to_string();
+    // A self_keyed directory is owner-free for life: no expected_owner is
+    // recorded for it (I3/I4) — rehydrate derives everything from the topic.
+    let is_self_keyed = matches!(policy, x0x::kv::AccessPolicy::SelfKeyed);
     match state
         .agent
         .create_kv_store_persistent(&req.name, &req.topic, policy, &state.kv_store_state_dir)
@@ -292,12 +303,14 @@ pub(in crate::server) async fn create_kv_store(
             // Persist the registration so it survives a daemon restart
             // (rehydrated after join_network — see crdt_subscriptions).
             // Record the owner so a restarted creator re-anchors on itself.
-            let owner_hex = hex::encode(state.agent.agent_id().as_bytes());
             let mut extra = serde_json::Map::new();
-            extra.insert(
-                "expected_owner".to_string(),
-                serde_json::Value::String(owner_hex),
-            );
+            if !is_self_keyed {
+                let owner_hex = hex::encode(state.agent.agent_id().as_bytes());
+                extra.insert(
+                    "expected_owner".to_string(),
+                    serde_json::Value::String(owner_hex),
+                );
+            }
             // Persist the policy so a restarted creator rehydrates with the
             // same policy (an append-only store must never come back Signed).
             extra.insert("policy".to_string(), serde_json::Value::String(policy_str));
@@ -345,11 +358,25 @@ pub(in crate::server) async fn join_kv_store(
     Path(id): Path<String>,
     body: Option<Json<JoinStoreRequest>>,
 ) -> impl IntoResponse {
-    // The out-of-band owner anchor is REQUIRED: a replica with no anchor can
-    // never accept policy-restricted data, so an unanchored join is a dead
-    // replica, not a successful join. The local user/operator is the trust
-    // root for this param.
-    let owner: AgentId = match body.and_then(|Json(r)| r.expected_owner) {
+    let body = body.map(|Json(r)| r).unwrap_or_default();
+    // The `self_keyed` directory policy is the one owner-free join: knowing
+    // only the topic is enough (I4). An `expected_owner` anchor is not
+    // merely unnecessary there — it is contradictory (the store has no owner
+    // for life, I3), so supplying one is a 422 rather than a silent ignore.
+    if body.policy.as_deref() == Some("self_keyed") {
+        if body.expected_owner.is_some() {
+            return api_error(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "owner_not_allowed: policy \"self_keyed\" stores have no owner — join without expected_owner",
+            );
+        }
+        return join_self_keyed_store(state, id).await;
+    }
+    // The out-of-band owner anchor is REQUIRED for every owner-anchored
+    // policy: a replica with no anchor can never accept policy-restricted
+    // data, so an unanchored join is a dead replica, not a successful join.
+    // The local user/operator is the trust root for this param.
+    let owner: AgentId = match body.expected_owner {
         Some(hex_owner) => match parse_agent_id_hex(&hex_owner) {
             Ok(agent) => agent,
             Err(e) => return bad_request(format!("invalid expected_owner: {e}")),
@@ -414,6 +441,70 @@ pub(in crate::server) async fn join_kv_store(
                 // its sync — the discarded handle's bootstrap requester is
                 // infinite while unconverged (issue #238) and would otherwise
                 // chatter until daemon shutdown.
+                tracing::error!("failed to persist kv store join {id}: {e}");
+                if let Some(h) = state.kv_stores.write().await.remove(&id) {
+                    h.cancel_sync();
+                }
+                return api_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("failed to persist subscription registration: {e}"),
+                );
+            }
+            let mut resp = serde_json::to_value(&info).unwrap_or_else(|_| serde_json::json!({}));
+            if let Some(obj) = resp.as_object_mut() {
+                obj.insert("ok".to_string(), serde_json::Value::Bool(true));
+                obj.insert("id".to_string(), serde_json::Value::String(id));
+            }
+            (StatusCode::OK, Json(resp))
+        }
+        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}")),
+    }
+}
+
+/// Owner-free join for `self_keyed` directory stores (issue #340).
+///
+/// Shared tail of `POST /stores/:id/join` for the `policy: "self_keyed"`
+/// body: reserves the (kind,id), joins by topic alone, and persists a
+/// manifest entry whose `extra` records the policy but deliberately OMITS
+/// `expected_owner` (the store has none — rehydrate must not require one).
+async fn join_self_keyed_store(
+    state: Arc<AppState>,
+    id: String,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let reservation =
+        crdt_subscriptions::handle_reservation(&state, crdt_subscriptions::KIND_KV_STORE, &id)
+            .await;
+    let _guard = reservation.lock().await;
+    if state.kv_stores.read().await.contains_key(&id) {
+        return api_error(StatusCode::CONFLICT, "store already joined");
+    }
+    match state
+        .agent
+        .join_self_keyed_kv_store_persistent(&id, &state.kv_store_state_dir)
+        .await
+    {
+        Ok(handle) => {
+            let info = handle.ownership_info().await;
+            state.kv_stores.write().await.insert(id.clone(), handle);
+            let mut extra = serde_json::Map::new();
+            // No expected_owner: a self_keyed store is owner-free for life.
+            extra.insert(
+                "policy".to_string(),
+                serde_json::Value::String("self_keyed".to_string()),
+            );
+            if let Err(e) = crdt_subscriptions::record(
+                &state,
+                crdt_subscriptions::CrdtSubscriptionEntry {
+                    kind: crdt_subscriptions::KIND_KV_STORE.to_string(),
+                    id: id.clone(),
+                    name: id.clone(),
+                    topic: id.clone(),
+                    role: crdt_subscriptions::ROLE_JOINED.to_string(),
+                    extra,
+                },
+            )
+            .await
+            {
                 tracing::error!("failed to persist kv store join {id}: {e}");
                 if let Some(h) = state.kv_stores.write().await.remove(&id) {
                     h.cancel_sync();

--- a/tests/kv_self_keyed_rest.rs
+++ b/tests/kv_self_keyed_rest.rs
@@ -1,0 +1,278 @@
+//! REST surface of `AccessPolicy::SelfKeyed` (issue #340).
+//!
+//! WHY: an open directory — one topic, many mutually-unknown agents, each
+//! writing only the keys prefixed by its own AgentId — must be expressible
+//! without a blessed owner. Knowing only the topic is enough to create,
+//! join, write, and rehydrate (I4); supplying an `expected_owner` to such a
+//! store is a contradiction (the store has no owner for life, I3) and must
+//! be a 422, while owner-anchored policies keep requiring the anchor.
+//!
+//! NOTE on keys: the REST routes address a key as a single path segment
+//! (`/stores/:id/:key`), so these tests use the grammar's BARE 64-hex root
+//! record (`hex(AgentId)`); suffixed keys (`hex(AgentId)/suffix`) are
+//! addressable through the library handle (see the store/lib unit tests).
+//!
+//! All tests are `#[ignore]` — they boot real x0xd daemons.
+//! Run with: cargo nextest run --test kv_self_keyed_rest -- --ignored
+//! Before running: cargo build --bin x0xd
+
+use base64::Engine;
+use std::time::{Duration, Instant};
+
+#[path = "harness/src/cluster.rs"]
+mod cluster;
+
+fn b64(s: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(s)
+}
+
+/// A syntactically valid 64-hex AgentId prefix (not any real peer).
+fn foreign_prefix() -> String {
+    "0f".repeat(32)
+}
+
+/// Fetch the policy string GET /stores reports for `topic`.
+async fn store_policy(node: &cluster::AgentInstance, topic: &str) -> Option<String> {
+    let r = node.get("/stores").await;
+    if !r.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = r.json().await.ok()?;
+    body["stores"]
+        .as_array()?
+        .iter()
+        .find(|s| s["topic"] == topic)
+        .and_then(|s| s["policy"].as_str().map(str::to_string))
+}
+
+#[tokio::test]
+#[ignore]
+async fn selfkeyed_join_without_expected_owner() {
+    let pair = cluster::pair().await;
+    let topic = format!("kv-sk-{}", rand::random::<u32>());
+
+    // Create with the self_keyed policy; the response must reflect it, the
+    // owner must be null (the store is owner-free for life), and the id must
+    // stay the topic string (not the blake3 hex).
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "directory", "topic": topic, "policy": "self_keyed" }),
+        )
+        .await;
+    assert_eq!(r.status().as_u16(), 201, "create self_keyed store");
+    let body: serde_json::Value = r.json().await.expect("create body json");
+    assert_eq!(body["policy"], "self_keyed");
+    assert_eq!(body["id"], topic, "the REST id stays the topic string");
+    assert!(
+        body["owner"].is_null(),
+        "self_keyed store has no owner: {body}"
+    );
+
+    // Join WITHOUT expected_owner succeeds (I4).
+    let r = pair
+        .bob
+        .post(
+            &format!("/stores/{topic}/join"),
+            serde_json::json!({ "policy": "self_keyed" }),
+        )
+        .await;
+    assert_eq!(
+        r.status().as_u16(),
+        200,
+        "self_keyed join needs only the topic"
+    );
+    let body: serde_json::Value = r.json().await.expect("join body json");
+    assert_eq!(body["policy"], "self_keyed");
+    assert!(body["owner"].is_null());
+
+    // expected_owner + self_keyed is a contradiction: 422 owner_not_allowed.
+    let r = pair
+        .bob
+        .post(
+            &format!("/stores/{topic}-x/join"),
+            serde_json::json!({ "policy": "self_keyed", "expected_owner": foreign_prefix() }),
+        )
+        .await;
+    assert_eq!(r.status().as_u16(), 422);
+    let body: serde_json::Value = r.json().await.expect("422 body json");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("owner_not_allowed"),
+        "422 body names owner_not_allowed; got: {body}"
+    );
+
+    // Regression: an owner-anchored join WITHOUT expected_owner is still
+    // 422 owner_required (I10 — the fail-closed default is unchanged).
+    let r = pair
+        .bob
+        .post(
+            &format!("/stores/{topic}-signed/join"),
+            serde_json::json!({}),
+        )
+        .await;
+    assert_eq!(r.status().as_u16(), 422);
+    let body: serde_json::Value = r.json().await.expect("422 body json");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("owner_required"),
+        "422 body names owner_required; got: {body}"
+    );
+
+    // Prefix gating over REST via the grammar's bare root record: alice
+    // writes her own namespace, cannot write a foreign one.
+    let alice_prefix = pair.alice.agent_id().await;
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/{alice_prefix}"),
+            serde_json::json!({ "value": b64(b"alice") }),
+        )
+        .await;
+    assert!(
+        r.status().is_success(),
+        "own-prefix put succeeds: {}",
+        r.status()
+    );
+    let foreign_key = foreign_prefix();
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/{foreign_key}"),
+            serde_json::json!({ "value": b64(b"hijack") }),
+        )
+        .await;
+    assert_eq!(
+        r.status().as_u16(),
+        403,
+        "a foreign-prefix put must be 403 Forbidden"
+    );
+    let r = pair
+        .alice
+        .get(&format!("/stores/{topic}/{foreign_key}"))
+        .await;
+    assert_eq!(
+        r.status().as_u16(),
+        404,
+        "the foreign key was never applied"
+    );
+
+    // Bob (joined) writes his own namespace too — two publishers, no owner.
+    let bob_prefix = pair.bob.agent_id().await;
+    let r = pair
+        .bob
+        .put(
+            &format!("/stores/{topic}/{bob_prefix}"),
+            serde_json::json!({ "value": b64(b"bob") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "joiner writes its own namespace");
+
+    // Bob eventually sees alice's root record (directory convergence through
+    // the existing sync path).
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let r = pair
+            .bob
+            .get(&format!("/stores/{topic}/{alice_prefix}"))
+            .await;
+        if r.status().is_success() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "bob did not observe alice's key within 60s"
+        );
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn selfkeyed_subscription_rehydrate_keeps_policy() {
+    let mut pair = cluster::pair().await;
+    let topic = format!("kv-sk-restart-{}", rand::random::<u32>());
+
+    // Alice creates; bob joins by topic only; both write their root record.
+    let r = pair
+        .alice
+        .post(
+            "/stores",
+            serde_json::json!({ "name": "directory", "topic": topic, "policy": "self_keyed" }),
+        )
+        .await;
+    assert_eq!(r.status().as_u16(), 201);
+    let r = pair
+        .bob
+        .post(
+            &format!("/stores/{topic}/join"),
+            serde_json::json!({ "policy": "self_keyed" }),
+        )
+        .await;
+    assert_eq!(r.status().as_u16(), 200);
+
+    let alice_prefix = pair.alice.agent_id().await;
+    let bob_prefix = pair.bob.agent_id().await;
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/{alice_prefix}"),
+            serde_json::json!({ "value": b64(b"alice") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "alice writes her root record");
+    let r = pair
+        .bob
+        .put(
+            &format!("/stores/{topic}/{bob_prefix}"),
+            serde_json::json!({ "value": b64(b"bob") }),
+        )
+        .await;
+    assert!(r.status().is_success(), "bob writes his root record");
+
+    // Restart both: created and joined self_keyed entries must rehydrate as
+    // self_keyed (not Signed) WITHOUT any expected_owner, and stay writable.
+    pair.alice.restart().await;
+    pair.bob.restart().await;
+    for (node, label) in [(&pair.alice, "creator"), (&pair.bob, "joiner")] {
+        let deadline = Instant::now() + Duration::from_secs(120);
+        loop {
+            if store_policy(node, &topic).await.as_deref() == Some("self_keyed") {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "{label} did not rehydrate the self_keyed store within 120s"
+            );
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+    // Still writable after restart (own prefix).
+    let r = pair
+        .alice
+        .put(
+            &format!("/stores/{topic}/{alice_prefix}"),
+            serde_json::json!({ "value": b64(b"alice2") }),
+        )
+        .await;
+    assert!(
+        r.status().is_success(),
+        "rehydrated creator stays writable in its own namespace"
+    );
+    let r = pair
+        .bob
+        .put(
+            &format!("/stores/{topic}/{bob_prefix}"),
+            serde_json::json!({ "value": b64(b"bob2") }),
+        )
+        .await;
+    assert!(
+        r.status().is_success(),
+        "rehydrated joiner stays writable in its own namespace"
+    );
+}


### PR DESCRIPTION
## Summary

Implements #340 per the consensus design: an owner-free open-directory store policy. Any agent that knows the topic can join and write exclusively under the key namespace bound to its own AgentId — no blessed owner, one shared topic, many mutually-unknown publishers.

- **Enum**: `AccessPolicy::SelfKeyed` appended as bincode discriminant **4** only; the "MUST stay last" note moved from `AppendOnly` to `SelfKeyed`; the pin test now asserts `0..=4`. Policies `0..=3` (including the reserved permissive `Encrypted` path, #341) are untouched.
- **Key grammar** (the binding): `key := lowercase_hex(AgentId, 64) [ "/" suffix ]`, parsed by `key_agent_prefix`. No `KvEntry.author`. Uppercase, short prefixes, and non-`/` separators are rejected, so one agent's namespace is never a prefix of another's.
- **Identity**: `KvStoreId::for_self_keyed_topic = blake3("x0x.store.selfkeyed.v1" ‖ topic)` — domain-separated from both owner-anchored derivations. The REST handle id stays the topic string.
- **Owner-free for life**: `owner = None`; `OwnerUnknown` never fires for SelfKeyed; the legacy key-less `is_authorized(agent)` returns `false` (fail-closed); `learn_ownership`/allowlist/checkpoint paths reject or no-op; cold-sync prune stays `Signed && writer == owner` (plus an explicit `SelfKeyed` no-op guard in `prune_to_served_set`).
- **merge_delta (SelfKeyed)**: anonymous deltas apply **nothing** (not the Encrypted permissive path); a verified writer's own tombstones apply first (freeing budget), then its own prefix-bound puts, admitted by **deterministic lowest-N** (`MAX_SELFKEYED_KEYS_PER_AGENT = 64`, `MAX_SELFKEYED_BYTES_PER_AGENT = 256 KiB`, lexicographic, drop the tail); foreign keys and allowlist mutations are skipped, and the writer's live set is evicted down to the admitted subset so replicas fed in different orders converge on the same keys (I7).
- **Local writes**: `put`/`remove` route through the key-aware `authorize_write` / `authorize_put` — the same predicate as the remote merge, so local and remote cannot diverge; quota failures return the new `KvError::AgentQuotaExceeded` (REST surfaces it as 403 with the quota in the message; `MAX_INLINE_SIZE` still wins on a single oversized value).
- **Surface**: `KvStore::new_self_keyed` / `join_self_keyed`; `Agent::join_self_keyed_kv_store_persistent` (new function, deliberately not an `Option<owner>` overload of the Signed join); REST `POST /stores` accepts `policy: "self_keyed"`; `POST /stores/:id/join` accepts `policy` and rejects `expected_owner` + `self_keyed` with **422 `owner_not_allowed`** while owner-anchored joins still 422 `owner_required`; rehydrate parses `self_keyed` and joins **without** an owner anchor.

Known REST limitation (out of scope here, matches the design's blast radius): `/stores/:id/:key` addresses a single path segment, so suffixed keys (`hex/suffix`) are writable via the library handle and the bare root record (`hex`) via REST.

## Tests

- `selfkeyed_quota_lowest_n_converges` (proof): two replicas, same 80 keys, opposite delivery orders → both converge on exactly the 64 lex-lowest keys.
- Store unit tests: key grammar table, own-prefix/foreign/malformed local puts (never `OwnerUnknown`), anonymous-delta rejection with the Encrypted contrast, mixed-delta foreign-key skipping, foreign-tombstone dropping, local quota (key-count + byte fields + inline-size precedence), tombstone-frees-budget (incl. same-delta tombstone-then-put at the cap), id determinism/domain separation, no-checkpoint/no-prune (a co-writer's key survives a full serve), announce/allowlist ignored.
- Handle/Agent test: create → write own prefix → foreign prefix rejected → second agent joins by topic alone → writes own namespace → restart rehydrates without an owner anchor.
- REST daemon tests (`tests/kv_self_keyed_rest.rs`, `--ignored`): create/join/422s, prefix gating over REST, two-daemon convergence, restart rehydrate keeps `self_keyed` and stays writable.
- Regressions green: all 2060 lib tests (Signed/Allowlisted/AppendOnly/Encrypted suites, discriminant pin, legacy decode), `kv_store_integration` (35), `kv_append_only_rest` (2), `kv_signed_store_auth` (1), `crdt_subscription_persistence` (8).

Gates: `cargo fmt --all`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo check --workspace --all-targets` — all clean on the pushed tree.

Closes #340.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements an owner-free SelfKeyed KV access policy in which agents write only beneath their AgentId-derived key namespace.

- Adds deterministic per-agent key and byte quotas with lowest-lexicographic admission.
- Adds topic-only creation, joining, persistence, and restart rehydration.
- Exposes SelfKeyed through the REST and CLI surfaces with prefix and owner-argument validation.
- Adds unit, handle-level, and daemon integration coverage for authorization, convergence, and persistence.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until SelfKeyed quota admission is based on the values actually retained after LWW resolution.

Remote admission can count an older incoming value’s smaller length while LWW preserves a larger local value, breaking the byte cap and deterministic convergence guarantee.

**Files Needing Attention:** src/kv/store.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/kv/store.rs | Adds SelfKeyed authorization and deterministic quota merging, but pre-merge byte accounting can disagree with LWW-retained values. |
| src/lib.rs | Adds topic-derived SelfKeyed creation/joining, persistence, and key-aware local mutation checks. |
| src/server/routes/stores.rs | Adds REST creation and owner-free joining for SelfKeyed stores with explicit validation and manifest recording. |
| src/server/crdt_subscriptions.rs | Rehydrates SelfKeyed subscriptions through the owner-free topic-only join path. |
| tests/kv_self_keyed_rest.rs | Covers REST creation, joining, prefix authorization, convergence, and restart behavior. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Agent writes AgentId-prefixed key] --> B[Local authorize_put]
  B --> C[Prefix and quota admission]
  C --> D[Publish signed KV delta]
  D --> E[Peer verifies sender]
  E --> F[merge_delta_self_keyed]
  F --> G[Filter foreign keys and tombstones]
  G --> H[Compute lowest-N admitted set]
  H --> I[LWW merge admitted entries]
  I --> J[Evict keys outside admitted set]
  J --> K[Persist converged replica]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/kv/store.rs:1526-1535
**Quota counts pre-merge values**

When a smaller incoming entry loses LWW resolution to a larger existing value, admission counts the incoming length but retains the larger value, causing the live set to exceed `MAX_SELFKEYED_BYTES_PER_AGENT` and replicas to admit different subsets.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(kv): AccessPolicy::SelfKeyed lowest..."](https://github.com/saorsa-labs/x0x/commit/6c6297a1f676830c9d43fab40e9ad5ac04e141b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54719790)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [KV Store](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/kv.md)
- Knowledge Base — [Server API: HTTP/WebSocket/SSE surface and agent signing](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api.md)
- Knowledge Base — [CLI and daemon startup](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/cli-daemon.md)
</details>

<!-- /greptile_comment -->