### PR TITLE
feat(diagnostics): surface holepunched_connections on /diagnostics/transport (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`holepunched_connections` surfaced on `GET /diagnostics/transport` (#398).** ant-quic
+  0.27.47'''s honest-counter scheme counts coordinated hole-punch outcomes separately from the
+  aggregate `nat_traversal_successes`; the hand-mapped transport snapshot now passes it through.
+
 ## [v0.39.6] - 2026-08-24
 
 ### Changed

--- a/src/network.rs
+++ b/src/network.rs
@@ -743,6 +743,11 @@ pub struct TransportDiagnosticsSnapshot {
     /// Cumulative NAT traversal attempts / successes.
     pub nat_traversal_attempts: u64,
     pub nat_traversal_successes: u64,
+    /// Connections established via coordinated hole-punch (ant-quic 0.27.47
+    /// honest-counter scheme, #398): unlike `nat_traversal_successes` this
+    /// counts only TraversalMethod::HolePunch/PortPrediction outcomes.
+    #[serde(default)]
+    pub holepunched_connections: u64,
     /// Cumulative direct (no relay/coordinator) connections.
     pub direct_connections: u64,
     /// Cumulative relayed connections.
@@ -811,6 +816,7 @@ impl TransportDiagnosticsSnapshot {
             failed_connections: stats.failed_connections,
             nat_traversal_attempts: stats.nat_traversal_attempts,
             nat_traversal_successes: stats.nat_traversal_successes,
+            holepunched_connections: stats.holepunched_connections,
             direct_connections: stats.direct_connections,
             relayed_connections: stats.relayed_connections,
             connected_bootstrap_nodes: u64::try_from(stats.connected_bootstrap_nodes)


### PR DESCRIPTION
Surfaces ant-quic 0.27.47's `holepunched_connections` in the hand-mapped transport snapshot (#398 follow-up a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the ant-quic `holepunched_connections` counter to the transport diagnostics snapshot and documents the new API field.
- Defaults the field during deserialization for backward compatibility.
- Maps the upstream transport statistic into `GET /diagnostics/transport`.
- Records the addition in the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, compatibility, or security issues identified.

The new defaulted snapshot field is initialized from the corresponding transport statistic and is automatically included by the endpoint’s existing whole-snapshot serialization path.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/network.rs | Adds and populates the defaulted hole-punched connection counter without disrupting snapshot construction or generic JSON serialization. |
| CHANGELOG.md | Documents the newly exposed diagnostics counter and its distinction from aggregate NAT traversal successes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(diagnostics): surface holepunched\_c..."](https://github.com/saorsa-labs/x0x/commit/6745b7ff1d7c2cdfcf49f397ff48cffca91a8876) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56431575)</sub>

<!-- /greptile_comment -->