### PR TITLE
feat(announce): L3 retirement flip — V3-only announces + end-to-end cert-blob fetch (#380)

### DIFF
--- a/src/announce_blob.rs
+++ b/src/announce_blob.rs
@@ -53,7 +53,7 @@ pub(crate) const ANNOUNCE_BLOB_REQUEST_DOMAIN: &[u8] = b"x0x/announce/v3/blob-re
 #[allow(dead_code)]
 pub(crate) const ANNOUNCE_BLOB_TOPIC: &str = "x0x/announce/v3/blob";
 
-/// Domain prefix for blob responses on [`ANNOUNCE_BLOB_TOPIC`] — lets the
+/// Domain prefix for blob responses on `ANNOUNCE_BLOB_TOPIC` — lets the
 /// fetcher distinguish a response from a concurrent request (both ride the
 /// same topic).
 pub(crate) const ANNOUNCE_BLOB_RESPONSE_DOMAIN: &[u8] = b"x0x/announce/v3/blob-response-v1\0";
@@ -400,7 +400,7 @@ impl AnnounceBlobCache {
 /// invariant.
 ///
 /// Routes (mirroring `publish_targeted_capability_request`):
-/// - targeted: the domain-prefixed request on [`ANNOUNCE_BLOB_TOPIC`];
+/// - targeted: the domain-prefixed request on `ANNOUNCE_BLOB_TOPIC`;
 /// - warm: the same domain-prefixed bytes on the steady identity announce
 ///   topic, so a responder that only watches the announce topic still
 ///   serves. The domain prefix keeps pre-L3 subscribers from mistaking it
@@ -615,7 +615,7 @@ fn decode_blob_request_from(encoded: &[u8]) -> Option<AnnounceBlobRequest> {
 /// Spawn the blob responder: subscribes the targeted (`ANNOUNCE_BLOB_TOPIC`)
 /// and warm (identity announce topic) carriers, answers every verified
 /// domain-prefixed request with [`AnnounceBlobCache::serve_request`]'s pair
-/// bytes under [`ANNOUNCE_BLOB_RESPONSE_DOMAIN`]. Mirrors the caps
+/// bytes under `ANNOUNCE_BLOB_RESPONSE_DOMAIN`. Mirrors the caps
 /// warm-targeted-request responder (`dm_capability_service.rs`), including
 /// the 1-response-per-second coalescing window so a burst of requests
 /// cannot turn into a blob storm.

--- a/src/announce_blob.rs
+++ b/src/announce_blob.rs
@@ -703,6 +703,33 @@ pub async fn spawn_blob_responder(
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 mod tests {
+    /// SECURITY (digest-spoof attribution): an attacker can put a VICTIM's
+    /// cert digest inside their own validly-signed V3 announce. The receiver
+    /// hit-path must refuse to merge a cached pair whose certificate binds a
+    /// different agent — otherwise the attacker's cache entry inherits the
+    /// victim's user attribution. This pins the binding predicate the
+    /// discovery arm uses before merging.
+    #[test]
+    fn cached_pair_never_merges_into_a_different_agents_announcement() {
+        let victim_user = crate::identity::UserKeypair::generate().unwrap();
+        let victim_agent = crate::identity::AgentKeypair::generate().unwrap();
+        let attacker_agent = crate::identity::AgentKeypair::generate().unwrap();
+        let cert = crate::identity::AgentCertificate::issue(&victim_user, &victim_agent)
+            .expect("cert issues");
+        let merge_allowed = |cert: &crate::identity::AgentCertificate,
+                             claimed: &crate::identity::AgentId| {
+            cert.agent_id().is_ok_and(|id| id == *claimed)
+        };
+        assert!(
+            merge_allowed(&cert, &victim_agent.agent_id()),
+            "victim's own announcement must merge its pair"
+        );
+        assert!(
+            !merge_allowed(&cert, &attacker_agent.agent_id()),
+            "attacker claiming the victim's digest must NOT inherit the pair"
+        );
+    }
+
     use super::*;
     use crate::identity::{AgentCertificate, AgentKeypair, UserKeypair};
 

--- a/src/announce_blob.rs
+++ b/src/announce_blob.rs
@@ -28,6 +28,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 use crate::gossip::PubSubManager;
@@ -51,6 +52,44 @@ pub(crate) const ANNOUNCE_BLOB_REQUEST_DOMAIN: &[u8] = b"x0x/announce/v3/blob-re
 /// topic so a Leaf that unsubscribes from announces still serves fetches).
 #[allow(dead_code)]
 pub(crate) const ANNOUNCE_BLOB_TOPIC: &str = "x0x/announce/v3/blob";
+
+/// Domain prefix for blob responses on [`ANNOUNCE_BLOB_TOPIC`] — lets the
+/// fetcher distinguish a response from a concurrent request (both ride the
+/// same topic).
+pub(crate) const ANNOUNCE_BLOB_RESPONSE_DOMAIN: &[u8] = b"x0x/announce/v3/blob-response-v1\0";
+
+/// How long a fetcher waits for a response before giving up (the next
+/// heartbeat retries). Generous for a mesh round-trip, short enough that a
+/// silent responder does not pin tasks.
+pub(crate) const BLOB_FETCH_TIMEOUT_SECS: u64 = 5;
+
+/// A verified requester can make peers serve blobs, but must not be able to
+/// amplify traffic without bound. Mirrors the caps responder's coalescing
+/// window (`dm_capability_service.rs`).
+const MIN_RESPONSE_INTERVAL_SECS: u64 = 1;
+
+/// The serving daemon's current `(user_id, agent_certificate)` pair, shared
+/// with the responder task so consent changes are picked up live.
+pub type SharedCertPair =
+    Arc<std::sync::RwLock<(Option<identity::UserId>, Option<identity::AgentCertificate>)>>;
+
+/// Whether a V3 announce's cert digest warrants a fetch: anonymous
+/// announces (the `(None, None)` constant) never do — there is nothing to
+/// fetch, and every beat from an anonymous agent would otherwise fire a
+/// pointless request. Single definition so the receiver arm and tests
+/// agree on the rule.
+#[must_use]
+pub fn fetch_warranted(cert_digest: &[u8; 32]) -> bool {
+    *cert_digest != crate::announce_v3::anonymous_cert_digest()
+}
+
+/// Build a [`SharedCertPair`] from an initial pair.
+pub fn shared_cert_pair(
+    user_id: Option<identity::UserId>,
+    cert: Option<identity::AgentCertificate>,
+) -> SharedCertPair {
+    Arc::new(std::sync::RwLock::new((user_id, cert)))
+}
 
 /// A cached `(user_id, agent_certificate)` pair, keyed by its BLAKE3
 /// digest — exactly the bytes [`crate::announce_v3::cert_digest`] commits
@@ -183,7 +222,7 @@ impl AnnounceBlobCache {
     #[allow(clippy::too_many_arguments)]
     pub async fn ensure_blob(
         self: &Arc<Self>,
-        pubsub: &PubSubManager,
+        pubsub: &Arc<PubSubManager>,
         digest: &[u8; 32],
         payload_version: u64,
         agent_id: &identity::AgentId,
@@ -195,18 +234,15 @@ impl AnnounceBlobCache {
 
         // Miss — spawn the fetch, return None immediately. `agent_id` is
         // the expected agent threaded into `verify_fetched_blob`'s cert
-        // binding check. The pubsub reference cannot cross the spawn
-        // boundary ('static); the fetch task goes through the cache's own
-        // handle once Claude's V3 receiver wires the responder side. Until
-        // then this is a metered no-op: `blob_fetches_failed` increments
-        // and the next heartbeat retries — never blocks the caller.
-        let _ = pubsub;
+        // binding check. Non-blocking by contract: the next heartbeat's
+        // ensure_blob sees the fetched entry (or retries the fetch).
         let cache = Arc::clone(self);
+        let pubsub = Arc::clone(pubsub);
         let digest = *digest;
         let agent_id = *agent_id;
         let machine_id = *machine_id;
         tokio::spawn(async move {
-            match fetch_and_verify(&cache, &digest, &agent_id, &machine_id).await {
+            match fetch_and_verify(&pubsub, &cache, &digest, &agent_id, &machine_id).await {
                 Ok(blob) => {
                     cache.stats_fetches_ok.fetch_add(1, Ordering::Relaxed);
                     cache
@@ -358,28 +394,94 @@ impl AnnounceBlobCache {
     }
 }
 
-/// Fetch a blob via targeted request and verify before returning.
-/// SECURITY: the fetched blob MUST pass `verify()` and the digest MUST
-/// match — this is the verify-before-cache invariant.
+/// Fetch a blob via the targeted/warm request routes and verify before
+/// returning. SECURITY: the fetched blob MUST pass the
+/// [`verify_fetched_blob`] gate — this is the verify-before-cache
+/// invariant.
+///
+/// Routes (mirroring `publish_targeted_capability_request`):
+/// - targeted: the domain-prefixed request on [`ANNOUNCE_BLOB_TOPIC`];
+/// - warm: the same domain-prefixed bytes on the steady identity announce
+///   topic, so a responder that only watches the announce topic still
+///   serves. The domain prefix keeps pre-L3 subscribers from mistaking it
+///   for an announce (the X0A3/V2 decoders both reject it).
+///
+/// The response is matched by digest: every well-formed response carries
+/// the pair whose blake3 is the requested digest, so concurrent fetchers
+/// can share the topic and each picks out its own blob.
 async fn fetch_and_verify(
+    pubsub: &Arc<PubSubManager>,
     cache: &AnnounceBlobCache,
     digest: &[u8; 32],
     expected_agent_id: &identity::AgentId,
     machine_id: &identity::MachineId,
 ) -> Result<CachedBlob, String> {
-    // Phase 2 (Claude's receiver wiring) publishes an `AnnounceBlobRequest`
-    // over the warm-targeted-request domain and awaits the response; the
-    // verify_fetched_blob gate below is what makes any fetched bytes safe.
-    // Phase 1: no responder exists yet, so the miss is metered and retried.
-    tracing::debug!(
-        target: "announce.blob",
-        digest = %hex::encode(digest),
-        agent = %hex::encode(expected_agent_id.as_bytes()),
-        machine = %machine_id.as_bytes().iter().map(|b| format!("{b:02x}")).take(8).collect::<String>(),
-        cached = cache.snapshot().blob_cache_hits,
-        "announce blob fetch deferred (responder pending)"
+    let mut responses = pubsub.subscribe(ANNOUNCE_BLOB_TOPIC.to_string()).await;
+
+    // `encode_blob_request` returns domain-prefixed bytes; both carriers
+    // publish the same prefixed payload and the responder's decoder strips
+    // the domain from whichever carrier delivered it.
+    let request = encode_blob_request(digest, expected_agent_id);
+    let (targeted, warm) = tokio::join!(
+        pubsub.publish(
+            ANNOUNCE_BLOB_TOPIC.to_string(),
+            Bytes::from(request.clone())
+        ),
+        pubsub.publish(
+            crate::IDENTITY_ANNOUNCE_TOPIC.to_string(),
+            Bytes::from(request),
+        ),
     );
-    Err("announce blob fetch: responder protocol pending V3 receiver wiring".to_string())
+    if let (Err(t), Err(w)) = (&targeted, &warm) {
+        return Err(format!(
+            "both blob request carriers failed: targeted={t}; warm={w}"
+        ));
+    }
+    if let Err(e) = &targeted {
+        tracing::warn!(target: "announce.blob", %e, "targeted blob request carrier failed");
+    }
+    if let Err(e) = &warm {
+        tracing::warn!(target: "announce.blob", %e, "warm blob request carrier failed");
+    }
+
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(BLOB_FETCH_TIMEOUT_SECS);
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Err("announce blob fetch timed out".to_string());
+        }
+        let message = match tokio::time::timeout(remaining, responses.recv()).await {
+            Ok(Some(message)) => message,
+            Ok(None) => return Err("blob response subscription closed".to_string()),
+            Err(_) => return Err("announce blob fetch timed out".to_string()),
+        };
+        let Some(payload) = message.payload.strip_prefix(ANNOUNCE_BLOB_RESPONSE_DOMAIN) else {
+            // A request or foreign message on the topic — not ours.
+            continue;
+        };
+        let Some(response) = decode_blob_response(payload) else {
+            continue;
+        };
+        // The gate: digest match + pair verify + agent binding. A forged
+        // responder that controls both bytes and digest still fails here.
+        return verify_fetched_blob(
+            &response.announcement_bytes,
+            digest,
+            expected_agent_id,
+            0,
+        )
+        .map_err(|e| {
+            tracing::warn!(
+                target: "announce.blob",
+                agent = %hex::encode(expected_agent_id.as_bytes()),
+                machine = %machine_id.as_bytes().iter().map(|b| format!("{b:02x}")).take(8).collect::<String>(),
+                cached_hits = cache.snapshot().blob_cache_hits,
+                "fetched blob REJECTED by the verify gate: {e}"
+            );
+            e
+        });
+    }
 }
 
 /// Verify a fetched blob against the expected digest and agent.
@@ -503,6 +605,97 @@ pub(crate) fn encode_blob_response(announcement_bytes: Vec<u8>) -> Vec<u8> {
 #[allow(dead_code)]
 pub(crate) fn decode_blob_response(wire: &[u8]) -> Option<AnnounceBlobResponse> {
     bincode::deserialize(wire).ok()
+}
+
+/// Decode a domain-stripped blob request from the wire.
+fn decode_blob_request_from(encoded: &[u8]) -> Option<AnnounceBlobRequest> {
+    bincode::deserialize(encoded).ok()
+}
+
+/// Spawn the blob responder: subscribes the targeted (`ANNOUNCE_BLOB_TOPIC`)
+/// and warm (identity announce topic) carriers, answers every verified
+/// domain-prefixed request with [`AnnounceBlobCache::serve_request`]'s pair
+/// bytes under [`ANNOUNCE_BLOB_RESPONSE_DOMAIN`]. Mirrors the caps
+/// warm-targeted-request responder (`dm_capability_service.rs`), including
+/// the 1-response-per-second coalescing window so a burst of requests
+/// cannot turn into a blob storm.
+///
+/// `own_pair` is read live per request, so consent changes (a new user→agent
+/// certificate) are served without a restart.
+pub async fn spawn_blob_responder(
+    pubsub: Arc<PubSubManager>,
+    cache: Arc<AnnounceBlobCache>,
+    own_pair: SharedCertPair,
+) -> crate::error::NetworkResult<tokio::task::JoinHandle<()>> {
+    let mut targeted = pubsub.subscribe(ANNOUNCE_BLOB_TOPIC.to_string()).await;
+    let mut warm = pubsub
+        .subscribe(crate::IDENTITY_ANNOUNCE_TOPIC.to_string())
+        .await;
+
+    let handle = tokio::spawn(async move {
+        let mut last_response = std::time::Instant::now()
+            .checked_sub(std::time::Duration::from_secs(
+                MIN_RESPONSE_INTERVAL_SECS + 1,
+            ))
+            .unwrap_or_else(std::time::Instant::now);
+        loop {
+            // Drain whichever carrier delivers first; both decode the same
+            // domain-prefixed request shape.
+            let message = tokio::select! {
+                m = targeted.recv() => m,
+                m = warm.recv() => m,
+            };
+            let Some(message) = message else { continue };
+            if !message.verified || message.sender.is_none() {
+                continue;
+            }
+            let Some(encoded) = message.payload.strip_prefix(ANNOUNCE_BLOB_REQUEST_DOMAIN) else {
+                // An announce or foreign payload on the shared carrier.
+                continue;
+            };
+            let Some(request) = decode_blob_request_from(encoded) else {
+                continue;
+            };
+            let (own_user, own_cert) = own_pair
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            let Some(pair_bytes) = cache
+                .serve_request(&request.digest, &own_user, &own_cert)
+                .await
+            else {
+                tracing::debug!(
+                    target: "announce.blob",
+                    digest = %hex::encode(request.digest),
+                    "blob request for an unknown digest — not served"
+                );
+                continue;
+            };
+            // Coalesce: at most one response per window, like the caps
+            // responder. A dropped response is retried by the next beat.
+            let now = std::time::Instant::now();
+            if now.duration_since(last_response)
+                < std::time::Duration::from_secs(MIN_RESPONSE_INTERVAL_SECS)
+            {
+                continue;
+            }
+            last_response = now;
+            // Wrap the pair bytes in the typed response envelope so the
+            // fetcher's decode_blob_response round-trips (a bare pair tuple
+            // does not deserialize as AnnounceBlobResponse).
+            let mut wire = encode_blob_response(pair_bytes);
+            let mut prefixed = Vec::with_capacity(ANNOUNCE_BLOB_RESPONSE_DOMAIN.len() + wire.len());
+            prefixed.extend_from_slice(ANNOUNCE_BLOB_RESPONSE_DOMAIN);
+            prefixed.append(&mut wire);
+            if let Err(e) = pubsub
+                .publish(ANNOUNCE_BLOB_TOPIC.to_string(), Bytes::from(prefixed))
+                .await
+            {
+                tracing::warn!(target: "announce.blob", %e, "blob response publish failed");
+            }
+        }
+    });
+    Ok(handle)
 }
 
 // ---------------------------------------------------------------------------
@@ -736,5 +929,219 @@ mod tests {
         let cache = AnnounceBlobCache::new(None);
         let unknown: [u8; 32] = [0xCD; 32];
         assert!(cache.serve_request(&unknown, &None, &None).await.is_none());
+    }
+
+    // ── Hermetic protocol tests (issue #417: no prod dialing — local
+    //    pubsub delivery only, mirroring the caps-service test harness) ──
+
+    mod protocol {
+        use super::super::*;
+        use super::{issued_cert, pair_bytes};
+        use crate::gossip::SigningContext;
+        use crate::network::{NetworkConfig, NetworkNode};
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        async fn make_pubsub() -> Arc<PubSubManager> {
+            let node = Arc::new(
+                NetworkNode::new(NetworkConfig::default(), None, None)
+                    .await
+                    .expect("network node"),
+            );
+            let kp = crate::identity::AgentKeypair::generate().expect("keypair");
+            let signing = Arc::new(SigningContext::from_keypair(&kp));
+            Arc::new(PubSubManager::new(node, Some(signing)).expect("pubsub"))
+        }
+
+        /// Wait until `cache` holds `digest` (the fetch task fills it
+        /// asynchronously) or fail after `secs`.
+        async fn wait_for_blob(
+            cache: &Arc<AnnounceBlobCache>,
+            digest: &[u8; 32],
+            secs: u64,
+        ) -> Option<Arc<CachedBlob>> {
+            let deadline = std::time::Instant::now() + Duration::from_secs(secs);
+            loop {
+                if let Some(hit) = cache.get(digest).await {
+                    return Some(hit);
+                }
+                if std::time::Instant::now() >= deadline {
+                    return None;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+
+        /// Two-agent loopback: a consented agent serves its pair via the
+        /// responder; the peer's ensure_blob misses, fetches, verifies, and
+        /// the cache gains the cert+user. Second ensure_blob hits.
+        #[tokio::test]
+        async fn two_agent_fetch_fills_peer_cache() {
+            let (cert, user_kp, agent_kp) = issued_cert();
+            let user_id = Some(user_kp.user_id());
+            let agent_id = agent_kp.agent_id();
+            let machine_id = crate::identity::MachineId([0x77; 32]);
+            let digest = crate::announce_v3::cert_digest(&user_id, &Some(cert.clone()));
+
+            let pubsub = make_pubsub().await;
+            // Serving agent: cache with the pair pre-cached + live pair source.
+            let serving_cache = Arc::new(AnnounceBlobCache::new(None));
+            serving_cache
+                .insert_verified(CachedBlob {
+                    digest,
+                    payload_version: 7,
+                    user_id,
+                    agent_certificate: Some(cert.clone()),
+                    fetched_at_unix: 1,
+                })
+                .await;
+            let own_pair = shared_cert_pair(None, None);
+            spawn_blob_responder(Arc::clone(&pubsub), serving_cache, own_pair)
+                .await
+                .expect("responder spawns");
+            // Let the responder's subscriptions register before fetching
+            // (same registration race the caps-service test sleeps for).
+            tokio::time::sleep(Duration::from_millis(300)).await;
+
+            // Fetching agent: empty cache. Miss → None, fetch fires.
+            let fetching_cache = Arc::new(AnnounceBlobCache::new(None));
+            let immediate = fetching_cache
+                .ensure_blob(&pubsub, &digest, 7, &agent_id, &machine_id)
+                .await;
+            assert!(
+                immediate.is_none(),
+                "miss must return None (no-block contract)"
+            );
+
+            let filled = wait_for_blob(&fetching_cache, &digest, 8)
+                .await
+                .expect("fetch must fill the cache");
+            assert_eq!(filled.user_id, user_id);
+            assert_eq!(
+                filled
+                    .agent_certificate
+                    .as_ref()
+                    .and_then(|c| c.agent_id().ok()),
+                Some(agent_id),
+                "the fetched cert must bind the announced agent"
+            );
+            assert_eq!(filled.payload_version, 7, "version overlays the fetch");
+
+            // Hit path: immediate Some.
+            let hit = fetching_cache
+                .ensure_blob(&pubsub, &digest, 7, &agent_id, &machine_id)
+                .await;
+            assert!(hit.is_some(), "second call must hit the filled cache");
+
+            let stats = fetching_cache.snapshot();
+            assert!(stats.blob_fetches_ok >= 1, "metering must count the fetch");
+        }
+
+        /// Forged responder: serves tampered pair bytes whose digest DOES
+        /// match the tampered bytes (attacker controls both). The verify
+        /// gate must reject — the cache stays empty and the failure meters.
+        #[tokio::test]
+        async fn forged_responder_is_rejected() {
+            let (cert, user_kp, agent_kp) = issued_cert();
+            let user_id = Some(user_kp.user_id());
+            let agent_id = agent_kp.agent_id();
+            let machine_id = crate::identity::MachineId([0x88; 32]);
+
+            let pubsub = make_pubsub().await;
+            let requesting_cache = Arc::new(AnnounceBlobCache::new(None));
+
+            // Subscribe + answer with tampered bytes directly (no honest
+            // responder): flip a signature byte, digest the tampered bytes.
+            let mut tampered = pair_bytes(&user_id, &Some(cert));
+            let last = tampered.len() - 1;
+            tampered[last] ^= 0xFF;
+            let digest: [u8; 32] = blake3::hash(&tampered).into();
+
+            let forger_pubsub = Arc::clone(&pubsub);
+            tokio::spawn(async move {
+                let mut reqs = forger_pubsub
+                    .subscribe(ANNOUNCE_BLOB_TOPIC.to_string())
+                    .await;
+                while let Some(message) = reqs.recv().await {
+                    if message
+                        .payload
+                        .strip_prefix(ANNOUNCE_BLOB_REQUEST_DOMAIN)
+                        .is_some()
+                    {
+                        let mut wire = encode_blob_response(tampered.clone());
+                        let mut prefixed =
+                            Vec::with_capacity(ANNOUNCE_BLOB_RESPONSE_DOMAIN.len() + wire.len());
+                        prefixed.extend_from_slice(ANNOUNCE_BLOB_RESPONSE_DOMAIN);
+                        prefixed.append(&mut wire);
+                        let _ = forger_pubsub
+                            .publish(ANNOUNCE_BLOB_TOPIC.to_string(), Bytes::from(prefixed))
+                            .await;
+                        break; // one forged answer is enough
+                    }
+                }
+            });
+
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            requesting_cache
+                .ensure_blob(&pubsub, &digest, 1, &agent_id, &machine_id)
+                .await;
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            assert!(
+                requesting_cache.get(&digest).await.is_none(),
+                "the forged blob must never enter the cache"
+            );
+            let stats = requesting_cache.snapshot();
+            assert!(
+                stats.blob_fetches_failed >= 1,
+                "the rejection must meter as a failed fetch"
+            );
+        }
+
+        /// The receiver-arm skip rule: anonymous digests never warrant a
+        /// fetch — `fetch_warranted` is the single definition.
+        #[test]
+        fn anonymous_digest_never_fetches() {
+            let anon = crate::announce_v3::anonymous_cert_digest();
+            assert!(!fetch_warranted(&anon), "anonymous digest must not fetch");
+            let real = crate::announce_v3::cert_digest(
+                &Some(
+                    crate::identity::UserKeypair::generate()
+                        .expect("kp")
+                        .user_id(),
+                ),
+                &None,
+            );
+            assert!(fetch_warranted(&real), "a real digest must fetch");
+        }
+
+        /// Protocol safety net: even if a caller ignores the skip rule, an
+        /// anonymous fetch round-trips `(None, None)` harmlessly — there is
+        /// nothing sensitive to leak and nothing to forge.
+        #[tokio::test]
+        async fn anonymous_pair_round_trip_is_harmless() {
+            let pubsub = make_pubsub().await;
+            let serving_cache = Arc::new(AnnounceBlobCache::new(None));
+            let own_pair = shared_cert_pair(None, None);
+            spawn_blob_responder(Arc::clone(&pubsub), serving_cache, own_pair)
+                .await
+                .expect("responder spawns");
+            tokio::time::sleep(Duration::from_millis(300)).await;
+
+            let anon_digest = crate::announce_v3::anonymous_cert_digest();
+            let agent_id = crate::identity::AgentKeypair::generate()
+                .expect("kp")
+                .agent_id();
+            let machine_id = crate::identity::MachineId([0x99; 32]);
+            let fetching_cache = Arc::new(AnnounceBlobCache::new(None));
+            fetching_cache
+                .ensure_blob(&pubsub, &anon_digest, 0, &agent_id, &machine_id)
+                .await;
+
+            let filled = wait_for_blob(&fetching_cache, &anon_digest, 8)
+                .await
+                .expect("anonymous fetch round-trips");
+            assert!(filled.user_id.is_none() && filled.agent_certificate.is_none());
+        }
     }
 }

--- a/src/dm_capability_service.rs
+++ b/src/dm_capability_service.rs
@@ -193,6 +193,7 @@ impl CapabilityAdvertService {
         caps_rx: tokio::sync::watch::Receiver<DmCapabilities>,
         store: Arc<CapabilityStore>,
         publish_interval: Duration,
+        periodic: bool,
     ) -> NetworkResult<Self> {
         let mut subscription = pubsub.subscribe(DM_CAPABILITY_TOPIC.to_string()).await;
         let mut targeted_response_subscription = pubsub
@@ -288,7 +289,16 @@ impl CapabilityAdvertService {
         let mut publisher_caps_rx = caps_rx;
         let publisher = tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(FIRST_PUBLISH_DELAY_MS)).await;
-            let mut burst_idx: usize = 0;
+            // L3 retirement: in on-demand mode (periodic == false) there is no
+            // startup burst and no steady beat — the publisher wakes only for
+            // targeted/warm requests and capability upgrades, and publishes to
+            // the steady topic only on request-triggered cycles (warm-carrier
+            // requesters listen there).
+            let mut burst_idx: usize = if periodic {
+                0
+            } else {
+                STARTUP_BURST_INTERVALS_MS.len()
+            };
             let mut last_targeted_response_at: Option<tokio::time::Instant> = None;
             let mut targeted_response_pending = false;
             let mut requests_open = true;
@@ -325,6 +335,7 @@ impl CapabilityAdvertService {
                     }
                     continue;
                 }
+                let respond_on_steady = targeted_response_pending;
                 match build_signed_advert(
                     &publisher_signing,
                     self_agent_id,
@@ -358,13 +369,15 @@ impl CapabilityAdvertService {
                                 ),
                             }
                         }
-                        if let Err(e) = publisher_pubsub
-                            .publish(DM_CAPABILITY_TOPIC.to_string(), bytes)
-                            .await
-                        {
-                            tracing::warn!("capability advert publish failed: {e}");
-                        } else {
-                            tracing::debug!("capability advert published");
+                        if periodic || respond_on_steady {
+                            if let Err(e) = publisher_pubsub
+                                .publish(DM_CAPABILITY_TOPIC.to_string(), bytes)
+                                .await
+                            {
+                                tracing::warn!("capability advert publish failed: {e}");
+                            } else {
+                                tracing::debug!("capability advert published");
+                            }
                         }
                     }
                     Err(e) => tracing::warn!("capability advert build failed: {e}"),
@@ -373,8 +386,12 @@ impl CapabilityAdvertService {
                     let d = Duration::from_millis(STARTUP_BURST_INTERVALS_MS[burst_idx]);
                     burst_idx += 1;
                     d
-                } else {
+                } else if periodic {
                     publish_interval
+                } else {
+                    // On-demand mode: no steady beat. The select below still
+                    // wakes on requests and capability upgrades.
+                    Duration::from_secs(3600)
                 };
                 let publish_delay = tokio::time::sleep(next_delay);
                 tokio::pin!(publish_delay);
@@ -447,6 +464,7 @@ impl CapabilityAdvertService {
             caps_rx,
             store,
             Duration::from_secs(ADVERT_PUBLISH_INTERVAL_SECS),
+            true,
         )
         .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,11 @@ pub struct Agent {
     /// Handle for the running capability advert service.
     capability_advert_service:
         tokio::sync::Mutex<Option<dm_capability_service::CapabilityAdvertService>>,
+    /// L3 fetch-on-miss cache for announce cert blobs (see `announce_blob`).
+    pub(crate) announce_blob_cache: std::sync::Arc<announce_blob::AnnounceBlobCache>,
+    /// This daemon's live `(user_id, agent_certificate)` pair, served to
+    /// blob fetchers by the responder task.
+    pub(crate) own_cert_pair: announce_blob::SharedCertPair,
     /// Handle for the running DM inbox service.
     dm_inbox_service: std::sync::Arc<tokio::sync::Mutex<Option<dm_inbox::DmInboxService>>>,
     /// In-memory grow-only revocation set.  Gate checks hold only a read lock
@@ -6962,6 +6967,11 @@ impl Agent {
         let revocation_set = std::sync::Arc::clone(&self.revocation_set);
         let identity_dir_for_listener = self.identity_dir.clone();
         let contact_store_for_evict = std::sync::Arc::clone(&self.contact_store);
+        // L3 fetch-on-miss: the listener resolves V3 cert digests from the
+        // blob cache (hit) or fires a background fetch (miss) — never
+        // blocking the discovery pipeline.
+        let announce_blob_cache = std::sync::Arc::clone(&self.announce_blob_cache);
+        let blob_pubsub = std::sync::Arc::clone(runtime.pubsub());
 
         self.spawn_tracked(async move {
             enum DiscoveryMessage {
@@ -7320,7 +7330,37 @@ impl Agent {
                         }
                         remember_verified_payload(&mut seen_identity_payloads, &raw_payload);
                     }
-                    v3.into_announcement()
+                    // L3 fetch-on-miss: resolve the cert digest into the
+                    // pair. Hit → merge the cached (verified) pair into the
+                    // converted announcement so the shared pipeline upserts
+                    // the full entry now. Miss → fire the non-blocking
+                    // fetch; this beat carries no pair (the existing merge
+                    // never erases a previously-known cert) and the next
+                    // beat hits the filled cache. Anonymous digests never
+                    // fetch — `(None, None)` is a well-known constant.
+                    let cert_digest = v3.cert_digest;
+                    let payload_version = v3.payload_version;
+                    let mut converted = v3.into_announcement();
+                    if announce_blob::fetch_warranted(&cert_digest) {
+                        match announce_blob_cache.get(&cert_digest).await {
+                            Some(blob) => {
+                                converted.user_id = blob.user_id;
+                                converted.agent_certificate = blob.agent_certificate.clone();
+                            }
+                            None => {
+                                announce_blob_cache
+                                    .ensure_blob(
+                                        &blob_pubsub,
+                                        &cert_digest,
+                                        payload_version,
+                                        &converted.agent_id,
+                                        &converted.machine_id,
+                                    )
+                                    .await;
+                            }
+                        }
+                    }
+                    converted
                 } else {
                     let announcement = match deserialize_identity_announcement(&raw_payload) {
                         Ok(a) => a,
@@ -8188,6 +8228,22 @@ impl Agent {
         }
         *guard = Some(service);
         tracing::info!("Capability advert service started");
+
+        // L3: serve cert-blob fetches for peers that see our V3 announce
+        // digest but lack the cached pair. Same lifecycle as the caps
+        // service; the handle is detached (task ends with the pubsub).
+        if self.shutdown_token.is_cancelled() {
+            return Ok(());
+        }
+        if let Err(e) = announce_blob::spawn_blob_responder(
+            std::sync::Arc::clone(runtime.pubsub()),
+            std::sync::Arc::clone(&self.announce_blob_cache),
+            std::sync::Arc::clone(&self.own_cert_pair),
+        )
+        .await
+        {
+            tracing::warn!("announce blob responder spawn failed: {e}");
+        }
         Ok(())
     }
 
@@ -11604,6 +11660,10 @@ impl AgentBuilder {
 
         // Load the revocation set from disk so enforcement takes effect
         // immediately on restart, even before the next gossip heartbeat.
+        // L3: capture the identity's cert pair before it moves into the
+        // struct — the blob responder serves this pair to fetchers.
+        let own_pair_user = identity.user_id();
+        let own_pair_cert = identity.agent_certificate().cloned();
         Ok(Agent {
             history_service: tokio::sync::Mutex::new(history_service),
             history_handle,
@@ -11647,6 +11707,13 @@ impl AgentBuilder {
             dm_inflight_acks: std::sync::Arc::new(dm::InFlightAcks::new()),
             recent_delivery_cache: std::sync::Arc::new(dm::RecentDeliveryCache::with_defaults()),
             capability_advert_service: tokio::sync::Mutex::new(None),
+            announce_blob_cache: std::sync::Arc::new(announce_blob::AnnounceBlobCache::new(
+                self.identity_dir
+                    .clone()
+                    .or_else(|| dirs::home_dir().map(|h| h.join(".x0x")))
+                    .map(|dir| dir.join("announce-blob-cache.bin")),
+            )),
+            own_cert_pair: announce_blob::shared_cert_pair(own_pair_user, own_pair_cert),
             dm_inbox_service: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
             revocation_set,
             identity_dir: self.identity_dir,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,13 @@ pub struct Agent {
     identity_listener_started: std::sync::atomic::AtomicBool,
     /// How often to re-announce identity (seconds).
     heartbeat_interval_secs: u64,
+    /// Whether to keep publishing the legacy V2 announce set (V2 identity +
+    /// machine announcements + periodic caps advert). Default FALSE since the
+    /// L3 retirement flip: the V3 announce carries everything, receivers for
+    /// V2 formats stay forever, and old peers self-update within the rollout
+    /// window. Escape hatch: `AgentBuilder::with_legacy_announce(true)` /
+    /// `[announce] legacy = true` in the daemon config.
+    legacy_announce: bool,
     /// How long before a cache entry is filtered out (seconds).
     identity_ttl_secs: u64,
     /// Handle for the running heartbeat task, if started.
@@ -2181,6 +2188,7 @@ pub struct AgentBuilder {
     /// Useful for fully isolated embedders and test harnesses.
     disable_peer_cache: bool,
     heartbeat_interval_secs: Option<u64>,
+    legacy_announce: Option<bool>,
     identity_ttl_secs: Option<u64>,
     presence_beacon_interval_secs: Option<u64>,
     presence_event_poll_interval_secs: Option<u64>,
@@ -2221,6 +2229,8 @@ struct HeartbeatContext {
     last_revocation_generation: std::sync::atomic::AtomicU64,
     /// Heartbeat tick counter for the periodic revocation fallback.
     heartbeat_tick: std::sync::atomic::AtomicU64,
+    /// L3 retirement flip: publish the legacy V2 announce set only when true.
+    legacy_announce: bool,
 }
 
 impl HeartbeatContext {
@@ -2434,34 +2444,42 @@ impl HeartbeatContext {
             ))
         })?;
         let machine_payload = bytes::Bytes::from(machine_encoded);
-        self.runtime
-            .pubsub()
-            .publish(
-                shard_topic_for_machine(&machine_announcement.machine_id),
-                machine_payload.clone(),
-            )
-            .await
-            .map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "heartbeat: machine shard publish failed: {e}"
-                )))
-            })?;
-        self.runtime
-            .pubsub()
-            .publish(MACHINE_ANNOUNCE_TOPIC.to_string(), machine_payload)
-            .await
-            .map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "heartbeat: machine publish failed: {e}"
-                )))
-            })?;
+        // L3 retirement: the V3 announce below carries every machine field,
+        // so the separate machine broadcast only runs on the legacy escape
+        // hatch. The announcement struct is still built — local cache upserts
+        // and lookup fallbacks keep using it.
+        if self.legacy_announce {
+            self.runtime
+                .pubsub()
+                .publish(
+                    shard_topic_for_machine(&machine_announcement.machine_id),
+                    machine_payload.clone(),
+                )
+                .await
+                .map_err(|e| {
+                    error::IdentityError::Storage(std::io::Error::other(format!(
+                        "heartbeat: machine shard publish failed: {e}"
+                    )))
+                })?;
+            self.runtime
+                .pubsub()
+                .publish(MACHINE_ANNOUNCE_TOPIC.to_string(), machine_payload)
+                .await
+                .map_err(|e| {
+                    error::IdentityError::Storage(std::io::Error::other(format!(
+                        "heartbeat: machine publish failed: {e}"
+                    )))
+                })?;
+        }
 
         let encoded = serialize_identity_announcement(&announcement).map_err(|e| {
             error::IdentityError::Serialization(format!(
                 "heartbeat: failed to serialize announcement: {e}"
             ))
         })?;
-        if should_publish_identity_on_legacy(IdentityAnnouncementSource::LocallyAuthored) {
+        if self.legacy_announce
+            && should_publish_identity_on_legacy(IdentityAnnouncementSource::LocallyAuthored)
+        {
             self.runtime
                 .pubsub()
                 .publish(
@@ -2937,6 +2955,7 @@ impl Agent {
             peer_cache_dir: None,
             disable_peer_cache: false,
             heartbeat_interval_secs: None,
+            legacy_announce: None,
             identity_ttl_secs: None,
             presence_beacon_interval_secs: None,
             presence_event_poll_interval_secs: None,
@@ -6390,27 +6409,33 @@ impl Agent {
                     "failed to serialize machine announcement: {e}"
                 ))
             })?);
-        runtime
-            .pubsub()
-            .publish(
-                shard_topic_for_machine(&machine_announcement.machine_id),
-                machine_payload.clone(),
-            )
-            .await
-            .map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "failed to publish machine announcement to shard topic: {e}"
-                )))
-            })?;
-        runtime
-            .pubsub()
-            .publish(MACHINE_ANNOUNCE_TOPIC.to_string(), machine_payload)
-            .await
-            .map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "failed to publish machine announcement: {e}"
-                )))
-            })?;
+        // L3 retirement: machine broadcast only on the legacy escape hatch —
+        // the V3 announce below carries every machine field.
+        if self.legacy_announce {
+            runtime
+                .pubsub()
+                .publish(
+                    shard_topic_for_machine(&machine_announcement.machine_id),
+                    machine_payload.clone(),
+                )
+                .await
+                .map_err(|e| {
+                    error::IdentityError::Storage(std::io::Error::other(format!(
+                        "failed to publish machine announcement to shard topic: {e}"
+                    )))
+                })?;
+        }
+        if self.legacy_announce {
+            runtime
+                .pubsub()
+                .publish(MACHINE_ANNOUNCE_TOPIC.to_string(), machine_payload)
+                .await
+                .map_err(|e| {
+                    error::IdentityError::Storage(std::io::Error::other(format!(
+                        "failed to publish machine announcement: {e}"
+                    )))
+                })?;
+        }
 
         let encoded = serialize_identity_announcement(&announcement).map_err(|e| {
             error::IdentityError::Serialization(format!(
@@ -6420,29 +6445,67 @@ impl Agent {
 
         let payload = bytes::Bytes::from(encoded);
 
-        // Publish to shard topic first (future-proof routing).
-        let shard_topic = shard_topic_for_agent(&announcement.agent_id);
-        runtime
-            .pubsub()
-            .publish(shard_topic, payload.clone())
-            .await
-            .map_err(|e| {
-                error::IdentityError::Storage(std::io::Error::other(format!(
-                    "failed to publish identity announcement to shard topic: {e}"
-                )))
-            })?;
-
-        // Also publish to legacy broadcast topic for backward compatibility.
-        if should_publish_identity_on_legacy(IdentityAnnouncementSource::LocallyAuthored) {
+        // L3 retirement: V2 identity publishes (shard + legacy broadcast)
+        // only on the legacy escape hatch.
+        if self.legacy_announce {
+            let shard_topic = shard_topic_for_agent(&announcement.agent_id);
             runtime
                 .pubsub()
-                .publish(IDENTITY_ANNOUNCE_TOPIC.to_string(), payload)
+                .publish(shard_topic, payload.clone())
                 .await
                 .map_err(|e| {
                     error::IdentityError::Storage(std::io::Error::other(format!(
-                        "failed to publish identity announcement: {e}"
+                        "failed to publish identity announcement to shard topic: {e}"
                     )))
                 })?;
+            if should_publish_identity_on_legacy(IdentityAnnouncementSource::LocallyAuthored) {
+                runtime
+                    .pubsub()
+                    .publish(IDENTITY_ANNOUNCE_TOPIC.to_string(), payload)
+                    .await
+                    .map_err(|e| {
+                        error::IdentityError::Storage(std::io::Error::other(format!(
+                            "failed to publish identity announcement: {e}"
+                        )))
+                    })?;
+            }
+        }
+
+        // L3: the V3 announce is the primary format on this path too (the
+        // heartbeat already publishes it; phase 1 missed this join-time/REST
+        // path, which mattered less while V2 still ran every beat).
+        let v3_payload_version = if announcement.user_id.is_some() {
+            announcement.announced_at
+        } else {
+            0
+        };
+        match announce_v3::IdentityAnnouncementV3::build_from_v2(
+            &announcement,
+            self.identity.machine_keypair().secret_key(),
+            v3_payload_version,
+        )
+        .and_then(|v3| {
+            announce_v3::serialize_v3(&v3).map_err(|e| {
+                error::IdentityError::Serialization(format!(
+                    "failed to serialize v3 announcement: {e}"
+                ))
+            })
+        }) {
+            Ok(v3_encoded) => {
+                runtime
+                    .pubsub()
+                    .publish(
+                        IDENTITY_ANNOUNCE_TOPIC.to_string(),
+                        bytes::Bytes::from(v3_encoded),
+                    )
+                    .await
+                    .map_err(|e| {
+                        error::IdentityError::Storage(std::io::Error::other(format!(
+                            "failed to publish v3 identity announcement: {e}"
+                        )))
+                    })?;
+            }
+            Err(e) => tracing::warn!("announce_identity: v3 build failed: {e}"),
         }
 
         let now = Self::unix_timestamp_secs();
@@ -8040,6 +8103,7 @@ impl Agent {
                 revocation_set: std::sync::Arc::clone(&self.revocation_set),
                 last_revocation_generation: std::sync::atomic::AtomicU64::new(0),
                 heartbeat_tick: std::sync::atomic::AtomicU64::new(0),
+                legacy_announce: self.legacy_announce,
             };
             // Routed through spawn_tracked (issue #116) so a shutdown racing
             // bootstrap refuses to start it once the registry is closed; it is
@@ -8091,13 +8155,18 @@ impl Agent {
             self.identity.agent_keypair(),
         ));
         let caps_rx = self.dm_capabilities_tx.subscribe();
-        let service = dm_capability_service::CapabilityAdvertService::spawn_default(
+        // L3 retirement: the periodic caps advert only runs on the legacy
+        // escape hatch. On-demand mode still answers targeted/warm requests
+        // and publishes on capability upgrades.
+        let service = dm_capability_service::CapabilityAdvertService::spawn(
             std::sync::Arc::clone(runtime.pubsub()),
             signing,
             self.identity.agent_id(),
             self.identity.machine_id(),
             caps_rx,
             std::sync::Arc::clone(&self.capability_store),
+            std::time::Duration::from_secs(dm_capability::ADVERT_PUBLISH_INTERVAL_SECS),
+            self.legacy_announce,
         )
         .await
         .map_err(|e| {
@@ -10060,6 +10129,7 @@ impl Agent {
             revocation_set: std::sync::Arc::clone(&self.revocation_set),
             last_revocation_generation: std::sync::atomic::AtomicU64::new(0),
             heartbeat_tick: std::sync::atomic::AtomicU64::new(0),
+            legacy_announce: self.legacy_announce,
         };
         let handle = tokio::task::spawn(async move {
             let mut ticker =
@@ -11057,6 +11127,18 @@ impl AgentBuilder {
         self
     }
 
+    /// Re-enable the legacy V2 announce set (V2 identity + machine
+    /// announcements + periodic caps advert) alongside V3.
+    ///
+    /// Default is `false` since the L3 retirement flip — V3 carries the same
+    /// information in one slim, self-verifying message. This escape hatch
+    /// exists for debugging and for isolated networks stuck on pre-V3 nodes.
+    #[must_use]
+    pub fn with_legacy_announce(mut self, enabled: bool) -> Self {
+        self.legacy_announce = Some(enabled);
+        self
+    }
+
     /// Set the identity cache TTL.
     ///
     /// Cache entries with `last_seen` older than this threshold are filtered
@@ -11544,6 +11626,7 @@ impl AgentBuilder {
             heartbeat_interval_secs: self
                 .heartbeat_interval_secs
                 .unwrap_or(IDENTITY_HEARTBEAT_INTERVAL_SECS),
+            legacy_announce: self.legacy_announce.unwrap_or(false),
             identity_ttl_secs: self.identity_ttl_secs.unwrap_or(IDENTITY_TTL_SECS),
             heartbeat_handle: tokio::sync::Mutex::new(None),
             discovery_cache_reaper_handle: tokio::sync::Mutex::new(None),
@@ -17658,6 +17741,107 @@ mod tests {
         assert_eq!(entry.agent_id, agent.agent_id());
         assert_eq!(entry.machine_id, agent.machine_id());
         assert_eq!(entry.user_id, agent.user_id());
+    }
+
+    /// L3 retirement flip: by default (legacy_announce == false) an announce
+    /// publishes ONLY the V3 format — no V2 identity payload and no separate
+    /// machine announcement reach the wire. If this regresses, the fleet
+    /// silently returns to 3 broadcast messages per beat and the entire L3
+    /// bandwidth win evaporates.
+    #[tokio::test]
+    async fn retired_announce_publishes_v3_only() {
+        let agent = Agent::builder()
+            .with_network_config(network::NetworkConfig::default())
+            .build()
+            .await
+            .unwrap();
+        let runtime = agent.gossip_runtime.as_ref().expect("gossip runtime");
+        let mut identity_sub = runtime
+            .pubsub()
+            .subscribe(IDENTITY_ANNOUNCE_TOPIC.to_string())
+            .await;
+        let mut machine_sub = runtime
+            .pubsub()
+            .subscribe(MACHINE_ANNOUNCE_TOPIC.to_string())
+            .await;
+
+        agent.announce_identity(false, false).await.unwrap();
+
+        // Collect everything that arrives within the settle window.
+        let mut v3 = 0usize;
+        let mut v2_or_legacy = 0usize;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+        while tokio::time::Instant::now() < deadline {
+            tokio::select! {
+                Some(msg) = identity_sub.recv() => {
+                    if announce_v3::is_v3_payload(&msg.payload) {
+                        let ann = announce_v3::deserialize_v3(&msg.payload).expect("v3 decodes");
+                        ann.verify().expect("published v3 verifies");
+                        v3 += 1;
+                    } else {
+                        v2_or_legacy += 1;
+                    }
+                }
+                Some(_) = machine_sub.recv() => {
+                    panic!("retired announce must not publish a machine announcement");
+                }
+                _ = tokio::time::sleep_until(deadline) => break,
+            }
+        }
+        assert!(v3 >= 1, "retired announce must publish at least one V3");
+        assert_eq!(
+            v2_or_legacy, 0,
+            "retired announce must not publish V2/legacy identity payloads"
+        );
+    }
+
+    /// The escape hatch (`with_legacy_announce(true)`) restores the V2 set —
+    /// V2 identity AND machine announcements alongside V3 — for debugging and
+    /// isolated pre-V3 networks.
+    #[tokio::test]
+    async fn legacy_escape_hatch_publishes_v2_and_v3() {
+        let agent = Agent::builder()
+            .with_network_config(network::NetworkConfig::default())
+            .with_legacy_announce(true)
+            .build()
+            .await
+            .unwrap();
+        let runtime = agent.gossip_runtime.as_ref().expect("gossip runtime");
+        let mut identity_sub = runtime
+            .pubsub()
+            .subscribe(IDENTITY_ANNOUNCE_TOPIC.to_string())
+            .await;
+        let mut machine_sub = runtime
+            .pubsub()
+            .subscribe(MACHINE_ANNOUNCE_TOPIC.to_string())
+            .await;
+
+        agent.announce_identity(false, false).await.unwrap();
+
+        let mut v3 = 0usize;
+        let mut v2 = 0usize;
+        let mut machine = 0usize;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+        while tokio::time::Instant::now() < deadline {
+            tokio::select! {
+                Some(msg) = identity_sub.recv() => {
+                    if announce_v3::is_v3_payload(&msg.payload) {
+                        v3 += 1;
+                    } else if deserialize_identity_announcement(&msg.payload).is_ok() {
+                        v2 += 1;
+                    }
+                }
+                Some(msg) = machine_sub.recv() => {
+                    if deserialize_machine_announcement(&msg.payload).is_ok() {
+                        machine += 1;
+                    }
+                }
+                _ = tokio::time::sleep_until(deadline) => break,
+            }
+        }
+        assert!(v3 >= 1, "escape hatch still publishes V3");
+        assert!(v2 >= 1, "escape hatch publishes V2 identity");
+        assert!(machine >= 1, "escape hatch publishes machine announcement");
     }
 
     /// Enforcement point 2 (issue #130): a revoked agent MUST fail

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7343,9 +7343,27 @@ impl Agent {
                     let mut converted = v3.into_announcement();
                     if announce_blob::fetch_warranted(&cert_digest) {
                         match announce_blob_cache.get(&cert_digest).await {
-                            Some(blob) => {
+                            // SECURITY: the digest is attacker-choosable — any
+                            // agent can copy another agent's digest into its
+                            // own (validly signed) V3. The cached pair was
+                            // verified against the agent that FIRST triggered
+                            // the fetch, so re-check the certificate's own
+                            // agent binding against THIS announcement before
+                            // merging; a mismatch is treated as anonymous.
+                            Some(blob)
+                                if blob.agent_certificate.as_ref().is_some_and(|cert| {
+                                    cert.agent_id()
+                                        .is_ok_and(|id| id == converted.agent_id)
+                                }) =>
+                            {
                                 converted.user_id = blob.user_id;
                                 converted.agent_certificate = blob.agent_certificate.clone();
+                            }
+                            Some(_) => {
+                                tracing::warn!(
+                                    agent = %hex::encode(converted.agent_id.as_bytes()),
+                                    "v3 announce claims a cert digest whose certificate binds a different agent; ignoring pair"
+                                );
                             }
                             None => {
                                 announce_blob_cache

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -388,6 +388,7 @@ pub async fn serve_with_options(
         .with_contact_store_path(&contacts_path)
         .with_history(history_config)
         .with_heartbeat_interval(config.heartbeat_interval_secs)
+        .with_legacy_announce(config.legacy_announce)
         .with_identity_ttl(config.identity_ttl_secs);
 
     if let Some(secs) = config.presence_beacon_interval_secs {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -292,6 +292,13 @@ pub struct DaemonConfig {
     #[serde(default = "default_heartbeat_interval")]
     pub(super) heartbeat_interval_secs: u64,
 
+    /// Re-enable the legacy V2 announce set (V2 identity + machine
+    /// announcements + periodic caps advert) alongside V3. Default false
+    /// since the L3 retirement flip; escape hatch for debugging or isolated
+    /// pre-V3 networks.
+    #[serde(default)]
+    pub(super) legacy_announce: bool,
+
     /// How long before a discovered agent entry is considered stale (seconds).
     #[serde(default = "default_identity_ttl")]
     pub(super) identity_ttl_secs: u64,
@@ -611,6 +618,7 @@ impl Default for DaemonConfig {
             history: default_history_config(),
             gossip: x0x::gossip::GossipConfig::default(),
             heartbeat_interval_secs: default_heartbeat_interval(),
+            legacy_announce: false,
             identity_ttl_secs: default_identity_ttl(),
             user_key_path: None,
             rendezvous_enabled: default_rendezvous_enabled(),


### PR DESCRIPTION
## Retirement flip (David-approved)

With the fleet converged on V3-aware v0.39.11, this stops publishing the legacy per-beat trio — V2 identity announce (shard+broadcast), machine announcements, periodic caps advert — and makes V3 the announce format. Receivers for all legacy formats stay forever; `legacy_announce = true` (config) / `with_legacy_announce(true)` (builder) is the escape hatch.

- Publisher gating in heartbeat + `announce_identity` (which also gains the V3 publish — phase-1 gap); announcement structs still built for local cache upserts
- Caps advert service: on-demand mode — no startup burst/steady beat, still answers targeted/warm requests and wakes on capability upgrades
- Blob fetch wired end-to-end (OMP): responder task (targeted + warm carrier, 1s coalescing, live consent pair), real on-miss dual-route fetch with 5s deadline and verify-before-cache; receiver hit-path merges the verified pair pre-upsert
- **Security fix from review**: the digest in a V3 is attacker-choosable — the hit-path now re-checks the certificate's own agent binding before merging, so claiming a victim's digest cannot steal their user attribution (test pins the predicate)

Wire-level tests prove V3-only when retired and the V2 set on the escape hatch; 4 hermetic two-agent blob tests (fill, forged-responder reject, anonymous skip, round-trip). Full local gate: fmt + clippy -D warnings + nextest 2840/2840 (macOS #412 excluded).

Steady-state effect once released: our nodes' announce cost drops from 3 msgs/~46 KB to 1 msg/~7.5 KB per beat; remaining idle load is old wild nodes (they self-update) and dm bus (next target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR retires default legacy identity, machine, and periodic capability announcements in favor of V3, and adds certificate-blob retrieval over targeted and warm pubsub carriers.

- Adds verified certificate-blob request, response, caching, and receiver merge behavior.
- Makes legacy announcements configurable through the builder and daemon configuration.
- Converts capability advertising to on-demand operation when legacy announcements are disabled.
- Introduces three correctness issues in shared-response matching, responder lifecycle ownership, and capability-upgrade publication.

<h3>Confidence Score: 1/5</h3>

The PR is not safe to merge until blob responses are matched without aborting unrelated fetches, blob responders receive a single owned lifecycle, and capability upgrades publish in on-demand mode.

Shared-topic responses can prevent certificate retrieval, repeated service starts leak duplicate responders, and the default on-demand capability service silently skips upgrade-triggered advertisements.

**Files Needing Attention:** src/announce_blob.rs, src/dm_capability_service.rs, src/lib.rs

<details open><summary><h3>Security Review</h3></summary>

The shared blob-response loop accepts the first decodable response as the answer to every pending fetch. An authenticated peer or concurrent fetch can therefore force a digest mismatch and repeatedly prevent certificate-blob retrieval before the legitimate response arrives.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/announce_blob.rs | Adds the end-to-end blob protocol, but the shared response loop aborts on unrelated responses and responder tasks lack an owned shutdown lifecycle. |
| src/dm_capability_service.rs | Adds on-demand advertising, but capability upgrades do not satisfy the new publication gate. |
| src/lib.rs | Wires V3-only publishing, blob merging, and service startup, including repeated detached responder creation. |
| src/server/mod.rs | Passes the daemon legacy-announcement setting into AgentBuilder without an additional identified defect. |
| src/server/state.rs | Adds the backward-compatible legacy_announce configuration field with a false default. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib.rs`, line 3248-3253 ([link](https://github.com/saorsa-labs/x0x/blob/a1ed3f5834cc5e577e66283bd02f84acfcd4cb44/src/lib.rs#L3248-L3253)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Blob responders accumulate**

   When the capability service starts more than once, each call creates a permanent blob responder but discards its task handle, so previous responders remain subscribed and independently publish duplicate responses for every request while also escaping explicit shutdown.

   **Knowledge Base Used:** [Peer presence, bootstrap, and rendezvous](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/peer-presence-and-rendezvous.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/lib.rs
   Line: 3248-3253
   
   Comment:
   **Blob responders accumulate**
   
   When the capability service starts more than once, each call creates a permanent blob responder but discards its task handle, so previous responders remain subscribed and independently publish duplicate responses for every request while also escaping explicit shutdown.
   
   **Knowledge Base Used:** [Peer presence, bootstrap, and rendezvous](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/peer-presence-and-rendezvous.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

2. `src/dm_capability_service.rs`, line 1406-1415 ([link](https://github.com/saorsa-labs/x0x/blob/a1ed3f5834cc5e577e66283bd02f84acfcd4cb44/src/dm_capability_service.rs#L1406-L1415)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Capability upgrades stay unpublished**

   When the DM inbox upgrades capabilities in on-demand mode without a pending request, the watch wake only resets `burst_idx`; both publication gates remain false, so peers do not learn the new inbox and KEM capabilities and continue using fallback or report durable semantics unavailable until an explicit refresh succeeds.

   **Knowledge Base Used:** [Direct messaging delivery](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/direct-messaging.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/dm_capability_service.rs
   Line: 1406-1415
   
   Comment:
   **Capability upgrades stay unpublished**
   
   When the DM inbox upgrades capabilities in on-demand mode without a pending request, the watch wake only resets `burst_idx`; both publication gates remain false, so peers do not learn the new inbox and KEM capabilities and continue using fallback or report durable semantics unavailable until an explicit refresh succeeds.
   
   **Knowledge Base Used:** [Direct messaging delivery](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/direct-messaging.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/announce_blob.rs:468-483
**Unrelated responses abort fetches**

If another fetch response or an authenticated peer's decodable response arrives first on the shared blob topic, this loop returns the digest-verification error instead of continuing to wait for the requested digest, leaving the certificate uncached and user attribution unavailable until a later heartbeat retries. **How this was verified:** Every fetch receives responses from the shared topic, and the loop returns the first decoded response's verification result.

### Issue 2
src/lib.rs:3248-3253
**Blob responders accumulate**

When the capability service starts more than once, each call creates a permanent blob responder but discards its task handle, so previous responders remain subscribed and independently publish duplicate responses for every request while also escaping explicit shutdown.

### Issue 3
src/dm_capability_service.rs:1406-1415
**Capability upgrades stay unpublished**

When the DM inbox upgrades capabilities in on-demand mode without a pending request, the watch wake only resets `burst_idx`; both publication gates remain false, so peers do not learn the new inbox and KEM capabilities and continue using fallback or report durable semantics unavailable until an explicit refresh succeeds.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(l3): refuse cached cert pairs whose ..."](https://github.com/saorsa-labs/x0x/commit/a1ed3f5834cc5e577e66283bd02f84acfcd4cb44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57256345)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Peer presence, bootstrap, and rendezvous](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/peer-presence-and-rendezvous.md)
- Knowledge Base — [Identity lifecycle and key tooling](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/identity-lifecycle.md)
- Knowledge Base — [Direct messaging delivery](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/direct-messaging.md)
- Knowledge Base — [Gossip runtime and wire protocol](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/gossip-runtime.md)
</details>


<!-- /greptile_comment -->