### PR TITLE
chore(release): v0.39.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.39.3] - 2026-08-22
+
+### Added
+
+- **GUI: transport connection-accounting card** on the embedded dashboard
+  (QUIC open / active connections / x0x peers / orphan closes / send-unacked /
+  recv-buffered bytes), fed live from `GET /diagnostics/transport` (#368, #381).
+
+### Docs
+
+- `docs/api.md` and `docs/api-reference.md` now list `GET /diagnostics/transport`,
+  closing the registry↔docs parity gap left by v0.39.2 (#381).
+
+### Known issues
+
+- Durable (ADR-0030 default) direct sends can fail with `504 budget_stage=publish_ms`
+  or a false `409 recipient_ack_semantics_unavailable` between directly connected
+  desktops when the gossip plane is in a GRAFT/PRUNE storm; `--no-durable-ack`
+  (raw QUIC) is unaffected. Tracked in #380.
+
 ## [v0.39.2] - 2026-08-22
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.2"
+version = "0.39.3"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.2
+version: 0.39.3
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Version bump 0.39.2 → 0.39.3: GUI transport card + docs parity (#381). Known issue #380 recorded in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates release metadata from v0.39.2 to v0.39.3 and documents the transport diagnostics dashboard work and known durable-send issue.
- Bumps the package version in Cargo.toml.
- Keeps SKILL.md metadata aligned with the package release.
- Adds the v0.39.3 changelog entry covering the GUI transport card, API documentation parity, and known issue #380.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with consistent release metadata and release notes supported by the included commit history.

The version values agree across release metadata, the repository does not require a committed Cargo.lock, and the changelog accurately describes functionality and documentation present in v0.39.3.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds accurate v0.39.3 release notes for transport diagnostics UI/docs changes and the acknowledged durable-send issue. |
| Cargo.toml | Bumps the package version to 0.39.3 consistently with the release metadata. |
| SKILL.md | Updates the published skill metadata version to 0.39.3. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.3"](https://github.com/saorsa-labs/x0x/commit/f10cb9b59eab09a24c8c3a2557f8ad2ea13f6251) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55892373)</sub>

<!-- /greptile_comment -->