### PR TITLE
feat(voice): ADR-0042 — loss-tolerant datagram audio lane with reliable fallback

### DIFF
--- a/examples/voice_call.rs
+++ b/examples/voice_call.rs
@@ -9,13 +9,15 @@
 //! and jitter counters printed at the end.
 //!
 //! Lane mode: **Reliable** (a single ordered ADR-0022 byte stream per
-//! lane). The saorsa-webrtc `AudioLaneMode::Datagram` path exists in
-//! `saorsa-webrtc-core 0.5.0` over raw ant-quic connections, but the x0x
-//! adapter seam (`X0xLinkTransport` over `PeerStream`) does not expose an
-//! unreliable lane yet — that is V1.2/V1.3 follow-up work, noted in
-//! `docs/design/` upstream. The datagram *wire format* and the jitter
-//! buffer run end-to-end here regardless, so the playout path is the real
-//! one.
+//! lane) — the default. The ADR-0042 (c) datagram lane is available via
+//! `X0xLinkTransport::with_audio_lane_mode(AudioLaneMode::Datagram)`:
+//! audio then rides unreliable QUIC datagrams on the peer connection
+//! once both ends exchange the capability advert, falling back to this
+//! reliable lane otherwise. This demo keeps the reliable lane; the
+//! datagram path (including injected loss/reorder) is proven in
+//! `tests/voice_datagram_e2e.rs`. The datagram *wire format*
+//! (`AudioDatagram`) and the jitter buffer run end-to-end here
+//! regardless, so the playout path is the real one.
 //!
 //! Run:
 //! ```text

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10113,6 +10113,45 @@ impl Agent {
         agent_id: &identity::AgentId,
         protocol: streams::StreamProtocol,
     ) -> error::NetworkResult<streams::PeerStream> {
+        let machine_id = self.gate_peer_outbound(agent_id).await?;
+
+        let network = self
+            .network
+            .as_ref()
+            .ok_or_else(|| error::NetworkError::NodeError("network not initialized".to_string()))?;
+        let peer = ant_quic::PeerId(machine_id.0);
+        let (mut send, recv) = network.open_bi(&peer).await?;
+        streams::write_protocol_prefix(&mut send, protocol).await?;
+        tracing::info!(
+            target: "x0x::streams",
+            agent = %hex::encode(agent_id.as_bytes()),
+            machine = %hex::encode(machine_id.as_bytes()),
+            protocol = ?protocol,
+            "outbound peer stream opened (identity gate cleared)"
+        );
+        Ok(streams::PeerStream::new(
+            vec![*agent_id],
+            machine_id,
+            protocol,
+            send,
+            recv,
+        ))
+    }
+
+    /// Outbound identity gate shared by every lane a peer connection can
+    /// carry — byte-streams ([`Self::open_peer_stream`]) and the
+    /// unreliable datagram lane ([`Self::open_peer_datagram_lane`]) — so
+    /// the two paths can never drift.
+    ///
+    /// Resolves `agent_id` → machine via the identity discovery cache
+    /// (a missing binding is [`error::NetworkError::PeerNotVerified`],
+    /// exactly like a raw `open_bi` caller without a verified binding),
+    /// then enforces [`streams::stream_gate`] in its fixed order:
+    /// not-revoked → not-expired → trust `Accept`.
+    async fn gate_peer_outbound(
+        &self,
+        agent_id: &identity::AgentId,
+    ) -> error::NetworkResult<identity::MachineId> {
         let (machine_id, cert_not_after) = {
             let cache = self.identity_discovery_cache.read().await;
             cache
@@ -10123,9 +10162,9 @@ impl Agent {
                 })?
         };
         // Runtime cert-expiry gate (issue #191): EP1 drops expired
-        // announcements at ingest but never re-checks a cached entry on the
-        // live path. Absent expiry (None) is fail-open — is_expired returns
-        // false, preserving compatibility with pre-#130 peers.
+        // announcements at ingest but never re-checks a cached entry on
+        // the live path. Absent expiry (None) is fail-open — is_expired
+        // returns false, preserving compatibility with pre-#130 peers.
         let expired = identity::is_expired(cert_not_after, Self::unix_timestamp_secs());
 
         let trust_decision = {
@@ -10150,28 +10189,181 @@ impl Agent {
             revoked_machine,
             expired,
         )?;
+        Ok(machine_id)
+    }
+
+    /// Inbound gate for connection-borne traffic from a
+    /// transport-authenticated machine — the accept-loop posture, shared
+    /// by inbound byte-streams and the datagram lane
+    /// ([`Self::open_peer_datagram_lane`]) so unsolicited datagrams can
+    /// never surface from a peer whose stream the accept loop would
+    /// reset.
+    ///
+    /// Resolves EVERY agent announced on `machine_id` (the QUIC session
+    /// proves the machine, not the specific opener) and requires each to
+    /// clear [`streams::stream_gate`] (fail-closed multi-agent, #192),
+    /// then the connect-ACL pair gate ([`streams::stream_acl_gate`],
+    /// #131). Each lock is taken in its own scope so no two identity
+    /// locks are held at once (`evict_revoked_subject` takes them in a
+    /// different order). Denials log with the accept loop's `outcome`
+    /// tags and surface the typed [`error::NetworkError`]; success
+    /// returns the ordered agent list for the stream/lane handle.
+    async fn gate_peer_machine_inbound(
+        discovery_cache: &std::sync::Arc<
+            tokio::sync::RwLock<std::collections::HashMap<identity::AgentId, DiscoveredAgent>>,
+        >,
+        contact_store: &std::sync::Arc<tokio::sync::RwLock<contacts::ContactStore>>,
+        revocation_set: &std::sync::Arc<tokio::sync::RwLock<revocation::RevocationSet>>,
+        connect_policy: &std::sync::Arc<std::sync::RwLock<std::sync::Arc<connect::ConnectPolicy>>>,
+        machine_id: &identity::MachineId,
+    ) -> error::NetworkResult<Vec<identity::AgentId>> {
+        // Identity gate — resolve ALL agents on this machine from the
+        // discovery cache, then check each (revoked → trust). A single
+        // non-Accept agent denies the traffic (fail-closed, #192).
+        let agents: Vec<(identity::AgentId, Option<u64>)> = {
+            let cache = discovery_cache.read().await;
+            let mut found: Vec<(identity::AgentId, Option<u64>)> = cache
+                .values()
+                .filter(|a| a.machine_id == *machine_id)
+                .map(|a| (a.agent_id, a.cert_not_after))
+                .collect();
+            // Deterministic order so logging / per-peer concurrency
+            // keying are stable across HashMap iteration orders.
+            found.sort_by_key(|(a, _)| a.0);
+            found
+        };
+        if agents.is_empty() {
+            tracing::info!(
+                target: "x0x::streams",
+                machine = %hex::encode(machine_id.as_bytes()),
+                outcome = "deny_not_verified",
+                "inbound traffic from machine with no known agent — denied"
+            );
+            return Err(error::NetworkError::PeerNotVerified {
+                agent_id: machine_id.0,
+            });
+        }
+        let now_secs = Self::unix_timestamp_secs();
+        for (agent_id, cert_not_after) in &agents {
+            // Runtime cert-expiry gate (issue #191): a cached entry whose
+            // cert has expired must be refused on the live path.
+            let expired = identity::is_expired(*cert_not_after, now_secs);
+            let trust_decision = {
+                let contacts = contact_store.read().await;
+                let evaluator = trust::TrustEvaluator::new(&contacts);
+                Some(evaluator.evaluate(&trust::TrustContext {
+                    agent_id,
+                    machine_id,
+                }))
+            };
+            let (revoked_agent, revoked_machine) = {
+                let revoked = revocation_set.read().await;
+                (
+                    revoked.is_agent_revoked(agent_id),
+                    revoked.is_machine_revoked(machine_id),
+                )
+            };
+            if let Err(e) = streams::stream_gate(
+                agent_id,
+                trust_decision,
+                revoked_agent,
+                revoked_machine,
+                expired,
+            ) {
+                tracing::info!(
+                    target: "x0x::streams",
+                    agent = %hex::encode(agent_id.as_bytes()),
+                    machine = %hex::encode(machine_id.as_bytes()),
+                    agent_count = agents.len(),
+                    outcome = "deny_gate",
+                    error = %e,
+                    "inbound traffic denied at identity gate (one agent on the machine failed)"
+                );
+                return Err(e);
+            }
+        }
+
+        // Gate cleared for every agent — drop the expiry metadata and
+        // keep the ordered agent list for the stream/lane handle.
+        let agents: Vec<identity::AgentId> = agents.into_iter().map(|(a, _)| a).collect();
+
+        // Connect-ACL gate (#131 × #132): with an Enabled policy every
+        // announced agent on this machine must be pair-listed in the ACL;
+        // an unlisted peer's traffic is denied with zero application
+        // bytes surfaced (fail-closed second layer, mirrors
+        // forward::decide_inbound's every-agent rule, #192). A Disabled
+        // policy adds no constraint.
+        let policy = {
+            let guard = connect_policy
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::sync::Arc::clone(&guard)
+        };
+        if let Err(e) = streams::stream_acl_gate(&policy, &agents, machine_id) {
+            tracing::info!(
+                target: "x0x::streams",
+                machine = %hex::encode(machine_id.as_bytes()),
+                agent_count = agents.len(),
+                outcome = "deny_acl",
+                error = %e,
+                "inbound traffic denied at connect-ACL gate (unlisted peer)"
+            );
+            return Err(e);
+        }
+        Ok(agents)
+    }
+
+    /// Open the unreliable datagram lane to a verified, trusted peer
+    /// (ADR-0042 decision (c)) — the carriage for loss-tolerant voice
+    /// audio.
+    ///
+    /// Returns the ant-quic [`P2pLinkConn`] seam for the peer's QUIC
+    /// connection (`send_datagram` / `read_datagram` on
+    /// [`ant_quic::link_transport::LinkConn`]). Datagrams ride the
+    /// connection, not a stream, so they get **no** voice shortcut around
+    /// the stream gates — the lane clears both directions' posture once,
+    /// at open (the same granularity as stream open/accept; per-frame
+    /// re-checks would differ from stream semantics):
+    ///
+    /// * outbound: the shared identity gate ([`Self::gate_peer_outbound`])
+    ///   — the caller will *send* datagrams on the connection;
+    /// * inbound: [`Self::gate_peer_machine_inbound`] — unsolicited
+    ///   datagrams *arrive* on the same connection and must never surface
+    ///   from a peer whose inbound stream the accept loop would reset.
+    ///
+    /// # Errors
+    ///
+    /// Gate failures surface the same typed [`error::NetworkError`]s as
+    /// [`Self::open_peer_stream`] / the inbound accept loop;
+    /// [`error::NetworkError::NotConnected`] when no QUIC connection to
+    /// the peer's machine exists.
+    pub async fn open_peer_datagram_lane(
+        &self,
+        agent_id: &identity::AgentId,
+    ) -> error::NetworkResult<ant_quic::P2pLinkConn> {
+        let machine_id = self.gate_peer_outbound(agent_id).await?;
+        Self::gate_peer_machine_inbound(
+            &self.identity_discovery_cache,
+            &self.contact_store,
+            &self.revocation_set,
+            &self.connect_policy,
+            &machine_id,
+        )
+        .await?;
 
         let network = self
             .network
             .as_ref()
             .ok_or_else(|| error::NetworkError::NodeError("network not initialized".to_string()))?;
         let peer = ant_quic::PeerId(machine_id.0);
-        let (mut send, recv) = network.open_bi(&peer).await?;
-        streams::write_protocol_prefix(&mut send, protocol).await?;
+        let conn = network.peer_link_conn(&peer).await?;
         tracing::info!(
             target: "x0x::streams",
             agent = %hex::encode(agent_id.as_bytes()),
             machine = %hex::encode(machine_id.as_bytes()),
-            protocol = ?protocol,
-            "outbound peer stream opened (identity gate cleared)"
+            "outbound datagram lane opened (identity + ACL gates cleared)"
         );
-        Ok(streams::PeerStream::new(
-            vec![*agent_id],
-            machine_id,
-            protocol,
-            send,
-            recv,
-        ))
+        Ok(conn)
     }
 
     /// Await the next inbound byte-stream that has cleared the identity gate
@@ -10286,108 +10478,27 @@ impl Agent {
                 };
                 let machine_id = identity::MachineId(ant_peer_id.0);
 
-                // Identity gate — resolve ALL agents on this machine from
-                // the discovery cache, then check each (revoked → trust).
-                // The QUIC transport authenticates the machine, not the
-                // specific agent, so every agent on the machine must clear
-                // the gate — a single revoked or untrusted agent denies the
-                // stream (fail-closed, #192). Each lock is taken in its own
-                // scope so no two identity locks are held at once
-                // (evict_revoked_subject takes them in a different order).
-                let agents: Vec<(identity::AgentId, Option<u64>)> = {
-                    let cache = discovery_cache.read().await;
-                    let mut found: Vec<(identity::AgentId, Option<u64>)> = cache
-                        .values()
-                        .filter(|a| a.machine_id == machine_id)
-                        .map(|a| (a.agent_id, a.cert_not_after))
-                        .collect();
-                    // Deterministic order so logging / per-peer concurrency
-                    // keying are stable across HashMap iteration orders.
-                    found.sort_by_key(|(a, _)| a.0);
-                    found
+                // Identity gate + connect-ACL gate — the shared inbound
+                // posture (also used by the datagram lane) resolves every
+                // agent announced on the transport-authenticated machine
+                // and denies unless ALL clear: revoked → expired → trust
+                // `Accept` per agent (#192 fail-closed), then the ACL
+                // pair gate when the policy is Enabled (#131). Denials
+                // are logged inside the gate; the stream halves are
+                // dropped (→ QUIC reset) with zero application bytes.
+                let agents = match Agent::gate_peer_machine_inbound(
+                    &discovery_cache,
+                    &contact_store,
+                    &revocation_set,
+                    &connect_policy,
+                    &machine_id,
+                )
+                .await
+                {
+                    Ok(agents) => agents,
+                    Err(_) => continue,
                 };
-                if agents.is_empty() {
-                    tracing::info!(
-                        target: "x0x::streams",
-                        machine = %hex::encode(machine_id.as_bytes()),
-                        outcome = "deny_not_verified",
-                        "inbound stream from machine with no known agent — denied"
-                    );
-                    continue;
-                }
-                let now_secs = Agent::unix_timestamp_secs();
-                let mut gate_denied: Option<(identity::AgentId, error::NetworkError)> = None;
-                for (agent_id, cert_not_after) in &agents {
-                    // Runtime cert-expiry gate (issue #191): a cached entry
-                    // whose cert has expired must be refused on the live path.
-                    let expired = identity::is_expired(*cert_not_after, now_secs);
-                    let trust_decision = {
-                        let contacts = contact_store.read().await;
-                        let evaluator = trust::TrustEvaluator::new(&contacts);
-                        Some(evaluator.evaluate(&trust::TrustContext {
-                            agent_id,
-                            machine_id: &machine_id,
-                        }))
-                    };
-                    let (revoked_agent, revoked_machine) = {
-                        let revoked = revocation_set.read().await;
-                        (
-                            revoked.is_agent_revoked(agent_id),
-                            revoked.is_machine_revoked(&machine_id),
-                        )
-                    };
-                    if let Err(e) = streams::stream_gate(
-                        agent_id,
-                        trust_decision,
-                        revoked_agent,
-                        revoked_machine,
-                        expired,
-                    ) {
-                        gate_denied = Some((*agent_id, e));
-                        break;
-                    }
-                }
-                if let Some((agent_id, e)) = gate_denied {
-                    tracing::info!(
-                        target: "x0x::streams",
-                        agent = %hex::encode(agent_id.as_bytes()),
-                        machine = %hex::encode(machine_id.as_bytes()),
-                        agent_count = agents.len(),
-                        outcome = "deny_gate",
-                        error = %e,
-                        "inbound stream denied at identity gate (one agent on the machine failed)"
-                    );
-                    continue;
-                }
 
-                // Gate cleared for every agent — drop the expiry metadata and
-                // keep the ordered agent list for the stream handle.
-                let agents: Vec<identity::AgentId> =
-                    agents.into_iter().map(|(a, _)| a).collect();
-
-                // Connect-ACL gate (#131 × #132): with an Enabled policy every
-                // announced agent on this machine must be pair-listed in the
-                // ACL; an unlisted peer's stream is reset here with zero
-                // application bytes exchanged (fail-closed second layer,
-                // mirrors forward::decide_inbound's every-agent rule, #192).
-                // A Disabled policy adds no constraint.
-                let policy = {
-                    let guard = connect_policy
-                        .read()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    std::sync::Arc::clone(&guard)
-                };
-                if let Err(e) = streams::stream_acl_gate(&policy, &agents, &machine_id) {
-                    tracing::info!(
-                        target: "x0x::streams",
-                        machine = %hex::encode(machine_id.as_bytes()),
-                        agent_count = agents.len(),
-                        outcome = "deny_acl",
-                        error = %e,
-                        "inbound stream denied at connect-ACL gate (unlisted peer)"
-                    );
-                    continue;
-                }
 
                 // DISPATCH (DoS hardening, issue #132): the protocol-prefix
                 // read + surfacing run in a per-stream task so a peer that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10317,7 +10317,7 @@ impl Agent {
     /// (ADR-0042 decision (c)) — the carriage for loss-tolerant voice
     /// audio.
     ///
-    /// Returns the ant-quic [`P2pLinkConn`] seam for the peer's QUIC
+    /// Returns the ant-quic `P2pLinkConn` seam for the peer's QUIC
     /// connection (`send_datagram` / `read_datagram` on
     /// [`ant_quic::link_transport::LinkConn`]). Datagrams ride the
     /// connection, not a stream, so they get **no** voice shortcut around
@@ -10325,9 +10325,10 @@ impl Agent {
     /// at open (the same granularity as stream open/accept; per-frame
     /// re-checks would differ from stream semantics):
     ///
-    /// * outbound: the shared identity gate ([`Self::gate_peer_outbound`])
-    ///   — the caller will *send* datagrams on the connection;
-    /// * inbound: [`Self::gate_peer_machine_inbound`] — unsolicited
+    /// * outbound: the shared identity gate (`gate_peer_outbound`, also
+    ///   used by `open_peer_stream`) — the caller will *send* datagrams
+    ///   on the connection;
+    /// * inbound: the accept-loop posture (`gate_peer_machine_inbound`) — unsolicited
     ///   datagrams *arrive* on the same connection and must never surface
     ///   from a peer whose inbound stream the accept loop would reset.
     ///

--- a/src/network.rs
+++ b/src/network.rs
@@ -3727,6 +3727,44 @@ impl NetworkNode {
             .map_err(|e| NetworkError::NodeError(format!("accept_bi: {e}")))
     }
 
+    // === Unreliable datagram lane (ADR-0042 c) ===
+
+    /// Get the ant-quic [`P2pLinkConn`] seam for a connected peer's QUIC
+    /// connection — the unreliable-datagram surface (`send_datagram` /
+    /// `read_datagram`) used by the voice audio lane.
+    ///
+    /// Thin transport wrapper over
+    /// `Node::inner_endpoint().get_quic_connection`, mirroring
+    /// [`Self::open_bi`]: the identity gate (outbound + inbound posture)
+    /// lives in [`crate::Agent::open_peer_datagram_lane`], the sole
+    /// caller — application code never reaches this without clearing the
+    /// gate.
+    ///
+    /// # Errors
+    ///
+    /// [`NetworkError::NodeError`] when the node is not initialized;
+    /// [`NetworkError::NotConnected`] when no QUIC connection to
+    /// `peer_id` exists.
+    pub(crate) async fn peer_link_conn(
+        &self,
+        peer_id: &AntPeerId,
+    ) -> NetworkResult<ant_quic::P2pLinkConn> {
+        let node = self
+            .node
+            .read()
+            .await
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| NetworkError::NodeError("node not initialized".to_string()))?;
+        let conn = node
+            .inner_endpoint()
+            .get_quic_connection(peer_id)
+            .map_err(|e| NetworkError::NodeError(format!("get_quic_connection: {e}")))?
+            .ok_or(NetworkError::NotConnected(peer_id.0))?;
+        let remote_addr = conn.remote_address();
+        Ok(ant_quic::P2pLinkConn::new(conn, *peer_id, remote_addr))
+    }
+
     // === Direct Messaging ===
 
     /// Send a direct message to a connected peer.

--- a/src/voice/link_transport.rs
+++ b/src/voice/link_transport.rs
@@ -103,6 +103,30 @@ const DATAGRAM_BYTE_RATE: u64 = 100 * 1024;
 /// absorbs a keyframe-scale burst before the sustained rate binds.
 const DATAGRAM_BYTE_BURST: u64 = 50 * 1024;
 
+/// Advert initial re-send cadence (Codex r2 finding 1): DM subscribers
+/// only receive future messages, so the peer may start after our first
+/// challenge and never see it. The initial is re-sent on this cadence
+/// until answered.
+const ADVERT_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Total initial-send attempts (20 s at [`ADVERT_RETRY_INTERVAL`]) before
+/// settling on the reliable lane for this session.
+const ADVERT_RETRY_ATTEMPTS: usize = 10;
+
+/// Per-send bound for advert DMs: the DM layer can park a send on its
+/// ack/backoff window for far longer than the retry cadence, and a
+/// stalled send must never stall the listener loop consuming inbound
+/// frames.
+const ADVERT_SEND_BOUND: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Per-write bound on the reliable lane: a stream whose connection died
+/// mid-churn does not ERROR — its flow control simply stops progressing
+/// and `write_all` awaits forever (observed as an 18-of-50 stall when
+/// the advert DM churn replaced the connection underneath the lane). A
+/// write exceeding this bound is treated as a dead lane: evicted and
+/// reopened once.
+const RELIABLE_WRITE_BOUND: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Outbound lane: the send half of an opened `WebRtcV1` stream, keyed by
 /// [`StreamType`]. The recv half is parked alongside so the peer's stream
 /// state stays open for the lane's lifetime.
@@ -125,6 +149,12 @@ struct DatagramLane {
     /// Listens on the DM fan-out for the peer's capability advert; exits
     /// once seen (or when the agent's DM channel closes).
     advert_listener: tokio::task::JoinHandle<()>,
+    /// Re-sends our session initial (challenge) every 2 s for up to 20 s
+    /// until answered — DM subscribers only receive FUTURE messages
+    /// (`direct.rs`), so a peer that starts later than our first send
+    /// would otherwise never see the challenge and negotiation would
+    /// time out into silent reliable fallback (Codex r2 finding 1).
+    advert_retry: tokio::task::JoinHandle<()>,
 }
 
 /// Challenge-response state binding the datagram lane to THIS transport
@@ -141,9 +171,6 @@ struct DatagramSession {
     /// Our per-start nonce (hex). The peer echoes it to prove liveness
     /// on this session.
     our_nonce: String,
-    /// The peer challenge we have already acked (dedup: one ack per
-    /// distinct challenge, no loops).
-    acked_challenge: Option<String>,
 }
 
 /// [`LinkTransport`] over x0x `WebRtcV1` peer streams.
@@ -437,7 +464,6 @@ impl X0xLinkTransport {
             .unwrap_or_else(|p| p.into_inner()) = Some(DatagramSession {
             machine,
             our_nonce: our_nonce.clone(),
-            acked_challenge: None,
         });
 
         // Inbound reader — the SOLE consumer of read_datagram on this
@@ -461,11 +487,18 @@ impl X0xLinkTransport {
         // inside a multi-agent machine is impossible at this layer (the
         // wire format carries no sender field) — parity with the
         // reliable stream path, which also has no per-stream sender
-        // discriminator. A per-datagram session tag is an upstream
-        // (saorsa-webrtc) wire change — recorded as the follow-up.
-        // Revocation mid-call does NOT tear the reader down: no cheap
-        // revocation hook exists, and accepted byte-streams behave
-        // identically (gates run at open/accept time only).
+        // discriminator. ACCEPTED v1 TRUST BOUNDARY (Codex r2): the
+        // single-acceptor `SessionConflict` rule (one call session per
+        // agent per connection) bounds the datagram injection surface
+        // to a co-located agent on the SAME machine under the SAME
+        // daemon custody — i.e. an actor already inside the daemon's
+        // process trust domain, identical to every other DM/stream
+        // control path. A per-datagram wire discriminator and a
+        // connection-level dispatcher are recorded follow-ups (upstream
+        // saorsa-webrtc wire v2 + the daemon demux hub), deliberately
+        // not built in v1. Revocation mid-call does NOT tear the reader
+        // down: no cheap revocation hook exists, and accepted byte-streams
+        // behave identically (gates run at open/accept time only).
         //
         // Replay stance (v1): in-call duplicates/replays are absorbed by
         // the mandatory jitter buffer's sequence dedupe (upstream
@@ -487,6 +520,7 @@ impl X0xLinkTransport {
         let reader = tokio::spawn(async move {
             let mut bucket = DATAGRAM_BYTE_BURST;
             let mut invalid = 0u64;
+            let mut over_rate = 0u64;
             let mut last_refill = std::time::Instant::now();
             while let Ok(bytes) = hl_conn.read_datagram().await {
                 {
@@ -501,11 +535,15 @@ impl X0xLinkTransport {
                     let len_u64 = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
                     if len_u64 > bucket {
                         rate_dropped.fetch_add(1, Ordering::Relaxed);
-                        tracing::warn!(
-                            target: "voice",
-                            len = bytes.len(),
-                            "datagram exceeded per-connection byte ceiling; dropped"
-                        );
+                        over_rate += 1;
+                        if over_rate == 1 || over_rate.is_multiple_of(100) {
+                            tracing::warn!(
+                                target: "voice",
+                                len = bytes.len(),
+                                total_over_rate = over_rate,
+                                "datagram exceeded per-connection byte ceiling; dropped (log throttled)"
+                            );
+                        }
                         continue;
                     }
                     bucket -= len_u64;
@@ -581,16 +619,12 @@ impl X0xLinkTransport {
                 }
                 // Copy the session facts out and release the guard — a
                 // std MutexGuard must never live across the await below.
-                let (session_machine, our_nonce, acked_challenge) = {
+                let (session_machine, our_nonce) = {
                     let state = session_state.lock().unwrap_or_else(|p| p.into_inner());
                     let Some(session) = state.as_ref() else {
                         continue; // no live session — lane torn down
                     };
-                    (
-                        session.machine,
-                        session.our_nonce.clone(),
-                        session.acked_challenge.clone(),
-                    )
+                    (session.machine, session.our_nonce.clone())
                 };
                 // Authenticated binding (P1-1): right machine, verified
                 // binding, trust Accept.
@@ -615,70 +649,89 @@ impl X0xLinkTransport {
                     .and_then(serde_json::Value::as_str)
                     .map(str::to_owned);
                 if response.as_deref() == Some(our_nonce.as_str()) {
-                    capable.store(true, Ordering::SeqCst);
-                    tracing::info!(
-                        target: "voice",
-                        "peer proved the datagram lane session (nonce echo); Audio sends switch to datagrams"
-                    );
-                    return;
+                    if !capable.swap(true, Ordering::SeqCst) {
+                        tracing::info!(
+                            target: "voice",
+                            "peer proved the datagram lane session (nonce echo); Audio sends switch to datagrams"
+                        );
+                    }
+                    // Keep listening: exiting here would DROP this
+                    // receiver from the DM registry, and the peer —
+                    // which may still be re-sending its initial on the
+                    // retry cadence — would never get its ack (the
+                    // sequential-startup deadlock). stop()/Drop owns
+                    // this task's lifetime. Repeat echoes are idempotent
+                    // (swap logs once).
+                    continue;
                 }
                 // A peer initial (challenge, no valid response): ack it
-                // once per distinct challenge so the peer can prove its
-                // session — but never flip our own lane on it.
+                // EVERY time. Acks are idempotent and never generate a
+                // reply (no loop), and a peer whose earlier ack raced its
+                // own subscription needs the re-send — deduping here
+                // would recreate the one-shot startup regression. Never
+                // flip our own lane on a peer initial.
                 if let Some(challenge) = value.get("challenge").and_then(serde_json::Value::as_str)
                 {
-                    if acked_challenge.as_deref() != Some(challenge) {
-                        let challenge = challenge.to_owned();
-                        let _ = send_advert_frame(
-                            &agent,
-                            &remote,
-                            serde_json::json!({
-                                "type": DATAGRAM_ADVERT_TYPE,
-                                "datagram": true,
-                                "response": challenge,
-                            }),
-                        )
-                        .await;
-                        if let Some(state) = session_state
-                            .lock()
-                            .unwrap_or_else(|p| p.into_inner())
-                            .as_mut()
-                        {
-                            state.acked_challenge = Some(challenge);
-                        }
-                    }
+                    let _ = send_advert_frame(
+                        &agent,
+                        &remote,
+                        serde_json::json!({
+                            "type": DATAGRAM_ADVERT_TYPE,
+                            "datagram": true,
+                            "response": challenge,
+                        }),
+                    )
+                    .await;
                 }
             }
         });
 
         // Advertise our capability — the session initial with our fresh
-        // challenge. A failed DM send leaves the lane up (the reader
-        // still drains) but the peer will never switch to datagrams
-        // toward us; audio stays reliable in that direction until the
-        // next start.
+        // challenge, re-sent every 2 s for up to 20 s until answered
+        // (the peer's subscriber only sees future messages; one-shot
+        // negotiation silently timed out under sequential startup).
+        let agent_for_retry = Arc::clone(&self.agent);
+        let remote_for_retry = self.remote;
+        let capable_for_retry = Arc::clone(&self.peer_datagram_capable);
         let initial = serde_json::json!({
             "type": DATAGRAM_ADVERT_TYPE,
             "datagram": true,
             "challenge": our_nonce,
         });
-        if let Err(e) = send_advert_frame(&self.agent, &self.remote, initial).await {
-            tracing::warn!(
-                target: "voice",
-                error = %e,
-                "datagram capability advert not delivered; audio stays reliable"
-            );
-        }
+        let advert_retry = tokio::spawn(async move {
+            for _ in 0..ADVERT_RETRY_ATTEMPTS {
+                if capable_for_retry.load(Ordering::SeqCst) {
+                    return; // answered — stop sending
+                }
+                // Bound each send: a stalled DM backoff must not stall
+                // the retry cadence (the attempt is abandoned, not
+                // awaited).
+                let _ = tokio::time::timeout(
+                    ADVERT_RETRY_INTERVAL,
+                    send_advert_frame(&agent_for_retry, &remote_for_retry, initial.clone()),
+                )
+                .await;
+                tokio::time::sleep(ADVERT_RETRY_INTERVAL).await;
+            }
+        });
 
         *lane_guard = Some(DatagramLane {
             conn,
             reader,
             advert_listener,
+            advert_retry,
         });
         Ok(())
     }
 
     /// Reliable path: one ordered `WebRtcV1` stream per
     /// `(direction, StreamType)` lane, `u32-BE length ‖ payload` frames.
+    ///
+    /// Connection churn (Codex r2 finding 2): a cached stream from a
+    /// replaced connection errors on write ("sending stopped by peer").
+    /// On any write failure the cached lane is EVICTED and reopened on
+    /// the current connection (one retry); a stream from a dead
+    /// connection must never wedge the reliable path.
     async fn send_reliable(
         &self,
         stream_type: StreamType,
@@ -692,35 +745,96 @@ impl X0xLinkTransport {
             })?;
 
         let mut lanes = self.lanes.lock().await;
-        if let std::collections::hash_map::Entry::Vacant(slot) = lanes.entry(stream_type.as_u8()) {
-            let mut stream = self
-                .agent
-                .open_peer_stream(&self.remote, StreamProtocol::WebRtcV1)
+        // First attempt on the cached lane (opening it if absent); on a
+        // write failure evict and re-open once on the current
+        // connection.
+        for attempt in 0..2 {
+            if let std::collections::hash_map::Entry::Vacant(slot) =
+                lanes.entry(stream_type.as_u8())
+            {
+                let mut stream = self
+                    .agent
+                    .open_peer_stream(&self.remote, StreamProtocol::WebRtcV1)
+                    .await
+                    .map_err(|e| {
+                        LinkTransportError::SendError(format!("open WebRtcV1 lane: {e}"))
+                    })?;
+                match tokio::time::timeout(
+                    RELIABLE_WRITE_BOUND,
+                    stream.send_mut().write_all(&[stream_type.as_u8()]),
+                )
                 .await
-                .map_err(|e| LinkTransportError::SendError(format!("open WebRtcV1 lane: {e}")))?;
-            stream
-                .send_mut()
-                .write_all(&[stream_type.as_u8()])
-                .await
-                .map_err(|e| lt_err("write StreamType byte", e))?;
-            let (send, recv) = stream.into_split();
-            slot.insert(OutboundLane { send, _recv: recv });
+                {
+                    Ok(Ok(())) => {}
+                    // A stream whose open/prefix write already failed is
+                    // useless — do not cache it.
+                    Ok(Err(e)) if attempt == 0 => {
+                        tracing::warn!(
+                            target: "voice",
+                            error = %e,
+                            "lane prefix write failed; reopening on the current connection"
+                        );
+                        continue; // evicted by not inserting; retry open
+                    }
+                    Ok(Err(e)) => return Err(lt_err("write StreamType byte", e)),
+                    Err(_) if attempt == 0 => {
+                        tracing::warn!(
+                            target: "voice",
+                            "lane prefix write exceeded bound; reopening on the current connection"
+                        );
+                        continue;
+                    }
+                    Err(_) => {
+                        return Err(LinkTransportError::SendError(
+                            "lane prefix write timed out — connection likely replaced".to_owned(),
+                        ));
+                    }
+                }
+                let (send, recv) = stream.into_split();
+                slot.insert(OutboundLane { send, _recv: recv });
+            }
+            let Some(lane) = lanes.get_mut(&stream_type.as_u8()) else {
+                return Err(LinkTransportError::SendError(
+                    "lane vanished during send".to_owned(),
+                ));
+            };
+            // Bounded write: a stream whose connection died mid-churn
+            // does not error — flow control stops progressing and
+            // write_all awaits forever. The bound converts that stall
+            // into an eviction + reopen.
+            let written = tokio::time::timeout(RELIABLE_WRITE_BOUND, async {
+                lane.send.write_all(&len.to_be_bytes()).await?;
+                lane.send.write_all(data).await
+            })
+            .await;
+            match written {
+                Ok(Ok(())) => return Ok(()),
+                Ok(Err(e)) if attempt == 0 => {
+                    tracing::warn!(
+                        target: "voice",
+                        error = %e,
+                        "cached reliable lane failed; evicting and reopening on the current connection"
+                    );
+                    lanes.remove(&stream_type.as_u8());
+                }
+                Ok(Err(e)) => return Err(lt_err("write frame", e)),
+                Err(_) if attempt == 0 => {
+                    tracing::warn!(
+                        target: "voice",
+                        "reliable lane write exceeded bound; evicting and reopening on the current connection"
+                    );
+                    lanes.remove(&stream_type.as_u8());
+                }
+                Err(_) => {
+                    return Err(LinkTransportError::SendError(
+                        "reliable lane write timed out — connection likely replaced".to_owned(),
+                    ));
+                }
+            }
         }
-        // Entry guaranteed by the insert above; avoid unwrap per house rules.
-        let Some(lane) = lanes.get_mut(&stream_type.as_u8()) else {
-            return Err(LinkTransportError::SendError(
-                "lane vanished during send".to_owned(),
-            ));
-        };
-        lane.send
-            .write_all(&len.to_be_bytes())
-            .await
-            .map_err(|e| lt_err("write frame length", e))?;
-        lane.send
-            .write_all(data)
-            .await
-            .map_err(|e| lt_err("write frame body", e))?;
-        Ok(())
+        Err(LinkTransportError::SendError(
+            "reliable lane reopen failed after eviction".to_owned(),
+        ))
     }
 
     /// Datagram path (ADR-0042 c): one unreliable QUIC datagram per
@@ -789,6 +903,7 @@ impl Drop for X0xLinkTransport {
             if let Some(lane) = guard.take() {
                 lane.reader.abort();
                 lane.advert_listener.abort();
+                lane.advert_retry.abort();
             }
         }
         *self
@@ -810,15 +925,26 @@ fn placeholder_addr() -> SocketAddr {
 async fn send_advert_frame(
     agent: &Arc<Agent>,
     remote: &AgentId,
-    frame: serde_json::Value,
+    mut frame: serde_json::Value,
 ) -> Result<(), String> {
+    // Unique per-send id (additive, serde-defaulted, ignored by
+    // receivers): the DM layer dedupes identical payloads, so retrying
+    // an unchanged frame is silently swallowed — the sequential-startup
+    // regression traced to exactly this.
+    frame["id"] = serde_json::Value::String(hex::encode(rand::random::<u32>().to_be_bytes()));
     let mut payload = VOICE_SIGNALING_DM_PREFIX.to_vec();
     payload.extend_from_slice(&serde_json::to_vec(&frame).map_err(|e| e.to_string())?);
-    agent
-        .send_direct(remote, payload)
-        .await
-        .map(|_| ())
-        .map_err(|e| e.to_string())
+    // Bound the send: the DM machinery can park a send on its
+    // ack/backoff window for a long time, and an unbounded await would
+    // stall the CALLER — for the listener that means inbound advert
+    // frames queue (and evict) behind a stuck ack, which is exactly the
+    // sequential-startup deadlock this bounds away. A timed-out attempt
+    // is abandoned; the peer's retry cadence re-covers it.
+    match tokio::time::timeout(ADVERT_SEND_BOUND, agent.send_direct(remote, payload)).await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(e)) => Err(e.to_string()),
+        Err(_) => Err("advert send exceeded bound; abandoned".to_owned()),
+    }
 }
 
 fn lt_err(context: &str, e: impl std::fmt::Display) -> LinkTransportError {

--- a/src/voice/link_transport.rs
+++ b/src/voice/link_transport.rs
@@ -1,4 +1,5 @@
-//! [`LinkTransport`] over ADR-0022 byte streams (saorsa-webrtc V1.2).
+//! [`LinkTransport`] over ADR-0022 byte streams (saorsa-webrtc V1.2), plus
+//! the ADR-0042 (c) unreliable datagram lane for audio.
 //!
 //! Wire shape per stream: the x0x protocol prefix
 //! ([`StreamProtocol::WebRtcV1`], `0x04`) is written/consumed by the
@@ -7,18 +8,34 @@
 //! `u32-BE length ‖ payload`. One x0x stream per `(direction, StreamType)`
 //! lane, opened lazily on first send.
 //!
+//! Datagram lane (ADR-0042 decision (c)): with
+//! [`AudioLaneMode::Datagram`] pinned, encoded audio frames also ride the
+//! peer connection as unreliable QUIC datagrams — one datagram per frame,
+//! payload unchanged (`AudioDatagram`-encoded, the same payload contract
+//! the reliable Audio lane carries, so the mandatory receive-side jitter
+//! buffer consumes both lanes identically). The switch is gated on a
+//! mutual capability advert exchanged over the voice signaling DM
+//! channel (additive; see [`DATAGRAM_ADVERT_TYPE`]); until — and
+//! unless — the peer advertises back, audio keeps the reliable stream
+//! (old peers, peers pinned `Reliable`, or a lane that failed its gate).
+//!
 //! Addressing: x0x reaches peers by [`AgentId`], not socket address — the
 //! target agent is fixed at construction and [`LinkTransport::connect`]'s
 //! `SocketAddr` argument is recorded for display only. Every open and
 //! accept passes the identity gate, trust evaluation, revocation checks,
-//! and the connect-ACL pair gate exactly like `ForwardV1/V2` streams.
+//! and the connect-ACL pair gate exactly like `ForwardV1/V2` streams —
+//! the datagram lane opens through [`Agent::open_peer_datagram_lane`],
+//! which enforces the same gates in both directions. There is no voice
+//! bypass.
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
+use saorsa_webrtc_core::datagram_lane::{AudioDatagram, AudioLaneMode, MAX_DATAGRAM_PAYLOAD};
 use saorsa_webrtc_core::link_transport::{
     LinkTransport, LinkTransportError, PeerConnection, StreamType,
 };
@@ -27,6 +44,8 @@ use tokio::sync::{mpsc, Mutex};
 use crate::identity::AgentId;
 use crate::streams::{PeerStream, StreamProtocol};
 use crate::Agent;
+
+use super::VOICE_SIGNALING_DM_PREFIX;
 
 /// Bound on the inbound frame queue. Media consumers drain continuously;
 /// a full queue drops the oldest pressure onto QUIC flow control (the
@@ -38,12 +57,41 @@ const INBOUND_QUEUE_DEPTH: usize = 1024;
 /// lane is dropped.
 const MAX_FRAME_BYTES: u32 = 1024 * 1024;
 
+/// JSON `type` tag of the additive datagram-capability advert that rides
+/// the existing voice signaling DM channel (`x0x-voice-sig-v1\n` —
+/// already classified Ephemeral on every deployed peer).
+///
+/// Additivity contract: older [`super::X0xSignaling`] readers fail
+/// `SignalingMessage` decoding on the unknown tag and drop the frame —
+/// they never advertise back, so a `Datagram`-pinned sender falls back to
+/// the reliable lane with zero interop break. The `x0x_` namespace keeps
+/// the tag disjoint from upstream's snake_case `SignalingMessage` tags.
+/// The decode side reads fields from a JSON value with missing-field
+/// defaults (serde-defaulted), so richer future adverts still parse here.
+const DATAGRAM_ADVERT_TYPE: &str = "x0x_datagram_cap";
+
 /// Outbound lane: the send half of an opened `WebRtcV1` stream, keyed by
 /// [`StreamType`]. The recv half is parked alongside so the peer's stream
 /// state stays open for the lane's lifetime.
 struct OutboundLane {
     send: ant_quic::HighLevelSendStream,
     _recv: ant_quic::HighLevelRecvStream,
+}
+
+/// Live unreliable datagram lane (ADR-0042 c). Present only when the
+/// local mode is [`AudioLaneMode::Datagram`] and the gated lane opened
+/// successfully in [`X0xLinkTransport::start`].
+struct DatagramLane {
+    /// Send seam for the peer connection (`send_datagram` on the inner
+    /// high-level connection; opened through
+    /// [`Agent::open_peer_datagram_lane`], never raw).
+    conn: ant_quic::P2pLinkConn,
+    /// Sole consumer of `read_datagram` on the connection: forwards
+    /// `AudioDatagram`-encoded frames into the shared inbound queue.
+    reader: tokio::task::JoinHandle<()>,
+    /// Listens on the DM fan-out for the peer's capability advert; exits
+    /// once seen (or when the agent's DM channel closes).
+    advert_listener: tokio::task::JoinHandle<()>,
 }
 
 /// [`LinkTransport`] over x0x `WebRtcV1` peer streams.
@@ -58,6 +106,18 @@ pub struct X0xLinkTransport {
     accepted_peers_tx: mpsc::Sender<PeerConnection>,
     accepted_peers: Mutex<mpsc::Receiver<PeerConnection>>,
     acceptor_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Configured audio lane mode. Default [`AudioLaneMode::Reliable`]
+    /// preserves the V1.2 wire behavior; see [`Self::with_audio_lane_mode`].
+    audio_lane: AudioLaneMode,
+    /// Peer advertised datagram-lane support (set by the advert listener).
+    peer_datagram_capable: Arc<AtomicBool>,
+    /// The live datagram lane, when enabled and opened.
+    datagram: Mutex<Option<DatagramLane>>,
+    /// Audio frames sent as datagrams (observability; proves which lane
+    /// carried audio — the e2e gates assert on it).
+    datagram_frames_sent: Arc<AtomicU64>,
+    /// Datagrams decoded and queued inbound (see `datagram_frames_sent`).
+    datagram_frames_received: Arc<AtomicU64>,
 }
 
 impl X0xLinkTransport {
@@ -77,7 +137,52 @@ impl X0xLinkTransport {
             accepted_peers_tx: accepted_tx,
             accepted_peers: Mutex::new(accepted_rx),
             acceptor_task: Mutex::new(None),
+            audio_lane: AudioLaneMode::default(),
+            peer_datagram_capable: Arc::new(AtomicBool::new(false)),
+            datagram: Mutex::new(None),
+            datagram_frames_sent: Arc::new(AtomicU64::new(0)),
+            datagram_frames_received: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Pin which lane carries encoded audio (ADR-0042 c).
+    ///
+    /// Default [`AudioLaneMode::Reliable`] preserves the V1.2 wire
+    /// behavior byte-for-byte. [`AudioLaneMode::Datagram`] advertises
+    /// datagram capability to the peer (additive signaling frame) and
+    /// routes `StreamType::Audio` over unreliable QUIC datagrams **once
+    /// the peer advertises back**, falling back to the reliable stream
+    /// lane otherwise — old peers, peers pinned `Reliable`, or a lane
+    /// whose gate/open failed. Other lane types always keep their
+    /// reliable streams.
+    #[must_use]
+    pub fn with_audio_lane_mode(mut self, mode: AudioLaneMode) -> Self {
+        self.audio_lane = mode;
+        self
+    }
+
+    /// The configured audio lane mode.
+    #[must_use]
+    pub fn audio_lane_mode(&self) -> AudioLaneMode {
+        self.audio_lane
+    }
+
+    /// Whether the peer has advertised datagram-lane support.
+    #[must_use]
+    pub fn peer_datagram_capable(&self) -> bool {
+        self.peer_datagram_capable.load(Ordering::Relaxed)
+    }
+
+    /// Audio frames sent as unreliable datagrams (observability).
+    #[must_use]
+    pub fn datagram_frames_sent(&self) -> u64 {
+        self.datagram_frames_sent.load(Ordering::Relaxed)
+    }
+
+    /// Datagrams decoded and queued inbound (observability).
+    #[must_use]
+    pub fn datagram_frames_received(&self) -> u64 {
+        self.datagram_frames_received.load(Ordering::Relaxed)
     }
 
     /// The fixed remote agent this transport talks to.
@@ -145,84 +250,134 @@ impl X0xLinkTransport {
             }
         }
     }
-}
 
-fn placeholder_addr() -> SocketAddr {
-    // x0x addresses peers by identity; the socket address in
-    // `PeerConnection` is informational only for this transport.
-    SocketAddr::from(([127, 0, 0, 1], 0))
-}
-
-fn lt_err(context: &str, e: impl std::fmt::Display) -> LinkTransportError {
-    LinkTransportError::IoError(format!("{context}: {e}"))
-}
-
-#[async_trait]
-impl LinkTransport for X0xLinkTransport {
-    async fn start(&mut self) -> Result<(), LinkTransportError> {
-        if self.running.swap(true, Ordering::SeqCst) {
-            return Ok(());
-        }
-        let mut acceptor = self
+    /// Bring up the unreliable datagram lane (ADR-0042 c): open the
+    /// gated connection seam, start the inbound datagram reader, then
+    /// advertise capability to the peer over the signaling DM channel.
+    ///
+    /// Ordering guarantee: the reader is consuming before our advert can
+    /// reach the peer, and the peer only sends datagrams after seeing our
+    /// advert — so no audio datagram can arrive before a reader exists.
+    /// Any failure here is non-fatal by design: audio keeps the reliable
+    /// lane (the ADR-0042 fallback) and the caller logs.
+    async fn setup_datagram_lane(&self) -> Result<(), LinkTransportError> {
+        let conn = self
             .agent
-            .register_stream_acceptor(StreamProtocol::WebRtcV1)
-            .map_err(|e| lt_err("register WebRtcV1 acceptor", e))?;
+            .open_peer_datagram_lane(&self.remote)
+            .await
+            .map_err(|e| LinkTransportError::IoError(format!("datagram lane gate/open: {e}")))?;
+        // The peer's transport parameters must actually enable datagram
+        // frames; otherwise every send would fail (send-side gate).
+        if conn.inner().max_datagram_size().is_none() {
+            return Err(LinkTransportError::IoError(
+                "peer did not enable QUIC datagrams".to_owned(),
+            ));
+        }
+
+        let mut lane_guard = self.datagram.lock().await;
+        if lane_guard.is_some() {
+            return Ok(()); // already up (start is idempotent)
+        }
+
+        // Inbound reader — the SOLE consumer of read_datagram on this
+        // connection. Each datagram must decode as one AudioDatagram
+        // frame (the lane's payload contract — identical to the reliable
+        // Audio lane's, so the mandatory jitter buffer consumes both);
+        // anything else is foreign traffic and is dropped, never
+        // surfaced. The task ends when the connection closes, exactly
+        // like a peer-closed stream lane.
         let inbound_tx = self.inbound_tx.clone();
-        let accepted_tx = self.accepted_peers_tx.clone();
-        let task = tokio::spawn(async move {
-            while let Some(stream) = acceptor.next().await {
-                tokio::spawn(Self::drive_inbound_stream(
-                    stream,
-                    inbound_tx.clone(),
-                    accepted_tx.clone(),
-                ));
+        let peer_conn = self.peer_connection();
+        let frames_received = Arc::clone(&self.datagram_frames_received);
+        let hl_conn = conn.inner().clone();
+        let reader = tokio::spawn(async move {
+            loop {
+                match hl_conn.read_datagram().await {
+                    Ok(bytes) => {
+                        if AudioDatagram::decode(bytes.clone()).is_err() {
+                            tracing::warn!(
+                                target: "voice",
+                                len = bytes.len(),
+                                "non-AudioDatagram datagram dropped on voice lane"
+                            );
+                            continue;
+                        }
+                        frames_received.fetch_add(1, Ordering::Relaxed);
+                        if inbound_tx
+                            .send((peer_conn.clone(), StreamType::Audio, bytes.to_vec()))
+                            .await
+                            .is_err()
+                        {
+                            return; // transport dropped
+                        }
+                    }
+                    Err(_) => return, // connection closed — lane ends
+                }
             }
         });
-        *self.acceptor_task.lock().await = Some(task);
+
+        // Advert listener — watches the DM fan-out for the peer's
+        // capability advert. Only the fixed remote's frames count.
+        let mut direct = self.agent.subscribe_direct();
+        let remote = self.remote;
+        let capable = Arc::clone(&self.peer_datagram_capable);
+        let advert_listener = tokio::spawn(async move {
+            while let Some(msg) = direct.recv().await {
+                if msg.sender != remote {
+                    continue;
+                }
+                let Some(body) = msg.payload.strip_prefix(VOICE_SIGNALING_DM_PREFIX) else {
+                    continue;
+                };
+                // Missing-field defaults: an advert without `"datagram":
+                // true` (or without the field at all) is not a capability.
+                if let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) {
+                    if value.get("type").and_then(serde_json::Value::as_str)
+                        == Some(DATAGRAM_ADVERT_TYPE)
+                        && value.get("datagram").and_then(serde_json::Value::as_bool) == Some(true)
+                    {
+                        capable.store(true, Ordering::Relaxed);
+                        tracing::info!(
+                            target: "voice",
+                            "peer advertised the datagram audio lane; Audio sends switch to datagrams"
+                        );
+                        return;
+                    }
+                }
+            }
+        });
+
+        // Advertise our capability — additive frame on the signaling
+        // channel. A failed DM send leaves the lane up (the reader still
+        // drains) but the peer will never switch to datagrams toward us;
+        // audio stays reliable in that direction until the next start.
+        let mut payload = VOICE_SIGNALING_DM_PREFIX.to_vec();
+        payload.extend_from_slice(
+            &serde_json::to_vec(&serde_json::json!({
+                "type": DATAGRAM_ADVERT_TYPE,
+                "datagram": true,
+            }))
+            .map_err(|e| LinkTransportError::IoError(format!("encode advert: {e}")))?,
+        );
+        if let Err(e) = self.agent.send_direct(&self.remote, payload).await {
+            tracing::warn!(
+                target: "voice",
+                error = %e,
+                "datagram capability advert not delivered; audio stays reliable"
+            );
+        }
+
+        *lane_guard = Some(DatagramLane {
+            conn,
+            reader,
+            advert_listener,
+        });
         Ok(())
     }
-
-    async fn stop(&mut self) -> Result<(), LinkTransportError> {
-        self.running.store(false, Ordering::SeqCst);
-        if let Some(task) = self.acceptor_task.lock().await.take() {
-            task.abort();
-        }
-        self.lanes.lock().await.clear();
-        Ok(())
-    }
-
-    async fn is_running(&self) -> bool {
-        self.running.load(Ordering::SeqCst)
-    }
-
-    async fn local_addr(&self) -> Result<SocketAddr, LinkTransportError> {
-        let network = self
-            .agent
-            .network()
-            .ok_or(LinkTransportError::NotConnected)?;
-        network
-            .bound_addr()
-            .await
-            .ok_or(LinkTransportError::NotConnected)
-    }
-
-    async fn connect(&mut self, addr: SocketAddr) -> Result<PeerConnection, LinkTransportError> {
-        if let Ok(mut hint) = self.remote_addr_hint.lock() {
-            *hint = addr;
-        }
-        // Streams open lazily per lane in `send`; connection-level
-        // reachability, identity, trust, and ACL are enforced there by
-        // `Agent::open_peer_stream`.
-        Ok(self.peer_connection())
-    }
-
-    async fn accept(&mut self) -> Result<Option<PeerConnection>, LinkTransportError> {
-        Ok(self.accepted_peers.lock().await.recv().await)
-    }
-
-    async fn send(
+    /// Reliable path: one ordered `WebRtcV1` stream per
+    /// `(direction, StreamType)` lane, `u32-BE length ‖ payload` frames.
+    async fn send_reliable(
         &self,
-        _peer: &PeerConnection,
         stream_type: StreamType,
         data: &[u8],
     ) -> Result<(), LinkTransportError> {
@@ -263,6 +418,145 @@ impl LinkTransport for X0xLinkTransport {
             .await
             .map_err(|e| lt_err("write frame body", e))?;
         Ok(())
+    }
+
+    /// Datagram path (ADR-0042 c): one unreliable QUIC datagram per
+    /// encoded audio frame — payload unchanged from the reliable lane's
+    /// contract (`AudioDatagram`-encoded), so the receive-side jitter
+    /// buffer consumes both lanes identically. Loss costs a frame, never
+    /// head-of-line blocking.
+    async fn send_audio_datagram(&self, data: &[u8]) -> Result<(), LinkTransportError> {
+        if data.len() > MAX_DATAGRAM_PAYLOAD {
+            return Err(LinkTransportError::SendError(format!(
+                "audio datagram length {} exceeds {MAX_DATAGRAM_PAYLOAD}",
+                data.len()
+            )));
+        }
+        let lane = self.datagram.lock().await;
+        let Some(lane) = lane.as_ref() else {
+            // Peer advertised but the local lane never opened (gate/open
+            // failed at start): reliable fallback rather than a hard
+            // error — the caller's audio must still flow.
+            drop(lane);
+            return self.send_reliable(StreamType::Audio, data).await;
+        };
+        lane.conn
+            .inner()
+            .send_datagram(Bytes::copy_from_slice(data))
+            .map_err(|e| LinkTransportError::SendError(format!("audio datagram: {e}")))?;
+        self.datagram_frames_sent.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+fn placeholder_addr() -> SocketAddr {
+    // x0x addresses peers by identity; the socket address in
+    // `PeerConnection` is informational only for this transport.
+    SocketAddr::from(([127, 0, 0, 1], 0))
+}
+
+fn lt_err(context: &str, e: impl std::fmt::Display) -> LinkTransportError {
+    LinkTransportError::IoError(format!("{context}: {e}"))
+}
+
+#[async_trait]
+impl LinkTransport for X0xLinkTransport {
+    async fn start(&mut self) -> Result<(), LinkTransportError> {
+        if self.running.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
+        let mut acceptor = self
+            .agent
+            .register_stream_acceptor(StreamProtocol::WebRtcV1)
+            .map_err(|e| lt_err("register WebRtcV1 acceptor", e))?;
+        let inbound_tx = self.inbound_tx.clone();
+        let accepted_tx = self.accepted_peers_tx.clone();
+        let task = tokio::spawn(async move {
+            while let Some(stream) = acceptor.next().await {
+                tokio::spawn(Self::drive_inbound_stream(
+                    stream,
+                    inbound_tx.clone(),
+                    accepted_tx.clone(),
+                ));
+            }
+        });
+        *self.acceptor_task.lock().await = Some(task);
+
+        // ADR-0042 (c): bring up the unreliable datagram lane when the
+        // local mode asks for it. Failure is non-fatal — audio keeps the
+        // reliable stream (the fallback) — but it is loud: a Datagram
+        // pin that silently degrades is a latency bug.
+        if self.audio_lane == AudioLaneMode::Datagram {
+            if let Err(e) = self.setup_datagram_lane().await {
+                tracing::warn!(
+                    target: "voice",
+                    error = %e,
+                    "datagram audio lane unavailable; audio stays on the reliable stream"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), LinkTransportError> {
+        self.running.store(false, Ordering::SeqCst);
+        if let Some(task) = self.acceptor_task.lock().await.take() {
+            task.abort();
+        }
+        if let Some(lane) = self.datagram.lock().await.take() {
+            lane.reader.abort();
+            lane.advert_listener.abort();
+        }
+        self.peer_datagram_capable.store(false, Ordering::SeqCst);
+        self.lanes.lock().await.clear();
+        Ok(())
+    }
+
+    async fn is_running(&self) -> bool {
+        self.running.load(Ordering::SeqCst)
+    }
+
+    async fn local_addr(&self) -> Result<SocketAddr, LinkTransportError> {
+        let network = self
+            .agent
+            .network()
+            .ok_or(LinkTransportError::NotConnected)?;
+        network
+            .bound_addr()
+            .await
+            .ok_or(LinkTransportError::NotConnected)
+    }
+
+    async fn connect(&mut self, addr: SocketAddr) -> Result<PeerConnection, LinkTransportError> {
+        if let Ok(mut hint) = self.remote_addr_hint.lock() {
+            *hint = addr;
+        }
+        // Streams open lazily per lane in `send`; connection-level
+        // reachability, identity, trust, and ACL are enforced there by
+        // `Agent::open_peer_stream`.
+        Ok(self.peer_connection())
+    }
+
+    async fn accept(&mut self) -> Result<Option<PeerConnection>, LinkTransportError> {
+        Ok(self.accepted_peers.lock().await.recv().await)
+    }
+
+    async fn send(
+        &self,
+        _peer: &PeerConnection,
+        stream_type: StreamType,
+        data: &[u8],
+    ) -> Result<(), LinkTransportError> {
+        // ADR-0042 (c): encoded audio rides unreliable datagrams once
+        // BOTH ends advertised the lane; everything else (and audio
+        // before/without the advert exchange) keeps the reliable stream.
+        if stream_type == StreamType::Audio
+            && self.audio_lane == AudioLaneMode::Datagram
+            && self.peer_datagram_capable()
+        {
+            return self.send_audio_datagram(data).await;
+        }
+        self.send_reliable(stream_type, data).await
     }
 
     async fn receive(&self) -> Result<(PeerConnection, StreamType, Vec<u8>), LinkTransportError> {
@@ -307,5 +601,59 @@ mod tests {
         ] {
             assert!(StreamProtocol::from_u8(ty.as_u8()).is_none());
         }
+    }
+
+    /// The advert body as `X0xLinkTransport` writes it on the wire.
+    fn advert_body(datagram: bool) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "type": DATAGRAM_ADVERT_TYPE,
+            "datagram": datagram,
+        }))
+        .expect("advert JSON is static and always encodes")
+    }
+
+    /// The advert-decode predicate from `setup_datagram_lane`'s listener,
+    /// as a pure function over a DM body (missing fields default — the
+    /// additive/serde-defaulted contract).
+    fn advertises_datagram(body: &[u8]) -> bool {
+        serde_json::from_slice::<serde_json::Value>(body).is_ok_and(|value| {
+            value.get("type").and_then(serde_json::Value::as_str) == Some(DATAGRAM_ADVERT_TYPE)
+                && value.get("datagram").and_then(serde_json::Value::as_bool) == Some(true)
+        })
+    }
+
+    #[test]
+    fn datagram_advert_round_trips_and_defaults_to_not_capable() {
+        // Full advert: capable.
+        assert!(advertises_datagram(&advert_body(true)));
+        // Explicit refusal.
+        assert!(!advertises_datagram(&advert_body(false)));
+        // Additivity: an advert missing the `datagram` field entirely (a
+        // future/older sender) must decode as NOT capable — missing
+        // fields default, never panic, never over-advertise.
+        assert!(!advertises_datagram(br#"{"type":"x0x_datagram_cap"}"#));
+        // Unknown tags are not adverts.
+        assert!(!advertises_datagram(br#"{"type":"capability_exchange"}"#));
+    }
+
+    #[test]
+    fn datagram_advert_is_not_a_signaling_message() {
+        // Old-peer interop: a pre-extension X0xSignaling fails
+        // SignalingMessage decoding on the advert and DROPS it — the
+        // advert must never decode as a real (e.g. legacy SDP) message
+        // that could corrupt call state.
+        let body = advert_body(true);
+        assert!(
+            serde_json::from_slice::<saorsa_webrtc_core::signaling::SignalingMessage>(&body)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn audio_stream_type_byte_is_pinned() {
+        // ADR-0042 (a): the audio lane byte is 0x20 (0x21 is Video) —
+        // pinned so the datagram routing can never capture another lane.
+        assert_eq!(StreamType::Audio.as_u8(), 0x20);
+        assert_eq!(StreamType::try_from_u8(0x20), Some(StreamType::Audio));
     }
 }

--- a/src/voice/link_transport.rs
+++ b/src/voice/link_transport.rs
@@ -70,6 +70,39 @@ const MAX_FRAME_BYTES: u32 = 1024 * 1024;
 /// defaults (serde-defaulted), so richer future adverts still parse here.
 const DATAGRAM_ADVERT_TYPE: &str = "x0x_datagram_cap";
 
+/// Typed lane-setup errors for [`X0xLinkTransport`]. The trait's
+/// [`LinkTransportError`] is upstream's stringly enum; the single-acceptor
+/// conflict is an x0x condition callers must be able to `match` on.
+#[derive(Debug, thiserror::Error)]
+pub enum VoiceLaneError {
+    /// Another live WebRtcV1 session already holds this agent's single
+    /// stream acceptor (the single-acceptor rule in
+    /// [`Agent::register_stream_acceptor`]). A second concurrent call on
+    /// the same agent cannot start until the first session's `stop()`
+    /// releases the acceptor. A shared daemon-level acceptor that demuxes
+    /// inbound lanes to per-call sessions is the recorded follow-up (see
+    /// the WP3 report addendum) — until it lands, concurrent second
+    /// calls fail fast and typed instead of silently stealing or sharing
+    /// the acceptor.
+    #[error("WebRtcV1 stream acceptor already held by a concurrent call session on this agent")]
+    SessionConflict,
+    /// Other setup failure (acceptor registration or transport error).
+    #[error("lane setup failed: {0}")]
+    Setup(String),
+}
+
+/// Per-connection inbound datagram byte ceiling — sustained bytes/sec
+/// (ADR-0042 addendum: rate-limit per peer). Real audio is ~200 B ×
+/// 50 fps = 10 KB/s; the ceiling allows an order of magnitude headroom
+/// (codec bursts, higher sample rates) while making a datagram flood
+/// cost the sender, not the lane: excess is dropped and counted, never
+/// queued. Send-side traffic is self-limited by the local capture rate.
+const DATAGRAM_BYTE_RATE: u64 = 100 * 1024;
+
+/// Burst allowance for the byte ceiling (token-bucket capacity): ~50 KB
+/// absorbs a keyframe-scale burst before the sustained rate binds.
+const DATAGRAM_BYTE_BURST: u64 = 50 * 1024;
+
 /// Outbound lane: the send half of an opened `WebRtcV1` stream, keyed by
 /// [`StreamType`]. The recv half is parked alongside so the peer's stream
 /// state stays open for the lane's lifetime.
@@ -94,6 +127,25 @@ struct DatagramLane {
     advert_listener: tokio::task::JoinHandle<()>,
 }
 
+/// Challenge-response state binding the datagram lane to THIS transport
+/// instance (Codex review P1-1: adverts must be authenticated AND
+/// session-bound so spoofed, stale, or cross-call frames cannot flip
+/// the lane). `our_nonce` is freshly random per `start()`; a peer may
+/// only flip the lane by echoing it — which a replayed or foreign
+/// advert cannot do.
+#[derive(Debug)]
+struct DatagramSession {
+    /// Machine the gate resolved for `remote` (QUIC-authenticated);
+    /// inbound adverts must come from exactly this machine.
+    machine: crate::identity::MachineId,
+    /// Our per-start nonce (hex). The peer echoes it to prove liveness
+    /// on this session.
+    our_nonce: String,
+    /// The peer challenge we have already acked (dedup: one ack per
+    /// distinct challenge, no loops).
+    acked_challenge: Option<String>,
+}
+
 /// [`LinkTransport`] over x0x `WebRtcV1` peer streams.
 pub struct X0xLinkTransport {
     agent: Arc<Agent>,
@@ -113,11 +165,16 @@ pub struct X0xLinkTransport {
     peer_datagram_capable: Arc<AtomicBool>,
     /// The live datagram lane, when enabled and opened.
     datagram: Mutex<Option<DatagramLane>>,
+    /// Challenge-response state for the lane negotiation (P1-1).
+    datagram_session: Arc<std::sync::Mutex<Option<DatagramSession>>>,
     /// Audio frames sent as datagrams (observability; proves which lane
     /// carried audio — the e2e gates assert on it).
     datagram_frames_sent: Arc<AtomicU64>,
     /// Datagrams decoded and queued inbound (see `datagram_frames_sent`).
     datagram_frames_received: Arc<AtomicU64>,
+    /// Datagrams dropped by the per-connection byte ceiling (flood
+    /// defense; see [`DATAGRAM_BYTE_RATE`]).
+    datagram_rate_limited: Arc<AtomicU64>,
 }
 
 impl X0xLinkTransport {
@@ -140,8 +197,10 @@ impl X0xLinkTransport {
             audio_lane: AudioLaneMode::default(),
             peer_datagram_capable: Arc::new(AtomicBool::new(false)),
             datagram: Mutex::new(None),
+            datagram_session: Arc::new(std::sync::Mutex::new(None)),
             datagram_frames_sent: Arc::new(AtomicU64::new(0)),
             datagram_frames_received: Arc::new(AtomicU64::new(0)),
+            datagram_rate_limited: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -183,6 +242,81 @@ impl X0xLinkTransport {
     #[must_use]
     pub fn datagram_frames_received(&self) -> u64 {
         self.datagram_frames_received.load(Ordering::Relaxed)
+    }
+
+    /// Datagrams dropped by the per-connection byte ceiling (see
+    /// [`DATAGRAM_BYTE_RATE`]) — observability for the flood defense.
+    #[must_use]
+    pub fn datagram_rate_limited_dropped(&self) -> u64 {
+        self.datagram_rate_limited.load(Ordering::Relaxed)
+    }
+
+    /// Typed lane setup (what [`LinkTransport::start`] does, with the
+    /// x0x-typed error preserved for callers that must match on it).
+    ///
+    /// Registers the agent's single `WebRtcV1` stream acceptor, starts
+    /// the inbound stream pump, and — in [`AudioLaneMode::Datagram`] —
+    /// brings up the gated datagram lane (non-fatal on failure: audio
+    /// keeps the reliable stream). A second concurrent call on the same
+    /// agent fails with [`VoiceLaneError::SessionConflict`] (the
+    /// single-acceptor rule in [`Agent::register_stream_acceptor`]);
+    /// `stop()` releases the acceptor so a later session can start.
+    ///
+    /// # Errors
+    ///
+    /// [`VoiceLaneError::SessionConflict`] when another live session
+    /// holds the acceptor; [`VoiceLaneError::Setup`] for other
+    /// registration/transport failures.
+    pub async fn start_lane(&mut self) -> Result<(), VoiceLaneError> {
+        if self.running.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
+        let setup = self.start_lane_inner().await;
+        if setup.is_err() {
+            // Registration failed — leave the transport restartable
+            // (without this, a failed start would wedge `running`).
+            self.running.store(false, Ordering::SeqCst);
+        }
+        setup
+    }
+
+    async fn start_lane_inner(&mut self) -> Result<(), VoiceLaneError> {
+        let mut acceptor = self
+            .agent
+            .register_stream_acceptor(StreamProtocol::WebRtcV1)
+            .map_err(|e| match e {
+                crate::error::NetworkError::StreamAcceptorConflict { .. } => {
+                    VoiceLaneError::SessionConflict
+                }
+                other => VoiceLaneError::Setup(other.to_string()),
+            })?;
+        let inbound_tx = self.inbound_tx.clone();
+        let accepted_tx = self.accepted_peers_tx.clone();
+        let task = tokio::spawn(async move {
+            while let Some(stream) = acceptor.next().await {
+                tokio::spawn(Self::drive_inbound_stream(
+                    stream,
+                    inbound_tx.clone(),
+                    accepted_tx.clone(),
+                ));
+            }
+        });
+        *self.acceptor_task.lock().await = Some(task);
+
+        // ADR-0042 (c): bring up the unreliable datagram lane when the
+        // local mode asks for it. Failure is non-fatal — audio keeps the
+        // reliable stream (the fallback) — but it is loud: a Datagram
+        // pin that silently degrades is a latency bug.
+        if self.audio_lane == AudioLaneMode::Datagram {
+            if let Err(e) = self.setup_datagram_lane().await {
+                tracing::warn!(
+                    target: "voice",
+                    error = %e,
+                    "datagram audio lane unavailable; audio stays on the reliable stream"
+                );
+            }
+        }
+        Ok(())
     }
 
     /// The fixed remote agent this transport talks to.
@@ -256,10 +390,11 @@ impl X0xLinkTransport {
     /// advertise capability to the peer over the signaling DM channel.
     ///
     /// Ordering guarantee: the reader is consuming before our advert can
-    /// reach the peer, and the peer only sends datagrams after seeing our
-    /// advert — so no audio datagram can arrive before a reader exists.
-    /// Any failure here is non-fatal by design: audio keeps the reliable
-    /// lane (the ADR-0042 fallback) and the caller logs.
+    /// reach the peer, and the peer only sends datagrams after proving
+    /// the session (nonce echo) — so no audio datagram can arrive
+    /// before a reader exists. Any failure here is non-fatal by design:
+    /// audio keeps the reliable lane (the ADR-0042 fallback) and the
+    /// caller logs.
     async fn setup_datagram_lane(&self) -> Result<(), LinkTransportError> {
         let conn = self
             .agent
@@ -279,48 +414,152 @@ impl X0xLinkTransport {
             return Ok(()); // already up (start is idempotent)
         }
 
+        // Resolve the gate-cleared machine for the advert binding check
+        // (the same cache the gate consulted; a changed binding here can
+        // only fail-safe — adverts stop matching and audio stays
+        // reliable).
+        let machine = {
+            let cache = self.agent.identity_discovery_cache.read().await;
+            cache
+                .get(&self.remote)
+                .map(|entry| entry.machine_id)
+                .ok_or_else(|| {
+                    LinkTransportError::IoError(
+                        "remote binding vanished after lane gate — datagram lane not started"
+                            .to_owned(),
+                    )
+                })?
+        };
+        let our_nonce = hex::encode(rand::random::<[u8; 16]>());
+        *self
+            .datagram_session
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) = Some(DatagramSession {
+            machine,
+            our_nonce: our_nonce.clone(),
+            acked_challenge: None,
+        });
+
         // Inbound reader — the SOLE consumer of read_datagram on this
         // connection. Each datagram must decode as one AudioDatagram
         // frame (the lane's payload contract — identical to the reliable
         // Audio lane's, so the mandatory jitter buffer consumes both);
         // anything else is foreign traffic and is dropped, never
         // surfaced. The task ends when the connection closes, exactly
-        // like a peer-closed stream lane.
+        // like a peer-closed stream lane — and on ANY exit it clears the
+        // capability flag, so connection churn/replacement falls audio
+        // back to the reliable lane instead of wedging sends on a dead
+        // connection (Codex review P1-3).
+        //
+        // Session binding (ADR-0042 addendum): datagrams are consumed
+        // ONLY while this gate-cleared session is open — the reader is
+        // spawned after `Agent::open_peer_datagram_lane` cleared the
+        // identity + connect-ACL gates for this specific remote, and is
+        // aborted by `stop()` (call teardown). QUIC authenticates the
+        // machine, so datagrams are bound to the gate-resolved
+        // (remote AgentId → MachineId) session; per-agent attribution
+        // inside a multi-agent machine is impossible at this layer (the
+        // wire format carries no sender field) — parity with the
+        // reliable stream path, which also has no per-stream sender
+        // discriminator. A per-datagram session tag is an upstream
+        // (saorsa-webrtc) wire change — recorded as the follow-up.
+        // Revocation mid-call does NOT tear the reader down: no cheap
+        // revocation hook exists, and accepted byte-streams behave
+        // identically (gates run at open/accept time only).
+        //
+        // Replay stance (v1): in-call duplicates/replays are absorbed by
+        // the mandatory jitter buffer's sequence dedupe (upstream
+        // `duplicates_dropped` / `late_dropped`); a stopped session's
+        // reader is aborted, so cross-call replay has no consumer on
+        // this transport.
+        //
+        // Rate limit: a per-connection byte ceiling (see
+        // [`DATAGRAM_BYTE_RATE`]) bounds a flood to burst + rate — the
+        // excess is dropped and counted here, never queued. Invalid
+        // (undecodable) datagrams are counted and their warns throttled
+        // (first + every 100th) so garbage cannot also spam the log.
         let inbound_tx = self.inbound_tx.clone();
         let peer_conn = self.peer_connection();
         let frames_received = Arc::clone(&self.datagram_frames_received);
+        let rate_dropped = Arc::clone(&self.datagram_rate_limited);
+        let capable_flag = Arc::clone(&self.peer_datagram_capable);
         let hl_conn = conn.inner().clone();
         let reader = tokio::spawn(async move {
-            loop {
-                match hl_conn.read_datagram().await {
-                    Ok(bytes) => {
-                        if AudioDatagram::decode(bytes.clone()).is_err() {
+            let mut bucket = DATAGRAM_BYTE_BURST;
+            let mut invalid = 0u64;
+            let mut last_refill = std::time::Instant::now();
+            while let Ok(bytes) = hl_conn.read_datagram().await {
+                {
+                    // Token bucket by bytes: refill at the sustained
+                    // ceiling, capped at the burst allowance.
+                    let now = std::time::Instant::now();
+                    let elapsed_ms = u64::try_from(now.duration_since(last_refill).as_millis())
+                        .unwrap_or(u64::MAX);
+                    last_refill = now;
+                    bucket =
+                        (bucket + elapsed_ms * DATAGRAM_BYTE_RATE / 1000).min(DATAGRAM_BYTE_BURST);
+                    let len_u64 = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+                    if len_u64 > bucket {
+                        rate_dropped.fetch_add(1, Ordering::Relaxed);
+                        tracing::warn!(
+                            target: "voice",
+                            len = bytes.len(),
+                            "datagram exceeded per-connection byte ceiling; dropped"
+                        );
+                        continue;
+                    }
+                    bucket -= len_u64;
+                    if AudioDatagram::decode(bytes.clone()).is_err() {
+                        invalid += 1;
+                        if invalid == 1 || invalid.is_multiple_of(100) {
                             tracing::warn!(
                                 target: "voice",
                                 len = bytes.len(),
-                                "non-AudioDatagram datagram dropped on voice lane"
+                                total_invalid = invalid,
+                                "non-AudioDatagram datagram dropped on voice lane (log throttled)"
                             );
-                            continue;
                         }
-                        frames_received.fetch_add(1, Ordering::Relaxed);
-                        if inbound_tx
-                            .send((peer_conn.clone(), StreamType::Audio, bytes.to_vec()))
-                            .await
-                            .is_err()
-                        {
-                            return; // transport dropped
-                        }
+                        continue;
                     }
-                    Err(_) => return, // connection closed — lane ends
+                    frames_received.fetch_add(1, Ordering::Relaxed);
+                    if inbound_tx
+                        .send((peer_conn.clone(), StreamType::Audio, bytes.to_vec()))
+                        .await
+                        .is_err()
+                    {
+                        break; // transport dropped
+                    }
                 }
             }
+            // P1-3: the connection is gone (closed or replaced); sends
+            // must not keep targeting it.
+            capable_flag.store(false, Ordering::SeqCst);
+            tracing::info!(
+                target: "voice",
+                "datagram reader exited (connection closed); audio falls back to the reliable lane"
+            );
         });
 
         // Advert listener — watches the DM fan-out for the peer's
-        // capability advert. Only the fixed remote's frames count.
+        // capability advert. Codex review P1-1: `DirectMessage.sender`
+        // is self-asserted, so an advert only counts when the
+        // QUIC-authenticated `machine_id` matches the gate-resolved
+        // machine of this session, the AgentId→MachineId binding is
+        // verified, trust is `Accept` (mirroring the stream gates —
+        // `AcceptWithFlag` denies), AND the frame carries this session's
+        // challenge-response: the peer proves liveness on THIS call by
+        // echoing our per-start nonce. A spoofed sender id, a stale
+        // replay, or a cross-call advert cannot produce the echo.
+        //
+        // Wire shape (additive, serde-defaulted on the same signaling
+        // prefix): initial `{"type","datagram","challenge"}`, ack
+        // `{"type","datagram","response"}`. Old peers send neither and
+        // never flip the lane.
         let mut direct = self.agent.subscribe_direct();
         let remote = self.remote;
         let capable = Arc::clone(&self.peer_datagram_capable);
+        let session_state = Arc::clone(&self.datagram_session);
+        let agent = Arc::clone(&self.agent);
         let advert_listener = tokio::spawn(async move {
             while let Some(msg) = direct.recv().await {
                 if msg.sender != remote {
@@ -329,37 +568,100 @@ impl X0xLinkTransport {
                 let Some(body) = msg.payload.strip_prefix(VOICE_SIGNALING_DM_PREFIX) else {
                     continue;
                 };
-                // Missing-field defaults: an advert without `"datagram":
-                // true` (or without the field at all) is not a capability.
-                if let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) {
-                    if value.get("type").and_then(serde_json::Value::as_str)
-                        == Some(DATAGRAM_ADVERT_TYPE)
-                        && value.get("datagram").and_then(serde_json::Value::as_bool) == Some(true)
-                    {
-                        capable.store(true, Ordering::Relaxed);
-                        tracing::info!(
-                            target: "voice",
-                            "peer advertised the datagram audio lane; Audio sends switch to datagrams"
-                        );
-                        return;
+                let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+                    continue;
+                };
+                if value.get("type").and_then(serde_json::Value::as_str)
+                    != Some(DATAGRAM_ADVERT_TYPE)
+                {
+                    continue;
+                }
+                if value.get("datagram").and_then(serde_json::Value::as_bool) != Some(true) {
+                    continue; // missing-field default: not a capability
+                }
+                // Copy the session facts out and release the guard — a
+                // std MutexGuard must never live across the await below.
+                let (session_machine, our_nonce, acked_challenge) = {
+                    let state = session_state.lock().unwrap_or_else(|p| p.into_inner());
+                    let Some(session) = state.as_ref() else {
+                        continue; // no live session — lane torn down
+                    };
+                    (
+                        session.machine,
+                        session.our_nonce.clone(),
+                        session.acked_challenge.clone(),
+                    )
+                };
+                // Authenticated binding (P1-1): right machine, verified
+                // binding, trust Accept.
+                if msg.machine_id != session_machine
+                    || !msg.verified
+                    || !matches!(
+                        msg.trust_decision,
+                        Some(crate::trust::TrustDecision::Accept)
+                    )
+                {
+                    tracing::warn!(
+                        target: "voice",
+                        machine = %hex::encode(msg.machine_id.as_bytes()),
+                        "unauthenticated datagram advert rejected (machine/verified/trust mismatch)"
+                    );
+                    continue;
+                }
+                // Challenge-response (P1-1): only an echo of OUR fresh
+                // nonce flips the lane.
+                let response = value
+                    .get("response")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned);
+                if response.as_deref() == Some(our_nonce.as_str()) {
+                    capable.store(true, Ordering::SeqCst);
+                    tracing::info!(
+                        target: "voice",
+                        "peer proved the datagram lane session (nonce echo); Audio sends switch to datagrams"
+                    );
+                    return;
+                }
+                // A peer initial (challenge, no valid response): ack it
+                // once per distinct challenge so the peer can prove its
+                // session — but never flip our own lane on it.
+                if let Some(challenge) = value.get("challenge").and_then(serde_json::Value::as_str)
+                {
+                    if acked_challenge.as_deref() != Some(challenge) {
+                        let challenge = challenge.to_owned();
+                        let _ = send_advert_frame(
+                            &agent,
+                            &remote,
+                            serde_json::json!({
+                                "type": DATAGRAM_ADVERT_TYPE,
+                                "datagram": true,
+                                "response": challenge,
+                            }),
+                        )
+                        .await;
+                        if let Some(state) = session_state
+                            .lock()
+                            .unwrap_or_else(|p| p.into_inner())
+                            .as_mut()
+                        {
+                            state.acked_challenge = Some(challenge);
+                        }
                     }
                 }
             }
         });
 
-        // Advertise our capability — additive frame on the signaling
-        // channel. A failed DM send leaves the lane up (the reader still
-        // drains) but the peer will never switch to datagrams toward us;
-        // audio stays reliable in that direction until the next start.
-        let mut payload = VOICE_SIGNALING_DM_PREFIX.to_vec();
-        payload.extend_from_slice(
-            &serde_json::to_vec(&serde_json::json!({
-                "type": DATAGRAM_ADVERT_TYPE,
-                "datagram": true,
-            }))
-            .map_err(|e| LinkTransportError::IoError(format!("encode advert: {e}")))?,
-        );
-        if let Err(e) = self.agent.send_direct(&self.remote, payload).await {
+        // Advertise our capability — the session initial with our fresh
+        // challenge. A failed DM send leaves the lane up (the reader
+        // still drains) but the peer will never switch to datagrams
+        // toward us; audio stays reliable in that direction until the
+        // next start.
+        let initial = serde_json::json!({
+            "type": DATAGRAM_ADVERT_TYPE,
+            "datagram": true,
+            "challenge": our_nonce,
+        });
+        if let Err(e) = send_advert_frame(&self.agent, &self.remote, initial).await {
             tracing::warn!(
                 target: "voice",
                 error = %e,
@@ -374,6 +676,7 @@ impl X0xLinkTransport {
         });
         Ok(())
     }
+
     /// Reliable path: one ordered `WebRtcV1` stream per
     /// `(direction, StreamType)` lane, `u32-BE length ‖ payload` frames.
     async fn send_reliable(
@@ -432,20 +735,66 @@ impl X0xLinkTransport {
                 data.len()
             )));
         }
-        let lane = self.datagram.lock().await;
-        let Some(lane) = lane.as_ref() else {
+        // Take the send result under the lock, then release the guard
+        // before any fallback await (a held tokio guard across the
+        // reliable path would serialize the two lanes needlessly).
+        let guard = self.datagram.lock().await;
+        let outcome = guard.as_ref().map(|lane| {
+            lane.conn
+                .inner()
+                .send_datagram(Bytes::copy_from_slice(data))
+        });
+        drop(guard);
+        match outcome {
+            Some(Ok(())) => {
+                self.datagram_frames_sent.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Some(Err(e)) => {
+                // P1-3: the negotiated connection is dead (closed or
+                // replaced). Clear capability so subsequent sends take
+                // the reliable path immediately, and deliver THIS frame
+                // reliably — connection churn must degrade the lane,
+                // never kill the call.
+                self.peer_datagram_capable.store(false, Ordering::SeqCst);
+                tracing::warn!(
+                    target: "voice",
+                    error = %e,
+                    "audio datagram send failed; lane falls back to the reliable stream"
+                );
+                self.send_reliable(StreamType::Audio, data).await
+            }
             // Peer advertised but the local lane never opened (gate/open
             // failed at start): reliable fallback rather than a hard
             // error — the caller's audio must still flow.
-            drop(lane);
-            return self.send_reliable(StreamType::Audio, data).await;
-        };
-        lane.conn
-            .inner()
-            .send_datagram(Bytes::copy_from_slice(data))
-            .map_err(|e| LinkTransportError::SendError(format!("audio datagram: {e}")))?;
-        self.datagram_frames_sent.fetch_add(1, Ordering::Relaxed);
-        Ok(())
+            None => self.send_reliable(StreamType::Audio, data).await,
+        }
+    }
+}
+
+impl Drop for X0xLinkTransport {
+    fn drop(&mut self) {
+        // Best-effort leak guard (Codex review P2): `stop()` is the
+        // clean, awaited teardown (its awaited abort is what guarantees
+        // the acceptor's deregistration); `Drop` cannot await, so abort
+        // what is abortable without blocking. A contended lock means a
+        // task is mid-operation — the runtime finishes it and the
+        // channel-close then ends its loop.
+        if let Ok(mut guard) = self.acceptor_task.try_lock() {
+            if let Some(task) = guard.take() {
+                task.abort();
+            }
+        }
+        if let Ok(mut guard) = self.datagram.try_lock() {
+            if let Some(lane) = guard.take() {
+                lane.reader.abort();
+                lane.advert_listener.abort();
+            }
+        }
+        *self
+            .datagram_session
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) = None;
     }
 }
 
@@ -455,6 +804,23 @@ fn placeholder_addr() -> SocketAddr {
     SocketAddr::from(([127, 0, 0, 1], 0))
 }
 
+/// Send one x0x datagram-lane advert frame (`initial` or `ack`) on the
+/// voice signaling DM channel. Pure transport — all session logic lives
+/// in the listener.
+async fn send_advert_frame(
+    agent: &Arc<Agent>,
+    remote: &AgentId,
+    frame: serde_json::Value,
+) -> Result<(), String> {
+    let mut payload = VOICE_SIGNALING_DM_PREFIX.to_vec();
+    payload.extend_from_slice(&serde_json::to_vec(&frame).map_err(|e| e.to_string())?);
+    agent
+        .send_direct(remote, payload)
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
 fn lt_err(context: &str, e: impl std::fmt::Display) -> LinkTransportError {
     LinkTransportError::IoError(format!("{context}: {e}"))
 }
@@ -462,46 +828,22 @@ fn lt_err(context: &str, e: impl std::fmt::Display) -> LinkTransportError {
 #[async_trait]
 impl LinkTransport for X0xLinkTransport {
     async fn start(&mut self) -> Result<(), LinkTransportError> {
-        if self.running.swap(true, Ordering::SeqCst) {
-            return Ok(());
-        }
-        let mut acceptor = self
-            .agent
-            .register_stream_acceptor(StreamProtocol::WebRtcV1)
-            .map_err(|e| lt_err("register WebRtcV1 acceptor", e))?;
-        let inbound_tx = self.inbound_tx.clone();
-        let accepted_tx = self.accepted_peers_tx.clone();
-        let task = tokio::spawn(async move {
-            while let Some(stream) = acceptor.next().await {
-                tokio::spawn(Self::drive_inbound_stream(
-                    stream,
-                    inbound_tx.clone(),
-                    accepted_tx.clone(),
-                ));
-            }
-        });
-        *self.acceptor_task.lock().await = Some(task);
-
-        // ADR-0042 (c): bring up the unreliable datagram lane when the
-        // local mode asks for it. Failure is non-fatal — audio keeps the
-        // reliable stream (the fallback) — but it is loud: a Datagram
-        // pin that silently degrades is a latency bug.
-        if self.audio_lane == AudioLaneMode::Datagram {
-            if let Err(e) = self.setup_datagram_lane().await {
-                tracing::warn!(
-                    target: "voice",
-                    error = %e,
-                    "datagram audio lane unavailable; audio stays on the reliable stream"
-                );
-            }
-        }
-        Ok(())
+        // Typed setup path is [`Self::start_lane`]; the trait surface maps
+        // the typed error into the upstream stringly enum.
+        self.start_lane()
+            .await
+            .map_err(|e| LinkTransportError::IoError(e.to_string()))
     }
 
     async fn stop(&mut self) -> Result<(), LinkTransportError> {
         self.running.store(false, Ordering::SeqCst);
         if let Some(task) = self.acceptor_task.lock().await.take() {
             task.abort();
+            // Await the aborted task so its `StreamAcceptor` (whose Drop
+            // deregisters the protocol) is gone before `stop()` returns
+            // — a restart after stop must not race the release, or it
+            // would spuriously hit `SessionConflict`.
+            let _ = task.await;
         }
         if let Some(lane) = self.datagram.lock().await.take() {
             lane.reader.abort();
@@ -603,37 +945,76 @@ mod tests {
         }
     }
 
-    /// The advert body as `X0xLinkTransport` writes it on the wire.
-    fn advert_body(datagram: bool) -> Vec<u8> {
-        serde_json::to_vec(&serde_json::json!({
-            "type": DATAGRAM_ADVERT_TYPE,
-            "datagram": datagram,
-        }))
-        .expect("advert JSON is static and always encodes")
-    }
-
-    /// The advert-decode predicate from `setup_datagram_lane`'s listener,
-    /// as a pure function over a DM body (missing fields default — the
-    /// additive/serde-defaulted contract).
-    fn advertises_datagram(body: &[u8]) -> bool {
-        serde_json::from_slice::<serde_json::Value>(body).is_ok_and(|value| {
-            value.get("type").and_then(serde_json::Value::as_str) == Some(DATAGRAM_ADVERT_TYPE)
-                && value.get("datagram").and_then(serde_json::Value::as_bool) == Some(true)
-        })
+    /// One parsed advert frame: (datagram flag, challenge, response).
+    /// The listener's decode contract as a pure function — missing
+    /// fields default (the additive/serde-defaulted contract).
+    fn parse_advert(body: &[u8]) -> Option<(bool, Option<String>, Option<String>)> {
+        let value = serde_json::from_slice::<serde_json::Value>(body).ok()?;
+        if value.get("type").and_then(serde_json::Value::as_str) != Some(DATAGRAM_ADVERT_TYPE) {
+            return None;
+        }
+        let flag = value.get("datagram").and_then(serde_json::Value::as_bool)?;
+        let field = |name: &str| {
+            value
+                .get(name)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        };
+        Some((flag, field("challenge"), field("response")))
     }
 
     #[test]
     fn datagram_advert_round_trips_and_defaults_to_not_capable() {
-        // Full advert: capable.
-        assert!(advertises_datagram(&advert_body(true)));
+        // Session initial: capability + challenge, no response.
+        let initial = serde_json::to_vec(&serde_json::json!({
+            "type": DATAGRAM_ADVERT_TYPE,
+            "datagram": true,
+            "challenge": "cafebabe",
+        }))
+        .expect("static JSON encodes");
+        assert_eq!(
+            parse_advert(&initial),
+            Some((true, Some("cafebabe".to_owned()), None))
+        );
+        // Session ack: response echo, no challenge.
+        let ack = serde_json::to_vec(&serde_json::json!({
+            "type": DATAGRAM_ADVERT_TYPE,
+            "datagram": true,
+            "response": "deadbeef",
+        }))
+        .expect("static JSON encodes");
+        assert_eq!(
+            parse_advert(&ack),
+            Some((true, None, Some("deadbeef".to_owned())))
+        );
         // Explicit refusal.
-        assert!(!advertises_datagram(&advert_body(false)));
-        // Additivity: an advert missing the `datagram` field entirely (a
-        // future/older sender) must decode as NOT capable — missing
-        // fields default, never panic, never over-advertise.
-        assert!(!advertises_datagram(br#"{"type":"x0x_datagram_cap"}"#));
-        // Unknown tags are not adverts.
-        assert!(!advertises_datagram(br#"{"type":"capability_exchange"}"#));
+        assert_eq!(
+            parse_advert(br#"{"type":"x0x_datagram_cap","datagram":false}"#),
+            Some((false, None, None))
+        );
+        // Additivity: a frame missing `datagram` entirely (a future or
+        // older sender) is NOT an advert — missing fields default,
+        // never over-advertise. Neither is an unknown tag.
+        assert_eq!(parse_advert(br#"{"type":"x0x_datagram_cap"}"#), None);
+        assert_eq!(parse_advert(br#"{"type":"capability_exchange"}"#), None);
+    }
+
+    /// Only an echo of OUR per-start nonce flips the lane — the pure
+    /// core of the listener's challenge-response rule (P1-1): a frame
+    /// with no response, a wrong response, or a replayed foreign
+    /// response must all leave the lane capable = false.
+    #[test]
+    fn only_our_nonce_echo_flips_the_lane() {
+        let our_nonce = "0123abcd";
+        let flips = |challenge: Option<&str>, response: Option<&str>, our: &str| {
+            response.is_some_and(|r| r == our) && challenge.is_none()
+        };
+        // Correct echo.
+        assert!(flips(None, Some(our_nonce), our_nonce));
+        // Wrong/replayed response.
+        assert!(!flips(None, Some("stale-replay"), our_nonce));
+        // Peer initial (challenge, no response) never flips our lane.
+        assert!(!flips(Some("peer-challenge"), None, our_nonce));
     }
 
     #[test]
@@ -642,13 +1023,17 @@ mod tests {
         // SignalingMessage decoding on the advert and DROPS it — the
         // advert must never decode as a real (e.g. legacy SDP) message
         // that could corrupt call state.
-        let body = advert_body(true);
+        let body = serde_json::to_vec(&serde_json::json!({
+            "type": DATAGRAM_ADVERT_TYPE,
+            "datagram": true,
+            "challenge": "cafebabe",
+        }))
+        .expect("static JSON encodes");
         assert!(
             serde_json::from_slice::<saorsa_webrtc_core::signaling::SignalingMessage>(&body)
                 .is_err()
         );
     }
-
     #[test]
     fn audio_stream_type_byte_is_pinned() {
         // ADR-0042 (a): the audio lane byte is 0x20 (0x21 is Video) —

--- a/src/voice/link_transport.rs
+++ b/src/voice/link_transport.rs
@@ -271,8 +271,9 @@ impl X0xLinkTransport {
         self.datagram_frames_received.load(Ordering::Relaxed)
     }
 
-    /// Datagrams dropped by the per-connection byte ceiling (see
-    /// [`DATAGRAM_BYTE_RATE`]) — observability for the flood defense.
+    /// Datagrams dropped by the per-connection byte ceiling (see the
+    /// `DATAGRAM_BYTE_RATE` token bucket) — observability for the flood
+    /// defense.
     #[must_use]
     pub fn datagram_rate_limited_dropped(&self) -> u64 {
         self.datagram_rate_limited.load(Ordering::Relaxed)

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -1,28 +1,43 @@
 //! Voice adapters for `saorsa-webrtc` (feature `voice`).
 //!
 //! Implements the two seams the saorsa-webrtc revival design (V1.1/V1.2)
-//! assigns to x0x:
+//! assigns to x0x, plus the ADR-0042 (c) unreliable datagram lane:
 //!
 //! * [`X0xSignaling`](crate::voice::X0xSignaling) — [`saorsa_webrtc_core::signaling::SignalingTransport`]
 //!   over x0x direct messages. Signaling frames ride the DM path with the
 //!   [`crate::history::classify::VOICE_SIGNALING_DM_PREFIX`] typed prefix and
-//!   are classified **Ephemeral** (never recorded to history).
+//!   are classified **Ephemeral** (never recorded to history). The ADR-0042
+//!   datagram-capability advert rides the same channel as an additive
+//!   `x0x_*`-tagged extension frame.
 //! * [`X0xLinkTransport`](crate::voice::X0xLinkTransport) — [`saorsa_webrtc_core::link_transport::LinkTransport`]
 //!   over ADR-0022 byte streams using
 //!   [`crate::streams::StreamProtocol::WebRtcV1`] (`0x04`). The byte after
 //!   the x0x protocol prefix is the saorsa-webrtc
 //!   [`saorsa_webrtc_core::link_transport::StreamType`] (0x20–0x24), so
 //!   audio/video/control lanes nest inside one gated x0x stream protocol.
+//!   With [`AudioLaneMode::Datagram`] pinned, encoded audio additionally
+//!   rides unreliable QUIC datagrams on the same peer connection once both
+//!   ends advertise the lane — falling back to the reliable stream
+//!   otherwise (ADR-0042 decision (c)); the jitter buffer stays mandatory
+//!   on the receive side.
 //!
 //! Both adapters sit **behind** the existing identity gate, trust
 //! evaluation, revocation checks, and the connect-ACL pair gate — voice
-//! traffic gets no special path through any of them.
+//! traffic gets no special path through any of them. The datagram lane
+//! opens through [`crate::Agent::open_peer_datagram_lane`], which enforces
+//! the gates in both directions.
 
 mod link_transport;
 mod signaling;
 
 pub use link_transport::X0xLinkTransport;
 pub use signaling::{VoicePeerId, X0xSignaling};
+
+/// Which lane carries encoded audio (ADR-0042 c): the ordered reliable
+/// stream (default) or unreliable QUIC datagrams with automatic reliable
+/// fallback. Re-exported so applications pin exactly one voice dependency
+/// (`x0x` with the `voice` feature).
+pub use saorsa_webrtc_core::datagram_lane::AudioLaneMode;
 
 /// The codec crate matching this transport (real Opus; video codecs stay
 /// feature-gated upstream). Re-exported so applications pin exactly one

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -15,7 +15,7 @@
 //!   the x0x protocol prefix is the saorsa-webrtc
 //!   [`saorsa_webrtc_core::link_transport::StreamType`] (0x20–0x24), so
 //!   audio/video/control lanes nest inside one gated x0x stream protocol.
-//!   With [`AudioLaneMode::Datagram`] pinned, encoded audio additionally
+//!   With `AudioLaneMode::Datagram` pinned, encoded audio additionally
 //!   rides unreliable QUIC datagrams on the same peer connection once both
 //!   ends advertise the lane — falling back to the reliable stream
 //!   otherwise (ADR-0042 decision (c)); the jitter buffer stays mandatory

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -30,7 +30,7 @@
 mod link_transport;
 mod signaling;
 
-pub use link_transport::X0xLinkTransport;
+pub use link_transport::{VoiceLaneError, X0xLinkTransport};
 pub use signaling::{VoicePeerId, X0xSignaling};
 
 /// Which lane carries encoded audio (ADR-0042 c): the ordered reliable

--- a/src/voice/signaling.rs
+++ b/src/voice/signaling.rs
@@ -78,6 +78,14 @@ impl X0xSignaling {
                 let Some(body) = msg.payload.strip_prefix(VOICE_SIGNALING_DM_PREFIX) else {
                     continue;
                 };
+                // x0x transport-extension frames (`"type": "x0x_*"`, e.g.
+                // the ADR-0042 datagram-capability advert) ride the same
+                // prefix but are consumed by `X0xLinkTransport`'s own
+                // subscriber — skip them silently here instead of logging
+                // a decode warning per frame.
+                if is_x0x_extension_frame(body) {
+                    continue;
+                }
                 match serde_json::from_slice::<SignalingMessage>(body) {
                     Ok(parsed) => {
                         if tx.try_send((VoicePeerId(msg.sender), parsed)).is_err() {
@@ -157,6 +165,25 @@ impl SignalingTransport for X0xSignaling {
     }
 }
 
+/// Whether a voice-signaling DM body is an x0x transport-extension frame
+/// (`"type"` starting with `x0x_`) rather than an upstream
+/// [`SignalingMessage`].
+///
+/// The `x0x_` namespace is disjoint from upstream's snake_case tags, so
+/// this never swallows a real signaling message. Extension frames have
+/// their own consumers (e.g. the ADR-0042 datagram-capability advert is
+/// consumed by `X0xLinkTransport`'s DM subscriber); this predicate lets
+/// the signaling reader skip them silently instead of logging a decode
+/// warning per frame. Undecodable bodies are NOT extensions (only a
+/// decodable JSON object with a matching tag is).
+fn is_x0x_extension_frame(body: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(body).is_ok_and(|value| {
+        value
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|tag| tag.starts_with("x0x_"))
+    })
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,6 +201,23 @@ mod tests {
     fn voice_peer_id_rejects_bad_input() {
         assert!(VoicePeerId::from_str("zz").is_err());
         assert!(VoicePeerId::from_str(&"ab".repeat(31)).is_err());
+    }
+
+    #[test]
+    fn x0x_extension_frames_are_recognized_and_upstream_tags_are_not() {
+        // The ADR-0042 datagram advert is an extension frame.
+        assert!(is_x0x_extension_frame(
+            br#"{"type":"x0x_datagram_cap","datagram":true}"#
+        ));
+        // Future x0x_ extensions too.
+        assert!(is_x0x_extension_frame(br#"{"type":"x0x_anything"}"#));
+        // Upstream SignalingMessage tags never match the namespace…
+        assert!(!is_x0x_extension_frame(
+            br#"{"type":"capability_exchange","session_id":"s"}"#
+        ));
+        // …and neither do undecodable bodies (they keep the decode-warn
+        // path — an extension frame must be valid JSON by definition).
+        assert!(!is_x0x_extension_frame(b"not json"));
     }
 
     #[test]

--- a/tests/voice_adapters.rs
+++ b/tests/voice_adapters.rs
@@ -432,3 +432,50 @@ async fn connect_acl_denies_unlisted_datagram_lane() {
         ),
     }
 }
+
+/// Single-acceptor rule (Codex review finding 2): exactly ONE consumer
+/// may register `WebRtcV1` per agent, so a second concurrent call on the
+/// same agent cannot start today. It must fail FAST and TYPED
+/// (`VoiceLaneError::SessionConflict`) — never silently steal or share
+/// the acceptor — and `stop()` must release the acceptor so a later
+/// session starts cleanly (self-heal). The shared daemon-level demux
+/// that would make concurrent calls WORK is the recorded follow-up.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback acceptor-conflict proof; binds UDP. Integration tier."]
+async fn second_concurrent_call_fails_typed_and_stop_self_heals() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    let mut first = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id());
+    first
+        .start_lane()
+        .await
+        .expect("first session claims the WebRtcV1 acceptor");
+
+    // A second concurrent call on the SAME agent (any remote) hits the
+    // single-acceptor rule: typed rejection, not a stringly error and
+    // not a silent takeover.
+    let mut second = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id());
+    match second.start_lane().await {
+        Err(x0x::voice::VoiceLaneError::SessionConflict) => {}
+        other => panic!("expected SessionConflict, got: {other:?}"),
+    }
+    // The failed start must not wedge the transport: `running` was
+    // reset, so a retry after the conflict is cleared succeeds below.
+
+    first
+        .stop()
+        .await
+        .expect("first session stops (releases acceptor)");
+
+    second
+        .start_lane()
+        .await
+        .expect("acceptor released by stop; second session now starts");
+    let _ = second.stop().await;
+
+    alice.shutdown().await;
+    bob.shutdown().await;
+}

--- a/tests/voice_adapters.rs
+++ b/tests/voice_adapters.rs
@@ -22,7 +22,7 @@ use saorsa_webrtc_core::link_transport::{LinkTransport, StreamType};
 use saorsa_webrtc_core::signaling::{SignalingMessage, SignalingTransport};
 use tempfile::TempDir;
 use x0x::network::NetworkConfig;
-use x0x::voice::{X0xLinkTransport, X0xSignaling};
+use x0x::voice::{AudioLaneMode, X0xLinkTransport, X0xSignaling};
 use x0x::DiscoveredAgent;
 
 fn loopback_network_config() -> NetworkConfig {
@@ -303,6 +303,7 @@ async fn connect_acl_denies_unlisted_voice_peer() {
     let _ = alice_link.send(&peer, StreamType::Audio, &[0u8; 200]).await;
 
     let nothing = tokio::time::timeout(Duration::from_secs(5), bob_link.receive()).await;
+
     assert!(
         nothing.is_err(),
         "bob must not receive frames from an ACL-unlisted peer: {nothing:?}"
@@ -310,4 +311,124 @@ async fn connect_acl_denies_unlisted_voice_peer() {
 
     alice.shutdown().await;
     bob.shutdown().await;
+}
+
+/// ADR-0042 (c) fallback: alice pins `Datagram`, bob stays on the
+/// default `Reliable` (the old-peer stand-in — he never advertises).
+/// Alice's audio must ride the reliable stream lane anyway:
+/// byte-identical ordered frames, and the datagram frame counter stays
+/// zero (proving the fallback actually engaged, not that datagrams
+/// silently worked).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback fallback proof; binds UDP + waits on convergence. Integration tier."]
+async fn datagram_mode_falls_back_to_reliable_lane_without_peer_advert() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    let mut alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+    let mut bob_link = X0xLinkTransport::new(Arc::clone(&bob), alice.agent_id());
+    assert_eq!(
+        bob_link.audio_lane_mode(),
+        AudioLaneMode::Reliable,
+        "default mode must stay Reliable (V1.2 wire behavior preserved)"
+    );
+    bob_link.start().await.expect("bob link starts");
+    alice_link.start().await.expect("alice link starts");
+
+    let frames: Vec<Vec<u8>> = (0u8..50)
+        .map(|i| {
+            let mut f = vec![i; 200]; // opus-frame-sized
+            f[0] = i; // sequence marker
+            f
+        })
+        .collect();
+    let peer = alice_link.default_peer().expect("default peer");
+    for frame in &frames {
+        alice_link
+            .send(&peer, StreamType::Audio, frame)
+            .await
+            .expect("send audio frame");
+    }
+    // Give a (never-arriving) advert ample time to land before the
+    // fallback assertions — the counter must be zero by conviction, not
+    // by race.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let mut received = Vec::with_capacity(frames.len());
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while received.len() < frames.len() && Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, bob_link.receive()).await {
+            Ok(Ok((_, ty, data))) => {
+                assert_eq!(ty, StreamType::Audio);
+                received.push(data);
+            }
+            Ok(Err(e)) => panic!("bob receive failed: {e}"),
+            Err(_) => break,
+        }
+    }
+    // Reliable-lane semantics held: byte-identical AND ordered.
+    assert_eq!(
+        received.len(),
+        frames.len(),
+        "all frames delivered via fallback"
+    );
+    assert_eq!(received, frames, "byte-identical, in order (reliable lane)");
+    // Fallback proof: no audio datagram was ever sent, and alice never
+    // saw bob advertise.
+    assert_eq!(
+        alice_link.datagram_frames_sent(),
+        0,
+        "datagram-pinned sender must not send datagrams to a silent peer"
+    );
+    assert!(
+        !alice_link.peer_datagram_capable(),
+        "old-peer (non-advertising) peer must never mark the lane capable"
+    );
+
+    alice_link.stop().await.expect("alice stop");
+    bob_link.stop().await.expect("bob stop");
+    alice.shutdown().await;
+    bob.shutdown().await;
+}
+
+/// The datagram lane gets no connect-ACL bypass: with an Enabled policy
+/// that does not list alice, bob's `open_peer_datagram_lane` must fail
+/// at the inbound ACL gate — the lane surface must never appear for a
+/// peer whose inbound stream the accept loop would reset.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback datagram-lane ACL denial; binds UDP. Integration tier."]
+async fn connect_acl_denies_unlisted_datagram_lane() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    // Bob enables a policy listing a random pair that is NOT
+    // (alice, alice-machine) — alice becomes an unlisted peer inbound.
+    let stranger_agent = x0x::identity::AgentId([0x55; 32]);
+    let stranger_machine = x0x::identity::MachineId([0x66; 32]);
+    bob.set_connect_policy(Arc::new(x0x::connect::ConnectPolicy::Enabled(
+        x0x::connect::ConnectAcl {
+            loaded_from: std::path::Path::new("/test").to_path_buf(),
+            loaded_at_unix_ms: 0,
+            allow: vec![x0x::connect::ConnectAllowEntry {
+                description: None,
+                agent_id: stranger_agent,
+                machine_id: stranger_machine,
+                targets: vec!["127.0.0.1:22".parse().expect("loopback literal")],
+            }],
+        },
+    )));
+
+    match bob.open_peer_datagram_lane(&alice.agent_id()).await {
+        Ok(_) => panic!("unlisted peer must be denied the datagram lane"),
+        Err(e) => assert!(
+            matches!(e, x0x::error::NetworkError::PeerNotInConnectAcl { .. }),
+            "expected PeerNotInConnectAcl, got: {e:?}"
+        ),
+    }
 }

--- a/tests/voice_adapters.rs
+++ b/tests/voice_adapters.rs
@@ -358,7 +358,9 @@ async fn datagram_mode_falls_back_to_reliable_lane_without_peer_advert() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let mut received = Vec::with_capacity(frames.len());
-    let deadline = Instant::now() + Duration::from_secs(30);
+    // Generous deadline: this suite runs UDP-binding integration tests in
+    // parallel; under load the loopback convergence eats into a tight one.
+    let deadline = Instant::now() + Duration::from_secs(60);
     while received.len() < frames.len() && Instant::now() < deadline {
         let remaining = deadline.saturating_duration_since(Instant::now());
         match tokio::time::timeout(remaining, bob_link.receive()).await {

--- a/tests/voice_datagram_e2e.rs
+++ b/tests/voice_datagram_e2e.rs
@@ -70,12 +70,12 @@ async fn build_agent(dir: &TempDir, name: &str) -> Option<x0x::Agent> {
         .await
     {
         Ok(agent) => Some(agent),
-        // Explicit skip, never a silent pass (Codex review P2): without
-        // real UDP sockets this e2e proves nothing, so say so loudly.
-        Err(e) if is_network_bind_permission_error(&e) => {
-            eprintln!("SKIP: UDP binds forbidden in this environment — datagram e2e requires real sockets");
-            None
-        }
+        // Never a silent pass on environment failure (Codex r2 finding
+        // 4): without real UDP sockets this e2e proves nothing, so fail
+        // loudly rather than returning Ok from a body that ran nothing.
+        Err(e) if is_network_bind_permission_error(&e) => panic!(
+            "environment forbids UDP binds — this datagram e2e cannot run and must not pass: {e}"
+        ),
         Err(e) => panic!("agent build failed: {e}"),
     }
 }
@@ -713,6 +713,16 @@ async fn connection_churn_falls_back_to_reliable() {
         "mutual capability must land before the churn"
     );
 
+    // PRIME a reliable lane before the churn (Codex r2 finding 2): the
+    // Data lane always rides the reliable stream (only Audio is
+    // routable to datagrams), so this populates the cached-stream map
+    // the eviction logic must recover from.
+    let peer = alice_link.default_peer().expect("default peer");
+    alice_link
+        .send(&peer, StreamType::Data, &[0xA5; 64])
+        .await
+        .expect("prime reliable Data lane");
+
     // Kill the connection alice's datagram lane negotiated on, then
     // bring up its REPLACEMENT (realistic churn: the old connection is
     // gone, a new one takes over — `disconnect` removes the peer, so the
@@ -761,9 +771,14 @@ async fn connection_churn_falls_back_to_reliable() {
     );
     let sent_at_churn = alice_link.datagram_frames_sent();
 
-    // Post-churn audio: reliable lane, still delivered (open_peer_stream
-    // redials through the discovery cache).
-    let peer = alice_link.default_peer().expect("default peer");
+    // Post-churn audio: reliable lane, still delivered — the primed
+    // cached stream from the dead connection must be evicted and
+    // reopened (audio lane was never cached, so also exercise the Data
+    // lane again: eviction covers every cached lane type).
+    alice_link
+        .send(&peer, StreamType::Data, &[0x5A; 64])
+        .await
+        .expect("post-churn Data send must evict the dead cached lane and reopen");
     const POST: usize = 25;
     for seq in 0..POST {
         let dg = AudioDatagram {
@@ -779,14 +794,18 @@ async fn connection_churn_falls_back_to_reliable() {
             .expect("post-churn send must fall back to the reliable lane");
     }
 
+    // Count AUDIO frames only: the primed + evicted Data-lane frames
+    // also surface here (same inbound queue) and prove their own
+    // delivery by arriving at all.
     let mut received = 0usize;
     let deadline = Instant::now() + Duration::from_secs(30);
     while received < POST && Instant::now() < deadline {
         let remaining = deadline.saturating_duration_since(Instant::now());
         match tokio::time::timeout(remaining, bob_link.receive()).await {
             Ok(Ok((_, ty, _))) => {
-                assert_eq!(ty, StreamType::Audio);
-                received += 1;
+                if ty == StreamType::Audio {
+                    received += 1;
+                }
             }
             Ok(Err(e)) => panic!("bob receive failed: {e}"),
             Err(_) => break,
@@ -794,12 +813,54 @@ async fn connection_churn_falls_back_to_reliable() {
     }
     assert_eq!(
         received, POST,
-        "post-churn frames must arrive via the reliable lane"
+        "post-churn audio frames must arrive via the reliable lane"
     );
     assert_eq!(
         alice_link.datagram_frames_sent(),
         sent_at_churn,
         "no post-churn frame may leave as a datagram"
+    );
+
+    let _ = alice_link.stop().await;
+    let _ = bob_link.stop().await;
+    alice.shutdown().await;
+    bob.shutdown().await;
+}
+
+/// Sequential startup regression (Codex r2 finding 1): DM subscribers
+/// only receive FUTURE messages, so a peer that starts AFTER our first
+/// challenge never sees it. The periodic advert retry (2 s cadence,
+/// 20 s budget) must recover mutual capability even when one side is
+/// already running for seconds before the other starts — the one-shot
+/// implementation silently timed out here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback sequential-startup negotiation; binds UDP. Integration tier."]
+async fn sequential_startup_still_negotiates_datagram_lane() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    // Alice fully starts FIRST — her initial challenge is fanned out
+    // long before bob's listener exists (well past the DM window).
+    let mut alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+    alice_link.start().await.expect("alice link starts alone");
+    assert!(
+        !alice_link.peer_datagram_capable(),
+        "no peer yet — lane must not be capable"
+    );
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Bob starts NOW; alice's retry cadence must deliver a fresh
+    // challenge his subscriber can see, and his ack must flip her lane.
+    let mut bob_link = X0xLinkTransport::new(Arc::clone(&bob), alice.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+    bob_link.start().await.expect("bob link starts late");
+
+    assert!(
+        await_mutual_capability(&alice_link, &bob_link).await,
+        "periodic advert retry must recover negotiation across sequential startup"
     );
 
     let _ = alice_link.stop().await;

--- a/tests/voice_datagram_e2e.rs
+++ b/tests/voice_datagram_e2e.rs
@@ -1,0 +1,525 @@
+//! Datagram audio lane e2e (ADR-0042 decision (c), feature `voice`).
+//!
+//! Mirrors `voice_e2e.rs` with BOTH transports pinned
+//! [`AudioLaneMode::Datagram`]: the same real Opus pipeline (encode →
+//! `AudioDatagram` wire framing → lane → jitter buffer → decode), but
+//! audio rides **unreliable QUIC datagrams** on the peer connection
+//! instead of the ordered `WebRtcV1` stream.
+//!
+//! Why a separate file (not a mode flag inside `voice_e2e`): the two
+//! files pin different contracts. `voice_e2e` guards the reliable lane's
+//! ≥99 %/SNR/latency posture; this file guards the datagram lane's
+//! ≥96 % post-jitter gate (the saorsa-webrtc `e2e_datagram_lane.rs`
+//! standard) under both clean loopback and injected loss/reorder, plus
+//! the lane-routing proof — the frame counters must show audio actually
+//! left as datagrams, so a silent reliable-fallback bug cannot pass as
+//! green.
+//!
+//! `#[ignore]`: binds real UDP sockets and waits on loopback convergence
+//! (integration tier, like `voice_e2e.rs`).
+
+#![cfg(feature = "voice")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::f64::consts::TAU;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use saorsa_webrtc_core::link_transport::{LinkTransport, StreamType};
+use saorsa_webrtc_core::{AudioDatagram, JitterBuffer, JitterConfig, JitterEvent};
+use tempfile::TempDir;
+use x0x::network::NetworkConfig;
+use x0x::voice::codecs::opus::{
+    samples_per_20ms, AudioFrame, Channels, OpusDecoder, OpusEncoder, OpusEncoderConfig, SampleRate,
+};
+use x0x::voice::{AudioLaneMode, X0xLinkTransport};
+use x0x::DiscoveredAgent;
+
+const FRAMES: usize = 250;
+const TONE_A_HZ: f64 = 440.0;
+const TONE_B_HZ: f64 = 1200.0;
+
+/// Post-jitter delivery gate on the datagram lane (the saorsa-webrtc
+/// `e2e_datagram_lane.rs` standard — looser than the reliable lane's
+/// ≥99 % because datagrams may legitimately be lost).
+const MIN_DELIVERED_PERCENT: usize = 96;
+
+fn loopback_network_config() -> NetworkConfig {
+    NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr literal")),
+        bootstrap_nodes: Vec::new(),
+        ..NetworkConfig::default()
+    }
+}
+
+fn is_network_bind_permission_error(error: &impl std::fmt::Display) -> bool {
+    let message = error.to_string();
+    message.contains("Operation not permitted")
+        && (message.contains("bind UDP socket")
+            || message.contains("network initialization failed"))
+}
+
+async fn build_agent(dir: &TempDir, name: &str) -> Option<x0x::Agent> {
+    match x0x::Agent::builder()
+        .with_machine_key(dir.path().join(format!("{name}-machine.key")))
+        .with_agent_key_path(dir.path().join(format!("{name}-agent.key")))
+        .with_contact_store_path(dir.path().join(format!("{name}-contacts.json")))
+        .with_peer_cache_dir(dir.path().join(format!("{name}-peer-cache")))
+        .with_network_config(loopback_network_config())
+        .build()
+        .await
+    {
+        Ok(agent) => Some(agent),
+        Err(e) if is_network_bind_permission_error(&e) => None,
+        Err(e) => panic!("agent build failed: {e}"),
+    }
+}
+
+fn normalize_loopback(addr: std::net::SocketAddr) -> std::net::SocketAddr {
+    if addr.ip().is_unspecified() {
+        std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            addr.port(),
+        )
+    } else {
+        addr
+    }
+}
+
+fn discovered_agent(
+    agent: &x0x::Agent,
+    addr: std::net::SocketAddr,
+    now_secs: u64,
+) -> DiscoveredAgent {
+    DiscoveredAgent {
+        agent_id: agent.agent_id(),
+        machine_id: agent.machine_id(),
+        user_id: None,
+        addresses: vec![addr],
+        announced_at: now_secs,
+        last_seen: now_secs,
+        machine_public_key: Vec::new(),
+        nat_type: None,
+        can_receive_direct: Some(true),
+        is_relay: None,
+        is_coordinator: None,
+        reachable_via: Vec::new(),
+        relay_candidates: Vec::new(),
+        cert_not_after: None,
+        agent_certificate: None,
+        agent_public_key: Vec::new(),
+    }
+}
+
+async fn trusted_pair(dir: &TempDir) -> Option<(Arc<x0x::Agent>, Arc<x0x::Agent>)> {
+    let alice = Arc::new(build_agent(dir, "alice").await?);
+    let bob = Arc::new(build_agent(dir, "bob").await?);
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let bob_addr = normalize_loopback(bob_network.bound_addr().await.expect("bob bound"));
+    let alice_addr = normalize_loopback(alice_network.bound_addr().await.expect("alice bound"));
+    alice_network
+        .connect_addr(bob_addr)
+        .await
+        .expect("alice connects to bob");
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+    let alice_peer = ant_quic::PeerId(alice.machine_id().0);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if alice_network.is_connected(&bob_peer).await
+            && bob_network.is_connected(&alice_peer).await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_secs();
+    alice
+        .insert_discovered_agent_for_testing(discovered_agent(&bob, bob_addr, now_secs))
+        .await;
+    alice.set_contact_trusted_for_testing(bob.agent_id()).await;
+    bob.insert_discovered_agent_for_testing(discovered_agent(&alice, alice_addr, now_secs))
+        .await;
+    bob.set_contact_trusted_for_testing(alice.agent_id()).await;
+    Some((alice, bob))
+}
+
+fn tone_frame(frame_idx: usize, samples: usize) -> Vec<i16> {
+    let sr = f64::from(SampleRate::Hz48000.as_hz());
+    (0..samples)
+        .map(|i| {
+            let t = (frame_idx * samples + i) as f64 / sr;
+            let v = 0.4 * (TAU * TONE_A_HZ * t).sin() + 0.3 * (TAU * TONE_B_HZ * t).sin();
+            (v * f64::from(i16::MAX) * 0.5) as i16
+        })
+        .collect()
+}
+
+fn goertzel(pcm: &[i16], freq: f64) -> f64 {
+    let sr = f64::from(SampleRate::Hz48000.as_hz());
+    let w = TAU * freq / sr;
+    let coeff = 2.0 * w.cos();
+    let (mut s1, mut s2) = (0.0f64, 0.0f64);
+    for &x in pcm {
+        let s0 = f64::from(x) + coeff * s1 - s2;
+        s2 = s1;
+        s1 = s0;
+    }
+    (s1 * s1 + s2 * s2 - coeff * s1 * s2) / pcm.len() as f64
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_millis() as u64
+}
+
+/// Both sides must see the peer's advert before media flows — the switch
+/// to datagrams is gated on it, so waiting here makes the frame-counter
+/// assertions below exact (`sent == FRAMES`), not racy.
+async fn await_mutual_capability(alice: &X0xLinkTransport, bob: &X0xLinkTransport) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline {
+        if alice.peer_datagram_capable() && bob.peer_datagram_capable() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    false
+}
+
+/// Outcome of one datagram-lane call: receiver stats plus both sides'
+/// lane counters (the links are consumed by the call, so the counters
+/// ride out as values).
+struct CallOutcome {
+    pcm: Vec<i16>,
+    latencies_ms: Vec<u64>,
+    delivered: usize,
+    gaps: usize,
+    /// Datagrams sent by the caller (routing proof: must equal FRAMES).
+    datagrams_sent: u64,
+    /// Datagrams decoded + queued by the callee.
+    datagrams_received: u64,
+}
+
+/// Drive the full pipeline over the datagram lane.
+async fn run_call(mut bob_link: X0xLinkTransport, mut alice_link: X0xLinkTransport) -> CallOutcome {
+    bob_link.start().await.expect("bob link");
+    alice_link.start().await.expect("alice link");
+    assert!(
+        await_mutual_capability(&alice_link, &bob_link).await,
+        "mutual datagram capability advert did not land — DM path broken?"
+    );
+
+    let receiver = tokio::spawn(async move {
+        let mut jitter = JitterBuffer::new(JitterConfig::default());
+        let mut decoder = OpusDecoder::new(SampleRate::Hz48000, Channels::Mono).expect("decoder");
+        let mut pcm: Vec<i16> = Vec::new();
+        let mut latencies_ms: Vec<u64> = Vec::new();
+        let mut delivered = 0usize;
+        let mut gaps = 0usize;
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while delivered + gaps < FRAMES && Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Ok(Ok((_, ty, data))) = tokio::time::timeout(remaining, bob_link.receive()).await
+            else {
+                break;
+            };
+            if ty != StreamType::Audio {
+                continue;
+            }
+            let dg = AudioDatagram::decode(data.into()).expect("wire decode");
+            latencies_ms.push(now_ms().saturating_sub(dg.timestamp_ms));
+            jitter.push(dg);
+            for ev in jitter.poll_ready() {
+                match ev {
+                    JitterEvent::Frame(f) => {
+                        pcm.extend_from_slice(
+                            &decoder.decode(&f.payload).expect("opus decode").data,
+                        );
+                        delivered += 1;
+                    }
+                    JitterEvent::Gap { .. } => gaps += 1,
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        for ev in jitter.poll_ready() {
+            match ev {
+                JitterEvent::Frame(f) => {
+                    pcm.extend_from_slice(&decoder.decode(&f.payload).expect("opus decode").data);
+                    delivered += 1;
+                }
+                JitterEvent::Gap { .. } => gaps += 1,
+            }
+        }
+        // Capture the receive-side lane counter before stop() drops it.
+        let datagrams_received = bob_link.datagram_frames_received();
+        let _ = bob_link.stop().await;
+        (pcm, latencies_ms, delivered, gaps, datagrams_received)
+    });
+
+    let samples = samples_per_20ms(SampleRate::Hz48000);
+    let mut encoder = OpusEncoder::new(OpusEncoderConfig::default()).expect("encoder");
+    for seq in 0..FRAMES {
+        let frame = AudioFrame {
+            data: tone_frame(seq, samples),
+            sample_rate: SampleRate::Hz48000,
+            channels: Channels::Mono,
+            timestamp: (seq * 20) as u64,
+        };
+        let payload = encoder.encode(&frame).expect("opus encode");
+        let dg = AudioDatagram {
+            seq: seq as u32,
+            timestamp_ms: now_ms(),
+            flags: 0,
+            payload,
+        };
+        let wire = dg.encode().expect("wire encode");
+        let peer = alice_link.default_peer().expect("default peer");
+        alice_link
+            .send(&peer, StreamType::Audio, &wire)
+            .await
+            .expect("send frame");
+        // Real-audio pacing (one 20 ms frame per tick): the jitter
+        // buffer's reorder window is 3 frames/60 ms, so a tight burst
+        // would exceed it BY CONSTRUCTION (dozens in flight, independent
+        // per-packet delays) and emit false gaps — that would test the
+        // proxy, not the lane. Real capture is paced; loss, not burst
+        // reorder, is the condition under test.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let (pcm, latencies_ms, delivered, gaps, datagrams_received) =
+        receiver.await.expect("receiver task");
+    let datagrams_sent = alice_link.datagram_frames_sent();
+    let _ = alice_link.stop().await;
+    CallOutcome {
+        pcm,
+        latencies_ms,
+        delivered,
+        gaps,
+        datagrams_sent,
+        datagrams_received,
+    }
+}
+
+/// Lossy, reordering UDP proxy: two-party (1:1 call scope) — side B is
+/// pinned to `bob_addr` at construction (bob otherwise never sends to
+/// the proxy, so it could never be learned from traffic); the first
+/// OTHER source address to send becomes side A. Every packet between
+/// the sides is forwarded with `drop_pct` % loss and 0–7 ms of
+/// per-packet jitter. Jittered per-packet delays are what create
+/// reordering (a fixed delay would preserve order). QUIC's own loss
+/// recovery retransmits the reliable traffic (handshake, signaling DMs,
+/// stream lanes); the datagram lane must eat the loss with the jitter
+/// buffer — exactly the condition ADR-0042 (c) exists for.
+struct LossyUdpProxy {
+    addr: std::net::SocketAddr,
+}
+
+/// Tiny LCG — deterministic, no rand dependency.
+struct Lcg(u64);
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.0 >> 16
+    }
+}
+
+async fn spawn_lossy_udp_proxy(drop_pct: u64, bob_addr: std::net::SocketAddr) -> LossyUdpProxy {
+    let sock = Arc::new(
+        tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("proxy bind"),
+    );
+    let addr = sock.local_addr().expect("proxy addr");
+    let recv = Arc::clone(&sock);
+    tokio::spawn(async move {
+        // PQC handshakes can carry multi-kilobyte datagrams; size the
+        // buffer for the UDP maximum so nothing is truncated silently.
+        let mut buf = vec![0u8; 65_507];
+        // Side B is pinned (bob's real socket); the first other source
+        // address to send becomes side A (alice's QUIC socket).
+        let mut sides: [Option<std::net::SocketAddr>; 2] = [None, Some(bob_addr)];
+        let mut rng = Lcg(0x5EED_1234_ABCD_0001);
+        loop {
+            let (n, from) = match recv.recv_from(&mut buf).await {
+                Ok(x) => x,
+                Err(_) => break,
+            };
+            if sides.contains(&Some(from)) {
+                // known side
+            } else if from == bob_addr || sides[0].is_some() {
+                continue; // third party — two-party proxy by contract
+            } else {
+                sides[0] = Some(from);
+            }
+            let (Some(a), Some(b)) = (sides[0], sides[1]) else {
+                continue; // only one side seen yet
+            };
+            let to = if from == a { b } else { a };
+            if rng.next() % 100 < drop_pct {
+                continue; // injected loss
+            }
+            let delay_ms = rng.next() % 8; // 0–7 ms → reordering
+            let data = buf[..n].to_vec();
+            let fwd = Arc::clone(&recv);
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                let _ = fwd.send_to(&data, to).await;
+            });
+        }
+    });
+    LossyUdpProxy { addr }
+}
+
+/// Clean-loopback datagram parity with the reliable path: the full Opus
+/// pipeline over QUIC datagrams — ≥96 % post-jitter (saorsa
+/// `e2e_datagram_lane` gate), tone SNR sanity, p95 < 100 ms — and the
+/// routing proof: every audio frame left as a datagram (a silent
+/// reliable-fallback bug cannot pass this).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback datagram voice pipeline; binds UDP + waits on convergence. Integration tier."]
+async fn datagram_lane_delivers_decodable_audio_on_loopback() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    let alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+    let bob_link = X0xLinkTransport::new(Arc::clone(&bob), alice.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+
+    let out = run_call(bob_link, alice_link).await;
+
+    // Routing proof: all audio took the datagram lane, both directions
+    // of the contract (sent as datagrams, consumed as datagrams).
+    assert_eq!(
+        out.datagrams_sent, FRAMES as u64,
+        "every audio frame must leave as a datagram"
+    );
+    assert!(
+        out.datagrams_received >= out.delivered as u64,
+        "datagrams received ({}) must cover post-jitter delivery ({})",
+        out.datagrams_received,
+        out.delivered
+    );
+
+    assert!(
+        out.delivered * 100 >= FRAMES * MIN_DELIVERED_PERCENT,
+        "delivered {}/{} (gaps {}) — below {MIN_DELIVERED_PERCENT}%",
+        out.delivered,
+        FRAMES,
+        out.gaps
+    );
+
+    let p_a = goertzel(&out.pcm, TONE_A_HZ);
+    let p_b = goertzel(&out.pcm, TONE_B_HZ);
+    let p_off = goertzel(&out.pcm, 700.0).max(1e-9);
+    assert!(
+        p_a / p_off > 100.0 && p_b / p_off > 100.0,
+        "decoded tone SNR too low: 440Hz ratio {:.1}, 1200Hz ratio {:.1}",
+        p_a / p_off,
+        p_b / p_off
+    );
+
+    let mut sorted = out.latencies_ms;
+    sorted.sort_unstable();
+    if !sorted.is_empty() {
+        let p95 = sorted[((sorted.len() as f64 - 1.0) * 0.95) as usize];
+        assert!(p95 < 100, "p95 one-way frame latency {p95} ms ≥ 100 ms");
+    }
+
+    alice.shutdown().await;
+    bob.shutdown().await;
+}
+
+/// The ADR-0042 (c) condition itself: 2 % injected loss + 0–7 ms
+/// reordering through a UDP proxy between the two agents. The datagram
+/// lane must still deliver ≥96 % of frames post-jitter — loss costs
+/// single frames, never head-of-line blocking.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "lossy-proxy datagram voice pipeline; binds UDP + injects loss/reorder. Integration tier."]
+async fn datagram_lane_survives_injected_loss_and_reorder() {
+    let dir = TempDir::new().expect("tmpdir");
+    let alice = Arc::new(build_agent(&dir, "alice").await.expect("agent"));
+    let bob = Arc::new(build_agent(&dir, "bob").await.expect("agent"));
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let bob_addr = normalize_loopback(bob_network.bound_addr().await.expect("bob bound"));
+    let proxy = spawn_lossy_udp_proxy(2, bob_addr).await;
+    alice_network
+        .connect_addr(proxy.addr)
+        .await
+        .expect("alice connects through the lossy proxy");
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+    let alice_peer = ant_quic::PeerId(alice.machine_id().0);
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if alice_network.is_connected(&bob_peer).await
+            && bob_network.is_connected(&alice_peer).await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        alice_network.is_connected(&bob_peer).await,
+        "connection through the lossy proxy must converge (QUIC loss recovery)"
+    );
+
+    let alice_addr = normalize_loopback(alice_network.bound_addr().await.expect("alice bound"));
+    let bob_addr = normalize_loopback(bob_network.bound_addr().await.expect("bob bound"));
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_secs();
+    alice
+        .insert_discovered_agent_for_testing(discovered_agent(&bob, bob_addr, now_secs))
+        .await;
+    alice.set_contact_trusted_for_testing(bob.agent_id()).await;
+    bob.insert_discovered_agent_for_testing(discovered_agent(&alice, alice_addr, now_secs))
+        .await;
+    bob.set_contact_trusted_for_testing(alice.agent_id()).await;
+
+    let alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+    let bob_link = X0xLinkTransport::new(Arc::clone(&bob), alice.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+
+    let out = run_call(bob_link, alice_link).await;
+
+    // 2 % injected loss must not cost more than the datagram gate allows:
+    // ≥96 % of frames still delivered post-jitter. (The jitter buffer's
+    // reorder window covers the 0–7 ms reorder; anything beyond surfaces
+    // as a bounded Gap, exactly like real-network jitter.)
+    assert!(
+        out.delivered * 100 >= FRAMES * MIN_DELIVERED_PERCENT,
+        "delivered {}/{} (gaps {}) under 2% loss + reorder — below {MIN_DELIVERED_PERCENT}%",
+        out.delivered,
+        FRAMES,
+        out.gaps
+    );
+    // And the lane must have carried the audio as datagrams throughout.
+    assert_eq!(
+        out.datagrams_sent, FRAMES as u64,
+        "every audio frame must leave as a datagram"
+    );
+
+    alice.shutdown().await;
+    bob.shutdown().await;
+}

--- a/tests/voice_datagram_e2e.rs
+++ b/tests/voice_datagram_e2e.rs
@@ -70,7 +70,12 @@ async fn build_agent(dir: &TempDir, name: &str) -> Option<x0x::Agent> {
         .await
     {
         Ok(agent) => Some(agent),
-        Err(e) if is_network_bind_permission_error(&e) => None,
+        // Explicit skip, never a silent pass (Codex review P2): without
+        // real UDP sockets this e2e proves nothing, so say so loudly.
+        Err(e) if is_network_bind_permission_error(&e) => {
+            eprintln!("SKIP: UDP binds forbidden in this environment — datagram e2e requires real sockets");
+            None
+        }
         Err(e) => panic!("agent build failed: {e}"),
     }
 }
@@ -520,6 +525,285 @@ async fn datagram_lane_survives_injected_loss_and_reorder() {
         "every audio frame must leave as a datagram"
     );
 
+    alice.shutdown().await;
+    bob.shutdown().await;
+}
+
+/// Flood defense (ADR-0042 addendum): the per-connection inbound byte
+/// ceiling must make a datagram flood cost the SENDER, not the lane —
+/// excess is dropped and counted, and the limiter must recover (bucket
+/// refills) so legitimate post-flood audio still flows. 300 × ~1 KB
+/// valid frames in a tight loop ≈ 300 KB against a 50 KB burst +
+/// 100 KB/s ceiling ⇒ a large fraction must drop on any fast machine.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback datagram flood; binds UDP. Integration tier."]
+async fn datagram_flood_rate_limited_and_lane_recovers() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    let mut alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+    let mut bob_link = X0xLinkTransport::new(Arc::clone(&bob), alice.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+    bob_link.start().await.expect("bob link");
+    alice_link.start().await.expect("alice link");
+    assert!(
+        await_mutual_capability(&alice_link, &bob_link).await,
+        "mutual datagram capability advert did not land"
+    );
+
+    const FLOOD: u32 = 300;
+    let peer = alice_link.default_peer().expect("default peer");
+    for seq in 0..FLOOD {
+        let dg = AudioDatagram {
+            seq,
+            timestamp_ms: now_ms(),
+            flags: 0,
+            payload: bytes::Bytes::from(vec![0u8; 1000]), // ~1 KB wire frame
+        };
+        let wire = dg.encode().expect("wire encode");
+        alice_link
+            .send(&peer, StreamType::Audio, &wire)
+            .await
+            .expect("send flood frame");
+    }
+
+    // Let the reader drain and the counters settle.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let dropped = bob_link.datagram_rate_limited_dropped();
+    let received = bob_link.datagram_frames_received();
+    assert!(
+        dropped > 0,
+        "a {FLOOD}-frame ~1 KB tight-loop flood (~{} KB) must exceed the 50 KB burst + 100 KB/s ceiling",
+        FLOOD
+    );
+    assert!(
+        received < u64::from(FLOOD),
+        "not all flood frames may be accepted (received {received}, dropped {dropped})"
+    );
+
+    // Recovery: after the bucket refills, paced real-rate audio still
+    // flows (the limiter is a token bucket, not a circuit breaker).
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    for seq in FLOOD..FLOOD + 10 {
+        let dg = AudioDatagram {
+            seq,
+            timestamp_ms: now_ms(),
+            flags: 0,
+            payload: bytes::Bytes::from(vec![0u8; 200]),
+        };
+        let wire = dg.encode().expect("wire encode");
+        alice_link
+            .send(&peer, StreamType::Audio, &wire)
+            .await
+            .expect("send post-flood frame");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Drain: flood leftovers first, then the paced tail. Recovery is
+    // proven by any post-flood seq (≥ FLOOD) surfacing.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut max_seq = None;
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, bob_link.receive()).await {
+            Ok(Ok((_, ty, data))) => {
+                assert_eq!(ty, StreamType::Audio);
+                if let Ok(dg) = AudioDatagram::decode(data.into()) {
+                    max_seq = Some(max_seq.map_or(dg.seq, |m: u32| m.max(dg.seq)));
+                    if dg.seq >= FLOOD {
+                        break; // post-flood frame surfaced — lane recovered
+                    }
+                }
+            }
+            Ok(Err(e)) => panic!("bob receive failed: {e}"),
+            Err(_) => break,
+        }
+    }
+    assert!(
+        max_seq.is_some_and(|s| s >= FLOOD),
+        "post-flood paced audio must still flow after the byte ceiling refills (max seq {max_seq:?})"
+    );
+
+    let _ = alice_link.stop().await;
+    let _ = bob_link.stop().await;
+    alice.shutdown().await;
+    bob.shutdown().await;
+}
+
+/// Advert authentication + session binding (Codex review P1-1): a
+/// connected, authenticated peer that is NOT running a datagram-capable
+/// transport must not be able to flip our lane by sending crafted
+/// advert frames — right sender id, right (authenticated) machine, but
+/// no valid echo of OUR per-start nonce. Every variant (old v1 shape,
+/// bogus response, bare challenge) must leave the lane un-flipped.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback advert-auth proof; binds UDP. Integration tier."]
+async fn spoofed_or_replayed_advert_cannot_flip_lane() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    // Alice pins Datagram; bob runs NO transport at all (old-peer
+    // stand-in — nothing of his will ever legitimately respond).
+    let mut alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+    alice_link.start().await.expect("alice link");
+
+    // Crafted advert frames from the REAL bob (his DMs carry the right
+    // authenticated machine + verified + trust) — the auth layer alone
+    // would pass all of these; only the nonce binding must stop them.
+    let crafted = [
+        // v1 shape (no challenge/response) — a replay of an old build.
+        r#"{"type":"x0x_datagram_cap","datagram":true}"#,
+        // Bogus response echo.
+        r#"{"type":"x0x_datagram_cap","datagram":true,"response":"0000000000000000"}"#,
+        // A bare challenge (peer initial) — must never flip OUR lane.
+        r#"{"type":"x0x_datagram_cap","datagram":true,"challenge":"deadbeef"}"#,
+    ];
+    for body in crafted {
+        let mut payload = x0x::voice::VOICE_SIGNALING_DM_PREFIX.to_vec();
+        payload.extend_from_slice(body.as_bytes());
+        bob.send_direct(&alice.agent_id(), payload)
+            .await
+            .expect("crafted advert DM delivered");
+    }
+    // Give the listener ample time to (wrongly) process them.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert!(
+        !alice_link.peer_datagram_capable(),
+        "crafted/replayed adverts without our nonce echo must never flip the lane"
+    );
+    assert_eq!(
+        alice_link.datagram_frames_sent(),
+        0,
+        "lane never flipped, so no audio left as datagrams"
+    );
+
+    let _ = alice_link.stop().await;
+    alice.shutdown().await;
+    bob.shutdown().await;
+}
+
+/// Connection churn must degrade the lane, never kill the call (Codex
+/// review P1-3): after the negotiated connection closes, the reader
+/// exits and clears capability, and subsequent audio flows over the
+/// reliable stream (re-opened through the redial machinery) instead of
+/// wedging on the dead datagram connection.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback churn-fallback proof; binds UDP. Integration tier."]
+async fn connection_churn_falls_back_to_reliable() {
+    let dir = TempDir::new().expect("tmpdir");
+    let Some((alice, bob)) = trusted_pair(&dir).await else {
+        return;
+    };
+
+    let mut alice_link = X0xLinkTransport::new(Arc::clone(&alice), bob.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+    let mut bob_link = X0xLinkTransport::new(Arc::clone(&bob), alice.agent_id())
+        .with_audio_lane_mode(AudioLaneMode::Datagram);
+    bob_link.start().await.expect("bob link");
+    alice_link.start().await.expect("alice link");
+    assert!(
+        await_mutual_capability(&alice_link, &bob_link).await,
+        "mutual capability must land before the churn"
+    );
+
+    // Kill the connection alice's datagram lane negotiated on, then
+    // bring up its REPLACEMENT (realistic churn: the old connection is
+    // gone, a new one takes over — `disconnect` removes the peer, so the
+    // reliable path needs the replacement before open_bi can succeed).
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_addr = normalize_loopback(
+        bob.network()
+            .expect("bob network")
+            .bound_addr()
+            .await
+            .expect("bob bound"),
+    );
+    alice_network
+        .disconnect(&bob_peer)
+        .await
+        .expect("disconnect");
+    alice_network
+        .connect_addr(bob_addr)
+        .await
+        .expect("replacement connection");
+    // Let the replacement converge on BOTH sides (same discipline as
+    // `trusted_pair`): a stream opened into a half-torn-down connection
+    // gets reset by the teardown, not by the peer's accept loop.
+    let alice_peer = ant_quic::PeerId(alice.machine_id().0);
+    let bob_network = bob.network().expect("bob network").clone();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if alice_network.is_connected(&bob_peer).await
+            && bob_network.is_connected(&alice_peer).await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // The reader must exit and clear capability (this is the regression:
+    // a stale capable flag would wedge every send on the dead lane).
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while alice_link.peer_datagram_capable() && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        !alice_link.peer_datagram_capable(),
+        "reader exit on connection close must clear the capability flag"
+    );
+    let sent_at_churn = alice_link.datagram_frames_sent();
+
+    // Post-churn audio: reliable lane, still delivered (open_peer_stream
+    // redials through the discovery cache).
+    let peer = alice_link.default_peer().expect("default peer");
+    const POST: usize = 25;
+    for seq in 0..POST {
+        let dg = AudioDatagram {
+            seq: seq as u32,
+            timestamp_ms: now_ms(),
+            flags: 0,
+            payload: bytes::Bytes::from(vec![0u8; 200]),
+        };
+        let wire = dg.encode().expect("wire encode");
+        alice_link
+            .send(&peer, StreamType::Audio, &wire)
+            .await
+            .expect("post-churn send must fall back to the reliable lane");
+    }
+
+    let mut received = 0usize;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while received < POST && Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, bob_link.receive()).await {
+            Ok(Ok((_, ty, _))) => {
+                assert_eq!(ty, StreamType::Audio);
+                received += 1;
+            }
+            Ok(Err(e)) => panic!("bob receive failed: {e}"),
+            Err(_) => break,
+        }
+    }
+    assert_eq!(
+        received, POST,
+        "post-churn frames must arrive via the reliable lane"
+    );
+    assert_eq!(
+        alice_link.datagram_frames_sent(),
+        sent_at_churn,
+        "no post-churn frame may leave as a datagram"
+    );
+
+    let _ = alice_link.stop().await;
+    let _ = bob_link.stop().await;
     alice.shutdown().await;
     bob.shutdown().await;
 }


### PR DESCRIPTION
Implements ADR-0042 decision (c) (accepted, PR #429): QUIC datagram audio lane through the gated x0x adapter — same identity + connect-ACL gates as streams (no voice bypass), challenge-response session-bound capability advert with periodic retry, per-connection byte-rate ceiling, typed `SessionConflict` for a second concurrent call, reliable-stream fallback that survives connection churn (evict+reopen), `Drop` teardown, throttled warns.

Review: 3-round loop — omp (GLM-5.3) implementation, Codex adversarial review + Claude verification; round-3 verdict **APPROVE**. Accepted documented v1 limitation (follow-up filed): per-datagram call/session wire discriminator + connection-level demux hub.

Gates: fmt ✓ clippy -D warnings ✓ nextest 2861/2862 (sole failure = pre-existing env `addr_is_free` probe) ✓ voice e2e tier 12/12 with real UDP incl. 2%-loss lossy-proxy, sequential-startup negotiation, and churn tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a gated QUIC-datagram audio lane with authenticated capability negotiation, byte-rate limiting, and reliable-stream fallback. It also refactors shared stream authorization and adds integration coverage for loss, startup ordering, ACL enforcement, session conflicts, and connection churn.

- Adds connection-level datagram access behind the existing identity, trust, revocation, and connect-ACL gates.
- Adds challenge-response lane negotiation and reliable fallback for unsupported peers or failed datagram sends.
- Adds typed concurrent-session rejection and expanded voice transport integration tests.
- The stop path currently leaves the capability-advert retry task running after teardown.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until stop() reliably cancels the capability-advert retry task so a terminated call cannot continue sending control traffic.

The new datagram transport is otherwise guarded and covered across its principal fallback paths, but its explicit teardown leaves one spawned task detached for up to the remainder of the negotiation window.

**Files Needing Attention:** src/voice/link_transport.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/voice/link_transport.rs | Implements the datagram lane, negotiation, limiting, fallback, and lifecycle management; stop omits cancellation of the advert retry task. |
| src/lib.rs | Extracts shared inbound and outbound authorization gates and exposes gated access to a connected peer's datagram lane. |
| src/network.rs | Adds a narrow wrapper that retrieves the authenticated peer's current QUIC connection for datagram use. |
| src/voice/signaling.rs | Separates x0x transport-extension frames from upstream voice signaling messages. |
| tests/voice_datagram_e2e.rs | Adds end-to-end coverage for datagram routing, loss and reorder tolerance, rate limiting, advert authentication, churn fallback, and sequential startup. |
| tests/voice_adapters.rs | Adds fallback, datagram ACL, and typed session-conflict integration coverage. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as Caller transport
    participant DM as Direct messaging
    participant B as Peer transport
    participant Q as QUIC connection
    A->>Q: Open gated datagram lane
    A->>DM: Advertise capability + challenge
    DM->>B: Deliver challenge
    B->>DM: Echo challenge
    DM->>A: Deliver response
    A->>A: Mark peer datagram-capable
    A->>Q: Send encoded audio datagrams
    alt Datagram unavailable or connection churn
        A->>B: Send audio on reliable stream
    end
    Note over A,DM: stop must cancel reader, listener, and advert retry
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/voice/link_transport.rs:974-977
**Advert retry survives teardown**

When `stop()` runs during capability negotiation, it drops the retry handle without aborting its task, causing the stopped call to retain the agent and continue sending stale capability challenges for the remainder of the retry window.

```suggestion
        if let Some(lane) = self.datagram.lock().await.take() {
            lane.reader.abort();
            lane.advert_listener.abort();
            lane.advert_retry.abort();
        }
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(voice): round-3 datagram lane harden..."](https://github.com/saorsa-labs/x0x/commit/188e2fbb1a53c53b6c3a93ada2dd94e66ce7f106) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57767380)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->