### PR TITLE
chore(release): v0.39.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.39.4] - 2026-08-23
+
 ### Fixed
 
 - **tests/e2e_full_audit.sh modernised to the current API contract** (#383):

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.3"
+version = "0.39.4"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.3
+version: 0.39.4
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Version bump 0.39.3 → 0.39.4: API-unserved watchdog (#387), x0xd-443 own identity + ignored-config-key warning (#386), e2e_full_audit modernised (#388).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prepares the v0.39.4 release by synchronizing package metadata and cutting the existing unreleased changelog entries into a dated release.
- Bumps the Cargo package version from 0.39.3 to 0.39.4.
- Synchronizes the version in SKILL.md.
- Adds the v0.39.4 changelog heading for the watchdog, identity, and configuration-warning changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or release-metadata issues identified.

The package and skill versions are synchronized, and the new changelog section accurately groups the changes described for v0.39.4.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the package version to 0.39.4 consistently with the repository’s other release metadata. |
| SKILL.md | Synchronizes the skill frontmatter version with Cargo.toml at 0.39.4. |
| CHANGELOG.md | Cuts the existing unreleased entries into a conventionally formatted v0.39.4 section dated 2026-08-23. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.4"](https://github.com/saorsa-labs/x0x/commit/e6dd3321b410fbfbe2c00b473fbf7e19054c0bdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55984538)</sub>

<!-- /greptile_comment -->