### PR TITLE
chore(deps): bump ant-quic 0.27.39 -> 0.27.41, saorsa-gossip 0.5.70 -> 0.5.71

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.39"
+ant-quic = "0.27.41"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"
@@ -40,17 +40,17 @@ hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 rand = "0.8"
-saorsa-gossip-coordinator = "0.5.70"
-saorsa-gossip-crdt-sync = "0.5.70"
-saorsa-gossip-groups = "0.5.70"
-saorsa-gossip-identity = "0.5.70"
-saorsa-gossip-membership = "0.5.70"
-saorsa-gossip-presence = "0.5.70"
-saorsa-gossip-pubsub = "0.5.70"
-saorsa-gossip-rendezvous = "0.5.70"
-saorsa-gossip-runtime = "0.5.70"
-saorsa-gossip-transport = "0.5.70"
-saorsa-gossip-types = "0.5.70"
+saorsa-gossip-coordinator = "0.5.71"
+saorsa-gossip-crdt-sync = "0.5.71"
+saorsa-gossip-groups = "0.5.71"
+saorsa-gossip-identity = "0.5.71"
+saorsa-gossip-membership = "0.5.71"
+saorsa-gossip-presence = "0.5.71"
+saorsa-gossip-pubsub = "0.5.71"
+saorsa-gossip-rendezvous = "0.5.71"
+saorsa-gossip-runtime = "0.5.71"
+saorsa-gossip-transport = "0.5.71"
+saorsa-gossip-types = "0.5.71"
 saorsa-pqc = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/benches/gossip_dispatch_throughput.rs
+++ b/benches/gossip_dispatch_throughput.rs
@@ -46,6 +46,7 @@ fn build_eager_wire(
         kind: MessageKind::Eager,
         hop: 0,
         ttl: 10,
+        payload_hash: None,
     };
     let header_bytes = postcard::to_stdvec(&header).expect("bench header serializes");
     let signature = signing_key.sign(&header_bytes).expect("bench header signs");

--- a/src/network.rs
+++ b/src/network.rs
@@ -5644,6 +5644,7 @@ mod pressure_tests {
                     kind,
                     hop: 0,
                     ttl: 10,
+                    payload_hash: None,
                 },
                 payload: None,
                 signature: Vec::new(),


### PR DESCRIPTION
Brings x0x onto yesterday's dep releases.

**ant-quic 0.27.40/0.27.41**
- h2 0.4.16 bump for RUSTSEC-2026-0258
- masque: finish relay send stream at frame boundary on clean half-close (#249)

**saorsa-gossip 0.5.71**
- ADR-012 payload-covering gossip message signature (sg #39). Version-gated `MessageHeader` 1→2 with a migration window: v2 receivers accept v1, so the mixed 0.5.70 fleet is safe — no flag day.

**x0x changes required by the bump**
`MessageHeader` gained `payload_hash: Option<[u8;32]>`. The two literal v1 constructions (a `network.rs` unit test and the dispatch bench) now set `payload_hash: None`, matching the types crate's own v1 constructor.

Local verification: `cargo fmt --check` clean, `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean, 2085/2085 lib unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades ant-quic and the saorsa-gossip crate family, including the release that introduces version-gated payload-covering gossip signatures.

- Updates ant-quic from 0.27.39 to 0.27.41.
- Updates all saorsa-gossip dependencies from 0.5.70 to 0.5.71.
- Adapts two legacy v1 `MessageHeader` literals to the new optional `payload_hash` field.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete defects identified in the dependency updates or required header-literal adaptations.

The upgraded dependency family is applied consistently, and both source adaptations retain explicit v1 header semantics in benchmark and test-only code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Upgrades ant-quic and the complete saorsa-gossip dependency family together; no concrete compatibility defect was identified. |
| benches/gossip_dispatch_throughput.rs | Preserves the benchmark’s legacy v1 header semantics by explicitly setting the newly required payload hash to `None`. |
| src/network.rs | Updates a pressure-test-only v1 header literal for the dependency’s expanded data structure without changing production network behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump ant-quic 0.27.39 -&gt; 0...."](https://github.com/saorsa-labs/x0x/commit/215f9c678c3e37e454533c3fc50c142b6033977e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55067282)</sub>

**Context used:**

- Knowledge Base — [Network Transport](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/network-transport.md)

<!-- /greptile_comment -->