### PR TITLE
chore(release): v0.40.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x0x"
-version = "0.40.2"
+version = "0.40.4"
 edition = "2021"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x0x
 description: "Secure computer-to-computer networking for AI agents — gossip broadcast, direct messaging, CRDTs, group encryption. Post-quantum encrypted, NAT-traversing. Everything you need to build any decentralized application."
-version: 0.40.2
+version: 0.40.4
 license: MIT OR Apache-2.0
 repository: https://github.com/saorsa-labs/x0x
 homepage: https://saorsalabs.com


### PR DESCRIPTION
Release v0.40.4 — ADR-0035 metering (#427).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the crate and skill metadata from version 0.40.2 to 0.40.4 for the ADR-0035 metering release.
- Synchronizes the package version in Cargo.toml.
- Synchronizes the published skill version in SKILL.md.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the release metadata is synchronized and no blocking or non-blocking defects were identified.

The two active release-version fields are updated consistently, no stale version references remain, and existing release validation checks their agreement with the release tag.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the root package version to 0.40.4; no lockfile or release-build inconsistency was identified. |
| SKILL.md | Updates the skill metadata to 0.40.4, matching the package version required by release validation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.40.4"](https://github.com/saorsa-labs/x0x/commit/4795b5da69d29492c53b89d6ca0b2e8b17db7f52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57622088)</sub>

<!-- /greptile_comment -->