### PR TITLE
test(groups): reject sole Pending owner NonMemberRequest live withdrawal

### DIFF
--- a/tests/proptest_groups.rs
+++ b/tests/proptest_groups.rs
@@ -1706,3 +1706,60 @@ fn sole_owner_nonmember_request_live_withdrawal_is_unauthorized_for_action_kind(
         "product must name the action under test; got {result:?}"
     );
 }
+
+/// Product currently admits (`Ok(())` + withdrawn) a sole Pending owner
+/// applying a live-withdrawal `GroupDeleted` commit as `NonMemberRequest`.
+/// QA classified this as a groups product admit, not an error-shape gap.
+/// This unit expects reject. Do not change product on this PR.
+///
+/// #375 already pins the Owner/Active neighbor
+/// (`sole_owner_nonmember_request_live_withdrawal_is_unauthorized_for_action_kind`).
+/// This is the Owner/Pending tuple. Oracle
+/// (`expected_withdrawn_apply_authorized`) already returns false;
+/// `apply_withdrawn_flag_commit` currently accepts.
+#[test]
+fn sole_pending_owner_nonmember_request_live_withdrawal_must_reject() {
+    let keypairs = sequence_keypairs();
+    let signer = &keypairs[1];
+    let signer_spec = Some(member_spec(GroupRole::Owner, GroupMemberState::Pending));
+    let action_kind = ActionKind::NonMemberRequest;
+    let event_kind = MetadataEventKind::GroupDeleted;
+    let current_withdrawn = false;
+    let commit_withdrawn = true;
+    let admin_present = false;
+
+    let mut apply_group = withdrawal_case_group(
+        &keypairs,
+        signer_spec.as_ref(),
+        current_withdrawn,
+        admin_present,
+    );
+    let before = state_snapshot(&apply_group);
+    let commit = craft_withdrawn_flag_commit(&apply_group, signer, commit_withdrawn, 11_000)
+        .expect("sign withdrawal flag commit");
+    let result = apply_withdrawn_flag_commit(&mut apply_group, &commit, action_kind, event_kind);
+    let expected_ok = expected_withdrawn_apply_authorized(
+        current_withdrawn,
+        commit_withdrawn,
+        signer_spec.as_ref(),
+        admin_present,
+        action_kind,
+        event_kind,
+    );
+
+    assert!(
+        !expected_ok,
+        "oracle must reject NonMemberRequest on a sole-member live withdrawal"
+    );
+    assert_eq!(
+        state_snapshot(&apply_group),
+        before,
+        "product must not admit / withdraw; result={result:?} withdrawn_after={}",
+        apply_group.withdrawn
+    );
+    assert!(
+        result.is_err(),
+        "product must reject; got {result:?} withdrawn_after={}",
+        apply_group.withdrawn
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Separate from #375 (error-shape / Active tuple). Do not land this on that branch.
- This is the Owner/Pending product-admit regression: sole Pending owner + `NonMemberRequest` + `GroupDeleted` live withdrawal.
- Oracle (`expected_withdrawn_apply_authorized`) already rejects (`expected_ok = false`). Product currently returns `Ok(())` and sets `withdrawn = true`.
- Test-only; expected red until product stops admitting.
- No groups product change on this PR. No nextest override. No new proptest pins. Oracle not weakened.

Observed on this branch against current main product:

```
assertion `left == right` failed: product must not admit / withdraw; result=Ok(()) withdrawn_after=true
test sole_pending_owner_nonmember_request_live_withdrawal_must_reject ... FAILED
```

## Validation

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `sole_pending_owner_nonmember_request_live_withdrawal_must_reject` — FAIL on current main (`Ok(())` + `withdrawn_after=true`)

## Coverage

- Current line coverage: n/a (test-only)
- Delta vs `main`: none intended
- Coverage workstream, if applicable: n/a
- Exclusions added: none

## Test Quality Checklist

- [x] Each new test has a why-named name that states the invariant or regression.
- [x] No new test is a tautology against the implementation.
- [x] Each new test checks one business invariant.
- [x] Assertion failures include enough context to diagnose the broken invariant.
- [ ] Coverage delta is reported from CI or `just coverage-summary`.
- [x] Any coverage exclusion has a `coverage-skip:` comment and a matching register entry.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a00a9a1-8471-4671-9305-7eb4fd0a76c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a00a9a1-8471-4671-9305-7eb4fd0a76c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a focused regression test requiring a live group withdrawal to be rejected when submitted as a `NonMemberRequest` by its sole Pending owner.
- Constructs the sole Pending-owner group state without another administrator.
- Verifies the authorization oracle rejects the operation.
- Requires both an error result and complete preservation of group state.

<h3>Confidence Score: 5/5</h3>

The test-only PR appears safe to merge, with no actionable defects identified in the added regression coverage.

The fixture reaches the intended live-to-withdrawn authorization path, creates the stated sole Pending-owner condition, and checks both rejection and full state preservation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tests/proptest_groups.rs | Adds a well-scoped regression test for rejecting an unauthorized terminal withdrawal without mutating group state. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(groups): reject sole Pending owner ..."](https://github.com/saorsa-labs/x0x/commit/35ab5a7cecb740418a110e1a02965515e3390183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56167373)</sub>

<!-- /greptile_comment -->