### PR TITLE
chore(release): v0.39.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.39.5] - 2026-08-24
+
 ### Changed
 
 - **ant-quic 0.27.44 → 0.27.45 (#378 fixes A+C).** Stream-scoped read errors no longer kill a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.4"
+version = "0.39.5"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.4
+version: 0.39.5
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Version bump 0.39.4 → 0.39.5: the #378/#380 transport fix set (ant-quic 0.27.45 #393, receive-pump ADR-0033 + stream budget #392; sg 0.5.73 was in 0.39.4's successor commits). Desktop soak numbers on #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prepares the v0.39.5 release by synchronizing package and skill metadata and finalizing the transport-related changelog entries.
- Bumps the Cargo package version from 0.39.4 to 0.39.5.
- Synchronizes the version in `SKILL.md`.
- Adds the v0.39.5 changelog heading for the ant-quic and receive-pump fixes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with release versions synchronized and no actionable failures identified.

The changes are limited to consistent release metadata and changelog organization, and the repository’s release and build conventions do not reveal a broken contract.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the package version to 0.39.5; it remains synchronized with the skill metadata. |
| SKILL.md | Updates the declared skill version to match the Cargo package. |
| CHANGELOG.md | Finalizes the existing transport-fix notes under a conventionally formatted v0.39.5 release heading. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.5"](https://github.com/saorsa-labs/x0x/commit/e4059fbca1079b4d3653c5ca8ed801c29c758cb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56092530)</sub>

<!-- /greptile_comment -->