### PR TITLE
fix(tests): repair main compile break from #430/#431 cross-merge

### DIFF
--- a/tests/voice_datagram_e2e.rs
+++ b/tests/voice_datagram_e2e.rs
@@ -113,6 +113,7 @@ fn discovered_agent(
         cert_not_after: None,
         agent_certificate: None,
         agent_public_key: Vec::new(),
+        self_name: None,
     }
 }
 


### PR DESCRIPTION
## What broke

`origin/main` fails to compile under `--all-features`:

```
error[E0063]: missing field `self_name` in initializer of `DiscoveredAgent`
  --> tests/voice_datagram_e2e.rs:99:5
```

## Root cause: concurrent-merge cross-break

- **#430** (ADR-0036 owner singleton + naming registry) added `pub self_name: Option<String>` to `DiscoveredAgent` (src/lib.rs:1683).
- **#431** (ADR-0042 voice datagram lane) added `tests/voice_datagram_e2e.rs` with a `discovered_agent(...)` fixture written against the **pre-#430** struct — its initializer omits `self_name`.

Each PR's CI ran against a merge ref that predated the other's landing, so both went green independently; after both merged, main was red for every subsequent `--all-targets`/`--all-features` build (clippy, check, nextest compile step).

## The fix

One line: `self_name: None` in the fixture initializer (`None` is correct — the fixture announces no self-name; the field is `Option<String>` for "peer set one"). All six tests in the file are `#[ignore]`d integration-tier (bind real UDP), so the damage was compile-only — no test could even run to catch it, which is exactly how a test-file compile break slips through per-PR CI.

## Unblocks #433

#433 (addr_is_free exact-address probe) is correct and verified, but its merge-ref Clippy job inherits this main breakage. Merging this restores main — and #433's CI — to green.

## Gates (macOS arm64, this machine, on this branch)

- `cargo check --workspace --all-targets --all-features` — **clean** (was the break)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo nextest run --all-features` — **2891/2891 passed** excluding the one documented pre-existing macOS failure `addr_is_free_probes_loopback_for_unspecified_bind`, which lives on main and is fixed by #433 (full run: 2195/2196 during the interrupted first pass, sole failure = that known one)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores all-targets/all-features compilation by initializing the newly required optional `self_name` field in the voice datagram test fixture.
- Sets `self_name` to `None`, matching a fixture that does not announce a peer-defined self-name.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The change supplies the newly required optional fixture field with the semantically appropriate empty value, and no blocking or non-blocking defects were identified.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tests/voice_datagram_e2e.rs | Adds the missing optional field to the `DiscoveredAgent` fixture initializer, resolving the compile failure without changing test behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tests): repair main compile break fr..."](https://github.com/saorsa-labs/x0x/commit/c7190545ed9e6aa9ab49d53cf8aa0003b11fc601) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57831446)</sub>

<!-- /greptile_comment -->