### PR TITLE
chore(release): v0.40.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.40.0"
+version = "0.40.1"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.40.0
+version: 0.40.1
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Release v0.40.1 — storm-control validators (#421, sg 0.5.75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the project’s release metadata for v0.40.1.
- Bumps the Rust package version in Cargo.toml from 0.40.0 to 0.40.1.
- Synchronizes the SKILL.md frontmatter version with the package version.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the release version is synchronized across the required metadata files.

The changes are limited to matching version bumps in Cargo.toml and SKILL.md, with no stale version-bearing release metadata identified.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the package version to 0.40.1; the release metadata remains consistent. |
| SKILL.md | Updates the skill metadata to the same 0.40.1 release version. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.40.1"](https://github.com/saorsa-labs/x0x/commit/3fb3242291925de6ea61014d31512d4ab7413839) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57415241)</sub>

<!-- /greptile_comment -->