### PR TITLE
chore(release): v0.40.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.40.2"
+version = "0.40.3"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.40.2
+version: 0.40.3
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Release v0.40.3 — storm-control envelope fix (#425).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the project’s release metadata from version 0.40.2 to 0.40.3.
- Bumps the Rust package version in Cargo.toml.
- Synchronizes the skill manifest version in SKILL.md.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because its two release-version declarations are synchronized and no blocking defect was identified.

The change follows the repository’s established release pattern, and tracked runtime and release consumers either derive the Cargo version or validate it against the synchronized skill metadata.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the package version to 0.40.3 with no dependency or runtime configuration changes. |
| SKILL.md | Keeps the skill metadata synchronized with the Cargo package version. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.40.3"](https://github.com/saorsa-labs/x0x/commit/bdb96246c9beb8b4920649bfc12a51dbd10ae46d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57525833)</sub>

<!-- /greptile_comment -->