### PR TITLE
fix(dm): leaf receivers can ALWAYS return the durable ACK (#380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Leaf↔reverse-ACK interaction: a durable DM receiver can ALWAYS return the ACK (#380).**
+  Live evidence on v0.39.8: durable messages arrived, verified, and committed on studio1, then the
+  receiver's ACK publish failed every route (`ack_publish_route_failed: 3/3`) — the sender 504'd at
+  `budget_stage: ack_wait_ms`. Three defects, all fixed:
+  1. **Receipt-triggered pre-subscribe (fix a)**: on a Leaf receiver, the sender's inbox topic was
+     not in the subscribed set (C2/C4 pre-warm only fires on connect events with a resolvable
+     agent_id and a trusted contact — neither guaranteed on a fresh daemon or first-ever message).
+     The targeted-inbox ACK publish found zero peers; the compat bus had the same zero-peer problem.
+     Now a signature-verified durable envelope pre-subscribes the sender's inbox topic at the
+     receipt point — before the durable dispatch, independent of commit outcome — so the ACK always
+     has a gossip route. No trust gate: the sender just delivered a verified envelope addressed to
+     us; we owe them the receipt.
+  2. **Agent→machine registration from the envelope (fix b)**: the C5 Direct hedge's
+     `get_machine_id` returned `SkippedNoDirect` on inbound connections where the `PeerConnected`
+     handler could not resolve the agent_id from the machine_id (fresh cache, no DM history). The
+     verified envelope carries both identities — the strongest binding evidence — and now
+     registers them, so the Direct hedge can fire.
+  3. **Split ACK-route outcome counters (fix c)**: `ack_publish_route_failed` incremented for
+     gossip failure AND Direct failure and warned "ACK never left" even when Direct had Sent — the
+     3/3 fleet reading was ambiguous. New split counters on `/diagnostics/dm`:
+     `ack_gossip_route_succeeded/failed` and `ack_direct_hedge_sent/saved_failure/skipped/failed`,
+     so "gossip routes dead, Direct saved it" is now distinguishable from "all dead". The legacy
+     combined counter still moves on gossip failure for existing gates.
+
 ## [v0.39.8] - 2026-08-25
 
 ### Fixed

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -499,6 +499,12 @@ struct DirectDiagnosticsCounters {
     incoming_dropped_expired: AtomicU64,
     incoming_typed_route_dropped: AtomicU64,
     ack_publish_route_failed: AtomicU64,
+    ack_gossip_route_succeeded: AtomicU64,
+    ack_gossip_route_failed: AtomicU64,
+    ack_direct_hedge_sent: AtomicU64,
+    ack_direct_hedge_saved_failure: AtomicU64,
+    ack_direct_hedge_skipped: AtomicU64,
+    ack_direct_hedge_failed: AtomicU64,
     incoming_delivered_to_subscribe: AtomicU64,
     subscriber_channel_lagged: AtomicU64,
     subscriber_events_evicted: AtomicU64,
@@ -572,6 +578,21 @@ pub struct DmDiagnosticsStats {
     /// results are not counted.
     #[serde(default)]
     pub ack_publish_route_failed: u64,
+    /// #380 leaf-reverse-ACK: gossip (inbox + compat-bus) ACK route split.
+    #[serde(default)]
+    pub ack_gossip_route_succeeded: u64,
+    #[serde(default)]
+    pub ack_gossip_route_failed: u64,
+    /// #380 leaf-reverse-ACK: Direct/typed ACK hedge outcome split —
+    /// `saved_failure` counts Direct carrying the ACK when gossip failed.
+    #[serde(default)]
+    pub ack_direct_hedge_sent: u64,
+    #[serde(default)]
+    pub ack_direct_hedge_saved_failure: u64,
+    #[serde(default)]
+    pub ack_direct_hedge_skipped: u64,
+    #[serde(default)]
+    pub ack_direct_hedge_failed: u64,
     pub incoming_delivered_to_subscribe: u64,
     /// Number of oldest buffered events evicted from slow subscriber queues.
     pub subscriber_events_evicted: u64,
@@ -665,6 +686,19 @@ pub struct DirectMessaging {
 
     /// #336 phase 1: last durable ACK publish duration (receiver side).
     last_ack_publish_ms: Mutex<Option<u64>>,
+}
+
+/// #380 leaf-reverse-ACK: Direct/typed ACK hedge outcome record.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum AckDirectHedgeOutcomeRecord {
+    /// Direct hedge sent the envelope (gossip may or may not have too).
+    Sent,
+    /// Gossip failed but Direct carried the ACK — the save.
+    SavedFailure,
+    /// No Direct connection existed (or agent→machine mapping missing).
+    SkippedOrNoDirect,
+    /// Direct send failed after a live connection existed.
+    Failed,
 }
 
 impl DirectMessaging {
@@ -1000,6 +1034,39 @@ impl DirectMessaging {
     /// Record an ACK publication in which every required route failed, or
     /// the job could not be scheduled. After the first-success hedge this
     /// is "ACK never left", not "one hedge was slow".
+    /// #380 leaf-reverse-ACK: gossip-route outcome counters (split from the
+    /// old combined `ack_publish_route_failed`; the legacy counter also
+    /// moves on gossip failure for existing gates).
+    pub(crate) fn record_ack_gossip_route_succeeded(&self) {
+        self.diagnostics
+            .ack_gossip_route_succeeded
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_ack_gossip_route_failed(&self) {
+        self.diagnostics
+            .ack_gossip_route_failed
+            .fetch_add(1, Ordering::Relaxed);
+        self.diagnostics
+            .ack_publish_route_failed
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// #380 leaf-reverse-ACK: Direct hedge outcome counter.
+    pub(crate) fn record_ack_direct_hedge(&self, outcome: AckDirectHedgeOutcomeRecord) {
+        let counter = match outcome {
+            AckDirectHedgeOutcomeRecord::Sent => &self.diagnostics.ack_direct_hedge_sent,
+            AckDirectHedgeOutcomeRecord::SavedFailure => {
+                &self.diagnostics.ack_direct_hedge_saved_failure
+            }
+            AckDirectHedgeOutcomeRecord::SkippedOrNoDirect => {
+                &self.diagnostics.ack_direct_hedge_skipped
+            }
+            AckDirectHedgeOutcomeRecord::Failed => &self.diagnostics.ack_direct_hedge_failed,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
     pub(crate) fn record_ack_publish_route_failed(&self) {
         self.diagnostics
             .ack_publish_route_failed
@@ -1086,6 +1153,30 @@ impl DirectMessaging {
             ack_publish_route_failed: self
                 .diagnostics
                 .ack_publish_route_failed
+                .load(Ordering::Relaxed),
+            ack_gossip_route_succeeded: self
+                .diagnostics
+                .ack_gossip_route_succeeded
+                .load(Ordering::Relaxed),
+            ack_gossip_route_failed: self
+                .diagnostics
+                .ack_gossip_route_failed
+                .load(Ordering::Relaxed),
+            ack_direct_hedge_sent: self
+                .diagnostics
+                .ack_direct_hedge_sent
+                .load(Ordering::Relaxed),
+            ack_direct_hedge_saved_failure: self
+                .diagnostics
+                .ack_direct_hedge_saved_failure
+                .load(Ordering::Relaxed),
+            ack_direct_hedge_skipped: self
+                .diagnostics
+                .ack_direct_hedge_skipped
+                .load(Ordering::Relaxed),
+            ack_direct_hedge_failed: self
+                .diagnostics
+                .ack_direct_hedge_failed
                 .load(Ordering::Relaxed),
             incoming_delivered_to_subscribe: self
                 .diagnostics

--- a/src/dm_inbox.rs
+++ b/src/dm_inbox.rs
@@ -666,55 +666,90 @@ async fn publish_durable_ack_job(
     // C5: same v2 ACK envelope on live Direct/typed as a third hedge.
     // Detached from gossip: missing Direct is fail-open, and Direct send-ok
     // is not a sender receipt. Do not abort sibling gossip routes.
-    let direct =
-        hedge_direct_ack_fail_open(direct_hedge, job.recipient, Bytes::clone(&job.encoded));
+    // `direct_hedge_was_sent` distinguishes Sent from SkippedNoDirect for
+    // the (c) outcome counters.
+    let direct_hedge_was_sent = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let direct = {
+        let sent_flag = Arc::clone(&direct_hedge_was_sent);
+        let hedge = direct_hedge.clone();
+        let recipient = job.recipient;
+        let encoded = Bytes::clone(&job.encoded);
+        async move {
+            let Some(hedge) = hedge else {
+                return Ok(());
+            };
+            match hedge.hedge(recipient, encoded).await {
+                DirectAckHedgeOutcome::Sent => {
+                    sent_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+                    Ok(())
+                }
+                DirectAckHedgeOutcome::SkippedNoDirect => Ok(()),
+                DirectAckHedgeOutcome::Failed => Err(NetworkError::ConnectionFailed(
+                    "direct ACK hedge failed".to_string(),
+                )),
+            }
+        }
+    };
     let publish_started = Instant::now();
     let (gossip, direct_outcome) = tokio::join!(
         publish_durable_ack_routes(DURABLE_ACK_ROUTE_TIMEOUT, primary, legacy),
         publish_ack_route_with_timeout("direct-typed", DURABLE_ACK_ROUTE_TIMEOUT, direct),
     );
     dm.record_ack_publish_ms(crate::dm::millis_since(publish_started));
-    if let Err(error) = gossip {
-        dm.record_ack_publish_route_failed();
-        tracing::warn!(
-            target: "dm.trace",
-            stage = "ack_publish_route_failed",
-            acked_request_id = %hex::encode(job.acked_request_id),
-            recipient = %hex::encode(job.recipient.as_bytes()),
-            protocol_version = job.protocol_version,
-            hedged = true,
-            %error,
-            "both durable ACK routes failed; ACK never left this recipient"
-        );
-    } else if let Err(error) = direct_outcome {
-        // Gossip landed; Direct failed after a live connection existed.
-        // Count it for Tester visibility, but do not fail the ACK.
-        dm.record_ack_publish_route_failed();
-        tracing::debug!(
-            target: "dm.trace",
-            stage = "ack_publish_direct_hedge_failed",
-            acked_request_id = %hex::encode(job.acked_request_id),
-            recipient = %hex::encode(job.recipient.as_bytes()),
-            protocol_version = job.protocol_version,
-            %error,
-            "Direct/typed ACK hedge failed; gossip hedges still count"
-        );
-    }
-}
-
-async fn hedge_direct_ack_fail_open(
-    direct_hedge: Option<Arc<dyn DirectAckHedge>>,
-    recipient: AgentId,
-    encoded: Bytes,
-) -> NetworkResult<()> {
-    let Some(hedge) = direct_hedge else {
-        return Ok(());
-    };
-    match hedge.hedge(recipient, encoded).await {
-        DirectAckHedgeOutcome::Sent | DirectAckHedgeOutcome::SkippedNoDirect => Ok(()),
-        DirectAckHedgeOutcome::Failed => Err(NetworkError::ConnectionFailed(
-            "direct ACK hedge failed".to_string(),
-        )),
+    // #380 leaf-reverse-ACK fix (c): count gossip and Direct hedge outcomes
+    // SEPARATELY so /diagnostics/dm distinguishes "gossip routes dead,
+    // Direct saved it" from "all dead". The old code incremented the same
+    // ack_publish_route_failed counter for gossip failure AND direct
+    // failure, and warned "ACK never left" even when Direct had Sent —
+    // the 3/3 fleet reading was ambiguous.
+    let direct_sent = matches!(direct_outcome, Ok(()))
+        && direct_hedge_was_sent.load(std::sync::atomic::Ordering::Relaxed);
+    match (gossip, direct_outcome) {
+        (Ok(()), _) => {
+            dm.record_ack_gossip_route_succeeded();
+            if direct_sent {
+                dm.record_ack_direct_hedge(crate::direct::AckDirectHedgeOutcomeRecord::Sent);
+            }
+        }
+        (Err(error), Ok(())) => {
+            // Gossip failed but the Direct hedge fired — the ACK still had a
+            // route. Count the gossip failure for visibility; Direct carries
+            // the receipt.
+            dm.record_ack_gossip_route_failed();
+            if direct_sent {
+                dm.record_ack_direct_hedge(
+                    crate::direct::AckDirectHedgeOutcomeRecord::SavedFailure,
+                );
+            } else {
+                dm.record_ack_direct_hedge(
+                    crate::direct::AckDirectHedgeOutcomeRecord::SkippedOrNoDirect,
+                );
+            }
+            tracing::warn!(
+                target: "dm.trace",
+                stage = "ack_gossip_routes_failed_direct_hedge",
+                acked_request_id = %hex::encode(job.acked_request_id),
+                recipient = %hex::encode(job.recipient.as_bytes()),
+                direct_sent,
+                %error,
+                "gossip ACK routes failed; Direct hedge state recorded separately"
+            );
+        }
+        (Err(error), Err(direct_error)) => {
+            // All routes dead — the ACK genuinely never left.
+            dm.record_ack_gossip_route_failed();
+            dm.record_ack_direct_hedge(crate::direct::AckDirectHedgeOutcomeRecord::Failed);
+            tracing::warn!(
+                target: "dm.trace",
+                stage = "ack_publish_all_routes_failed",
+                acked_request_id = %hex::encode(job.acked_request_id),
+                recipient = %hex::encode(job.recipient.as_bytes()),
+                protocol_version = job.protocol_version,
+                gossip_error = %error,
+                direct_error = %direct_error,
+                "both gossip routes AND the Direct hedge failed; ACK never left this recipient"
+            );
+        }
     }
 }
 
@@ -1384,6 +1419,46 @@ impl InboxPipeline {
         // which can only happen against a peer that believed a false v2
         // capability advert (this daemon advertises v2 iff history is on).
         if envelope.protocol_version >= DM_PROTOCOL_DURABLE_ACK {
+            // #380 leaf-reverse-ACK fix (a): a signature-verified durable
+            // envelope just arrived — this is the authoritative moment the
+            // receiver owes a reverse route. On a Leaf receiver, the
+            // sender's inbox topic is not in the subscribed set (C2/C4
+            // pre-warm only fires on connect events with a resolvable
+            // agent_id and a trusted contact — neither is guaranteed on a
+            // fresh daemon or a first-ever message). Without a subscription
+            // the targeted-inbox ACK publish finds zero peers and fails;
+            // the compat bus has the same zero-peer problem in Leaf mode.
+            // Subscribe the SENDER's inbox topic right now so the ACK that
+            // follows has a gossip route. No trust gate and no
+            // commit-success gate: the sender just delivered a
+            // signature-verified envelope addressed to us — we owe them the
+            // receipt, and the route must exist even if the commit below
+            // withholds (the sender will retry).
+            {
+                let sender_agent = AgentId(envelope.sender_agent_id);
+                crate::dm_inbox::warm_reverse_ack_topics(
+                    self.pubsub.as_ref(),
+                    &self.self_agent_id,
+                    &sender_agent,
+                )
+                .await;
+            }
+
+            // #380 leaf-reverse-ACK fix (b): register the sender's
+            // agent→machine mapping from the verified envelope itself. The
+            // C5 Direct hedge's `get_machine_id` lookup was SkippedNoDirect
+            // whenever the connected_agents map lacked the entry — which
+            // happens on inbound connections where the PeerConnected
+            // handler could not resolve the agent_id from the machine_id
+            // (fresh cache, no DM history yet). The envelope carries both
+            // identities and just passed signature verification; this is
+            // the strongest binding evidence we will get.
+            {
+                let sender_agent = AgentId(envelope.sender_agent_id);
+                let sender_machine = MachineId(envelope.sender_machine_id);
+                self.dm.mark_connected(sender_agent, sender_machine).await;
+            }
+
             let _decision = self
                 .handle_payload_durable(
                     envelope,
@@ -3404,6 +3479,88 @@ mod tests {
             rx.await.expect("oneshot"),
             DmAckOutcome::Accepted,
             "only the matching request_id envelope completes the waiter"
+        );
+    }
+
+    /// #380 leaf-reverse-ACK: the failing fleet case, end-to-end at the
+    /// PubSubManager level. A Leaf receiver with ZERO prior subscription
+    /// state (no C2/C4 connect-event warm) receives a durable DM. The fix
+    /// pre-subscribes the sender's inbox topic ON RECEIPT (the authoritative
+    /// moment), so the ACK publish that follows has a gossip route. Also
+    /// verifies the agent→machine registration for the C5 Direct hedge.
+    #[tokio::test]
+    async fn leaf_receiver_of_durable_dm_pre_subscribes_sender_inbox_on_receipt() {
+        let sender = test_keypair();
+        let machine_kp = MachineKeypair::generate().expect("machine");
+        let machine = machine_kp.machine_id();
+        let harness = make_inbox_harness(&sender, Some(machine), None).await;
+
+        // Zero prior subscription state: prove the sender's inbox topic is
+        // NOT in PlumTree before the DM arrives (the leaf fleet condition).
+        let sender_inbox_topic_id = dm_inbox_topic(&sender.agent_id());
+        let sender_inbox_name = DmInboxService::inbox_topic_name(&sender.agent_id());
+        let before = harness.pipeline.pubsub.plumtree_topic_ids().await;
+        assert!(
+            !before.contains(&sender_inbox_topic_id),
+            "precondition: sender inbox topic NOT subscribed (the leaf zero-state case)"
+        );
+
+        // Build a real durable v2 envelope using the production builder.
+        let request_id = [0xE1; 16];
+        let created = now_unix_ms();
+        let envelope = EnvelopeBuilder::build_payload_envelope_with_version(
+            DM_PROTOCOL_DURABLE_ACK,
+            request_id,
+            &sender.agent_id(),
+            &machine,
+            &machine_kp,
+            &harness.recipient_agent_id,
+            &harness.recipient_kem.public_bytes,
+            created,
+            created + ACK_ENVELOPE_LIFETIME_MS,
+            b"leaf-reverse-ack-proof".to_vec(),
+            |bytes| {
+                ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(sender.secret_key(), bytes)
+                    .map(|sig| sig.as_bytes().to_vec())
+                    .map_err(|e| e.to_string())
+            },
+        )
+        .expect("build durable envelope");
+        let encoded = Bytes::from(envelope.to_wire_bytes().expect("encode"));
+
+        let msg = PubSubMessage {
+            topic: sender_inbox_name.clone(),
+            payload: encoded,
+            sender: Some(sender.agent_id()),
+            sender_public_key: Some(sender.public_key().as_bytes().to_vec()),
+            verified: true,
+            trust_level: None,
+            raw_envelope: None,
+        };
+        harness.pipeline.handle_incoming(msg, false).await;
+
+        // The fix: the sender's inbox topic is now subscribed (the receipt
+        // is the trigger), so the ACK publish has peers.
+        let after = harness.pipeline.pubsub.plumtree_topic_ids().await;
+        assert!(
+            after.contains(&sender_inbox_topic_id),
+            "receipt of a durable DM must pre-subscribe the sender's inbox for the reverse ACK: {after:?}"
+        );
+        assert!(
+            harness
+                .pipeline
+                .pubsub
+                .is_topic_subscribed(&sender_inbox_name)
+                .await,
+            "the subscription must be live (membership hold), not a one-shot refresh"
+        );
+
+        // The agent→machine mapping is registered from the envelope (fix b),
+        // so the C5 Direct hedge can look up the sender.
+        assert_eq!(
+            harness.pipeline.dm.get_machine_id(&sender.agent_id()).await,
+            Some(machine),
+            "the verified envelope must register the sender's agent→machine binding for the C5 Direct hedge"
         );
     }
 


### PR DESCRIPTION
The LAST durable-DM 504. Live evidence on v0.39.8 fleet: durable messages arrived, verified, committed on studio1 — then the receiver's ACK publish failed every route (`ack_publish_route_failed: 3/3`), sender 504'd at `budget_stage: ack_wait_ms`. Both desktops `mode=leaf, reason=default_leaf`.

## Root cause: THREE defects compounding on the Leaf default

1. **Leaf zero-peer publish (confirmed)**: on a Leaf receiver, the sender's inbox topic is not in the subscribed set. C2/C4 pre-warm only fires on connect events with a resolvable agent_id **and** a trusted contact — neither is guaranteed on a fresh daemon or a first-ever message. The targeted-inbox ACK publish found zero peers; the compat bus had the same zero-peer problem.
2. **C5 Direct hedge SkippedNoDirect (Claude's finding, confirmed)**: the hedge depends on `dm.get_machine_id` (the `connected_agents` map). On inbound connections where the PeerConnected handler couldn't resolve the agent_id from the machine_id (fresh cache, no DM history), `mark_connected` never fired — the hedge was SkippedNoDirect.
3. **Ambiguous counter (Claude's finding, confirmed)**: `ack_publish_route_failed` incremented for gossip failure AND Direct failure, and warned "ACK never left" even when Direct had Sent — the 3/3 reading couldn't distinguish "gossip dead, Direct saved it" from "all dead".

## Fixes

- **(a) Receipt-triggered pre-subscribe**: a signature-verified durable envelope pre-subscribes the sender's inbox topic at the **receipt point** — before the durable dispatch, independent of commit outcome (the sender will retry if the commit withholds). No trust gate: the sender delivered a verified envelope addressed to us; we owe them the receipt. This is the authoritative moment, not a connect event.
- **(b) Agent-to-machine registration from the envelope**: the verified envelope carries both identities — the strongest binding evidence we will get. Registered at receipt, so the C5 Direct hedge's lookup works on every inbound connection.
- **(c) Split ACK-route outcome counters**: `ack_gossip_route_succeeded/failed` + `ack_direct_hedge_sent/saved_failure/skipped/failed` on `/diagnostics/dm`. "Gossip dead, Direct saved it" is now distinguishable from "all dead". The legacy combined counter still moves on gossip failure for existing gates.

## Test

`leaf_receiver_of_durable_dm_pre_subscribes_sender_inbox_on_receipt` — zero prior subscription state (the precondition is asserted), a real durable v2 envelope built with the production `EnvelopeBuilder` through `handle_incoming`, then: sender inbox topic subscribed in PlumTree, subscription live (membership hold), agent-to-machine registered for the Direct hedge.

## Gate
fmt / clippy green; nextest **2815/2815** (two documented pre-existing macOS flakes excluded, both pass solo).

Companion: Claude is independently verifying the C5 Direct route Mac-to-studio1 in parallel.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds receipt-time reverse-ACK topic warming and agent-to-machine registration for durable DMs on Leaf receivers, together with route-specific ACK diagnostics.
- Pre-subscribes reverse-ACK gossip topics when a verified durable envelope is received.
- Registers the envelope’s sender mapping so the Direct ACK hedge can resolve it.
- Splits gossip and Direct ACK route outcomes into dedicated diagnostic counters.
- Documents the Leaf durable-ACK repair in the changelog.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until the unbounded receipt-created subscription path and incomplete Direct hedge accounting are corrected.

Valid unknown senders can permanently grow receiver pubsub state through distinct identities, while successful gossip suppresses failed or skipped Direct outcomes from the new diagnostics.

**Files Needing Attention:** src/dm_inbox.rs

<details open><summary><h3>Security Review</h3></summary>

The receipt-time warming path permits valid but untrusted senders to create unlimited permanent sender-specific pubsub subscriptions and drain tasks. **How this was verified:** Unknown signature-valid senders reach the unconditional warm call, and each distinct topic is retained in `membership_holds` with no removal path.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/dm_inbox.rs | Adds receipt-time ACK-route preparation and split outcome accounting, but creates unbounded sender-derived subscriptions and omits several Direct outcomes when gossip succeeds. |
| src/direct.rs | Adds storage, recording helpers, and serialization for the new ACK route counters; correctness depends on complete outcome recording by dm_inbox. |
| CHANGELOG.md | Documents the Leaf reverse-ACK failure and the three intended fixes. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant S as Durable DM sender
    participant I as Receiver inbox
    participant P as PubSub
    participant D as Direct messaging
    I->>I: Verify envelope, origin, and policy
    I->>P: Ensure sender inbox subscription
    I->>D: Register sender AgentId → MachineId
    I->>I: Dispatch and durably commit
    par Gossip ACK routes
        I->>P: Publish inbox and compatibility ACK
    and Direct hedge
        I->>D: Send typed ACK on live connection
    end
    I->>D: Record independent route outcomes
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/dm_inbox.rs:1437-1444
**Unbounded sender subscriptions**

A valid unknown sender can use distinct signed agent identities to reach this unconditional warm-up, and each identity creates a permanent sender-specific subscription and drain task with no cardinality or cleanup limit, causing unbounded receiver memory and gossip-state growth. **How this was verified:** Unknown signature-valid senders reach this call, while each distinct topic is retained in `membership_holds` with no removal path.

### Issue 2
src/dm_inbox.rs:708-713
**Direct outcomes discarded**

When gossip succeeds while the Direct hedge is skipped, fails, or times out, this branch records only gossip success and drops the Direct outcome, causing `ack_direct_hedge_skipped` and `ack_direct_hedge_failed` to undercount route degradation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dm): leaf receivers can ALWAYS retur..."](https://github.com/saorsa-labs/x0x/commit/f2042cd969971be16b747950c134ba63052b0c7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56972362)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Direct messaging delivery](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/direct-messaging.md)
- Knowledge Base — [Gossip runtime and wire protocol](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/gossip-runtime.md)
- Knowledge Base — [Secure identity and trust](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/secure-identity-and-trust.md)
</details>


<!-- /greptile_comment -->