### PR TITLE
chore(release): v0.39.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.9"
+version = "0.39.10"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.9
+version: 0.39.10
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Release v0.39.10 — system-topic demand tuning (#413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR advances the package and skill metadata from v0.39.9 to v0.39.10.
- Updates the Rust package version in Cargo.toml.
- Updates the published skill metadata version in SKILL.md.
- Leaves the corresponding v0.39.10 changelog entry to be added.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking omission of the v0.39.10 changelog entry.

Cargo.toml and SKILL.md remain synchronized and release validation prevents tag mismatches, but CHANGELOG.md still presents v0.39.9 as the latest documented release.

**Files Needing Attention:** Cargo.toml and CHANGELOG.md

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the crate version to 0.39.10, but the release bump is missing its documented changelog entry. |
| SKILL.md | Keeps the skill metadata version synchronized with Cargo.toml at 0.39.10. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Cargo.toml:3
**Changelog entry omitted**

The release version advances to v0.39.10 while `CHANGELOG.md` still lists v0.39.9 as the latest release, leaving readers without the release notes required by the documented version-bump process.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.10"](https://github.com/saorsa-labs/x0x/commit/edb17056af8a0c39eb13bef75e4621f0edac9705) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57071844)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->