### PR TITLE
feat(diagnostics): transport GUI card + docs parity (#368)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1167,6 +1167,7 @@ All diagnostics endpoints require the normal local daemon bearer token and retur
 | GET | `/diagnostics/connectivity` | `x0x diagnostics connectivity` | ant-quic NodeStatus snapshot (UPnP, NAT, relay, mDNS) |
 | GET | `/diagnostics/ack` | `x0x diagnostics ack` | ACK-v2 per-stage latency buckets and outcome counters |
 | GET | `/diagnostics/gossip` | `x0x diagnostics gossip` | PubSub drop-detection counters (publish/deliver deltas) |
+| GET | `/diagnostics/transport` | `x0x diagnostics transport` | Transport connection accounting (zombie-connection hunt, #368) |
 | GET | `/diagnostics/dm` | `x0x diagnostics dm` | Direct-message send/receive counters, per-peer health, and last durable-send stage timers (`last_durable_send`, `last_ack_publish_ms`) |
 | GET | `/diagnostics/groups` | `x0x diagnostics groups` | Per-group ingest counters, listener state, and drop buckets |
 | GET | `/diagnostics/exec` | `x0x diagnostics exec` | Remote exec counters, warnings, active sessions, and ACL summary |

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,6 +50,7 @@ token (`Authorization: Bearer …`). The token is auto-discovered from
 | GET | `/diagnostics/gossip` | `x0x diagnostics gossip` | PubSub drop-detection counters |
 | GET | `/diagnostics/dm` | `x0x diagnostics dm` | DM send/receive counters, per-peer health, and last durable-send stage timers |
 | GET | `/diagnostics/groups` | `x0x diagnostics groups` | Per-group ingest counters and drop buckets |
+| GET | `/diagnostics/transport` | `x0x diagnostics transport` | Transport connection accounting: active conns, x0x peers, churn lifecycle, orphan closes, buffered bytes (#368) |
 | GET | `/diagnostics/exec` | `x0x diagnostics exec` | Remote-exec counters, warnings, ACL summary |
 | POST | `/peers/:peer_id/probe` | `x0x peer probe` | Active liveness + RTT probe (ant-quic) |
 | GET | `/peers/:peer_id/health` | `x0x peer health` | Connection health snapshot |

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -3059,6 +3059,16 @@ function renderNetwork(){
     </div>
     <div id="g-note" style="margin-top:var(--sp2);color:var(--tx2);font-size:11px"></div>
   </div>
+  <div class="card mb2" id="n-transport-card" style="font-size:12px">
+    <div class="grid g2" style="gap:var(--sp3)">
+      <div><span class="k">QUIC open</span>: <span id="t-open" class="v">—</span></div>
+      <div><span class="k">Active conns</span>: <span id="t-active" class="v">—</span></div>
+      <div><span class="k">x0x peers</span>: <span id="t-x0x" class="v">—</span></div>
+      <div><span class="k">Orphan closes</span>: <span id="t-orphan" class="v">—</span></div>
+      <div><span class="k">Send unacked (B)</span>: <span id="t-sunack" class="v">—</span></div>
+      <div><span class="k">Recv buffered (B)</span>: <span id="t-rbuf" class="v">—</span></div>
+    </div>
+  </div>
   <h3>Subsystem Diagnostics</h3>
   <div class="grid g2 mb2" style="gap:var(--sp3)">
     <div class="card">
@@ -3292,6 +3302,17 @@ async function pollNetworkView(){
     if(el)el.textContent='Cached peers: '+(c.cached_peers||0);
   }
   // Gossip pipeline drop-detection counters (release 0.18.0+).
+  const gt=await api('/diagnostics/transport');
+  if(gt&&gt.ok){
+    const t=gt.transport||{};
+    const sg=id=>document.getElementById(id);
+    if(sg('t-open'))sg('t-open').textContent=t.quic_open_connections??'—';
+    if(sg('t-active'))sg('t-active').textContent=t.active_connections??'—';
+    if(sg('t-x0x'))sg('t-x0x').textContent=t.x0x_visible_peers??'—';
+    if(sg('t-orphan'))sg('t-orphan').textContent=t.orphan_connections_closed??'—';
+    if(sg('t-sunack'))sg('t-sunack').textContent=t.send_unacked_bytes??'—';
+    if(sg('t-rbuf'))sg('t-rbuf').textContent=t.recv_buffered_bytes??'—';
+  }
   const gg=await api('/diagnostics/gossip');
   if(gg&&gg.ok&&gg.stats){
     const s=gg.stats;


### PR DESCRIPTION
Rescue of the #368 parity sweep from `fix/368-destructive-cooldown` (cherry-pick of d0efc75, deduped against main).

## Surfaces
- **CLI**: already shipped on main via #373 (443e823) — `x0x diagnostics transport` works live on 0.39.2. Duplicate fn/match-arm/enum variant from d0efc75 dropped in favor of main's versions; no CLI change in this PR.
- **GUI** (net-new): transport connection-accounting card in x0x-gui.html — QUIC open, active conns, x0x peers, orphan closes, send-unacked / recv-buffered bytes, with live JS fetch.
- **Docs** (net-new): `docs/api.md` table row + `docs/api-reference.md` row with CLI name for `/diagnostics/transport`.
- **api-manifest + api_coverage test**: also already on main via #373 (282e836 cherry-pick came back empty); verified present.

## Notes
- The data_tx/data_rx fix bundled into d0efc75 was worktree-local damage and is NOT needed on main.
- ant-quic 0.27.44 pin (1c8b745) skipped — main already pins it.

## Gate
fmt / clippy (-D warnings, all targets/features) / build / doc / audit / deny green. Tests: 2759/2759 pass; `upgrade::restart::tests::addr_is_free_probes_loopback_for_unspecified_bind` excluded — pre-existing macOS failure (std sets SO_REUSEADDR, so loopback bind over a wildcard bind succeeds on Darwin); fails identically on clean origin/main c2745d7.

Do not merge yet — review requested.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds transport connection-accounting diagnostics to the embedded GUI and documents the existing endpoint and CLI command. Major changes:
- Adds a Network-view card for QUIC connections, visible peers, orphan closes, and buffered-byte counters.
- Polls `/diagnostics/transport` and maps its snapshot into the new card.
- Adds `/diagnostics/transport` to both API documentation tables.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking polling concern where a slow transport request can delay unrelated diagnostics cards.

The documented endpoint and GUI response mapping agree with the server contract, while the only accepted concern is avoidable serial coupling between otherwise independent diagnostics requests.

**Files Needing Attention:** src/gui/x0x-gui.html

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/gui/x0x-gui.html | Adds a correctly mapped transport card, but its serial fetch can delay unrelated diagnostics refreshes. |
| docs/api-reference.md | Correctly adds the existing transport diagnostics endpoint and CLI command to the detailed API table. |
| docs/api.md | Correctly adds the transport diagnostics endpoint and its principal counters to the concise API table. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Timer as Network poll timer
  participant GUI as pollNetworkView
  participant Transport as /diagnostics/transport
  participant Gossip as /diagnostics/gossip
  participant Other as ACK/DM/Groups/Exec
  Timer->>GUI: poll every 5 seconds
  GUI->>Transport: await request
  Transport-->>GUI: transport snapshot
  GUI->>Gossip: await request
  Gossip-->>GUI: gossip snapshot
  GUI->>Other: refresh concurrently
  Other-->>GUI: subsystem snapshots
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/gui/x0x-gui.html:3305
**Transport fetch gates other diagnostics**

The new transport request is awaited before the gossip and subsystem-diagnostics refreshes, so a slow or non-responsive `/diagnostics/transport` request leaves those unrelated cards stale and repeated timer ticks accumulate overlapping polls. Fetch this optional diagnostic independently or concurrently so it cannot block the rest of the Network view.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(diagnostics): GUI transport card + ..."](https://github.com/saorsa-labs/x0x/commit/bfcc7dc0648ce5b24ba2ce120971df5dae5d11ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55866190)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Add transport diagnostics and a shutdown watchdog](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/reverts/incident-mitigation_373-20260821-transport-watchdog-443e823.md)

<!-- /greptile_comment -->