### PR TITLE
feat(gossip): storm-control — announce replay drop + per-author forward limit (sg 0.5.75)

### DIFF
--- a/src/gossip/pubsub.rs
+++ b/src/gossip/pubsub.rs
@@ -492,6 +492,7 @@ impl PubSubManager {
         };
         let plumtree = Arc::new(plumtree_inner);
         register_x0x_topic_priorities(plumtree.admission().registry());
+        crate::storm_control::register_announce_validators(plumtree.as_ref());
 
         Ok(Self {
             network,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,9 @@ pub mod announce_blob;
 /// V3 identity announcement (L3 slimming — merged + digest, self-verifying).
 pub mod announce_v3;
 
+/// Storm control: announce-topic forward suppression (replay + flood).
+pub mod storm_control;
+
 /// Bootstrap node discovery and connection.
 ///
 /// This module handles initial connection to bootstrap nodes with

--- a/src/storm_control.rs
+++ b/src/storm_control.rs
@@ -11,14 +11,14 @@
 //!
 //! - **Stale replay** — the payload's *signed* `announced_at` is older than
 //!   the freshness TTL (or unreasonably far in the future). Unforgeable
-//!   without the author's machine key. → [`Verdict::Drop`]: neither
+//!   without the author's machine key. → `Verdict::Drop`: neither
 //!   delivered nor forwarded.
 //! - **Author flood** — more than one announce per author inside the
-//!   per-author window. Valid but redundant. → [`Verdict::DeliverOnly`]:
+//!   per-author window. Valid but redundant. → `Verdict::DeliverOnly`:
 //!   local subscribers still see it (the app dedupes), but it is not
 //!   forwarded, so the flood dies one hop from its source.
 //! - **Anything else** — fresh, in-rate, or *undecodable*. →
-//!   [`Verdict::Forward`]. Fail-open on decode: a future announce format
+//!   `Verdict::Forward`. Fail-open on decode: a future announce format
 //!   must not be censored by old relays; garbage without a valid gossip
 //!   signature already dies in saorsa-gossip's verify stage.
 //!

--- a/src/storm_control.rs
+++ b/src/storm_control.rs
@@ -153,6 +153,70 @@ pub fn classify_announce(
     }
 }
 
+/// Register announce-topic validators on the PlumTree instance.
+///
+/// Called once at `PubSubManager` construction. Identity announces (legacy /
+/// `X0A2` / `X0A3`) and machine announces each get a classifier keyed on the
+/// SIGNED author id; both share the stale-TTL policy. Shard topics carry the
+/// same payload formats, but shard ids are per-entity and unbounded — the
+/// global broadcast topics are where the measured storm lives, so those are
+/// the enforcement points.
+pub fn register_announce_validators<T>(plumtree: &saorsa_gossip_pubsub::PlumtreePubSub<T>)
+where
+    T: saorsa_gossip_transport::GossipTransport + Send + Sync + 'static,
+{
+    use saorsa_gossip_pubsub::ValidationAction;
+    use saorsa_gossip_types::TopicId;
+
+    fn now_unix() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+    fn to_action(v: Verdict) -> ValidationAction {
+        match v {
+            Verdict::Forward => ValidationAction::ForwardAndDeliver,
+            Verdict::DeliverOnly => ValidationAction::DeliverOnly,
+            Verdict::Drop => ValidationAction::Drop,
+        }
+    }
+
+    let identity_rate = std::sync::Arc::new(std::sync::Mutex::new(AuthorRate::default()));
+    let identity_validator: saorsa_gossip_pubsub::TopicValidator = {
+        let rate = std::sync::Arc::clone(&identity_rate);
+        std::sync::Arc::new(move |_topic, payload| {
+            let facts = identity_announce_facts(payload);
+            // A poisoned lock means a panic elsewhere; fail open rather than
+            // let the validator become a network-wide censor.
+            let Ok(mut rate) = rate.lock() else {
+                return ValidationAction::ForwardAndDeliver;
+            };
+            to_action(classify_announce(facts, &mut rate, now_unix()))
+        })
+    };
+    plumtree.set_topic_validator(
+        TopicId::from_entity(crate::IDENTITY_ANNOUNCE_TOPIC.as_bytes()),
+        identity_validator,
+    );
+
+    let machine_rate = std::sync::Arc::new(std::sync::Mutex::new(AuthorRate::default()));
+    let machine_validator: saorsa_gossip_pubsub::TopicValidator = {
+        let rate = std::sync::Arc::clone(&machine_rate);
+        std::sync::Arc::new(move |_topic, payload| {
+            let facts = machine_announce_facts(payload);
+            let Ok(mut rate) = rate.lock() else {
+                return ValidationAction::ForwardAndDeliver;
+            };
+            to_action(classify_announce(facts, &mut rate, now_unix()))
+        })
+    };
+    plumtree.set_topic_validator(
+        TopicId::from_entity(crate::MACHINE_ANNOUNCE_TOPIC.as_bytes()),
+        machine_validator,
+    );
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]

--- a/src/storm_control.rs
+++ b/src/storm_control.rs
@@ -1,0 +1,304 @@
+//! Storm control — announce-topic forward suppression (2026-08-27).
+//!
+//! Live forensics (`.scratch/cadence-measurement.md`) showed 92% of announce
+//! traffic coming from a handful of old, never-updating daemons that replay
+//! hours of cached announcements with fresh gossip message-ids every ~2
+//! seconds, defeating PlumTree dedupe forever. Their traffic transits every
+//! relaying node, so the whole network pays for eight broken machines.
+//!
+//! This module classifies announce payloads BEFORE they are forwarded (via
+//! saorsa-gossip's per-topic validation hook, sg ≥ 0.5.75):
+//!
+//! - **Stale replay** — the payload's *signed* `announced_at` is older than
+//!   the freshness TTL (or unreasonably far in the future). Unforgeable
+//!   without the author's machine key. → [`Verdict::Drop`]: neither
+//!   delivered nor forwarded.
+//! - **Author flood** — more than one announce per author inside the
+//!   per-author window. Valid but redundant. → [`Verdict::DeliverOnly`]:
+//!   local subscribers still see it (the app dedupes), but it is not
+//!   forwarded, so the flood dies one hop from its source.
+//! - **Anything else** — fresh, in-rate, or *undecodable*. →
+//!   [`Verdict::Forward`]. Fail-open on decode: a future announce format
+//!   must not be censored by old relays; garbage without a valid gossip
+//!   signature already dies in saorsa-gossip's verify stage.
+//!
+//! The classifier is pure and deterministic (caller supplies `now`), so the
+//! whole policy is unit-testable without a network.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// What to do with an inbound announce payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Deliver locally and forward to eager peers (default behavior).
+    Forward,
+    /// Deliver locally, do NOT forward (valid but rate-limited).
+    DeliverOnly,
+    /// Neither deliver nor forward (stale replay).
+    Drop,
+}
+
+/// Maximum accepted announce age before a payload is classified as a stale
+/// replay. Matches the discovery-cache freshness horizon: an announcement
+/// this old is already rejected by every receiver's cache gate, so
+/// forwarding it can only waste bandwidth.
+pub const STALE_ANNOUNCE_TTL_SECS: u64 = 900;
+
+/// Maximum tolerated future skew, mirroring the identity-announcement
+/// clock-skew policy. Beyond this the timestamp is not credible and the
+/// payload is treated as a replay/forgery artifact.
+pub const MAX_FUTURE_SKEW_SECS: u64 = 300;
+
+/// Per-author minimum spacing between *forwarded* announces. The legitimate
+/// cadence is one announce per [`crate::IDENTITY_HEARTBEAT_INTERVAL_SECS`]
+/// (600 s); 60 s leaves a wide margin for join-time announces, consent
+/// changes, and multi-address refreshes while capping a flooding author at
+/// 1/60th of the storm rate.
+pub const PER_AUTHOR_FORWARD_WINDOW: Duration = Duration::from_secs(60);
+
+/// Bound on the per-author rate table. At one entry per distinct announcing
+/// author this is far above any realistic network size; the cap only guards
+/// against an adversary minting authors to grow the map.
+const MAX_TRACKED_AUTHORS: usize = 8192;
+
+/// The author identity and signed timestamp extracted from an announce
+/// payload, independent of wire format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnnounceFacts {
+    /// 32-byte author id (agent id for identity announces, machine id for
+    /// machine announces).
+    pub author: [u8; 32],
+    /// The signed `announced_at` (unix seconds).
+    pub announced_at: u64,
+}
+
+/// Extract [`AnnounceFacts`] from an identity-announce payload (legacy,
+/// `X0A2`, or `X0A3`). `None` when the payload does not decode — callers
+/// MUST fail open on `None`.
+pub fn identity_announce_facts(payload: &[u8]) -> Option<AnnounceFacts> {
+    if crate::announce_v3::is_v3_payload(payload) {
+        let v3 = crate::announce_v3::deserialize_v3(payload).ok()?;
+        return Some(AnnounceFacts {
+            author: v3.agent_id.0,
+            announced_at: v3.announced_at,
+        });
+    }
+    let v2 = crate::deserialize_identity_announcement(payload).ok()?;
+    Some(AnnounceFacts {
+        author: v2.agent_id.0,
+        announced_at: v2.announced_at,
+    })
+}
+
+/// Extract [`AnnounceFacts`] from a machine-announce payload.
+pub fn machine_announce_facts(payload: &[u8]) -> Option<AnnounceFacts> {
+    let ann = crate::deserialize_machine_announcement(payload).ok()?;
+    Some(AnnounceFacts {
+        author: ann.machine_id.0,
+        announced_at: ann.announced_at,
+    })
+}
+
+/// Per-author forward rate limiter. Time is injected (`now` as a monotonic
+/// tick in seconds) so the policy is deterministic under test.
+#[derive(Debug, Default)]
+pub struct AuthorRate {
+    last_forward: HashMap<[u8; 32], u64>,
+}
+
+impl AuthorRate {
+    /// True when a forward is allowed for this author at `now_secs`;
+    /// records the forward when allowed.
+    pub fn allow(&mut self, author: [u8; 32], now_secs: u64, window: Duration) -> bool {
+        if self.last_forward.len() >= MAX_TRACKED_AUTHORS {
+            // Evict entries older than the window rather than growing.
+            let cutoff = now_secs.saturating_sub(window.as_secs());
+            self.last_forward.retain(|_, t| *t >= cutoff);
+        }
+        match self.last_forward.get(&author) {
+            Some(last) if now_secs.saturating_sub(*last) < window.as_secs() => false,
+            _ => {
+                self.last_forward.insert(author, now_secs);
+                true
+            }
+        }
+    }
+}
+
+/// Classify one announce payload.
+///
+/// `facts` comes from [`identity_announce_facts`] /
+/// [`machine_announce_facts`]; pass `None` for an undecodable payload to
+/// fail open.
+pub fn classify_announce(
+    facts: Option<AnnounceFacts>,
+    rate: &mut AuthorRate,
+    now_unix: u64,
+) -> Verdict {
+    let Some(facts) = facts else {
+        // Unknown format: fail open. Future announce versions must traverse
+        // old relays; unsigned garbage already died in sg's verify stage.
+        return Verdict::Forward;
+    };
+    let stale = facts.announced_at + STALE_ANNOUNCE_TTL_SECS < now_unix;
+    let far_future = facts.announced_at > now_unix + MAX_FUTURE_SKEW_SECS;
+    if stale || far_future {
+        return Verdict::Drop;
+    }
+    if rate.allow(facts.author, now_unix, PER_AUTHOR_FORWARD_WINDOW) {
+        Verdict::Forward
+    } else {
+        Verdict::DeliverOnly
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    const NOW: u64 = 1_787_800_000;
+
+    fn facts(author: u8, announced_at: u64) -> Option<AnnounceFacts> {
+        Some(AnnounceFacts {
+            author: [author; 32],
+            announced_at,
+        })
+    }
+
+    /// The storm signature: a payload whose signed timestamp is hours old
+    /// must never be forwarded OR delivered — replays waste every hop they
+    /// touch and receivers' cache gates reject them anyway.
+    #[test]
+    fn stale_replays_are_dropped() {
+        let mut rate = AuthorRate::default();
+        let hours_old = NOW - 6 * 3600;
+        assert_eq!(
+            classify_announce(facts(1, hours_old), &mut rate, NOW),
+            Verdict::Drop
+        );
+        // Just past the TTL boundary also drops…
+        assert_eq!(
+            classify_announce(facts(2, NOW - STALE_ANNOUNCE_TTL_SECS - 1), &mut rate, NOW),
+            Verdict::Drop
+        );
+        // …and exactly at the boundary still forwards.
+        assert_eq!(
+            classify_announce(facts(3, NOW - STALE_ANNOUNCE_TTL_SECS), &mut rate, NOW),
+            Verdict::Forward
+        );
+    }
+
+    /// A credible-but-flooding author (fresh timestamps every ~2 s, the
+    /// other half of the observed storm) gets one forward per window; the
+    /// rest deliver locally only, so the flood dies one hop from its source
+    /// without hiding a genuinely fresh announce from the local node.
+    #[test]
+    fn author_floods_are_forward_limited_not_hidden() {
+        let mut rate = AuthorRate::default();
+        assert_eq!(
+            classify_announce(facts(7, NOW), &mut rate, NOW),
+            Verdict::Forward
+        );
+        for dt in [2, 4, 30, 59] {
+            assert_eq!(
+                classify_announce(facts(7, NOW + dt), &mut rate, NOW + dt),
+                Verdict::DeliverOnly,
+                "flood at +{dt}s must not be forwarded"
+            );
+        }
+        assert_eq!(
+            classify_announce(facts(7, NOW + 60), &mut rate, NOW + 60),
+            Verdict::Forward,
+            "window expiry restores forwarding"
+        );
+    }
+
+    /// Different authors never rate-limit each other: the limiter keys on
+    /// the SIGNED author id, not the gossip sender, so one flooding node
+    /// cannot starve announcements from healthy agents it relays.
+    #[test]
+    fn rate_limit_is_per_author() {
+        let mut rate = AuthorRate::default();
+        for a in 0..20u8 {
+            assert_eq!(
+                classify_announce(facts(a, NOW), &mut rate, NOW),
+                Verdict::Forward
+            );
+        }
+    }
+
+    /// Fail-open contract: undecodable payloads (future formats) forward.
+    /// If this regresses, shipping V4 announces would be censored by every
+    /// deployed relay running this code.
+    #[test]
+    fn unknown_formats_fail_open() {
+        let mut rate = AuthorRate::default();
+        assert_eq!(classify_announce(None, &mut rate, NOW), Verdict::Forward);
+    }
+
+    /// Far-future timestamps are as suspect as stale ones (mirrors the
+    /// identity clock-skew policy): a forged timestamp cannot buy immunity
+    /// from the stale check.
+    #[test]
+    fn far_future_is_dropped() {
+        let mut rate = AuthorRate::default();
+        assert_eq!(
+            classify_announce(facts(9, NOW + MAX_FUTURE_SKEW_SECS + 1), &mut rate, NOW),
+            Verdict::Drop
+        );
+        assert_eq!(
+            classify_announce(facts(10, NOW + MAX_FUTURE_SKEW_SECS), &mut rate, NOW),
+            Verdict::Forward
+        );
+    }
+
+    /// The author table stays bounded under an author-minting adversary.
+    #[test]
+    fn author_table_is_bounded() {
+        let mut rate = AuthorRate::default();
+        for i in 0..(super::MAX_TRACKED_AUTHORS + 100) {
+            let mut a = [0u8; 32];
+            a[..8].copy_from_slice(&(i as u64).to_le_bytes());
+            // Old entries: all at NOW - 120 (outside window) so eviction fires.
+            rate.allow(a, NOW - 120, PER_AUTHOR_FORWARD_WINDOW);
+        }
+        // Trigger eviction with a fresh insert.
+        rate.allow([0xFF; 32], NOW, PER_AUTHOR_FORWARD_WINDOW);
+        assert!(rate.last_forward.len() <= super::MAX_TRACKED_AUTHORS);
+    }
+
+    /// End-to-end facts extraction: a real V3 payload yields its signed
+    /// author + timestamp, and truncated bytes yield None (fail-open path).
+    #[test]
+    fn facts_extraction_from_real_v3() {
+        let agent = crate::identity::AgentKeypair::generate().unwrap();
+        let machine = crate::identity::MachineKeypair::generate().unwrap();
+        let v2 = crate::IdentityAnnouncement {
+            agent_id: agent.agent_id(),
+            machine_id: machine.machine_id(),
+            user_id: None,
+            agent_certificate: None,
+            machine_public_key: machine.public_key().as_bytes().to_vec(),
+            machine_signature: Vec::new(),
+            addresses: vec![],
+            announced_at: NOW,
+            nat_type: None,
+            can_receive_direct: None,
+            is_relay: None,
+            is_coordinator: None,
+            reachable_via: vec![],
+            relay_candidates: vec![],
+            agent_public_key: agent.public_key().as_bytes().to_vec(),
+        };
+        let v3 =
+            crate::announce_v3::IdentityAnnouncementV3::build_from_v2(&v2, machine.secret_key(), 0)
+                .unwrap();
+        let bytes = crate::announce_v3::serialize_v3(&v3).unwrap();
+        let f = identity_announce_facts(&bytes).expect("decodes");
+        assert_eq!(f.author, agent.agent_id().0);
+        assert_eq!(f.announced_at, NOW);
+        assert!(identity_announce_facts(&bytes[..10]).is_none());
+    }
+}


### PR DESCRIPTION
Kills the announce storm at the relay layer. Forensics (see the session report): 92% of announce traffic is ~11 old daemons replaying hours of cached announcements with fresh gossip msg-ids every ~2s — immune to dedupe, immune to everything we ship for our own nodes.

- **sg 0.5.75** (published): per-topic validation hook — validate AFTER sig-verify/replay-check, BEFORE delivery+forward; `Drop` keeps the msg-id deduped and marks the payload never-serveable (IWANT/anti-entropy refuse); `DeliverOnly` withholds forward+IHAVE.
- **x0x classifier** (`storm_control.rs`, pure + deterministic): signed `announced_at` older than 900s or >300s future → Drop; per-**author** (signed id, not gossip sender) forward limit 1/60s → DeliverOnly (flood dies one hop from source, local delivery preserved); undecodable → Forward (fail-open: future formats must not be censored).
- Registered on the identity + machine global announce topics at PubSubManager construction. Metering arrives free via sg's `validator_dropped`/`validator_deliver_only` snapshot pass-through.

7 classifier tests (boundaries, per-author isolation, fail-open contract, bounded author table, real-V3 extraction). Full gate: fmt + clippy -D warnings + rustdoc -D warnings + nextest 2858/2858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds topic validators that drop stale identity and machine announcements and suppress forwarding when an author exceeds a per-minute allowance.
- Registers validators for the global identity and machine announcement topics during PubSubManager construction.
- Adds announcement fact extraction, timestamp classification, and per-author forwarding state.
- Exposes the storm-control module and adds focused classifier tests.

<h3>Confidence Score: 1/5</h3>

This PR is not safe to merge until targeted author-suppression and unbounded limiter-state growth are fixed.

The validator makes forwarding decisions from an inner author field that has not yet been cryptographically verified, and its capacity path inserts new fresh authors even after the configured limit is reached.

**Files Needing Attention:** src/storm_control.rs

<details open><summary><h3>Security Review</h3></summary>

Two denial-of-service paths remain: forwarding state is keyed by an unauthenticated inner author field, permitting targeted suppression, and the supposedly bounded author table can grow beyond its cap under fresh distinct-author traffic.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/storm_control.rs | Adds the classifier and validator registration logic, but trusts unauthenticated inner author fields and fails to enforce its author-table capacity. |
| src/gossip/pubsub.rs | Registers the new validators during PubSubManager construction, exposing the storm-control behavior to all inbound global announcements. |
| src/lib.rs | Publicly exports the new storm_control module without otherwise changing runtime behavior. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant P as Gossip publisher
  participant G as Envelope verification
  participant V as Storm validator
  participant R as AuthorRate
  participant D as Discovery consumer
  P->>G: Signed envelope + announce payload
  G->>V: Authenticated sender, raw inner payload
  V->>V: Decode claimed author and timestamp
  V->>R: Check or record claimed author
  alt Fresh and allowed
    V->>D: Deliver and forward
  else Author recently recorded
    V->>D: Deliver locally only
  else Stale or far future
    V-->>P: Drop
  end
  D->>D: Verify inner announcement
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/storm_control.rs:79-92
**Unauthenticated author controls limiter**

When a connected hostile publisher sends a decodable announcement containing a victim's author ID and a fresh timestamp, these extractors use that unverified ID as the rate-limit key. The attacker's message consumes the victim's forwarding allowance, causing the victim's next genuine announcement to stop at direct neighbors. **How this was verified:** The extractors act on deserialized IDs before the downstream discovery consumer verifies the inner announcement.

### Issue 2
src/storm_control.rs:114-124
**Author table exceeds cap**

When more than 8,192 distinct authors announce within one 60-second window, `retain` preserves every fresh entry and the subsequent insertion grows the map past `MAX_TRACKED_AUTHORS`. Sustained identity minting therefore causes progressively increasing relay memory use despite the documented bound. **How this was verified:** The capacity branch has no eviction or insertion guard when all existing timestamps remain inside the window.

### Issue 3
src/storm_control.rs:144-145
**Timestamp arithmetic can overflow**

A decodable announcement whose `announced_at` is near `u64::MAX` overflows the stale-age addition in overflow-checked builds, panicking while the shared rate mutex is held and poisoning it. Saturating arithmetic makes classification deterministic for the full decoded timestamp range.

```suggestion
    let stale = facts
        .announced_at
        .saturating_add(STALE_ANNOUNCE_TTL_SECS)
        < now_unix;
    let far_future = facts.announced_at > now_unix.saturating_add(MAX_FUTURE_SKEW_SECS);
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(gossip): wire storm-control validat..."](https://github.com/saorsa-labs/x0x/commit/9f86e0ebdf4ee0cc44ca7347615d650d4b249cd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57410733)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Gossip runtime and wire protocol](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/gossip-runtime.md)
- Knowledge Base — [Peer presence, bootstrap, and rendezvous](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/peer-presence-and-rendezvous.md)
- Knowledge Base — [Identity lifecycle and key tooling](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/identity-lifecycle.md)
- Knowledge Base — [Raise data channel capacity to contain pubsub saturation](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/reverts/incident-mitigation_75-20260511-data-tx-saturation-c489c7c.md)
</details>


<!-- /greptile_comment -->