### PR TITLE
chore(deps): ant-quic 0.27.46 — candidate seeding + honest traversal counters (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **ant-quic 0.27.45 → 0.27.46 (#398/#262).** Connection-local NAT candidates are now seeded at
+  traversal start (candidate pairs / path migration reachable for the first time) and traversal
+  counters are honest (attempts on session start; successes per TraversalMethod; new
+  holepunched_connections). Together with #399's dial-by-PeerId this makes the
+  direct→hole-punch→relay ladder reachable end-to-end.
+
 ### Fixed
 
 - **NAT traversal was unreachable: hot connect paths dialled by address, discarding known

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.45"
+ant-quic = "0.27.46"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
ant-quic 0.27.45→0.27.46 (#262 fixes 2+3 via ant-quic#263). With #399 merged, the punch/relay ladder is now reachable end-to-end from x0x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates ant-quic from 0.27.45 to 0.27.46 to enable connection-local NAT candidate seeding and correct traversal metrics.
- Raises the ant-quic dependency requirement to 0.27.46.
- Documents the newly reachable direct, hole-punch, and relay connection ladder and revised counters.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the dependency bump or changelog update.

The manifest resolves ant-quic at or above 0.27.46 without a stale checked-in lockfile, and no evidence indicates that the release breaks the APIs used by x0x.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the ant-quic dependency requirement to 0.27.46; no concrete compatibility or resolution defect was identified. |
| CHANGELOG.md | Documents the dependency bump and its NAT traversal and metrics behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): ant-quic 0.27.46 — candidat..."](https://github.com/saorsa-labs/x0x/commit/6402e4c22a5d1415a8b324dba3067fac936a243b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56230018)</sub>

**Context used:**

- Knowledge Base — [Peer networking and connectivity](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/peer-networking.md)

<!-- /greptile_comment -->