### PR TITLE
fix(announce): role flags honest — capability requires plausibly-public reachability (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Announcement role honesty (#398 follow-up b).** x0x's machine/identity
+  announcements advertised `is_coordinator: true, is_relay: true` for every
+  node — `relay_service_enabled`/`coordinator_service_enabled` are true on all
+  default daemons (the local MASQUE server always runs), so NATed desktops
+  with zero third-party reachability claimed both roles, and coordinator/relay
+  selection then picked nodes that cannot serve anyone. The flags are now
+  gated on plausibly-public reachability AND the service:
+  peer-verified inbound at global scope (`direct_reachability_scope == Global`
+  — an OBSERVED reflexive address alone is NOT proof), or an active router
+  port mapping (UPnP listener-bound), or explicit operator opt-in
+  (`--relay`/`--relay-opt-in` flag or `X0X_RELAY_OPT_IN=1` — the escape hatch
+  for manually port-forwarded hosts). A NATed default daemon now announces
+  false for both.
+
+## [Unreleased]
+
 ## [v0.39.6] - 2026-08-24
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1591,15 +1591,53 @@ struct AnnouncementAssistSnapshot {
 
 impl AnnouncementAssistSnapshot {
     fn from_node_status(status: &ant_quic::NodeStatus) -> Self {
+        // #398 announcement honesty: relay/coordinator capability is only
+        // advertised when OTHER nodes could plausibly reach us to use it.
+        // `relay_service_enabled` merely says the local MASQUE server /
+        // coordination logic is running — every default daemon has that —
+        // so gating on it alone made every NATed desktop advertise
+        // is_coordinator=true / is_relay=true, and coordinator/relay
+        // selection then picked nodes that cannot serve third parties.
+        //
+        // A node is plausibly publicly reachable when either:
+        // (a) inbound direct reachability was PEER-VERIFIED at global scope
+        //     (`direct_reachability_scope == Some(Global)` — an OBSERVED
+        //     reflexive address alone is NOT proof; it sets
+        //     has_global_address, which we deliberately do not trust), or
+        // (b) a router port mapping is active (UPnP/IGD listener-bound
+        //     external address), or
+        // (c) the operator explicitly opted in via X0X_RELAY_OPT_IN=1 /
+        //     --relay (the escape hatch for nodes that know better than we
+        //     do, e.g. a manually port-forwarded box).
+        let plausibly_public = status
+            .direct_reachability_scope
+            .is_some_and(|scope| matches!(scope, ant_quic::ReachabilityScope::Global))
+            || status.port_mapping_active
+            || relay_opt_in_explicit();
         Self {
             nat_type: Some(status.nat_type.to_string()),
             can_receive_direct: Some(status.can_receive_direct),
-            relay_capable: Some(status.relay_service_enabled),
-            coordinator_capable: Some(status.coordinator_service_enabled),
+            relay_capable: Some(status.relay_service_enabled && plausibly_public),
+            coordinator_capable: Some(status.coordinator_service_enabled && plausibly_public),
             relay_active: Some(status.is_relaying),
             coordinator_active: Some(status.is_coordinating),
         }
     }
+}
+
+/// #398: explicit operator opt-in for announcing relay/coordinator
+/// capability without verified public reachability (manually
+/// port-forwarded hosts, hosts behind an operator-trusted edge). Checked
+/// once per process; absent by default.
+fn relay_opt_in_explicit() -> bool {
+    static OPT_IN: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *OPT_IN.get_or_init(|| {
+        // Command line: --relay / --relay-opt-in flag present.
+        let argv_opt_in = std::env::args().any(|arg| arg == "--relay" || arg == "--relay-opt-in");
+        // Environment: X0X_RELAY_OPT_IN=1.
+        let env_opt_in = std::env::var_os("X0X_RELAY_OPT_IN").is_some_and(|v| v == "1");
+        argv_opt_in || env_opt_in
+    })
 }
 
 struct IdentityAnnouncementBuildOptions<'a> {
@@ -13020,6 +13058,96 @@ fn spawn_relay_dm_listener(
 
 #[cfg(test)]
 mod tests {
+    mod announcement_role_honesty {
+        use super::*;
+
+        /// #398: a NATed desktop's DEFAULT announcement must not claim
+        /// relay/coordinator capability. `relay_service_enabled` is true on
+        /// every default daemon (the local MASQUE server always runs), so
+        /// gating on it alone advertised is_coordinator/is_relay = true for
+        /// nodes that cannot serve third parties — coordinator/relay
+        /// selection then picked NATed desktops. An OBSERVED reflexive
+        /// address alone (`has_global_address = true`, scope LocalNetwork)
+        /// must NOT flip the flags.
+        #[test]
+        fn nat_default_daemon_does_not_advertise_relay_or_coordinator() {
+            let status = ant_quic::NodeStatus {
+                // OBSERVED_ADDRESS reflexive candidate exists — address
+                // property, NOT verified inbound reachability.
+                has_global_address: true,
+                // No peer-verified inbound evidence at global scope.
+                direct_reachability_scope: Some(ant_quic::ReachabilityScope::LocalNetwork),
+                can_receive_direct: false,
+                port_mapping_active: false,
+                // Services running (they always are).
+                relay_service_enabled: true,
+                coordinator_service_enabled: true,
+                ..ant_quic::NodeStatus::default()
+            };
+            let snapshot = AnnouncementAssistSnapshot::from_node_status(&status);
+            assert_eq!(
+                snapshot.relay_capable,
+                Some(false),
+                "NATed default must not advertise relay capability"
+            );
+            assert_eq!(
+                snapshot.coordinator_capable,
+                Some(false),
+                "NATed default must not advertise coordinator capability"
+            );
+        }
+
+        /// #398: peer-verified inbound reachability at GLOBAL scope is the
+        /// primary honest signal — a public node (VPS) may advertise both.
+        #[test]
+        fn globally_verified_node_advertises_capabilities() {
+            let status = ant_quic::NodeStatus {
+                direct_reachability_scope: Some(ant_quic::ReachabilityScope::Global),
+                can_receive_direct: true,
+                relay_service_enabled: true,
+                coordinator_service_enabled: true,
+                ..ant_quic::NodeStatus::default()
+            };
+            let snapshot = AnnouncementAssistSnapshot::from_node_status(&status);
+            assert_eq!(snapshot.relay_capable, Some(true));
+            assert_eq!(snapshot.coordinator_capable, Some(true));
+        }
+
+        /// #398: an active router port mapping (UPnP listener-bound
+        /// external address) is plausibly publicly reachable — may
+        /// advertise even without peer-verified scope.
+        #[test]
+        fn port_mapped_node_advertises_capabilities() {
+            let status = ant_quic::NodeStatus {
+                direct_reachability_scope: None,
+                can_receive_direct: false,
+                port_mapping_active: true,
+                relay_service_enabled: true,
+                coordinator_service_enabled: true,
+                ..ant_quic::NodeStatus::default()
+            };
+            let snapshot = AnnouncementAssistSnapshot::from_node_status(&status);
+            assert_eq!(snapshot.relay_capable, Some(true));
+            assert_eq!(snapshot.coordinator_capable, Some(true));
+        }
+
+        /// #398: capability still requires the service — reachability
+        /// alone is not enough when the service is off.
+        #[test]
+        fn reachable_node_without_service_advertises_nothing() {
+            let status = ant_quic::NodeStatus {
+                direct_reachability_scope: Some(ant_quic::ReachabilityScope::Global),
+                can_receive_direct: true,
+                relay_service_enabled: false,
+                coordinator_service_enabled: false,
+                ..ant_quic::NodeStatus::default()
+            };
+            let snapshot = AnnouncementAssistSnapshot::from_node_status(&status);
+            assert_eq!(snapshot.relay_capable, Some(false));
+            assert_eq!(snapshot.coordinator_capable, Some(false));
+        }
+    }
+
     use super::*;
 
     fn sa(s: &str) -> std::net::SocketAddr {
@@ -17537,9 +17665,17 @@ mod tests {
 
     #[test]
     fn announcement_assist_snapshot_uses_capabilities_not_activity() {
+        // #398: this test's original fixture (services on, everything else
+        // defaulted) now honestly yields relay/coordinator = Some(false):
+        // capability requires PLAUSIBLY-PUBLIC reachability in addition to
+        // the service, and the default NodeStatus has neither peer-verified
+        // global scope nor a port mapping. The reachability signal is added
+        // to the fixture so the capability-vs-activity distinction (the
+        // point of this test) stays under test.
         let status = ant_quic::NodeStatus {
             nat_type: ant_quic::NatType::FullCone,
             can_receive_direct: true,
+            direct_reachability_scope: Some(ant_quic::ReachabilityScope::Global),
             relay_service_enabled: true,
             coordinator_service_enabled: true,
             is_relaying: false,


### PR DESCRIPTION
Follow-up b to #398 (companion to ant-quic #264, which stopped the bootstrap cache granting relay/coordinator from inbound evidence — this closes the x0x-side over-advertisement).

## Defect
`AnnouncementAssistSnapshot::from_node_status` gated `relay_capable`/`coordinator_capable` on `relay_service_enabled`/`coordinator_service_enabled` alone — **true on every default daemon** (the local MASQUE server always runs). Result: every NATed desktop announced `is_coordinator: true, is_relay: true`, and coordinator/relay selection picked nodes that cannot serve third parties (`/machines/discovered` showed exactly this).

## Fix
Capability flags now require **plausibly-public reachability AND the service**:
- **peer-verified inbound at global scope** (`direct_reachability_scope == Global`). An OBSERVED reflexive address alone is NOT proof — it sets `has_global_address`, which is deliberately not trusted;
- **active router port mapping** (UPnP/IGD listener-bound external address);
- **explicit operator opt-in**: `--relay` / `--relay-opt-in` flag or `X0X_RELAY_OPT_IN=1` — the escape hatch for manually port-forwarded hosts whose reachability we can't verify. (ant-quic exposes enough to decide via `direct_reachability_scope` + `port_mapping_active`; the opt-in covers the residual blind spot.)

The capability-vs-activity distinction (`relay_capable` vs `relay_active`) is unchanged.

## Tests (encode the WHY)
- NATed default (reflexive addr present, LocalNetwork scope, services on) → **Some(false)** for both — the reflexive-address-alone case is the heart of the bug.
- Global peer-verified scope → Some(true).
- Port mapping active → Some(true).
- Reachable but service off → Some(false).
- The legacy capability-vs-activity test's fixture gained the reachability signal it now honestly requires — its old fixture (services on, everything defaulted) was exactly the over-advertisement this PR fixes.

## Gate
fmt / clippy / doc green; nextest **2782/2782** (excluding the documented pre-existing macOS-only `addr_is_free` flake).

Do not merge yet.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes relay and coordinator capability announcements depend on service availability plus verified global reachability, active port mapping, or explicit operator opt-in.
- Prevents default NATed nodes with only reflexive addresses from advertising public relay or coordinator capability.
- Adds focused tests for NATed defaults, globally reachable nodes, port-mapped nodes, and disabled services.
- Documents the announcement-role correction in the changelog.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because manually port-forwarded operators cannot activate the documented command-line opt-in through the normal daemon launch path.

The long-running daemon scans its own arguments, but neither `x0x start` accepts and forwards the opt-in flags nor `x0xd` accepts them, so manually port-forwarded nodes launched normally still announce no relay or coordinator capability.

**Files Needing Attention:** src/lib.rs, src/bin/x0x.rs, src/cli/commands/daemon.rs, and src/bin/x0xd.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib.rs | Adds reachability-aware capability gating and tests, but the advertised command-line opt-in remains unavailable through the normal daemon launch path. |
| CHANGELOG.md | Documents the reachability-based announcement behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: retrigger workflows"](https://github.com/saorsa-labs/x0x/commit/cda16f58b960a1b20b65a658a23db1ca0fef8a6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56438189)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Peer presence, bootstrap, and rendezvous](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/peer-presence-and-rendezvous.md)
- Knowledge Base — [Command-line and daemon entrypoints](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/command-line-and-daemon.md)
- Knowledge Base — [Client, daemon, and API platform](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/client-and-daemon-platform.md)
</details>


<!-- /greptile_comment -->