### PR TITLE
fix(groups): reject NonMemberRequest on live-to-withdrawn (#369 follow-on)

### DIFF
--- a/src/groups/state_commit.rs
+++ b/src/groups/state_commit.rs
@@ -645,6 +645,17 @@ fn validate_live_to_withdrawn_authority(
         ));
     }
 
+    // NonMemberRequest is never withdrawal authority. Without this gate a
+    // Pending sole member-in-being (`active_signer_role` is `None`) would
+    // pass the sole-member carve-out below and then satisfy the ordinary
+    // `NonMemberRequest => signer_role.is_none()` arm, withdrawing the group.
+    if action_kind == ActionKind::NonMemberRequest {
+        return Err(ApplyError::Unauthorized {
+            signer: commit.committed_by.clone(),
+            action: ActionKind::NonMemberRequest.name(),
+        });
+    }
+
     // #369 / PR #370 review item 3: the sole member-in-being may terminalize
     // the group regardless of role — their withdrawal IS the entire (one
     // person) membership's unanimous decision. Any second member-in-being
@@ -1611,6 +1622,166 @@ mod tests {
         assert!(
             matches!(err, ApplyError::Unauthorized { .. }),
             "sole-member authority must not leak into ordinary admin acts"
+        );
+    }
+
+    #[test]
+    fn validate_apply_terminal_rejects_nmr_withdrawal_from_sole_pending_member() {
+        // The #369 follow-on hole: a sole Pending member-in-being has
+        // `active_signer_role == None`, so the #370 carve-out used to
+        // authorize their NonMemberRequest live withdrawal (the #375
+        // shrink: a Pending sole Owner withdrew the whole group).
+        let kp = AgentKeypair::generate().unwrap();
+        let signer_hex = hex::encode(kp.agent_id().as_bytes());
+        let mut members = BTreeMap::new();
+        let mut pending_owner = make_owner(&signer_hex);
+        pending_owner.state = GroupMemberState::Pending;
+        members.insert(signer_hex.clone(), pending_owner);
+
+        let commit = GroupStateCommit::sign(
+            "g1".into(),
+            2,
+            Some("current".into()),
+            "r".into(),
+            "p".into(),
+            "m".into(),
+            None,
+            true,
+            0,
+            &kp,
+        )
+        .unwrap();
+        let ctx = ApplyContext {
+            current_state_hash: "current",
+            current_revision: 1,
+            current_withdrawn: false,
+            members_v2: &members,
+            group_id: "g1",
+        };
+
+        let err = validate_apply_terminal(&ctx, &commit, ActionKind::NonMemberRequest).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ApplyError::Unauthorized { action, .. }
+                    if action == ActionKind::NonMemberRequest.name()
+            ),
+            "a pending sole member's NonMemberRequest must not withdraw the group: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_apply_terminal_rejects_nmr_withdrawal_from_sole_active_member() {
+        // NMR is never a withdraw kind for ANY rostered sole member-in-being
+        // (the apply oracle's `NonMemberRequest => false` arm). An Active
+        // sole Member was already rejected at the ordinary arm; the explicit
+        // gate keeps it rejected before the carve-out.
+        let kp = AgentKeypair::generate().unwrap();
+        let signer_hex = hex::encode(kp.agent_id().as_bytes());
+        let mut members = BTreeMap::new();
+        members.insert(
+            signer_hex.clone(),
+            make_member(&signer_hex, GroupRole::Member),
+        );
+
+        let commit = GroupStateCommit::sign(
+            "g1".into(),
+            2,
+            Some("current".into()),
+            "r".into(),
+            "p".into(),
+            "m".into(),
+            None,
+            true,
+            0,
+            &kp,
+        )
+        .unwrap();
+        let ctx = ApplyContext {
+            current_state_hash: "current",
+            current_revision: 1,
+            current_withdrawn: false,
+            members_v2: &members,
+            group_id: "g1",
+        };
+
+        let err = validate_apply_terminal(&ctx, &commit, ActionKind::NonMemberRequest).unwrap_err();
+        assert!(
+            matches!(err, ApplyError::Unauthorized { .. }),
+            "an active sole member's NonMemberRequest must not withdraw the group: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_apply_allows_nmr_non_terminal_from_sole_pending_member() {
+        // Closing the hole must not ban NMR outright: a sole Pending
+        // signer's ordinary (non-withdrawn) join-request commits keep
+        // passing `NonMemberRequest => signer_role.is_none()`.
+        let kp = AgentKeypair::generate().unwrap();
+        let signer_hex = hex::encode(kp.agent_id().as_bytes());
+        let mut members = BTreeMap::new();
+        let mut pending_owner = make_owner(&signer_hex);
+        pending_owner.state = GroupMemberState::Pending;
+        members.insert(signer_hex.clone(), pending_owner);
+
+        let commit = GroupStateCommit::sign(
+            "g1".into(),
+            2,
+            Some("current".into()),
+            "r".into(),
+            "p".into(),
+            "m".into(),
+            None,
+            false,
+            0,
+            &kp,
+        )
+        .unwrap();
+        let ctx = ApplyContext {
+            current_state_hash: "current",
+            current_revision: 1,
+            current_withdrawn: false,
+            members_v2: &members,
+            group_id: "g1",
+        };
+
+        validate_apply(&ctx, &commit, ActionKind::NonMemberRequest).unwrap();
+    }
+
+    #[test]
+    fn validate_apply_terminal_rejects_nmr_withdrawal_from_outsider() {
+        // The sole-member carve-out does not apply to signers outside the
+        // roster: their NonMemberRequest withdrawal is refused outright.
+        let kp = AgentKeypair::generate().unwrap();
+        let admin_hex = "ff".repeat(32);
+        let mut members = BTreeMap::new();
+        members.insert(admin_hex.clone(), make_member(&admin_hex, GroupRole::Admin));
+
+        let commit = GroupStateCommit::sign(
+            "g1".into(),
+            2,
+            Some("current".into()),
+            "r".into(),
+            "p".into(),
+            "m".into(),
+            None,
+            true,
+            0,
+            &kp,
+        )
+        .unwrap();
+        let ctx = ApplyContext {
+            current_state_hash: "current",
+            current_revision: 1,
+            current_withdrawn: false,
+            members_v2: &members,
+            group_id: "g1",
+        };
+
+        let err = validate_apply_terminal(&ctx, &commit, ActionKind::NonMemberRequest).unwrap_err();
+        assert!(
+            matches!(err, ApplyError::Unauthorized { .. }),
+            "an outsider's NonMemberRequest must not withdraw the group: {err}"
         );
     }
 

--- a/tests/proptest_groups.rs
+++ b/tests/proptest_groups.rs
@@ -1395,12 +1395,23 @@ proptest! {
             }
             if !current_withdrawn && commit_withdrawn {
                 if event_kind.allows_live_withdrawal() {
-                    let rejected_by_withdrawal_authority = matches!(
-                        result,
-                        Err(ApplyError::Unauthorized { action, .. })
-                            if action == ActionKind::AdminOrHigher.name()
+                    // Product names the action actually applied for
+                    // NonMemberRequest (including signer_spec = None →
+                    // "non-member-request"). Other rejected live
+                    // withdrawals stay Unauthorized without hardcoding
+                    // AdminOrHigher as the only accepted action name.
+                    let rejected_by_withdrawal_authority = match &result {
+                        Err(ApplyError::Unauthorized { action, .. }) => {
+                            action_kind != ActionKind::NonMemberRequest
+                                || *action == action_kind.name()
+                        }
+                        _ => false,
+                    };
+                    prop_assert!(
+                        rejected_by_withdrawal_authority,
+                        "rejected live withdrawal must be Unauthorized {{ action: {} }}; got {result:?}",
+                        action_kind.name()
                     );
-                    prop_assert!(rejected_by_withdrawal_authority);
                 } else {
                     prop_assert!(matches!(result, Err(ApplyError::Invariant(_))));
                 }
@@ -1644,5 +1655,54 @@ fn sole_admin_self_leave_routes_to_deletion_disposition() {
     assert!(
         SOLE_MEMBER_DELETE_STEPS.load(std::sync::atomic::Ordering::Relaxed) >= 1,
         "sole-member SelfLeave must reach the SoleMemberDelete branch"
+    );
+}
+
+/// Sole Owner/Active applying a live-withdrawal `GroupDeleted` commit as
+/// `NonMemberRequest` is rejected (`expected_ok = false`). Product names
+/// the action under test (`"non-member-request"`), not hardcoded
+/// `AdminOrHigher`.
+#[test]
+fn sole_owner_nonmember_request_live_withdrawal_is_unauthorized_for_action_kind() {
+    let keypairs = sequence_keypairs();
+    let signer = &keypairs[1];
+    let signer_spec = Some(member_spec(GroupRole::Owner, GroupMemberState::Active));
+    let action_kind = ActionKind::NonMemberRequest;
+    let event_kind = MetadataEventKind::GroupDeleted;
+    let current_withdrawn = false;
+    let commit_withdrawn = true;
+    let admin_present = false;
+
+    let mut apply_group = withdrawal_case_group(
+        &keypairs,
+        signer_spec.as_ref(),
+        current_withdrawn,
+        admin_present,
+    );
+    let before = state_snapshot(&apply_group);
+    let commit = craft_withdrawn_flag_commit(&apply_group, signer, commit_withdrawn, 11_000)
+        .expect("sign withdrawal flag commit");
+    let result = apply_withdrawn_flag_commit(&mut apply_group, &commit, action_kind, event_kind);
+    let expected_ok = expected_withdrawn_apply_authorized(
+        current_withdrawn,
+        commit_withdrawn,
+        signer_spec.as_ref(),
+        admin_present,
+        action_kind,
+        event_kind,
+    );
+
+    assert!(
+        !expected_ok,
+        "oracle must reject NonMemberRequest on a sole-member live withdrawal"
+    );
+    assert_eq!(state_snapshot(&apply_group), before);
+    assert!(
+        matches!(
+            result,
+            Err(ApplyError::Unauthorized { action, .. })
+                if action == ActionKind::NonMemberRequest.name()
+        ),
+        "product must name the action under test; got {result:?}"
     );
 }


### PR DESCRIPTION
## Problem

Follow-on to #370. The sole-member-in-being carve-out in `validate_live_to_withdrawn_authority` (`src/groups/state_commit.rs`) returned `Ok` for **any** sole member-in-being with no `action_kind` check. A **Pending** sole signer applying a live→withdrawn commit as `NonMemberRequest` was therefore authorized: `Pending` ⇒ `active_signer_role` is `None` ⇒ the carve-out passes and the ordinary `NonMemberRequest => signer_role.is_none()` arm succeeds, and the group withdraws.

The #370 apply oracle (`expected_withdrawn_apply_authorized`) already forbids this (`NonMemberRequest => false` for any rostered sole member); the product did not match it.

## Fix (design I1 — reject NMR, then carve-out)

Inside `validate_live_to_withdrawn_authority`, after the existing not-a-transition `Ok` and after the `allow_live_withdrawal` check:

```rust
if action_kind == ActionKind::NonMemberRequest {
    return Err(ApplyError::Unauthorized {
        signer: commit.committed_by.clone(),
        action: ActionKind::NonMemberRequest.name(),
    });
}
if signer_is_sole_member {
    return Ok(());
}
```

The existing `AdminOrHigher` / role check stays **after** both lines, so #369 SoleMemberDelete keeps working (`AdminOrHigher` / `MemberSelf` sole member-in-being still `Ok`). No fourth `ActionKind`; the conjunctive-skip variant was deliberately avoided (it leaves the Pending+NMR hole open via the ordinary arm).

Untouched, as required: `sole_member_in_being` (Pending keeps counting), `active_signer_role` / `is_active`, the non-withdrawn `NonMemberRequest => signer_role.is_none()` arm, `leave_disposition`, `seal_withdrawal` authoring, `enforce_last_admin_invariant`, ADR-0016 §3 / ADR-0031 routing, REST 409 strings, `GroupStateCommit` wire/revision/`withdrawn` encoding, and `src/network.rs` (#374).

## Tests

New deterministic units in `src/groups/state_commit.rs` (same fixture style as the existing terminal tests):

1. `validate_apply_terminal_rejects_nmr_withdrawal_from_sole_pending_member` — the hole itself (sole `Pending` Owner, the #375 shrink): withdrawn commit + NMR → `Unauthorized`, asserting the `"non-member-request"` action name.
2. `validate_apply_terminal_rejects_nmr_withdrawal_from_sole_active_member` — any rostered sole + NMR fails (Active Member case).
3. `validate_apply_allows_nmr_non_terminal_from_sole_pending_member` — NMR non-terminal authority stays (`validate_apply` + non-withdrawn → `Ok`).
4. `validate_apply_terminal_rejects_nmr_withdrawal_from_outsider` — foreign-signer roster + NMR + withdrawn → `Unauthorized`.

Kept green, unweakened: `validate_apply_terminal_allows_sole_member_in_being_non_admin` (#369 still holds), `validate_apply_terminal_rejects_non_admin_withdrawal`, `seal_withdrawal_allows_sole_member_regardless_of_role` (+ non-admin rejection half), all `leave_disposition_*` tests, and the last-admin sequence proptest `last_admin_generated_sequences_hold_on_rest_and_gossip_paths`.

Gates on the pushed tree: `cargo fmt --all` / `cargo clippy --all-features --all-targets -- -D warnings` / `cargo check --workspace --all-targets` all clean.

## Known: `withdrawal_flag_authority_matches_transition_oracle` stays red (pre-existing, #375 territory)

This proptest was **already failing on `main`** — verified by running it 5× on unmodified `e150786`: the minimal failing inputs are rostered sole signers (e.g. `Owner/Pending + NonMemberRequest` → product `Ok(())` vs oracle `expected_ok=false`, i.e. this hole). With this fix the `result.is_ok() == expected_ok` assertion now matches the oracle everywhere; the residual failure is only the error-shape `prop_assert` (asserts `AdminOrHigher.name()` while the product now names `"non-member-request"` for rejected NMR live-withdrawals — the explicit name this fix is required to use). Per the design, that assertion is intentionally **not** edited here and no nextest override is added; the test-only realignment belongs to #375, which rebases on top of this product fail-closed change.

No soak, no network test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes an authorization hole by rejecting NonMemberRequest as authority for live-to-withdrawn group transitions while retaining the sole-member carve-out for valid withdrawal actions.
- Adds the fail-closed action-kind check before sole-member authorization.
- Adds deterministic coverage for pending members, active members, outsiders, and preserved non-terminal requests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it narrows terminal withdrawal authority without disrupting any current legitimate caller.

The new rejection is reached only for live-to-withdrawn terminal validation using NonMemberRequest; current production terminal deletion uses AdminOrHigher, and ordinary join-request commits remain on the unaffected non-terminal path.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/groups/state_commit.rs | Adds a narrowly scoped terminal-withdrawal authorization gate and focused regression tests without affecting current non-terminal NonMemberRequest paths. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(groups): reject NonMemberRequest on ..."](https://github.com/saorsa-labs/x0x/commit/57014dedf97b65d565d6c85eca3e0362a07f26f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55506650)</sub>

**Context used:**

- Knowledge Base — [Groups: Membership, Discovery, and State Commits](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/groups-messaging.md)

<!-- /greptile_comment -->