### PR TITLE
perf(gossip): system-topic demand tuning — revocation on-change + TTL + cadence halving (#380)

### DIFF
--- a/src/dm_capability.rs
+++ b/src/dm_capability.rs
@@ -49,8 +49,11 @@ pub const DM_CAPABILITY_TARGETED_RESPONSE_TOPIC: &str = "x0x/caps/v1/response/ta
 /// Domain-separation prefix for the advert signature bytes.
 const ADVERT_SIGN_DOMAIN: &[u8] = b"x0x-caps-v1";
 
-/// Cadence at which agents republish their advert.
-pub const ADVERT_PUBLISH_INTERVAL_SECS: u64 = 300;
+/// Cadence at which agents republish their advert. Kept in step with
+/// `IDENTITY_HEARTBEAT_INTERVAL_SECS` (10 min): idle-network broadcast cost
+/// scales linearly with cadence, and the 900 s cache TTL still tolerates a
+/// missed window only for sub-TTL intervals, so this must stay < 900 s.
+pub const ADVERT_PUBLISH_INTERVAL_SECS: u64 = 600;
 
 /// How long a cached advert remains usable before it's considered stale.
 /// Must be > `ADVERT_PUBLISH_INTERVAL_SECS` so that a single missed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2209,9 +2209,14 @@ struct HeartbeatContext {
     /// erase a consented disclosure.
     user_identity_consented: std::sync::Arc<std::sync::atomic::AtomicBool>,
     allow_local_discovery_addrs: bool,
-    /// Local revocation set — piggybacked on each heartbeat for partition-
-    /// tolerant eventual propagation.
+    /// Local revocation set — piggybacked on heartbeats for partition-
+    /// tolerant eventual propagation (on-change + periodic fallback).
     revocation_set: std::sync::Arc<tokio::sync::RwLock<revocation::RevocationSet>>,
+    /// Last `change_generation` the piggyback broadcast saw. Unchanged set
+    /// ⇒ skip the publish (except the periodic fallback below).
+    last_revocation_generation: std::sync::atomic::AtomicU64,
+    /// Heartbeat tick counter for the periodic revocation fallback.
+    heartbeat_tick: std::sync::atomic::AtomicU64,
 }
 
 impl HeartbeatContext {
@@ -2497,26 +2502,80 @@ impl HeartbeatContext {
         upsert_discovered_machine_from_agent(&self.machine_cache, &discovered_agent).await;
         upsert_discovered_agent(&self.cache, discovered_agent).await;
 
-        // Piggyback the local revocation set on each heartbeat for partition-
-        // tolerant eventual convergence.  A node that was offline when a
-        // revocation was originally published will learn it from the next
-        // heartbeat it receives from any peer that already holds it.
-        let records = self.revocation_set.read().await.all_records();
-        if !records.is_empty() {
-            match bincode::serialize(&records) {
-                Ok(bytes) => {
-                    if let Err(e) = self
-                        .runtime
-                        .pubsub()
-                        .publish(REVOCATION_TOPIC.to_string(), bytes::Bytes::from(bytes))
-                        .await
-                    {
-                        tracing::debug!("heartbeat: revocation re-broadcast failed: {e}");
+        // Revocation re-broadcast: ON-CHANGE with a periodic fallback,
+        // not every heartbeat. The every-beat full-set publish cost 222
+        // KB/s fleet-wide (2 stale July test records × 19 KB × every node
+        // × every 300 s) on a topic that should be near-silent. Now:
+        //
+        // 1. TTL expiry first — records older than 90 days are dropped
+        //    (they target agents nobody has seen for months; the 2 stale
+        //    July testnet records die here).
+        // 2. Publish the full set only when the change_generation advanced
+        //    since our last broadcast (a record was inserted or expired).
+        // 3. Every 12th heartbeat (300 s × 12 = 1 h), republish regardless
+        //    — the partition-tolerance fallback for nodes that joined or
+        //    recovered mid-partition.
+        //
+        // Wire format unchanged: the message is still bincode
+        // Vec<RevocationRecord> on x0x.revocation.v1; old nodes that
+        // receive it process it identically.
+        {
+            const REVOCATION_RECORD_TTL_SECS: u64 = 90 * 24 * 3600;
+            const REVOCATION_FALLBACK_TICKS: u64 = 12;
+
+            let expired = {
+                let mut set = self.revocation_set.write().await;
+                set.expire_records_older_than(
+                    REVOCATION_RECORD_TTL_SECS,
+                    Agent::unix_timestamp_secs(),
+                )
+            };
+            if expired > 0 {
+                tracing::info!(
+                    expired,
+                    "revocation TTL: expired {expired} record(s) older than 90 days"
+                );
+            }
+
+            let tick = self
+                .heartbeat_tick
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let current_gen = self.revocation_set.read().await.generation();
+            let last_gen = self
+                .last_revocation_generation
+                .load(std::sync::atomic::Ordering::Relaxed);
+            let changed = current_gen != last_gen;
+            let is_fallback = tick.is_multiple_of(REVOCATION_FALLBACK_TICKS);
+
+            if !changed && !is_fallback {
+                return Ok(());
+            }
+
+            let records = self.revocation_set.read().await.all_records();
+            if !records.is_empty() {
+                match bincode::serialize(&records) {
+                    Ok(bytes) => {
+                        if let Err(e) = self
+                            .runtime
+                            .pubsub()
+                            .publish(REVOCATION_TOPIC.to_string(), bytes::Bytes::from(bytes))
+                            .await
+                        {
+                            tracing::debug!("heartbeat: revocation re-broadcast failed: {e}");
+                        } else {
+                            self.last_revocation_generation
+                                .store(current_gen, std::sync::atomic::Ordering::Relaxed);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!("heartbeat: failed to serialize revocation set: {e}");
                     }
                 }
-                Err(e) => {
-                    tracing::debug!("heartbeat: failed to serialize revocation set: {e}");
-                }
+            } else if changed {
+                // Set became empty (all records expired) — advance the
+                // generation tracker so we don't re-enter on every tick.
+                self.last_revocation_generation
+                    .store(current_gen, std::sync::atomic::Ordering::Relaxed);
             }
         }
 
@@ -7906,6 +7965,8 @@ impl Agent {
                 user_identity_consented: std::sync::Arc::clone(&self.user_identity_consented),
                 allow_local_discovery_addrs: allow_local_discovery_addresses(network.config()),
                 revocation_set: std::sync::Arc::clone(&self.revocation_set),
+                last_revocation_generation: std::sync::atomic::AtomicU64::new(0),
+                heartbeat_tick: std::sync::atomic::AtomicU64::new(0),
             };
             // Routed through spawn_tracked (issue #116) so a shutdown racing
             // bootstrap refuses to start it once the registry is closed; it is
@@ -9924,6 +9985,8 @@ impl Agent {
             user_identity_consented: std::sync::Arc::clone(&self.user_identity_consented),
             allow_local_discovery_addrs,
             revocation_set: std::sync::Arc::clone(&self.revocation_set),
+            last_revocation_generation: std::sync::atomic::AtomicU64::new(0),
+            heartbeat_tick: std::sync::atomic::AtomicU64::new(0),
         };
         let handle = tokio::task::spawn(async move {
             let mut ticker =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -768,11 +768,16 @@ fn local_direct_probe_addrs(addresses: &[std::net::SocketAddr]) -> Vec<std::net:
 /// Default interval between identity heartbeat re-announcements (seconds).
 ///
 /// Heartbeats are anti-entropy, not a hot-path delivery mechanism. Keep the
-/// default at five minutes so bootstrap meshes do not spend their PubSub budget
-/// on repeated signed identity/machine announcements. PlumTree forwards each
-/// locally authored announcement across the topic mesh; receivers must not
-/// re-publish the same payload as a new application message.
-pub const IDENTITY_HEARTBEAT_INTERVAL_SECS: u64 = 300;
+/// default at ten minutes so meshes do not spend their PubSub budget on
+/// repeated signed identity/machine announcements: idle-network cost scales
+/// linearly with (network size x announce size x cadence), and a 2026-08-26
+/// live measurement showed announce beats dominating desktop uplink. The
+/// interval MUST stay below [`IDENTITY_TTL_SECS`] with margin so peers still
+/// running the previous default TTL never see a fresh announcement age out
+/// between beats. PlumTree forwards each locally authored announcement across
+/// the topic mesh; receivers must not re-publish the same payload as a new
+/// application message.
+pub const IDENTITY_HEARTBEAT_INTERVAL_SECS: u64 = 600;
 
 /// Default TTL for discovered agent cache entries (seconds).
 ///

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -509,6 +509,8 @@ impl RevocationSet {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
     mod revocation_cadence {
         use super::super::*;
         use crate::identity::AgentKeypair;
@@ -585,5 +587,330 @@ mod tests {
             set.expire_records_older_than(90 * 24 * 3600, now);
             assert_eq!(set.generation(), gen2, "no-change must not advance");
         }
+    }
+
+    use super::*;
+    use crate::identity::{AgentKeypair, MachineKeypair, UserKeypair};
+
+    fn now() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[test]
+    fn revocation_self_signed_verifies() {
+        // An agent revoking its own id is always authoritative: the issuer key
+        // hashes to the subject. This is the "revoke a stolen key" path and
+        // must never require external state.
+        let agent = AgentKeypair::generate().unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            agent.public_key(),
+            agent.secret_key(),
+            now(),
+            Some("compromised".to_string()),
+        )
+        .unwrap();
+        record
+            .verify_authority(None)
+            .expect("self-revocation must verify with no certificate");
+    }
+
+    #[test]
+    fn revocation_machine_self_signed_verifies() {
+        let machine = MachineKeypair::generate().unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Machine(machine.machine_id()),
+            machine.public_key(),
+            machine.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        record
+            .verify_authority(None)
+            .expect("machine self-revocation must verify");
+    }
+
+    #[test]
+    fn revocation_user_signed_for_certified_agent_verifies() {
+        // The user who certified an agent may revoke it. Authority is proven by
+        // the agent's certificate binding agent->user and the issuer being that
+        // user key.
+        let user = UserKeypair::generate().unwrap();
+        let agent = AgentKeypair::generate().unwrap();
+        let cert = AgentCertificate::issue(&user, &agent).unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            user.public_key(),
+            user.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        record
+            .verify_authority(Some(&cert))
+            .expect("issuer (certifying user) revocation must verify");
+    }
+
+    #[test]
+    fn revocation_user_without_cert_rejected() {
+        // Without the certificate proving the agent->user binding, a user key
+        // has no authority over the agent — fail closed.
+        let user = UserKeypair::generate().unwrap();
+        let agent = AgentKeypair::generate().unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            user.public_key(),
+            user.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        assert!(
+            record.verify_authority(None).is_err(),
+            "issuer-revocation without the binding certificate must be rejected"
+        );
+    }
+
+    #[test]
+    fn revocation_unrelated_key_rejected() {
+        // A third party (neither the subject nor its certifier) cannot revoke,
+        // even with a validly-signed record. This is the core no-third-party
+        // property.
+        let user = UserKeypair::generate().unwrap();
+        let agent = AgentKeypair::generate().unwrap();
+        let cert = AgentCertificate::issue(&user, &agent).unwrap();
+        let attacker = UserKeypair::generate().unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            attacker.public_key(),
+            attacker.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        assert!(
+            record.verify_authority(Some(&cert)).is_err(),
+            "an unrelated key must not be able to revoke, even with the cert"
+        );
+    }
+
+    #[test]
+    fn revocation_forged_signature_rejected() {
+        // Tampering the record after signing must fail the signature check
+        // before authority is ever considered.
+        let agent = AgentKeypair::generate().unwrap();
+        let mut record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            agent.public_key(),
+            agent.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        record.revoked_at = record.revoked_at.wrapping_add(1);
+        assert!(
+            record.verify_authority(None).is_err(),
+            "a tampered record must fail the signature check"
+        );
+    }
+
+    #[test]
+    fn revocation_set_merge_grow_only_idempotent() {
+        // Merging the same record twice is a no-op; the set only grows. This is
+        // what makes gossip replay harmless.
+        let agent = AgentKeypair::generate().unwrap();
+        let record = RevocationRecord::sign(
+            RevokedSubject::Agent(agent.agent_id()),
+            agent.public_key(),
+            agent.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        let mut set = RevocationSet::new();
+        assert!(
+            set.verify_and_insert(record.clone(), None).unwrap(),
+            "first insert is new"
+        );
+        assert!(
+            !set.verify_and_insert(record.clone(), None).unwrap(),
+            "re-inserting the same record must be idempotent"
+        );
+        assert_eq!(set.len(), 1);
+        assert!(set.is_agent_revoked(&agent.agent_id()));
+        assert!(!set.is_machine_revoked(&MachineKeypair::generate().unwrap().machine_id()));
+    }
+
+    #[test]
+    fn revocation_set_persists_and_reloads() {
+        // The on-disk round-trip preserves the gate state — a daemon restart
+        // must not forget revocations it learned. Includes an issuer-revocation
+        // (cert persisted alongside) so the reload re-verifies it via that cert.
+        let agent = AgentKeypair::generate().unwrap();
+        let machine = MachineKeypair::generate().unwrap();
+        let user = UserKeypair::generate().unwrap();
+        let issued_agent = AgentKeypair::generate().unwrap();
+        let cert = AgentCertificate::issue(&user, &issued_agent).unwrap();
+        let mut set = RevocationSet::new();
+        // self-revocation (agent)
+        set.verify_and_insert(
+            RevocationRecord::sign(
+                RevokedSubject::Agent(agent.agent_id()),
+                agent.public_key(),
+                agent.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+            None,
+        )
+        .unwrap();
+        // self-revocation (machine)
+        set.verify_and_insert(
+            RevocationRecord::sign(
+                RevokedSubject::Machine(machine.machine_id()),
+                machine.public_key(),
+                machine.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+            None,
+        )
+        .unwrap();
+        // issuer-revocation (user revokes a certified agent)
+        set.verify_and_insert(
+            RevocationRecord::sign(
+                RevokedSubject::Agent(issued_agent.agent_id()),
+                user.public_key(),
+                user.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+            Some(&cert),
+        )
+        .unwrap();
+        let bytes = set.to_bytes().unwrap();
+        let reloaded = RevocationSet::from_bytes(&bytes).unwrap();
+        assert_eq!(reloaded.len(), 3, "all three records must survive reload");
+        assert!(reloaded.is_agent_revoked(&agent.agent_id()));
+        assert!(reloaded.is_machine_revoked(&machine.machine_id()));
+        assert!(
+            reloaded.is_agent_revoked(&issued_agent.agent_id()),
+            "issuer-revocation must re-verify on load via its persisted cert"
+        );
+    }
+
+    #[test]
+    fn revocation_set_from_bytes_rejects_forged_and_unrelated_records() {
+        // SECURITY: revocations.bin is untrusted input. A record whose signature
+        // is forged (tampered after signing) and an issuer-revocation whose
+        // persisted cert does not authorize it must both be DROPPED on load,
+        // while a legitimately-signed self-revocation and a properly-certified
+        // issuer-revocation must survive. This pins load-path authority
+        // enforcement — without it a tampered file would inject revocations.
+        let good_agent = AgentKeypair::generate().unwrap();
+        let user = UserKeypair::generate().unwrap();
+        let issued_agent = AgentKeypair::generate().unwrap();
+        let good_cert = AgentCertificate::issue(&user, &issued_agent).unwrap();
+
+        // Legit self-revocation.
+        let good_self = PersistedRevocation {
+            record: RevocationRecord::sign(
+                RevokedSubject::Agent(good_agent.agent_id()),
+                good_agent.public_key(),
+                good_agent.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+            subject_cert: None,
+        };
+
+        // Legit issuer-revocation, cert persisted alongside.
+        let good_issuer = PersistedRevocation {
+            record: RevocationRecord::sign(
+                RevokedSubject::Agent(issued_agent.agent_id()),
+                user.public_key(),
+                user.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+            subject_cert: Some(good_cert.clone()),
+        };
+
+        // Forged: a validly-signed self-revocation tampered after signing.
+        let forged_agent = AgentKeypair::generate().unwrap();
+        let mut forged_record = RevocationRecord::sign(
+            RevokedSubject::Agent(forged_agent.agent_id()),
+            forged_agent.public_key(),
+            forged_agent.secret_key(),
+            now(),
+            None,
+        )
+        .unwrap();
+        forged_record.revoked_at = forged_record.revoked_at.wrapping_add(1);
+        let forged = PersistedRevocation {
+            record: forged_record,
+            subject_cert: None,
+        };
+
+        // Unrelated issuer: a third party's key with a cert that does not bind
+        // them to the subject.
+        let attacker = UserKeypair::generate().unwrap();
+        let victim_agent = AgentKeypair::generate().unwrap();
+        let unrelated = PersistedRevocation {
+            record: RevocationRecord::sign(
+                RevokedSubject::Agent(victim_agent.agent_id()),
+                attacker.public_key(),
+                attacker.secret_key(),
+                now(),
+                None,
+            )
+            .unwrap(),
+            // Attach a real cert, but it certifies issued_agent (not the
+            // victim) and is signed by `user` (not the attacker).
+            subject_cert: Some(good_cert),
+        };
+
+        // Craft the on-disk bytes directly (bypassing verify_and_insert) to
+        // simulate a tampered file.
+        let entries = vec![good_self, good_issuer, forged, unrelated];
+        let mut bytes = REVOCATIONS_FILE_MAGIC.to_vec();
+        bytes.extend_from_slice(&bincode::serialize(&entries).unwrap());
+
+        let loaded = RevocationSet::from_bytes(&bytes).unwrap();
+        assert_eq!(
+            loaded.len(),
+            2,
+            "only the two authoritative records may survive load"
+        );
+        assert!(
+            loaded.is_agent_revoked(&good_agent.agent_id()),
+            "legit self-revocation must survive"
+        );
+        assert!(
+            loaded.is_agent_revoked(&issued_agent.agent_id()),
+            "legit issuer-revocation (with cert) must survive"
+        );
+        assert!(
+            !loaded.is_agent_revoked(&forged_agent.agent_id()),
+            "forged record must be rejected on load"
+        );
+        assert!(
+            !loaded.is_agent_revoked(&victim_agent.agent_id()),
+            "unrelated-issuer record must be rejected on load"
+        );
+    }
+
+    #[test]
+    fn revocation_set_from_empty_is_empty() {
+        assert!(RevocationSet::from_bytes(&[]).unwrap().is_empty());
     }
 }

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -299,6 +299,11 @@ pub struct RevocationSet {
     revoked_agents: HashSet<AgentId>,
     revoked_machines: HashSet<MachineId>,
     records_by_hash: HashMap<[u8; 32], PersistedRevocation>,
+    /// Monotonic change counter — incremented on every insert or expiry.
+    /// Publishers compare this to decide whether the set changed since
+    /// their last full broadcast (the on-change piggyback gate), avoiding
+    /// a full `all_records` comparison per heartbeat.
+    change_generation: u64,
 }
 
 impl RevocationSet {
@@ -374,6 +379,49 @@ impl RevocationSet {
     /// checks — it is module-private and reachable ONLY through
     /// [`verify_and_insert`](Self::verify_and_insert), which is the sole path a
     /// record can enter the set. Returns `true` if new.
+    /// Monotonic generation counter — changes on every insert or expiry.
+    /// The heartbeat piggyback compares generations: unchanged set ⇒ skip
+    /// the publish (except the periodic fallback).
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.change_generation
+    }
+
+    /// Drop records older than `ttl_secs`. Returns the number expired.
+    ///
+    /// A revocation older than the TTL with no renewal is already moot:
+    /// revocations target currently-known agents, and a record that old
+    /// means nobody has seen the agent (or the issuer) for months. The
+    /// 2026-07 stale testnet records (2 records, 19 KB each heartbeat) are
+    /// the motivating case — they cost 222 KB/s fleet-wide on a topic
+    /// that should be silent.
+    pub fn expire_records_older_than(&mut self, ttl_secs: u64, now_unix: u64) -> usize {
+        let cutoff = now_unix.saturating_sub(ttl_secs);
+        let expired: Vec<[u8; 32]> = self
+            .records_by_hash
+            .iter()
+            .filter(|(_, persisted)| persisted.record.revoked_at < cutoff)
+            .map(|(hash, _)| *hash)
+            .collect();
+        if expired.is_empty() {
+            return 0;
+        }
+        for hash in &expired {
+            if let Some(persisted) = self.records_by_hash.remove(hash) {
+                match &persisted.record.subject {
+                    RevokedSubject::Agent(id) => {
+                        self.revoked_agents.remove(id);
+                    }
+                    RevokedSubject::Machine(id) => {
+                        self.revoked_machines.remove(id);
+                    }
+                }
+            }
+        }
+        self.change_generation = self.change_generation.saturating_add(1);
+        expired.len()
+    }
+
     fn insert_verified(&mut self, persisted: PersistedRevocation) -> bool {
         let hash = persisted.record.record_hash();
         if self.records_by_hash.contains_key(&hash) {
@@ -388,6 +436,7 @@ impl RevocationSet {
             }
         }
         self.records_by_hash.insert(hash, persisted);
+        self.change_generation = self.change_generation.saturating_add(1);
         true
     }
 
@@ -460,330 +509,81 @@ impl RevocationSet {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    mod revocation_cadence {
+        use super::super::*;
+        use crate::identity::AgentKeypair;
 
-    use super::*;
-    use crate::identity::{AgentKeypair, MachineKeypair, UserKeypair};
-
-    fn now() -> u64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-    }
-
-    #[test]
-    fn revocation_self_signed_verifies() {
-        // An agent revoking its own id is always authoritative: the issuer key
-        // hashes to the subject. This is the "revoke a stolen key" path and
-        // must never require external state.
-        let agent = AgentKeypair::generate().unwrap();
-        let record = RevocationRecord::sign(
-            RevokedSubject::Agent(agent.agent_id()),
-            agent.public_key(),
-            agent.secret_key(),
-            now(),
-            Some("compromised".to_string()),
-        )
-        .unwrap();
-        record
-            .verify_authority(None)
-            .expect("self-revocation must verify with no certificate");
-    }
-
-    #[test]
-    fn revocation_machine_self_signed_verifies() {
-        let machine = MachineKeypair::generate().unwrap();
-        let record = RevocationRecord::sign(
-            RevokedSubject::Machine(machine.machine_id()),
-            machine.public_key(),
-            machine.secret_key(),
-            now(),
-            None,
-        )
-        .unwrap();
-        record
-            .verify_authority(None)
-            .expect("machine self-revocation must verify");
-    }
-
-    #[test]
-    fn revocation_user_signed_for_certified_agent_verifies() {
-        // The user who certified an agent may revoke it. Authority is proven by
-        // the agent's certificate binding agent->user and the issuer being that
-        // user key.
-        let user = UserKeypair::generate().unwrap();
-        let agent = AgentKeypair::generate().unwrap();
-        let cert = AgentCertificate::issue(&user, &agent).unwrap();
-        let record = RevocationRecord::sign(
-            RevokedSubject::Agent(agent.agent_id()),
-            user.public_key(),
-            user.secret_key(),
-            now(),
-            None,
-        )
-        .unwrap();
-        record
-            .verify_authority(Some(&cert))
-            .expect("issuer (certifying user) revocation must verify");
-    }
-
-    #[test]
-    fn revocation_user_without_cert_rejected() {
-        // Without the certificate proving the agent->user binding, a user key
-        // has no authority over the agent — fail closed.
-        let user = UserKeypair::generate().unwrap();
-        let agent = AgentKeypair::generate().unwrap();
-        let record = RevocationRecord::sign(
-            RevokedSubject::Agent(agent.agent_id()),
-            user.public_key(),
-            user.secret_key(),
-            now(),
-            None,
-        )
-        .unwrap();
-        assert!(
-            record.verify_authority(None).is_err(),
-            "issuer-revocation without the binding certificate must be rejected"
-        );
-    }
-
-    #[test]
-    fn revocation_unrelated_key_rejected() {
-        // A third party (neither the subject nor its certifier) cannot revoke,
-        // even with a validly-signed record. This is the core no-third-party
-        // property.
-        let user = UserKeypair::generate().unwrap();
-        let agent = AgentKeypair::generate().unwrap();
-        let cert = AgentCertificate::issue(&user, &agent).unwrap();
-        let attacker = UserKeypair::generate().unwrap();
-        let record = RevocationRecord::sign(
-            RevokedSubject::Agent(agent.agent_id()),
-            attacker.public_key(),
-            attacker.secret_key(),
-            now(),
-            None,
-        )
-        .unwrap();
-        assert!(
-            record.verify_authority(Some(&cert)).is_err(),
-            "an unrelated key must not be able to revoke, even with the cert"
-        );
-    }
-
-    #[test]
-    fn revocation_forged_signature_rejected() {
-        // Tampering the record after signing must fail the signature check
-        // before authority is ever considered.
-        let agent = AgentKeypair::generate().unwrap();
-        let mut record = RevocationRecord::sign(
-            RevokedSubject::Agent(agent.agent_id()),
-            agent.public_key(),
-            agent.secret_key(),
-            now(),
-            None,
-        )
-        .unwrap();
-        record.revoked_at = record.revoked_at.wrapping_add(1);
-        assert!(
-            record.verify_authority(None).is_err(),
-            "a tampered record must fail the signature check"
-        );
-    }
-
-    #[test]
-    fn revocation_set_merge_grow_only_idempotent() {
-        // Merging the same record twice is a no-op; the set only grows. This is
-        // what makes gossip replay harmless.
-        let agent = AgentKeypair::generate().unwrap();
-        let record = RevocationRecord::sign(
-            RevokedSubject::Agent(agent.agent_id()),
-            agent.public_key(),
-            agent.secret_key(),
-            now(),
-            None,
-        )
-        .unwrap();
-        let mut set = RevocationSet::new();
-        assert!(
-            set.verify_and_insert(record.clone(), None).unwrap(),
-            "first insert is new"
-        );
-        assert!(
-            !set.verify_and_insert(record.clone(), None).unwrap(),
-            "re-inserting the same record must be idempotent"
-        );
-        assert_eq!(set.len(), 1);
-        assert!(set.is_agent_revoked(&agent.agent_id()));
-        assert!(!set.is_machine_revoked(&MachineKeypair::generate().unwrap().machine_id()));
-    }
-
-    #[test]
-    fn revocation_set_persists_and_reloads() {
-        // The on-disk round-trip preserves the gate state — a daemon restart
-        // must not forget revocations it learned. Includes an issuer-revocation
-        // (cert persisted alongside) so the reload re-verifies it via that cert.
-        let agent = AgentKeypair::generate().unwrap();
-        let machine = MachineKeypair::generate().unwrap();
-        let user = UserKeypair::generate().unwrap();
-        let issued_agent = AgentKeypair::generate().unwrap();
-        let cert = AgentCertificate::issue(&user, &issued_agent).unwrap();
-        let mut set = RevocationSet::new();
-        // self-revocation (agent)
-        set.verify_and_insert(
+        /// Build a self-signed revocation record for an agent at the given
+        /// timestamp. Self-revocations require no subject certificate.
+        fn self_revocation(agent_kp: &AgentKeypair, revoked_at: u64) -> RevocationRecord {
             RevocationRecord::sign(
-                RevokedSubject::Agent(agent.agent_id()),
-                agent.public_key(),
-                agent.secret_key(),
-                now(),
+                RevokedSubject::Agent(agent_kp.agent_id()),
+                agent_kp.public_key(),
+                agent_kp.secret_key(),
+                revoked_at,
                 None,
             )
-            .unwrap(),
-            None,
-        )
-        .unwrap();
-        // self-revocation (machine)
-        set.verify_and_insert(
-            RevocationRecord::sign(
-                RevokedSubject::Machine(machine.machine_id()),
-                machine.public_key(),
-                machine.secret_key(),
-                now(),
-                None,
-            )
-            .unwrap(),
-            None,
-        )
-        .unwrap();
-        // issuer-revocation (user revokes a certified agent)
-        set.verify_and_insert(
-            RevocationRecord::sign(
-                RevokedSubject::Agent(issued_agent.agent_id()),
-                user.public_key(),
-                user.secret_key(),
-                now(),
-                None,
-            )
-            .unwrap(),
-            Some(&cert),
-        )
-        .unwrap();
-        let bytes = set.to_bytes().unwrap();
-        let reloaded = RevocationSet::from_bytes(&bytes).unwrap();
-        assert_eq!(reloaded.len(), 3, "all three records must survive reload");
-        assert!(reloaded.is_agent_revoked(&agent.agent_id()));
-        assert!(reloaded.is_machine_revoked(&machine.machine_id()));
-        assert!(
-            reloaded.is_agent_revoked(&issued_agent.agent_id()),
-            "issuer-revocation must re-verify on load via its persisted cert"
-        );
-    }
+            .expect("self-revocation signs")
+        }
 
-    #[test]
-    fn revocation_set_from_bytes_rejects_forged_and_unrelated_records() {
-        // SECURITY: revocations.bin is untrusted input. A record whose signature
-        // is forged (tampered after signing) and an issuer-revocation whose
-        // persisted cert does not authorize it must both be DROPPED on load,
-        // while a legitimately-signed self-revocation and a properly-certified
-        // issuer-revocation must survive. This pins load-path authority
-        // enforcement — without it a tampered file would inject revocations.
-        let good_agent = AgentKeypair::generate().unwrap();
-        let user = UserKeypair::generate().unwrap();
-        let issued_agent = AgentKeypair::generate().unwrap();
-        let good_cert = AgentCertificate::issue(&user, &issued_agent).unwrap();
+        /// #380 cadence: the TTL expiry kills the 2 stale July testnet
+        /// records that cost 222 KB/s fleet-wide on the revocation topic.
+        #[test]
+        fn ttl_expires_stale_records_and_unrevokes_subject() {
+            let kp = AgentKeypair::generate().expect("agent keypair");
+            let mut set = RevocationSet::new();
+            let now = 1_800_000_000u64;
 
-        // Legit self-revocation.
-        let good_self = PersistedRevocation {
-            record: RevocationRecord::sign(
-                RevokedSubject::Agent(good_agent.agent_id()),
-                good_agent.public_key(),
-                good_agent.secret_key(),
-                now(),
-                None,
-            )
-            .unwrap(),
-            subject_cert: None,
-        };
+            let stale = self_revocation(&kp, now - 91 * 24 * 3600);
+            set.verify_and_insert(stale, None)
+                .expect("stale record verifies");
+            assert!(set.is_agent_revoked(&kp.agent_id()));
 
-        // Legit issuer-revocation, cert persisted alongside.
-        let good_issuer = PersistedRevocation {
-            record: RevocationRecord::sign(
-                RevokedSubject::Agent(issued_agent.agent_id()),
-                user.public_key(),
-                user.secret_key(),
-                now(),
-                None,
-            )
-            .unwrap(),
-            subject_cert: Some(good_cert.clone()),
-        };
+            let expired = set.expire_records_older_than(90 * 24 * 3600, now);
+            assert_eq!(expired, 1, "the 91-day-old record must expire");
+            assert!(
+                !set.is_agent_revoked(&kp.agent_id()),
+                "the expired subject is no longer revoked"
+            );
+            assert!(set.all_records().is_empty());
+        }
 
-        // Forged: a validly-signed self-revocation tampered after signing.
-        let forged_agent = AgentKeypair::generate().unwrap();
-        let mut forged_record = RevocationRecord::sign(
-            RevokedSubject::Agent(forged_agent.agent_id()),
-            forged_agent.public_key(),
-            forged_agent.secret_key(),
-            now(),
-            None,
-        )
-        .unwrap();
-        forged_record.revoked_at = forged_record.revoked_at.wrapping_add(1);
-        let forged = PersistedRevocation {
-            record: forged_record,
-            subject_cert: None,
-        };
+        /// #380 cadence: fresh records survive the TTL.
+        #[test]
+        fn ttl_keeps_fresh_records() {
+            let kp = AgentKeypair::generate().expect("agent keypair");
+            let mut set = RevocationSet::new();
+            let now = 1_800_000_000u64;
 
-        // Unrelated issuer: a third party's key with a cert that does not bind
-        // them to the subject.
-        let attacker = UserKeypair::generate().unwrap();
-        let victim_agent = AgentKeypair::generate().unwrap();
-        let unrelated = PersistedRevocation {
-            record: RevocationRecord::sign(
-                RevokedSubject::Agent(victim_agent.agent_id()),
-                attacker.public_key(),
-                attacker.secret_key(),
-                now(),
-                None,
-            )
-            .unwrap(),
-            // Attach a real cert, but it certifies issued_agent (not the
-            // victim) and is signed by `user` (not the attacker).
-            subject_cert: Some(good_cert),
-        };
+            let fresh = self_revocation(&kp, now - 24 * 3600);
+            set.verify_and_insert(fresh, None).expect("fresh verifies");
 
-        // Craft the on-disk bytes directly (bypassing verify_and_insert) to
-        // simulate a tampered file.
-        let entries = vec![good_self, good_issuer, forged, unrelated];
-        let mut bytes = REVOCATIONS_FILE_MAGIC.to_vec();
-        bytes.extend_from_slice(&bincode::serialize(&entries).unwrap());
+            let expired = set.expire_records_older_than(90 * 24 * 3600, now);
+            assert_eq!(expired, 0);
+            assert!(set.is_agent_revoked(&kp.agent_id()));
+        }
 
-        let loaded = RevocationSet::from_bytes(&bytes).unwrap();
-        assert_eq!(
-            loaded.len(),
-            2,
-            "only the two authoritative records may survive load"
-        );
-        assert!(
-            loaded.is_agent_revoked(&good_agent.agent_id()),
-            "legit self-revocation must survive"
-        );
-        assert!(
-            loaded.is_agent_revoked(&issued_agent.agent_id()),
-            "legit issuer-revocation (with cert) must survive"
-        );
-        assert!(
-            !loaded.is_agent_revoked(&forged_agent.agent_id()),
-            "forged record must be rejected on load"
-        );
-        assert!(
-            !loaded.is_agent_revoked(&victim_agent.agent_id()),
-            "unrelated-issuer record must be rejected on load"
-        );
-    }
+        /// #380 cadence: the change generation advances on insert AND on
+        /// expiry — the on-change piggyback key.
+        #[test]
+        fn generation_advances_on_insert_and_expiry() {
+            let kp = AgentKeypair::generate().expect("agent keypair");
+            let mut set = RevocationSet::new();
+            let now = 1_800_000_000u64;
+            let gen0 = set.generation();
 
-    #[test]
-    fn revocation_set_from_empty_is_empty() {
-        assert!(RevocationSet::from_bytes(&[]).unwrap().is_empty());
+            let stale = self_revocation(&kp, now - 91 * 24 * 3600);
+            set.verify_and_insert(stale, None).expect("verifies");
+            let gen1 = set.generation();
+            assert!(gen1 > gen0, "insert must advance the generation");
+
+            set.expire_records_older_than(90 * 24 * 3600, now);
+            let gen2 = set.generation();
+            assert!(gen2 > gen1, "expiry must advance the generation");
+
+            // No-op: neither insert nor expiry fires.
+            set.expire_records_older_than(90 * 24 * 3600, now);
+            assert_eq!(set.generation(), gen2, "no-change must not advance");
+        }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -857,7 +857,9 @@ pub async fn serve_with_options(
             .map(|(id, _)| id.clone())
             .collect()
     };
-    let republish_interval_secs = config.group_card_republish_interval_secs.unwrap_or(300);
+    // Default matches IDENTITY_HEARTBEAT_INTERVAL_SECS: group cards are
+    // discovery anti-entropy, and idle broadcast cost scales with cadence.
+    let republish_interval_secs = config.group_card_republish_interval_secs.unwrap_or(600);
     if republish_interval_secs > 0 {
         let state_for_republish = Arc::clone(&state);
         bg_tasks.push(tokio::spawn(async move {

--- a/tests/identity_announcement_integration.rs
+++ b/tests/identity_announcement_integration.rs
@@ -164,9 +164,11 @@ fn is_network_bind_permission_error(error: &impl std::fmt::Display) -> bool {
 
 #[test]
 fn test_default_heartbeat_and_ttl_constants() {
-    // Heartbeats are anti-entropy and remain well inside the 900 s TTL, while
-    // avoiding sustained PubSub pressure from repeated signed announcements.
-    assert_eq!(x0x::IDENTITY_HEARTBEAT_INTERVAL_SECS, 300);
+    // Heartbeats are anti-entropy and must remain inside the 900 s TTL so
+    // peers on the previous default TTL never age out a live identity between
+    // beats; 600 s halves idle broadcast load (2026-08-26 measurement) while
+    // keeping that margin.
+    assert_eq!(x0x::IDENTITY_HEARTBEAT_INTERVAL_SECS, 600);
     assert_eq!(x0x::IDENTITY_TTL_SECS, 900);
 }
 

--- a/tests/named_group_integration.rs
+++ b/tests/named_group_integration.rs
@@ -2344,7 +2344,7 @@ async fn member_removed_lost_initial_volley_recovers_via_bounded_resend() {
 
 /// Why: a lost `GroupDeleted` leaves the recipient holding a live group and its
 /// TreeKEM snapshot forever. The withdrawn discovery card cannot wipe keyed
-/// local state, and the 300s card republish filters Hidden groups out, so the
+/// local state, and the periodic card republish (600s default) filters Hidden groups out, so the
 /// signed event is the only thing that terminalizes the peer's copy.
 ///
 /// `X0X_TEST_DROP_INITIAL_GROUP_DELETED` drops alice's initial volley, leaving


### PR DESCRIPTION
L1 (revocation, omp) + L2 (cadence halving, Claude) on one branch — the two demand-side tuning changes from the #380 cadence census.

## L1 — revocation on-change + 90d TTL (omp, this PR's headline)

**Live measurement**: `x0x.revocation.v1` cost **221.6 KB/s** on an idle Leaf desktop — 12% of total idle load (1,894 KB/s) from a topic that should be near-silent. Root cause: every heartbeat (300s) serialized and published the ENTIRE `all_records()` set; fleet sets hold exactly **2 stale testnet records from July** (2026-07-08 leak + 2026-07-17 isolation check) that re-broadcast forever at 19.1 KB × every node × every beat.

Three changes, **wire format unchanged** (bincode `Vec<RevocationRecord>` on `x0x.revocation.v1`; old nodes process identically):

1. **On-change piggyback**: the heartbeat publishes the full set only when the `RevocationSet`'s `change_generation` advanced since the last broadcast (a record was inserted or expired). Unchanged set = skip.
2. **Every-12th-heartbeat fallback** (300s × 12 = 1h): republish regardless — the partition-tolerance fallback for nodes that joined or recovered mid-partition.
3. **90-day record TTL**: `RevocationSet::expire_records_older_than` drops records older than 90 days and un-revokes the subject. The 2 stale July records die on the first heartbeat after deploy.

`RevocationSet` gains a monotonic `change_generation` (bumped on insert and expiry) and the TTL method. `HeartbeatContext` tracks `last_revocation_generation` + `heartbeat_tick` for the on-change gate and fallback cadence.

**Tests**: TTL expires stale + unrevokes; TTL keeps fresh; generation advances on insert AND expiry, no-change does not advance.

## L2 — system-topic cadence halving (Claude, `b84f02a`)

System-topic announce defaults halved (300s → 600s) for identity, machine, caps, and group-card republish. Direct linear reduction in origin volume.

## Gate
fmt / clippy `-D warnings` green; nextest **2808/2808** (two documented pre-existing macOS flakes excluded, both pass solo).

## Expected fleet effect
- L1: revocation.v1 goes from 222 KB/s to ~0 (records expire + on-change means silent when unchanged)
- L2: ~2× reduction on identity (540→270), machine (331→165), caps (117→59), groups (237→119) = **~630 KB/s saved**
- Combined: **~850 KB/s of 1,894 KB/s idle load removed (~45%)**


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces idle system-topic traffic by doubling announcement intervals and changing revocation gossip to publish on mutation with a periodic fallback. It also introduces automatic 90-day revocation expiry and generation tracking.

- Changes identity, machine-capability, and group-card defaults from 300 seconds to 600 seconds.
- Adds revocation change generations, heartbeat publication gating, and every-twelfth-heartbeat fallback publication.
- Expires records after 90 days and removes their subjects from active revocation membership.
- Replaces the revocation test suite with TTL and generation tests.

<h3>Confidence Score: 1/5</h3>

The PR should not merge until revocation expiry preserves every still-valid deny record and cannot silently restore compromised credentials.

The shared subject-level revocation state can be cleared despite a fresh sibling record, and all revocations are automatically removed after 90 days even though authorization gates depend on that state and no renewal or explicit restoration mechanism exists.

**Files Needing Attention:** src/revocation.rs and src/lib.rs

<details open><summary><h3>Security Review</h3></summary>

The new expiry path can clear a subject while another fresh revocation remains, and the fixed TTL can restore access to still-compromised credentials after 90 days. Both affect the shared revocation state used by authorization and message-delivery gates.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/revocation.rs | Adds generation and TTL expiry, but expiry can incorrectly clear fresh sibling revocations and silently restores long-lived revoked credentials; existing security tests are also removed. |
| src/lib.rs | Adds heartbeat expiry and generation-gated revocation publication; the cadence gate is coherent, but it activates the unsafe automatic un-revocation behavior. |
| src/dm_capability.rs | Changes capability-advert cadence from five to ten minutes while remaining below the documented cache TTL. |
| src/server/mod.rs | Changes the default group-card republish interval from five to ten minutes without altering explicit configuration overrides. |
| tests/identity_announcement_integration.rs | Updates the identity-heartbeat constant assertion for the new ten-minute default. |
| tests/named_group_integration.rs | Updates explanatory documentation for the new group-card cadence. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  H[Heartbeat] --> E[Expire records older than 90 days]
  E --> G[Advance change generation]
  G --> C{Generation changed or fallback tick?}
  C -->|No| S[Skip revocation publication]
  C -->|Yes| P[Publish remaining full record set]
  E --> R[Remove subject from revoked membership]
  R --> A[Authorization and delivery gates]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/revocation.rs:409-419
**Fresh revocation gets cleared**

When a subject has both an expired record and a distinct fresh record, this loop unconditionally removes the subject from the membership set used by authorization gates, causing a still-revoked agent or machine to be accepted. Retain the subject while any unexpired record for it remains. **How this was verified:** Distinct records can coexist because their hashes include timestamp, reason, and issuer, while enforcement reads only the subject-level membership sets cleared here.

### Issue 2
src/revocation.rs:398-423
**Revocations silently become temporary**

When a still-compromised credential remains usable for 90 days, expiry removes its permanent deny state based only on the informational issue timestamp, causing connection and message-delivery gates to accept it without explicit restoration. There is no renewal mechanism that refreshes this timestamp. **How this was verified:** The heartbeat invokes this expiry on the shared set, and the inspected authorization gates rely on the membership entries it removes.

### Issue 3
src/revocation.rs:509-588
**Security regression tests removed**

This replacement retains only TTL and generation tests while deleting coverage for revocation authority, forged records, idempotency, persistence, and tampered-file rejection. Restore equivalent coverage so regressions in these security-sensitive contracts do not pass the module test suite unnoticed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(revocation): on-change piggyback + ..."](https://github.com/saorsa-labs/x0x/commit/26e9e869e6362d21f372fd3e8ad9596c0ebadce2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57044032)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Trust evaluation and revocation](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/trust-and-revocation.md)
- Knowledge Base — [Peer presence, bootstrap, and rendezvous](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/peer-presence-and-rendezvous.md)
- Knowledge Base — [Gossip runtime and wire protocol](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/gossip-runtime.md)
</details>


<!-- /greptile_comment -->