### PR TITLE
chore(release): v0.39.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.39.6] - 2026-08-24
+
+### Changed
+
+- **ant-quic 0.27.45 -> 0.27.47 (#398).** Capability honesty (inbound accepts no longer grant
+  relay/coordinator capability) and MASQUE relay engagement (custom strategy authoritative; the
+  punch stage reserves a relay budget slice so the last line always runs; first runtime relay
+  e2e proof). Completes the 100%-connectable fix set with #399/#400/#401.
+
 ### Fixed
 
 - **Discovery-cache hygiene: dead peers no longer live forever (issue #398).** Two causes fixed:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.5"
+version = "0.39.6"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.5
+version: 0.39.6
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Version bump 0.39.5 -> 0.39.6: the #398 100%-connectable fix set.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the project’s release metadata from v0.39.5 to v0.39.6 for the 100%-connectable fix set.
- Bumps the crate and skill metadata to v0.39.6.
- Adds the v0.39.6 changelog heading and summarizes the ant-quic update.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with consistent release metadata and changelog contents.

The authoritative version declarations agree on 0.39.6, and the changelog entries grouped into the release correspond to changes in its commit ancestry.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the authoritative crate version to 0.39.6 consistently with the release metadata. |
| SKILL.md | Bumps the skill frontmatter version to 0.39.6, matching Cargo.toml. |
| CHANGELOG.md | Adds the v0.39.6 release section and correctly groups the changes included since v0.39.5. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.6"](https://github.com/saorsa-labs/x0x/commit/cd76d49fafa9812b8ee15077ef6f4591ba8ba30f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56395244)</sub>

<!-- /greptile_comment -->