### PR TITLE
fix(upgrade): probe exact bind address in addr_is_free

### DIFF
--- a/src/upgrade/restart.rs
+++ b/src/upgrade/restart.rs
@@ -653,24 +653,17 @@ fn pid_alive(_pid: u32) -> bool {
     false
 }
 
-/// Whether a loopback probe can bind the address right now. Unspecified IPs
-/// are probed on loopback. `AddrInUse` is the only "busy" answer; anything
-/// else (firewalled, unsupported family) reads as free so the wait cannot
+/// Whether the exact address can be bound right now. The probe binds the
+/// address verbatim — including unspecified wildcard binds — because that is
+/// precisely what the restarted daemon will attempt. BSD `SO_REUSEADDR`
+/// permits overlapping wildcard/specific binds, so substituting loopback for
+/// a wildcard address can report a held port as free; an exact-duplicate
+/// bind is refused on every platform (`SO_REUSEPORT` would be required to
+/// steal it). `AddrInUse` is the only "busy" answer; anything else
+/// (firewalled, unsupported family) reads as free so the wait cannot
 /// deadlock on exotic setups.
 fn addr_is_free(addr: SocketAddr) -> bool {
-    let probe = if addr.ip().is_unspecified() {
-        SocketAddr::new(
-            if addr.is_ipv4() {
-                std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
-            } else {
-                std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)
-            },
-            addr.port(),
-        )
-    } else {
-        addr
-    };
-    match TcpListener::bind(probe) {
+    match TcpListener::bind(addr) {
         Ok(listener) => {
             drop(listener);
             true
@@ -1074,11 +1067,18 @@ mod tests {
     }
 
     #[test]
-    fn addr_is_free_probes_loopback_for_unspecified_bind() {
+    fn addr_is_free_detects_wildcard_bound_port() {
         let listener = TcpListener::bind(("0.0.0.0", 0)).unwrap();
         let addr = listener.local_addr().unwrap();
         assert!(!addr_is_free(addr));
         drop(listener);
+        // Same small race window after drop as above; the wildcard address
+        // must read free again so the release wait cannot wedge.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && !addr_is_free(addr) {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(addr_is_free(addr));
     }
 
     #[test]


### PR DESCRIPTION
## Root cause

`upgrade::restart::tests::addr_is_free_probes_loopback_for_unspecified_bind` has failed deterministically on macOS for weeks (verified on pristine `origin/main` at d5d652f and since) while passing Linux CI.

`addr_is_free` guarded the self-update restart by bind-probing the port, but for unspecified (wildcard) bind addresses it first substituted loopback: a daemon on `0.0.0.0:PORT` was probed as `127.0.0.1:PORT`. Rust std sets `SO_REUSEADDR` on `TcpListener::bind` on Unix, and BSD-derived stacks (macOS) permit **overlapping wildcard/specific binds** under `SO_REUSEADDR` — so while the old daemon still held `0.0.0.0:PORT`, the loopback probe bound successfully and the guard read the port as **free**. Linux refuses that overlap, which is why CI never caught it.

Empirical confirmation on macOS 25.6 (Apple Silicon), listeners created with `SO_REUSEADDR` exactly as std does:

| Held listener | Probe bind | Result |
|---|---|---|
| `0.0.0.0:P` | `127.0.0.1:P` (old probe) | **succeeds** — reads free while taken |
| `0.0.0.0:P` | `0.0.0.0:P` (new probe) | `EADDRINUSE` — correct |

## The fix

Probe the recorded address **verbatim**, including wildcard binds. `api_addr` at both call sites (`bounded_graceful_wait`, `wait_for_old_process_release`) is exactly the address the old daemon bound and the replacement will bind — so the honest question is "can that exact address be bound right now?" An exact-duplicate bind is refused on every platform (`SO_REUSEADDR` permits overlap, never duplicates — stealing one needs `SO_REUSEPORT`), so the guard is now faithful on macOS and Linux alike. No `#[ignore]`, no cfg-skip.

The regression test is renamed to `addr_is_free_detects_wildcard_bound_port` and **strengthened**: besides asserting a held wildcard port reads taken, it now also asserts the address reads free again after the listener drops — proving the probe can't wedge the release wait into a permanent "busy".

## Why every recent gate run carried this

Each recent x0x PR gate run has had to note this failure as "known env / known macOS flake" (e.g. the scratch briefs for recent task batches). Merging this retires that caveat — `cargo nextest run --all-features` now runs clean on macOS with no carve-outs.

## Gates (this machine, macOS arm64)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo clippy --all-features --lib --bins -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used` — clean
- `cargo nextest run --all-features` — **2857/2857 passed** (target test green on the machine where it always failed)

## Unrelated observations (not addressed here)

- `tests::suppressed_peer_outbound_dial_is_refused` (src/lib.rs:17184) is a **pre-existing flake**: reproduced failing 3/8 runs on pristine `origin/main` @ 62c77f6 in a clean worktree, same nondeterministic assertion values. Separate issue.
- `origin/main` @ e884b21 (#431) does not compile its test targets (`tests/voice_datagram_e2e.rs`: missing field `self_name` in `DiscoveredAgent` initializer). This branch is cut from 62c77f6 and is unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects restart availability checks by probing the daemon’s recorded bind address verbatim, preventing wildcard listeners from appearing free on BSD-derived platforms.
- Removes wildcard-to-loopback address substitution from `addr_is_free`.
- Strengthens the wildcard regression test to verify both occupied and released states.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code defects identified.

The availability probe now checks the same fixed-port address used by the old and replacement listeners, correctly preventing premature restart on wildcard binds while preserving release detection.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/upgrade/restart.rs | The exact-address probe matches fixed-port daemon bind behavior and the updated regression test covers wildcard occupation and release without introducing a changed-code defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(upgrade): probe exact bind address i..."](https://github.com/saorsa-labs/x0x/commit/7a8382a090e52f9e2d1bc21da49c34e0500a001a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57827590)</sub>

<!-- /greptile_comment -->