### PR TITLE
test(harness): extend hermetic gossip-plane isolation to solo/join_peer (#337)

### DIFF
--- a/tests/harness/src/cluster.rs
+++ b/tests/harness/src/cluster.rs
@@ -7,6 +7,7 @@
 use std::net::{TcpListener, UdpSocket};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
+use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::sync::OnceCell;
 
@@ -363,6 +364,22 @@ pub async fn pair() -> AgentPair {
     pair_with_extra_config("").await
 }
 
+/// Gossip plane shared by the [`solo`]/[`join_peer`] family for this test
+/// process (#337).
+///
+/// `pair*` and the trio each mint an id inside a single constructor call, but
+/// these are two independent entry points that must land on ONE plane:
+/// [`join_peer`] bootstraps to a [`solo`] anchor and then asserts the two
+/// peered, and it cannot read the anchor's plane. Nextest runs every test in its
+/// own process, so a process-scoped id is per-test in practice — the daemons of
+/// one test share a plane while other tests and ambient daemons stay out.
+/// Mirrors `daemon.rs`'s `process_gossip_plane_id`.
+fn solo_plane_id() -> &'static str {
+    static PLANE_ID: LazyLock<String> =
+        LazyLock::new(|| format!("x0x-test-{}", rand::random::<u32>()));
+    PLANE_ID.as_str()
+}
+
 /// Start a single daemon with no bootstrap peers. Returns the instance
 /// and its UDP bind port so a later daemon can bootstrap to it — the
 /// staggered-start primitive for cold-late-join tests (issue #96), where
@@ -372,7 +389,15 @@ pub async fn solo() -> (AgentInstance, u16) {
     let suffix = rand::random::<u16>();
     let api = allocate_unused_tcp_port();
     let bind = allocate_unused_udp_port();
-    let instance = start_instance(&binary, &format!("solo-{suffix}"), api, bind, "", "").await;
+    let instance = start_instance(
+        &binary,
+        &format!("solo-{suffix}"),
+        api,
+        bind,
+        "",
+        &with_private_plane(solo_plane_id(), ""),
+    )
+    .await;
     (instance, bind)
 }
 
@@ -390,7 +415,7 @@ pub async fn join_peer(anchor: &AgentInstance, anchor_bind: u16) -> AgentInstanc
         api,
         bind,
         &format!("bootstrap_peers = [\"127.0.0.1:{anchor_bind}\"]"),
-        "",
+        &with_private_plane(solo_plane_id(), ""),
     )
     .await;
     tokio::time::sleep(MESH_SETTLE_TIME).await;


### PR DESCRIPTION
Extends #348's hermetic gossip-plane isolation (#337) to the `solo`/`join_peer` staggered-start family via a process-scoped plane id (per-test under nextest). Mirrors `daemon.rs`'s `process_gossip_plane_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends hermetic gossip-plane isolation to the staggered-start harness so `solo` and `join_peer` daemons share a private, process-scoped network ID.

- Adds a lazily initialized gossip-plane ID scoped to the test process.
- Applies that plane consistently to both the anchor and joining daemon.
- Preserves per-test isolation under the repository’s nextest-based test execution.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with the staggered-start daemons correctly sharing an isolated gossip plane under the configured test runner.

The new process-scoped ID is applied to both solo and join_peer, while nextest process isolation prevents unrelated tests from sharing that plane.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/harness/src/cluster.rs | Adds a shared process-scoped gossip plane to solo/join_peer startup; no actionable defect was identified under the configured nextest execution model. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant Plane as Process-scoped plane ID
    participant Solo as solo daemon
    participant Join as join_peer daemon
    Test->>Plane: Initialize once per test process
    Test->>Solo: Start with private network_id
    Test->>Join: Start with same network_id and Solo bootstrap address
    Join->>Solo: Bootstrap and peer
    Note over Solo,Join: Ambient and other nextest processes use different planes
```

<sub>Reviews (1): Last reviewed commit: ["test(harness): extend hermetic gossip-pl..."](https://github.com/saorsa-labs/x0x/commit/b4bb24589e26b521fc9a07edfea99903d10ea042) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55084084)</sub>

<!-- /greptile_comment -->