### PR TITLE
fix(net): peer_admission stay-down A-D+F (#292)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7292,7 +7292,15 @@ impl Agent {
                             let addresses = auto_connect_addresses.clone();
                             tokio::spawn(async move {
                                 for addr in &addresses {
-                                    match net.connect_addr(*addr).await {
+                                    // #292: the spawned dial still passes
+                                    // through the dial gate — the cheap
+                                    // `announcement_should_auto_connect`
+                                    // check above can race a tombstone that
+                                    // lands after it.
+                                    match net
+                                        .connect_addr_with_origin(*addr, "announcement")
+                                        .await
+                                    {
                                         Ok(_) => {
                                             tracing::info!(
                                                 "Auto-connected to discovered agent at {addr}",
@@ -16162,6 +16170,462 @@ mod tests {
         assert!(
             alice_network.is_reconnect_suppressed(bob_id),
             "rejecting the inbound redial must not clear the tombstone"
+        );
+    }
+
+    /// Issue #292 (invariants C+F): after a PolicyRejection, every outbound
+    /// dial seam must refuse with no side effects — no `PeerConnected`, no
+    /// bootstrap-cache success, and no tombstone refresh (`set_at` stays
+    /// write-once). The id seams (`connect_peer`, `connect_peer_with_addrs`,
+    /// `connect_cached_peer`) refuse pre-socket; the address-only seam
+    /// (`connect_addr`) refuses post-handshake, which is also the
+    /// deterministic proof that a tombstone live at handshake-completion
+    /// time never admits — the same code path that guards a tombstone
+    /// landing mid-handshake. A gossip send toward the suppressed peer is
+    /// held (invariant B), never placed on the wire.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn suppressed_peer_outbound_dial_is_refused() {
+        use saorsa_gossip_transport::{GossipStreamType, GossipTransport as _};
+
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("alice");
+        let alice_network = alice.network().expect("alice network");
+
+        let bob = Agent::builder()
+            .with_machine_key(dir.path().join("bob-machine.key"))
+            .with_agent_key_path(dir.path().join("bob-agent.key"))
+            .with_contact_store_path(dir.path().join("bob-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("bob-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("bob");
+        let bob_network = bob.network().expect("bob network");
+        let bob_addr = normalize_loopback_addr(bob_network.bound_addr().await.expect("bob bound"));
+        let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+        let bob_id = bob.machine_id().0;
+
+        let connected = alice_network
+            .connect_addr(bob_addr)
+            .await
+            .expect("alice connects bob");
+        assert_eq!(connected.0, bob_id);
+        let reg = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < reg {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await,
+            "bob connected before rejection"
+        );
+
+        alice_network
+            .disconnect_with_reason(&bob_peer, network::DisconnectReason::PolicyRejection)
+            .await
+            .expect("policy reject");
+        assert!(alice_network.is_reconnect_suppressed(bob_id));
+
+        // Baselines for the no-side-effect assertions.
+        let mut events = alice_network.subscribe();
+        let cache = alice_network.bootstrap_cache().expect("bootstrap cache");
+        // The original session's inbound accept can record_success after
+        // the PolicyRejection close (accept() already yielded). Wait until
+        // that bookkeeping is idle so it is not blamed on the refused seams.
+        let stabilize_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+        let mut successes_before = cache
+            .get_peer(&bob_peer)
+            .await
+            .expect("bob cached from initial connect")
+            .stats
+            .success_count;
+        let mut last_change = tokio::time::Instant::now();
+        while tokio::time::Instant::now() < stabilize_deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            let now_count = cache
+                .get_peer(&bob_peer)
+                .await
+                .expect("bob cached")
+                .stats
+                .success_count;
+            if now_count != successes_before {
+                successes_before = now_count;
+                last_change = tokio::time::Instant::now();
+            } else if last_change.elapsed() >= std::time::Duration::from_millis(150) {
+                break;
+            }
+        }
+        let set_at_before = alice_network
+            .reconnect_suppression_set_at(bob_id)
+            .expect("permanent tombstone after PolicyRejection");
+        let bob_queue_before = bob_network
+            .gossip_recv_queue_depth(GossipStreamType::PubSub)
+            .0;
+
+        // Id seams refuse pre-socket — deterministic: the gate runs before
+        // any transport work, so the refusal itself must carry the
+        // suppression reason.
+        for (seam, err) in [
+            (
+                "connect_peer",
+                alice_network
+                    .connect_peer(bob_peer)
+                    .await
+                    .expect_err("connect_peer must refuse a suppressed peer"),
+            ),
+            (
+                "connect_peer_with_addrs",
+                alice_network
+                    .connect_peer_with_addrs(bob_peer, vec![bob_addr])
+                    .await
+                    .expect_err("connect_peer_with_addrs must refuse a suppressed peer"),
+            ),
+            (
+                "connect_cached_peer",
+                alice_network
+                    .connect_cached_peer(bob_peer)
+                    .await
+                    .expect_err("connect_cached_peer must refuse a suppressed peer"),
+            ),
+            (
+                "connect_addr",
+                alice_network
+                    .connect_addr(bob_addr)
+                    .await
+                    .expect_err("connect_addr must refuse a suppressed answered id"),
+            ),
+        ] {
+            assert!(
+                err.to_string().contains("reconnect-suppressed"),
+                "{seam}: refusal must come from the dial gate, got: {err}"
+            );
+        }
+
+        // No seam produced a PeerConnected for bob.
+        while let Ok(event) = events.try_recv() {
+            if let network::NetworkEvent::PeerConnected { peer_id, .. } = event {
+                assert_ne!(
+                    peer_id, bob_id,
+                    "refused dials must not surface a PeerConnected event"
+                );
+            }
+        }
+
+        // Admission stays Suppressed (invariant A), the tombstone was not
+        // refreshed (invariant F), and no cache success was recorded
+        // (invariant C).
+        assert_eq!(
+            alice_network.peer_admission(&bob_peer).await,
+            network::PeerAdmission::Suppressed,
+            "suppressed peer must never read Admitted"
+        );
+        assert_eq!(
+            alice_network
+                .reconnect_suppression_set_at(bob_id)
+                .expect("tombstone still live"),
+            set_at_before,
+            "refused dials must not refresh the tombstone (set_at write-once)"
+        );
+        let cached_after = cache.get_peer(&bob_peer).await.expect("bob still cached");
+        assert_eq!(
+            cached_after.stats.success_count, successes_before,
+            "refused dials must not record a cache success"
+        );
+
+        // Invariant B: gossip toward the suppressed peer is held — reported
+        // success like the plane-pending hold, but nothing reaches the wire,
+        // so bob's receive queue must not grow.
+        alice_network
+            .send_to_peer(
+                saorsa_gossip_types::PeerId::new(bob_id),
+                GossipStreamType::PubSub,
+                bytes::Bytes::from_static(b"#292 suppressed-send probe"),
+            )
+            .await
+            .expect("send toward a suppressed peer is held, not failed");
+        assert_eq!(
+            bob_network
+                .gossip_recv_queue_depth(GossipStreamType::PubSub)
+                .0,
+            bob_queue_before,
+            "held gossip must not be delivered to the suppressed peer"
+        );
+    }
+
+    /// Issue #292 (invariants B+D): an inbound redial of a suppressed peer
+    /// never admits. Across the accept-then-close window: zero
+    /// `PeerConnected`, `peer_admission == Suppressed` throughout, and a
+    /// gossip frame pushed on the transient connection is not delivered —
+    /// the receiver drops frames from suppressed peers. Deterministic
+    /// companion to `suppressed_peer_inbound_redial_is_rejected` (#228),
+    /// adding the admission-predicate and frame-delivery teeth.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn inbound_redial_of_suppressed_peer_emits_no_peer_connected() {
+        use saorsa_gossip_transport::{GossipStreamType, GossipTransport as _};
+
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("alice");
+        let alice_network = alice.network().expect("alice network");
+        let alice_addr =
+            normalize_loopback_addr(alice_network.bound_addr().await.expect("alice bound"));
+
+        let bob = Agent::builder()
+            .with_machine_key(dir.path().join("bob-machine.key"))
+            .with_agent_key_path(dir.path().join("bob-agent.key"))
+            .with_contact_store_path(dir.path().join("bob-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("bob-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("bob");
+        let bob_network = bob.network().expect("bob network");
+        let bob_addr = normalize_loopback_addr(bob_network.bound_addr().await.expect("bob bound"));
+        let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+        let bob_id = bob.machine_id().0;
+
+        let connected = alice_network
+            .connect_addr(bob_addr)
+            .await
+            .expect("alice connects bob");
+        assert_eq!(connected.0, bob_id);
+        let reg = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < reg {
+            if alice_network.is_connected(&bob_peer).await {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await,
+            "bob connected before rejection"
+        );
+
+        alice_network
+            .disconnect_with_reason(&bob_peer, network::DisconnectReason::PolicyRejection)
+            .await
+            .expect("policy reject");
+        assert!(alice_network.is_reconnect_suppressed(bob_id));
+
+        let mut events = alice_network.subscribe();
+        let depth_before = alice_network
+            .gossip_recv_queue_depth(GossipStreamType::PubSub)
+            .0;
+
+        // One explicit remote redial: bob dials alice back. The handshake
+        // completes on bob's side (alice is not suppressed on bob's side —
+        // the far side sees a Transport close, the #292 asymmetry), so
+        // alice's accept loop observes the transient winner and must close
+        // it without admitting.
+        let dialed = bob_network
+            .connect_addr(alice_addr)
+            .await
+            .expect("bob redials alice after rejection");
+
+        // Push a gossip frame on the transient connection. The send may
+        // fail outright if alice's close already landed — either way the
+        // frame must never be delivered.
+        let _ = bob_network
+            .send_to_peer(
+                saorsa_gossip_types::PeerId::new(dialed.0),
+                GossipStreamType::PubSub,
+                bytes::Bytes::from_static(b"#292 transient-window frame"),
+            )
+            .await;
+
+        // Sample across the accept-then-close window (and past it, so bob's
+        // own proactive Transport redials of alice also hit the gate).
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut transport_connected_samples = 0usize;
+        while tokio::time::Instant::now() < deadline {
+            assert_eq!(
+                alice_network.peer_admission(&bob_peer).await,
+                network::PeerAdmission::Suppressed,
+                "admission must read Suppressed throughout the accept-to-close window"
+            );
+            assert_eq!(
+                alice_network
+                    .gossip_recv_queue_depth(GossipStreamType::PubSub)
+                    .0,
+                depth_before,
+                "a frame pushed on the transient connection must not be delivered"
+            );
+            if alice_network.is_connected(&bob_peer).await {
+                transport_connected_samples += 1;
+            }
+            while let Ok(event) = events.try_recv() {
+                if let network::NetworkEvent::PeerConnected { peer_id, .. } = event {
+                    assert_ne!(
+                        peer_id, bob_id,
+                        "inbound redial of a suppressed peer must never surface PeerConnected"
+                    );
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        // Raw transport truth is logged, not asserted: a transient winner
+        // inside the window is expected and invisible to admission (#292).
+        eprintln!(
+            "raw is_connected observations during the accept-to-close window: \
+             {transport_connected_samples}"
+        );
+        assert!(
+            alice_network.is_reconnect_suppressed(bob_id),
+            "refusing the inbound redial must not clear the tombstone"
+        );
+    }
+
+    /// Issue #292 (invariant A): a suppressed peer never appears in
+    /// `gossip_plane_peers` — even while ant-quic transiently reports it
+    /// transport-connected (the accept-to-close redial window) — while a
+    /// healthy peer stays admitted, guarding against over-suppression.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn gossip_plane_peers_excludes_suppressed_transport_connected_peer() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let alice = Agent::builder()
+            .with_machine_key(dir.path().join("alice-machine.key"))
+            .with_agent_key_path(dir.path().join("alice-agent.key"))
+            .with_contact_store_path(dir.path().join("alice-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("alice-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("alice");
+        let alice_network = alice.network().expect("alice network");
+        let alice_addr =
+            normalize_loopback_addr(alice_network.bound_addr().await.expect("alice bound"));
+
+        let bob = Agent::builder()
+            .with_machine_key(dir.path().join("bob-machine.key"))
+            .with_agent_key_path(dir.path().join("bob-agent.key"))
+            .with_contact_store_path(dir.path().join("bob-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("bob-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("bob");
+        let bob_network = bob.network().expect("bob network");
+        let bob_addr = normalize_loopback_addr(bob_network.bound_addr().await.expect("bob bound"));
+        let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+
+        let carol = Agent::builder()
+            .with_machine_key(dir.path().join("carol-machine.key"))
+            .with_agent_key_path(dir.path().join("carol-agent.key"))
+            .with_contact_store_path(dir.path().join("carol-contacts.json"))
+            .with_peer_cache_dir(dir.path().join("carol-peers"))
+            .with_network_config(loopback_network_config())
+            .build()
+            .await
+            .expect("carol");
+        let carol_network = carol.network().expect("carol network");
+        let carol_addr =
+            normalize_loopback_addr(carol_network.bound_addr().await.expect("carol bound"));
+        let carol_peer = ant_quic::PeerId(carol.machine_id().0);
+
+        for (addr, peer, name) in [
+            (bob_addr, bob_peer, "bob"),
+            (carol_addr, carol_peer, "carol"),
+        ] {
+            let connected = alice_network
+                .connect_addr(addr)
+                .await
+                .unwrap_or_else(|e| panic!("alice connects {name}: {e}"));
+            assert_eq!(connected.0, peer.0, "{name} identity");
+        }
+        let reg = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < reg {
+            if alice_network.is_connected(&bob_peer).await
+                && alice_network.is_connected(&carol_peer).await
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            alice_network.is_connected(&bob_peer).await
+                && alice_network.is_connected(&carol_peer).await,
+            "bob and carol connected before rejection"
+        );
+
+        // Baseline: both peers are gossip-plane carriers.
+        let plane = alice_network.gossip_plane_peers().await;
+        assert!(plane.contains(&bob_peer), "healthy bob is a gossip carrier");
+        assert!(
+            plane.contains(&carol_peer),
+            "healthy carol is a gossip carrier"
+        );
+
+        alice_network
+            .disconnect_with_reason(&bob_peer, network::DisconnectReason::PolicyRejection)
+            .await
+            .expect("policy reject");
+
+        // Excluded immediately, carol untouched (over-suppression guard).
+        let plane = alice_network.gossip_plane_peers().await;
+        assert!(
+            !plane.contains(&bob_peer),
+            "suppressed bob must leave gossip_plane_peers immediately"
+        );
+        assert_eq!(
+            alice_network.peer_admission(&bob_peer).await,
+            network::PeerAdmission::Suppressed
+        );
+        assert_eq!(
+            alice_network.peer_admission(&carol_peer).await,
+            network::PeerAdmission::Admitted,
+            "carol must stay admitted — suppression is per-peer"
+        );
+
+        // Drive the transient transport-connected window: bob redials, so
+        // ant-quic briefly holds a winner alice must not expose. Sample
+        // fast enough to catch the window when it opens; the exclusion
+        // assertions hold on every sample either way.
+        let _ = bob_network
+            .connect_addr(alice_addr)
+            .await
+            .expect("bob redials alice after rejection");
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(1500);
+        let mut transport_connected_samples = 0usize;
+        while tokio::time::Instant::now() < deadline {
+            if alice_network.is_connected(&bob_peer).await {
+                transport_connected_samples += 1;
+                let plane = alice_network.gossip_plane_peers().await;
+                assert!(
+                    !plane.contains(&bob_peer),
+                    "a transport-connected suppressed peer must never enter gossip_plane_peers"
+                );
+            }
+            let plane = alice_network.gossip_plane_peers().await;
+            assert!(
+                plane.contains(&carol_peer),
+                "carol must remain a gossip carrier throughout"
+            );
+            assert_eq!(
+                alice_network.peer_admission(&bob_peer).await,
+                network::PeerAdmission::Suppressed
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        eprintln!(
+            "raw is_connected observations during the redial window: \
+             {transport_connected_samples}"
         );
     }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -4543,8 +4543,8 @@ pub enum PeerAdmission {
     /// no `PeerConnected` — even while a transient transport connection
     /// exists.
     Suppressed,
-    /// Connected and unsuppressed, but the plane is unresolved inside
-    /// [`PLANE_LEGACY_GRACE`] (issue #206 fail-closed pending).
+    /// Connected and unsuppressed, but the plane is unresolved inside the
+    /// 10s plane-legacy grace (issue #206 fail-closed pending).
     PlanePending,
     /// No transport connection.
     NotConnected,

--- a/src/network.rs
+++ b/src/network.rs
@@ -2303,6 +2303,12 @@ impl NetworkNode {
     /// Returns `NetworkError` if the peer is not cached or none of its cached
     /// addresses lead back to the expected peer.
     pub async fn connect_cached_peer(&self, peer_id: AntPeerId) -> NetworkResult<SocketAddr> {
+        // Issue #292 invariant C: the gate outranks the connected
+        // fast-path below — a suppressed peer refuses even while a
+        // transient transport winner exists, and never refreshes the
+        // tombstone doing so.
+        self.dial_gated(&peer_id, "cached_peer")?;
+
         if self.is_connected(&peer_id).await {
             let node_guard = self.node.read().await;
             if let Some(node) = node_guard.as_ref() {
@@ -2374,6 +2380,23 @@ impl NetworkNode {
     ///
     /// Returns `NetworkError` if connection fails or node is not initialized.
     pub async fn connect_addr(&self, addr: SocketAddr) -> NetworkResult<AntPeerId> {
+        self.connect_addr_with_origin(addr, "manual").await
+    }
+
+    /// Address-only dial carrying the #292 refusal-log origin (eager-set,
+    /// announcement, bootstrap, manual). The peer id is learned only from
+    /// the answered handshake, so the suppression gate is the
+    /// post-handshake re-check (invariant C): no cache write, no
+    /// `PeerConnected`, no plane admission for a suppressed answered id.
+    pub(crate) async fn connect_addr_with_origin(
+        &self,
+        addr: SocketAddr,
+        origin: &'static str,
+    ) -> NetworkResult<AntPeerId> {
+        // Optional invariant-C skip: if this address already maps to a
+        // suppressed cache entry, refuse pre-socket so the handshake
+        // cannot write cache success (shared ant-quic BootstrapCache).
+        self.dial_gated_cached_addr(addr, origin).await?;
         let node = self.require_node().await?;
         let family = if addr.is_ipv4() { "v4" } else { "v6" };
         tracing::debug!(
@@ -2389,6 +2412,13 @@ impl NetworkNode {
 
         match result {
             Ok(peer_conn) => {
+                // Issue #292 invariant C: gate the ANSWERED id after the
+                // handshake and before any bookkeeping, admission, or event,
+                // so a tombstone that landed mid-dial never admits. The
+                // close is a plain transport disconnect (invariant F).
+                self.dial_gated_answered(&node, &peer_conn.peer_id, origin)
+                    .await?;
+
                 let rtt_ms = dur_ms as u32;
                 if let Some(ref cache) = self.bootstrap_cache {
                     cache
@@ -2457,12 +2487,19 @@ impl NetworkNode {
     ///
     /// Returns `NetworkError` if connection fails.
     pub async fn connect_peer(&self, peer_id: AntPeerId) -> NetworkResult<(SocketAddr, AntPeerId)> {
+        // Issue #292 invariant C: refuse pre-socket when the id is known.
+        self.dial_gated(&peer_id, "peer")?;
         let node = self.require_node().await?;
         let start = std::time::Instant::now();
         let peer_conn = node
             .connect_peer(peer_id)
             .await
             .map_err(|e| NetworkError::ConnectionFailed(e.to_string()))?;
+
+        // Issue #292 invariant C: a tombstone that landed mid-handshake
+        // must not admit — re-check the answered id before any bookkeeping.
+        self.dial_gated_answered(&node, &peer_conn.peer_id, "peer")
+            .await?;
 
         let addr = match peer_conn.remote_addr {
             TransportAddr::Udp(socket_addr) => socket_addr,
@@ -2525,6 +2562,8 @@ impl NetworkNode {
         peer_id: AntPeerId,
         addrs: Vec<SocketAddr>,
     ) -> NetworkResult<(SocketAddr, AntPeerId)> {
+        // Issue #292 invariant C: refuse pre-socket when the id is known.
+        self.dial_gated(&peer_id, "peer_with_addrs")?;
         let node = self.require_node().await?;
         let v4_count = addrs.iter().filter(|a| a.is_ipv4()).count();
         let v6_count = addrs.len() - v4_count;
@@ -2585,6 +2624,12 @@ impl NetworkNode {
                 ));
             }
         };
+
+        // Issue #292 invariant C: re-check the answered id after the
+        // handshake and before any bookkeeping so a tombstone that landed
+        // mid-dial never admits.
+        self.dial_gated_answered(&node, &peer_conn.peer_id, "peer_with_addrs")
+            .await?;
 
         // Identity gate — verify the responding peer is the one we requested
         // BEFORE running any cache bookkeeping or emitting PeerConnected.
@@ -2759,6 +2804,155 @@ impl NetworkNode {
         reconnect_suppression_is_live(self.reconnect_suppressions.as_ref(), peer_id)
     }
 
+    /// Gossip-plane admission verdict for a peer (issue #292, invariant A).
+    ///
+    /// This is the single predicate gossip-affecting consumers must consult;
+    /// [`Self::is_connected`] stays ant-quic transport truth for lifecycle
+    /// and transport-recovery callers (issue #241) and must never be used to
+    /// decide gossip eligibility.
+    ///
+    /// `Suppressed` outranks transport truth: a peer with a live
+    /// reconnect-suppression tombstone never reads `Admitted`, even while
+    /// ant-quic still reports a connection — the transient windows the
+    /// accept loop has not closed yet (#228/#292 accept-then-close) and an
+    /// in-flight dial answered mid-handshake.
+    pub async fn peer_admission(&self, peer_id: &AntPeerId) -> PeerAdmission {
+        if self.is_reconnect_suppressed(peer_id.0) {
+            return PeerAdmission::Suppressed;
+        }
+        if !self.is_connected(peer_id).await {
+            return PeerAdmission::NotConnected;
+        }
+        if self.plane_gate_allows(peer_id) {
+            PeerAdmission::Admitted
+        } else {
+            PeerAdmission::PlanePending
+        }
+    }
+
+    /// `true` iff `peer_id` is fully admitted to the gossip plane:
+    /// transport-connected, unsuppressed, and plane-allowed (issue #292).
+    ///
+    /// Gossip consumers (eager-set seeds, pubsub/CRDT fanout, membership
+    /// keepalives) must use this instead of raw [`Self::is_connected`].
+    pub async fn is_peer_admitted(&self, peer_id: &AntPeerId) -> bool {
+        self.peer_admission(peer_id).await == PeerAdmission::Admitted
+    }
+
+    /// `set_at` of the live suppression tombstone for `peer_id`, if any.
+    ///
+    /// Test observable for issue #292 invariant F: refused dials/accepts
+    /// must never refresh an existing tombstone.
+    #[cfg(test)]
+    pub(crate) fn reconnect_suppression_set_at(&self, peer_id: [u8; 32]) -> Option<Instant> {
+        let map = self
+            .reconnect_suppressions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let now = Instant::now();
+        map.get(&peer_id)
+            .filter(|s| s.is_live(now))
+            .map(|s| s.set_at)
+    }
+
+    /// Outbound dial choke point, pre-socket half (issue #292, invariant C).
+    ///
+    /// Every id-known outbound seam — [`Self::connect_peer`],
+    /// [`Self::connect_peer_with_addrs`], [`Self::connect_cached_peer`],
+    /// and `GossipTransport::dial` — must pass through here before opening
+    /// a socket. A suppressed peer refuses with no socket, no event, no
+    /// cache write, and no tombstone mutation (invariant F: a refused
+    /// attempt must not refresh the tombstone). Address-only seams have no
+    /// id pre-socket and use [`Self::dial_gated_answered`] after the
+    /// handshake answers the id.
+    async fn dial_gated_cached_addr(
+        &self,
+        addr: SocketAddr,
+        origin: &'static str,
+    ) -> NetworkResult<()> {
+        let Some(cache) = self.bootstrap_cache.as_ref() else {
+            return Ok(());
+        };
+        for peer in cache.all_peers().await {
+            if peer.addresses.contains(&addr)
+                && reconnect_suppression_is_live(
+                    self.reconnect_suppressions.as_ref(),
+                    peer.peer_id.0,
+                )
+            {
+                tracing::warn!(
+                    target: "x0x::connect",
+                    origin,
+                    %addr,
+                    peer_id_prefix = %hex_prefix(&peer.peer_id.0, 4),
+                    "dial refused: address maps to reconnect-suppressed peer (issue #292)"
+                );
+                return Err(NetworkError::ConnectionFailed(format!(
+                    "dial of reconnect-suppressed peer {:?} refused ({origin})",
+                    peer.peer_id
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn dial_gated(&self, peer_id: &AntPeerId, origin: &'static str) -> NetworkResult<()> {
+        if reconnect_suppression_is_live(self.reconnect_suppressions.as_ref(), peer_id.0) {
+            tracing::warn!(
+                target: "x0x::connect",
+                origin,
+                peer_id_prefix = %hex_prefix(&peer_id.0, 4),
+                "dial refused: peer is reconnect-suppressed (issue #292)"
+            );
+            return Err(NetworkError::ConnectionFailed(format!(
+                "dial of reconnect-suppressed peer {:?} refused ({origin})",
+                peer_id
+            )));
+        }
+        Ok(())
+    }
+
+    /// Outbound dial choke point, post-handshake half (issue #292,
+    /// invariant C).
+    ///
+    /// Re-checks the suppression tombstone against the id the handshake
+    /// *answered*, so a tombstone that landed mid-dial never admits. Used by
+    /// [`Self::connect_addr`] (address-only: no id is known pre-socket, so
+    /// this is the only gate) and re-run by the id-known seams after their
+    /// socket completes, before any cache write, `PeerConnected`, or plane
+    /// admission. The transient connection is closed with a plain transport
+    /// disconnect — never [`Self::disconnect_with_reason`], whose
+    /// `suppress_reconnect` would refresh the tombstone (invariant F).
+    async fn dial_gated_answered(
+        &self,
+        node: &Node,
+        answered: &AntPeerId,
+        origin: &'static str,
+    ) -> NetworkResult<()> {
+        if reconnect_suppression_is_live(self.reconnect_suppressions.as_ref(), answered.0) {
+            tracing::warn!(
+                target: "x0x::connect",
+                origin,
+                peer_id_prefix = %hex_prefix(&answered.0, 4),
+                "dial closed post-handshake: answered peer is reconnect-suppressed (issue #292)"
+            );
+            if let Err(e) = node.disconnect(answered).await {
+                tracing::debug!(
+                    target: "x0x::connect",
+                    origin,
+                    peer_id_prefix = %hex_prefix(&answered.0, 4),
+                    error = %e,
+                    "close of suppressed answered dial failed"
+                );
+            }
+            return Err(NetworkError::ConnectionFailed(format!(
+                "dial answered reconnect-suppressed peer {:?}; closed ({origin})",
+                answered
+            )));
+        }
+        Ok(())
+    }
+
     /// Gossip-plane gate (issue #206).
     ///
     /// Returns `true` when gossip traffic with `peer` is plane-allowed:
@@ -2819,15 +3013,19 @@ impl NetworkNode {
     /// [`Self::connected_peers`] when seeding gossip peer sets (PlumTree
     /// eager sets, membership keepalives) so stale outer-table entries and
     /// cross-plane or not-yet-verified peers never enter the gossip plane.
+    ///
+    /// Issue #292, invariant A: eligibility is decided by
+    /// [`Self::peer_admission`], never raw transport truth — a
+    /// transport-connected peer with a live suppression tombstone is
+    /// excluded even inside the transient accept-to-close window.
     pub(crate) async fn gossip_plane_peers(&self) -> Vec<AntPeerId> {
-        let connected = self.send_ready_peers().await;
-        if self.config.network_id.is_none() {
-            return connected;
+        let mut admitted = Vec::new();
+        for peer in self.send_ready_peers().await {
+            if self.peer_admission(&peer).await == PeerAdmission::Admitted {
+                admitted.push(peer);
+            }
         }
-        connected
-            .into_iter()
-            .filter(|peer| self.plane_gate_allows(peer))
-            .collect()
+        admitted
     }
 
     /// Handle an inbound plane hello (issue #206).
@@ -3612,6 +3810,26 @@ impl NetworkNode {
                             continue;
                         }
 
+                        // Issue #292 invariant B: a suppressed peer's gossip
+                        // frames are not answered. The accept loop closes the
+                        // transient inbound, but a frame already delivered
+                        // inside the accept-to-close window must not reach
+                        // the gossip plane either. Checked BEFORE the plane
+                        // gate so a suppressed peer never seeds plane state.
+                        // (DM bytes (0x10/0x11) above stay out of #206/#292
+                        // gossip-plane scope.)
+                        if GossipStreamType::from_byte(type_byte).is_some()
+                            && plane_node.is_reconnect_suppressed(peer_id.0)
+                        {
+                            tracing::warn!(
+                                target: "x0x::connect",
+                                origin = "recv",
+                                peer_id_prefix = %hex_prefix(&peer_id.0, 4),
+                                "dropping gossip frame from reconnect-suppressed peer (issue #292)"
+                            );
+                            continue;
+                        }
+
                         // Issue #206: gossip-plane gate. Peers that are not
                         // plane-cleared (hello outstanding, legacy grace not
                         // yet elapsed) may not carry gossip traffic in either
@@ -3758,14 +3976,20 @@ impl NetworkNode {
                         // success, emitting `PeerConnected`, touching the
                         // connection pool, or touching the tombstone itself
                         // (`Node::disconnect` maps to a plain transport close
-                        // and never mutates x0x suppressions).
+                        // and never mutates x0x suppressions). Issue #292
+                        // invariant D: this transient transport winner is
+                        // invisible to admission via `peer_admission`
+                        // (invariant A) and must never call
+                        // `suppress_reconnect` (invariant F).
                         if reconnect_suppression_is_live(
                             reconnect_suppressions.as_ref(),
                             peer_conn.peer_id.0,
                         ) {
                             tracing::warn!(
-                                "SECURITY: Rejecting inbound connection from reconnect-suppressed peer {:?}",
-                                peer_conn.peer_id
+                                target: "x0x::connect",
+                                origin = "accept",
+                                peer_id_prefix = %hex_prefix(&peer_conn.peer_id.0, 4),
+                                "accept closed: inbound connection from reconnect-suppressed peer (issue #292)"
                             );
                             if let Err(e) = node_ref.disconnect(&peer_conn.peer_id).await {
                                 debug!(
@@ -4021,6 +4245,12 @@ impl saorsa_gossip_transport::GossipTransport for NetworkNode {
     async fn dial(&self, peer: GossipPeerId, addr: SocketAddr) -> anyhow::Result<()> {
         let ant_peer = gossip_to_ant_peer_id(&peer);
 
+        // Issue #292 invariant C: the dial gate outranks the connected
+        // fast-path — a suppressed peer must not read as a successful
+        // gossip dial even while a transient transport connection exists.
+        self.dial_gated(&ant_peer, "eager_set")
+            .map_err(|e| anyhow::anyhow!("dial refused: {}", e))?;
+
         // Check if already connected
         if self.is_connected(&ant_peer).await {
             debug!("Already connected to peer {:?} at {}", peer, addr);
@@ -4029,7 +4259,7 @@ impl saorsa_gossip_transport::GossipTransport for NetworkNode {
 
         // Connect by address
         let connected_peer = self
-            .connect_addr(addr)
+            .connect_addr_with_origin(addr, "eager_set")
             .await
             .map_err(|e| anyhow::anyhow!("dial failed: {}", e))?;
 
@@ -4057,8 +4287,10 @@ impl saorsa_gossip_transport::GossipTransport for NetworkNode {
     }
 
     async fn dial_bootstrap(&self, addr: SocketAddr) -> anyhow::Result<GossipPeerId> {
+        // Address-only: no id pre-socket, so the #292 suppression gate is
+        // connect_addr's post-handshake re-check of the answered id.
         let ant_peer_id = self
-            .connect_addr(addr)
+            .connect_addr_with_origin(addr, "bootstrap")
             .await
             .map_err(|e| anyhow::anyhow!("bootstrap dial failed: {}", e))?;
 
@@ -4101,6 +4333,21 @@ impl saorsa_gossip_transport::GossipTransport for NetworkNode {
         data: bytes::Bytes,
     ) -> anyhow::Result<()> {
         let ant_peer = gossip_to_ant_peer_id(&peer);
+
+        // Issue #292 invariant B: no gossip stream is opened toward a
+        // reconnect-suppressed peer. Reported as success for the same
+        // reason as the plane-pending hold below — the peer is already
+        // excluded from `gossip_plane_peers`, so there is no overlay view
+        // to protect, and a suppressed peer must never receive gossip.
+        if self.is_reconnect_suppressed(ant_peer.0) {
+            debug!(
+                "[1/6 network] send: holding {:?} ({} bytes) — peer {:?} is reconnect-suppressed",
+                stream_type,
+                data.len(),
+                peer
+            );
+            return Ok(());
+        }
 
         // Issue #206: hold gossip sends to peers that have not cleared the
         // plane gate (hello outstanding / legacy grace). Reported as success
@@ -4280,6 +4527,27 @@ impl ReconnectSuppression {
             Some(ttl) => now.duration_since(self.set_at) < ttl,
         }
     }
+}
+
+/// Gossip-plane admission verdict for a peer (issue #292, invariant A).
+///
+/// Produced by [`NetworkNode::peer_admission`]. `Suppressed` outranks
+/// transport truth: a transient QUIC winner (accept-then-close window,
+/// in-flight dial answered mid-handshake) is `Suppressed`, never
+/// `Admitted`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerAdmission {
+    /// Transport-connected, unsuppressed, and plane-allowed: gossip may flow.
+    Admitted,
+    /// A live reconnect-suppression tombstone exists: no gossip, no dials,
+    /// no `PeerConnected` — even while a transient transport connection
+    /// exists.
+    Suppressed,
+    /// Connected and unsuppressed, but the plane is unresolved inside
+    /// [`PLANE_LEGACY_GRACE`] (issue #206 fail-closed pending).
+    PlanePending,
+    /// No transport connection.
+    NotConnected,
 }
 
 /// Returns `true` iff a live suppression tombstone for `peer_id` exists in


### PR DESCRIPTION
## Summary
- Add `NetworkNode::peer_admission` / `is_peer_admitted` (`Admitted` | `Suppressed` | `PlanePending` | `NotConnected`). `Suppressed` outranks transport; `gossip_plane_peers` and gossip send/recv consult admission, never raw `is_connected`.
- Funnel `connect_addr`, `connect_peer`, `connect_peer_with_addrs`, `connect_cached_peer`, `GossipTransport::dial`, `dial_bootstrap`, and announcement auto-connect through `dial_gated` / `dial_gated_answered`. Cached address mapped to a suppressed peer refuses pre-socket. No socket/event/cache write/tombstone mutation on refuse (invariant F).
- Inbound accept of a suppressed peer disconnects without `PeerConnected`, `cache.record_success`, or `suppress_reconnect`. No PlaneRefuse / no invariant E.

## Test plan
- [x] `suppressed_peer_outbound_dial_is_refused` — id + address seams refuse; `peer_admission == Suppressed`; tombstone `set_at` unchanged
- [x] `inbound_redial_of_suppressed_peer_emits_no_peer_connected` — explicit remote redial; zero `PeerConnected`; no gossip delivery
- [x] `gossip_plane_peers_excludes_suppressed_transport_connected_peer`
- [x] `transport_disconnect_is_reconnect_eligible_and_recovers` (#241)
- [x] `suppressed_peer_announcement_is_not_auto_connected`
- [x] `pool_cap_eviction_does_not_churn_redial`
- [x] `admin_revocation_shutdown_disconnect_suppresses_proactive_reconnect`

Does not merge. Does not implement E/PlaneRefuse. Does not change `is_connected` semantics.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a unified peer-admission decision and routes outbound, inbound, and gossip paths through reconnect-suppression gates so policy-rejected peers remain down.
- Adds suppression-aware admission, dial, receive, send, and inbound-accept checks.
- Routes announcement, bootstrap, cached-peer, and gossip dials through the new gates.
- Adds integration coverage for suppressed outbound and inbound connections and gossip exclusion.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until address-only dialing stops treating stale cache associations as authoritative peer identity.

The new pre-socket cache gate can reject a valid non-suppressed peer whenever its address remains cached under a suppressed peer, breaking bootstrap, announcement, and gossip connection paths before handshake authentication can resolve the actual identity.

**Files Needing Attention:** src/network.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/network.rs | Adds suppression-aware admission and dial gating, but the cached-address preflight can reject a healthy peer based on a stale association to another suppressed identity. |
| src/lib.rs | Routes announcement auto-connect through the origin-aware gated address dial and adds broad stay-down integration tests. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Address-only dial] --> B{Cached address belongs to any suppressed peer?}
  B -- Yes --> C[Refuse before socket]
  B -- No --> D[Perform authenticated handshake]
  D --> E{Answered PeerId suppressed?}
  E -- Yes --> F[Disconnect and refuse]
  E -- No --> G[Bookkeeping and PeerConnected]
  H[Known-PeerId dial] --> I{Requested PeerId suppressed?}
  I -- Yes --> J[Refuse before socket]
  I -- No --> D
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/network.rs:2876-2884
**Cached address blocks valid peers**

When an address cached for a suppressed peer is later used to reach a different non-suppressed peer, `dial_gated_cached_addr` treats the stale address association as authoritative and refuses before authenticating the responder, preventing valid manual, bootstrap, announcement, or eager-set connections.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(net): peer\_admission stay-down A-D+F..."](https://github.com/saorsa-labs/x0x/commit/8f2cb7dec0bf1f2176fdf06095f67e7a47e19924) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54726513)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Network Transport](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/network-transport.md)

<!-- /greptile_comment -->