### PR TITLE
chore(release): v0.40.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.39.11"
+version = "0.40.0"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.39.11
+version: 0.40.0
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Release v0.40.0 — L3 retirement flip (#419) + #376 + #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the project and skill metadata for the v0.40.0 release.
- Bumps the Rust package version in `Cargo.toml` from 0.39.11 to 0.40.0.
- Bumps the matching skill version in `SKILL.md` from 0.39.11 to 0.40.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because both required release-version sources are synchronized at 0.40.0.

The release workflows and metadata validator use Cargo.toml and SKILL.md as the authoritative version sources, and this change updates both consistently without altering runtime behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the package version to 0.40.0, consistent with the release tag and repository release policy. |
| SKILL.md | Updates the skill metadata to the same 0.40.0 version, preserving required synchronization with Cargo.toml. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.40.0"](https://github.com/saorsa-labs/x0x/commit/657c0e07f1318cc8eeb100fff935f55db91727e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57277230)</sub>

<!-- /greptile_comment -->