### PR TITLE
fix(connect): dial by PeerId everywhere a PeerId is known — unlock punch/relay ladder (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **NAT traversal was unreachable: hot connect paths dialled by address, discarding known
+  PeerIds (issue #398).** ant-quic's direct→hole-punch→MASQUE-relay ladder only engages on
+  peer-authenticated dials; announcement auto-connect, eager-set reconnect and both send-path
+  reconnect branches dialled bare addresses, so NATed desktop↔desktop pairs never punched,
+  never relayed (`nat_traversal_attempts` was 0 on every desktop) and the auto-connect loop
+  re-dialled remote private addresses forever. All four sites now use
+  `connect_peer_with_addrs(peer_id, addrs)`; bootstrap dials (no prior PeerId) are unchanged.
+
 ## [v0.39.5] - 2026-08-24
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7325,30 +7325,40 @@ impl Agent {
                                 .insert(announcement.agent_id, std::time::Instant::now());
                             let net = std::sync::Arc::clone(net);
                             let addresses = auto_connect_addresses.clone();
+                            let target_machine = announcement.machine_id;
                             tokio::spawn(async move {
-                                for addr in &addresses {
-                                    // #292: the spawned dial still passes
-                                    // through the dial gate — the cheap
-                                    // `announcement_should_auto_connect`
-                                    // check above can race a tombstone that
-                                    // lands after it.
-                                    match net
-                                        .connect_addr_with_origin(*addr, "announcement")
-                                        .await
-                                    {
-                                        Ok(_) => {
-                                            tracing::info!(
-                                                "Auto-connected to discovered agent at {addr}",
-                                            );
-                                            return;
-                                        }
-                                        Err(e) => {
-                                            tracing::debug!("Auto-connect to {addr} failed: {e}",);
-                                        }
+                                // #398: dial by PeerId, not by address. The
+                                // announcement carries the target's machine id
+                                // (= ant-quic PeerId); an address-only dial
+                                // skips ant-quic's HolePunching and Relay
+                                // stages entirely ("hole-punch requires the
+                                // target's PeerId"), which left NATed
+                                // desktop↔desktop pairs permanently
+                                // unreachable while this loop re-dialled their
+                                // private addresses forever. `connect_peer_with_addrs`
+                                // still passes the #292 dial gate and errors
+                                // on identity mismatch.
+                                match net
+                                    .connect_peer_with_addrs(
+                                        ant_quic::PeerId(target_machine.0),
+                                        addresses.clone(),
+                                    )
+                                    .await
+                                {
+                                    Ok((addr, _)) => {
+                                        tracing::info!(
+                                            "Auto-connected to discovered agent at {addr}",
+                                        );
+                                        return;
+                                    }
+                                    Err(e) => {
+                                        tracing::debug!(
+                                            "Auto-connect via peer-authenticated dial failed: {e}",
+                                        );
                                     }
                                 }
                                 tracing::debug!(
-                                    "Auto-connect exhausted all {} addresses for discovered agent",
+                                    "Auto-connect failed across all {} candidate addresses",
                                     addresses.len(),
                                 );
                             });

--- a/src/network.rs
+++ b/src/network.rs
@@ -2316,11 +2316,17 @@ impl NetworkNode {
                     });
                 };
 
-                match tokio::time::timeout(PRE_SEND_RECONNECT_TIMEOUT, self.connect_addr(addr))
-                    .await
+                // #398: peer-authenticated dial so a NATed peer can be
+                // re-reached via the punch/relay ladder instead of a doomed
+                // direct dial to a stale address.
+                match tokio::time::timeout(
+                    PRE_SEND_RECONNECT_TIMEOUT,
+                    self.connect_peer_with_addrs(*peer_id, vec![addr]),
+                )
+                .await
                 {
-                    Ok(Ok(connected_peer)) if connected_peer == *peer_id => Ok(()),
-                    Ok(Ok(connected_peer)) => Err(NetworkError::ConnectionFailed(format!(
+                    Ok(Ok((_, connected_peer))) if connected_peer == *peer_id => Ok(()),
+                    Ok(Ok((_, connected_peer))) => Err(NetworkError::ConnectionFailed(format!(
                         "peer refresh at {addr} connected to unexpected peer {:?}",
                         connected_peer
                     ))),
@@ -2339,11 +2345,15 @@ impl NetworkNode {
                     return Err(cache_err);
                 };
 
-                match tokio::time::timeout(PRE_SEND_RECONNECT_TIMEOUT, self.connect_addr(addr))
-                    .await
+                // #398: peer-authenticated dial (see branch above).
+                match tokio::time::timeout(
+                    PRE_SEND_RECONNECT_TIMEOUT,
+                    self.connect_peer_with_addrs(*peer_id, vec![addr]),
+                )
+                .await
                 {
-                    Ok(Ok(connected_peer)) if connected_peer == *peer_id => Ok(()),
-                    Ok(Ok(connected_peer)) => Err(NetworkError::ConnectionFailed(format!(
+                    Ok(Ok((_, connected_peer))) if connected_peer == *peer_id => Ok(()),
+                    Ok(Ok((_, connected_peer))) => Err(NetworkError::ConnectionFailed(format!(
                         "peer refresh at {addr} connected to unexpected peer {:?}",
                         connected_peer
                     ))),
@@ -4558,13 +4568,18 @@ impl saorsa_gossip_transport::GossipTransport for NetworkNode {
             return Ok(());
         }
 
-        // Connect by address
-        let connected_peer = self
-            .connect_addr_with_origin(addr, "eager_set")
+        // #398: peer-authenticated dial. Dialling by bare address skipped
+        // ant-quic's HolePunching/Relay stages (they require the target's
+        // PeerId), so an eager-set peer behind a NAT could never be
+        // re-reached. `connect_peer_with_addrs` runs the full
+        // direct→punch→relay ladder and errors on identity mismatch.
+        let (_, connected_peer) = self
+            .connect_peer_with_addrs(ant_peer, vec![addr])
             .await
             .map_err(|e| anyhow::anyhow!("dial failed: {}", e))?;
 
-        // Verify we connected to the expected peer
+        // Defence in depth: connect_peer_with_addrs already refuses a
+        // mismatched identity; keep the check as an invariant guard.
         if connected_peer != ant_peer {
             warn!(
                 "SECURITY: Peer mismatch - expected {:?}, got {:?}",


### PR DESCRIPTION
Primary fix for #398 (fix 1 of the agreed ranked list; companion ant-quic PR for fixes 2+3 in flight by omp). Address-only dials skip ant-quic's HolePunching/Relay stages by design; x0x's hot paths had PeerIds and threw them away. Proof target after the ant-quic half lands: `nat_traversal_attempts > 0` on a NATed desktop and no more eternal re-dials of remote private addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes connection paths that already know a machine PeerId to use peer-authenticated dialing, enabling ant-quic’s NAT traversal ladder instead of address-only attempts.

- Updates announcement auto-connect and eager-set reconnects to retain the known PeerId.
- Updates both pre-send fallback branches to use authenticated peer dialing.
- Documents the NAT traversal correction in the changelog.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking concern that the pre-send fallback may not give the newly enabled traversal ladder enough time to complete.

Peer identity binding and reconnect suppression remain intact, but the send-repair path now places a multi-stage authenticated dial inside the three-second timeout previously used for an address-only attempt.

**Files Needing Attention:** src/network.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib.rs | Announcement auto-connect now retains the verified machine PeerId and delegates all filtered address candidates to authenticated dialing. |
| src/network.rs | Eager-set and pre-send reconnects now use authenticated dialing, but the pre-send fallbacks retain a potentially undersized three-second timeout around the expanded traversal ladder. |
| CHANGELOG.md | Documents the affected connection paths and the intended restoration of hole-punch and relay traversal. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Known PeerId and address hints] --> B[Peer-authenticated dial]
  B --> C{Direct path succeeds?}
  C -->|Yes| D[Authenticated QUIC connection]
  C -->|No| E[Hole-punch attempt]
  E -->|Succeeds| D
  E -->|Fails| F[Relay fallback]
  F -->|Succeeds| D
  F -->|Fails| G[Connection error]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/network.rs:2323-2326
**Three-second traversal timeout**

If a NATed peer requires hole punching or relay after its direct address fails, this fallback runs the complete peer-authenticated dial ladder under the existing three-second timeout. That budget is shorter than authenticated dial budgets elsewhere and can end pre-send repair with `AgentNotConnected` before later traversal stages complete.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(connect): dial by PeerId everywhere ..."](https://github.com/saorsa-labs/x0x/commit/5b629a420557d624b59266009aa05214cebaa250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56205307)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Peer networking and connectivity](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/peer-networking.md)
- Knowledge Base — [Peer presence, bootstrap, and rendezvous](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/peer-presence-and-rendezvous.md)
- Knowledge Base — [Gossip runtime and wire protocol](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/gossip-runtime.md)
</details>


<!-- /greptile_comment -->