### PR TITLE
chore(release): v0.39.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.39.8] - 2026-08-25
+
 ### Fixed
 
 - **C5 Direct/typed ACK hedge after durable commit (#380, PR #408).** The

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.7"
+version = "0.39.8"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.7
+version: 0.39.8
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Version bump 0.39.7 -> 0.39.8: the #380 demand-side + DM-ACK completion set (#395/#396/#397/#408, ADR-0034).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR advances x0x from 0.39.7 to 0.39.8 and closes the current changelog section for the demand-side and DM-ACK completion set.
- Updates the Rust package version in Cargo.toml.
- Synchronizes the SKILL.md metadata version.
- Adds the dated v0.39.8 changelog heading.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with its release metadata synchronized and no actionable defects identified.

Cargo.toml and SKILL.md consistently declare version 0.39.8, satisfying the blocking release-version contract, while the changelog change follows the repository’s existing release-heading format.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the crate version to 0.39.8 consistently with the repository’s release metadata contract. |
| SKILL.md | Synchronizes the skill frontmatter version with Cargo.toml and the intended release tag. |
| CHANGELOG.md | Adds the dated v0.39.8 release heading above the completed fixes without altering release content. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.8"](https://github.com/saorsa-labs/x0x/commit/1c8cd6edd1dc832de17410ba868e301bca78f0d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56831092)</sub>

<!-- /greptile_comment -->