### PR TITLE
chore(release): v0.40.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.40.1"
+version = "0.40.2"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.40.1
+version: 0.40.2
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Release v0.40.2 — storm-control envelope fix (#423).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the crate and skill metadata from v0.40.1 to v0.40.2 for the storm-control envelope fix release.
- Bumps the Rust package version in Cargo.toml.
- Keeps the SKILL.md frontmatter version synchronized with the package version.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because its two release-version declarations are synchronized and no blocking defect was identified.

The package and skill metadata consistently declare version 0.40.2, matching the repository’s established release process without leaving stale required metadata.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the package version to 0.40.2 in accordance with the repository’s release convention. |
| SKILL.md | Synchronizes the skill metadata version with Cargo.toml at 0.40.2. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.40.2"](https://github.com/saorsa-labs/x0x/commit/581c5c35bc28763c29339fabe7ccff87208c5686) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57471652)</sub>

<!-- /greptile_comment -->