### PR TITLE
chore(deps): ant-quic 0.27.45 — #378 fixes A+C (reader survives stream errors; concurrent uni reads)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **ant-quic 0.27.44 → 0.27.45 (#378 fixes A+C).** Stream-scoped read errors no longer kill a
+  connection's reader (ant-quic#259: skip + `stream_read_errors_survived` counter), and uni
+  streams are read concurrently under a 64-permit per-connection budget with a 60 s per-stream
+  deadline (ant-quic#260) — removes the reader head-of-line blocking behind one stalled sender.
+
 ### Fixed
 
 - **Receive pump never blocks (ADR 0033, amends ADR 0009; issue #378 fix D).** The single

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.44"
+ant-quic = "0.27.45"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
ant-quic 0.27.44→0.27.45: #255 fixes A (stream-scoped read errors skip+count instead of killing the reader) and C (bounded concurrent per-stream uni reads, 64-permit budget, 60 s deadline). Completes the A–D set with #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates ant-quic from 0.27.44 to 0.27.45 and documents the upstream stream-reader reliability and concurrency improvements.
- Isolates stream-scoped read errors so they do not terminate the connection reader.
- Adds bounded concurrent uni-stream reads with a per-connection permit budget and per-stream deadline.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking issues identified.

The dependency bump and matching changelog entry introduce no established build incompatibility, broken repository contract, or reachable transport regression.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps ant-quic to 0.27.45; no concrete compatibility or runtime defect was established. |
| CHANGELOG.md | Documents the dependency update and its stream error-handling and concurrency behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): ant-quic 0.27.45 — #378 fix..."](https://github.com/saorsa-labs/x0x/commit/750294fc00c46c251b04bbd3735b800d56d5514d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56087669)</sub>

<!-- /greptile_comment -->