### PR TITLE
chore(release): v0.39.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.10"
+version = "0.39.11"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.10
+version: 0.39.11
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Release v0.39.11 — L3 phase 1: V3 announce + blob cache (#416).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release PR synchronizes the package and skill metadata at v0.39.11.
- Updates the Rust package version in Cargo.toml.
- Updates the matching skill-manifest version in SKILL.md.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking omission of a v0.39.11 changelog section.

The two release versions are synchronized and no build or security failure remains, but users will not find the v0.39.11 changes in the repository changelog.

**Files Needing Attention:** Cargo.toml and CHANGELOG.md

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the crate version to 0.39.11, but the release lacks the corresponding changelog section. |
| SKILL.md | Updates the skill metadata to 0.39.11, matching Cargo.toml. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Cargo.toml:3
**Changelog misses release**

The package version advances to 0.39.11 without the corresponding changelog section required by the repository's release-bump workflow, so consumers cannot discover the changes shipped in this release.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.39.11"](https://github.com/saorsa-labs/x0x/commit/1611559db1e361ba8c22910de1ad77f8a898bdc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57190977)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->