### PR TITLE
chore(release): v0.39.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.39.7] - 2026-08-25
+
 ### Added
 
 - **`holepunched_connections` surfaced on `GET /diagnostics/transport` (#398).** ant-quic

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.6"
+version = "0.39.7"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.6
+version: 0.39.7
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Version bump 0.39.6 -> 0.39.7: #404 traversal-counter surfacing + #406 announce-role honesty.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR synchronizes the project metadata at version 0.39.7 and finalizes changelog entries for transport diagnostics and honest relay/coordinator announcements.
- Bumps the Cargo package and skill metadata from 0.39.6 to 0.39.7.
- Adds the dated v0.39.7 changelog heading.
- Documents the surfaced hole-punch counter and reachability-gated announcement roles.

<h3>Confidence Score: 5/5</h3>

The release metadata changes appear safe to merge.

The Cargo and skill versions agree at 0.39.7, the changelog establishes the matching release, and no changed behavior introduces a build, runtime, or security failure.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds the v0.39.7 release heading around the existing diagnostics and announcement-role entries; no changed-code defect was found. |
| Cargo.toml | Bumps the package version to 0.39.7, consistent with the repository's release metadata. |
| SKILL.md | Synchronizes the published skill metadata with package version 0.39.7. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.7"](https://github.com/saorsa-labs/x0x/commit/44394f9fde8bf0847eb73bd56c2e2a8a0e56d81c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56551405)</sub>

<!-- /greptile_comment -->