### PR TITLE
chore(release): v0.39.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.39.9] - 2026-08-26
+
 ### Fixed
 
 - **Leaf↔reverse-ACK interaction: a durable DM receiver can ALWAYS return the ACK (#380).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.8"
+version = "0.39.9"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.8
+version: 0.39.9
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Version bump 0.39.8 -> 0.39.9: the #380 closing fix (#410).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the project’s release metadata from v0.39.8 to v0.39.9 for the durable direct-message reverse-ACK fix.
- Bumps the Cargo package version to 0.39.9.
- Synchronizes the SKILL.md version.
- Adds the dated v0.39.9 changelog heading.

<h3>Confidence Score: 5/5</h3>

The release metadata is internally consistent and appears safe to merge.

The changed version declarations agree, the changelog structure correctly associates the fix with v0.39.9, and no blocking release or build contract is violated.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the crate version to 0.39.9 consistently with the repository’s release metadata contract. |
| SKILL.md | Synchronizes the skill frontmatter version with Cargo.toml. |
| CHANGELOG.md | Adds the v0.39.9 release heading and correctly associates the existing fix entry with it. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.9"](https://github.com/saorsa-labs/x0x/commit/4c4640a1de5baba015008b3cacda474f29b4a55e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56983061)</sub>

<!-- /greptile_comment -->