### PR TITLE
chore(release): v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.39.0] - 2026-08-20
+
+### Added
+
+- **KV `AccessPolicy::SelfKeyed` with lowest-N quota (issue #340).** A store
+  policy where each agent may write only keys prefixed by its own agent id,
+  bounded by a per-agent lowest-N key quota enforced at merge.
+
+### Dependencies
+
+- **ant-quic 0.27.39 → 0.27.41.** h2 0.4.16 (RUSTSEC-2026-0258); masque relay
+  send stream finished at frame boundary on clean half-close.
+- **saorsa-gossip 0.5.70 → 0.5.71 — ADR-012 payload-covering gossip message
+  signature.** `MessageHeader` v1→2 adds `payload_hash`; v2 receivers accept
+  v1 during the migration window, so the mixed fleet upgrades with no flag
+  day. This release is the fleet's first v2-capable daemon.
+
 ### Fixed
 
 - **Unsupervised self-update restart is now transactional (issue #261).**
@@ -36,6 +53,19 @@ All notable changes to this project will be documented in this file.
   only. First unicast attempt is budgeted at 3s here; durable DMs and
   roster/control events keep their 8s defaults. `require_gossip_ack` is
   not dropped. No `fan_out` field (#296).
+
+- **TaskList `merge_delta` now routes writes through the envelope writer
+  (issue #349 Layer A).**
+- **Peer admission: PolicyRejection tombstones now stay down across planes
+  (issue #292, phases A–D+F).** Closes the intermittent redial permit.
+- **Reserved `Encrypted` KV policy fails closed until #88 lands (issue #341
+  Phase A).**
+- **MLS epoch history `msg_id` is salted with a length-prefixed group scope
+  (issue #276).** Removes cross-group id collision potential.
+- **History db path is resolved and named at pragma setup (issue #281
+  leftover).**
+- **Machine discovery addresses capped at 8 MRU entries (issue #308).**
+- **`MemberBanned` gets bounded two-channel redelivery (issue #344).**
 
 ## [v0.38.1] - 2026-08-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.38.1"
+version = "0.39.0"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.38.1
+version: 0.39.0
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Release v0.39.0: the post-v0.38.1 fix wave (#347–#363), `AccessPolicy::SelfKeyed` (#340), and the dep bump to ant-quic 0.27.41 + saorsa-gossip 0.5.71 (ADR-012 — first v2-capable daemon, migration-window compatible with the 0.5.70 fleet). CHANGELOG back-filled for the nine wave PRs that shipped without entries.

Merge → tag `v0.39.0` on main → release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prepares the v0.39.0 release by synchronizing package and skill metadata and back-filling release notes.
- Bumps Cargo.toml and SKILL.md from 0.38.1 to 0.39.0.
- Documents the SelfKeyed KV policy, dependency updates, and the post-v0.38.1 fix wave.

<h3>Confidence Score: 5/5</h3>

The release metadata and documented contents are consistent, so this PR appears safe to merge.

The authoritative package and skill versions agree at 0.39.0, and the new changelog entries correspond to dependencies and changes included in the release.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds v0.39.0 release notes whose dependency, feature, and fix entries align with the release contents. |
| Cargo.toml | Updates the authoritative crate version to 0.39.0 consistently with the intended release tag. |
| SKILL.md | Updates skill frontmatter to 0.39.0, matching the Cargo package version and release validation requirements. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.0"](https://github.com/saorsa-labs/x0x/commit/454eab6e229103c33ab99a846fb1d495008ce737) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55085344)</sub>

<!-- /greptile_comment -->