### PR TITLE
feat(gossip): broadcast-topic storm guards — revocation.v1 + discovery.groups

### DIFF
--- a/src/storm_control.rs
+++ b/src/storm_control.rs
@@ -171,6 +171,62 @@ pub fn classify_announce(
     }
 }
 
+/// Window for the inner-payload dedupe on broadcast topics: an identical
+/// inner payload (envelope stripped) re-published inside this window is a
+/// replay — sg's own payload-replay cache cannot catch it because each
+/// re-publish carries a fresh envelope signature, making the wire bytes
+/// unique every time (the same envelope-blindness that hid the announce
+/// storm from the validators until #423).
+pub const INNER_REPLAY_WINDOW: Duration = Duration::from_secs(300);
+
+/// Per-author + inner-payload state for a generic broadcast-topic validator.
+#[derive(Debug, Default)]
+pub struct BroadcastGuard {
+    rate: AuthorRate,
+    seen_inner: HashMap<[u8; 32], u64>,
+}
+
+impl BroadcastGuard {
+    /// Classify a wire payload on a broadcast topic with no per-format
+    /// timestamp semantics (revocation sets, group cards):
+    ///
+    /// - identical INNER payload (envelope stripped) seen inside
+    ///   `INNER_REPLAY_WINDOW` → `Drop` (pure replay; receivers already
+    ///   have it);
+    /// - envelope author exceeding the per-author forward window →
+    ///   `DeliverOnly`;
+    /// - unwrappable payloads (no envelope) → fail open per the same
+    ///   contract as the announce validators.
+    pub fn classify(
+        &mut self,
+        author: Option<[u8; 32]>,
+        inner_hash: [u8; 32],
+        now_unix: u64,
+    ) -> Verdict {
+        // Bound + expire the inner-seen table.
+        if self.seen_inner.len() >= MAX_TRACKED_AUTHORS {
+            let cutoff = now_unix.saturating_sub(INNER_REPLAY_WINDOW.as_secs());
+            self.seen_inner.retain(|_, t| *t >= cutoff);
+        }
+        match self.seen_inner.get(&inner_hash) {
+            Some(t) if now_unix.saturating_sub(*t) < INNER_REPLAY_WINDOW.as_secs() => {
+                return Verdict::Drop;
+            }
+            _ => {
+                self.seen_inner.insert(inner_hash, now_unix);
+            }
+        }
+        let Some(author) = author else {
+            return Verdict::Forward; // fail open: no envelope, unknown sender
+        };
+        if self.rate.allow(author, now_unix, PER_AUTHOR_FORWARD_WINDOW) {
+            Verdict::Forward
+        } else {
+            Verdict::DeliverOnly
+        }
+    }
+}
+
 /// Register announce-topic validators on the PlumTree instance.
 ///
 /// Called once at `PubSubManager` construction. Identity announces (legacy /
@@ -233,6 +289,31 @@ where
         TopicId::from_entity(crate::MACHINE_ANNOUNCE_TOPIC.as_bytes()),
         machine_validator,
     );
+
+    // Broadcast topics with no per-format timestamp semantics get the
+    // generic guard: inner-payload replay dedupe + per-author rate limit.
+    // The measured storm migrated here the moment the announce topics were
+    // guarded (revocation.v1 hit 405 KB/s of identical stale sets).
+    for topic in [crate::REVOCATION_TOPIC, "x0x.discovery.groups"] {
+        let guard = std::sync::Arc::new(std::sync::Mutex::new(BroadcastGuard::default()));
+        let validator: saorsa_gossip_pubsub::TopicValidator = {
+            let guard = std::sync::Arc::clone(&guard);
+            std::sync::Arc::new(move |_topic, payload| {
+                let (author, inner_hash) = match crate::gossip::pubsub::decode_v2(payload) {
+                    Ok(msg) => (
+                        msg.sender.map(|a| a.0),
+                        *blake3::hash(msg.payload.as_ref()).as_bytes(),
+                    ),
+                    Err(_) => (None, *blake3::hash(payload).as_bytes()),
+                };
+                let Ok(mut guard) = guard.lock() else {
+                    return ValidationAction::ForwardAndDeliver;
+                };
+                to_action(guard.classify(author, inner_hash, now_unix()))
+            })
+        };
+        plumtree.set_topic_validator(TopicId::from_entity(topic.as_bytes()), validator);
+    }
 }
 
 #[cfg(test)]
@@ -332,6 +413,38 @@ mod tests {
         );
         assert_eq!(
             classify_announce(facts(10, NOW + MAX_FUTURE_SKEW_SECS), &mut rate, NOW),
+            Verdict::Forward
+        );
+    }
+
+    /// Broadcast-guard semantics: identical inner payloads inside the
+    /// replay window are DROPPED even from a compliant author (that is the
+    /// revocation-storm signature — same 2-record set re-published forever
+    /// under fresh envelope signatures), while distinct payloads from a
+    /// flooding author fall back to the per-author DeliverOnly limit, and
+    /// envelope-less payloads fail open on authorship.
+    #[test]
+    fn broadcast_guard_drops_inner_replays_and_limits_authors() {
+        let mut g = BroadcastGuard::default();
+        let author = Some([1u8; 32]);
+        let set_hash = [7u8; 32];
+        assert_eq!(g.classify(author, set_hash, NOW), Verdict::Forward);
+        // Same inner payload 2s later (fresh envelope in reality) — replay.
+        assert_eq!(g.classify(author, set_hash, NOW + 2), Verdict::Drop);
+        assert_eq!(g.classify(author, set_hash, NOW + 200), Verdict::Drop);
+        // Distinct payload, same author, inside the author window — limited.
+        assert_eq!(g.classify(author, [8u8; 32], NOW + 3), Verdict::DeliverOnly);
+        // Distinct payload from another author — forwards.
+        assert_eq!(
+            g.classify(Some([2u8; 32]), [9u8; 32], NOW + 4),
+            Verdict::Forward
+        );
+        // No envelope: dedupe still applies, authorship fails open.
+        assert_eq!(g.classify(None, [10u8; 32], NOW + 5), Verdict::Forward);
+        assert_eq!(g.classify(None, [10u8; 32], NOW + 6), Verdict::Drop);
+        // Window expiry readmits the original set (fallback anti-entropy).
+        assert_eq!(
+            g.classify(author, set_hash, NOW + INNER_REPLAY_WINDOW.as_secs() + 200),
             Verdict::Forward
         );
     }


### PR DESCRIPTION
v0.40.2 killed the announce storm (identity −85%, machine −87%, 15.5k drops in the first hour) — and the same daemons' traffic immediately became visible on the unguarded broadcast topics: revocation.v1 at 405 KB/s of identical stale 2-record sets under fresh envelope signatures (envelope-blindness defeats sg's payload-replay cache, same as #423).

Generic `BroadcastGuard` for topics without per-format timestamps: inner-payload (envelope-stripped) dedupe over 300s → Drop; per-envelope-author limit 1/60s → DeliverOnly; fail-open without an envelope. Window chosen so the 1h revocation fallback and 600s group-card republish are untouched.

Gate: fmt/clippy/rustdoc clean, 2859/2860 (one documented dirty-checkout flake, passes solo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds shared replay-deduplication and per-author forwarding guards for revocation and group-discovery broadcast topics.
- Hashes envelope-stripped payloads and drops duplicates within 300 seconds.
- Limits distinct payload forwarding per envelope author while retaining local delivery.
- Registers the guard for revocation and global group-discovery topics and adds unit coverage.

<h3>Confidence Score: 1/5</h3>

This PR should not merge until the validator uses authenticated authorship and strictly bounds its remotely populated replay state.

Parseable invalid envelopes can bypass per-author forwarding control, while a distinct-payload flood can make the replay map and its per-message cleanup cost grow throughout the active window.

**Files Needing Attention:** src/storm_control.rs

<details open><summary><h3>Security Review</h3></summary>

Two availability weaknesses remain in the new guard: invalid signed envelopes can rotate unverified sender identities to evade author shaping, and distinct payload floods can grow the replay table without a hard bound while forcing full-table scans.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/storm_control.rs | Adds broadcast-topic storm guards, but trusts unverified envelope senders and permits remotely driven replay-state growth beyond the intended bound. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Incoming broadcast payload] --> B{V2 decode succeeds?}
  B -->|Yes| C[Extract sender and inner payload hash]
  B -->|No| D[No author; hash raw payload]
  C --> E{Inner hash seen within 300s?}
  D --> E
  E -->|Yes| F[Drop]
  E -->|No| G[Insert inner hash]
  G --> H{Author available?}
  H -->|No| I[Forward and deliver]
  H -->|Yes| J{Author allowed in 60s window?}
  J -->|Yes| I
  J -->|No| K[Deliver locally only]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/storm_control.rs:302-306
**Unverified authors bypass shaping**

When a remote peer sends parseable V2 envelopes with invalid signatures while rotating embedded sender IDs and inner payloads, the validator keys its forwarding limit from `msg.sender` without checking `msg.verified`, allowing invalid traffic to keep propagating even though local delivery rejects it later.

**How this was verified:** `decode_v2` retains the embedded sender with `verified=false`, and this validator reads that sender before the later delivery-time signature check.

### Issue 2
src/storm_control.rs:207-215
**Replay table grows unbounded**

When more than 8,192 distinct inner payloads arrive during the 300-second window, `retain` removes no fresh entries and each subsequent insertion grows the map while repeatedly scanning it, allowing remote traffic to consume increasing memory and CPU in the pubsub validator.

**How this was verified:** Once the map reaches `MAX_TRACKED_AUTHORS`, the cleanup retains every fresh timestamp and the code inserts another hash without enforcing the bound.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(gossip): broadcast-topic storm guar..."](https://github.com/saorsa-labs/x0x/commit/3c183fbd3e3c1777c19782b9929edbd7190d2cb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57519225)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Gossip runtime and wire protocol](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/gossip-runtime.md)
- Knowledge Base — [Trust evaluation and revocation](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/trust-and-revocation.md)
- Knowledge Base — [Group lifecycle and membership](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/group-lifecycle.md)
</details>


<!-- /greptile_comment -->