### PR TITLE
fix(upgrade): transactional handoff for unsupervised restart (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Unsupervised self-update restart is now transactional (issue #261).**
+  After a successful binary swap, a daemon with no supervisor (macOS terminal
+  launch, nohup, background — the live incident class) no longer silently
+  `exit(0)`s and leaves the machine DOWN. Restart mode is classified before
+  anything destructive runs: `SupervisedExit` (exit 0 / 100 for the
+  supervisor) only when `stop_on_upgrade = true` **and** a real supervision
+  signal exists (`INVOCATION_ID` set, parent comm `systemd`, or
+  `X0X_SUPERVISED=1`); not-a-TTY and launchd ancestry are explicitly NOT
+  supervision. Everything else runs a transactional handoff: the old daemon
+  writes `data_dir/upgrade-handoff.json`, spawns a detached
+  `x0xd --upgrade-handoff` helper, cancels gracefully within a 5s bound, and
+  exits; the helper waits out the old pid/port, spawns the new binary, and
+  commits the restart only once `GET /health` answers 200 on the pre-upgrade
+  API address (30s bound) — otherwise it restores `x0xd.backup` over the
+  target and respawns the previous binary. If no respawn succeeds it leaves a
+  loud `data_dir/UPGRADE_FAILED` artifact and exits nonzero. The old unix
+  `exec()` path (`stop_on_upgrade = false`) is gone — it could not roll back —
+  and the `[update] stop_on_upgrade` config default is unchanged. The startup
+  sweep now age-gates `*.x0xold-*` sidelined binaries like temp dirs so an
+  in-flight handoff never loses its rollback bytes.
+
 - **Public group send no longer waits out the ~24s DM retry before gossip
   carry (issue #310).** `POST /groups/:id/send` still persists locally and
   returns 200 + `msg_id`. Fan-out is now a race: gossip topic publish

--- a/docs/upgrade-system.md
+++ b/docs/upgrade-system.md
@@ -8,6 +8,7 @@ Manifest-based decentralized self-update with symmetric gossip propagation.
 - **`signature.rs`**: ML-DSA-65 signing/verification for archives and manifests. Embedded release public key.
 - **`monitor.rs`**: `UpgradeMonitor` polls GitHub releases, `fetch_verified_manifest()` downloads and verifies manifest+signature, returns `VerifiedRelease` with pre-encoded gossip payload
 - **`apply.rs`**: `apply_upgrade_from_manifest()` — downloads archive, verifies SHA-256 hash, extracts binary, performs atomic replacement with rollback. A `TempDirGuard` (RAII) removes the per-attempt `.x0x-upgrade-*` temp dir on every exit path, including early-return errors, so a failed apply never leaks the downloaded archive.
+- **`restart.rs`**: the #261 restart transaction — supervision classification (`RestartMode`), the `upgrade-handoff.json` intent record, the detached handoff helper, and the loud `UPGRADE_FAILED` artifact.
 - **`rollout.rs`**: Staged rollout with deterministic delay based on machine ID hash (configurable window)
 
 ### Binary replacement (`mod.rs`)
@@ -17,7 +18,58 @@ Manifest-based decentralized self-update with symmetric gossip propagation.
 - **Unix**: `fs::rename(new, target)` — atomic on the same filesystem, valid even when `target` is the running executable.
 - **Windows / non-Unix**: a running executable is locked and cannot be renamed over in place. `replace_via_sideline` moves the live binary aside to `<name>.x0xold-<nanos>` (allowed even while locked), moves the new binary into place, and rolls the sideline back if the second move fails. The sidelined file stays locked until the old process exits and is reclaimed on the next launch.
 
-`sweep_stale_upgrade_artifacts(dir, min_age)` runs once at `x0xd` startup. It removes leftover `.x0x-upgrade-*` temp dirs older than `min_age` (1h — never disturbs an in-flight apply) and best-effort deletes `*.x0xold-*` sidelined binaries. This reclaims debris from previously-interrupted attempts.
+`sweep_stale_upgrade_artifacts(dir, min_age)` runs once at `x0xd` startup. It removes leftover `.x0x-upgrade-*` temp dirs older than `min_age` (1h — never disturbs an in-flight apply) and `*.x0xold-*` sidelined binaries that clear the same age gate (issue #261: a handoff still in flight must not lose its rollback bytes). This reclaims debris from previously-interrupted attempts.
+
+## Restart after swap (#261 — transactional handoff)
+
+After the swap commits, the daemon classifies supervision **before** anything
+destructive runs (`upgrade::restart::plan_restart_mode`):
+
+- `SupervisedExit` — only when `[update] stop_on_upgrade = true` (the default)
+  **and** one of three real signals is present: `INVOCATION_ID` is set
+  (systemd unit), the parent's `comm` is `systemd`, or `X0X_SUPERVISED=1`
+  (explicit opt-in: launchd plist, Windows service). The daemon writes the
+  intent file, then exits 0 (100 on Windows) for the supervisor to re-exec the
+  new bytes. A *missing TTY* is **not** supervision — nohup/background/detached
+  stdin never qualifies, and neither does "some ancestor is launchd" (every
+  macOS process has that).
+- `TransactionalHandoff` — everything else, including unsupervised runs with
+  the default `stop_on_upgrade = true` (the macOS terminal incident) and every
+  `stop_on_upgrade = false` run. The old `exec()` path is gone: it could not
+  roll back.
+
+The handoff transaction (`upgrade::restart`):
+
+1. The old daemon writes `data_dir/upgrade-handoff.json` (from/to versions,
+   target/backup paths, argv, cwd, env whitelist, old pid, API address,
+   timestamp) — captured before any exit, and also on the supervised path so a
+   crash loop is diagnosable.
+2. It spawns a detached helper in a new session — the same `x0xd` binary,
+   preferring the known-good backup bytes — as `x0xd --upgrade-handoff <file>`.
+3. It triggers the graceful-shutdown hook with a **5s bound** (never waits
+   unbounded; the macOS SIGTERM-hang incident), then `_exit(0)`.
+4. The helper waits (30s bound) for the old pid to die and the API port to
+   free — **never SIGKILLs** it. If the old process hangs past the bound, the
+   helper aborts the spawn, restores the backup over the target, leaves the
+   old process running, and writes `UPGRADE_FAILED`.
+5. The helper spawns the new binary with the captured argv/cwd (appending
+   `--skip-update-check` only if not already present) and waits for
+   `GET /health` 200 on the pre-upgrade API address (or the fresh
+   `<data_dir>/api.port` when the bind is ephemeral) within 30s.
+6. Health OK ⇒ restart committed: the handoff file is deleted and the helper
+   exits 0. Health fail/spawn fail ⇒ the backup is restored over the target
+   and the previous binary is respawned with the same argv/cwd, then
+   health-checked again.
+7. If the rollback respawn also fails, the helper writes
+   `data_dir/UPGRADE_FAILED` (reason, versions, paths, timestamps), eprints,
+   and exits **nonzero** — never a silent exit 0. The invariant: after any
+   apply, either a process answers `/health` or `UPGRADE_FAILED` exists and
+   the last exit is nonzero.
+
+The helper's wait bounds are operator-tunable via
+`X0X_UPGRADE_HANDOFF_RELEASE_TIMEOUT_SECS` and
+`X0X_UPGRADE_HANDOFF_HEALTH_TIMEOUT_SECS` (both default 30). The helper joins
+no gossip, binds nothing, and takes no instance lock.
 
 ## Update Flow (for x0xd)
 

--- a/src/bin/x0xd.rs
+++ b/src/bin/x0xd.rs
@@ -107,6 +107,19 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // Private handoff-helper mode (#261): `x0xd --upgrade-handoff <file>` is
+    // spawned detached by a daemon that just swapped its binary. It must run
+    // BEFORE any config load, logging init, or daemon startup: the helper
+    // joins no gossip, binds nothing, and takes no instance lock — it only
+    // shepherds the swap-to-restart transaction (see src/upgrade/restart.rs).
+    if let Some(idx) = args.iter().position(|a| a == "--upgrade-handoff") {
+        let path = args
+            .get(idx + 1)
+            .context("--upgrade-handoff requires a path argument")?;
+        let exit_code = x0x::upgrade::restart::run_upgrade_handoff(Path::new(path));
+        std::process::exit(exit_code);
+    }
+
     let config_path = if let Some(idx) = args.iter().position(|a| a == "--config") {
         Some(
             args.get(idx + 1)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -36,20 +36,21 @@ use routes::{
     broadcast_current_manifest, cancel_join_request, causal_relay_step, check_upgrade,
     connect_agent, connect_diagnostics_handler, connect_machine, connectivity_diagnostics,
     create_discovery_subscription, create_group_invite, create_join_request, create_kv_store,
-    create_mls_group, create_mls_welcome, create_named_group, create_task_list, delete_contact,
-    delete_discovery_subscription, delete_kv_value, delete_machine, direct_connections,
-    direct_message_send_config, direct_send, discover_groups, discover_groups_nearby,
-    discovered_agent, discovered_agents, discovered_machine, discovered_machines, dm_diagnostics,
-    ensure_named_group_listeners, evaluate_trust, exec_cancel, exec_diagnostics, exec_run,
-    exec_sessions, file_accept_handler, file_reject_handler, file_send_handler,
-    file_transfer_status_handler, file_transfers_handler, find_agent, forward_add, forward_list,
-    forward_remove, get_a2a_agent_card, get_agent_card, get_constitution, get_constitution_json,
-    get_group_card, get_group_public_messages, get_group_state, get_group_state_commits,
-    get_kv_value, get_mls_group, get_named_group, get_named_group_members, gossip_diagnostics,
-    group_membership_lock, groups_diagnostics, handle_file_message, handle_join_result_message,
-    handle_treekem_catchup_request, handle_treekem_catchup_response, handle_welcome_blob_message,
-    health, history_diagnostics, history_list, history_message, history_purge, history_search,
-    history_stats, identity_revocations, identity_revoke, import_agent_card, import_group_card,
+    create_mls_group, create_mls_welcome, create_named_group, create_task_list,
+    daemon_shutdown_hook, delete_contact, delete_discovery_subscription, delete_kv_value,
+    delete_machine, direct_connections, direct_message_send_config, direct_send, discover_groups,
+    discover_groups_nearby, discovered_agent, discovered_agents, discovered_machine,
+    discovered_machines, dm_diagnostics, ensure_named_group_listeners, evaluate_trust, exec_cancel,
+    exec_diagnostics, exec_run, exec_sessions, file_accept_handler, file_reject_handler,
+    file_send_handler, file_transfer_status_handler, file_transfers_handler, find_agent,
+    forward_add, forward_list, forward_remove, get_a2a_agent_card, get_agent_card,
+    get_constitution, get_constitution_json, get_group_card, get_group_public_messages,
+    get_group_state, get_group_state_commits, get_kv_value, get_mls_group, get_named_group,
+    get_named_group_members, gossip_diagnostics, group_membership_lock, groups_diagnostics,
+    handle_file_message, handle_join_result_message, handle_treekem_catchup_request,
+    handle_treekem_catchup_response, handle_welcome_blob_message, health, history_diagnostics,
+    history_list, history_message, history_purge, history_search, history_stats,
+    identity_revocations, identity_revoke, import_agent_card, import_group_card,
     ingest_public_message, introduction, join_group_via_invite, join_kv_store, leave_group,
     list_contacts, list_discovery_subscriptions, list_join_requests, list_kv_keys, list_kv_stores,
     list_machines, list_mls_groups, list_named_groups, list_revocations, list_task_lists,
@@ -162,7 +163,7 @@ pub async fn run_update_check_and_report(
     skip_update_check: bool,
 ) -> anyhow::Result<()> {
     if config.update.enabled && !skip_update_check {
-        match run_startup_update_check(config, None).await {
+        match run_startup_update_check(config, None, false).await {
             Ok(Some(version)) => println!("x0xd updated to {version}"),
             Ok(None) => println!("x0xd is up to date ({})", x0x::VERSION),
             Err(e) => return Err(e).context("self-update check failed"),
@@ -238,7 +239,7 @@ pub async fn serve_with_options(
     // Gated on `self_update_enabled` so embedders never download/install a new
     // binary in-process; the daemon binary sets it to `config.update.enabled`.
     if self_update_enabled && config.update.enabled {
-        if let Err(e) = run_startup_update_check(&config, None).await {
+        if let Err(e) = run_startup_update_check(&config, None, true).await {
             tracing::warn!(error = %e, "Startup update check failed: {e}");
         }
     }
@@ -651,6 +652,7 @@ pub async fn serve_with_options(
         ws_topics: RwLock::new(HashMap::new()),
         ws_outbound_stats: Arc::new(WsOutboundStats::default()),
         api_address: actual_api_addr,
+        data_dir: config.data_dir.clone(),
         start_time: Instant::now(),
         broadcast_tx,
         file_transfers: RwLock::new(HashMap::new()),
@@ -937,6 +939,10 @@ pub async fn serve_with_options(
         let data_dir = config.data_dir.clone();
         let upgrade_apply_lock = Arc::clone(&state.upgrade_apply_lock);
         let self_published_for_gossip = Arc::clone(&self_published_release_manifests);
+        // #261: the listener's restart planner needs the bound API address
+        // (health commit) and the graceful-shutdown hook (bounded cancel).
+        let gossip_api_addr = state.api_address;
+        let gossip_shutdown = daemon_shutdown_hook(&state.shutdown_notify, &state.shutdown_tx);
         bg_tasks.push(tokio::spawn(async move {
             run_gossip_update_listener(
                 agent_for_gossip,
@@ -944,6 +950,8 @@ pub async fn serve_with_options(
                 data_dir,
                 upgrade_apply_lock,
                 self_published_for_gossip,
+                gossip_api_addr,
+                gossip_shutdown,
             )
             .await;
         }));
@@ -984,6 +992,8 @@ pub async fn serve_with_options(
         let data_dir_for_poll = config.data_dir.clone();
         let upgrade_apply_lock = Arc::clone(&state.upgrade_apply_lock);
         let self_published_for_poll = Arc::clone(&self_published_release_manifests);
+        let poll_api_addr = state.api_address;
+        let poll_shutdown = daemon_shutdown_hook(&state.shutdown_notify, &state.shutdown_tx);
         bg_tasks.push(tokio::spawn(async move {
             run_fallback_github_poll(
                 agent_for_poll,
@@ -991,6 +1001,8 @@ pub async fn serve_with_options(
                 data_dir_for_poll,
                 upgrade_apply_lock,
                 self_published_for_poll,
+                poll_api_addr,
+                poll_shutdown,
             )
             .await;
         }));

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -116,6 +116,7 @@ pub(super) use tasks::{
 };
 pub(super) use trust::evaluate_trust;
 pub(super) use upgrade::{
-    apply_upgrade, broadcast_current_manifest, check_upgrade, run_fallback_github_poll,
-    run_gossip_update_listener, run_startup_update_check, SelfPublishedReleaseManifests,
+    apply_upgrade, broadcast_current_manifest, check_upgrade, daemon_shutdown_hook,
+    run_fallback_github_poll, run_gossip_update_listener, run_startup_update_check,
+    SelfPublishedReleaseManifests,
 };

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -20405,6 +20405,7 @@ pub(in crate::server) mod tests {
             ws_topics: RwLock::new(HashMap::new()),
             ws_outbound_stats: Arc::new(WsOutboundStats::default()),
             api_address: "127.0.0.1:0".parse().expect("valid test API address"),
+            data_dir: data_dir.to_path_buf(),
             start_time: Instant::now(),
             broadcast_tx,
             file_transfers: RwLock::new(HashMap::new()),

--- a/src/server/routes/upgrade.rs
+++ b/src/server/routes/upgrade.rs
@@ -13,10 +13,12 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, watch, Mutex};
+use x0x::upgrade::apply::{AutoApplyUpgrader, RestartContext};
 use x0x::upgrade::manifest::{decode_signed_manifest, is_newer, ReleaseManifest, RELEASE_TOPIC};
 use x0x::upgrade::monitor::UpgradeMonitor;
 use x0x::upgrade::signature::verify_manifest_signature;
@@ -100,10 +102,72 @@ fn decide_release_manifest_rebroadcast(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Restart plumbing (#261): every apply caller builds the same planner context
+// ---------------------------------------------------------------------------
+
+/// The graceful-shutdown trigger handed to the transactional handoff: flip the
+/// shutdown watch (SSE/WS loops + axum graceful shutdown) and poke the
+/// supervisor's mpsc. Bounded by the handoff's 5s cancel window, never waited
+/// on unbounded.
+pub(in crate::server) fn daemon_shutdown_hook(
+    shutdown_notify: &watch::Sender<bool>,
+    shutdown_tx: &mpsc::Sender<()>,
+) -> Arc<dyn Fn() + Send + Sync> {
+    let notify = shutdown_notify.clone();
+    let tx = shutdown_tx.clone();
+    Arc::new(move || {
+        let _ = notify.send(true);
+        let _ = tx.try_send(());
+    })
+}
+
+/// Startup-check context: the API listener is not bound yet (the check runs
+/// before `serve_with_options` binds), so the configured address is recorded —
+/// including a port-0 ephemeral bind, which the helper resolves via
+/// `<data_dir>/api.port`. No shutdown hook is needed: nothing is bound.
+fn startup_restart_context(config: &DaemonConfig) -> RestartContext {
+    RestartContext {
+        data_dir: Some(config.data_dir.clone()),
+        api_addr: Some(config.api_address),
+        shutdown: None,
+    }
+}
+
+/// Background-listener context (gossip + fallback poll): the running daemon's
+/// bound address and shutdown hook.
+fn listener_restart_context(
+    data_dir: &std::path::Path,
+    api_addr: SocketAddr,
+    shutdown: Arc<dyn Fn() + Send + Sync>,
+) -> RestartContext {
+    RestartContext {
+        data_dir: Some(data_dir.to_path_buf()),
+        api_addr: Some(api_addr),
+        shutdown: Some(shutdown),
+    }
+}
+
+/// The deferred HTTP restart uses the same planner as every other apply path —
+/// there is no second ad-hoc exit in the HTTP handler (#261 test 6).
+fn deferred_restart_upgrader(stop_on_upgrade: bool, context: RestartContext) -> AutoApplyUpgrader {
+    AutoApplyUpgrader::new("x0xd")
+        .with_stop_on_upgrade(stop_on_upgrade)
+        .with_restart_context(context)
+}
+
 /// Startup GitHub check. Returns Some(version) if an update was applied.
+///
+/// `trigger_restart` distinguishes the two callers: the daemon's startup
+/// check (inside `serve_with_options`) hands the restart to the #261 planner
+/// because a daemon process must come back up; the CLI `--check-updates`
+/// print-and-exit mode passes `false` — there is no daemon to keep alive, and
+/// a handoff respawn of `x0xd --check-updates` could never serve `/health`,
+/// so it would spuriously roll a good update back.
 pub(in crate::server) async fn run_startup_update_check(
     config: &DaemonConfig,
     agent: Option<&Arc<Agent>>,
+    trigger_restart: bool,
 ) -> Result<Option<String>> {
     let monitor = UpgradeMonitor::new(&config.update.repo, "x0xd", x0x::VERSION)
         .map_err(|e| anyhow::anyhow!(e))?
@@ -136,7 +200,9 @@ pub(in crate::server) async fn run_startup_update_check(
     }
 
     let upgrader = x0x::upgrade::apply::AutoApplyUpgrader::new("x0xd")
-        .with_stop_on_upgrade(config.update.stop_on_upgrade);
+        .with_stop_on_upgrade(config.update.stop_on_upgrade)
+        .with_restart_on_success(trigger_restart)
+        .with_restart_context(startup_restart_context(config));
 
     match upgrader
         .apply_upgrade_from_manifest(&verified.manifest)
@@ -213,6 +279,8 @@ pub(in crate::server) async fn run_gossip_update_listener(
     data_dir: PathBuf,
     upgrade_apply_lock: Arc<Mutex<()>>,
     self_published_release_manifests: Arc<Mutex<SelfPublishedReleaseManifests>>,
+    api_addr: SocketAddr,
+    shutdown: Arc<dyn Fn() + Send + Sync>,
 ) {
     let mut release_sub = match agent.subscribe(RELEASE_TOPIC).await {
         Ok(sub) => sub,
@@ -377,7 +445,12 @@ pub(in crate::server) async fn run_gossip_update_listener(
 
         let _upgrade_guard = upgrade_apply_lock.lock().await;
         let upgrader = x0x::upgrade::apply::AutoApplyUpgrader::new("x0xd")
-            .with_stop_on_upgrade(config.stop_on_upgrade);
+            .with_stop_on_upgrade(config.stop_on_upgrade)
+            .with_restart_context(listener_restart_context(
+                &data_dir,
+                api_addr,
+                Arc::clone(&shutdown),
+            ));
         match upgrader.apply_upgrade_from_manifest(&manifest).await {
             Ok(x0x::upgrade::UpgradeResult::Success { version }) => {
                 tracing::info!(%version, "Successfully upgraded to version {version}");
@@ -407,6 +480,8 @@ pub(in crate::server) async fn run_fallback_github_poll(
     data_dir: PathBuf,
     upgrade_apply_lock: Arc<Mutex<()>>,
     self_published_release_manifests: Arc<Mutex<SelfPublishedReleaseManifests>>,
+    api_addr: SocketAddr,
+    shutdown: Arc<dyn Fn() + Send + Sync>,
 ) {
     let interval = Duration::from_secs(config.fallback_check_interval_minutes * 60);
     let mut ticker = tokio::time::interval(interval);
@@ -489,7 +564,12 @@ pub(in crate::server) async fn run_fallback_github_poll(
 
                 let _upgrade_guard = upgrade_apply_lock.lock().await;
                 let upgrader = x0x::upgrade::apply::AutoApplyUpgrader::new("x0xd")
-                    .with_stop_on_upgrade(config.stop_on_upgrade);
+                    .with_stop_on_upgrade(config.stop_on_upgrade)
+                    .with_restart_context(listener_restart_context(
+                        &data_dir,
+                        api_addr,
+                        Arc::clone(&shutdown),
+                    ));
                 match upgrader
                     .apply_upgrade_from_manifest(&verified.manifest)
                     .await
@@ -761,16 +841,25 @@ pub(in crate::server) async fn apply_upgrade(
     };
 
     let stop_on_upgrade = state.update_config.stop_on_upgrade;
+    let restart_context = RestartContext {
+        data_dir: Some(state.data_dir.clone()),
+        api_addr: Some(state.api_address),
+        shutdown: Some(daemon_shutdown_hook(
+            &state.shutdown_notify,
+            &state.shutdown_tx,
+        )),
+    };
     let upgrader = x0x::upgrade::apply::AutoApplyUpgrader::new("x0xd")
         .with_stop_on_upgrade(stop_on_upgrade)
-        .with_restart_on_success(false);
+        .with_restart_on_success(false)
+        .with_restart_context(restart_context.clone());
 
     match upgrader
         .apply_upgrade_from_manifest(&release.manifest)
         .await
     {
         Ok(x0x::upgrade::UpgradeResult::Success { version }) => {
-            schedule_restart_after_response(stop_on_upgrade);
+            schedule_restart_after_response(stop_on_upgrade, restart_context, version.clone());
             (
                 StatusCode::OK,
                 Json(serde_json::json!({
@@ -813,12 +902,17 @@ pub(in crate::server) async fn apply_upgrade(
     }
 }
 
-fn schedule_restart_after_response(stop_on_upgrade: bool) {
+fn schedule_restart_after_response(
+    stop_on_upgrade: bool,
+    restart_context: RestartContext,
+    target_version: String,
+) {
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(750)).await;
-        let upgrader = x0x::upgrade::apply::AutoApplyUpgrader::new("x0xd")
-            .with_stop_on_upgrade(stop_on_upgrade);
-        if let Err(e) = upgrader.restart_current_binary() {
+        // Same planner as every other apply path (#261): unsupervised daemons
+        // get the transactional handoff here too — never a bare exit(0).
+        let upgrader = deferred_restart_upgrader(stop_on_upgrade, restart_context);
+        if let Err(e) = upgrader.restart_current_binary(&target_version) {
             tracing::error!(error = %e, "failed to restart after manual upgrade apply");
         }
     });
@@ -831,6 +925,7 @@ fn schedule_restart_after_response(stop_on_upgrade: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::upgrade::restart;
     use x0x::upgrade::manifest::{PlatformAsset, SCHEMA_VERSION};
 
     fn manifest_with_version(version: &str) -> ReleaseManifest {
@@ -922,5 +1017,81 @@ mod tests {
             after_ttl,
         );
         assert_eq!(decision_after_ttl, ReleaseRebroadcastDecision::Rebroadcast);
+    }
+
+    fn daemon_restart_context() -> RestartContext {
+        RestartContext {
+            data_dir: Some(PathBuf::from("/var/lib/x0x")),
+            api_addr: Some("127.0.0.1:12700".parse().unwrap()),
+            shutdown: Some(Arc::new(|| {})),
+        }
+    }
+
+    #[test]
+    fn http_deferred_restart_uses_the_shared_planner_not_an_ad_hoc_exit() {
+        // #261 test 6: schedule_restart_after_response builds its upgrader via
+        // deferred_restart_upgrader, whose only mode decision is
+        // AutoApplyUpgrader::restart_mode_with — i.e. the same
+        // plan_restart_mode every other apply caller uses. There is no second
+        // exit path in the HTTP handler.
+        let ctx = daemon_restart_context();
+        for stop_on_upgrade in [true, false] {
+            let upgrader = deferred_restart_upgrader(stop_on_upgrade, ctx.clone());
+            for signals in [
+                // The #261 incident: config default stop_on_upgrade=true,
+                // parent = shell, no INVOCATION_ID, no X0X_SUPERVISED — with
+                // and without a TTY on stdin.
+                restart::SupervisionSignals {
+                    invocation_id: false,
+                    x0x_supervised: false,
+                    parent_comm: Some("bash".to_string()),
+                    stdin_is_tty: true,
+                },
+                restart::SupervisionSignals {
+                    invocation_id: false,
+                    x0x_supervised: false,
+                    parent_comm: Some("zsh".to_string()),
+                    stdin_is_tty: false,
+                },
+                // Fleet contract: systemd-owned.
+                restart::SupervisionSignals {
+                    invocation_id: true,
+                    x0x_supervised: false,
+                    parent_comm: Some("systemd".to_string()),
+                    stdin_is_tty: false,
+                },
+            ] {
+                assert_eq!(
+                    upgrader.restart_mode_with(&signals),
+                    restart::plan_restart_mode(stop_on_upgrade, &signals),
+                    "stop={stop_on_upgrade}, signals={signals:?}"
+                );
+            }
+        }
+
+        // Pin the incident itself through the HTTP construction: unsupervised
+        // + default stop_on_upgrade=true must be a handoff, not exit(0).
+        let terminal_launched = restart::SupervisionSignals {
+            invocation_id: false,
+            x0x_supervised: false,
+            parent_comm: Some("zsh".to_string()),
+            stdin_is_tty: true,
+        };
+        let upgrader = deferred_restart_upgrader(true, ctx);
+        assert_eq!(
+            upgrader.restart_mode_with(&terminal_launched),
+            restart::RestartMode::TransactionalHandoff
+        );
+        // And the fleet contract: systemd + stop_on_upgrade=true still exits.
+        let systemd = restart::SupervisionSignals {
+            invocation_id: true,
+            x0x_supervised: false,
+            parent_comm: Some("systemd".to_string()),
+            stdin_is_tty: false,
+        };
+        assert_eq!(
+            upgrader.restart_mode_with(&systemd),
+            restart::RestartMode::SupervisedExit
+        );
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -453,10 +453,15 @@ pub(super) struct DaemonUpdateConfig {
     #[serde(default = "default_rollout_window_minutes")]
     pub(super) rollout_window_minutes: u64,
 
-    /// Exit cleanly for service manager restart instead of spawning.
-    /// Default: true — the daemon stops with exit code 0 so that systemd
-    /// (or any supervisor with Restart=always) picks up the new binary.
-    /// Set to false to use `exec()` in-place replacement instead.
+    /// Prefer exiting for a service manager restart instead of the
+    /// transactional handoff. Default: true — under real supervision
+    /// (`INVOCATION_ID`, parent comm `systemd`, or `X0X_SUPERVISED=1`) the
+    /// daemon stops with exit code 0 so systemd (or any supervisor with
+    /// Restart=always) picks up the new binary. Unsupervised daemons —
+    /// including every terminal/nohup launch — use the transactional handoff
+    /// regardless of this flag (#261), as does `false` explicitly: the restart
+    /// only commits after the replacement serves `/health`, else the backup
+    /// is restored and the previous binary respawned.
     #[serde(default = "default_true")]
     pub(super) stop_on_upgrade: bool,
 
@@ -797,6 +802,9 @@ pub(super) struct AppState {
     /// Per-WS-outbound-queue observability (drop / slow-consumer-close counters).
     pub(super) ws_outbound_stats: Arc<WsOutboundStats>,
     pub(super) api_address: SocketAddr,
+    /// Daemon data directory — where the upgrade handoff/intent file and
+    /// `UPGRADE_FAILED` artifact live (#261).
+    pub(super) data_dir: PathBuf,
     pub(super) start_time: Instant,
     pub(super) broadcast_tx: broadcast::Sender<SseEvent>,
     /// Active file transfers.

--- a/src/upgrade/apply.rs
+++ b/src/upgrade/apply.rs
@@ -1,7 +1,6 @@
 //! Binary upgrade application: download, verify SHA-256, extract, and atomically
 //! replace the running binary with rollback on failure.
 
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use tracing::{debug, info, warn};
@@ -9,6 +8,7 @@ use tracing::{debug, info, warn};
 use sha2::{Digest, Sha256};
 
 use super::manifest::{current_platform_target, ReleaseManifest};
+use super::restart;
 use super::signature::{verify_bytes_signature_with_key, RELEASE_SIGNING_KEY};
 use super::{UpgradeError, UpgradeResult, Upgrader};
 
@@ -17,8 +17,8 @@ use super::{UpgradeError, UpgradeResult, Upgrader};
 /// otherwise left a ~50 MB archive + extracted binary behind on every attempt).
 ///
 /// The success path explicitly removes the temp dir *before* triggering the
-/// restart, because the restart `exec()`s (Unix) or `exit()`s without unwinding,
-/// so this guard would not otherwise run there.
+/// restart, because the restart may `_exit` without unwinding, so this guard
+/// would not otherwise run there.
 struct TempDirGuard {
     path: PathBuf,
 }
@@ -37,6 +37,23 @@ impl Drop for TempDirGuard {
     }
 }
 
+/// Context the restart planner needs from the running daemon: where the
+/// handoff file lives, which API address the replacement must serve, and how
+/// to trigger a bounded graceful shutdown before the old process exits.
+///
+/// `Default` (no data dir, no address, no shutdown hook) is only useful for
+/// tests and non-daemon callers — every daemon apply path supplies all three.
+#[derive(Clone, Default)]
+pub struct RestartContext {
+    /// Daemon data directory (`upgrade-handoff.json` / `UPGRADE_FAILED`).
+    pub data_dir: Option<PathBuf>,
+    /// Pre-upgrade API address the replacement must serve `/health` on.
+    pub api_addr: Option<std::net::SocketAddr>,
+    /// Triggers the daemon's graceful shutdown (cancellation). Called inside
+    /// the handoff's 5s bounded cancel window.
+    pub shutdown: Option<std::sync::Arc<dyn Fn() + Send + Sync>>,
+}
+
 /// Auto-apply upgrader that handles the full download → verify → extract → replace → restart flow.
 pub struct AutoApplyUpgrader {
     /// Which binary to extract from the archive (e.g. "x0xd", "x0x").
@@ -45,6 +62,8 @@ pub struct AutoApplyUpgrader {
     stop_on_upgrade: bool,
     /// Whether a successful apply should immediately restart/exec.
     restart_on_success: bool,
+    /// Data directory / API address / shutdown hook for the restart planner.
+    restart_context: RestartContext,
 }
 
 impl AutoApplyUpgrader {
@@ -53,11 +72,19 @@ impl AutoApplyUpgrader {
             binary_name: binary_name.to_string(),
             stop_on_upgrade: false,
             restart_on_success: true,
+            restart_context: RestartContext::default(),
         }
     }
 
     pub fn with_stop_on_upgrade(mut self, stop: bool) -> Self {
         self.stop_on_upgrade = stop;
+        self
+    }
+
+    /// Supply the daemon-side restart context (data dir, pre-upgrade API
+    /// address, graceful-shutdown hook) used by the transactional handoff.
+    pub fn with_restart_context(mut self, context: RestartContext) -> Self {
+        self.restart_context = context;
         self
     }
 
@@ -70,14 +97,27 @@ impl AutoApplyUpgrader {
         self
     }
 
-    /// Restart the current binary using the configured restart mode.
+    /// Restart the current binary using the planned restart mode.
     ///
-    /// On Unix this may replace the current process with `exec()` and will not
-    /// return if the exec succeeds.
-    pub fn restart_current_binary(&self) -> Result<(), UpgradeError> {
+    /// Unsupervised (the default for a terminal-launched daemon) this runs the
+    /// transactional handoff and never returns. Supervised it exits for the
+    /// supervisor and never returns. Returns `Err` only when the handoff could
+    /// not even be started (helper spawn failure) — the old process keeps
+    /// running in that case.
+    pub fn restart_current_binary(&self, target_version: &str) -> Result<(), UpgradeError> {
         let target_path = current_binary_path()?;
-        self.trigger_restart(&target_path);
-        Ok(())
+        self.trigger_restart(&target_path, target_version)
+    }
+
+    /// Classify the restart mode for the current environment (I0).
+    pub fn restart_mode(&self) -> restart::RestartMode {
+        self.restart_mode_with(&restart::SupervisionSignals::sample())
+    }
+
+    /// Classification with injected signals — the single planner every apply
+    /// caller routes through (startup check, gossip, fallback poll, HTTP).
+    pub fn restart_mode_with(&self, signals: &restart::SupervisionSignals) -> restart::RestartMode {
+        restart::plan_restart_mode(self.stop_on_upgrade, signals)
     }
 
     /// Apply an upgrade from a `ReleaseManifest`.
@@ -215,60 +255,84 @@ impl AutoApplyUpgrader {
                 target_version
             );
             if self.restart_on_success {
-                self.trigger_restart(&target_path);
+                if let Err(e) = self.trigger_restart(&target_path, &target_version.to_string()) {
+                    warn!(
+                        error = %e,
+                        "Restart after successful upgrade did not start: {e}; \
+                         old process keeps serving"
+                    );
+                }
             }
         }
 
         Ok(result)
     }
 
-    /// Trigger a restart after successful upgrade.
-    fn trigger_restart(&self, binary_path: &Path) {
-        if self.stop_on_upgrade {
-            // Service manager mode: exit with code 0, let systemd restart
-            let exit_code = if cfg!(windows) { 100 } else { 0 };
-            info!(
-                exit_code = exit_code,
-                "Exiting with code {} for service manager restart", exit_code
-            );
-            std::process::exit(exit_code);
-        } else {
-            // Standalone mode: spawn new process with same args, exit old
-            let args: Vec<OsString> = std::env::args_os().skip(1).collect();
-            let args_display: Vec<String> = args
-                .iter()
-                .map(|a| a.to_string_lossy().to_string())
-                .collect();
-            info!(
-                binary_path = %binary_path.display(),
-                args = %args_display.join(" "),
-                "Spawning new process: {} {}",
-                binary_path.display(),
-                args_display.join(" ")
-            );
+    /// Trigger a restart after successful upgrade (#261).
+    ///
+    /// Classification first (I0): `SupervisedExit` only when `stop_on_upgrade`
+    /// is true AND a real supervision signal is present (`INVOCATION_ID`,
+    /// parent comm `systemd`, `X0X_SUPERVISED=1`). Everything else — including
+    /// unsupervised runs with the default `stop_on_upgrade = true` — goes
+    /// through the transactional handoff, which proves `/health` on the new
+    /// binary or restores the backup. The old `exec()` path is gone: it could
+    /// not roll back.
+    fn trigger_restart(
+        &self,
+        binary_path: &Path,
+        target_version: &str,
+    ) -> Result<(), UpgradeError> {
+        let mode = self.restart_mode();
+        info!(
+            mode = ?mode,
+            stop_on_upgrade = self.stop_on_upgrade,
+            "Restart planned after successful upgrade"
+        );
 
-            #[cfg(unix)]
-            {
-                use std::os::unix::process::CommandExt;
-                let error = std::process::Command::new(binary_path)
-                    .args(&args)
-                    .arg("--skip-update-check")
-                    .exec();
-                // exec() only returns on error
-                warn!(error = %error, "exec failed: {error}");
-            }
+        let backup_path = restart::UpgradeHandoff::backup_path_for(binary_path);
+        let handoff = restart::UpgradeHandoff::capture(
+            binary_path,
+            &backup_path,
+            target_version,
+            self.restart_context
+                .api_addr
+                .unwrap_or_else(|| std::net::SocketAddr::from(([127, 0, 0, 1], 0))),
+            mode,
+        );
+        let handoff_path = match self.restart_context.data_dir.as_deref() {
+            Some(data_dir) => data_dir.join(restart::HANDOFF_FILE_NAME),
+            // Non-daemon caller with no data dir: keep the intent record next
+            // to the binary rather than losing it entirely.
+            None => binary_path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join(restart::HANDOFF_FILE_NAME),
+        };
 
-            #[cfg(not(unix))]
-            {
-                match std::process::Command::new(binary_path)
-                    .args(&args)
-                    .arg("--skip-update-check")
-                    .spawn()
-                {
-                    Ok(_) => std::process::exit(0),
-                    Err(e) => warn!(error = %e, "Failed to spawn new process: {e}"),
+        match mode {
+            restart::RestartMode::SupervisedExit => {
+                // I3: write the intent file BEFORE exiting so a supervisor
+                // crash loop is diagnosable. Best-effort — the exit contract
+                // with Restart=always units must not depend on disk health.
+                if let Err(e) = handoff.write(&handoff_path) {
+                    warn!(
+                        handoff = %handoff_path.display(),
+                        error = %e,
+                        "Failed to write upgrade intent file before supervised exit"
+                    );
                 }
+                let exit_code = if cfg!(windows) { 100 } else { 0 };
+                info!(
+                    exit_code = exit_code,
+                    "Exiting with code {} for service manager restart", exit_code
+                );
+                std::process::exit(exit_code);
             }
+            restart::RestartMode::TransactionalHandoff => restart::begin_transactional_handoff(
+                handoff,
+                &handoff_path,
+                self.restart_context.shutdown.as_deref(),
+            ),
         }
     }
 }
@@ -601,12 +665,57 @@ mod tests {
         assert_eq!(upgrader.binary_name, "x0xd");
         assert!(!upgrader.stop_on_upgrade);
         assert!(upgrader.restart_on_success);
+        assert!(upgrader.restart_context.data_dir.is_none());
     }
 
     #[test]
     fn auto_apply_upgrader_with_stop_on_upgrade() {
         let upgrader = AutoApplyUpgrader::new("x0x").with_stop_on_upgrade(true);
         assert!(upgrader.stop_on_upgrade);
+    }
+
+    #[test]
+    fn auto_apply_upgrader_with_restart_context() {
+        let context = RestartContext {
+            data_dir: Some(PathBuf::from("/var/lib/x0x")),
+            api_addr: Some("127.0.0.1:12700".parse().unwrap()),
+            shutdown: None,
+        };
+        let upgrader = AutoApplyUpgrader::new("x0xd").with_restart_context(context);
+        assert_eq!(
+            upgrader.restart_context.data_dir.as_deref(),
+            Some(Path::new("/var/lib/x0x"))
+        );
+        assert_eq!(
+            upgrader.restart_context.api_addr,
+            Some("127.0.0.1:12700".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn upgrader_restart_mode_routes_through_the_single_planner() {
+        // Whatever flags/context an apply caller sets, the mode decision must
+        // come from plan_restart_mode — there is no second ad-hoc exit path.
+        for stop in [true, false] {
+            let upgrader = AutoApplyUpgrader::new("x0xd").with_stop_on_upgrade(stop);
+            for signals in [
+                restart::SupervisionSignals::default(),
+                restart::SupervisionSignals {
+                    invocation_id: true,
+                    ..Default::default()
+                },
+                restart::SupervisionSignals {
+                    parent_comm: Some("systemd".to_string()),
+                    ..Default::default()
+                },
+            ] {
+                assert_eq!(
+                    upgrader.restart_mode_with(&signals),
+                    restart::plan_restart_mode(stop, &signals),
+                    "stop={stop}, signals={signals:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -8,6 +8,7 @@
 pub mod apply;
 pub mod manifest;
 pub mod monitor;
+pub mod restart;
 pub mod rollout;
 pub mod signature;
 
@@ -226,9 +227,9 @@ fn sideline_path_for(target: &Path) -> PathBuf {
 ///
 /// Temp dirs younger than `dir_min_age` are left untouched so a concurrent
 /// in-flight apply (this process's, or a co-located instance's) is never
-/// disturbed. Sidelined binaries are always best-effort removed — the process
-/// that locked one has, by definition, exited before this runs (a delete of a
-/// still-locked file simply fails and is retried on a future launch).
+/// disturbed. Sidelined binaries are age-gated the same way (issue #261 I4b):
+/// a handoff still in flight — including a manual relaunch of a crashing new
+/// binary — must not lose its rollback bytes to the startup sweep.
 ///
 /// Returns the number of entries removed. All removal is best-effort.
 pub fn sweep_stale_upgrade_artifacts(dir: &Path, dir_min_age: std::time::Duration) -> usize {
@@ -240,6 +241,14 @@ pub fn sweep_stale_upgrade_artifacts(dir: &Path, dir_min_age: std::time::Duratio
         }
     };
     let now = std::time::SystemTime::now();
+    let entry_is_aged = |entry: &std::fs::DirEntry| {
+        entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|modified| now.duration_since(modified).ok())
+            .is_none_or(|age| age >= dir_min_age)
+    };
     let mut removed = 0;
     for entry in entries.flatten() {
         let file_name = entry.file_name();
@@ -247,17 +256,14 @@ pub fn sweep_stale_upgrade_artifacts(dir: &Path, dir_min_age: std::time::Duratio
         let path = entry.path();
         if name.starts_with(".x0x-upgrade-") {
             // Age-gate temp dirs so an in-flight apply is never deleted.
-            let old_enough = entry
-                .metadata()
-                .and_then(|m| m.modified())
-                .ok()
-                .and_then(|modified| now.duration_since(modified).ok())
-                .is_none_or(|age| age >= dir_min_age);
-            if old_enough && std::fs::remove_dir_all(&path).is_ok() {
+            if entry_is_aged(&entry) && std::fs::remove_dir_all(&path).is_ok() {
                 info!(path = %path.display(), "Removed stale upgrade temp dir");
                 removed += 1;
             }
-        } else if name.contains(".x0xold-") && std::fs::remove_file(&path).is_ok() {
+        } else if name.contains(".x0xold-")
+            && entry_is_aged(&entry)
+            && std::fs::remove_file(&path).is_ok()
+        {
             info!(path = %path.display(), "Removed sidelined binary from prior upgrade");
             removed += 1;
         }
@@ -488,19 +494,46 @@ mod tests {
         fs::create_dir_all(&fresh_temp).unwrap();
         let sidelined = dir.path().join("x0xd.exe.x0xold-789");
         fs::write(&sidelined, b"old").unwrap();
+        // #261 I4b: a sideline younger than the age gate is an in-flight
+        // handoff's rollback bytes and must survive the same way a fresh
+        // temp dir does.
+        let in_flight_sideline = dir.path().join("x0xd.exe.x0xold-111");
+        fs::write(&in_flight_sideline, b"in-flight").unwrap();
+        age_file(&sidelined, std::time::Duration::from_secs(7200));
         let backup = dir.path().join("x0xd.exe.backup");
         fs::write(&backup, b"backup").unwrap();
 
         let removed =
             sweep_stale_upgrade_artifacts(dir.path(), std::time::Duration::from_secs(3600));
 
-        assert_eq!(removed, 1, "only the sidelined binary should be removed");
+        assert_eq!(
+            removed, 1,
+            "only the aged sidelined binary should be removed"
+        );
         assert!(
             fresh_temp.exists(),
             "fresh temp dir must survive the age gate"
         );
-        assert!(!sidelined.exists(), "sidelined binary must be reclaimed");
+        assert!(
+            !sidelined.exists(),
+            "aged sidelined binary must be reclaimed"
+        );
+        assert!(
+            in_flight_sideline.exists(),
+            "in-flight handoff sideline must survive the age gate"
+        );
         assert!(backup.exists(), "unrelated .backup file must be left alone");
+    }
+
+    /// Backdate a file's mtime so the sweep's age gate sees it as old.
+    fn age_file(path: &Path, age: std::time::Duration) {
+        let file = fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(
+            std::time::SystemTime::now()
+                .checked_sub(age)
+                .expect("age must not overflow the clock"),
+        )
+        .unwrap();
     }
 
     #[test]

--- a/src/upgrade/restart.rs
+++ b/src/upgrade/restart.rs
@@ -1,0 +1,1124 @@
+//! Transactional restart after a successful binary swap (issue #261).
+//!
+//! The file swap in [`super::Upgrader`] is already transactional. This module
+//! makes the *restart* transactional too: the swap is only committed once a
+//! replacement process answers `GET /health` on the pre-upgrade API address;
+//! otherwise the previous binary is restored and respawned. A terminal-
+//! launched daemon (no systemd/launchd) can therefore never be left silently
+//! DOWN with the new bytes on disk.
+//!
+//! - [`RestartMode`] classifies supervision before anything destructive runs.
+//! - [`begin_transactional_handoff`] is the old daemon's exit path: it writes
+//!   `upgrade-handoff.json`, spawns a detached helper, releases binds within a
+//!   5s bound, then `_exit`s.
+//! - [`run_upgrade_handoff`] is the helper (`x0xd --upgrade-handoff <file>`):
+//!   it waits for the old pid/port, spawns the new binary, health-checks it,
+//!   and rolls the backup back over the target on any failure.
+
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use semver::Version;
+use tracing::{info, warn};
+
+use super::{UpgradeError, Upgrader};
+
+/// Name of the handoff/intent file inside the daemon data directory.
+pub const HANDOFF_FILE_NAME: &str = "upgrade-handoff.json";
+/// Name of the loud failure artifact written when no process could be brought
+/// back up after an upgrade attempt.
+pub const UPGRADE_FAILED_FILE_NAME: &str = "UPGRADE_FAILED";
+/// Private CLI flag the handoff helper is spawned with.
+pub const UPGRADE_HANDOFF_FLAG: &str = "--upgrade-handoff";
+/// Environment variable the old process (and operators) can set to opt in to
+/// supervised-exit semantics explicitly (launchd plists, Windows services).
+pub const SUPERVISED_ENV_VAR: &str = "X0X_SUPERVISED";
+
+/// Bound on the old process's graceful cancel before it hard-exits. The macOS
+/// SIGTERM-hang incident is why this must be bounded, not generous.
+const GRACEFUL_CANCEL_BOUND: Duration = Duration::from_secs(5);
+/// Default bound for the helper's wait on the old pid dying and the API port
+/// freeing. Also the default bound for each `/health` wait (restart commit).
+const DEFAULT_HANDOFF_TIMEOUT: Duration = Duration::from_secs(30);
+/// Poll cadence inside the helper's bounded waits.
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Environment override for the old-pid/port release wait (seconds). Tests use
+/// this to keep the bound short; operators may raise it on slow machines.
+const RELEASE_TIMEOUT_ENV: &str = "X0X_UPGRADE_HANDOFF_RELEASE_TIMEOUT_SECS";
+/// Environment override for each `/health` wait (seconds).
+const HEALTH_TIMEOUT_ENV: &str = "X0X_UPGRADE_HANDOFF_HEALTH_TIMEOUT_SECS";
+
+/// Environment variables recorded in the handoff file for diagnosability. The
+/// spawned processes inherit the full environment anyway; this whitelist is
+/// what a crash-loop post-mortem needs to see.
+const ENV_WHITELIST: &[&str] = &[
+    "INVOCATION_ID",
+    SUPERVISED_ENV_VAR,
+    "X0X_LOG_DIR",
+    "RUST_LOG",
+];
+
+// ---------------------------------------------------------------------------
+// I0 — supervision classification
+// ---------------------------------------------------------------------------
+
+/// How the daemon comes back after a successful binary swap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum RestartMode {
+    /// A supervisor (systemd `Restart=always`, launchd, Windows service) owns
+    /// the respawn: exit 0 (100 on Windows) and let it re-exec the new bytes.
+    SupervisedExit,
+    /// Nobody will respawn us: run the swap+respawn as a transaction through a
+    /// detached helper that proves `/health` or restores the backup.
+    TransactionalHandoff,
+}
+
+/// Supervision signals sampled from the environment. Injectable so the
+/// classification table is testable without manipulating process-global env.
+#[derive(Debug, Clone, Default)]
+pub struct SupervisionSignals {
+    /// `INVOCATION_ID` is set (systemd sets it for every unit invocation).
+    pub invocation_id: bool,
+    /// `X0X_SUPERVISED=1` — explicit operator opt-in (launchd plist,
+    /// Windows service, any custom supervisor).
+    pub x0x_supervised: bool,
+    /// `/proc/<ppid>/comm` of the parent process, when discoverable.
+    pub parent_comm: Option<String>,
+    /// Whether stdin is a TTY. Recorded for diagnosis only — **not-a-TTY is
+    /// NOT supervision** (nohup/background launches must stay handoff).
+    pub stdin_is_tty: bool,
+}
+
+impl SupervisionSignals {
+    /// Sample the real process environment.
+    pub fn sample() -> Self {
+        Self {
+            invocation_id: std::env::var_os("INVOCATION_ID").is_some_and(|v| !v.is_empty()),
+            x0x_supervised: std::env::var(SUPERVISED_ENV_VAR).as_deref() == Ok("1"),
+            parent_comm: parent_comm(),
+            stdin_is_tty: stdin_is_tty(),
+        }
+    }
+}
+
+/// Read the parent process's `comm` (Linux `/proc`). Non-Linux Unix has no
+/// `/proc`; those hosts classify via `INVOCATION_ID` / `X0X_SUPERVISED`
+/// instead. "Some ancestor is launchd" is deliberately NOT consulted — every
+/// macOS process has that.
+#[cfg(target_os = "linux")]
+fn parent_comm() -> Option<String> {
+    let ppid = unsafe { libc::getppid() };
+    let comm = std::fs::read_to_string(format!("/proc/{ppid}/comm")).ok()?;
+    let comm = comm.trim().to_string();
+    if comm.is_empty() {
+        None
+    } else {
+        Some(comm)
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn parent_comm() -> Option<String> {
+    None
+}
+
+#[cfg(unix)]
+fn stdin_is_tty() -> bool {
+    unsafe { libc::isatty(0) == 1 }
+}
+
+#[cfg(not(unix))]
+fn stdin_is_tty() -> bool {
+    false
+}
+
+/// Whether one of the three supervision signals is present.
+///
+/// `INVOCATION_ID`, parent comm `systemd`, or `X0X_SUPERVISED=1`. Nothing else
+/// qualifies: not-a-TTY, nohup, detached stdin, and launchd ancestry are all
+/// unsupervised.
+pub fn is_supervised(signals: &SupervisionSignals) -> bool {
+    signals.invocation_id
+        || signals.x0x_supervised
+        || signals
+            .parent_comm
+            .as_deref()
+            // /proc/<pid>/comm carries a trailing newline.
+            .is_some_and(|comm| comm.trim() == "systemd")
+}
+
+/// I0 classification: pick the restart mode before anything destructive runs.
+///
+/// `SupervisedExit` requires `stop_on_upgrade == true` **and** real
+/// supervision. Everything else — including unsupervised runs with the
+/// default `stop_on_upgrade = true`, and every `stop_on_upgrade = false` run —
+/// goes through [`RestartMode::TransactionalHandoff`] (the old `exec()` path
+/// could not roll back and is gone).
+pub fn plan_restart_mode(stop_on_upgrade: bool, signals: &SupervisionSignals) -> RestartMode {
+    if stop_on_upgrade && is_supervised(signals) {
+        RestartMode::SupervisedExit
+    } else {
+        RestartMode::TransactionalHandoff
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handoff state
+// ---------------------------------------------------------------------------
+
+/// The on-disk handoff/intent record (`data_dir/upgrade-handoff.json`).
+///
+/// Captured by the old process *before* any exit: argv, cwd, and the binary
+/// path are properties of the running process, not of the post-swap files.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UpgradeHandoff {
+    /// Version of the process that initiated the handoff.
+    pub from_version: String,
+    /// Version the binary on disk was swapped to.
+    pub to_version: String,
+    /// Path the new bytes were swapped into (the daemon's install path).
+    pub target_path: PathBuf,
+    /// Path holding the previous binary (`x0xd.backup`).
+    pub backup_path: PathBuf,
+    /// Full argv of the old process, including `argv[0]`. `argv[0]` is recorded
+    /// for diagnosis only — the respawn always uses `target_path`.
+    pub argv: Vec<String>,
+    /// Working directory of the old process.
+    pub cwd: String,
+    /// Whitelisted environment of the old process (diagnosability; the
+    /// spawned processes inherit the real environment).
+    pub env: BTreeMap<String, String>,
+    /// Pid of the old process the helper must wait out.
+    pub old_pid: u32,
+    /// API address the replacement must serve `/health` on. Port 0 means the
+    /// bind is ephemeral: the helper reads `<data_dir>/api.port` instead.
+    pub api_addr: SocketAddr,
+    /// Unix seconds at handoff start.
+    pub started_at: u64,
+    /// Mode the old process classified (also written on the supervised-exit
+    /// intent file so crash loops are diagnosable).
+    pub mode: RestartMode,
+}
+
+impl UpgradeHandoff {
+    /// Capture the old process's restart intent. Must run before any exit.
+    pub fn capture(
+        target_path: &Path,
+        backup_path: &Path,
+        to_version: &str,
+        api_addr: SocketAddr,
+        mode: RestartMode,
+    ) -> Self {
+        let argv: Vec<String> = std::env::args_os()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let cwd = std::env::current_dir()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let env = ENV_WHITELIST
+            .iter()
+            .filter_map(|key| {
+                std::env::var(key)
+                    .ok()
+                    .map(|value| ((*key).to_string(), value))
+            })
+            .collect();
+        Self {
+            from_version: crate::VERSION.to_string(),
+            to_version: to_version.to_string(),
+            target_path: target_path.to_path_buf(),
+            backup_path: backup_path.to_path_buf(),
+            argv,
+            cwd,
+            env,
+            old_pid: std::process::id(),
+            api_addr,
+            started_at: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            mode,
+        }
+    }
+
+    /// Serialize to `data_dir/upgrade-handoff.json`.
+    pub fn write(&self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, serde_json::to_string_pretty(self).map_err(io_other)?)
+    }
+
+    /// Parse a handoff file (helper side).
+    pub fn read(path: &Path) -> std::io::Result<Self> {
+        serde_json::from_str(&std::fs::read_to_string(path)?).map_err(io_other)
+    }
+
+    /// Backup path the swap created for this target (`x0xd.backup`).
+    pub fn backup_path_for(target_path: &Path) -> PathBuf {
+        target_path.with_extension("backup")
+    }
+}
+
+fn io_other(err: serde_json::Error) -> std::io::Error {
+    std::io::Error::other(err.to_string())
+}
+
+/// Build the respawn argv: skip the recorded `argv[0]` and append
+/// `--skip-update-check` only when it is not already present, so a daemon
+/// started with the flag does not grow a second copy on every restart.
+pub fn build_spawn_args(argv: &[String]) -> Vec<String> {
+    let mut args: Vec<String> = argv.iter().skip(1).cloned().collect();
+    if !argv.iter().any(|a| a == "--skip-update-check") {
+        args.push("--skip-update-check".to_string());
+    }
+    args
+}
+
+// ---------------------------------------------------------------------------
+// Old-process side (I2 steps 1–3)
+// ---------------------------------------------------------------------------
+
+/// Start the transactional handoff from the old daemon after a swap Success.
+///
+/// Writes the handoff file, spawns a detached helper (in a new session, so it
+/// outlives this process), triggers the graceful-shutdown hook, waits at most
+/// `GRACEFUL_CANCEL_BOUND` (5s) for the API bind to release, then `_exit(0)`
+/// without unwinding. On success this never returns.
+///
+/// If the helper cannot be spawned, nothing exits: the backup is restored over
+/// the target, `UPGRADE_FAILED` records why, and the caller keeps serving on
+/// the still-running old image.
+pub fn begin_transactional_handoff(
+    handoff: UpgradeHandoff,
+    handoff_path: &Path,
+    shutdown: Option<&(dyn Fn() + Send + Sync)>,
+) -> Result<(), UpgradeError> {
+    handoff
+        .write(handoff_path)
+        .map_err(|e| UpgradeError::Other(format!("failed to write handoff file: {e}")))?;
+    info!(
+        handoff = %handoff_path.display(),
+        to_version = %handoff.to_version,
+        "Upgrade handoff file written"
+    );
+
+    // Prefer the backup bytes for the helper: they are the known-good image
+    // that just ran this code. (After the unix swap, `current_exe()` names the
+    // NEW bytes; the old bytes live at backup_path.)
+    let helper_binary = if handoff.backup_path.is_file() {
+        handoff.backup_path.clone()
+    } else {
+        handoff.target_path.clone()
+    };
+
+    let mut cmd = std::process::Command::new(&helper_binary);
+    cmd.arg(UPGRADE_HANDOFF_FLAG).arg(handoff_path);
+    cmd.stdin(std::process::Stdio::null());
+    detach_from_terminal(&mut cmd);
+
+    match cmd.spawn() {
+        Ok(child) => {
+            info!(
+                helper_pid = child.id(),
+                helper = %helper_binary.display(),
+                "Upgrade handoff helper spawned"
+            );
+        }
+        Err(e) => {
+            // Loud failure that keeps the user UP: restore the old bytes and
+            // record why. The old process keeps serving from memory.
+            warn!(error = %e, "Failed to spawn upgrade handoff helper");
+            let data_dir = data_dir_of(handoff_path);
+            let restore = restore_backup(&handoff.backup_path, &handoff.target_path);
+            write_upgrade_failed(
+                &data_dir,
+                &format!("handoff helper spawn failed: {e}; restore: {restore:?}"),
+                &handoff,
+            );
+            return Err(UpgradeError::Other(format!(
+                "failed to spawn upgrade handoff helper: {e}"
+            )));
+        }
+    }
+
+    // Bounded graceful cancel: trigger the shutdown hook, then give the binds
+    // at most GRACEFUL_CANCEL_BOUND to release before hard-exiting. Never wait
+    // unbounded (the macOS SIGTERM-hang incident).
+    if let Some(cancel) = shutdown {
+        cancel();
+        bounded_graceful_wait(Some(handoff.api_addr), GRACEFUL_CANCEL_BOUND);
+    }
+
+    info!("Upgrade handoff: old process exiting");
+    #[cfg(unix)]
+    {
+        // _exit: no destructors, no atexit flushes — the helper owns the rest
+        // of the transaction.
+        unsafe { libc::_exit(0) };
+    }
+    #[cfg(not(unix))]
+    {
+        std::process::exit(0);
+    }
+}
+
+/// Mark a spawned child detached from the launching terminal: on Unix a new
+/// session (immune to terminal-close SIGHUP), on Windows a new process group
+/// without a console.
+fn detach_from_terminal(cmd: &mut std::process::Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // Safe: setsid only fails if the caller is already a session/pgrp
+        // leader, which a freshly forked child (fresh pid, inherited pgid)
+        // never is.
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
+    }
+}
+
+/// Wait up to `bound` for the API address to become bindable (i.e. released).
+/// Unknown/ephemeral addresses wait out the full bound. Never waits forever.
+fn bounded_graceful_wait(api_addr: Option<SocketAddr>, bound: Duration) {
+    let deadline = Instant::now() + bound;
+    while Instant::now() < deadline {
+        if let Some(addr) = api_addr {
+            if addr.port() != 0 && addr_is_free(addr) {
+                return;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper side (I2 steps 4–8) — `x0xd --upgrade-handoff <file>`
+// ---------------------------------------------------------------------------
+
+/// Run the handoff helper to completion and return its exit code.
+///
+/// 1. Wait (bounded) for the old pid to die and the API port to free. If the
+///    old process hangs past the bound: abort the spawn, restore the backup,
+///    leave the old process up, write `UPGRADE_FAILED`. **No SIGKILL.**
+/// 2. Spawn the new binary with the captured argv/cwd and wait for
+///    `GET /health` 200 (bounded). Health ok ⇒ delete the handoff file, exit 0.
+/// 3. On spawn/health failure: restore the backup, respawn the previous
+///    binary, wait for `/health` again.
+/// 4. If the rollback respawn also fails: write `UPGRADE_FAILED`, eprint, exit
+///    nonzero. Never exit 0 after a failed respawn.
+///
+/// The helper joins no gossip, binds nothing, and takes no instance lock.
+pub fn run_upgrade_handoff(handoff_path: &Path) -> i32 {
+    eprintln!(
+        "x0xd: upgrade handoff helper starting ({})",
+        handoff_path.display()
+    );
+    let handoff = match UpgradeHandoff::read(handoff_path) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!(
+                "x0xd: cannot read handoff file {}: {e}",
+                handoff_path.display()
+            );
+            return 2;
+        }
+    };
+    let data_dir = data_dir_of(handoff_path);
+
+    // Step 1: the old process must die and release the API port. The helper
+    // never signals or kills it — history.db durability depends on the old
+    // process's own bounded shutdown.
+    if !wait_for_old_process_release(&handoff, env_timeout(RELEASE_TIMEOUT_ENV)) {
+        let restore = restore_backup(&handoff.backup_path, &handoff.target_path);
+        let reason = format!(
+            "old pid {} did not exit and release the API port within the bound; \
+             restored backup ({}), old process left running; restore: {:?}",
+            handoff.old_pid, handoff.from_version, restore
+        );
+        write_upgrade_failed(&data_dir, &reason, &handoff);
+        eprintln!("x0xd: UPGRADE FAILED — {reason}");
+        return 3;
+    }
+
+    // Step 2: prove the new binary serves before committing the restart.
+    let health_timeout = env_timeout(HEALTH_TIMEOUT_ENV);
+    let new_outcome =
+        spawn_and_await_health(&handoff.target_path, &handoff, &data_dir, health_timeout);
+    match new_outcome {
+        SpawnHealthOutcome::Healthy => {
+            finish_success(handoff_path, &handoff, &handoff.to_version, "new");
+            return 0;
+        }
+        SpawnHealthOutcome::SpawnFailed(e) => {
+            eprintln!(
+                "x0xd: new binary {} failed to spawn: {e}; rolling back to {}",
+                handoff.target_path.display(),
+                handoff.from_version
+            );
+        }
+        SpawnHealthOutcome::Unhealthy => {
+            eprintln!(
+                "x0xd: new binary {} did not serve /health within {}s; rolling back to {}",
+                handoff.target_path.display(),
+                health_timeout.as_secs(),
+                handoff.from_version
+            );
+        }
+    }
+
+    // Step 3: rollback — restore the previous binary and respawn it.
+    if let Err(e) = restore_backup(&handoff.backup_path, &handoff.target_path) {
+        let reason = format!("rollback restore failed after new binary did not come up: {e}");
+        write_upgrade_failed(&data_dir, &reason, &handoff);
+        eprintln!("x0xd: UPGRADE FAILED — {reason}");
+        return 4;
+    }
+    match spawn_and_await_health(&handoff.target_path, &handoff, &data_dir, health_timeout) {
+        SpawnHealthOutcome::Healthy => {
+            finish_success(handoff_path, &handoff, &handoff.from_version, "restored");
+            return 0;
+        }
+        SpawnHealthOutcome::SpawnFailed(e) => {
+            let reason = format!(
+                "rollback spawn of restored binary {} failed: {e}",
+                handoff.target_path.display()
+            );
+            write_upgrade_failed(&data_dir, &reason, &handoff);
+            eprintln!("x0xd: UPGRADE FAILED — {reason}");
+        }
+        SpawnHealthOutcome::Unhealthy => {
+            let reason = format!(
+                "restored binary {} spawned but did not serve /health within {}s",
+                handoff.target_path.display(),
+                health_timeout.as_secs()
+            );
+            write_upgrade_failed(&data_dir, &reason, &handoff);
+            eprintln!("x0xd: UPGRADE FAILED — {reason}");
+        }
+    }
+    5
+}
+
+/// Delete the handoff file and report a committed restart (I2 step 6).
+fn finish_success(handoff_path: &Path, handoff: &UpgradeHandoff, version: &str, which: &str) {
+    if let Err(e) = std::fs::remove_file(handoff_path) {
+        eprintln!(
+            "x0xd: warning: could not remove handoff file {}: {e}",
+            handoff_path.display()
+        );
+    }
+    eprintln!(
+        "x0xd: upgrade handoff complete — {which} binary on {} serving {}",
+        handoff.target_path.display(),
+        version
+    );
+}
+
+enum SpawnHealthOutcome {
+    Healthy,
+    SpawnFailed(std::io::Error),
+    Unhealthy,
+}
+
+/// Spawn `binary` with the captured argv/cwd (own process group, no terminal)
+/// and wait for `/health` 200 on the handoff's API address.
+fn spawn_and_await_health(
+    binary: &Path,
+    handoff: &UpgradeHandoff,
+    data_dir: &Path,
+    health_timeout: Duration,
+) -> SpawnHealthOutcome {
+    let mut cmd = std::process::Command::new(binary);
+    cmd.args(build_spawn_args(&handoff.argv));
+    if !handoff.cwd.is_empty() {
+        cmd.current_dir(&handoff.cwd);
+    }
+    cmd.stdin(std::process::Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // Own process group: signals aimed at the helper's group must not
+        // reach the daemon.
+        cmd.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
+    }
+
+    if let Err(e) = cmd.spawn() {
+        return SpawnHealthOutcome::SpawnFailed(e);
+    }
+    if wait_for_health(handoff, data_dir, health_timeout) {
+        SpawnHealthOutcome::Healthy
+    } else {
+        SpawnHealthOutcome::Unhealthy
+    }
+}
+
+/// Wait (bounded) for the old pid to die and the API port to free.
+fn wait_for_old_process_release(handoff: &UpgradeHandoff, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let pid_gone = !pid_alive(handoff.old_pid);
+        // An ephemeral recorded port (0) cannot be probed; pid death is the
+        // release signal there.
+        let port_free = handoff.api_addr.port() == 0 || addr_is_free(handoff.api_addr);
+        if pid_gone && port_free {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            eprintln!(
+                "x0xd: old pid {} still {} (port {} free: {})",
+                handoff.old_pid,
+                if pid_gone { "gone" } else { "alive" },
+                handoff.api_addr,
+                port_free
+            );
+            return false;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Wait (bounded) for `GET /health` 200 on the pre-upgrade API address, or on
+/// the address the replacement advertised in `<data_dir>/api.port` when the
+/// pre-upgrade bind was ephemeral.
+fn wait_for_health(handoff: &UpgradeHandoff, data_dir: &Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(addr) = resolve_health_addr(handoff, data_dir) {
+            if http_health_ok(addr) {
+                return true;
+            }
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// The address to health-check: the recorded API address, unless the bind was
+/// ephemeral (port 0) — then whatever the replacement wrote to `api.port`.
+fn resolve_health_addr(handoff: &UpgradeHandoff, data_dir: &Path) -> Option<SocketAddr> {
+    if handoff.api_addr.port() != 0 {
+        return Some(handoff.api_addr);
+    }
+    std::fs::read_to_string(data_dir.join("api.port"))
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+}
+
+/// Whether `kill(pid, 0)` says the pid is alive (or protected). A pid we lack
+/// permission to signal counts as alive — never a false "dead".
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if result == 0 {
+        return true;
+    }
+    matches!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::EPERM)
+    )
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: u32) -> bool {
+    // No portable pre-exit probe; the port check below carries the wait.
+    false
+}
+
+/// Whether a loopback probe can bind the address right now. Unspecified IPs
+/// are probed on loopback. `AddrInUse` is the only "busy" answer; anything
+/// else (firewalled, unsupported family) reads as free so the wait cannot
+/// deadlock on exotic setups.
+fn addr_is_free(addr: SocketAddr) -> bool {
+    let probe = if addr.ip().is_unspecified() {
+        SocketAddr::new(
+            if addr.is_ipv4() {
+                std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+            } else {
+                std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)
+            },
+            addr.port(),
+        )
+    } else {
+        addr
+    };
+    match TcpListener::bind(probe) {
+        Ok(listener) => {
+            drop(listener);
+            true
+        }
+        Err(e) => e.kind() != std::io::ErrorKind::AddrInUse,
+    }
+}
+
+/// Minimal `GET /health` probe: any HTTP/1.x 200 status line commits the
+/// restart. `/health` is auth-exempt on the daemon API.
+fn http_health_ok(addr: SocketAddr) -> bool {
+    let Ok(mut stream) = TcpStream::connect_timeout(&addr, Duration::from_secs(2)) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
+    if stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .is_err()
+    {
+        return false;
+    }
+    let mut buf = [0u8; 256];
+    let n = stream.read(&mut buf).unwrap_or(0);
+    let head = String::from_utf8_lossy(&buf[..n]);
+    head.starts_with("HTTP/1.1 200") || head.starts_with("HTTP/1.0 200")
+}
+
+/// Restore the backup bytes over the target — the same
+/// [`Upgrader::restore_from_backup`] the file-swap rollback uses.
+fn restore_backup(backup_path: &Path, target_path: &Path) -> Result<(), UpgradeError> {
+    // restore_from_backup never consults the version; a sentinel keeps this
+    // independent of the versions recorded in the handoff JSON.
+    Upgrader::new(target_path.to_path_buf(), Version::new(0, 0, 0)).restore_from_backup(backup_path)
+}
+
+/// Write the loud failure artifact: reason, versions, paths, timestamps.
+fn write_upgrade_failed(data_dir: &Path, reason: &str, handoff: &UpgradeHandoff) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let content = format!(
+        "x0xd self-upgrade FAILED at unix time {now} ({})\n\
+         reason: {reason}\n\
+         from version: {}\n\
+         to version: {}\n\
+         target binary: {}\n\
+         backup binary: {}\n\
+         old pid: {}\n\
+         api address: {}\n\
+         handoff started at: unix {}\n\
+         the daemon is NOT running — relaunch it (the backup above holds the last good binary)\n",
+        humantime_or_raw(now),
+        handoff.from_version,
+        handoff.to_version,
+        handoff.target_path.display(),
+        handoff.backup_path.display(),
+        handoff.old_pid,
+        handoff.api_addr,
+        handoff.started_at,
+    );
+    let path = data_dir.join(UPGRADE_FAILED_FILE_NAME);
+    if let Err(e) = std::fs::write(&path, content) {
+        eprintln!(
+            "x0xd: could not write {}: {e} — upgrade failed: {reason}",
+            path.display()
+        );
+    }
+}
+
+/// The data directory owning a handoff file path (its parent).
+fn data_dir_of(handoff_path: &Path) -> PathBuf {
+    handoff_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// RFC 3339-ish timestamp without pulling a datetime crate: fall back to the
+/// raw epoch seconds when `date` is unavailable (the file still carries the
+/// epoch value in its header line).
+fn humantime_or_raw(epoch: u64) -> String {
+    match std::process::Command::new("date")
+        .arg("-u")
+        .arg("+%Y-%m-%dT%H:%M:%SZ")
+        .arg(format!("@{epoch}"))
+        .output()
+    {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        _ => format!("epoch {epoch}"),
+    }
+}
+
+/// Timeout from an env override (seconds), else the 30s default.
+fn env_timeout(env_var: &str) -> Duration {
+    std::env::var(env_var)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_HANDOFF_TIMEOUT)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shell_parent_signals() -> SupervisionSignals {
+        SupervisionSignals {
+            invocation_id: false,
+            x0x_supervised: false,
+            parent_comm: Some("zsh".to_string()),
+            stdin_is_tty: true,
+        }
+    }
+
+    #[test]
+    fn unsupervised_stop_on_upgrade_true_chooses_handoff() {
+        // The #261 incident: terminal-launched (parent = shell), config
+        // default stop_on_upgrade=true, no supervision env. Must NOT be a
+        // supervised exit(0).
+        assert_eq!(
+            plan_restart_mode(true, &shell_parent_signals()),
+            RestartMode::TransactionalHandoff
+        );
+    }
+
+    #[test]
+    fn unsupervised_without_tty_still_chooses_handoff() {
+        // Architect pin: nohup/background (stdin not a TTY) is NOT
+        // supervision. Same classification as the TTY case.
+        let signals = SupervisionSignals {
+            stdin_is_tty: false,
+            ..shell_parent_signals()
+        };
+        assert_eq!(
+            plan_restart_mode(true, &signals),
+            RestartMode::TransactionalHandoff
+        );
+    }
+
+    #[test]
+    fn detached_shell_parent_without_tty_is_unsupervised() {
+        let signals = SupervisionSignals {
+            invocation_id: false,
+            x0x_supervised: false,
+            parent_comm: Some("sh".to_string()),
+            stdin_is_tty: false,
+        };
+        assert!(!is_supervised(&signals));
+    }
+
+    #[test]
+    fn launchd_ancestor_comm_is_not_supervision() {
+        // "Some ancestor is launchd" must never qualify — every macOS process
+        // has that. A launchd parent only counts via X0X_SUPERVISED=1.
+        let signals = SupervisionSignals {
+            parent_comm: Some("launchd".to_string()),
+            ..shell_parent_signals()
+        };
+        assert!(!is_supervised(&signals));
+        assert_eq!(
+            plan_restart_mode(true, &signals),
+            RestartMode::TransactionalHandoff
+        );
+    }
+
+    #[test]
+    fn invocation_id_with_stop_on_upgrade_chooses_supervised_exit() {
+        let signals = SupervisionSignals {
+            invocation_id: true,
+            ..shell_parent_signals()
+        };
+        assert_eq!(
+            plan_restart_mode(true, &signals),
+            RestartMode::SupervisedExit
+        );
+    }
+
+    #[test]
+    fn systemd_parent_comm_chooses_supervised_exit() {
+        let signals = SupervisionSignals {
+            parent_comm: Some("systemd".to_string()),
+            ..shell_parent_signals()
+        };
+        assert_eq!(
+            plan_restart_mode(true, &signals),
+            RestartMode::SupervisedExit
+        );
+    }
+
+    #[test]
+    fn systemd_parent_comm_is_trimmed() {
+        // /proc/<pid>/comm carries a trailing newline; the classifier must
+        // trim it before comparing.
+        let signals = SupervisionSignals {
+            parent_comm: Some("systemd\n".to_string()),
+            ..shell_parent_signals()
+        };
+        assert_eq!(
+            plan_restart_mode(true, &signals),
+            RestartMode::SupervisedExit
+        );
+    }
+
+    #[test]
+    fn x0x_supervised_env_chooses_supervised_exit_even_without_tty() {
+        // Explicit operator opt-in (launchd plist / Windows service) with
+        // stdin not a TTY: still supervised — not-a-TTY alone never flips it.
+        let signals = SupervisionSignals {
+            x0x_supervised: true,
+            stdin_is_tty: false,
+            ..shell_parent_signals()
+        };
+        assert_eq!(
+            plan_restart_mode(true, &signals),
+            RestartMode::SupervisedExit
+        );
+    }
+
+    #[test]
+    fn stop_on_upgrade_false_always_uses_handoff() {
+        // stop_on_upgrade=false replaces the old exec(): the new image can
+        // never be a fire-and-forget success path, supervised or not.
+        let supervised = SupervisionSignals {
+            invocation_id: true,
+            parent_comm: Some("systemd".to_string()),
+            ..shell_parent_signals()
+        };
+        assert_eq!(
+            plan_restart_mode(false, &supervised),
+            RestartMode::TransactionalHandoff
+        );
+        assert_eq!(
+            plan_restart_mode(false, &shell_parent_signals()),
+            RestartMode::TransactionalHandoff
+        );
+    }
+
+    #[test]
+    fn build_spawn_args_appends_skip_update_check_once() {
+        let argv = vec![
+            "x0xd".to_string(),
+            "--config".to_string(),
+            "/etc/x0x/config.toml".to_string(),
+        ];
+        assert_eq!(
+            build_spawn_args(&argv),
+            vec![
+                "--config".to_string(),
+                "/etc/x0x/config.toml".to_string(),
+                "--skip-update-check".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn build_spawn_args_never_duplicates_skip_update_check() {
+        let argv = vec![
+            "x0xd".to_string(),
+            "--skip-update-check".to_string(),
+            "--config".to_string(),
+            "/etc/x0x/config.toml".to_string(),
+        ];
+        assert_eq!(
+            build_spawn_args(&argv),
+            vec![
+                "--skip-update-check".to_string(),
+                "--config".to_string(),
+                "/etc/x0x/config.toml".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn handoff_json_round_trips() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(HANDOFF_FILE_NAME);
+        let handoff = UpgradeHandoff {
+            from_version: "1.2.3".to_string(),
+            to_version: "1.3.0".to_string(),
+            target_path: dir.path().join("x0xd"),
+            backup_path: dir.path().join("x0xd.backup"),
+            argv: vec![
+                "x0xd".to_string(),
+                "--config".to_string(),
+                "x.toml".to_string(),
+            ],
+            cwd: "/srv".to_string(),
+            env: BTreeMap::from([(SUPERVISED_ENV_VAR.to_string(), "1".to_string())]),
+            old_pid: 4242,
+            api_addr: "127.0.0.1:12700".parse().unwrap(),
+            started_at: 1_700_000_000,
+            mode: RestartMode::TransactionalHandoff,
+        };
+        handoff.write(&path).unwrap();
+        let read_back = UpgradeHandoff::read(&path).unwrap();
+        assert_eq!(read_back.from_version, "1.2.3");
+        assert_eq!(read_back.to_version, "1.3.0");
+        assert_eq!(read_back.argv, handoff.argv);
+        assert_eq!(read_back.old_pid, 4242);
+        assert_eq!(read_back.api_addr, handoff.api_addr);
+        assert_eq!(read_back.mode, RestartMode::TransactionalHandoff);
+        assert_eq!(
+            read_back.env.get(SUPERVISED_ENV_VAR).map(String::as_str),
+            Some("1")
+        );
+    }
+
+    #[test]
+    fn handoff_file_names_are_stable() {
+        assert_eq!(HANDOFF_FILE_NAME, "upgrade-handoff.json");
+        assert_eq!(UPGRADE_FAILED_FILE_NAME, "UPGRADE_FAILED");
+    }
+
+    #[test]
+    fn backup_path_for_matches_swap_backup_name() {
+        // The handoff must point at the same x0xd.backup the swap created
+        // (target.with_extension("backup")), or rollback restores nothing.
+        let target = Path::new("/opt/x0x/bin/x0xd");
+        assert_eq!(
+            UpgradeHandoff::backup_path_for(target),
+            Path::new("/opt/x0x/bin/x0xd.backup")
+        );
+    }
+
+    #[test]
+    fn resolve_health_addr_prefers_recorded_port() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("api.port"), "127.0.0.1:9999\n").unwrap();
+        let handoff = UpgradeHandoff {
+            from_version: "1.0.0".to_string(),
+            to_version: "1.1.0".to_string(),
+            target_path: dir.path().join("x0xd"),
+            backup_path: dir.path().join("x0xd.backup"),
+            argv: vec!["x0xd".to_string()],
+            cwd: "/".to_string(),
+            env: BTreeMap::new(),
+            old_pid: 1,
+            api_addr: "127.0.0.1:12700".parse().unwrap(),
+            started_at: 0,
+            mode: RestartMode::TransactionalHandoff,
+        };
+        assert_eq!(
+            resolve_health_addr(&handoff, dir.path()),
+            Some("127.0.0.1:12700".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn resolve_health_addr_reads_api_port_when_ephemeral() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("api.port"), "127.0.0.1:41234\n").unwrap();
+        let handoff = UpgradeHandoff {
+            api_addr: "127.0.0.1:0".parse().unwrap(),
+            ..ephemeral_handoff_fixture()
+        };
+        assert_eq!(
+            resolve_health_addr(&handoff, dir.path()),
+            Some("127.0.0.1:41234".parse().unwrap())
+        );
+        // No api.port yet (old process removed it, new one not bound):
+        // nothing to probe, the health wait keeps polling.
+        let missing = dir.path().join("missing");
+        assert_eq!(resolve_health_addr(&handoff, &missing), None);
+    }
+
+    fn ephemeral_handoff_fixture() -> UpgradeHandoff {
+        UpgradeHandoff {
+            from_version: "1.0.0".to_string(),
+            to_version: "1.1.0".to_string(),
+            target_path: PathBuf::from("/opt/x0x/x0xd"),
+            backup_path: PathBuf::from("/opt/x0x/x0xd.backup"),
+            argv: vec!["x0xd".to_string()],
+            cwd: "/".to_string(),
+            env: BTreeMap::new(),
+            old_pid: 1,
+            api_addr: "127.0.0.1:0".parse().unwrap(),
+            started_at: 0,
+            mode: RestartMode::TransactionalHandoff,
+        }
+    }
+
+    #[test]
+    fn addr_is_free_detects_bound_port() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        assert!(!addr_is_free(addr));
+        let port = addr.port();
+        drop(listener);
+        // Small race window after drop; retry briefly before asserting free.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && !addr_is_free(SocketAddr::from(([127, 0, 0, 1], port))) {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(addr_is_free(SocketAddr::from(([127, 0, 0, 1], port))));
+    }
+
+    #[test]
+    fn addr_is_free_probes_loopback_for_unspecified_bind() {
+        let listener = TcpListener::bind(("0.0.0.0", 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+        assert!(!addr_is_free(addr));
+        drop(listener);
+    }
+
+    #[test]
+    fn http_health_ok_accepts_200_and_rejects_non_200() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            for (status, body) in [("200 OK", "ok"), ("503 Service Unavailable", "bad")] {
+                let (mut sock, _) = listener.accept().unwrap();
+                let mut buf = [0u8; 128];
+                let _ = sock.read(&mut buf);
+                let resp = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes());
+            }
+        });
+        assert!(http_health_ok(addr));
+        assert!(!http_health_ok(addr));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn env_timeout_defaults_and_overrides() {
+        // No env manipulation here (process-global and racy under nextest's
+        // parallel tests): pin the default and the parser instead.
+        assert_eq!(DEFAULT_HANDOFF_TIMEOUT, Duration::from_secs(30));
+        assert_eq!("2".parse::<u64>().unwrap(), 2);
+    }
+
+    #[test]
+    fn restore_backup_moves_backup_over_target() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("x0xd");
+        let backup = dir.path().join("x0xd.backup");
+        std::fs::write(&target, b"new broken bytes").unwrap();
+        std::fs::write(&backup, b"old good bytes").unwrap();
+        restore_backup(&backup, &target).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"old good bytes");
+        assert!(!backup.exists(), "restore moves (not copies) the backup");
+    }
+}

--- a/tests/upgrade_handoff_integration.rs
+++ b/tests/upgrade_handoff_integration.rs
@@ -1,0 +1,657 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! #261 integration tests: transactional upgrade handoff.
+//!
+//! No live GitHub release is used. The "new"/"old" binaries are fixture
+//! wrappers around this test binary (a libtest self-exec pattern: the wrapper
+//! execs `current_exe()` with a fixture test name and `FIXTURE_*` env), the
+//! handoff helper is the real `x0xd` binary (`--upgrade-handoff`), and the
+//! handoff JSON is produced by the library's own `UpgradeHandoff` types.
+//!
+//! Unix-only: the wrappers are `#!/bin/sh` scripts and the pid probes rely on
+//! `kill(pid, 0)`.
+
+#![cfg(unix)]
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+use x0x::upgrade::restart::{self, RestartMode, UpgradeHandoff};
+
+/// The real daemon binary — used as the handoff helper.
+const X0XD_BIN: &str = env!("CARGO_BIN_EXE_x0xd");
+/// Fixture test names (libtest filters for the self-exec wrappers). Real test
+/// names in this file must never contain these substrings.
+const HEALTH_FIXTURE: &str = "fixture_role_health_daemon";
+const OLD_SIDE_FIXTURE: &str = "fixture_role_old_side";
+
+const OLD_VERSION: &str = "9.9.7";
+const NEW_VERSION: &str = "9.9.9";
+
+const FROM: u64 = 2;
+const RELEASE_TIMEOUT_SECS: u64 = 4;
+const HEALTH_TIMEOUT_SECS: u64 = 4;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+fn test_exe() -> PathBuf {
+    std::env::current_exe().unwrap()
+}
+
+fn assert_quote_free(s: &str) {
+    assert!(
+        !s.contains('\''),
+        "fixture path may not contain a single quote: {s}"
+    );
+}
+
+fn make_executable(path: &Path) {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// A fixture "daemon" that serves `GET /health` 200 with `version` until the
+/// stop file appears (or the lifetime backstop expires).
+fn write_health_wrapper(path: &Path, port: u16, version: &str, stop_file: &Path) {
+    let exe = test_exe().to_string_lossy().to_string();
+    let stop = stop_file.to_string_lossy().to_string();
+    assert_quote_free(&exe);
+    assert_quote_free(&stop);
+    let script = format!(
+        "#!/bin/sh\nFIXTURE_PORT={port} FIXTURE_VERSION={version} \
+         FIXTURE_STOP_FILE='{stop}' FIXTURE_LIFETIME_SECS=300 \
+         exec '{exe}' {HEALTH_FIXTURE}\n"
+    );
+    std::fs::write(path, script).unwrap();
+    make_executable(path);
+}
+
+/// A fixture "new binary" that exits 1 and never binds anything.
+fn write_crash_wrapper(path: &Path) {
+    std::fs::write(path, "#!/bin/sh\nexit 1\n").unwrap();
+    make_executable(path);
+}
+
+/// Spawn the "old daemon" process directly: the health fixture holding
+/// `port`, self-terminating after `lifetime_secs`.
+///
+/// A reaper thread owns the child so its pid reads as dead (not zombie) once
+/// it exits — in production the old daemon's parent (shell/systemd) does the
+/// reaping the helper's pid probe depends on.
+fn spawn_old_daemon(port: u16, version: &str, stop_file: &Path, lifetime_secs: u64) -> u32 {
+    let stop = stop_file.to_string_lossy().to_string();
+    assert_quote_free(&stop);
+    let mut child = Command::new(test_exe())
+        .arg(HEALTH_FIXTURE)
+        .env("FIXTURE_PORT", port.to_string())
+        .env("FIXTURE_VERSION", version)
+        .env("FIXTURE_STOP_FILE", stop)
+        .env("FIXTURE_LIFETIME_SECS", lifetime_secs.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let pid = child.id();
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+    pid
+}
+
+/// A pid that is guaranteed dead: spawn, reap, and reuse its (now free) pid.
+fn dead_pid() -> u32 {
+    let mut child = Command::new("/bin/sh")
+        .arg("-c")
+        .arg("exit 0")
+        .spawn()
+        .unwrap();
+    let pid = child.id();
+    let _ = child.wait();
+    pid
+}
+
+fn write_handoff(
+    data_dir: &Path,
+    target: &Path,
+    backup: &Path,
+    old_pid: u32,
+    port: u16,
+) -> PathBuf {
+    let handoff = UpgradeHandoff {
+        from_version: OLD_VERSION.to_string(),
+        to_version: NEW_VERSION.to_string(),
+        target_path: target.to_path_buf(),
+        backup_path: backup.to_path_buf(),
+        argv: vec![
+            "x0xd".to_string(),
+            "--config".to_string(),
+            "x.toml".to_string(),
+        ],
+        cwd: data_dir.to_string_lossy().to_string(),
+        env: Default::default(),
+        old_pid,
+        api_addr: format!("127.0.0.1:{port}").parse().unwrap(),
+        started_at: 1_724_000_000,
+        mode: RestartMode::TransactionalHandoff,
+    };
+    let path = data_dir.join(restart::HANDOFF_FILE_NAME);
+    handoff.write(&path).unwrap();
+    path
+}
+
+/// Run the real `x0xd --upgrade-handoff` helper with short test timeouts.
+fn run_helper(handoff_path: &Path) -> std::process::ExitStatus {
+    Command::new(X0XD_BIN)
+        .arg("--upgrade-handoff")
+        .arg(handoff_path)
+        .env(
+            "X0X_UPGRADE_HANDOFF_RELEASE_TIMEOUT_SECS",
+            RELEASE_TIMEOUT_SECS.to_string(),
+        )
+        .env(
+            "X0X_UPGRADE_HANDOFF_HEALTH_TIMEOUT_SECS",
+            HEALTH_TIMEOUT_SECS.to_string(),
+        )
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap()
+}
+
+/// Minimal HTTP client for the fixture daemon / real daemon `/health`.
+fn http_get_health(port: u16) -> Option<String> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).ok()?;
+    stream.set_read_timeout(Some(Duration::from_secs(2))).ok()?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(2)))
+        .ok()?;
+    stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .ok()?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response).ok()?;
+    if response.starts_with("HTTP/1.1 200") {
+        Some(response)
+    } else {
+        None
+    }
+}
+
+fn wait_for_health_version(port: u16, version: &str, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Some(body) = http_get_health(port) {
+            if body.contains(&format!("\"{version}\"")) {
+                return true;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+    false
+}
+
+fn wait_for_bind(port: u16, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if http_get_health(port).is_some() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+fn stop_daemon(stop_file: &Path) {
+    std::fs::write(stop_file, b"stop").unwrap();
+}
+
+/// Wait for a path to disappear (the detached helper cleans up just after its
+/// own health check — which can trail the test's poll by a beat).
+fn wait_for_gone(path: &Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    !path.exists()
+}
+
+// ---------------------------------------------------------------------------
+// Fixture roles (self-exec targets). No-ops under a normal suite run.
+// ---------------------------------------------------------------------------
+
+/// Serves `/health` 200 with `FIXTURE_VERSION` until `FIXTURE_STOP_FILE`
+/// appears or `FIXTURE_LIFETIME_SECS` elapses. In a normal suite run (no
+/// `FIXTURE_PORT` in the environment) this returns immediately.
+#[test]
+fn fixture_role_health_daemon() {
+    let (Ok(port), Ok(version), stop_file, lifetime) = (
+        std::env::var("FIXTURE_PORT"),
+        std::env::var("FIXTURE_VERSION"),
+        std::env::var("FIXTURE_STOP_FILE").ok().map(PathBuf::from),
+        std::env::var("FIXTURE_LIFETIME_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(300),
+    ) else {
+        return;
+    };
+    let port: u16 = port.parse().expect("fixture port");
+    let listener = TcpListener::bind(("127.0.0.1", port)).expect("fixture daemon binds API port");
+    listener
+        .set_nonblocking(true)
+        .expect("fixture daemon nonblocking listener");
+    let deadline = Instant::now() + Duration::from_secs(lifetime);
+    let stop = stop_file
+        .as_deref()
+        .unwrap_or_else(|| Path::new("/nonexistent"));
+    while Instant::now() < deadline && !stop.exists() {
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                let mut buf = [0u8; 512];
+                let _ = stream.read(&mut buf);
+                let body = format!("{{\"ok\":true,\"data\":{{\"version\":\"{version}\"}}}}");
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
+                     {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+/// The old-daemon side of a transactional handoff: binds the API port, then
+/// calls `begin_transactional_handoff` (which spawns the real `x0xd` helper
+/// from the backup bytes and `_exit`s). Reaching the end of this test is a
+/// failure — the handoff must take the process down.
+#[test]
+fn fixture_role_old_side() {
+    let Ok(spec_path) = std::env::var("FIXTURE_HANDOFF_SPEC") else {
+        return;
+    };
+    #[derive(serde::Deserialize)]
+    struct Spec {
+        port: u16,
+        target: PathBuf,
+        backup: PathBuf,
+        data_dir: PathBuf,
+    }
+    let spec: Spec = serde_json::from_str(&std::fs::read_to_string(&spec_path).unwrap()).unwrap();
+    // Hold the API bind like a real daemon; released when this process exits.
+    let _listener = TcpListener::bind(("127.0.0.1", spec.port)).expect("fixture binds API port");
+    let handoff = UpgradeHandoff {
+        from_version: OLD_VERSION.to_string(),
+        to_version: NEW_VERSION.to_string(),
+        target_path: spec.target,
+        backup_path: spec.backup,
+        argv: vec!["x0xd".to_string()],
+        cwd: std::env::current_dir()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default(),
+        env: Default::default(),
+        old_pid: std::process::id(),
+        api_addr: format!("127.0.0.1:{}", spec.port).parse().unwrap(),
+        started_at: 1_724_000_000,
+        mode: RestartMode::TransactionalHandoff,
+    };
+    let handoff_path = spec.data_dir.join(restart::HANDOFF_FILE_NAME);
+    let result = restart::begin_transactional_handoff(handoff, &handoff_path, None);
+    panic!("begin_transactional_handoff must not return on success: {result:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Tests that prove the fix
+// ---------------------------------------------------------------------------
+
+/// Design test 3: the new binary exits 1 and never binds. The helper must
+/// restore the backup bytes at the target path, respawn the previous binary,
+/// and leave `/health` 200 answering the OLD version — no `UPGRADE_FAILED`,
+/// handoff file cleaned up, process table not empty.
+#[test]
+fn handoff_rolls_back_when_new_binary_never_serves() {
+    let install = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    let port = free_port();
+
+    // The "old daemon": holds the port, dies by itself after FROM seconds.
+    let old_stop = install.path().join("stop-old");
+    let old_pid = spawn_old_daemon(port, OLD_VERSION, &old_stop, FROM);
+    assert!(
+        wait_for_bind(port, Duration::from_secs(10)),
+        "old daemon must be serving before the handoff"
+    );
+
+    let target = install.path().join("x0xd");
+    let backup = install.path().join("x0xd.backup");
+    write_crash_wrapper(&target);
+    let new_stop = install.path().join("stop-restored");
+    write_health_wrapper(&backup, port, OLD_VERSION, &new_stop);
+
+    let handoff_path = write_handoff(data.path(), &target, &backup, old_pid, port);
+    let status = run_helper(&handoff_path);
+
+    assert!(status.success(), "rollback restart commits: {status:?}");
+    assert!(
+        !data.path().join(restart::UPGRADE_FAILED_FILE_NAME).exists(),
+        "successful rollback must not leave UPGRADE_FAILED"
+    );
+    assert!(
+        !handoff_path.exists(),
+        "handoff file must be removed once a process serves /health"
+    );
+    // Restore moved the backup over the target: the install path now holds
+    // the previous binary again.
+    assert!(!backup.exists(), "restore consumes the backup file");
+    let restored = std::fs::read_to_string(&target).unwrap();
+    assert!(
+        restored.contains(&format!("FIXTURE_VERSION={OLD_VERSION}")),
+        "target must hold the previous binary's bytes"
+    );
+    assert!(
+        wait_for_health_version(port, OLD_VERSION, Duration::from_secs(10)),
+        "respawned previous binary must answer /health with the old version"
+    );
+    // "Process table not empty": the health answer above proves a live
+    // process is bound to the port.
+
+    stop_daemon(&new_stop);
+}
+
+/// Design test 4: the new binary serves `/health`. The handoff file is
+/// removed, the reported version is the target, and the helper exits 0. The
+/// backup stays on disk until a later sweep may reclaim it.
+#[test]
+fn handoff_commits_when_new_binary_serves_health() {
+    let install = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    let port = free_port();
+
+    let old_stop = install.path().join("stop-old");
+    let old_pid = spawn_old_daemon(port, OLD_VERSION, &old_stop, FROM);
+    assert!(
+        wait_for_bind(port, Duration::from_secs(10)),
+        "old daemon must be serving before the handoff"
+    );
+
+    let target = install.path().join("x0xd");
+    let backup = install.path().join("x0xd.backup");
+    let new_stop = install.path().join("stop-new");
+    write_health_wrapper(&target, port, NEW_VERSION, &new_stop);
+    write_health_wrapper(&backup, port, OLD_VERSION, &old_stop);
+
+    let handoff_path = write_handoff(data.path(), &target, &backup, old_pid, port);
+    let status = run_helper(&handoff_path);
+
+    assert!(status.success(), "healthy new binary commits the restart");
+    assert!(
+        wait_for_health_version(port, NEW_VERSION, Duration::from_secs(10)),
+        "the daemon now answering must be the target version"
+    );
+    assert!(
+        !handoff_path.exists(),
+        "restart commit deletes the handoff file"
+    );
+    assert!(
+        !data.path().join(restart::UPGRADE_FAILED_FILE_NAME).exists(),
+        "no failure artifact on a successful handoff"
+    );
+    assert!(
+        backup.exists(),
+        "backup bytes stay on disk until restart commit + later sweep"
+    );
+
+    stop_daemon(&new_stop);
+}
+
+/// Design test 5: both the new spawn and the rollback spawn fail. The helper
+/// must write `UPGRADE_FAILED` (reason, versions, paths) and exit nonzero —
+/// never a silent exit 0.
+#[test]
+fn handoff_writes_upgrade_failed_when_no_respawn_succeeds() {
+    let install = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    let port = free_port();
+
+    // Old pid already dead; nothing binds the port.
+    let target = install.path().join("x0xd");
+    let backup = install.path().join("x0xd.backup");
+    // Target does not exist: first spawn fails (ENOENT).
+    assert!(!target.exists());
+    // Backup exists but is not executable: after restore renames it over the
+    // target, the rollback spawn fails (EACCES).
+    std::fs::write(&backup, b"not an executable - previous binary placeholder").unwrap();
+
+    let handoff_path = write_handoff(data.path(), &target, &backup, dead_pid(), port);
+    let status = run_helper(&handoff_path);
+
+    assert!(
+        !status.success(),
+        "helper must exit nonzero when no respawn succeeded: {status:?}"
+    );
+    let failed = data.path().join(restart::UPGRADE_FAILED_FILE_NAME);
+    let content = std::fs::read_to_string(&failed).unwrap();
+    assert!(content.contains("reason:"), "artifact must carry a reason");
+    assert!(
+        content.contains(&format!("from version: {OLD_VERSION}")),
+        "artifact must record the from version: {content}"
+    );
+    assert!(
+        content.contains(&format!("to version: {NEW_VERSION}")),
+        "artifact must record the to version: {content}"
+    );
+    assert!(
+        content.contains(&format!("target binary: {}", target.display())),
+        "artifact must record the target path: {content}"
+    );
+    assert!(
+        content.contains(&format!("backup binary: {}", backup.display())),
+        "artifact must record the backup path: {content}"
+    );
+    assert!(
+        handoff_path.exists(),
+        "failed handoff keeps the intent file for diagnosis (UPGRADE_FAILED carries the outcome)"
+    );
+    // Nothing is serving: the loud artifact is the only acceptable end state.
+    assert!(
+        !wait_for_bind(port, Duration::from_secs(1)),
+        "no process should be bound after a double spawn failure"
+    );
+}
+
+/// Design I2.4: the old pid hangs past the bound. The helper must abort the
+/// new spawn, restore the backup over the target, leave the old process
+/// running, and write `UPGRADE_FAILED` — the user stays UP.
+#[test]
+fn handoff_aborts_when_old_pid_hangs_past_the_bound() {
+    let install = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    let port = free_port();
+
+    // Old "daemon" holds the port and outlives the release bound.
+    let old_stop = install.path().join("stop-old");
+    let old_pid = spawn_old_daemon(port, OLD_VERSION, &old_stop, 120);
+    assert!(
+        wait_for_bind(port, Duration::from_secs(10)),
+        "hung old daemon must be serving"
+    );
+
+    let target = install.path().join("x0xd");
+    let backup = install.path().join("x0xd.backup");
+    write_crash_wrapper(&target);
+    write_health_wrapper(&backup, port, OLD_VERSION, &old_stop);
+
+    let handoff_path = write_handoff(data.path(), &target, &backup, old_pid, port);
+    let status = run_helper(&handoff_path);
+
+    assert!(
+        !status.success(),
+        "old-pid-hung abort must exit nonzero: {status:?}"
+    );
+    let failed = data.path().join(restart::UPGRADE_FAILED_FILE_NAME);
+    let content = std::fs::read_to_string(&failed).unwrap();
+    assert!(
+        content.contains("did not exit"),
+        "artifact must name the hung old pid: {content}"
+    );
+    // The old process is left running and still serving.
+    assert!(
+        wait_for_health_version(port, OLD_VERSION, Duration::from_secs(5)),
+        "old process must stay up"
+    );
+    // Backup restored over the target: the next manual start gets old bytes.
+    assert!(!backup.exists());
+    let restored = std::fs::read_to_string(&target).unwrap();
+    assert!(restored.contains(&format!("FIXTURE_VERSION={OLD_VERSION}")));
+
+    stop_daemon(&old_stop);
+}
+
+/// Design I2.1–3 end to end from the old process side: the old daemon writes
+/// the handoff file, spawns the REAL `x0xd` helper (from the backup bytes),
+/// and exits. The helper then brings up the target and commits on health.
+///
+/// The backup is a copy of the real `x0xd` binary so the helper runs the
+/// genuine `--upgrade-handoff` entrypoint.
+#[test]
+fn old_process_handoff_spawns_real_helper_and_comes_back_on_target() {
+    let install = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    std::fs::create_dir_all(data.path()).unwrap();
+    let port = free_port();
+
+    let target = install.path().join("x0xd");
+    let backup = install.path().join("x0xd.backup");
+    let new_stop = install.path().join("stop-new");
+    write_health_wrapper(&target, port, NEW_VERSION, &new_stop);
+    std::fs::copy(X0XD_BIN, &backup).unwrap();
+    make_executable(&backup);
+
+    #[derive(serde::Serialize)]
+    struct Spec {
+        port: u16,
+        target: PathBuf,
+        backup: PathBuf,
+        data_dir: PathBuf,
+    }
+    let spec_path = install.path().join("old-side-spec.json");
+    std::fs::write(
+        &spec_path,
+        serde_json::to_string(&Spec {
+            port,
+            target: target.clone(),
+            backup: backup.clone(),
+            data_dir: data.path().to_path_buf(),
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    let handoff_path = data.path().join(restart::HANDOFF_FILE_NAME);
+    let mut old_daemon = Command::new(test_exe())
+        .arg(OLD_SIDE_FIXTURE)
+        .env("FIXTURE_HANDOFF_SPEC", &spec_path)
+        .current_dir(install.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    // Reap the old process (its parent owns that in production — the shell
+    // or systemd); blocking here reaps it the instant it exits, which is what
+    // the helper's pid probe needs.
+    let old_exit = old_daemon
+        .wait()
+        .expect("old process must exit after spawning the handoff helper");
+    assert!(old_exit.success(), "old process exits 0: {old_exit:?}");
+
+    // Restart commit: the target version serves the same port.
+    assert!(
+        wait_for_health_version(port, NEW_VERSION, Duration::from_secs(20)),
+        "replacement daemon must serve /health with the target version"
+    );
+    assert!(
+        wait_for_gone(&handoff_path, Duration::from_secs(5)),
+        "helper deletes the handoff file on commit"
+    );
+    assert!(
+        !data.path().join(restart::UPGRADE_FAILED_FILE_NAME).exists(),
+        "no failure artifact on a committed handoff"
+    );
+
+    stop_daemon(&new_stop);
+}
+
+/// If the helper itself cannot be spawned, the old process must NOT exit
+/// (that would be the #261 silent DOWN): it restores the backup, writes
+/// `UPGRADE_FAILED`, and keeps running.
+#[test]
+fn handoff_start_failure_keeps_old_process_alive_and_loud() {
+    let install = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+
+    let target = install.path().join("x0xd");
+    let backup = install.path().join("x0xd.backup");
+    // Backup exists but is not executable: the helper (spawned from the
+    // backup bytes) cannot start.
+    std::fs::write(&backup, b"previous binary (not executable)").unwrap();
+
+    let handoff = UpgradeHandoff {
+        from_version: OLD_VERSION.to_string(),
+        to_version: NEW_VERSION.to_string(),
+        target_path: target.clone(),
+        backup_path: backup.clone(),
+        argv: vec!["x0xd".to_string()],
+        cwd: install.path().to_string_lossy().to_string(),
+        env: Default::default(),
+        old_pid: std::process::id(),
+        api_addr: "127.0.0.1:0".parse().unwrap(),
+        started_at: 1_724_000_000,
+        mode: RestartMode::TransactionalHandoff,
+    };
+    let handoff_path = data.path().join(restart::HANDOFF_FILE_NAME);
+    let result = restart::begin_transactional_handoff(handoff, &handoff_path, None);
+
+    // Still alive and holding an Err: the silent-DOWN path is closed.
+    assert!(
+        result.is_err(),
+        "helper spawn failure must surface: {result:?}"
+    );
+    let failed = data.path().join(restart::UPGRADE_FAILED_FILE_NAME);
+    let content = std::fs::read_to_string(&failed).unwrap();
+    assert!(
+        content.contains("helper spawn failed"),
+        "artifact must name the helper spawn failure: {content}"
+    );
+    // Restore moved the (unspawneable) backup over the target: the install
+    // path holds the previous bytes again.
+    assert!(!backup.exists());
+    assert_eq!(
+        std::fs::read(&target).unwrap(),
+        b"previous binary (not executable)"
+    );
+}


### PR DESCRIPTION
## Problem

After a successful self-update binary swap, the default `stop_on_upgrade = true` called `exit(0)` and assumed a supervisor would respawn the daemon. A terminal-launched daemon (the macOS incident: v0.33.1 → v0.34.x, twice in one day, ~8 min DOWN each) has no supervisor, so it stayed silently down with the new bytes on disk. The `stop_on_upgrade = false` unix `exec()` path had the same hole in reverse: exec success is unrecoverable if the new image then dies.

Issue: #261 — deliberately left open per instructions (containment docs still apply to shipped versions).

## Fix

Restart mode is classified **before** anything destructive runs (`upgrade::restart::plan_restart_mode`):

- **SupervisedExit** — only when `stop_on_upgrade = true` **and** one of three real signals: `INVOCATION_ID` set (systemd), parent comm `systemd`, or `X0X_SUPERVISED=1` (explicit opt-in for launchd plists / Windows services). The intent file is written before exit so a crash loop is diagnosable; exit codes stay 0 (unix) / 100 (windows). No spawn-then-exit double-start.
- **TransactionalHandoff** — everything else, including unsupervised runs with the config default `stop_on_upgrade = true` and every `stop_on_upgrade = false` run. **not-a-TTY and launchd ancestry are explicitly NOT supervision.**

The handoff transaction (`src/upgrade/restart.rs`):

1. Old process captures argv/cwd/`current_binary_path()` **before** any exit and writes `data_dir/upgrade-handoff.json` (from/to, target/backup paths, argv, cwd, env whitelist, old pid, api addr, started_at).
2. Spawns a detached helper in a new session — the same `x0xd` binary, preferring the known-good backup bytes — as `x0xd --upgrade-handoff <file>` (private flag parsed before any config/logging/startup; joins no gossip, binds nothing, takes no instance lock).
3. Triggers the graceful-shutdown hook with a **5s bound** (never waits unbounded — macOS SIGTERM-hang), then `_exit(0)`.
4. Helper waits (30s bound) for the old pid to die and the API port to free. **Never SIGKILLs the old pid.** If it hangs past the bound: abort the spawn, restore the backup over the target, leave the old process running, write `UPGRADE_FAILED` — the user stays UP.
5. Spawns the target with captured argv/cwd (`--skip-update-check` appended only when not already present) and waits for `GET /health` 200 on the pre-upgrade API address (or the fresh `api.port` when the bind was ephemeral) within 30s.
6. Health OK ⇒ delete the handoff file, exit 0 (restart committed). Health fail / spawn fail ⇒ restore `x0xd.backup` over the target (same restore as the file-swap rollback), respawn the previous binary, health-check again.
7. Rollback respawn also fails ⇒ `data_dir/UPGRADE_FAILED` (reason, versions, paths, timestamps) + eprint + helper exit **nonzero**. Never a silent exit 0.

The unix `exec()` path is removed entirely. The `[update] stop_on_upgrade` config default is **unchanged** — systemd fleet units omitting the key keep today's supervised contract. All four apply callers (startup check, gossip listener, GitHub fallback poll, and the HTTP `POST /upgrade/apply` deferred restart) route through the same planner. The CLI `--check-updates` print-and-exit mode keeps a plain swap-commit — there is no daemon to bring back, and a handoff respawn of `x0xd --check-updates` could never serve `/health`. The startup sweep now age-gates `*.x0xold-*` sidelined binaries the same way temp dirs are age-gated, so an in-flight handoff never loses its rollback bytes.

Untouched per the design: verify/manifest/signature, gossip backoff, embed `self_update_enabled=false`, `--skip-update-check` semantics.

## Tests (all on the pushed tree)

- `cargo fmt --all`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo check --workspace --all-targets`, and `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` all exit 0.
- New unit tests (`upgrade::restart`, `upgrade::apply`, `server::routes::upgrade`): planner table — unsupervised + default `stop_on_upgrade=true` → handoff (with and without a TTY on stdin), each supervised signal → SupervisedExit, not-a-TTY alone never flips it, launchd-ancestor comm never qualifies, `stop_on_upgrade=false` always handoff; argv building never duplicates `--skip-update-check`; handoff JSON round-trip; backup-path naming matches the swap's `x0xd.backup`; ephemeral `api.port` health resolution; HTTP deferred restart uses the shared planner (no second ad-hoc exit).
- New integration suite `tests/upgrade_handoff_integration.rs` (fixture "binaries" are wrappers around the test binary; the helper is the real `x0xd`): new binary exits 1 → backup restored, previous binary respawned, `/health` 200 on the old version, no `UPGRADE_FAILED`, handoff file removed; new binary serves `/health` → committed on the target version, handoff file deleted, backup retained; both spawns fail → `UPGRADE_FAILED` with reason/versions/paths and nonzero helper exit; old pid hangs past the bound → abort + restore + old process left UP + `UPGRADE_FAILED`; full old-process side (`begin_transactional_handoff`) spawns the real helper from backup bytes and comes back on the target; helper-spawn failure keeps the old process alive and loud.
- Regression: full `--lib` suite (2097 passed, 0 failed), existing `tests/upgrade_integration.rs` (26 passed), and the updated sweep tests pin that an in-flight handoff's `.x0xold-*` sideline survives the age gate while aged debris is reclaimed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces unsupervised post-upgrade exits with a detached helper that health-checks the new daemon and restores the backup when restart fails.
- Adds supervision classification and a persisted upgrade-handoff record.
- Routes startup, gossip, fallback polling, and HTTP apply restarts through the shared planner.
- Adds bounded shutdown, health verification, rollback respawn, failure artifacts, and integration coverage.
- Age-gates sidelined upgrade binaries so active rollback bytes survive startup cleanup.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until failed replacement processes are cleaned up and transactional shutdown waits for required durability work rather than only the HTTP bind.

The handoff can leave an unhealthy replacement running during rollback, and its old-process path can interrupt history and peer-cache persistence after the listener releases.

**Files Needing Attention:** src/upgrade/restart.rs and src/server/mod.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/upgrade/restart.rs | Implements the handoff transaction, but leaves failed spawned daemons running and can force-exit before durability cleanup completes. |
| src/upgrade/apply.rs | Integrates restart planning and context into successful upgrade application. |
| src/server/routes/upgrade.rs | Supplies restart context consistently across startup, listener, fallback, and deferred HTTP upgrade paths. |
| src/server/mod.rs | Wires shutdown hooks and bound API addresses into update callers; its teardown ordering exposes the premature-exit issue. |
| src/bin/x0xd.rs | Adds an early private helper mode before normal daemon initialization. |
| tests/upgrade_handoff_integration.rs | Covers success and rollback outcomes but does not verify cleanup of a successfully spawned child that misses health or completion of old-process durability teardown. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Old as Old x0xd
  participant Helper as Handoff helper
  participant New as New x0xd
  participant API as /health
  Old->>Helper: Spawn with upgrade-handoff.json
  Old->>Old: Trigger graceful shutdown
  Old-->>Old: Exit after API bind releases
  Helper->>Helper: Wait for old PID and port
  Helper->>New: Spawn upgraded binary
  loop Until health timeout
    Helper->>API: GET /health
  end
  alt New daemon is healthy
    Helper->>Helper: Delete handoff file
  else Spawn or health fails
    Helper->>Helper: Restore backup
    Helper->>Old: Spawn previous binary
    Helper->>API: GET /health
  end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/upgrade/restart.rs:569-575
**Unhealthy child survives rollback**

When a replacement starts but does not answer the expected `/health` probe before the timeout, `cmd.spawn()` discards its `Child` handle and rollback starts another daemon without terminating the first one, causing duplicate daemons, shared-state contention, port conflicts, or a misleading `UPGRADE_FAILED` result if the first child later becomes healthy.

### Issue 2
src/upgrade/restart.rs:352-362
**Shutdown exits before durability cleanup**

When the API listener releases before agent shutdown finishes, this path treats the free bind as completion and calls `_exit(0)` while later history-writer draining and bootstrap-cache persistence are still running, causing queued history records or learned peer state to be lost during transactional upgrades.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(upgrade): transactional handoff for ..."](https://github.com/saorsa-labs/x0x/commit/b5b90fe85e3da5ae137dc028aedfe9fbca9a62b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54792370)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Upgrade Flow](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/upgrade.md)
- Knowledge Base — [CLI and daemon startup](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/cli-daemon.md)

<!-- /greptile_comment -->