### PR TITLE
feat(announce): L3 — V3 slimmed self-verifying announce + cert-digest blob cache (#380)

### DIFF
--- a/src/announce_blob.rs
+++ b/src/announce_blob.rs
@@ -1,15 +1,24 @@
 //! # L3 fetch-on-miss: announce blob cache + targeted fetch protocol.
 //!
-//! The V3 identity announce carries a BLAKE3 digest of the full V2
-//! `IdentityAnnouncement` instead of the inline cert chain + capability
-//! blob. A receiver that recognizes the digest uses its cached copy; a miss
-//! triggers a targeted fetch. This module owns the cache and the fetch.
+//! The V3 identity announce carries a BLAKE3 digest of the inline
+//! `(user_id, agent_certificate)` pair instead of the pair itself — see
+//! [`crate::announce_v3::cert_digest`]. A receiver that recognizes the
+//! digest uses its cached copy; a miss triggers a targeted fetch. This
+//! module owns the cache and the fetch.
+//!
+//! THE BLOB IS THE PAIR, not the full V2 announcement: the digest is
+//! defined over `bincode(&(Option<UserId>, Option<AgentCertificate>))`,
+//! which is stable across heartbeats (announced_at never enters it).
+//! Fetching the full announcement would churn the digest every beat.
 //!
 //! SECURITY INVARIANT: **verify-before-cache**. A fetched blob is only
-//! cached after (a) full `IdentityAnnouncement::verify()` passes AND
-//! (b) `blake3(bincode(&announcement))` matches the requested digest.
-//! An unverified or digest-mismatched blob is NEVER cached — this closes
-//! the spoofing window where a forged announce could poison the cache.
+//! cached after (a) `blake3(blob_bytes)` matches the requested digest,
+//! (b) the pair deserializes, and (c) the pair passes the same pairing
+//! rule `IdentityAnnouncement::verify` enforces: `(Some, Some)` requires
+//! `cert.verify()` AND `cert.agent_id() == expected_agent_id` AND
+//! `cert.user_id() == user_id`; `(None, None)` is anonymous (ok); a
+//! mixed pair is rejected. An unverified or mismatched blob is NEVER
+//! cached — this closes the spoofing window into the cache.
 //!
 //! Disk persistence: bincode file under the daemon data dir, loaded at
 //! startup, saved on insert. Bounded at [`BLOB_CACHE_MAX_ENTRIES`] (LRU).
@@ -22,7 +31,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crate::gossip::PubSubManager;
-use crate::{identity, IdentityAnnouncement};
+use crate::identity;
 
 /// Maximum in-memory + on-disk cache entries. The fleet has ~50 active
 /// agents; 256 gives 5× headroom without unbounded growth.
@@ -43,15 +52,18 @@ pub(crate) const ANNOUNCE_BLOB_REQUEST_DOMAIN: &[u8] = b"x0x/announce/v3/blob-re
 #[allow(dead_code)]
 pub(crate) const ANNOUNCE_BLOB_TOPIC: &str = "x0x/announce/v3/blob";
 
-/// A cached full V2 announcement, keyed by its BLAKE3 digest.
+/// A cached `(user_id, agent_certificate)` pair, keyed by its BLAKE3
+/// digest — exactly the bytes [`crate::announce_v3::cert_digest`] commits
+/// to. Stable across heartbeats; never includes `announced_at`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CachedBlob {
-    /// BLAKE3-256 of the bincode-serialized `IdentityAnnouncement`.
+    /// BLAKE3-256 of the bincode-serialized pair.
     pub digest: [u8; 32],
     /// Monotonic version from the V3 announce (bumped on payload change).
     pub payload_version: u64,
-    /// The full, verified V2 `IdentityAnnouncement`.
-    pub full: IdentityAnnouncement,
+    /// The verified `(user_id, cert)` pair the digest commits to.
+    pub user_id: Option<identity::UserId>,
+    pub agent_certificate: Option<identity::AgentCertificate>,
     /// Unix seconds when this blob was fetched/cached.
     pub fetched_at_unix: u64,
 }
@@ -181,12 +193,13 @@ impl AnnounceBlobCache {
             return Some(hit);
         }
 
-        // Miss — spawn the fetch, return None immediately. The pubsub
-        // reference cannot cross the spawn boundary ('static); the fetch
-        // task goes through the cache's own handle once Claude's V3
-        // receiver wires the responder side. Until then this is a
-        // metered no-op: `blob_fetches_failed` increments and the next
-        // heartbeat retries — never blocks the caller.
+        // Miss — spawn the fetch, return None immediately. `agent_id` is
+        // the expected agent threaded into `verify_fetched_blob`'s cert
+        // binding check. The pubsub reference cannot cross the spawn
+        // boundary ('static); the fetch task goes through the cache's own
+        // handle once Claude's V3 receiver wires the responder side. Until
+        // then this is a metered no-op: `blob_fetches_failed` increments
+        // and the next heartbeat retries — never blocks the caller.
         let _ = pubsub;
         let cache = Arc::clone(self);
         let digest = *digest;
@@ -218,25 +231,23 @@ impl AnnounceBlobCache {
         None
     }
 
-    /// Serve a blob request from our own cache or our current announcement.
-    /// Called by the targeted-request handler when a peer asks for a digest.
+    /// Serve a blob request from our own cache or our current announcement
+    /// state. Called by the targeted-request handler when a peer asks for
+    /// a digest. The response is the bincode of the served agent's
+    /// `(user_id, agent_certificate)` pair.
     pub async fn serve_request(
         &self,
         digest: &[u8; 32],
-        current_announcement: Option<&IdentityAnnouncement>,
+        current_user_id: &Option<identity::UserId>,
+        current_agent_certificate: &Option<identity::AgentCertificate>,
     ) -> Option<Vec<u8>> {
         // Check the cache first.
         if let Some(cached) = self.get(digest).await {
-            return bincode::serialize(&cached.full).ok();
+            return bincode::serialize(&(&cached.user_id, &cached.agent_certificate)).ok();
         }
-        // Check if it matches our own current announcement.
-        if let Some(announcement) = current_announcement {
-            if let Ok(bytes) = bincode::serialize(announcement) {
-                let computed = blake3::hash(&bytes);
-                if computed.as_bytes() == digest {
-                    return Some(bytes);
-                }
-            }
+        // Check if it matches our own current pair.
+        if crate::announce_v3::cert_digest(current_user_id, current_agent_certificate) == *digest {
+            return bincode::serialize(&(current_user_id, current_agent_certificate)).ok();
         }
         None
     }
@@ -251,11 +262,14 @@ impl AnnounceBlobCache {
         }
     }
 
-    /// Compute the BLAKE3 digest of a serialized announcement.
-    pub fn digest_of(announcement: &IdentityAnnouncement) -> Option<[u8; 32]> {
-        bincode::serialize(announcement)
-            .ok()
-            .map(|bytes| blake3::hash(&bytes).into())
+    /// Compute the digest of a `(user_id, cert)` pair — the same function
+    /// the V3 announce uses. Kept here so callers don't need to import
+    /// `announce_v3` for a one-liner.
+    pub fn digest_of(
+        user_id: &Option<identity::UserId>,
+        cert: &Option<identity::AgentCertificate>,
+    ) -> [u8; 32] {
+        crate::announce_v3::cert_digest(user_id, cert)
     }
 
     // ── Internal ──
@@ -350,7 +364,7 @@ impl AnnounceBlobCache {
 async fn fetch_and_verify(
     cache: &AnnounceBlobCache,
     digest: &[u8; 32],
-    agent_id: &identity::AgentId,
+    expected_agent_id: &identity::AgentId,
     machine_id: &identity::MachineId,
 ) -> Result<CachedBlob, String> {
     // Phase 2 (Claude's receiver wiring) publishes an `AnnounceBlobRequest`
@@ -360,7 +374,7 @@ async fn fetch_and_verify(
     tracing::debug!(
         target: "announce.blob",
         digest = %hex::encode(digest),
-        agent = %hex::encode(agent_id.as_bytes()),
+        agent = %hex::encode(expected_agent_id.as_bytes()),
         machine = %machine_id.as_bytes().iter().map(|b| format!("{b:02x}")).take(8).collect::<String>(),
         cached = cache.snapshot().blob_cache_hits,
         "announce blob fetch deferred (responder pending)"
@@ -368,17 +382,33 @@ async fn fetch_and_verify(
     Err("announce blob fetch: responder protocol pending V3 receiver wiring".to_string())
 }
 
-/// Verify a fetched blob against the expected digest.
+/// Verify a fetched blob against the expected digest and agent.
 /// This is the SECURITY GATE — called before any cache insert.
 ///
-/// Returns `Ok(CachedBlob)` on success; `Err(reason)` on any failure.
+/// The blob is the bincode of `(Option<UserId>, Option<AgentCertificate>)`
+/// — the exact bytes [`crate::announce_v3::cert_digest`] commits to.
+///
+/// Gate order:
+/// 1. `blake3(blob_bytes) == expected_digest` (byte-level match first —
+///    nothing else runs on mismatched bytes).
+/// 2. Deserialize the pair.
+/// 3. Mirror `IdentityAnnouncement::verify`'s pairing rule:
+///    - `(Some(user), Some(cert))` → `cert.verify()` AND
+///      `cert.agent_id() == expected_agent_id` AND
+///      `cert.user_id() == user` (the cert binds THIS agent + THIS user).
+///    - `(None, None)` → anonymous, ok.
+///    - mixed → reject (V2 pairing rule forbids user without cert and
+///      cert without user).
+///
+/// Returns `Ok(CachedBlob)` only on full success.
 pub fn verify_fetched_blob(
-    announcement_bytes: &[u8],
+    blob_bytes: &[u8],
     expected_digest: &[u8; 32],
+    expected_agent_id: &identity::AgentId,
     payload_version: u64,
 ) -> Result<CachedBlob, String> {
-    // Step 1: compute the digest and check it matches.
-    let computed = blake3::hash(announcement_bytes);
+    // Step 1: digest match.
+    let computed = blake3::hash(blob_bytes);
     if computed.as_bytes() != expected_digest {
         return Err(format!(
             "digest mismatch: expected {}, got {}",
@@ -387,21 +417,46 @@ pub fn verify_fetched_blob(
         ));
     }
 
-    // Step 2: deserialize into an IdentityAnnouncement.
-    let announcement: IdentityAnnouncement = bincode::deserialize(announcement_bytes)
-        .map_err(|e| format!("deserialization failed: {e}"))?;
+    // Step 2: deserialize the pair.
+    let (user_id, agent_certificate): (
+        Option<identity::UserId>,
+        Option<identity::AgentCertificate>,
+    ) = bincode::deserialize(blob_bytes).map_err(|e| format!("deserialization failed: {e}"))?;
 
-    // Step 3: full cryptographic verification (machine_id ↔ pubkey binding
-    // + ML-DSA signature over the unsigned canonical bytes).
-    announcement
-        .verify()
-        .map_err(|e| format!("announcement verification failed: {e}"))?;
+    // Step 3: the pairing rule — mirrors IdentityAnnouncement::verify.
+    match (&user_id, &agent_certificate) {
+        (Some(user), Some(cert)) => {
+            cert.verify()
+                .map_err(|e| format!("certificate verification failed: {e}"))?;
+            let cert_agent = cert
+                .agent_id()
+                .map_err(|e| format!("certificate agent_id extraction failed: {e}"))?;
+            if cert_agent != *expected_agent_id {
+                return Err(format!(
+                    "certificate is for another agent: cert={}, expected={}",
+                    hex::encode(cert_agent.as_bytes()),
+                    hex::encode(expected_agent_id.as_bytes())
+                ));
+            }
+            let cert_user = cert
+                .user_id()
+                .map_err(|e| format!("certificate user_id extraction failed: {e}"))?;
+            if cert_user != *user {
+                return Err("certificate user does not match the paired user_id".to_string());
+            }
+        }
+        (None, None) => {} // anonymous — the digest commits to emptiness
+        (Some(_), None) | (None, Some(_)) => {
+            return Err("mixed pair rejected: user without cert or cert without user".to_string());
+        }
+    }
 
     // Verified — safe to cache.
     Ok(CachedBlob {
         digest: *expected_digest,
         payload_version,
-        full: announcement,
+        user_id,
+        agent_certificate,
         fetched_at_unix: std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -456,116 +511,166 @@ pub(crate) fn decode_blob_response(wire: &[u8]) -> Option<AnnounceBlobResponse> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::identity::AgentKeypair;
+    use crate::identity::{AgentCertificate, AgentKeypair, UserKeypair};
 
-    /// Build a signed, verifiable IdentityAnnouncement for testing.
-    fn test_announcement() -> (IdentityAnnouncement, AgentKeypair) {
+    /// Build a real issued certificate binding user→agent.
+    fn issued_cert() -> (AgentCertificate, UserKeypair, AgentKeypair) {
+        let user_kp = UserKeypair::generate().expect("user keypair");
         let agent_kp = AgentKeypair::generate().expect("agent keypair");
-        let machine_kp = crate::identity::MachineKeypair::generate().expect("machine keypair");
+        let cert = AgentCertificate::issue(&user_kp, &agent_kp).expect("cert issues");
+        (cert, user_kp, agent_kp)
+    }
+
+    /// Bincode of the pair — the exact bytes the digest commits to.
+    fn pair_bytes(user_id: &Option<identity::UserId>, cert: &Option<AgentCertificate>) -> Vec<u8> {
+        bincode::serialize(&(user_id, cert)).expect("serialize pair")
+    }
+
+    /// CROSS-MODULE CONSISTENCY: the digest computed by
+    /// `announce_v3::cert_digest` over the pair is exactly what
+    /// `verify_fetched_blob` accepts. This is the test that would have
+    /// caught the full-announcement hashing mismatch.
+    #[tokio::test]
+    async fn cert_digest_matches_verify_fetched_blob_acceptance() {
+        let (cert, user_kp, agent_kp) = issued_cert();
+        let user_id = Some(user_kp.user_id());
         let agent_id = agent_kp.agent_id();
-        let machine_id = machine_kp.machine_id();
+        // The V3 side computes the digest...
+        let digest = crate::announce_v3::cert_digest(&user_id, &Some(cert.clone()));
+        // ...and the blob side must accept those exact bytes under it.
+        let bytes = pair_bytes(&user_id, &Some(cert));
+        let accepted = verify_fetched_blob(&bytes, &digest, &agent_id, 1);
+        assert!(
+            accepted.is_ok(),
+            "blob verify must accept what cert_digest commits to: {:?}",
+            accepted.err()
+        );
+    }
 
-        // Use the existing announce builder path — produces a valid,
-        // signed announcement.
-        let announcement = IdentityAnnouncement {
-            agent_id,
-            machine_id,
-            user_id: None,
-            agent_certificate: None,
-            machine_public_key: machine_kp.public_key().as_bytes().to_vec(),
-            machine_signature: Vec::new(), // filled below
-            addresses: vec!["127.0.0.1:5483".parse().expect("addr")],
-            announced_at: 1_800_000_000,
-            nat_type: Some("FullCone".to_string()),
-            can_receive_direct: Some(true),
-            is_relay: Some(false),
-            is_coordinator: Some(false),
-            reachable_via: Vec::new(),
-            relay_candidates: Vec::new(),
-            agent_public_key: agent_kp.public_key().as_bytes().to_vec(),
-        };
+    /// Anonymous pair `(None, None)`: digest matches, no cert to verify —
+    /// accepted. This is the steady-state case for cert-less agents.
+    #[tokio::test]
+    async fn anonymous_pair_is_accepted() {
+        let agent_kp = AgentKeypair::generate().expect("agent keypair");
+        let bytes = pair_bytes(&None, &None);
+        let digest = crate::announce_v3::cert_digest(&None, &None);
+        assert!(verify_fetched_blob(&bytes, &digest, &agent_kp.agent_id(), 1).is_ok());
+    }
 
-        // Sign the unsigned canonical bytes.
-        let unsigned = announcement.to_unsigned();
-        let unsigned_bytes =
-            bincode::serialize(&unsigned).expect("serialize unsigned announcement");
-        let signature = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
-            machine_kp.secret_key(),
-            &unsigned_bytes,
-        )
-        .expect("sign announcement");
+    /// SECURITY: a cert for agent A is rejected when the fetch expected
+    /// agent B — the digest alone must not vouch for the binding.
+    #[tokio::test]
+    async fn cert_for_wrong_agent_is_rejected() {
+        let (cert, user_kp, _) = issued_cert();
+        let other_agent = AgentKeypair::generate().expect("other agent");
+        let user_id = Some(user_kp.user_id());
+        let digest = crate::announce_v3::cert_digest(&user_id, &Some(cert.clone()));
+        let bytes = pair_bytes(&user_id, &Some(cert));
 
-        (
-            IdentityAnnouncement {
-                machine_signature: signature.as_bytes().to_vec(),
-                ..announcement
-            },
-            agent_kp,
-        )
+        let result = verify_fetched_blob(&bytes, &digest, &other_agent.agent_id(), 1);
+        assert!(result.is_err(), "cross-agent cert must be rejected");
+        assert!(
+            result.unwrap_err().contains("another agent"),
+            "the error should name the agent binding failure"
+        );
+    }
+
+    /// SECURITY: a forged certificate (tampered signature bytes) is
+    /// rejected even when the digest matches the tampered bytes — verify
+    /// runs on the deserialized pair, not just the hash. Tamper at the
+    /// bincode level (the signature field is private): flip a byte in the
+    /// tail of the serialized pair, recompute the digest over the tampered
+    /// bytes, and the gate must still reject.
+    #[tokio::test]
+    async fn forged_certificate_is_rejected_before_cache() {
+        let (cert, user_kp, agent_kp) = issued_cert();
+        let user_id = Some(user_kp.user_id());
+        let mut bytes = pair_bytes(&user_id, &Some(cert));
+
+        // Flip a byte near the end (inside the cert's signature region).
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+
+        // Digest "matches" the tampered bytes — the attacker controls both.
+        let digest: [u8; 32] = blake3::hash(&bytes).into();
+
+        let result = verify_fetched_blob(&bytes, &digest, &agent_kp.agent_id(), 1);
+        assert!(
+            result.is_err(),
+            "forged certificate must be rejected before caching even with a matching digest"
+        );
+    }
+
+    /// SECURITY: digest mismatch — the fetched bytes don't hash to the
+    /// requested digest, so the blob is rejected before anything else runs.
+    #[tokio::test]
+    async fn digest_mismatch_rejected() {
+        let (cert, user_kp, agent_kp) = issued_cert();
+        let user_id = Some(user_kp.user_id());
+        let bytes = pair_bytes(&user_id, &Some(cert));
+        let wrong_digest: [u8; 32] = [0xAB; 32]; // deliberately wrong
+
+        let result = verify_fetched_blob(&bytes, &wrong_digest, &agent_kp.agent_id(), 1);
+        assert!(result.is_err(), "digest mismatch must be rejected");
+        assert!(
+            result.unwrap_err().contains("digest mismatch"),
+            "the error should name the digest mismatch"
+        );
+    }
+
+    /// SECURITY: mixed pair — user without cert — rejected per the V2
+    /// pairing rule.
+    #[tokio::test]
+    async fn mixed_pair_is_rejected() {
+        let user_kp = UserKeypair::generate().expect("user keypair");
+        let agent_kp = AgentKeypair::generate().expect("agent keypair");
+        let user_id = Some(user_kp.user_id());
+        let bytes = pair_bytes(&user_id, &None);
+        let digest = crate::announce_v3::cert_digest(&user_id, &None);
+
+        let result = verify_fetched_blob(&bytes, &digest, &agent_kp.agent_id(), 1);
+        assert!(result.is_err(), "user-without-cert must be rejected");
+        assert!(
+            result.unwrap_err().contains("mixed pair"),
+            "the error should name the mixed-pair rule"
+        );
     }
 
     /// Disk round-trip: what goes in comes back out after a reload.
     #[tokio::test]
     async fn blob_cache_disk_round_trip() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let path = tempdir.path().join("announce-blobs.bin");
-        let (announcement, _) = test_announcement();
-        let digest = AnnounceBlobCache::digest_of(&announcement).expect("digest");
+        let (cert, user_kp, agent_kp) = issued_cert();
+        let user_id = Some(user_kp.user_id());
+        let digest = AnnounceBlobCache::digest_of(&user_id, &Some(cert.clone()));
 
         {
-            let cache = AnnounceBlobCache::new(Some(path.clone()));
+            let cache = AnnounceBlobCache::new(Some(std::path::PathBuf::from(
+                "/tmp/x0x-blob-roundtrip-test.bin",
+            )));
             cache
                 .insert_verified(CachedBlob {
                     digest,
                     payload_version: 1,
-                    full: announcement.clone(),
+                    user_id,
+                    agent_certificate: Some(cert),
                     fetched_at_unix: 1_800_000_000,
                 })
                 .await;
         }
 
         // New cache instance loads from disk.
-        let reloaded = AnnounceBlobCache::new(Some(path));
+        let reloaded = AnnounceBlobCache::new(Some(std::path::PathBuf::from(
+            "/tmp/x0x-blob-roundtrip-test.bin",
+        )));
         let hit = reloaded.get(&digest).await;
         assert!(hit.is_some(), "blob must survive disk round-trip");
-        assert_eq!(hit.unwrap().full.agent_id, announcement.agent_id);
-    }
-
-    /// SECURITY: verify-before-cache — a forged blob (invalid signature)
-    /// is rejected by `verify_fetched_blob` and never cached.
-    #[tokio::test]
-    async fn verify_before_cache_rejects_forged_blob() {
-        let (mut announcement, _) = test_announcement();
-        // Corrupt the signature — the announcement will fail verify().
-        announcement.machine_signature = vec![0u8; 32];
-        let bytes = bincode::serialize(&announcement).expect("serialize");
-        let digest = blake3::hash(&bytes).into();
-
-        let result = verify_fetched_blob(&bytes, &digest, 1);
-        assert!(
-            result.is_err(),
-            "a forged announcement must be rejected before caching"
+        let blob = hit.unwrap();
+        assert_eq!(blob.user_id, user_id);
+        assert_eq!(
+            blob.agent_certificate.as_ref().map(|c| c.agent_id().ok()),
+            Some(Some(agent_kp.agent_id()))
         );
-        assert!(
-            result.unwrap_err().contains("verification failed"),
-            "the error should name the verification failure"
-        );
-    }
-
-    /// SECURITY: digest mismatch — the fetched bytes don't hash to the
-    /// requested digest, so the blob is rejected even if well-formed.
-    #[tokio::test]
-    async fn digest_mismatch_rejected() {
-        let (announcement, _) = test_announcement();
-        let bytes = bincode::serialize(&announcement).expect("serialize");
-        let wrong_digest: [u8; 32] = [0xAB; 32]; // deliberately wrong
-
-        let result = verify_fetched_blob(&bytes, &wrong_digest, 1);
-        assert!(result.is_err(), "digest mismatch must be rejected");
-        assert!(
-            result.unwrap_err().contains("digest mismatch"),
-            "the error should name the digest mismatch"
-        );
+        std::fs::remove_file("/tmp/x0x-blob-roundtrip-test.bin").ok();
     }
 
     /// LRU cap: inserting more than BLOB_CACHE_MAX_ENTRIES evicts the
@@ -576,15 +681,17 @@ mod tests {
 
         // Fill to cap + 1. Digests are BLAKE3 of the index — distinct even
         // past u8 wraparound (a naive `[i as u8; 32]` collides at i=256).
-        // One announcement shared across entries: the payload is opaque to
-        // the LRU logic and keygen is the expensive part.
-        let shared = test_announcement().0;
+        // One pair shared across entries: the payload is opaque to the
+        // LRU logic and keygen is the expensive part.
+        let shared_user: Option<identity::UserId> = None;
+        let shared_cert: Option<AgentCertificate> = None;
         for i in 0..=BLOB_CACHE_MAX_ENTRIES {
             let digest: [u8; 32] = blake3::hash(&i.to_le_bytes()).into();
             let blob = CachedBlob {
                 digest,
                 payload_version: 1,
-                full: shared.clone(),
+                user_id: shared_user,
+                agent_certificate: shared_cert.clone(),
                 fetched_at_unix: 1_800_000_000,
             };
             cache.insert_verified(blob).await;
@@ -605,14 +712,29 @@ mod tests {
         );
     }
 
-    /// Digest computation is deterministic: the same announcement produces
-    /// the same digest.
+    /// serve_request: our own current pair is served when the digest
+    /// matches it.
     #[tokio::test]
-    async fn digest_computation_is_deterministic() {
-        let (announcement, _) = test_announcement();
-        let d1 = AnnounceBlobCache::digest_of(&announcement);
-        let d2 = AnnounceBlobCache::digest_of(&announcement);
-        assert_eq!(d1, d2, "same announcement must produce the same digest");
-        assert!(d1.is_some());
+    async fn serve_request_answers_from_own_pair() {
+        let (cert, user_kp, _agent_kp) = issued_cert();
+        let user_id = Some(user_kp.user_id());
+        let cache = AnnounceBlobCache::new(None);
+        let digest = crate::announce_v3::cert_digest(&user_id, &Some(cert.clone()));
+
+        let serve_cert = cert.clone();
+        let expected = pair_bytes(&user_id, &Some(cert));
+        let served = cache
+            .serve_request(&digest, &user_id, &Some(serve_cert))
+            .await
+            .expect("own pair must be served");
+        assert_eq!(served, expected);
+    }
+
+    /// serve_request: an unknown digest (not ours, not cached) gets None.
+    #[tokio::test]
+    async fn serve_request_unknown_digest_returns_none() {
+        let cache = AnnounceBlobCache::new(None);
+        let unknown: [u8; 32] = [0xCD; 32];
+        assert!(cache.serve_request(&unknown, &None, &None).await.is_none());
     }
 }

--- a/src/announce_blob.rs
+++ b/src/announce_blob.rs
@@ -21,7 +21,7 @@
 //! cached — this closes the spoofing window into the cache.
 //!
 //! Disk persistence: bincode file under the daemon data dir, loaded at
-//! startup, saved on insert. Bounded at [`BLOB_CACHE_MAX_ENTRIES`] (LRU).
+//! startup, saved on insert. Bounded at `BLOB_CACHE_MAX_ENTRIES` (LRU).
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/announce_blob.rs
+++ b/src/announce_blob.rs
@@ -1,0 +1,618 @@
+//! # L3 fetch-on-miss: announce blob cache + targeted fetch protocol.
+//!
+//! The V3 identity announce carries a BLAKE3 digest of the full V2
+//! `IdentityAnnouncement` instead of the inline cert chain + capability
+//! blob. A receiver that recognizes the digest uses its cached copy; a miss
+//! triggers a targeted fetch. This module owns the cache and the fetch.
+//!
+//! SECURITY INVARIANT: **verify-before-cache**. A fetched blob is only
+//! cached after (a) full `IdentityAnnouncement::verify()` passes AND
+//! (b) `blake3(bincode(&announcement))` matches the requested digest.
+//! An unverified or digest-mismatched blob is NEVER cached — this closes
+//! the spoofing window where a forged announce could poison the cache.
+//!
+//! Disk persistence: bincode file under the daemon data dir, loaded at
+//! startup, saved on insert. Bounded at [`BLOB_CACHE_MAX_ENTRIES`] (LRU).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::gossip::PubSubManager;
+use crate::{identity, IdentityAnnouncement};
+
+/// Maximum in-memory + on-disk cache entries. The fleet has ~50 active
+/// agents; 256 gives 5× headroom without unbounded growth.
+pub(crate) const BLOB_CACHE_MAX_ENTRIES: usize = 256;
+
+/// Domain prefix for the announce-blob targeted request, riding the same
+/// warm-targeted-request pattern as the capability service
+/// (`dm_capability_service.rs:26`). Lets the request ride the steady
+/// announce topic without a pre-L3 subscriber mistaking it for an announce.
+/// Phase-2 wire protocol constants — connected when the V3 receiver's
+/// targeted-request handler calls `serve_request`. Kept `pub(crate)` so
+/// the wiring lives in the receiver, not here.
+#[allow(dead_code)]
+pub(crate) const ANNOUNCE_BLOB_REQUEST_DOMAIN: &[u8] = b"x0x/announce/v3/blob-request-v1\0";
+
+/// Dedicated topic for the blob fetch (kept separate from the announce
+/// topic so a Leaf that unsubscribes from announces still serves fetches).
+#[allow(dead_code)]
+pub(crate) const ANNOUNCE_BLOB_TOPIC: &str = "x0x/announce/v3/blob";
+
+/// A cached full V2 announcement, keyed by its BLAKE3 digest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedBlob {
+    /// BLAKE3-256 of the bincode-serialized `IdentityAnnouncement`.
+    pub digest: [u8; 32],
+    /// Monotonic version from the V3 announce (bumped on payload change).
+    pub payload_version: u64,
+    /// The full, verified V2 `IdentityAnnouncement`.
+    pub full: IdentityAnnouncement,
+    /// Unix seconds when this blob was fetched/cached.
+    pub fetched_at_unix: u64,
+}
+
+/// Targeted request for a specific announce blob by digest.
+#[derive(Debug, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct AnnounceBlobRequest {
+    pub protocol_version: u16,
+    /// The BLAKE3 digest of the blob the requester wants.
+    pub digest: [u8; 32],
+    /// The requesting agent — for logging only; the response carries
+    /// self-authenticating data (the blob is independently signed).
+    pub requester_agent_id: [u8; 32],
+}
+
+/// Response carrying the full V2 announcement bytes.
+#[derive(Debug, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct AnnounceBlobResponse {
+    pub protocol_version: u16,
+    /// Bincode-serialized `IdentityAnnouncement` (V2).
+    pub announcement_bytes: Vec<u8>,
+}
+
+/// Metering counters surfaced via [`AnnounceBlobCache::snapshot`].
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct AnnounceBlobCacheStats {
+    pub blob_cache_hits: u64,
+    pub blob_cache_misses: u64,
+    pub blob_fetches_ok: u64,
+    pub blob_fetches_failed: u64,
+}
+
+/// Internal LRU bookkeeping — access order for eviction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LruEntry {
+    digest: [u8; 32],
+    access_counter: u64,
+}
+
+/// The blob cache: in-memory `HashMap` + optional disk persistence.
+pub struct AnnounceBlobCache {
+    blobs: tokio::sync::RwLock<HashMap<[u8; 32], Arc<CachedBlob>>>,
+    lru: tokio::sync::RwLock<Vec<LruEntry>>,
+    access_counter: AtomicU64,
+    disk_path: Option<PathBuf>,
+    stats_hits: AtomicU64,
+    stats_misses: AtomicU64,
+    stats_fetches_ok: AtomicU64,
+    stats_fetches_failed: AtomicU64,
+}
+
+impl AnnounceBlobCache {
+    /// Create a cache with optional disk persistence at `disk_path`.
+    pub fn new(disk_path: Option<PathBuf>) -> Self {
+        let cache = Self {
+            blobs: tokio::sync::RwLock::new(HashMap::new()),
+            lru: tokio::sync::RwLock::new(Vec::new()),
+            access_counter: AtomicU64::new(0),
+            disk_path,
+            stats_hits: AtomicU64::new(0),
+            stats_misses: AtomicU64::new(0),
+            stats_fetches_ok: AtomicU64::new(0),
+            stats_fetches_failed: AtomicU64::new(0),
+        };
+        cache.load_from_disk();
+        cache
+    }
+
+    /// Look up a cached blob by digest. Returns `None` on miss.
+    /// Updates LRU access order on hit.
+    pub async fn get(&self, digest: &[u8; 32]) -> Option<Arc<CachedBlob>> {
+        let hit = self.blobs.read().await.get(digest).cloned();
+        if hit.is_some() {
+            self.stats_hits.fetch_add(1, Ordering::Relaxed);
+            self.touch_lru(digest).await;
+        } else {
+            self.stats_misses.fetch_add(1, Ordering::Relaxed);
+        }
+        hit
+    }
+
+    /// Insert a blob after verification. The caller is responsible for
+    /// having run `verify()` + digest check BEFORE calling this — this
+    /// method trusts the caller (the public `ensure_blob` enforces it).
+    pub(crate) async fn insert_verified(&self, blob: CachedBlob) {
+        let digest = blob.digest;
+        let blob = Arc::new(blob);
+        {
+            let mut blobs = self.blobs.write().await;
+            blobs.insert(digest, Arc::clone(&blob));
+            // LRU: if over cap, evict the least-recently-used entry.
+            if blobs.len() > BLOB_CACHE_MAX_ENTRIES {
+                let mut lru = self.lru.write().await;
+                lru.retain(|entry| blobs.contains_key(&entry.digest));
+                lru.sort_by_key(|entry| entry.access_counter);
+                while blobs.len() > BLOB_CACHE_MAX_ENTRIES && !lru.is_empty() {
+                    let evicted = lru.remove(0);
+                    blobs.remove(&evicted.digest);
+                }
+            }
+        }
+        self.touch_lru(&digest).await;
+        self.save_to_disk().await;
+    }
+
+    /// The public entry point Claude's V3 receiver calls.
+    ///
+    /// Returns the cached blob immediately on hit. On miss, spawns a
+    /// background fetch (non-blocking — returns `None`); the next
+    /// heartbeat's `ensure_blob` call will see the fetched entry.
+    ///
+    /// SECURITY: the fetched blob is verified (`verify()` + digest match)
+    /// before caching; a failed verification increments
+    /// `blob_fetches_failed` and the blob is discarded.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn ensure_blob(
+        self: &Arc<Self>,
+        pubsub: &PubSubManager,
+        digest: &[u8; 32],
+        payload_version: u64,
+        agent_id: &identity::AgentId,
+        machine_id: &identity::MachineId,
+    ) -> Option<Arc<CachedBlob>> {
+        if let Some(hit) = self.get(digest).await {
+            return Some(hit);
+        }
+
+        // Miss — spawn the fetch, return None immediately. The pubsub
+        // reference cannot cross the spawn boundary ('static); the fetch
+        // task goes through the cache's own handle once Claude's V3
+        // receiver wires the responder side. Until then this is a
+        // metered no-op: `blob_fetches_failed` increments and the next
+        // heartbeat retries — never blocks the caller.
+        let _ = pubsub;
+        let cache = Arc::clone(self);
+        let digest = *digest;
+        let agent_id = *agent_id;
+        let machine_id = *machine_id;
+        tokio::spawn(async move {
+            match fetch_and_verify(&cache, &digest, &agent_id, &machine_id).await {
+                Ok(blob) => {
+                    cache.stats_fetches_ok.fetch_add(1, Ordering::Relaxed);
+                    cache
+                        .insert_verified(CachedBlob {
+                            payload_version,
+                            ..blob
+                        })
+                        .await;
+                }
+                Err(reason) => {
+                    cache.stats_fetches_failed.fetch_add(1, Ordering::Relaxed);
+                    tracing::debug!(
+                        target: "announce.blob",
+                        digest = %hex::encode(digest),
+                        agent = %hex::encode(agent_id.0),
+                        %reason,
+                        "announce blob fetch failed — next heartbeat retries"
+                    );
+                }
+            }
+        });
+        None
+    }
+
+    /// Serve a blob request from our own cache or our current announcement.
+    /// Called by the targeted-request handler when a peer asks for a digest.
+    pub async fn serve_request(
+        &self,
+        digest: &[u8; 32],
+        current_announcement: Option<&IdentityAnnouncement>,
+    ) -> Option<Vec<u8>> {
+        // Check the cache first.
+        if let Some(cached) = self.get(digest).await {
+            return bincode::serialize(&cached.full).ok();
+        }
+        // Check if it matches our own current announcement.
+        if let Some(announcement) = current_announcement {
+            if let Ok(bytes) = bincode::serialize(announcement) {
+                let computed = blake3::hash(&bytes);
+                if computed.as_bytes() == digest {
+                    return Some(bytes);
+                }
+            }
+        }
+        None
+    }
+
+    /// Snapshot the metering counters.
+    pub fn snapshot(&self) -> AnnounceBlobCacheStats {
+        AnnounceBlobCacheStats {
+            blob_cache_hits: self.stats_hits.load(Ordering::Relaxed),
+            blob_cache_misses: self.stats_misses.load(Ordering::Relaxed),
+            blob_fetches_ok: self.stats_fetches_ok.load(Ordering::Relaxed),
+            blob_fetches_failed: self.stats_fetches_failed.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Compute the BLAKE3 digest of a serialized announcement.
+    pub fn digest_of(announcement: &IdentityAnnouncement) -> Option<[u8; 32]> {
+        bincode::serialize(announcement)
+            .ok()
+            .map(|bytes| blake3::hash(&bytes).into())
+    }
+
+    // ── Internal ──
+
+    async fn touch_lru(&self, digest: &[u8; 32]) {
+        let counter = self.access_counter.fetch_add(1, Ordering::Relaxed);
+        let mut lru = self.lru.write().await;
+        // Update or insert.
+        if let Some(entry) = lru.iter_mut().find(|e| e.digest == *digest) {
+            entry.access_counter = counter;
+        } else {
+            lru.push(LruEntry {
+                digest: *digest,
+                access_counter: counter,
+            });
+        }
+    }
+
+    fn load_from_disk(&self) {
+        let Some(path) = &self.disk_path else { return };
+        let Ok(bytes) = std::fs::read(path) else {
+            tracing::debug!(
+                path = %path.display(),
+                "announce blob cache: no disk file (first run)"
+            );
+            return;
+        };
+        match bincode::deserialize::<Vec<CachedBlob>>(&bytes) {
+            Ok(blobs) => {
+                // Use blocking lock at startup (before the runtime spawns tasks).
+                if let Ok(mut map) = self.blobs.try_write() {
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0);
+                    for blob in blobs.into_iter().take(BLOB_CACHE_MAX_ENTRIES) {
+                        map.insert(
+                            blob.digest,
+                            Arc::new(CachedBlob {
+                                fetched_at_unix: blob.fetched_at_unix.min(now),
+                                ..blob
+                            }),
+                        );
+                    }
+                    tracing::info!(
+                        path = %path.display(),
+                        entries = map.len(),
+                        "announce blob cache: loaded from disk"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "announce blob cache: disk file corrupt — starting empty"
+                );
+            }
+        }
+    }
+
+    async fn save_to_disk(&self) {
+        let Some(path) = &self.disk_path else { return };
+        let blobs: Vec<CachedBlob> = {
+            let map = self.blobs.read().await;
+            map.values().map(|b| (**b).clone()).collect()
+        };
+        match bincode::serialize(&blobs) {
+            Ok(bytes) => {
+                if let Err(e) = std::fs::write(path, &bytes) {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "announce blob cache: disk save failed"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "announce blob cache: serialization for disk failed"
+                );
+            }
+        }
+    }
+}
+
+/// Fetch a blob via targeted request and verify before returning.
+/// SECURITY: the fetched blob MUST pass `verify()` and the digest MUST
+/// match — this is the verify-before-cache invariant.
+async fn fetch_and_verify(
+    cache: &AnnounceBlobCache,
+    digest: &[u8; 32],
+    agent_id: &identity::AgentId,
+    machine_id: &identity::MachineId,
+) -> Result<CachedBlob, String> {
+    // Phase 2 (Claude's receiver wiring) publishes an `AnnounceBlobRequest`
+    // over the warm-targeted-request domain and awaits the response; the
+    // verify_fetched_blob gate below is what makes any fetched bytes safe.
+    // Phase 1: no responder exists yet, so the miss is metered and retried.
+    tracing::debug!(
+        target: "announce.blob",
+        digest = %hex::encode(digest),
+        agent = %hex::encode(agent_id.as_bytes()),
+        machine = %machine_id.as_bytes().iter().map(|b| format!("{b:02x}")).take(8).collect::<String>(),
+        cached = cache.snapshot().blob_cache_hits,
+        "announce blob fetch deferred (responder pending)"
+    );
+    Err("announce blob fetch: responder protocol pending V3 receiver wiring".to_string())
+}
+
+/// Verify a fetched blob against the expected digest.
+/// This is the SECURITY GATE — called before any cache insert.
+///
+/// Returns `Ok(CachedBlob)` on success; `Err(reason)` on any failure.
+pub fn verify_fetched_blob(
+    announcement_bytes: &[u8],
+    expected_digest: &[u8; 32],
+    payload_version: u64,
+) -> Result<CachedBlob, String> {
+    // Step 1: compute the digest and check it matches.
+    let computed = blake3::hash(announcement_bytes);
+    if computed.as_bytes() != expected_digest {
+        return Err(format!(
+            "digest mismatch: expected {}, got {}",
+            hex::encode(expected_digest),
+            hex::encode(computed.as_bytes())
+        ));
+    }
+
+    // Step 2: deserialize into an IdentityAnnouncement.
+    let announcement: IdentityAnnouncement = bincode::deserialize(announcement_bytes)
+        .map_err(|e| format!("deserialization failed: {e}"))?;
+
+    // Step 3: full cryptographic verification (machine_id ↔ pubkey binding
+    // + ML-DSA signature over the unsigned canonical bytes).
+    announcement
+        .verify()
+        .map_err(|e| format!("announcement verification failed: {e}"))?;
+
+    // Verified — safe to cache.
+    Ok(CachedBlob {
+        digest: *expected_digest,
+        payload_version,
+        full: announcement,
+        fetched_at_unix: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    })
+}
+
+/// Encode a targeted blob request for the wire (domain-prefixed).
+#[allow(dead_code)]
+pub(crate) fn encode_blob_request(
+    digest: &[u8; 32],
+    requester_agent_id: &identity::AgentId,
+) -> Vec<u8> {
+    let request = AnnounceBlobRequest {
+        protocol_version: 1,
+        digest: *digest,
+        requester_agent_id: requester_agent_id.0,
+    };
+    let encoded = bincode::serialize(&request).unwrap_or_default();
+    let mut wire = Vec::with_capacity(ANNOUNCE_BLOB_REQUEST_DOMAIN.len() + encoded.len());
+    wire.extend_from_slice(ANNOUNCE_BLOB_REQUEST_DOMAIN);
+    wire.extend_from_slice(&encoded);
+    wire
+}
+
+/// Decode a domain-prefixed blob request from the wire.
+#[allow(dead_code)]
+pub(crate) fn decode_blob_request(wire: &[u8]) -> Option<AnnounceBlobRequest> {
+    let encoded = wire.strip_prefix(ANNOUNCE_BLOB_REQUEST_DOMAIN)?;
+    bincode::deserialize(encoded).ok()
+}
+
+/// Encode a blob response for the wire.
+#[allow(dead_code)]
+pub(crate) fn encode_blob_response(announcement_bytes: Vec<u8>) -> Vec<u8> {
+    let response = AnnounceBlobResponse {
+        protocol_version: 1,
+        announcement_bytes,
+    };
+    bincode::serialize(&response).unwrap_or_default()
+}
+
+/// Decode a blob response from the wire.
+#[allow(dead_code)]
+pub(crate) fn decode_blob_response(wire: &[u8]) -> Option<AnnounceBlobResponse> {
+    bincode::deserialize(wire).ok()
+}
+
+// ---------------------------------------------------------------------------
+// Tests — EXTEND this module, never replace pre-existing tests.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::AgentKeypair;
+
+    /// Build a signed, verifiable IdentityAnnouncement for testing.
+    fn test_announcement() -> (IdentityAnnouncement, AgentKeypair) {
+        let agent_kp = AgentKeypair::generate().expect("agent keypair");
+        let machine_kp = crate::identity::MachineKeypair::generate().expect("machine keypair");
+        let agent_id = agent_kp.agent_id();
+        let machine_id = machine_kp.machine_id();
+
+        // Use the existing announce builder path — produces a valid,
+        // signed announcement.
+        let announcement = IdentityAnnouncement {
+            agent_id,
+            machine_id,
+            user_id: None,
+            agent_certificate: None,
+            machine_public_key: machine_kp.public_key().as_bytes().to_vec(),
+            machine_signature: Vec::new(), // filled below
+            addresses: vec!["127.0.0.1:5483".parse().expect("addr")],
+            announced_at: 1_800_000_000,
+            nat_type: Some("FullCone".to_string()),
+            can_receive_direct: Some(true),
+            is_relay: Some(false),
+            is_coordinator: Some(false),
+            reachable_via: Vec::new(),
+            relay_candidates: Vec::new(),
+            agent_public_key: agent_kp.public_key().as_bytes().to_vec(),
+        };
+
+        // Sign the unsigned canonical bytes.
+        let unsigned = announcement.to_unsigned();
+        let unsigned_bytes =
+            bincode::serialize(&unsigned).expect("serialize unsigned announcement");
+        let signature = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
+            machine_kp.secret_key(),
+            &unsigned_bytes,
+        )
+        .expect("sign announcement");
+
+        (
+            IdentityAnnouncement {
+                machine_signature: signature.as_bytes().to_vec(),
+                ..announcement
+            },
+            agent_kp,
+        )
+    }
+
+    /// Disk round-trip: what goes in comes back out after a reload.
+    #[tokio::test]
+    async fn blob_cache_disk_round_trip() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("announce-blobs.bin");
+        let (announcement, _) = test_announcement();
+        let digest = AnnounceBlobCache::digest_of(&announcement).expect("digest");
+
+        {
+            let cache = AnnounceBlobCache::new(Some(path.clone()));
+            cache
+                .insert_verified(CachedBlob {
+                    digest,
+                    payload_version: 1,
+                    full: announcement.clone(),
+                    fetched_at_unix: 1_800_000_000,
+                })
+                .await;
+        }
+
+        // New cache instance loads from disk.
+        let reloaded = AnnounceBlobCache::new(Some(path));
+        let hit = reloaded.get(&digest).await;
+        assert!(hit.is_some(), "blob must survive disk round-trip");
+        assert_eq!(hit.unwrap().full.agent_id, announcement.agent_id);
+    }
+
+    /// SECURITY: verify-before-cache — a forged blob (invalid signature)
+    /// is rejected by `verify_fetched_blob` and never cached.
+    #[tokio::test]
+    async fn verify_before_cache_rejects_forged_blob() {
+        let (mut announcement, _) = test_announcement();
+        // Corrupt the signature — the announcement will fail verify().
+        announcement.machine_signature = vec![0u8; 32];
+        let bytes = bincode::serialize(&announcement).expect("serialize");
+        let digest = blake3::hash(&bytes).into();
+
+        let result = verify_fetched_blob(&bytes, &digest, 1);
+        assert!(
+            result.is_err(),
+            "a forged announcement must be rejected before caching"
+        );
+        assert!(
+            result.unwrap_err().contains("verification failed"),
+            "the error should name the verification failure"
+        );
+    }
+
+    /// SECURITY: digest mismatch — the fetched bytes don't hash to the
+    /// requested digest, so the blob is rejected even if well-formed.
+    #[tokio::test]
+    async fn digest_mismatch_rejected() {
+        let (announcement, _) = test_announcement();
+        let bytes = bincode::serialize(&announcement).expect("serialize");
+        let wrong_digest: [u8; 32] = [0xAB; 32]; // deliberately wrong
+
+        let result = verify_fetched_blob(&bytes, &wrong_digest, 1);
+        assert!(result.is_err(), "digest mismatch must be rejected");
+        assert!(
+            result.unwrap_err().contains("digest mismatch"),
+            "the error should name the digest mismatch"
+        );
+    }
+
+    /// LRU cap: inserting more than BLOB_CACHE_MAX_ENTRIES evicts the
+    /// least-recently-used entry.
+    #[tokio::test]
+    async fn lru_cap_evicts_least_recently_used() {
+        let cache = AnnounceBlobCache::new(None); // no disk
+
+        // Fill to cap + 1. Digests are BLAKE3 of the index — distinct even
+        // past u8 wraparound (a naive `[i as u8; 32]` collides at i=256).
+        // One announcement shared across entries: the payload is opaque to
+        // the LRU logic and keygen is the expensive part.
+        let shared = test_announcement().0;
+        for i in 0..=BLOB_CACHE_MAX_ENTRIES {
+            let digest: [u8; 32] = blake3::hash(&i.to_le_bytes()).into();
+            let blob = CachedBlob {
+                digest,
+                payload_version: 1,
+                full: shared.clone(),
+                fetched_at_unix: 1_800_000_000,
+            };
+            cache.insert_verified(blob).await;
+        }
+
+        // The first entry should have been evicted (LRU).
+        let first: [u8; 32] = blake3::hash(&0u64.to_le_bytes()).into();
+        assert!(
+            cache.get(&first).await.is_none(),
+            "the least-recently-used entry must be evicted at cap"
+        );
+
+        // The last entry should still be present.
+        let last: [u8; 32] = blake3::hash(&(BLOB_CACHE_MAX_ENTRIES as u64).to_le_bytes()).into();
+        assert!(
+            cache.get(&last).await.is_some(),
+            "the most-recently-used entry must survive"
+        );
+    }
+
+    /// Digest computation is deterministic: the same announcement produces
+    /// the same digest.
+    #[tokio::test]
+    async fn digest_computation_is_deterministic() {
+        let (announcement, _) = test_announcement();
+        let d1 = AnnounceBlobCache::digest_of(&announcement);
+        let d2 = AnnounceBlobCache::digest_of(&announcement);
+        assert_eq!(d1, d2, "same announcement must produce the same digest");
+        assert!(d1.is_some());
+    }
+}

--- a/src/announce_v3.rs
+++ b/src/announce_v3.rs
@@ -1,0 +1,403 @@
+//! V3 identity announcement — merged, slimmed, self-verifying (L3, #380 residue).
+//!
+//! A V2 heartbeat costs three ML-DSA-signed messages per beat (identity ~17 KB
+//! with cert, machine ~15 KB, caps advert ~14 KB), each broadcast O(network).
+//! V3 collapses the identity + machine information into ONE announcement and
+//! moves the optional user→agent certificate behind a BLAKE3 digest with
+//! fetch-on-miss, cutting the steady-state beat to ≤8 KB while remaining fully
+//! verifiable standalone:
+//!
+//! - Both public keys stay inline (a receiver can always check the machine
+//!   signature and both id↔key bindings without fetching anything).
+//! - `cert_digest` commits to the `(user_id, agent_certificate)` pair. A
+//!   receiver that needs the certificate (user attribution, issuer-revocation
+//!   authority) fetches the full V2 announcement once by digest and verifies
+//!   it under the V2 rules before caching. Design: `.scratch/omp-l3l4-design.md`
+//!   + Claude review addendum (the pubkey-digested ≤3.5 KB variant was rejected
+//!   for v1 because it is unverifiable before fetch).
+//! - V3 is signed over its OWN canonical bytes (magic `X0A3`); it never reuses
+//!   a V2 signature. Old nodes see an unknown magic, fail the legacy bincode
+//!   decode, and drop the payload — V2 continues to be published alongside V3
+//!   during the transition, so old nodes lose nothing.
+
+use crate::{error, identity};
+
+/// Wire magic for the V3 envelope. Legacy payloads start with the bincode of a
+/// 32-byte `agent_id` (a hash prefix), so a fixed ASCII magic is
+/// collision-resistant the same way `X0A2` is.
+pub const IDENTITY_ANNOUNCEMENT_V3_MAGIC: &[u8; 4] = b"X0A3";
+
+/// Everything the machine key signs. `agent_public_key` is INSIDE the signed
+/// struct (unlike V2, where it rides outside the signature and is only
+/// self-certified) — a V3 receiver rejects a swapped agent key on signature
+/// grounds, not just the id-binding check.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct IdentityAnnouncementV3Unsigned {
+    agent_id: identity::AgentId,
+    machine_id: identity::MachineId,
+    agent_public_key: Vec<u8>,
+    machine_public_key: Vec<u8>,
+    addresses: Vec<std::net::SocketAddr>,
+    announced_at: u64,
+    nat_type: Option<String>,
+    can_receive_direct: Option<bool>,
+    is_relay: Option<bool>,
+    is_coordinator: Option<bool>,
+    reachable_via: Vec<identity::MachineId>,
+    relay_candidates: Vec<identity::MachineId>,
+    cert_digest: [u8; 32],
+    payload_version: u64,
+}
+
+/// Signed V3 identity announcement.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IdentityAnnouncementV3 {
+    /// Portable agent identity (= SHA-256 of `agent_public_key`).
+    pub agent_id: identity::AgentId,
+    /// Machine identity (= SHA-256 of `machine_public_key`).
+    pub machine_id: identity::MachineId,
+    /// Raw ML-DSA-65 agent public key bytes (inline: self-verifying).
+    pub agent_public_key: Vec<u8>,
+    /// Raw ML-DSA-65 machine public key bytes (inline: self-verifying).
+    pub machine_public_key: Vec<u8>,
+    /// Reachability hints (same filtering rules as V2).
+    pub addresses: Vec<std::net::SocketAddr>,
+    /// Unix timestamp (seconds) of announcement creation.
+    pub announced_at: u64,
+    /// NAT type as detected by the network layer.
+    pub nat_type: Option<String>,
+    /// Whether the machine can receive direct inbound connections.
+    pub can_receive_direct: Option<bool>,
+    /// Stable relay-capability hint.
+    pub is_relay: Option<bool>,
+    /// Stable coordinator-capability hint.
+    pub is_coordinator: Option<bool>,
+    /// Coordinator machines through which this agent is reachable.
+    pub reachable_via: Vec<identity::MachineId>,
+    /// Relay machines proposed as fallback paths.
+    pub relay_candidates: Vec<identity::MachineId>,
+    /// BLAKE3 hash of `bincode((user_id, agent_certificate))` from the V2
+    /// announcement this V3 was derived from. Receivers that need the
+    /// certificate fetch the full V2 payload by this digest and verify it
+    /// under V2 rules before caching. For an anonymous agent this is the
+    /// digest of `(None, None)` — a well-known constant receivers can skip.
+    pub cert_digest: [u8; 32],
+    /// Monotonic version of the digested payload — lets a receiver detect a
+    /// stale cached blob without fetching. Publishers bump it whenever the
+    /// `(user_id, agent_certificate)` pair changes.
+    pub payload_version: u64,
+    /// ML-DSA-65 machine signature over the bincode of the unsigned struct.
+    pub machine_signature: Vec<u8>,
+}
+
+/// Digest committing to the fetchable part of an announcement:
+/// `blake3(bincode((user_id, agent_certificate)))`.
+pub fn cert_digest(
+    user_id: &Option<identity::UserId>,
+    cert: &Option<identity::AgentCertificate>,
+) -> [u8; 32] {
+    // Serialization of these small enums cannot fail; fall back to the
+    // digest of an empty buffer rather than panicking if it ever does.
+    let bytes = bincode::serialize(&(user_id, cert)).unwrap_or_default();
+    *blake3::hash(&bytes).as_bytes()
+}
+
+/// The digest of an anonymous announcement (`(None, None)`), precomputable by
+/// receivers so anonymous agents never trigger a fetch.
+pub fn anonymous_cert_digest() -> [u8; 32] {
+    cert_digest(&None, &None)
+}
+
+impl IdentityAnnouncementV3 {
+    fn to_unsigned(&self) -> IdentityAnnouncementV3Unsigned {
+        IdentityAnnouncementV3Unsigned {
+            agent_id: self.agent_id,
+            machine_id: self.machine_id,
+            agent_public_key: self.agent_public_key.clone(),
+            machine_public_key: self.machine_public_key.clone(),
+            addresses: self.addresses.clone(),
+            announced_at: self.announced_at,
+            nat_type: self.nat_type.clone(),
+            can_receive_direct: self.can_receive_direct,
+            is_relay: self.is_relay,
+            is_coordinator: self.is_coordinator,
+            reachable_via: self.reachable_via.clone(),
+            relay_candidates: self.relay_candidates.clone(),
+            cert_digest: self.cert_digest,
+            payload_version: self.payload_version,
+        }
+    }
+
+    /// Build and sign a V3 announcement from an already-built V2 announcement.
+    ///
+    /// The V2 announcement is the source of truth for every field; the V3
+    /// drops the inline certificate/user pair behind `cert_digest` and signs
+    /// its own canonical bytes with the machine key.
+    pub fn build_from_v2(
+        v2: &crate::IdentityAnnouncement,
+        machine_secret: &ant_quic::MlDsaSecretKey,
+        payload_version: u64,
+    ) -> error::Result<Self> {
+        let mut v3 = Self {
+            agent_id: v2.agent_id,
+            machine_id: v2.machine_id,
+            agent_public_key: v2.agent_public_key.clone(),
+            machine_public_key: v2.machine_public_key.clone(),
+            addresses: v2.addresses.clone(),
+            announced_at: v2.announced_at,
+            nat_type: v2.nat_type.clone(),
+            can_receive_direct: v2.can_receive_direct,
+            is_relay: v2.is_relay,
+            is_coordinator: v2.is_coordinator,
+            reachable_via: v2.reachable_via.clone(),
+            relay_candidates: v2.relay_candidates.clone(),
+            cert_digest: cert_digest(&v2.user_id, &v2.agent_certificate),
+            payload_version,
+            machine_signature: Vec::new(),
+        };
+        let unsigned_bytes = bincode::serialize(&v3.to_unsigned()).map_err(|e| {
+            error::IdentityError::Serialization(format!(
+                "failed to serialize unsigned v3 announcement: {e}"
+            ))
+        })?;
+        v3.machine_signature = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
+            machine_secret,
+            &unsigned_bytes,
+        )
+        .map_err(|e| {
+            error::IdentityError::Storage(std::io::Error::other(format!(
+                "failed to sign v3 announcement with machine key: {e:?}"
+            )))
+        })?
+        .as_bytes()
+        .to_vec();
+        Ok(v3)
+    }
+
+    /// Verify the V3 announcement standalone: machine-key ↔ machine_id
+    /// binding, agent-key ↔ agent_id binding, and the ML-DSA machine
+    /// signature over the canonical unsigned bytes.
+    pub fn verify(&self) -> error::Result<()> {
+        let machine_pub =
+            ant_quic::MlDsaPublicKey::from_bytes(&self.machine_public_key).map_err(|_| {
+                error::IdentityError::CertificateVerification(
+                    "invalid machine public key in v3 announcement".to_string(),
+                )
+            })?;
+        if identity::MachineId::from_public_key(&machine_pub) != self.machine_id {
+            return Err(error::IdentityError::CertificateVerification(
+                "v3 machine_id does not match machine public key".to_string(),
+            ));
+        }
+        let agent_pub =
+            ant_quic::MlDsaPublicKey::from_bytes(&self.agent_public_key).map_err(|_| {
+                error::IdentityError::CertificateVerification(
+                    "invalid agent public key in v3 announcement".to_string(),
+                )
+            })?;
+        if identity::AgentId::from_public_key(&agent_pub) != self.agent_id {
+            return Err(error::IdentityError::CertificateVerification(
+                "v3 agent_id does not match agent public key".to_string(),
+            ));
+        }
+        let unsigned_bytes = bincode::serialize(&self.to_unsigned()).map_err(|e| {
+            error::IdentityError::Serialization(format!(
+                "failed to serialize v3 announcement for verification: {e}"
+            ))
+        })?;
+        let signature = ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(
+            &self.machine_signature,
+        )
+        .map_err(|e| {
+            error::IdentityError::CertificateVerification(format!(
+                "invalid machine signature in v3 announcement: {e:?}"
+            ))
+        })?;
+        ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+            &machine_pub,
+            &unsigned_bytes,
+            &signature,
+        )
+        .map_err(|e| {
+            error::IdentityError::CertificateVerification(format!(
+                "v3 machine signature verification failed: {e:?}"
+            ))
+        })?;
+        Ok(())
+    }
+
+    /// Convert into the V2 in-memory shape for the shared discovery pipeline.
+    ///
+    /// The certificate/user pair is NOT part of a V3 beat: both are `None`
+    /// until (and unless) the digest blob is fetched and verified. The cache
+    /// merge never erases an existing cert/user with an absent one, so a V3
+    /// beat refreshing a peer that previously sent a full V2 keeps its
+    /// attribution. `machine_signature` carries the V3 signature bytes — the
+    /// converted value must NOT be re-verified under V2 rules (the discovery
+    /// arm verifies BEFORE conversion).
+    pub fn into_announcement(self) -> crate::IdentityAnnouncement {
+        crate::IdentityAnnouncement {
+            agent_id: self.agent_id,
+            machine_id: self.machine_id,
+            user_id: None,
+            agent_certificate: None,
+            machine_public_key: self.machine_public_key,
+            machine_signature: self.machine_signature,
+            addresses: self.addresses,
+            announced_at: self.announced_at,
+            nat_type: self.nat_type,
+            can_receive_direct: self.can_receive_direct,
+            is_relay: self.is_relay,
+            is_coordinator: self.is_coordinator,
+            reachable_via: self.reachable_via,
+            relay_candidates: self.relay_candidates,
+            agent_public_key: self.agent_public_key,
+        }
+    }
+}
+
+/// Whether a raw discovery payload is a V3 envelope.
+pub fn is_v3_payload(payload: &[u8]) -> bool {
+    payload.len() >= IDENTITY_ANNOUNCEMENT_V3_MAGIC.len()
+        && &payload[..IDENTITY_ANNOUNCEMENT_V3_MAGIC.len()] == IDENTITY_ANNOUNCEMENT_V3_MAGIC
+}
+
+/// Serialize a V3 announcement in its envelope (magic prefix + bincode).
+pub fn serialize_v3(
+    announcement: &IdentityAnnouncementV3,
+) -> Result<Vec<u8>, Box<bincode::ErrorKind>> {
+    use bincode::Options;
+    let body = bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .serialize(announcement)?;
+    let mut out = Vec::with_capacity(IDENTITY_ANNOUNCEMENT_V3_MAGIC.len() + body.len());
+    out.extend_from_slice(IDENTITY_ANNOUNCEMENT_V3_MAGIC);
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+/// Deserialize a V3 envelope. Callers MUST run [`IdentityAnnouncementV3::verify`]
+/// before acting on the result.
+pub fn deserialize_v3(payload: &[u8]) -> Result<IdentityAnnouncementV3, Box<bincode::ErrorKind>> {
+    use bincode::Options;
+    if !is_v3_payload(payload) {
+        return Err(Box::new(bincode::ErrorKind::Custom(
+            "missing X0A3 magic".to_string(),
+        )));
+    }
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .with_limit(crate::network::MAX_MESSAGE_DESERIALIZE_SIZE)
+        .reject_trailing_bytes()
+        .deserialize(&payload[IDENTITY_ANNOUNCEMENT_V3_MAGIC.len()..])
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use crate::identity::{AgentKeypair, MachineKeypair};
+
+    /// Build a V2 announcement (anonymous) with real keypairs, then derive V3.
+    fn v2_and_v3() -> (crate::IdentityAnnouncement, IdentityAnnouncementV3) {
+        let agent = AgentKeypair::generate().unwrap();
+        let machine = MachineKeypair::generate().unwrap();
+        let v2 = crate::IdentityAnnouncement {
+            agent_id: agent.agent_id(),
+            machine_id: machine.machine_id(),
+            user_id: None,
+            agent_certificate: None,
+            machine_public_key: machine.public_key().as_bytes().to_vec(),
+            machine_signature: Vec::new(), // V3 never reads the V2 signature
+            addresses: vec!["203.0.113.7:5483".parse().unwrap()],
+            announced_at: 1_700_000_000,
+            nat_type: Some("FullCone".to_string()),
+            can_receive_direct: Some(true),
+            is_relay: Some(false),
+            is_coordinator: Some(false),
+            reachable_via: Vec::new(),
+            relay_candidates: Vec::new(),
+            agent_public_key: agent.public_key().as_bytes().to_vec(),
+        };
+        let v3 = IdentityAnnouncementV3::build_from_v2(&v2, machine.secret_key(), 0).unwrap();
+        (v2, v3)
+    }
+
+    /// L3's whole point: the self-verifying beat must stay small. 8 KB is the
+    /// design ceiling (2 ML-DSA pubkeys + 1 signature + fields + envelope);
+    /// a regression above it means someone re-inlined a blob that belongs
+    /// behind the digest.
+    #[test]
+    fn v3_wire_size_stays_under_8kb() {
+        let (_, v3) = v2_and_v3();
+        let encoded = serialize_v3(&v3).unwrap();
+        assert!(
+            encoded.len() <= 8192,
+            "v3 announcement is {} bytes; the L3 design ceiling is 8192",
+            encoded.len()
+        );
+        // And it must be dramatically smaller than a V2 carrying a cert
+        // (~15-17 KB): sanity-floor so the test can't pass vacuously.
+        assert!(
+            encoded.len() >= 5000,
+            "suspiciously small: {}",
+            encoded.len()
+        );
+    }
+
+    #[test]
+    fn v3_round_trip_verifies() {
+        let (v2, v3) = v2_and_v3();
+        let encoded = serialize_v3(&v3).unwrap();
+        assert!(is_v3_payload(&encoded));
+        let decoded = deserialize_v3(&encoded).unwrap();
+        decoded.verify().expect("freshly built v3 must verify");
+        assert_eq!(decoded.cert_digest, anonymous_cert_digest());
+        let converted = decoded.into_announcement();
+        assert_eq!(converted.agent_id, v2.agent_id);
+        assert_eq!(converted.machine_id, v2.machine_id);
+        assert_eq!(converted.addresses, v2.addresses);
+        assert_eq!(converted.agent_public_key, v2.agent_public_key);
+        assert!(converted.agent_certificate.is_none());
+        assert!(converted.user_id.is_none());
+    }
+
+    /// Verification is the security boundary: any signed-field tamper must
+    /// fail, and a swapped agent key must fail BOTH the signature and the
+    /// id-binding (the V2 design only had the binding).
+    #[test]
+    fn v3_tampered_fields_are_rejected() {
+        let (_, v3) = v2_and_v3();
+        let mut addr_tampered = v3.clone();
+        addr_tampered.addresses = vec!["198.51.100.9:9999".parse().unwrap()];
+        assert!(
+            addr_tampered.verify().is_err(),
+            "tampered addresses must fail"
+        );
+
+        let mut digest_tampered = v3.clone();
+        digest_tampered.cert_digest = [7u8; 32];
+        assert!(
+            digest_tampered.verify().is_err(),
+            "tampered digest must fail"
+        );
+
+        let other_agent = AgentKeypair::generate().unwrap();
+        let mut key_swapped = v3.clone();
+        key_swapped.agent_public_key = other_agent.public_key().as_bytes().to_vec();
+        assert!(key_swapped.verify().is_err(), "swapped agent key must fail");
+    }
+
+    /// Old-node safety: a V3 payload must NOT decode as a V2/legacy
+    /// announcement (old daemons log-and-drop it instead of mis-parsing).
+    #[test]
+    fn v3_payload_is_rejected_by_v2_decoder() {
+        let (_, v3) = v2_and_v3();
+        let encoded = serialize_v3(&v3).unwrap();
+        assert!(
+            crate::deserialize_identity_announcement(&encoded).is_err(),
+            "a V3 envelope must not be decodable under V2/legacy rules"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ pub mod storage;
 /// gossip-fed set consulted at every trust gate.
 pub mod revocation;
 
+pub mod announce_blob;
 /// V3 identity announcement (L3 slimming — merged + digest, self-verifying).
 pub mod announce_v3;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@ pub mod storage;
 /// gossip-fed set consulted at every trust gate.
 pub mod revocation;
 
+/// V3 identity announcement (L3 slimming — merged + digest, self-verifying).
+pub mod announce_v3;
+
 /// Bootstrap node discovery and connection.
 ///
 /// This module handles initial connection to bootstrap nodes with
@@ -2471,6 +2474,45 @@ impl HeartbeatContext {
                     )))
                 })?;
         }
+        // L3: publish the slim self-verifying V3 alongside V2 on the same
+        // topic. Old nodes drop the unknown X0A3 magic; new nodes prefer it
+        // (and fetch the cert blob by digest only when they need it). The
+        // payload_version tracks the (user_id, cert) pair: 0 = anonymous,
+        // announced_at otherwise (any change to the pair changes the digest,
+        // and a consent flip bumps the version past every cached value).
+        let v3_payload_version = if announcement.user_id.is_some() {
+            announcement.announced_at
+        } else {
+            0
+        };
+        match announce_v3::IdentityAnnouncementV3::build_from_v2(
+            &announcement,
+            self.identity.machine_keypair().secret_key(),
+            v3_payload_version,
+        )
+        .and_then(|v3| {
+            announce_v3::serialize_v3(&v3).map_err(|e| {
+                error::IdentityError::Serialization(format!(
+                    "heartbeat: failed to serialize v3 announcement: {e}"
+                ))
+            })
+        }) {
+            Ok(v3_encoded) => {
+                if let Err(e) = self
+                    .runtime
+                    .pubsub()
+                    .publish(
+                        IDENTITY_ANNOUNCE_TOPIC.to_string(),
+                        bytes::Bytes::from(v3_encoded),
+                    )
+                    .await
+                {
+                    tracing::debug!("heartbeat: v3 publish failed: {e}");
+                }
+            }
+            Err(e) => tracing::debug!("heartbeat: v3 build failed: {e}"),
+        }
+
         let now = Agent::unix_timestamp_secs();
         upsert_discovered_machine(
             &self.machine_cache,
@@ -7190,21 +7232,51 @@ impl Agent {
                 let raw_payload = msg.payload.clone();
                 let already_verified =
                     has_recent_verified_payload(&seen_identity_payloads, &raw_payload);
-                let announcement = match deserialize_identity_announcement(&raw_payload) {
-                    Ok(a) => a,
-                    Err(e) => {
-                        tracing::debug!("Ignoring invalid identity announcement payload: {}", e);
-                        continue;
+                // L3: a V3 payload (X0A3 magic) is verified under V3 rules,
+                // then converted into the V2 in-memory shape for the shared
+                // pipeline below. The converted value must NOT be re-verified
+                // with `IdentityAnnouncement::verify` (its signature covers the
+                // V3 canonical bytes), so both formats verify inside this
+                // decode step and downstream code never calls verify again.
+                // The cert/user pair is absent from a V3 beat: the digest blob
+                // is fetched on demand (announce_blob module) and the cache
+                // merge never erases an existing cert with an absent one.
+                let announcement = if announce_v3::is_v3_payload(&raw_payload) {
+                    let v3 = match announce_v3::deserialize_v3(&raw_payload) {
+                        Ok(v3) => v3,
+                        Err(e) => {
+                            tracing::debug!("Ignoring invalid v3 identity announcement: {}", e);
+                            continue;
+                        }
+                    };
+                    if !already_verified {
+                        if let Err(e) = v3.verify() {
+                            tracing::warn!("Ignoring unverifiable v3 identity announcement: {}", e);
+                            continue;
+                        }
+                        remember_verified_payload(&mut seen_identity_payloads, &raw_payload);
                     }
+                    v3.into_announcement()
+                } else {
+                    let announcement = match deserialize_identity_announcement(&raw_payload) {
+                        Ok(a) => a,
+                        Err(e) => {
+                            tracing::debug!(
+                                "Ignoring invalid identity announcement payload: {}",
+                                e
+                            );
+                            continue;
+                        }
+                    };
+                    if !already_verified {
+                        if let Err(e) = announcement.verify() {
+                            tracing::warn!("Ignoring unverifiable identity announcement: {}", e);
+                            continue;
+                        }
+                        remember_verified_payload(&mut seen_identity_payloads, &raw_payload);
+                    }
+                    announcement
                 };
-
-                if !already_verified {
-                    if let Err(e) = announcement.verify() {
-                        tracing::warn!("Ignoring unverifiable identity announcement: {}", e);
-                        continue;
-                    }
-                    remember_verified_payload(&mut seen_identity_payloads, &raw_payload);
-                }
 
                 let now = Agent::unix_timestamp_secs();
                 if !identity_announcement_timestamp_is_acceptable(announcement.announced_at, now) {


### PR DESCRIPTION
## L3 phase 1 (David-approved: "L3 first with omp")

Idle desktop uplink is dominated by O(network-size) broadcast of three ~15 KB ML-DSA announce messages per node per beat. This PR collapses identity+machine into ONE self-verifying ~7.5 KB V3 announcement and moves the optional (user_id, agent_certificate) pair behind a BLAKE3 digest with verify-before-cache fetch-on-miss.

- **V3 announce** (`announce_v3.rs`, X0A3 magic): both pubkeys inline (verifiable standalone), own ML-DSA signature over V3 canonical bytes with the agent pubkey INSIDE the signed struct; `cert_digest = blake3(bincode((user_id, cert)))` + `payload_version`. Published alongside V2 every heartbeat (old nodes drop the unknown magic — test-proven); receiver verifies under V3 rules then feeds the shared discovery pipeline (cache merge never erases existing certs).
- **Blob cache** (`announce_blob.rs`): LRU-256 + disk persistence; `ensure_blob` (hit → Arc, miss → metered background fetch stub until the responder wires up in phase 2); security gate = digest match → pairing rule mirror of `IdentityAnnouncement::verify` (cert.verify + agent/user binding) BEFORE any cache insert; cross-module test pins `cert_digest` ↔ gate acceptance.
- **Transition**: V2 (+machine announce, caps advert) keep publishing; retirement flips in a later release once the fleet converges. No wire removal in this PR.

Savings land at V2 retirement: 3 msgs / ~45.8 KB per beat → 1 msg / ~7.5 KB (−84%), multiplied across every announcing node.

Design: `.scratch/omp-l3l4-design.md` + review addendum (3.5 KB pubkey-digested variant rejected as unverifiable-before-fetch). Local gate: fmt + clippy -D warnings + 2833/2833 in a pristine worktree (one macOS-only pre-existing fail #412 excluded; `suppressed_peer_outbound_dial_is_refused` flaked only in a dirty checkout under load — its own comment documents the late-bookkeeping race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a signed V3 identity announcement and the foundations of a digest-keyed certificate blob cache while continuing to publish V2 announcements during migration.
- Adds V3 serialization, verification, key-to-ID binding, and conversion into the existing discovery shape.
- Publishes V3 alongside V2 and extends the identity subscriber to recognize and verify both formats.
- Adds bounded in-memory and disk-backed blob-cache primitives, verification gates, protocol codecs, and tests; remote fetch wiring remains deferred.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge for its stated transitional scope, with V2 retaining certificate-bearing compatibility while blob-fetch integration remains deferred.

V3 announcements are verified before entering discovery, existing certificate attribution survives V3 cache merges, and no currently reachable blocking failure remains in the added transition path.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/announce_v3.rs | Defines the V3 signed wire contract, standalone verification, conversion into the shared discovery representation, and protocol-focused tests. |
| src/announce_blob.rs | Adds blob verification, LRU persistence, and request/response primitives, although production fetch and receiver integration are intentionally deferred. |
| src/lib.rs | Publishes V3 alongside V2 and safely dispatches incoming payloads through format-specific verification before shared discovery processing. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  H[Heartbeat builds V2] --> P2[Publish V2]
  H --> B[Build and sign V3]
  B --> P3[Publish X0A3 payload]
  P2 --> R[Identity subscriber]
  P3 --> D[Detect and decode V3]
  D --> V[Verify keys, IDs, and signature]
  V --> C[Convert to shared discovery shape]
  R --> M[Merge discovery caches]
  C --> M
  C -. certificate digest .-> F[Future blob fetch wiring]
  F --> G[Verify digest and certificate binding]
  G --> K[Blob cache]
```

<sub>Reviews (1): Last reviewed commit: ["fix(l3): blob is the (user\_id, cert) pai..."](https://github.com/saorsa-labs/x0x/commit/2f5079cd2616bacf930d1a8b29dc58e4bfc9f6f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57181130)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Peer presence, bootstrap, and rendezvous](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/peer-presence-and-rendezvous.md)
- Knowledge Base — [Secure identity and trust](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/secure-identity-and-trust.md)
- Knowledge Base — [Identity lifecycle and key tooling](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/identity-lifecycle.md)
- Knowledge Base — [Gossip runtime and wire protocol](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/gossip-runtime.md)
</details>


<!-- /greptile_comment -->