### PR TITLE
chore(release): v0.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.39.2] - 2026-08-22
+
 ### Fixed
 
+- **Desktop/NAT'd daemons no longer leak ~1 GB/h of RSS (issue #368; ant-quic
+  0.27.44).** An ant-quic connection left open with no reader task retained every
+  inbound stream chunk in its receive assembler — pinning whole datagrams, up to
+  the 16 MiB window per connection, for as long as the remote kept the connection
+  alive. Orphans were created on reader exit in the `Closing`/`Closed` lifecycle
+  arms and by re-promoting readerless superseded survivors; connection churn
+  (NAT'd peers redialling, peers dying without close) manufactured them, which is
+  why desktops bled ~1 GB/h while public VPS nodes trickled ~50 MB/h on the same
+  code. ant-quic 0.27.44 enforces "no reader ⇒ close" at promotion and reader
+  exit, with a 5 s janitor backstop. Proven with an identical LAN-churn run before
+  and after: the pinned-datagram heap signature (1.25 KB + 48 B classes climbing
+  1:1) is gone and unread streams drain. This was also the terminal cause of the
+  studio "UDP black-hole" (#312). Residual reader-throughput sawtooth tracked in #378.
 - **Inbound accept no longer emits `PeerConnected` after a suppression
   tombstone lands (issue #292 invariant D).** `accept()` can yield before
   `PolicyRejection` and then await cache bookkeeping; the admit path now
@@ -14,6 +29,21 @@ All notable changes to this project will be documented in this file.
   concurrent reject cannot sneak into that window. The refuse path still
   uses a plain transport close (no `suppress_reconnect`, invariant F).
   `is_connected` stays transport-only.
+
+### Added
+
+- **`GET /diagnostics/transport` and `x0x diagnostics transport` (#373).**
+  ant-quic connection accounting: active vs proto-open connections, successful /
+  failed / inbound / outbound / replaced generations, buffered send/receive bytes,
+  unread streams, and `orphan_connections_closed` — the #368 janitor signature.
+- **Shutdown watchdog (#371 interim).** `x0xd` force-exits 5 s after SIGTERM if the
+  runtime does not wind down (the saorsa-gossip IHAVE flusher has no shutdown
+  handle — saorsa-gossip #42 tracks the proper fix).
+
+### Dependencies
+
+- **ant-quic 0.27.41 → 0.27.44.** 0.27.42/0.27.43 add `#[doc(hidden)]`
+  connection-accounting and buffered-bytes accessors; 0.27.44 is the #368 fix.
 
 ## [v0.39.1] - 2026-08-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.1"
+version = "0.39.2"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.1
+version: 0.39.2
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Ships the #368 fix to the fleet: ant-quic 0.27.44 (readerless open connections pinned every inbound datagram — ~1 GB/h on NAT'd desktops, the terminal cause of the #312 UDP black-hole), plus `/diagnostics/transport` + `x0x diagnostics transport` (#373), the #371 interim shutdown watchdog, and the #374 inbound-admit race fix.

Proof of the fix (identical LAN-churn run, MallocStackLogging sidecar, two independent samplers) is on #368.

Merge → tag `v0.39.2` → release workflow → fleet self-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the project and skill metadata for the v0.39.2 release and documents the transport memory fix, diagnostics, shutdown watchdog, and inbound-admission race fix.
- Bumps Cargo and skill versions from 0.39.1 to 0.39.2.
- Adds the dated v0.39.2 changelog section.
- Records the ant-quic 0.27.44 dependency and associated transport fixes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with its release metadata synchronized and no actionable defects identified.

The changed package and skill versions agree, the release tooling validates that agreement against the tag, and the documented release features are present in the source being packaged.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds release notes for v0.39.2; the investigated user-visible claims are consistent with the release source. |
| Cargo.toml | Bumps the package version to 0.39.2 while retaining the ant-quic 0.27.44 dependency requirement. |
| SKILL.md | Synchronizes the published skill metadata with package version 0.39.2. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.2"](https://github.com/saorsa-labs/x0x/commit/99c3e76cb85fb479291defed234526b218a7f0d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55782663)</sub>

<!-- /greptile_comment -->