### PR TITLE
chore(deps): ant-quic 0.27.47 — capability honesty + relay engagement (#398)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["proofs/**", "tests/proof-reports/**", "target/**"]
 
 [dependencies]
 anyhow = "1.0"
-ant-quic = "0.27.46"
+ant-quic = "0.27.47"
 saorsa-mls = "0.3.8"
 async-trait = "0.1"
 bincode = "1.3"


### PR DESCRIPTION
ant-quic 0.27.46→0.27.47 (#264 capability honesty + #265 relay engagement). Completes the #398 fix set with #399/#400/#401.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the ant-quic dependency requirement from 0.27.46 to 0.27.47 to incorporate capability-advertisement and relay-engagement fixes.
- Bumps the ant-quic patch version in Cargo.toml.

<h3>Confidence Score: 5/5</h3>

The dependency-only change appears safe to merge, with no concrete blocking or non-blocking defects identified.

The manifest changes only the ant-quic patch-level requirement, and the reviewed repository usage provides no evidence of an incompatible API, broken configuration, or reachable connectivity regression.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates ant-quic from 0.27.46 to 0.27.47; no concrete compatibility or correctness issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): ant-quic 0.27.47 — capabili..."](https://github.com/saorsa-labs/x0x/commit/4ebff00d820e522c7b6295372087f650b6f2e89f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56381243)</sub>

<!-- /greptile_comment -->