### PR TITLE
fix(network): close inbound admit window after PolicyRejection (#292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ All notable changes to this project will be documented in this file.
   tombstone lands (issue #292 invariant D).** `accept()` can yield before
   `PolicyRejection` and then await cache bookkeeping; the admit path now
   re-checks the tombstone before `record_success` and holds the suppression
-  map across the `PeerConnected` emit so a concurrent reject cannot sneak
-  into that window. The refuse path still uses a plain transport close (no
-  `suppress_reconnect`, invariant F). `is_connected` stays transport-only.
+  map across the `PeerConnected` emit and pool `note_activity` so a
+  concurrent reject cannot sneak into that window. The refuse path still
+  uses a plain transport close (no `suppress_reconnect`, invariant F).
+  `is_connected` stays transport-only.
 
 ## [v0.39.1] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Inbound accept no longer emits `PeerConnected` after a suppression
+  tombstone lands (issue #292 invariant D).** `accept()` can yield before
+  `PolicyRejection` and then await cache bookkeeping; the admit path now
+  re-checks the tombstone before `record_success` and holds the suppression
+  map across the `PeerConnected` emit so a concurrent reject cannot sneak
+  into that window. The refuse path still uses a plain transport close (no
+  `suppress_reconnect`, invariant F). `is_connected` stays transport-only.
+
 ## [v0.39.1] - 2026-08-21
 
 ### Fixed

--- a/src/network.rs
+++ b/src/network.rs
@@ -3979,22 +3979,21 @@ impl NetworkNode {
                         // invisible to admission via `peer_admission`
                         // (invariant A) and must never call
                         // `suppress_reconnect` (invariant F).
+                        //
+                        // The gate is not a single check at `accept()`
+                        // return. Cache bookkeeping awaits below, and a
+                        // concurrent `PolicyRejection` can set the
+                        // tombstone in that window (the original session's
+                        // inbound accept yielding before the close). Every
+                        // admission side-effect re-checks; `PeerConnected`
+                        // is emitted while still holding the suppression
+                        // map so the tombstone cannot land between the
+                        // final check and the event.
                         if reconnect_suppression_is_live(
                             reconnect_suppressions.as_ref(),
                             peer_conn.peer_id.0,
                         ) {
-                            tracing::warn!(
-                                target: "x0x::connect",
-                                origin = "accept",
-                                peer_id_prefix = %hex_prefix(&peer_conn.peer_id.0, 4),
-                                "accept closed: inbound connection from reconnect-suppressed peer (issue #292)"
-                            );
-                            if let Err(e) = node_ref.disconnect(&peer_conn.peer_id).await {
-                                debug!(
-                                    "disconnect of suppressed inbound peer {:?} failed: {}",
-                                    peer_conn.peer_id, e
-                                );
-                            }
+                            close_suppressed_inbound(node_ref, &peer_conn.peer_id).await;
                             continue;
                         }
 
@@ -4008,17 +4007,36 @@ impl NetworkNode {
                             _ => None,
                         };
                         if let (Some(ref cache), Some(addr)) = (&bootstrap_cache, addr) {
+                            if reconnect_suppression_is_live(
+                                reconnect_suppressions.as_ref(),
+                                peer_conn.peer_id.0,
+                            ) {
+                                close_suppressed_inbound(node_ref, &peer_conn.peer_id).await;
+                                continue;
+                            }
                             cache
                                 .add_from_connection(peer_conn.peer_id, vec![addr], None)
                                 .await;
+                            if reconnect_suppression_is_live(
+                                reconnect_suppressions.as_ref(),
+                                peer_conn.peer_id.0,
+                            ) {
+                                close_suppressed_inbound(node_ref, &peer_conn.peer_id).await;
+                                continue;
+                            }
                             cache.record_success(&peer_conn.peer_id, 0).await;
                         }
                         let addr =
                             addr.unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], 0)));
-                        let _ = event_sender.send(NetworkEvent::PeerConnected {
-                            peer_id: peer_conn.peer_id.0,
-                            address: addr,
-                        });
+                        if !try_admit_inbound_peer_connected(
+                            reconnect_suppressions.as_ref(),
+                            &event_sender,
+                            peer_conn.peer_id.0,
+                            addr,
+                        ) {
+                            close_suppressed_inbound(node_ref, &peer_conn.peer_id).await;
+                            continue;
+                        }
                         let evicted = connection_pool.note_activity(peer_conn.peer_id);
                         if !evicted.is_empty() {
                             disconnect_pool_candidates(
@@ -4562,12 +4580,68 @@ fn reconnect_suppression_is_live(
         Ok(m) => m,
         Err(poisoned) => poisoned.into_inner(),
     };
+    reconnect_suppression_is_live_locked(&mut map, peer_id)
+}
+
+fn reconnect_suppression_is_live_locked(
+    map: &mut HashMap<[u8; 32], ReconnectSuppression>,
+    peer_id: [u8; 32],
+) -> bool {
     let now = Instant::now();
     let live = map.get(&peer_id).is_some_and(|s| s.is_live(now));
     if !live {
         map.remove(&peer_id);
     }
     live
+}
+
+/// Plain transport close for an inbound peer that lost the #292 D gate.
+///
+/// Never calls [`NetworkNode::suppress_reconnect`]: a refused accept must
+/// not refresh an existing tombstone (invariant F).
+async fn close_suppressed_inbound(node: &Node, peer_id: &AntPeerId) {
+    tracing::warn!(
+        target: "x0x::connect",
+        origin = "accept",
+        peer_id_prefix = %hex_prefix(&peer_id.0, 4),
+        "accept closed: inbound connection from reconnect-suppressed peer (issue #292)"
+    );
+    if let Err(e) = node.disconnect(peer_id).await {
+        debug!(
+            "disconnect of suppressed inbound peer {:?} failed: {}",
+            peer_id, e
+        );
+    }
+}
+
+/// Emit inbound [`NetworkEvent::PeerConnected`] only if `peer_id` is not
+/// suppressed, holding the suppression map across the check and the send.
+///
+/// A concurrent `PolicyRejection` takes the same mutex in
+/// [`NetworkNode::suppress_reconnect`]. Holding it here means the tombstone
+/// cannot land between the liveness check and the event — the accept-then-
+/// cache window that leaked admission on issue #292 invariant D.
+///
+/// Returns `true` when the event was emitted (caller may touch the
+/// connection pool). Returns `false` when a live tombstone exists: caller
+/// must close with [`close_suppressed_inbound`] and skip every other
+/// admission side-effect.
+#[must_use]
+fn try_admit_inbound_peer_connected(
+    map: &Mutex<HashMap<[u8; 32], ReconnectSuppression>>,
+    event_sender: &broadcast::Sender<NetworkEvent>,
+    peer_id: [u8; 32],
+    address: SocketAddr,
+) -> bool {
+    let mut map = match map.lock() {
+        Ok(m) => m,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if reconnect_suppression_is_live_locked(&mut map, peer_id) {
+        return false;
+    }
+    let _ = event_sender.send(NetworkEvent::PeerConnected { peer_id, address });
+    true
 }
 
 /// Events emitted by the network node.
@@ -4645,6 +4719,58 @@ mod tests {
         };
 
         assert_eq!(send_ready_peer_ids([connection]), vec![constrained]);
+    }
+
+    /// Issue #292 invariant D: a PolicyRejection tombstone present at the
+    /// inbound admit seam must not surface `PeerConnected`. This is the
+    /// atomic check+emit helper the accept loop uses after cache awaits —
+    /// the window that leaked admission when `accept()` had already
+    /// yielded before the tombstone landed.
+    #[test]
+    fn inbound_admit_emits_no_peer_connected_when_policy_rejection_tombstone_is_live() {
+        let map = Mutex::new(HashMap::from([(
+            [1u8; 32],
+            ReconnectSuppression {
+                reason: DisconnectReason::PolicyRejection,
+                set_at: Instant::now(),
+            },
+        )]));
+        let (tx, mut rx) = broadcast::channel(16);
+        let addr = "127.0.0.1:1".parse().unwrap();
+
+        assert!(
+            !try_admit_inbound_peer_connected(&map, &tx, [1u8; 32], addr),
+            "a live PolicyRejection tombstone must refuse inbound admit"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "refusing inbound admit must not emit PeerConnected"
+        );
+        assert!(
+            reconnect_suppression_is_live(&map, [1u8; 32]),
+            "the refuse path must not clear or refresh the tombstone"
+        );
+    }
+
+    /// Companion to the refuse test: an unsuppressed inbound peer still
+    /// admits. Guards against the helper becoming a permanent no-op.
+    #[test]
+    fn inbound_admit_emits_peer_connected_when_peer_is_unsuppressed() {
+        let map = Mutex::new(HashMap::new());
+        let (tx, mut rx) = broadcast::channel(16);
+        let addr = "127.0.0.1:2".parse().unwrap();
+
+        assert!(
+            try_admit_inbound_peer_connected(&map, &tx, [2u8; 32], addr),
+            "an unsuppressed inbound peer must admit"
+        );
+        match rx.try_recv() {
+            Ok(NetworkEvent::PeerConnected { peer_id, address }) => {
+                assert_eq!(peer_id, [2u8; 32], "emitted peer id");
+                assert_eq!(address, addr, "emitted address");
+            }
+            other => panic!("expected PeerConnected, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/network.rs
+++ b/src/network.rs
@@ -3986,9 +3986,9 @@ impl NetworkNode {
                         // tombstone in that window (the original session's
                         // inbound accept yielding before the close). Every
                         // admission side-effect re-checks; `PeerConnected`
-                        // is emitted while still holding the suppression
-                        // map so the tombstone cannot land between the
-                        // final check and the event.
+                        // and pool `note_activity` run while still holding
+                        // the suppression map so the tombstone cannot land
+                        // between the final check and either side-effect.
                         if reconnect_suppression_is_live(
                             reconnect_suppressions.as_ref(),
                             peer_conn.peer_id.0,
@@ -4028,16 +4028,16 @@ impl NetworkNode {
                         }
                         let addr =
                             addr.unwrap_or_else(|| std::net::SocketAddr::from(([0, 0, 0, 0], 0)));
-                        if !try_admit_inbound_peer_connected(
+                        let Some(evicted) = try_admit_inbound_peer(
                             reconnect_suppressions.as_ref(),
                             &event_sender,
+                            connection_pool.as_ref(),
                             peer_conn.peer_id.0,
                             addr,
-                        ) {
+                        ) else {
                             close_suppressed_inbound(node_ref, &peer_conn.peer_id).await;
                             continue;
-                        }
-                        let evicted = connection_pool.note_activity(peer_conn.peer_id);
+                        };
                         if !evicted.is_empty() {
                             disconnect_pool_candidates(
                                 node_ref,
@@ -4614,34 +4614,37 @@ async fn close_suppressed_inbound(node: &Node, peer_id: &AntPeerId) {
     }
 }
 
-/// Emit inbound [`NetworkEvent::PeerConnected`] only if `peer_id` is not
-/// suppressed, holding the suppression map across the check and the send.
+/// Admit an inbound peer only if `peer_id` is not suppressed, holding the
+/// suppression map across the liveness check, [`NetworkEvent::PeerConnected`],
+/// and connection-pool `note_activity`.
 ///
 /// A concurrent `PolicyRejection` takes the same mutex in
 /// [`NetworkNode::suppress_reconnect`]. Holding it here means the tombstone
-/// cannot land between the liveness check and the event — the accept-then-
-/// cache window that leaked admission on issue #292 invariant D.
+/// cannot land between the check and either admission side-effect — the
+/// accept-then-cache window that leaked `PeerConnected` on issue #292
+/// invariant D, and the post-emit pool update that could otherwise
+/// reinsert a just-rejected peer or LRU-evict an unrelated one.
 ///
-/// Returns `true` when the event was emitted (caller may touch the
-/// connection pool). Returns `false` when a live tombstone exists: caller
-/// must close with [`close_suppressed_inbound`] and skip every other
-/// admission side-effect.
+/// Returns `Some(evicted)` when admitted (caller disconnects LRU victims).
+/// Returns `None` when a live tombstone exists: caller must close with
+/// [`close_suppressed_inbound`] and skip every other admission side-effect.
 #[must_use]
-fn try_admit_inbound_peer_connected(
+fn try_admit_inbound_peer(
     map: &Mutex<HashMap<[u8; 32], ReconnectSuppression>>,
     event_sender: &broadcast::Sender<NetworkEvent>,
+    connection_pool: &ConnectionPool,
     peer_id: [u8; 32],
     address: SocketAddr,
-) -> bool {
+) -> Option<Vec<AntPeerId>> {
     let mut map = match map.lock() {
         Ok(m) => m,
         Err(poisoned) => poisoned.into_inner(),
     };
     if reconnect_suppression_is_live_locked(&mut map, peer_id) {
-        return false;
+        return None;
     }
     let _ = event_sender.send(NetworkEvent::PeerConnected { peer_id, address });
-    true
+    Some(connection_pool.note_activity(ant_quic::PeerId(peer_id)))
 }
 
 /// Events emitted by the network node.
@@ -4736,15 +4739,21 @@ mod tests {
             },
         )]));
         let (tx, mut rx) = broadcast::channel(16);
+        let pool = ConnectionPool::new(8, Duration::from_secs(300));
         let addr = "127.0.0.1:1".parse().unwrap();
 
         assert!(
-            !try_admit_inbound_peer_connected(&map, &tx, [1u8; 32], addr),
+            try_admit_inbound_peer(&map, &tx, &pool, [1u8; 32], addr).is_none(),
             "a live PolicyRejection tombstone must refuse inbound admit"
         );
         assert!(
             rx.try_recv().is_err(),
             "refusing inbound admit must not emit PeerConnected"
+        );
+        assert_eq!(
+            pool.snapshot().active_count,
+            0,
+            "refusing inbound admit must not record pool activity"
         );
         assert!(
             reconnect_suppression_is_live(&map, [1u8; 32]),
@@ -4758,11 +4767,14 @@ mod tests {
     fn inbound_admit_emits_peer_connected_when_peer_is_unsuppressed() {
         let map = Mutex::new(HashMap::new());
         let (tx, mut rx) = broadcast::channel(16);
+        let pool = ConnectionPool::new(8, Duration::from_secs(300));
         let addr = "127.0.0.1:2".parse().unwrap();
 
+        let evicted = try_admit_inbound_peer(&map, &tx, &pool, [2u8; 32], addr)
+            .expect("an unsuppressed inbound peer must admit");
         assert!(
-            try_admit_inbound_peer_connected(&map, &tx, [2u8; 32], addr),
-            "an unsuppressed inbound peer must admit"
+            evicted.is_empty(),
+            "a single admit under cap must not LRU-evict"
         );
         match rx.try_recv() {
             Ok(NetworkEvent::PeerConnected { peer_id, address }) => {
@@ -4771,6 +4783,11 @@ mod tests {
             }
             other => panic!("expected PeerConnected, got {other:?}"),
         }
+        assert_eq!(
+            pool.snapshot().active_count,
+            1,
+            "an admitted inbound peer must enter the connection pool"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **#292 invariant D leak on `main` at `e150786`:** `tests::inbound_redial_of_suppressed_peer_emits_no_peer_connected` failed on CI Test Suite (Coverage Gate lost lcov as a cascade). A `PeerConnected` event was emitted for a PolicyRejected / suppressed peer.
- **Cause:** the inbound accept loop gated suppression once at `accept()` return, then awaited bootstrap-cache bookkeeping (`add_from_connection` / `record_success`) before emitting `PeerConnected`. A concurrent `PolicyRejection` can set the tombstone in that window — including the original session's inbound accept that already yielded before the close.
- **Fix (product path only):** re-check the tombstone before `record_success`, and emit `PeerConnected` **and** record pool `note_activity` while still holding the suppression map so a concurrent reject cannot land between the final check and either side-effect. The refuse path stays a plain `Node::disconnect` (no `suppress_reconnect`, invariant F). `is_connected` stays transport-only.
- **Out of scope:** no PlaneRefuse / invariant E; no #349B / #321; no groups diff; #370 is untouched.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] CI **Test Suite** green on `8b4e559`
- [x] CI **Coverage Gate** green on `8b4e559` (rebased onto `main` after #375/#369; the earlier Coverage red was that unrelated groups proptest, not this admit path)
- [x] Integration (net) green on this PR

## Coverage

- Coverage workstream: issue #292 invariant D
- Exclusions added: none

## Test Quality Checklist

- [x] Each new test has a why-named name that states the invariant or regression.
- [x] No new test is a tautology against the implementation.
- [x] Each new test checks one business invariant.
- [x] Assertion failures include enough context to diagnose the broken invariant.
- [x] Coverage delta is reported from CI or `just coverage-summary`.
- [x] Any coverage exclusion has a `coverage-skip:` comment and a matching register entry.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6657262-346a-4c41-b55d-6ba81c7013e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6657262-346a-4c41-b55d-6ba81c7013e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a race in inbound peer admission by rechecking reconnect suppression around cache bookkeeping and making the final check plus `PeerConnected` emission atomic.

- Adds a shared locked suppression-liveness helper and a plain transport-close helper for refused inbound connections.
- Adds unit coverage for suppressed and unsuppressed admission outcomes.
- Documents the issue #292 invariant-D fix in the changelog.
- The connection-pool update remains outside the atomic admission boundary, leaving a concurrent rejection able to cause stale pool state or an unrelated LRU eviction.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the connection-pool update is included in, or independently protected by, the suppression admission boundary.

A PolicyRejection can land after the atomic event check but before `note_activity`, allowing a rejected peer to be inserted into the pool and potentially evict and disconnect an unrelated legitimate peer.

**Files Needing Attention:** src/network.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/network.rs | Adds atomic suppression-aware inbound event admission, but leaves the subsequent connection-pool mutation exposed to a concurrent PolicyRejection. |
| CHANGELOG.md | Documents the inbound suppression race fix and intended invariants accurately, aside from the remaining pool-side-effect window in the implementation. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Accept as Inbound accept loop
  participant Gate as Suppression map
  participant Events as Network events
  participant Reject as PolicyRejection task
  participant Pool as Connection pool
  Accept->>Gate: lock and check suppression
  Accept->>Events: emit PeerConnected
  Accept->>Gate: unlock
  Reject->>Gate: set tombstone
  Reject-->>Accept: rejection now active
  Accept->>Pool: note_activity(rejected peer)
  Pool-->>Accept: may return legitimate LRU peer
  Accept->>Pool: disconnect eviction candidate
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/network.rs:4040
**Pool update escapes admission gate**

If a concurrent `PolicyRejection` sets the tombstone after `try_admit_inbound_peer_connected` returns, the accept loop still calls `note_activity`, reinserting the rejected peer or evicting and disconnecting an unrelated legitimate peer when the pool is full.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(network): close inbound admit window..."](https://github.com/saorsa-labs/x0x/commit/8f2063a9512a9f2df7f6aeb391e3ce32b636a297) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55479818)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Network Transport](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/network-transport.md)

<!-- /greptile_comment -->