### PR TITLE
feat(home): ADR-0038 — Home auto-provisioning, primary agent, GUI owner space

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -162,7 +162,7 @@ Disabled unless an exec ACL is loaded with `[exec].enabled = true`. See
 
 | Method | Path | CLI | Description |
 |---|---|---|---|
-| POST | `/groups` | `x0x group create` | Create named group |
+| POST | `/groups` | `x0x group create` | Create named group. May carry `preset` OR an explicit `policy` object (never both); an `OwnerCertified` policy additionally requires this daemon's certificate to chain to the claimed owner (403 otherwise). The response echoes the **effective** policy — third-party callers that send an explicit policy MUST compare the echo and treat a missing/mismatching one as a version downgrade (an older daemon silently ignores the unknown field and applies the default) |
 | GET | `/groups` | `x0x group list` | List groups |
 | GET | `/groups/:id` | `x0x group info` | Group info |
 | PATCH | `/groups/:id` | `x0x group update` | Update name/description (admin+) |

--- a/docs/design/api-manifest.json
+++ b/docs/design/api-manifest.json
@@ -1,5 +1,5 @@
 {
-  "endpoint_count": 153,
+  "endpoint_count": 155,
   "endpoints": [
     {
       "category": "status",
@@ -112,6 +112,20 @@
       "description": "Update stored self-profile names (partial update)",
       "method": "PUT",
       "path": "/profile"
+    },
+    {
+      "category": "groups",
+      "cli_name": "home",
+      "description": "ADR-0038 Home space: group id, primary agent, members, warnings",
+      "method": "GET",
+      "path": "/home"
+    },
+    {
+      "category": "groups",
+      "cli_name": "home rename",
+      "description": "Rename the Home space (admin-gated, sealed)",
+      "method": "POST",
+      "path": "/home/rename"
     },
     {
       "category": "identity",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -165,6 +165,20 @@ pub const ENDPOINTS: &[EndpointDef] = &[
     },
     EndpointDef {
         method: Method::Get,
+        path: "/home",
+        cli_name: "home",
+        description: "ADR-0038 Home space: group id, primary agent, members, warnings",
+        category: "groups",
+    },
+    EndpointDef {
+        method: Method::Post,
+        path: "/home/rename",
+        cli_name: "home rename",
+        description: "Rename the Home space (admin-gated, sealed)",
+        category: "groups",
+    },
+    EndpointDef {
+        method: Method::Get,
         path: "/owner/agents",
         cli_name: "owner agents",
         description: "Roster of agents certified by this install's owner (journal-backed; survives restarts)",

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -955,6 +955,11 @@ enum GroupSub {
         /// Policy preset: private_secure | public_request_secure | public_open | public_announce.
         #[arg(long)]
         preset: Option<String>,
+        /// Explicit full policy as JSON (mutually exclusive with --preset).
+        /// The daemon echoes the effective policy back; a missing/mismatched
+        /// echo (older daemon silently ignoring the field) fails loudly.
+        #[arg(long)]
+        policy: Option<String>,
     },
     /// Get group details.
     Info {
@@ -1809,6 +1814,7 @@ async fn run(
                 description,
                 display_name,
                 preset,
+                policy,
             }) => {
                 commands::group::create(
                     &client,
@@ -1816,6 +1822,7 @@ async fn run(
                     description.as_deref(),
                     display_name.as_deref(),
                     preset.as_deref(),
+                    policy.as_deref(),
                 )
                 .await
             }

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -92,6 +92,11 @@ enum Commands {
         #[command(subcommand)]
         sub: Option<ProfileSub>,
     },
+    /// The owner's personal Home space (ADR-0038).
+    Home {
+        #[command(subcommand)]
+        sub: Option<HomeSub>,
+    },
     /// Owner-scoped views of this install (ADR-0036).
     Owner {
         #[command(subcommand)]
@@ -420,6 +425,17 @@ enum ProfileSub {
         /// Label for this machine.
         #[arg(long, value_name = "NAME")]
         machine_name: Option<String>,
+    },
+}
+
+/// `x0x home` subcommands (ADR-0038).
+#[derive(Subcommand)]
+enum HomeSub {
+    /// Rename the Home space (admin-gated sealed update).
+    Rename {
+        /// New display name for the Home space.
+        #[arg(value_name = "NAME")]
+        name: String,
     },
 }
 
@@ -1514,6 +1530,10 @@ async fn run(
                 )
                 .await
             }
+        },
+        Commands::Home { sub } => match sub {
+            None => commands::identity::home(&client).await,
+            Some(HomeSub::Rename { name }) => commands::identity::home_rename(&client, &name).await,
         },
         Commands::Owner { sub } => match sub {
             None | Some(OwnerSub::Agents) => commands::identity::owner_agents(&client).await,

--- a/src/cli/commands/group.rs
+++ b/src/cli/commands/group.rs
@@ -26,6 +26,7 @@ pub async fn create(
     description: Option<&str>,
     display_name: Option<&str>,
     preset: Option<&str>,
+    policy_json: Option<&str>,
 ) -> Result<()> {
     client.ensure_running().await?;
     let mut body = json!({ "name": name });
@@ -38,7 +39,36 @@ pub async fn create(
     if let Some(p) = preset {
         body["preset"] = Value::String(p.to_string());
     }
+    if let Some(p) = policy_json {
+        let parsed: Value = serde_json::from_str(p)
+            .map_err(|e| anyhow::anyhow!("--policy must be a JSON GroupPolicy object: {e}"))?;
+        body["policy"] = parsed;
+    }
     let resp = client.post("/groups", &body).await?;
+    // ADR-0038 round-2 fix 4: when an EXPLICIT policy was sent, the daemon
+    // echoes the effective policy back — validate it. A missing echo means
+    // an older daemon silently ignored the unknown `policy` field (the
+    // mixed-version downgrade); a mismatching echo must never pass quietly.
+    if body.get("policy").is_some() {
+        match resp.get("policy") {
+            Some(echoed) => {
+                if echoed != &body["policy"] {
+                    anyhow::bail!(
+                        "daemon applied a DIFFERENT policy than requested \
+                         (requested {}, applied {}) — group NOT created as intended",
+                        body["policy"],
+                        echoed
+                    );
+                }
+            }
+            None => anyhow::bail!(
+                "daemon did not echo the effective policy — it is probably an \
+                 older version that silently ignored `policy` and applied the \
+                 default. The group was created with the WRONG policy; delete \
+                 it or upgrade the daemon."
+            ),
+        }
+    }
     print_value(client.format(), &resp);
     Ok(())
 }
@@ -758,7 +788,7 @@ mod tests {
         let mock_resp = serde_json::json!({"id": "new-group", "name": "test"});
         let (url, _shutdown) = start_mock_server(mock_resp).await;
         let client = DaemonClient::new(None, Some(&url), crate::cli::OutputFormat::Json).unwrap();
-        let result = create(&client, "test-group", None, None, None).await;
+        let result = create(&client, "test-group", None, None, None, None).await;
         assert!(result.is_ok(), "create should succeed: {:?}", result);
     }
 

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -635,3 +635,16 @@ mod tests {
             .contains("pass either --file <PATH>"));
     }
 }
+
+/// `x0x home` — GET /home (ADR-0038 the owner's personal space).
+pub async fn home(client: &DaemonClient) -> Result<()> {
+    client.run_get("/home").await
+}
+
+/// `x0x home rename` — POST /home/rename.
+pub async fn home_rename(client: &DaemonClient, name: &str) -> Result<()> {
+    let body = serde_json::json!({ "name": name });
+    let resp = client.post("/home/rename", &body).await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -268,6 +268,19 @@ fn payload_b64_from_args(file: Option<&str>, payload_b64: Option<&str>) -> Resul
     }
 }
 
+/// `x0x home` — GET /home (ADR-0038 the owner's personal space).
+pub async fn home(client: &DaemonClient) -> Result<()> {
+    client.run_get("/home").await
+}
+
+/// `x0x home rename` — POST /home/rename.
+pub async fn home_rename(client: &DaemonClient, name: &str) -> Result<()> {
+    let body = serde_json::json!({ "name": name });
+    let resp = client.post("/home/rename", &body).await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
@@ -634,17 +647,4 @@ mod tests {
             .to_string()
             .contains("pass either --file <PATH>"));
     }
-}
-
-/// `x0x home` — GET /home (ADR-0038 the owner's personal space).
-pub async fn home(client: &DaemonClient) -> Result<()> {
-    client.run_get("/home").await
-}
-
-/// `x0x home rename` — POST /home/rename.
-pub async fn home_rename(client: &DaemonClient, name: &str) -> Result<()> {
-    let body = serde_json::json!({ "name": name });
-    let resp = client.post("/home/rename", &body).await?;
-    print_value(client.format(), &resp);
-    Ok(())
 }

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -94,6 +94,37 @@ fn default_invite_max_role() -> GroupRole {
     GroupRole::Member
 }
 
+/// ADR-0037 placement placeholder for Home members (ADR-0038 WP5).
+///
+/// An ABSENT entry in [`HomeMetadata::placements`] means `Pinned`. The
+/// real placement model + roaming move protocol land with the ADR-0037
+/// wave; this placeholder exists so the roaming guarantee (Home must
+/// contain at least one Roaming agent) is observable now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemberPlacement {
+    /// Bound to this machine (default).
+    Pinned,
+    /// Intended to follow the owner across machines (ADR-0037 roaming).
+    Roaming,
+}
+
+/// ADR-0038 Home metadata — carried by the auto-provisioned personal
+/// space (`GroupInfo::home`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HomeMetadata {
+    /// Agent hex of the owner's designated PRIMARY agent — the founding
+    /// member whose certificate binds it to the owner `UserId`. The owner
+    /// participates in Home through this agent (GUI renders its panel with
+    /// the "speaking as" chip).
+    pub primary_agent: String,
+    /// ADR-0037 placement placeholder per member (absent = Pinned).
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub placements: std::collections::BTreeMap<String, MemberPlacement>,
+    /// Unix ms when this Home was provisioned.
+    pub provisioned_at_ms: u64,
+}
+
 /// Metadata for a group.
 ///
 /// Persisted as JSON. The legacy v1 layout used a flat `members: BTreeSet`
@@ -208,6 +239,15 @@ pub struct GroupInfo {
     /// roster. Transient — never serialized.
     #[serde(skip)]
     pub owner_cert_reverify_required: bool,
+    /// ADR-0038 Home metadata: present iff this group is the install's
+    /// auto-provisioned personal space. `primary_agent` is the owner's
+    /// designated participating agent (the founding member at provisioning
+    /// — the provisioning commit is signed by that owner-certified agent).
+    /// `placements` is the ADR-0037 PLACEHOLDER — an absent member key
+    /// means `Pinned`; the real placement/move protocol lands with the
+    /// ADR-0037 wave.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home: Option<HomeMetadata>,
 
     /// Retained, applied state-commit history (issue #111, follow-up to
     /// ADR-0016). Each entry pairs a signed
@@ -490,6 +530,7 @@ impl GroupInfo {
             banner_url: None,
             withdrawn: false,
             owner_cert_reverify_required: false,
+            home: None,
             issued_invite_secrets: HashSet::new(),
             issued_invites: HashMap::new(),
         };

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -580,6 +580,10 @@ impl GroupInfo {
             tags: self.tags.clone(),
             avatar_url: self.avatar_url.clone(),
             banner_url: self.banner_url.clone(),
+            // ADR-0038 review fix 1: the Home metadata commitment rides
+            // the signed state hash; forging `home` after the fact breaks
+            // state-hash validation.
+            home_digest: self.home.as_ref().map(state_commit::compute_home_digest),
         }
     }
 

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -606,6 +606,31 @@ impl GroupInfo {
         );
     }
 
+    /// Whether the stored `state_hash` matches the state as currently
+    /// populated — i.e. nothing (including ADR-0038 `home` metadata, whose
+    /// digest rides the meta hash) changed since the last seal. Restore
+    /// paths use this to detect legacy-unsigned or tampered Home metadata
+    /// (round-2 fix 1): a `9c86f2d`-era Home (sealed before `home_digest`
+    /// existed) decodes with a state hash that does NOT commit to its
+    /// metadata.
+    #[must_use]
+    pub fn state_hash_is_current(&self) -> bool {
+        let roster_root = state_commit::compute_roster_root(&self.members_v2);
+        let policy_hash = state_commit::compute_policy_hash(&self.policy);
+        let meta_hash = state_commit::compute_public_meta_hash(&self.public_meta());
+        let recomputed = state_commit::compute_state_hash(
+            self.stable_group_id(),
+            self.state_revision,
+            self.prev_state_hash.as_deref(),
+            &roster_root,
+            &policy_hash,
+            &meta_hash,
+            self.security_binding.as_deref(),
+            self.withdrawn,
+        );
+        recomputed == self.state_hash
+    }
+
     /// Seal the current (already-mutated) state into a signed commit.
     ///
     /// - bumps `state_revision` by 1,

--- a/src/groups/state_commit.rs
+++ b/src/groups/state_commit.rs
@@ -250,6 +250,31 @@ pub fn compute_public_meta_hash(meta: &GroupPublicMeta) -> String {
         &mut buf,
         meta.banner_url.as_deref().unwrap_or("").as_bytes(),
     );
+    // ADR-0038 review fix 1: Home metadata commitment. Absent (legacy and
+    // non-Home groups) hashes byte-identically to the pre-0038 form.
+    if let Some(home_digest) = meta.home_digest.as_deref() {
+        buf.push(b'#');
+        push_len_prefixed(&mut buf, home_digest.as_bytes());
+    }
+    blake3_hex(&buf)
+}
+
+/// Canonical BLAKE3-256 (hex) commitment over a group's Home metadata —
+/// the value [`GroupPublicMeta::home_digest`] carries into the signed
+/// state hash. Length-prefixed field encoding, stable across field order.
+#[must_use]
+pub fn compute_home_digest(home: &super::HomeMetadata) -> String {
+    let mut buf = Vec::with_capacity(128);
+    buf.extend_from_slice(b"x0x.home-meta.v1");
+    push_len_prefixed(&mut buf, home.primary_agent.as_bytes());
+    // Placements in BTreeMap (deterministic key order): agent, placement
+    // byte, all length-prefixed.
+    buf.extend_from_slice(&(home.placements.len() as u32).to_le_bytes());
+    for (agent, placement) in &home.placements {
+        push_len_prefixed(&mut buf, agent.as_bytes());
+        buf.push(u8::from(*placement == super::MemberPlacement::Roaming));
+    }
+    buf.extend_from_slice(&home.provisioned_at_ms.to_le_bytes());
     blake3_hex(&buf)
 }
 
@@ -383,6 +408,14 @@ pub struct GroupPublicMeta {
     pub avatar_url: Option<String>,
     #[serde(default)]
     pub banner_url: Option<String>,
+    /// ADR-0038 review fix 1: BLAKE3 commitment over the group's Home
+    /// metadata (`GroupInfo::home`), when present. Including this digest
+    /// in the signed state hash makes injected/forged Home metadata
+    /// (primary-agent claims) fail state-hash validation instead of
+    /// persisting unsigned. `None` (every legacy group and every non-Home
+    /// group) hashes exactly as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home_digest: Option<String>,
 }
 
 /// A signed commitment to the current valid group state.
@@ -1183,6 +1216,7 @@ mod tests {
             tags: vec!["ai".into(), "rust".into()],
             avatar_url: None,
             banner_url: None,
+            home_digest: None,
         };
         let b = GroupPublicMeta {
             name: "N".into(),
@@ -1190,6 +1224,7 @@ mod tests {
             tags: vec!["rust".into(), "ai".into()],
             avatar_url: None,
             banner_url: None,
+            home_digest: None,
         };
         assert_eq!(compute_public_meta_hash(&a), compute_public_meta_hash(&b));
     }

--- a/src/gui/coverage-whitelist.txt
+++ b/src/gui/coverage-whitelist.txt
@@ -39,3 +39,8 @@ GET /gui
 
 # ── Admin/daemon — intentionally absent from end-user GUI ──
 POST /shutdown
+
+# ── ADR-0038 Home space — entered from the sidebar via navigate('homespace'),
+# not a URL the coverage crawler follows from /api listing. GUI calls both.
+GET /home
+POST /home/rename

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -5196,18 +5196,27 @@ async function createSpace(){
   if(desc)body.description=desc;
   const r=await api('/groups',{method:'POST',body:JSON.stringify(body)});
   if(r&&r.ok){
-    // ADR-0038 round-2 fix 4: when an EXPLICIT policy was sent, the daemon
-    // echoes the effective policy — validate it. Missing echo = older
-    // daemon silently ignored `policy` (mixed-version downgrade); mismatch
-    // = wrong policy applied. Fail loudly either way.
-    if(body.policy){
-      if(!r.policy){
-        toast('Daemon did not echo the applied policy — it may be an older version that ignored it. The space was created with the WRONG policy.','error');
-        if(r.group_id)toast('Delete space '+r.group_id+' or upgrade the daemon.','error');
-        return;
-      }
-      if(JSON.stringify(r.policy)!==JSON.stringify(body.policy)){
-        toast('Daemon applied a different policy than requested — space NOT created as intended.','error');
+    // ADR-0038 round-3 fix d: validate the daemon's POLICY ECHO
+    // unconditionally. We send a named preset (never a raw policy object),
+    // so compare the echoed admission axis against the preset's known
+    // value — a mismatch means the daemon applied a different policy than
+    // the preset promised; a MISSING echo means an older daemon without
+    // the echo contract (nothing to validate against — treated as
+    // tolerated legacy since preset handling predates the echo and was
+    // never silently-downgradable via an unknown field).
+    const PRESET_ADMISSION={
+      private_secure:'invite_only',
+      public_request_secure:'request_access',
+      public_open:'open_join',
+      public_announce:'open_join'
+    };
+    if(r.policy){
+      const want=PRESET_ADMISSION[preset];
+      const got=(r.policy.admission&&(
+        r.policy.admission.owner_certified!==undefined?'owner_certified':
+        typeof r.policy.admission==='string'?r.policy.admission:JSON.stringify(r.policy.admission)));
+      if(got&&want&&got!==want){
+        toast('Daemon applied a different admission policy ("'+got+'") than the selected preset ("+want+") — space NOT created as intended. Delete it.','error');
         return;
       }
     }

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -5196,6 +5196,21 @@ async function createSpace(){
   if(desc)body.description=desc;
   const r=await api('/groups',{method:'POST',body:JSON.stringify(body)});
   if(r&&r.ok){
+    // ADR-0038 round-2 fix 4: when an EXPLICIT policy was sent, the daemon
+    // echoes the effective policy — validate it. Missing echo = older
+    // daemon silently ignored `policy` (mixed-version downgrade); mismatch
+    // = wrong policy applied. Fail loudly either way.
+    if(body.policy){
+      if(!r.policy){
+        toast('Daemon did not echo the applied policy — it may be an older version that ignored it. The space was created with the WRONG policy.','error');
+        if(r.group_id)toast('Delete space '+r.group_id+' or upgrade the daemon.','error');
+        return;
+      }
+      if(JSON.stringify(r.policy)!==JSON.stringify(body.policy)){
+        toast('Daemon applied a different policy than requested — space NOT created as intended.','error');
+        return;
+      }
+    }
     document.querySelector('.modal-overlay').remove();
     toast('Space "'+name+'" created','success');
     await pollGroups();

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -1711,7 +1711,7 @@ function renderHomeSpace(){
       <span style="font-size:20px">🤖</span>
       <div>
         <div>${esc(hd.primary_agent.self_name||short(hd.primary_agent.agent_id,12))}</div>
-        <div style="font-size:11px;color:var(--tx3)">${short(hd.primary_agent.agent_id,16)} · speaks for the owner</div>
+        <div style="font-size:11px;color:var(--tx3)">${esc(short(hd.primary_agent.agent_id,16))} · ${hd.primary_agent.verified?'speaks for the owner':'unverified primary agent'}</div>
       </div>
     </div>
     <div class="label" style="font-size:10px;text-transform:uppercase;letter-spacing:1px;color:var(--tx3);margin-top:10px">Members</div>
@@ -1748,11 +1748,15 @@ async function mountHomeSpace(){
   renderSidebar();
   const el=document.getElementById('home-chat');
   if(el)renderSpaceChat(el,sid);
-  // Owner chip on the composer when the profile has a human_name
-  // (ADR-0038: the human participates through the primary agent).
+  // Owner chip (review fix 5): ONLY when the SENDING agent
+  // (S.agentId) IS the Home's verified primary agent and the profile
+  // has a human_name — otherwise messages would be signed by a
+  // different agent and the chip would assert false ownership.
   const human=hd.human_name;
+  const primary=hd.primary_agent&&hd.primary_agent.agent_id;
+  const primaryVerified=hd.primary_agent&&hd.primary_agent.verified;
   const chatIn=document.getElementById('chat-in');
-  if(human&&chatIn&&chatIn.parentElement){
+  if(human&&primary&&primaryVerified&&S.get('agentId')===primary&&chatIn&&chatIn.parentElement){
     const chip=document.createElement('span');
     chip.id='home-owner-chip';
     chip.title='Messages are signed by your primary agent';

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -5196,27 +5196,24 @@ async function createSpace(){
   if(desc)body.description=desc;
   const r=await api('/groups',{method:'POST',body:JSON.stringify(body)});
   if(r&&r.ok){
-    // ADR-0038 round-3 fix d: validate the daemon's POLICY ECHO
-    // unconditionally. We send a named preset (never a raw policy object),
-    // so compare the echoed admission axis against the preset's known
-    // value — a mismatch means the daemon applied a different policy than
-    // the preset promised; a MISSING echo means an older daemon without
-    // the echo contract (nothing to validate against — treated as
-    // tolerated legacy since preset handling predates the echo and was
-    // never silently-downgradable via an unknown field).
-    const PRESET_ADMISSION={
-      private_secure:'invite_only',
-      public_request_secure:'request_access',
-      public_open:'open_join',
-      public_announce:'open_join'
+    // Full-policy echo guard (codex r4/r5): compare EVERY axis, not just
+    // admission — public_open vs public_announce share open_join but differ
+    // in write access. A missing echo on a PRESET create is tolerated only
+    // because presets predate the echo and are interpreted identically by
+    // older daemons; any raw-policy create must fail closed on a missing
+    // echo (the GUI sends presets only).
+    const PRESET_POLICY={
+      private_secure:{discoverability:'hidden',admission:'invite_only',confidentiality:'mls_encrypted',read_access:'members_only',write_access:'members_only'},
+      public_request_secure:{discoverability:'public_directory',admission:'request_access',confidentiality:'mls_encrypted',read_access:'members_only',write_access:'members_only'},
+      public_open:{discoverability:'public_directory',admission:'open_join',confidentiality:'signed_public',read_access:'public',write_access:'members_only'},
+      public_announce:{discoverability:'public_directory',admission:'open_join',confidentiality:'signed_public',read_access:'public',write_access:'admin_only'}
     };
     if(r.policy){
-      const want=PRESET_ADMISSION[preset];
-      const got=(r.policy.admission&&(
-        r.policy.admission.owner_certified!==undefined?'owner_certified':
-        typeof r.policy.admission==='string'?r.policy.admission:JSON.stringify(r.policy.admission)));
-      if(got&&want&&got!==want){
-        toast('Daemon applied a different admission policy ("'+got+'") than the selected preset ("+want+") — space NOT created as intended. Delete it.','error');
+      const want=PRESET_POLICY[preset];
+      const norm=v=>typeof v==='string'?v:JSON.stringify(v);
+      const bad=want&&Object.keys(want).find(k=>norm(r.policy[k])!==want[k]);
+      if(bad){
+        toast('Daemon applied a different policy ('+bad+': "'+norm(r.policy[bad])+'" vs expected "'+want[bad]+'") than the selected preset — space NOT created as intended. Delete it.','error');
         return;
       }
     }

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -584,6 +584,7 @@ tr:hover td{background:rgba(255,255,255,.01)}
     <div class="chain" id="sb-chain"></div>
   </div>
   <div class="sb-section" style="flex:1;overflow-y:auto">
+    <div class="sb-item" id="sb-home" onclick="navigate('homespace')"><span class="icon">&#127968;</span><span>Home</span></div>
     <div class="sb-section-title" onclick="toggleSection('spaces')" style="cursor:pointer">
       <span>Spaces</span>
       <span style="display:flex;gap:2px">
@@ -1592,6 +1593,7 @@ function renderView(){
   el.className='main-content animate-in';
   switch(view){
     case 'home':el.innerHTML=renderHome();mountHome();break;
+    case 'homespace':el.innerHTML=renderHomeSpace();mountHomeSpace();break;
     case 'space':el.innerHTML=renderSpace();mountSpace();break;
     case 'dm':el.innerHTML=renderDm();mountDm();break;
     case 'discover':el.innerHTML=renderDiscover();mountDiscover();break;
@@ -1670,6 +1672,104 @@ function renderHome(){
 
 function mountHome(){
   pollDash();
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   ADR-0038 HOME SPACE VIEW — the owner's personal space (distinct from
+   this dashboard). Renders the auto-provisioned Home group's chat via
+   the standard space plumbing (renderSpaceChat/sendSpaceChat key off
+   S.get('spaceId')), plus the primary-agent panel, member self-names
+   (ADR-0036), the roaming warning, and the "speaking as … (owner)" chip
+   on the composer when a human_name is set.
+   ═══════════════════════════════════════════════════════════════════ */
+function renderHomeSpace(){
+  const hd=S.get('homeData');
+  if(!hd){
+    return `<h2>Home</h2><div class="card">Loading Home…</div>`;
+  }
+  const membersHtml=(hd.members||[]).map(m=>{
+    const label=m.self_name||short(m.agent_id,10);
+    const isPrimary=m.agent_id===hd.primary_agent.agent_id;
+    return `<div class="row" style="justify-content:space-between;padding:6px 0;border-bottom:1px solid var(--bd)">
+      <span>${esc(label)}${isPrimary?' <span class="tag" style="background:var(--cy);color:var(--bg1)">primary</span>':''}</span>
+      <span class="tag">${m.placement||'pinned'}</span>
+    </div>`;
+  }).join('');
+  const warn=hd.warnings&&hd.warnings.no_roaming_agent
+    ?`<div class="card" style="border-color:var(--wn,#c90);margin:8px 0">⚠ Home has no Roaming agent — it will not follow you to a new machine until one is marked Roaming (ADR-0037).</div>`
+    :'';
+  return `<div class="row mb" style="justify-content:space-between;align-items:center">
+    <h2 style="margin:0">🏠 ${esc(hd.name||'Home')}</h2>
+    <div class="row" style="gap:4px">
+      <button class="ghost" onclick="renameHomeSpace()" title="Rename Home">✏️</button>
+    </div>
+  </div>
+  ${warn}
+  <div class="card mb" id="home-primary-panel">
+    <div class="label" style="font-size:10px;text-transform:uppercase;letter-spacing:1px;color:var(--tx3)">Primary agent</div>
+    <div class="row" style="gap:8px;align-items:center;margin-top:4px">
+      <span style="font-size:20px">🤖</span>
+      <div>
+        <div>${esc(hd.primary_agent.self_name||short(hd.primary_agent.agent_id,12))}</div>
+        <div style="font-size:11px;color:var(--tx3)">${short(hd.primary_agent.agent_id,16)} · speaks for the owner</div>
+      </div>
+    </div>
+    <div class="label" style="font-size:10px;text-transform:uppercase;letter-spacing:1px;color:var(--tx3);margin-top:10px">Members</div>
+    ${membersHtml}
+  </div>
+  <div id="home-chat"></div>`;
+}
+
+async function mountHomeSpace(){
+  const hd=await api('/home');
+  if(!hd||!hd.ok){
+    document.getElementById('view-container').innerHTML=
+      `<h2>Home</h2><div class="card">No Home space${hd&&hd.error?' — '+esc(hd.error):''}. An owned install provisions one at daemon start.</div>`;
+    return;
+  }
+  S.set('homeData',hd);
+  // The shell rendered before the fetch resolved ("Loading Home…") —
+  // re-render now that the metadata is in state.
+  document.getElementById('view-container').innerHTML=renderHomeSpace();
+  // Reuse the standard space plumbing: renderSpaceChat + sendSpaceChat
+  // both key off S.get('spaceId').
+  const sid=hd.group_id;
+  S.set('spaceId',sid);
+  S.set('spaceApp','chat');
+  const g=await api('/groups/'+sid);
+  if(g&&g.ok){
+    spaceChatTopic=g.chat_topic||'';
+    if(spaceChatTopic)wsSub(spaceChatTopic);
+    currentSpaceConfidentiality=(g.policy&&g.policy.confidentiality)||'';
+  }
+  const chan=S.get('channel')||'general';
+  currentChannelTopic=getChannelTopic(sid,chan);
+  wsSub(currentChannelTopic);
+  renderSidebar();
+  const el=document.getElementById('home-chat');
+  if(el)renderSpaceChat(el,sid);
+  // Owner chip on the composer when the profile has a human_name
+  // (ADR-0038: the human participates through the primary agent).
+  const human=hd.human_name;
+  const chatIn=document.getElementById('chat-in');
+  if(human&&chatIn&&chatIn.parentElement){
+    const chip=document.createElement('span');
+    chip.id='home-owner-chip';
+    chip.title='Messages are signed by your primary agent';
+    chip.style.cssText='align-self:center;font-size:11px;padding:2px 8px;border-radius:10px;background:var(--cy);color:var(--bg1);white-space:nowrap';
+    chip.textContent='speaking as '+human+' (owner)';
+    chatIn.parentElement.insertBefore(chip,chatIn);
+  }
+}
+
+function renameHomeSpace(){
+  const hd=S.get('homeData');
+  const cur=hd?(hd.name||'Home'):'Home';
+  const name=prompt('Rename Home:',cur);
+  if(!name||name===cur)return;
+  api('/home/rename',{method:'POST',body:JSON.stringify({name})}).then(r=>{
+    if(r&&r.ok){mountHomeSpace();renderSidebar();}
+  });
 }
 
 function renderUpgradeBanner(upg){

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -5197,25 +5197,28 @@ async function createSpace(){
   const r=await api('/groups',{method:'POST',body:JSON.stringify(body)});
   if(r&&r.ok){
     // Full-policy echo guard (codex r4/r5): compare EVERY axis, not just
-    // admission — public_open vs public_announce share open_join but differ
-    // in write access. A missing echo on a PRESET create is tolerated only
-    // because presets predate the echo and are interpreted identically by
-    // older daemons; any raw-policy create must fail closed on a missing
-    // echo (the GUI sends presets only).
+    // admission — public_open vs public_announce share open_join but
+    // differ in write access. FAIL-CLOSED on a missing echo too: an older
+    // daemon without the echo contract is a downgrade signal — the space
+    // was still created, so tell the user to delete it rather than trust
+    // an unverifiable policy.
     const PRESET_POLICY={
       private_secure:{discoverability:'hidden',admission:'invite_only',confidentiality:'mls_encrypted',read_access:'members_only',write_access:'members_only'},
       public_request_secure:{discoverability:'public_directory',admission:'request_access',confidentiality:'mls_encrypted',read_access:'members_only',write_access:'members_only'},
       public_open:{discoverability:'public_directory',admission:'open_join',confidentiality:'signed_public',read_access:'public',write_access:'members_only'},
       public_announce:{discoverability:'public_directory',admission:'open_join',confidentiality:'signed_public',read_access:'public',write_access:'admin_only'}
     };
-    if(r.policy){
-      const want=PRESET_POLICY[preset];
-      const norm=v=>typeof v==='string'?v:JSON.stringify(v);
-      const bad=want&&Object.keys(want).find(k=>norm(r.policy[k])!==want[k]);
-      if(bad){
-        toast('Daemon applied a different policy ('+bad+': "'+norm(r.policy[bad])+'" vs expected "'+want[bad]+'") than the selected preset — space NOT created as intended. Delete it.','error');
-        return;
-      }
+    if(!r.policy){
+      toast('Daemon did not echo the applied policy (older version?) — cannot verify the space was created with the selected preset. Delete it and retry against an updated daemon.','error');
+      if(r.group_id)toast('Space id to delete: '+r.group_id,'error');
+      return;
+    }
+    const want=PRESET_POLICY[preset];
+    const norm=v=>typeof v==='string'?v:JSON.stringify(v);
+    const bad=want&&Object.keys(want).find(k=>norm(r.policy[k])!==want[k]);
+    if(bad){
+      toast('Daemon applied a different policy ('+bad+': "'+norm(r.policy[bad])+'" vs expected "'+want[bad]+'") than the selected preset — space NOT created as intended. Delete it.','error');
+      return;
     }
     document.querySelector('.modal-overlay').remove();
     toast('Space "'+name+'" created','success');

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -974,6 +974,11 @@ pub async fn serve_with_options(
         ensure_named_group_listeners(Arc::clone(&state), &group_id).await;
     }
 
+    // ADR-0038: auto-provision the Home space for an owned install. Runs
+    // AFTER restore so an existing Home is adopted (marker + roster scan)
+    // instead of duplicated; best-effort — never fails startup.
+    routes::home::provision_home(&state).await;
+
     // ADR 0028: post-restore queue drain — any queued approvals whose
     // predecessors arrived during downtime can now be drained (Kimi blocker 9).
     {
@@ -1636,6 +1641,8 @@ pub async fn serve_with_options(
         .route("/introduction", get(introduction))
         .route("/agent/card", get(get_agent_card))
         .route("/profile", get(get_profile).put(update_profile))
+        .route("/home", get(routes::home::get_home))
+        .route("/home/rename", post(routes::home::rename_home))
         .route("/owner/agents", get(owner_agents))
         .route("/.well-known/agent-card.json", get(get_a2a_agent_card))
         .route("/agent/card/import", post(import_agent_card))

--- a/src/server/routes/home.rs
+++ b/src/server/routes/home.rs
@@ -295,12 +295,17 @@ async fn repair_or_write_marker(
     }
 }
 
-/// Round-3 fix a: restore-side digest verification for EVERY group with
-/// nonempty `home` metadata (not just the trusted-Home pick). A record
-/// whose state hash does not commit to its digest is legacy-unsigned or
-/// tampered; reseal only when the group is OUR-owner Home policy with our
-/// active Admin seat, otherwise strip + warn.
-async fn verify_restored_home_records(state: &Arc<AppState>, owner: &crate::identity::UserId) {
+/// Round-3/4 fix a: restore-side digest verification for EVERY group with
+/// nonempty `home` metadata (not just the trusted-Home pick), running
+/// BEFORE any owned-install guard so un-owned and cert-less installs are
+/// covered too. A record whose state hash does not commit to its digest is
+/// legacy-unsigned or tampered; reseal only when the group is OUR-owner
+/// Home policy with our active Admin seat, otherwise strip + warn (with no
+/// owner at all there is nobody entitled to reseal — everything strips).
+async fn verify_restored_home_records(
+    state: &Arc<AppState>,
+    owner: Option<&crate::identity::UserId>,
+) {
     let local_hex = hex::encode(state.agent.agent_id().as_bytes());
     let records: Vec<(String, bool, bool)> = {
         let groups = state.named_groups.read().await;
@@ -308,7 +313,7 @@ async fn verify_restored_home_records(state: &Arc<AppState>, owner: &crate::iden
             .iter()
             .filter(|(_, info)| info.home.is_some() && !info.state_hash_is_current())
             .map(|(id, info)| {
-                let ours = is_home_policy(&info.policy, owner);
+                let ours = owner.is_some_and(|owner| is_home_policy(&info.policy, owner));
                 let admin = info
                     .caller_role(&local_hex)
                     .is_some_and(|r| r.at_least(crate::groups::GroupRole::Admin));
@@ -357,6 +362,13 @@ async fn strip_home_metadata(state: &AppState, group_id: &str) {
 /// best-effort: never fails startup — a provisioning failure logs loudly
 /// and retries on the next daemon start (no marker is written on failure).
 pub(in crate::server) async fn provision_home(state: &Arc<AppState>) {
+    // Round-4 fix 1: the restore sweep runs FIRST, before ANY owned-install
+    // guard — EVERY restored nonempty `home` record is digest-verified even
+    // on un-owned installs or installs without an agent certificate (there
+    // is simply nobody entitled to reseal, so unsigned records strip).
+    let owner_opt = state.agent.identity().user_keypair().map(|kp| kp.user_id());
+    verify_restored_home_records(state, owner_opt.as_ref()).await;
+
     // Only an OWNED install provisions: user key + builder-issued
     // certificate must both be live (OwnerCertified admission needs a
     // certifiable founding member).
@@ -371,15 +383,6 @@ pub(in crate::server) async fn provision_home(state: &Arc<AppState>) {
     let owner = user_kp.user_id();
     let owner_hex = hex::encode(owner.as_bytes());
     let marker_path = state.data_dir.join(HOME_MARKER_FILE);
-
-    // 0) Round-3 fix a: verify EVERY restored nonempty `home` record —
-    //    BEFORE any trusted-Home filtering, so foreign-owner, inactive,
-    //    malformed, and unowned records cannot skip digest verification
-    //    just because find_home would reject them. Mismatch or
-    //    legacy-unsigned → reseal when this group is our-owner Home policy
-    //    AND we hold an active Admin seat; otherwise strip the metadata
-    //    with a warning (unsigned Home claims never survive restore).
-    verify_restored_home_records(state, &owner).await;
 
     // 1) Trusted Home already present (the marker is only advisory — the
     //    roster scan is authoritative). Repair a missing/stale marker.
@@ -1208,11 +1211,13 @@ mod round2_tests {
         provision_home(&state).await;
         let (id, info) = find_home(&state, &owner).await.expect("home");
 
-        // Round-3 fix c: make resealing GENUINELY fail — demote our agent
-        // from Admin to Member. The reseal Admin gate refuses and the
-        // sweep's `ours && admin` condition is false, so the only remaining
-        // path is STRIP (this actually exercises the failure, unlike the
-        // previous withdrawn-flag trick which never reached the gate).
+        // Round-5 fix (codex r4/r5): exercise the reseal-FAILURE branch
+        // itself. The caller STAYS Admin (admin gate passes, reseal_home is
+        // genuinely invoked); the seal then fails because a SECOND member's
+        // evidence is missing with the grace window long expired (verdict =
+        // Failed → the owner-certified seal wrapper refuses with the typed
+        // eviction-required error), driving the "reseal failed; stripping"
+        // path — not the non-admin strip branch.
         let mut broken = info.clone();
         let meta = crate::groups::state_commit::GroupPublicMeta {
             home_digest: None,
@@ -1231,9 +1236,20 @@ mod round2_tests {
             broken.security_binding.as_deref(),
             broken.withdrawn,
         );
-        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
-        if let Some(member) = broken.members_v2.get_mut(&local_hex) {
-            member.role = crate::groups::GroupRole::Member;
+        // A second member whose certificate never resolved and whose grace
+        // window expired long ago: the seal verdict is Failed for it, so
+        // reseal_home's seal refuses (ordinary seals refuse on non-clean
+        // verdicts; the eviction path is not taken inside reseal).
+        let stranger = crate::identity::AgentKeypair::generate()?;
+        let stranger_hex = hex::encode(stranger.agent_id().as_bytes());
+        broken.add_member(
+            stranger_hex,
+            crate::groups::GroupRole::Member,
+            None,
+            None,
+        );
+        if let Some(member) = broken.members_v2.get_mut(&stranger_hex) {
+            member.certificate_missing_since_ms = Some(0); // grace expired long ago
         }
         assert!(!broken.state_hash_is_current(), "unsigned condition holds");
         state.named_groups.write().await.insert(id.clone(), broken);

--- a/src/server/routes/home.rs
+++ b/src/server/routes/home.rs
@@ -183,7 +183,13 @@ async fn stamp_and_seal_home(
     };
     let local_hex = hex::encode(state.agent.agent_id().as_bytes());
     let mut placements = std::collections::BTreeMap::new();
-    placements.insert(local_hex.clone(), crate::groups::MemberPlacement::Pinned);
+    // Round-2 fix 3: the founding agent provisions as ROAMING — ADR-0038
+    // requires the Home agent to follow the user across machines, so the
+    // invariant holds from first provisioning instead of warning on every
+    // fresh install. NOMINAL UNTIL ADR-0043: placement is still the
+    // ADR-0037 placeholder (no move protocol, no enforcement) — this bit
+    // is the stated intent; 0043 makes it load-bearing.
+    placements.insert(local_hex.clone(), crate::groups::MemberPlacement::Roaming);
     info.home = Some(crate::groups::HomeMetadata {
         primary_agent: local_hex,
         placements,
@@ -215,6 +221,65 @@ async fn stamp_and_seal_home(
     Some(info)
 }
 
+/// Reseal EXISTING Home metadata (round-2 fix 1): keep the metadata as
+/// restored, but push it through a fresh OwnerCertified-aware seal so the
+/// `home_digest` rides the signed state hash. Returns the resealed info.
+async fn reseal_home(state: &Arc<AppState>, group_id: &str) -> Option<crate::groups::GroupInfo> {
+    let signing_kp = state.agent.identity().agent_keypair();
+    let mut info = {
+        let groups = state.named_groups.read().await;
+        groups.get(group_id).cloned()?
+    };
+    info.home.as_ref()?;
+    if seal_commit_owner_certified(state, &mut info, signing_kp, now_millis_u64())
+        .await
+        .is_err()
+    {
+        tracing::error!(group_id, "Home reseal failed");
+        return None;
+    }
+    if !matches!(
+        persist_named_groups_mutation(state, |groups| {
+            groups.insert(group_id.to_string(), info.clone());
+            true
+        })
+        .await,
+        Ok(AtomicWriteOutcome::Durable)
+    ) {
+        tracing::error!(group_id, "resealed Home could not be persisted");
+        return None;
+    }
+    Some(info)
+}
+
+/// Write the marker if it is missing or points elsewhere.
+async fn repair_or_write_marker(
+    state: &AppState,
+    owner_hex: &str,
+    marker_path: &std::path::Path,
+    id: &str,
+    info: &crate::groups::GroupInfo,
+) {
+    let needs_repair = read_verified_marker(state, owner_hex)
+        .await
+        .is_none_or(|m| m.group_id != id);
+    if needs_repair {
+        tracing::info!(group_id = %id, "Home already present; recording marker");
+        write_marker(
+            marker_path,
+            &HomeMarker {
+                group_id: id.to_string(),
+                owner_user_id: owner_hex.to_string(),
+                provisioned_at_ms: info
+                    .home
+                    .as_ref()
+                    .map_or_else(now_millis_u64, |h| h.provisioned_at_ms),
+            },
+        )
+        .await;
+    }
+}
+
 /// Auto-provision the Home space for an owned install. Idempotent and
 /// best-effort: never fails startup — a provisioning failure logs loudly
 /// and retries on the next daemon start (no marker is written on failure).
@@ -237,23 +302,42 @@ pub(in crate::server) async fn provision_home(state: &Arc<AppState>) {
     // 1) Trusted Home already present (the marker is only advisory — the
     //    roster scan is authoritative). Repair a missing/stale marker.
     if let Some((id, info)) = find_home(state, &owner).await {
-        let needs_repair = read_verified_marker(state, &owner_hex)
-            .await
-            .is_none_or(|m| m.group_id != id);
-        if needs_repair {
-            tracing::info!(group_id = %id, "Home already present; recording marker");
-            write_marker(
-                &marker_path,
-                &HomeMarker {
-                    group_id: id,
-                    owner_user_id: owner_hex,
-                    provisioned_at_ms: info
-                        .home
-                        .as_ref()
-                        .map_or_else(now_millis_u64, |h| h.provisioned_at_ms),
-                },
-            )
-            .await;
+        // Round-2 fix 1: a restored Home whose state hash does not commit
+        // to its (nonempty) metadata is LEGACY-UNSIGNED (a `9c86f2d`-era
+        // Home sealed before `home_digest` existed) or tampered. We are
+        // the owner with an active Admin seat (find_home guarantees it),
+        // so reseal the existing metadata through the provisioning commit
+        // path; if resealing is impossible, strip the metadata and warn —
+        // never keep trusting unsigned Home claims.
+        if info.home.is_some() && !info.state_hash_is_current() {
+            tracing::warn!(
+                group_id = %id,
+                "restored Home metadata is not covered by the sealed state hash; resealing"
+            );
+            match reseal_home(state, &id).await {
+                Some(resealed) => {
+                    tracing::info!(group_id = %id, "legacy Home metadata resealed");
+                    repair_or_write_marker(state, &owner_hex, &marker_path, &id, &resealed).await;
+                    return;
+                }
+                None => {
+                    tracing::warn!(
+                        group_id = %id,
+                        "could not reseal Home metadata; stripping untrusted metadata"
+                    );
+                    let _ = persist_named_groups_mutation(state, |groups| {
+                        if let Some(info) = groups.get_mut(&id) {
+                            info.home = None;
+                        }
+                        true
+                    })
+                    .await;
+                    // Fall through: the (now unstamped) group becomes a
+                    // recovery candidate below and is re-stamped fresh.
+                }
+            }
+        } else {
+            repair_or_write_marker(state, &owner_hex, &marker_path, &id, &info).await;
         }
         return;
     }
@@ -308,18 +392,31 @@ pub(in crate::server) async fn provision_home(state: &Arc<AppState>) {
         );
         return;
     }
-    // Locate the freshly created Home and stamp its metadata + marker.
-    let group_id = {
-        let groups = state.named_groups.read().await;
-        groups
-            .iter()
-            .find(|(_, info)| info.home.is_none() && is_home_candidate(info, &owner))
-            .map(|(id, _)| id.clone())
-    };
-    let Some(group_id) = group_id else {
-        tracing::error!("Home group created but not found afterwards; marker not written");
+    // Round-2 fix 2: stamp the group id the creation call RETURNED — never
+    // re-scan. A scan could pick a concurrently provisioned same-policy
+    // group (or a pre-existing one) and stamp the wrong roster.
+    let body_bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap_or_default();
+    let created: Option<String> = serde_json::from_slice::<serde_json::Value>(&body_bytes)
+        .ok()
+        .and_then(|body| {
+            body["group_id"]
+                .as_str()
+                .map(std::string::ToString::to_string)
+        });
+    let Some(group_id) = created else {
+        tracing::error!("Home creation response carried no group_id; marker not written");
         return;
     };
+    // Defensive existence check (the create path inserted it durably).
+    if !state.named_groups.read().await.contains_key(&group_id) {
+        tracing::error!(
+            group_id = %group_id,
+            "Home creation returned an id that is not in the roster; marker not written"
+        );
+        return;
+    }
     if let Some(info) = stamp_and_seal_home(state, &group_id).await {
         write_marker(
             &marker_path,
@@ -527,7 +624,7 @@ mod tests {
 
     /// Owned test state: user key (deterministic seed so the owner id is
     /// stable across the "restart" arm) + builder-issued agent certificate.
-    async fn owned_state(
+    pub(in crate::server::routes::home) async fn owned_state(
         data_dir: &std::path::Path,
         owner_seed: [u8; 32],
     ) -> anyhow::Result<Arc<AppState>> {
@@ -576,7 +673,7 @@ mod tests {
         Ok((status, serde_json::from_slice(&body)?))
     }
 
-    fn owner_of(state: &AppState) -> crate::identity::UserId {
+    pub(in crate::server::routes::home) fn owner_of(state: &AppState) -> crate::identity::UserId {
         state
             .agent
             .identity()
@@ -604,7 +701,9 @@ mod tests {
         assert_eq!(home.primary_agent, local_hex);
         assert_eq!(
             home.placements.get(&local_hex),
-            Some(&crate::groups::MemberPlacement::Pinned)
+            Some(&crate::groups::MemberPlacement::Roaming),
+            "founding agent provisions Roaming (ADR-0038 roaming invariant; \
+             nominal until ADR-0043 enforcement)"
         );
 
         // Review fix 1: the home digest is committed by a signed seal —
@@ -862,7 +961,12 @@ mod tests {
         let (status, body) = response_json(response).await?;
         assert_eq!(status, StatusCode::OK, "{body}");
         assert_eq!(body["name"], "Home");
-        assert_eq!(body["warnings"]["no_roaming_agent"], true);
+        // Founding agent is provisioned Roaming (round-2 fix 3): the
+        // warning must NOT fire on a fresh Home.
+        assert_eq!(
+            body["warnings"]["no_roaming_agent"], false,
+            "fresh Home carries a Roaming founding agent"
+        );
         let health_json = crate::server::routes::status::health(State(Arc::clone(&state))).await;
         let health_body: serde_json::Value =
             serde_json::to_value(&health_json.0).unwrap_or_default();
@@ -920,6 +1024,135 @@ mod tests {
             .oneshot(Request::get("/home").body(Body::empty())?)
             .await?;
         assert_eq!(response.status(), StatusCode::OK);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod round2_tests {
+    use super::tests::{owned_state, owner_of};
+    use super::*;
+
+    /// WHY (round-2 fix 1): a persisted Home from the `9c86f2d` era (or an
+    /// attacker-persisted roster) carries nonempty `home` metadata whose
+    /// digest was NEVER sealed — the stored state hash predates
+    /// `home_digest`. Restore (provision_home at startup) must detect the
+    /// stale hash and RESEAL the metadata through the provisioning commit
+    /// path, never keep trusting it unsigned.
+    #[tokio::test]
+    async fn persisted_unsigned_home_metadata_is_resealed_on_restore() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x50; 32]).await?;
+        let owner = owner_of(&state);
+
+        // First provisioning (normal, sealed).
+        provision_home(&state).await;
+        let (id, info) = find_home(&state, &owner).await.expect("home");
+        assert!(
+            info.state_hash_is_current(),
+            "fresh Home is sealed: digest committed"
+        );
+
+        // Simulate the 9c86f2d-era / attacker state: rewrite the persisted
+        // roster with the metadata PRESENT but the state hash recomputed
+        // WITHOUT the digest (exactly what a pre-home_digest daemon stored).
+        let mut legacy = info.clone();
+        let sealed_hash = legacy.state_hash.clone();
+        {
+            let meta = crate::groups::state_commit::GroupPublicMeta {
+                home_digest: None,
+                ..legacy.public_meta()
+            };
+            let roster_root = crate::groups::compute_roster_root(&legacy.members_v2);
+            let policy_hash = crate::groups::compute_policy_hash(&legacy.policy);
+            let meta_hash = crate::groups::compute_public_meta_hash(&meta);
+            legacy.state_hash = crate::groups::state_commit::compute_state_hash(
+                legacy.stable_group_id(),
+                legacy.state_revision,
+                legacy.prev_state_hash.as_deref(),
+                &roster_root,
+                &policy_hash,
+                &meta_hash,
+                legacy.security_binding.as_deref(),
+                legacy.withdrawn,
+            );
+        }
+        assert_ne!(legacy.state_hash, sealed_hash);
+        assert!(
+            !legacy.state_hash_is_current(),
+            "legacy-unsigned metadata detected"
+        );
+        state.named_groups.write().await.insert(id.clone(), legacy);
+
+        // Restore path: provision_home must reseal.
+        provision_home(&state).await;
+        let (_, resealed) = find_home(&state, &owner).await.expect("home survives");
+        assert!(
+            resealed.state_hash_is_current(),
+            "metadata resealed: state hash now commits to the digest"
+        );
+        assert!(
+            resealed.home.is_some(),
+            "metadata kept (not stripped) when we are the owner+admin"
+        );
+        Ok(())
+    }
+
+    /// WHY (round-2 fix 1, strip branch): when resealing is impossible the
+    /// untrusted metadata is STRIPPED and the group is re-stamped fresh —
+    /// unsigned claims never survive a restore.
+    #[tokio::test]
+    async fn unrestorable_home_metadata_is_stripped() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x51; 32]).await?;
+        let owner = owner_of(&state);
+        provision_home(&state).await;
+        let (id, info) = find_home(&state, &owner).await.expect("home");
+
+        // Make resealing impossible: withdraw the group (the seal wrapper
+        // refuses withdrawn groups) while keeping the stale unsigned hash.
+        let mut broken = info.clone();
+        broken.withdrawn = true;
+        broken.recompute_state_hash(); // withdrawn hash recomputed WITH digest…
+                                       // …then revert the withdrawn flag in-memory without resealing, so the
+                                       // stored hash no longer matches the current fields.
+        broken.withdrawn = false;
+        assert!(!broken.state_hash_is_current());
+        state.named_groups.write().await.insert(id.clone(), broken);
+
+        provision_home(&state).await;
+        // Either stripped + re-stamped fresh, or (if the wrapper still
+        // refused) metadata gone — but NEVER trusted-unsigned.
+        let after = state.named_groups.read().await;
+        let info = after.get(&id).expect("group kept");
+        assert!(
+            info.home
+                .as_ref()
+                .is_none_or(|_| info.state_hash_is_current()),
+            "metadata is either absent or sealed — never unsigned"
+        );
+        Ok(())
+    }
+
+    /// WHY (round-2 fix 3): fresh provisioning records the founding agent
+    /// as Roaming and GET /home reports the invariant satisfied.
+    #[tokio::test]
+    async fn fresh_home_provisions_roaming_founding_agent() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x52; 32]).await?;
+        provision_home(&state).await;
+        let owner = owner_of(&state);
+        let (_, info) = find_home(&state, &owner).await.expect("home");
+        let home = info.home.as_ref().expect("meta");
+        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+        assert_eq!(
+            home.placements.get(&local_hex),
+            Some(&crate::groups::MemberPlacement::Roaming)
+        );
+        assert!(
+            home_roaming_warning_for(&info).is_none(),
+            "no warning on a fresh Home"
+        );
         Ok(())
     }
 }

--- a/src/server/routes/home.rs
+++ b/src/server/routes/home.rs
@@ -1243,7 +1243,7 @@ mod round2_tests {
         let stranger = crate::identity::AgentKeypair::generate()?;
         let stranger_hex = hex::encode(stranger.agent_id().as_bytes());
         broken.add_member(
-            stranger_hex,
+            stranger_hex.clone(),
             crate::groups::GroupRole::Member,
             None,
             None,

--- a/src/server/routes/home.rs
+++ b/src/server/routes/home.rs
@@ -231,6 +231,21 @@ async fn reseal_home(state: &Arc<AppState>, group_id: &str) -> Option<crate::gro
         groups.get(group_id).cloned()?
     };
     info.home.as_ref()?;
+    // Round-3 fix b: explicit Admin-role gate — resealing writes a signed
+    // commit for the group; only an active Admin (or better) of THIS group
+    // may author it. find_home guarantees it on the trusted path, but this
+    // function is also the chokepoint for any future caller.
+    let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+    if !info
+        .caller_role(&local_hex)
+        .is_some_and(|role| role.at_least(crate::groups::GroupRole::Admin))
+    {
+        tracing::warn!(
+            group_id,
+            "refusing to reseal Home metadata: local agent is not an active Admin"
+        );
+        return None;
+    }
     if seal_commit_owner_certified(state, &mut info, signing_kp, now_millis_u64())
         .await
         .is_err()
@@ -280,6 +295,64 @@ async fn repair_or_write_marker(
     }
 }
 
+/// Round-3 fix a: restore-side digest verification for EVERY group with
+/// nonempty `home` metadata (not just the trusted-Home pick). A record
+/// whose state hash does not commit to its digest is legacy-unsigned or
+/// tampered; reseal only when the group is OUR-owner Home policy with our
+/// active Admin seat, otherwise strip + warn.
+async fn verify_restored_home_records(state: &Arc<AppState>, owner: &crate::identity::UserId) {
+    let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+    let records: Vec<(String, bool, bool)> = {
+        let groups = state.named_groups.read().await;
+        groups
+            .iter()
+            .filter(|(_, info)| info.home.is_some() && !info.state_hash_is_current())
+            .map(|(id, info)| {
+                let ours = is_home_policy(&info.policy, owner);
+                let admin = info
+                    .caller_role(&local_hex)
+                    .is_some_and(|r| r.at_least(crate::groups::GroupRole::Admin));
+                (id.clone(), ours, admin)
+            })
+            .collect()
+    };
+    for (id, ours, admin) in records {
+        if ours && admin {
+            tracing::warn!(
+                group_id = %id,
+                "restored Home metadata is not covered by the sealed state hash; resealing"
+            );
+            if reseal_home(state, &id).await.is_some() {
+                tracing::info!(group_id = %id, "legacy Home metadata resealed");
+            } else {
+                tracing::warn!(
+                    group_id = %id,
+                    "reseal failed; stripping untrusted Home metadata"
+                );
+                strip_home_metadata(state, &id).await;
+            }
+        } else {
+            tracing::warn!(
+                group_id = %id,
+                "restored Home metadata is unsigned and the group is not ours to reseal \
+                 (foreign owner, non-Home policy, or no Admin seat); stripping"
+            );
+            strip_home_metadata(state, &id).await;
+        }
+    }
+}
+
+/// Strip untrusted Home metadata from a group (persisted).
+async fn strip_home_metadata(state: &AppState, group_id: &str) {
+    let _ = persist_named_groups_mutation(state, |groups| {
+        if let Some(info) = groups.get_mut(group_id) {
+            info.home = None;
+        }
+        true
+    })
+    .await;
+}
+
 /// Auto-provision the Home space for an owned install. Idempotent and
 /// best-effort: never fails startup — a provisioning failure logs loudly
 /// and retries on the next daemon start (no marker is written on failure).
@@ -298,6 +371,15 @@ pub(in crate::server) async fn provision_home(state: &Arc<AppState>) {
     let owner = user_kp.user_id();
     let owner_hex = hex::encode(owner.as_bytes());
     let marker_path = state.data_dir.join(HOME_MARKER_FILE);
+
+    // 0) Round-3 fix a: verify EVERY restored nonempty `home` record —
+    //    BEFORE any trusted-Home filtering, so foreign-owner, inactive,
+    //    malformed, and unowned records cannot skip digest verification
+    //    just because find_home would reject them. Mismatch or
+    //    legacy-unsigned → reseal when this group is our-owner Home policy
+    //    AND we hold an active Admin seat; otherwise strip the metadata
+    //    with a warning (unsigned Home claims never survive restore).
+    verify_restored_home_records(state, &owner).await;
 
     // 1) Trusted Home already present (the marker is only advisory — the
     //    roster scan is authoritative). Repair a missing/stale marker.
@@ -1082,7 +1164,24 @@ mod round2_tests {
             !legacy.state_hash_is_current(),
             "legacy-unsigned metadata detected"
         );
+        // Round-3 fix c: REAL write-to-disk + reload through the restore
+        // path (not an in-memory swap) — persist the legacy roster, reload
+        // via load_named_groups exactly like a daemon restart, and swap the
+        // reloaded map into state.
         state.named_groups.write().await.insert(id.clone(), legacy);
+        assert!(
+            super::super::named_groups::save_named_groups(&state).await,
+            "legacy roster persisted to disk"
+        );
+        let reloaded =
+            super::super::named_groups::load_named_groups(&state.named_groups_path).await?;
+        assert!(
+            reloaded
+                .get(&id)
+                .is_some_and(|i| !i.state_hash_is_current()),
+            "the reloaded record decodes legacy-unsigned, as a restart would see"
+        );
+        *state.named_groups.write().await = reloaded;
 
         // Restore path: provision_home must reseal.
         provision_home(&state).await;
@@ -1099,8 +1198,8 @@ mod round2_tests {
     }
 
     /// WHY (round-2 fix 1, strip branch): when resealing is impossible the
-    /// untrusted metadata is STRIPPED and the group is re-stamped fresh —
-    /// unsigned claims never survive a restore.
+    /// untrusted metadata is STRIPPED — unsigned claims never survive a
+    /// restore.
     #[tokio::test]
     async fn unrestorable_home_metadata_is_stripped() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -1109,15 +1208,34 @@ mod round2_tests {
         provision_home(&state).await;
         let (id, info) = find_home(&state, &owner).await.expect("home");
 
-        // Make resealing impossible: withdraw the group (the seal wrapper
-        // refuses withdrawn groups) while keeping the stale unsigned hash.
+        // Round-3 fix c: make resealing GENUINELY fail — demote our agent
+        // from Admin to Member. The reseal Admin gate refuses and the
+        // sweep's `ours && admin` condition is false, so the only remaining
+        // path is STRIP (this actually exercises the failure, unlike the
+        // previous withdrawn-flag trick which never reached the gate).
         let mut broken = info.clone();
-        broken.withdrawn = true;
-        broken.recompute_state_hash(); // withdrawn hash recomputed WITH digest…
-                                       // …then revert the withdrawn flag in-memory without resealing, so the
-                                       // stored hash no longer matches the current fields.
-        broken.withdrawn = false;
-        assert!(!broken.state_hash_is_current());
+        let meta = crate::groups::state_commit::GroupPublicMeta {
+            home_digest: None,
+            ..broken.public_meta()
+        };
+        let roster_root = crate::groups::compute_roster_root(&broken.members_v2);
+        let policy_hash = crate::groups::compute_policy_hash(&broken.policy);
+        let meta_hash = crate::groups::compute_public_meta_hash(&meta);
+        broken.state_hash = crate::groups::state_commit::compute_state_hash(
+            broken.stable_group_id(),
+            broken.state_revision,
+            broken.prev_state_hash.as_deref(),
+            &roster_root,
+            &policy_hash,
+            &meta_hash,
+            broken.security_binding.as_deref(),
+            broken.withdrawn,
+        );
+        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+        if let Some(member) = broken.members_v2.get_mut(&local_hex) {
+            member.role = crate::groups::GroupRole::Member;
+        }
+        assert!(!broken.state_hash_is_current(), "unsigned condition holds");
         state.named_groups.write().await.insert(id.clone(), broken);
 
         provision_home(&state).await;

--- a/src/server/routes/home.rs
+++ b/src/server/routes/home.rs
@@ -4,14 +4,13 @@
 //! exactly ONE Home at first daemon run: `Hidden + OwnerCertified(owner) +
 //! MlsEncrypted + MembersOnly/MembersOnly`, named "Home" (renamable). The
 //! daemon's own owner-certified agent is the founding member and the
-//! designated PRIMARY agent (`GroupInfo::home.primary_agent`); the
-//! provisioning commit is signed by that agent, so the Home metadata is
-//! owner-signed by construction.
+//! designated PRIMARY agent; the provisioning seal covers the Home metadata
+//! commitment (review fix 1: `home_digest` rides the signed state hash).
 //!
-//! Genesis race scope (v1): dedup is PER-MACHINE — a marker file in the
-//! instance data dir plus a scan for an existing Home in the loaded roster.
-//! Two machines provisioning their own Homes for the same owner is expected
-//! until ADR-0041's tier-1 cross-machine sync decides adoption; this module
+//! Genesis race scope (v1): dedup is PER-MACHINE — a verified marker file
+//! in the instance data dir plus a trust-checked roster scan. Two machines
+//! provisioning their own Homes for the same owner is expected until
+//! ADR-0041's tier-1 cross-machine sync decides adoption; this module
 //! deliberately does not invent that protocol (see the WP report).
 
 use std::sync::Arc;
@@ -23,10 +22,20 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 
 use super::named_groups::{
-    create_named_group, now_millis_u64, persist_named_groups_mutation, update_named_group,
-    AtomicWriteOutcome, CreateGroupRequest, UpdateGroupRequest,
+    create_named_group, now_millis_u64, persist_named_groups_mutation, seal_commit_owner_certified,
+    update_named_group, AtomicWriteOutcome, CreateGroupRequest, UpdateGroupRequest,
 };
 use crate::server::AppState;
+
+/// Owner-cert evidence for `agents` — thin re-export of the ADR-0038
+/// evidence builder (own identity + revocation set + discovery cache) for
+/// sibling modules (the POST /groups owner-chain gate).
+pub(in crate::server) async fn owner_chain_evidence(
+    state: &AppState,
+    agents: &[&str],
+) -> crate::groups::owner_cert::OwnerCertEvidence {
+    super::named_groups::owner_cert_evidence_for(state, agents).await
+}
 
 /// Marker file in the instance data dir recording that this machine already
 /// provisioned its Home (per-machine dedup; cross-machine is ADR-0041).
@@ -55,16 +64,155 @@ pub(in crate::server) fn home_policy(
     }
 }
 
-/// The loaded Home group, if this machine has one (roster scan —
-/// restart-safe even if the marker file was deleted).
+/// Whether `policy` is EXACTLY the Home policy for `owner` — all five axes
+/// (review fix 3: the crash-recovery scan must match the whole shape, not
+/// just name+admission).
+fn is_home_policy(policy: &crate::groups::GroupPolicy, owner: &crate::identity::UserId) -> bool {
+    *policy == home_policy(owner)
+}
+
+/// TRUSTED Home resolution (review fix 1): a group is this machine's Home
+/// only when it carries Home metadata AND its policy is exactly
+/// `OwnerCertified(owner)` Home-shaped AND our own agent is an active
+/// member. Anything else (injected metadata, a foreign owner's Home, a
+/// group we were removed from) is not trusted.
 pub(in crate::server) async fn find_home(
     state: &AppState,
+    owner: &crate::identity::UserId,
 ) -> Option<(String, crate::groups::GroupInfo)> {
+    let local_hex = hex::encode(state.agent.agent_id().as_bytes());
     let groups = state.named_groups.read().await;
     groups
         .iter()
-        .find(|(_, info)| info.home.is_some())
+        .find(|(_, info)| {
+            info.home.is_some()
+                && is_home_policy(&info.policy, owner)
+                && info.has_active_member(&local_hex)
+        })
         .map(|(id, info)| (id.clone(), info.clone()))
+}
+
+/// A group that matches the full Home policy for `owner` whether or not the
+/// Home metadata was stamped — the crash-recovery predicate (review fix 3:
+/// a crash between create and stamp must adopt the created group, not mint
+/// a second one).
+#[must_use]
+pub(in crate::server) fn is_home_candidate(
+    info: &crate::groups::GroupInfo,
+    owner: &crate::identity::UserId,
+) -> bool {
+    is_home_policy(&info.policy, owner)
+}
+
+/// Read + verify the marker (review fix 3): PARSED (never a bare
+/// existence check), checked against the CURRENT owner, and checked to
+/// point at a group that still exists. Absent/corrupt/stale → `None`
+/// (corrupt + stale are logged); the trusted roster scan re-derives.
+async fn read_verified_marker(state: &AppState, owner_hex: &str) -> Option<HomeMarker> {
+    let path = state.data_dir.join(HOME_MARKER_FILE);
+    let bytes = match tokio::fs::read(&path).await {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                "cannot read Home marker (treating as absent; the trusted roster scan re-derives): {e}"
+            );
+            return None;
+        }
+    };
+    match serde_json::from_slice::<HomeMarker>(&bytes) {
+        Ok(marker) => {
+            if marker.owner_user_id != owner_hex {
+                tracing::warn!(
+                    marker_owner = %marker.owner_user_id,
+                    "Home marker names a different owner (ownership transition?); ignoring it"
+                );
+                return None;
+            }
+            let exists = state
+                .named_groups
+                .read()
+                .await
+                .contains_key(&marker.group_id);
+            if !exists {
+                tracing::warn!(
+                    group_id = %marker.group_id,
+                    "Home marker points at a missing group; ignoring it"
+                );
+                return None;
+            }
+            Some(marker)
+        }
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                "corrupt Home marker (treating as absent; the trusted roster scan re-derives): {e}"
+            );
+            None
+        }
+    }
+}
+
+async fn write_marker(path: &std::path::Path, marker: &HomeMarker) {
+    match serde_json::to_vec_pretty(marker) {
+        Ok(bytes) => {
+            if let Err(e) = tokio::fs::write(path, bytes).await {
+                tracing::warn!(
+                    path = %path.display(),
+                    "failed to write Home marker (Home still provisioned; restart will adopt by scan): {e}"
+                );
+            }
+        }
+        Err(e) => tracing::warn!("failed to serialize Home marker: {e}"),
+    }
+}
+
+/// Stamp Home metadata on `group_id` and SEAL it into the signed state
+/// chain (review fix 1): the Home digest enters the state hash via
+/// `public_meta()`, so `primary_agent` is covered by an owner-agent-signed
+/// commit. Returns the stamped info on success.
+async fn stamp_and_seal_home(
+    state: &Arc<AppState>,
+    group_id: &str,
+) -> Option<crate::groups::GroupInfo> {
+    let signing_kp = state.agent.identity().agent_keypair();
+    let mut info = {
+        let groups = state.named_groups.read().await;
+        groups.get(group_id).cloned()?
+    };
+    let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+    let mut placements = std::collections::BTreeMap::new();
+    placements.insert(local_hex.clone(), crate::groups::MemberPlacement::Pinned);
+    info.home = Some(crate::groups::HomeMetadata {
+        primary_agent: local_hex,
+        placements,
+        provisioned_at_ms: now_millis_u64(),
+    });
+    // Seal through the OwnerCertified wrapper: it re-verifies the roster
+    // (refusing on any failing member) and the seal covers the freshly
+    // stamped home digest.
+    if let Err(e) =
+        seal_commit_owner_certified(state, &mut info, signing_kp, now_millis_u64()).await
+    {
+        tracing::error!(group_id, "Home metadata seal failed: {e}");
+        return None;
+    }
+    if !matches!(
+        persist_named_groups_mutation(state, |groups| {
+            groups.insert(group_id.to_string(), info.clone());
+            true
+        })
+        .await,
+        Ok(AtomicWriteOutcome::Durable)
+    ) {
+        tracing::error!(
+            group_id,
+            "Home metadata could not be persisted (marker not written; will retry)"
+        );
+        return None;
+    }
+    Some(info)
 }
 
 /// Auto-provision the Home space for an owned install. Idempotent and
@@ -82,32 +230,68 @@ pub(in crate::server) async fn provision_home(state: &Arc<AppState>) {
         tracing::warn!("owner key present but no agent certificate: Home not provisioned");
         return;
     }
+    let owner = user_kp.user_id();
+    let owner_hex = hex::encode(owner.as_bytes());
     let marker_path = state.data_dir.join(HOME_MARKER_FILE);
-    if tokio::fs::try_exists(&marker_path).await.unwrap_or(false) {
-        return; // Already provisioned on this machine.
-    }
-    // Restart safety even without the marker: adopt any existing Home.
-    if let Some((id, info)) = find_home(state).await {
-        tracing::info!(
-            group_id = %id,
-            "Home already present; recording marker (no duplicate provisioned)"
-        );
-        write_marker(
-            &marker_path,
-            &HomeMarker {
-                group_id: id,
-                owner_user_id: hex::encode(user_kp.user_id().as_bytes()),
-                provisioned_at_ms: info
-                    .home
-                    .as_ref()
-                    .map_or_else(now_millis_u64, |h| h.provisioned_at_ms),
-            },
-        )
-        .await;
+
+    // 1) Trusted Home already present (the marker is only advisory — the
+    //    roster scan is authoritative). Repair a missing/stale marker.
+    if let Some((id, info)) = find_home(state, &owner).await {
+        let needs_repair = read_verified_marker(state, &owner_hex)
+            .await
+            .is_none_or(|m| m.group_id != id);
+        if needs_repair {
+            tracing::info!(group_id = %id, "Home already present; recording marker");
+            write_marker(
+                &marker_path,
+                &HomeMarker {
+                    group_id: id,
+                    owner_user_id: owner_hex,
+                    provisioned_at_ms: info
+                        .home
+                        .as_ref()
+                        .map_or_else(now_millis_u64, |h| h.provisioned_at_ms),
+                },
+            )
+            .await;
+        }
         return;
     }
 
-    let owner = user_kp.user_id();
+    // 2) Crash recovery (review fix 3): a group matching the FULL Home
+    //    policy exists but was never stamped (crash between create and
+    //    stamp, or a failed stamp/persist). Adopt the OLDEST such group —
+    //    complete its metadata + seal instead of minting a duplicate.
+    let candidate: Option<String> = {
+        let groups = state.named_groups.read().await;
+        let mut matches: Vec<(&String, u64)> = groups
+            .iter()
+            .filter(|(_, info)| info.home.is_none() && is_home_candidate(info, &owner))
+            .map(|(id, info)| (id, info.created_at))
+            .collect();
+        matches.sort_by_key(|(_, created)| *created);
+        matches.first().map(|(id, _)| (*id).clone())
+    };
+    if let Some(id) = candidate {
+        tracing::info!(
+            group_id = %id,
+            "adopting unstamped Home-shaped group (crash recovery); stamping + sealing"
+        );
+        if let Some(info) = stamp_and_seal_home(state, &id).await {
+            write_marker(
+                &marker_path,
+                &HomeMarker {
+                    group_id: id,
+                    owner_user_id: owner_hex,
+                    provisioned_at_ms: info.home.as_ref().map_or(0, |h| h.provisioned_at_ms),
+                },
+            )
+            .await;
+        }
+        return;
+    }
+
+    // 3) Fresh provisioning through the full creation path.
     let req = CreateGroupRequest {
         name: "Home".to_string(),
         description: "Owner's personal space (auto-provisioned)".to_string(),
@@ -125,86 +309,48 @@ pub(in crate::server) async fn provision_home(state: &Arc<AppState>) {
         return;
     }
     // Locate the freshly created Home and stamp its metadata + marker.
-    let Some((group_id, mut info)) = find_home_by_policy(state, &owner).await else {
+    let group_id = {
+        let groups = state.named_groups.read().await;
+        groups
+            .iter()
+            .find(|(_, info)| info.home.is_none() && is_home_candidate(info, &owner))
+            .map(|(id, _)| id.clone())
+    };
+    let Some(group_id) = group_id else {
         tracing::error!("Home group created but not found afterwards; marker not written");
         return;
     };
-    let local_hex = hex::encode(state.agent.agent_id().as_bytes());
-    let mut placements = std::collections::BTreeMap::new();
-    placements.insert(local_hex.clone(), crate::groups::MemberPlacement::Pinned);
-    info.home = Some(crate::groups::HomeMetadata {
-        primary_agent: local_hex,
-        placements,
-        provisioned_at_ms: now_millis_u64(),
+    if let Some(info) = stamp_and_seal_home(state, &group_id).await {
+        write_marker(
+            &marker_path,
+            &HomeMarker {
+                group_id: group_id.clone(),
+                owner_user_id: owner_hex,
+                provisioned_at_ms: info.home.as_ref().map_or(0, |h| h.provisioned_at_ms),
+            },
+        )
+        .await;
+        tracing::info!(group_id = %group_id, "provisioned Home (ADR-0038)");
+    }
+}
+
+/// Roaming-guarantee warning computed from a GroupInfo ALREADY IN HAND
+/// (review fix 6: no lock re-acquisition — call while holding the roster
+/// guard). Intersects placements with ACTIVE members (review fix 7: a
+/// stale Roaming entry for a removed agent must not suppress it).
+///
+/// ADR-0038: Home always contains ≥1 Roaming agent so it follows the user
+/// across machines — surface the violation until ADR-0037 lands.
+#[must_use]
+pub(in crate::server) fn home_roaming_warning_for(
+    info: &crate::groups::GroupInfo,
+) -> Option<serde_json::Value> {
+    let home = info.home.as_ref()?;
+    let has_roaming = info.active_members().any(|m| {
+        home.placements
+            .get(&m.agent_id)
+            .is_some_and(|p| *p == crate::groups::MemberPlacement::Roaming)
     });
-    let stamped = info;
-    if !matches!(
-        persist_named_groups_mutation(state, |groups| {
-            groups.insert(group_id.clone(), stamped.clone());
-            true
-        })
-        .await,
-        Ok(AtomicWriteOutcome::Durable)
-    ) {
-        tracing::error!(
-            "Home provisioning could not persist metadata (marker not written; will retry)"
-        );
-        return;
-    }
-    write_marker(
-        &marker_path,
-        &HomeMarker {
-            group_id: group_id.clone(),
-            owner_user_id: hex::encode(owner.as_bytes()),
-            provisioned_at_ms: stamped.home.as_ref().map_or(0, |h| h.provisioned_at_ms),
-        },
-    )
-    .await;
-    tracing::info!(group_id = %group_id, "provisioned Home (ADR-0038)");
-}
-
-/// Find the group just created with the Home policy for `owner` (used
-/// between creation and metadata stamping, when `home` is still None).
-async fn find_home_by_policy(
-    state: &AppState,
-    owner: &crate::identity::UserId,
-) -> Option<(String, crate::groups::GroupInfo)> {
-    let groups = state.named_groups.read().await;
-    groups
-        .iter()
-        .find(|(_, info)| {
-            info.policy.admission == crate::groups::GroupAdmission::OwnerCertified(*owner)
-                && info.home.is_none()
-                && info.name == "Home"
-        })
-        .map(|(id, info)| (id.clone(), info.clone()))
-}
-
-async fn write_marker(path: &std::path::Path, marker: &HomeMarker) {
-    match serde_json::to_vec_pretty(marker) {
-        Ok(bytes) => {
-            if let Err(e) = tokio::fs::write(path, bytes).await {
-                tracing::warn!(
-                    path = %path.display(),
-                    "failed to write Home marker (Home still provisioned; restart will adopt by scan): {e}"
-                );
-            }
-        }
-        Err(e) => tracing::warn!("failed to serialize Home marker: {e}"),
-    }
-}
-
-/// Structured roaming warning for an existing Home with zero Roaming
-/// agents (ADR-0038: Home always contains ≥1 roaming agent so it follows
-/// the user across machines — surface the violation until ADR-0037 lands).
-pub(in crate::server) async fn home_roaming_warning(state: &AppState) -> Option<serde_json::Value> {
-    let (_, info) = find_home(state).await?;
-    let has_roaming = info
-        .home
-        .as_ref()?
-        .placements
-        .values()
-        .any(|p| *p == crate::groups::MemberPlacement::Roaming);
     if has_roaming {
         return None;
     }
@@ -226,25 +372,71 @@ async fn self_name_for(state: &AppState, agent_hex: &str) -> Option<String> {
         .and_then(|entry| entry.self_name.clone())
 }
 
-/// GET /home — resolve the Home group and its metadata.
+/// Whether `primary_agent` is an active member whose roster-embedded
+/// certificate chains to `owner` — the trust check behind the owner chip
+/// (review fix 5). Falls back to `false` when no committed certificate is
+/// present (fail-closed attribution).
+fn primary_agent_trusted(
+    info: &crate::groups::GroupInfo,
+    owner: &crate::identity::UserId,
+    now_unix: u64,
+) -> bool {
+    let Some(home) = info.home.as_ref() else {
+        return false;
+    };
+    let Some(member) = info.members_v2.get(&home.primary_agent) else {
+        return false;
+    };
+    if !member.is_active() {
+        return false;
+    }
+    member.certificate.as_ref().is_some_and(|cert| {
+        crate::groups::owner_cert::verify_cert_against_owner(
+            owner,
+            &home.primary_agent,
+            cert,
+            false,
+            now_unix,
+        )
+        .is_ok()
+    })
+}
+
+/// GET /home — resolve the Home group and its metadata. Trust-checked
+/// (review fix 5): the group must be the CURRENT owner's Home with our
+/// agent an active member; the primary agent's verification status is
+/// reported (`verified`) so the GUI only shows the owner chip when the
+/// SENDING agent is that verified primary.
 pub(in crate::server) async fn get_home(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let Some((group_id, info)) = find_home(state.as_ref()).await else {
-        return (
+    let not_found = |reason: &str| {
+        (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({
                 "ok": false,
-                "error": "no Home provisioned (un-owned install or not yet created)"
+                "error": reason,
             })),
-        );
+        )
     };
-    let home = info.home.clone().unwrap_or_else(|| {
-        // Adopted pre-metadata Home (should not happen; degrade honestly).
-        crate::groups::HomeMetadata {
+    let Some(user_kp) = state.agent.identity().user_keypair() else {
+        return not_found("no Home provisioned (un-owned install)");
+    };
+    let owner = user_kp.user_id();
+    let Some((group_id, info)) = find_home(state.as_ref(), &owner).await else {
+        return not_found("no Home provisioned");
+    };
+    let home = info
+        .home
+        .clone()
+        .unwrap_or_else(|| crate::groups::HomeMetadata {
             primary_agent: hex::encode(state.agent.agent_id().as_bytes()),
             placements: std::collections::BTreeMap::new(),
             provisioned_at_ms: 0,
-        }
-    });
+        });
+    let primary_ok = primary_agent_trusted(
+        &info,
+        &owner,
+        crate::groups::owner_cert::restore_clock_now(),
+    );
     let mut members = Vec::new();
     for member in info.active_members() {
         members.push(serde_json::json!({
@@ -275,10 +467,12 @@ pub(in crate::server) async fn get_home(State(state): State<Arc<AppState>>) -> i
             "primary_agent": {
                 "agent_id": home.primary_agent,
                 "self_name": primary_self_name,
+                "verified": primary_ok,
             },
             "members": members,
             "warnings": {
-                "no_roaming_agent": home_roaming_warning(state.as_ref()).await.is_some(),
+                "no_roaming_agent": home_roaming_warning_for(&info).is_some(),
+                "primary_agent_unverified": !primary_ok,
             },
         })),
     )
@@ -295,7 +489,17 @@ pub(in crate::server) async fn rename_home(
     State(state): State<Arc<AppState>>,
     Json(req): Json<RenameHomeRequest>,
 ) -> Response {
-    let Some((group_id, _)) = find_home(state.as_ref()).await else {
+    let Some(user_kp) = state.agent.identity().user_keypair() else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": "no Home provisioned"
+            })),
+        )
+            .into_response();
+    };
+    let Some((group_id, _)) = find_home(state.as_ref(), &user_kp.user_id()).await else {
         return (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({
@@ -322,8 +526,7 @@ mod tests {
     use tower::ServiceExt;
 
     /// Owned test state: user key (deterministic seed so the owner id is
-    /// stable across the "restart" arm) + builder-issued agent certificate —
-    /// the exact shape `serve` produces for an owned install.
+    /// stable across the "restart" arm) + builder-issued agent certificate.
     async fn owned_state(
         data_dir: &std::path::Path,
         owner_seed: [u8; 32],
@@ -332,7 +535,10 @@ mod tests {
         let agent = Arc::new(
             crate::Agent::builder()
                 .with_machine_key(data_dir.join("machine.key"))
-                .with_agent_key(crate::identity::AgentKeypair::generate()?)
+                // Persisted agent key: the "restart" arm reloads the SAME
+                // agent identity (a real restart), so Home membership and
+                // the marker survive it.
+                .with_agent_key_path(data_dir.join("agent.key"))
                 .with_agent_cert_path(data_dir.join("agent.cert"))
                 .with_user_key(user)
                 .with_contact_store_path(data_dir.join("contacts.json"))
@@ -370,63 +576,72 @@ mod tests {
         Ok((status, serde_json::from_slice(&body)?))
     }
 
-    /// WHY (ADR-0038 validation): a fresh owned install provisions exactly
-    /// one Home with the Home policy, the daemon's agent as founding member
-    /// and recorded primary agent — and a restart (fresh state over the
-    /// SAME data dir) does NOT provision a second one.
+    fn owner_of(state: &AppState) -> crate::identity::UserId {
+        state
+            .agent
+            .identity()
+            .user_keypair()
+            .expect("owned fixture")
+            .user_id()
+    }
+
+    /// WHY: a fresh owned install provisions exactly one Home, and the Home
+    /// metadata is SEALED (review fix 1) — mutating `home` after the fact
+    /// breaks state-hash validation. Restart does not duplicate.
     #[tokio::test]
     async fn owned_install_provisions_home_once_across_restart() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let state = owned_state(dir.path(), [0x38; 32]).await?;
         provision_home(&state).await;
-        let (group_id, info) = find_home(state.as_ref()).await.expect("Home provisioned");
+
+        let owner = owner_of(&state);
+        let (group_id, info) = find_home(&state, &owner).await.expect("Home provisioned");
         assert_eq!(info.name, "Home");
-        assert_eq!(
-            info.policy.discoverability,
-            crate::groups::GroupDiscoverability::Hidden
-        );
-        assert!(matches!(
-            info.policy.admission,
-            crate::groups::GroupAdmission::OwnerCertified(_)
-        ));
-        assert_eq!(
-            info.policy.confidentiality,
-            crate::groups::GroupConfidentiality::MlsEncrypted
-        );
+        assert!(is_home_policy(&info.policy, &owner));
         let local_hex = hex::encode(state.agent.agent_id().as_bytes());
-        assert!(
-            info.has_active_member(&local_hex),
-            "the daemon's own agent is the founding member"
-        );
+        assert!(info.has_active_member(&local_hex));
         let home = info.home.as_ref().expect("home metadata");
-        assert_eq!(home.primary_agent, local_hex, "primary agent persisted");
+        assert_eq!(home.primary_agent, local_hex);
         assert_eq!(
             home.placements.get(&local_hex),
-            Some(&crate::groups::MemberPlacement::Pinned),
-            "placement placeholder defaults to Pinned"
+            Some(&crate::groups::MemberPlacement::Pinned)
         );
-        // Owner-signed: the provisioning commit was authored by the
-        // owner-certified agent.
-        assert_eq!(
-            info.commit_log
-                .last()
-                .map(|c| c.commit.committed_by.as_str()),
-            Some(local_hex.as_str()),
-            "provisioning commit signed by the owner's agent"
+
+        // Review fix 1: the home digest is committed by a signed seal —
+        // forging `home` afterwards must change the state hash.
+        let sealed_hash = info.state_hash.clone();
+        let mut forged = info.clone();
+        let evil = "ff".repeat(32);
+        forged.home = Some(crate::groups::HomeMetadata {
+            primary_agent: evil,
+            placements: std::collections::BTreeMap::new(),
+            provisioned_at_ms: 0,
+        });
+        forged.recompute_state_hash();
+        assert_ne!(
+            forged.state_hash, sealed_hash,
+            "forged home metadata must not validate under the sealed state hash"
         );
+        // And the digest actually rides the meta hash (empty home == absent
+        // digest; present home == Some).
+        assert!(
+            crate::groups::compute_public_meta_hash(&info.public_meta())
+                != crate::groups::compute_public_meta_hash(&forged.public_meta())
+        );
+
+        // Marker was written and verifies.
+        assert!(read_verified_marker(&state, &hex::encode(owner.as_bytes()))
+            .await
+            .is_some());
 
         // Restart: fresh state over the same data dir — no duplicate.
         drop(state);
         let state2 = owned_state(dir.path(), [0x38; 32]).await?;
         provision_home(&state2).await;
-        provision_home(&state2).await; // and idempotent within one run
-        {
-            let groups = state2.named_groups.read().await;
-            let homes = groups.values().filter(|info| info.home.is_some()).count();
-            assert_eq!(homes, 1, "exactly one Home after restart + re-run");
-        }
-        let (group_id2, info2) = find_home(state2.as_ref()).await.expect("home found");
-        assert_eq!(group_id2, group_id, "same Home group id across restart");
+        provision_home(&state2).await; // idempotent within one run
+        let owner2 = owner_of(&state2);
+        let (group_id2, info2) = find_home(&state2, &owner2).await.expect("home found");
+        assert_eq!(group_id2, group_id, "same Home across restart");
         assert_eq!(
             info2.home.as_ref().expect("meta").primary_agent,
             local_hex,
@@ -435,14 +650,200 @@ mod tests {
         Ok(())
     }
 
-    /// WHY: an un-owned (anonymous) install provisions nothing — Home is
-    /// the OWNER's personal space.
+    /// WHY (review fix 3): a crash between group-create and home-stamp must
+    /// be RECOVERED — the next start adopts the unstamped Home-shaped group
+    /// instead of minting a duplicate.
+    #[tokio::test]
+    async fn crash_between_create_and_stamp_is_recovered() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x3C; 32]).await?;
+        let owner = owner_of(&state);
+        // Simulate the crash: create a Home-shaped group with NO metadata
+        // and NO marker.
+        let req = CreateGroupRequest {
+            name: "Home".to_string(),
+            description: String::new(),
+            display_name: None,
+            preset: None,
+            policy: Some(home_policy(&owner)),
+        };
+        let response = create_named_group(State(Arc::clone(&state)), Json(req)).await;
+        let (status, body) = response_json(response.into_response()).await?;
+        assert_eq!(status, StatusCode::CREATED, "{body}");
+        let created: String = body["group_id"].as_str().unwrap_or_default().to_string();
+        assert!(!created.is_empty());
+
+        provision_home(&state).await;
+        let (id, info) = find_home(&state, &owner).await.expect("recovered");
+        assert_eq!(
+            id, created,
+            "adopted the crashed-create group, not a new one"
+        );
+        assert!(info.home.is_some(), "metadata stamped + sealed");
+        Ok(())
+    }
+
+    /// WHY (review fix 3): a corrupt marker must not short-circuit
+    /// provisioning; the trusted scan re-derives.
+    #[tokio::test]
+    async fn corrupt_marker_does_not_suppress_provisioning() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x3D; 32]).await?;
+        tokio::fs::write(dir.path().join(HOME_MARKER_FILE), b"{not json").await?;
+        provision_home(&state).await;
+        let owner = owner_of(&state);
+        assert!(
+            find_home(&state, &owner).await.is_some(),
+            "provisioned despite corrupt marker"
+        );
+        Ok(())
+    }
+
+    /// WHY (review fix 1): injected home metadata on a group that is NOT
+    /// our-owner Home-shaped must not be trusted by find_home.
+    #[tokio::test]
+    async fn injected_home_metadata_on_foreign_group_is_untrusted() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x3E; 32]).await?;
+        let owner = owner_of(&state);
+        // A default InviteOnly group with attacker-stamped home metadata.
+        let mut info = crate::groups::GroupInfo::with_policy(
+            "evil".to_string(),
+            String::new(),
+            state.agent.agent_id(),
+            "ee".repeat(16),
+            crate::groups::GroupPolicy::default(),
+        );
+        info.home = Some(crate::groups::HomeMetadata {
+            primary_agent: "ff".repeat(32),
+            placements: std::collections::BTreeMap::new(),
+            provisioned_at_ms: 0,
+        });
+        state
+            .named_groups
+            .write()
+            .await
+            .insert("ee".repeat(16), info);
+        assert!(
+            find_home(&state, &owner).await.is_none(),
+            "home metadata without the OwnerCertified Home policy must be untrusted"
+        );
+        // And GET /home stays 404 rather than serving the forged metadata.
+        let response = get_home(State(Arc::clone(&state))).await.into_response();
+        let (status, _) = response_json(response).await?;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        Ok(())
+    }
+
+    /// WHY (review fix 2): POST /groups with an OwnerCertified policy for
+    /// an owner we do NOT chain to is a typed 403.
+    #[tokio::test]
+    async fn owner_certified_create_requires_cert_chain() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x3F; 32]).await?;
+        let victim = crate::identity::UserKeypair::generate()?;
+        let req = CreateGroupRequest {
+            name: "stolen".to_string(),
+            description: String::new(),
+            display_name: None,
+            preset: None,
+            policy: Some(home_policy(&victim.user_id())),
+        };
+        let response = create_named_group(State(Arc::clone(&state)), Json(req)).await;
+        let (status, body) = response_json(response.into_response()).await?;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+        assert!(body["error"].as_str().is_some_and(|e| e.contains("chain")));
+        // And no group was created.
+        assert!(state
+            .named_groups
+            .read()
+            .await
+            .values()
+            .all(|i| i.name != "stolen"));
+        Ok(())
+    }
+
+    /// WHY (review fix 2): the create response echoes the effective policy
+    /// so callers detect silent downgrade on older daemons.
+    #[tokio::test]
+    async fn create_response_echoes_effective_policy() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x40; 32]).await?;
+        let owner = owner_of(&state);
+        let req = CreateGroupRequest {
+            name: "echo".to_string(),
+            description: String::new(),
+            display_name: None,
+            preset: None,
+            policy: Some(home_policy(&owner)),
+        };
+        let response = create_named_group(State(Arc::clone(&state)), Json(req)).await;
+        let (status, body) = response_json(response.into_response()).await?;
+        assert_eq!(status, StatusCode::CREATED, "{body}");
+        let echoed = body["policy"]["admission"]["owner_certified"].as_str();
+        assert_eq!(
+            echoed,
+            Some(hex::encode(owner.as_bytes()).as_str()),
+            "effective policy echoed for downgrade detection: {body}"
+        );
+        Ok(())
+    }
+
+    /// WHY (review fix 7): a stale Roaming placement for a REMOVED agent
+    /// must not suppress the warning; an active Roaming member must.
+    #[tokio::test]
+    async fn roaming_warning_intersects_active_members() -> anyhow::Result<()> {
+        let mut info = crate::groups::GroupInfo::with_policy(
+            "Home".to_string(),
+            String::new(),
+            crate::identity::AgentId([1; 32]),
+            "aa".repeat(16),
+            crate::groups::GroupPolicy::default(),
+        );
+        let active = "11".repeat(32);
+        let removed = "22".repeat(32);
+        info.home = Some(crate::groups::HomeMetadata {
+            primary_agent: active.clone(),
+            placements: [
+                (removed.clone(), crate::groups::MemberPlacement::Roaming),
+                (active.clone(), crate::groups::MemberPlacement::Pinned),
+            ]
+            .into_iter()
+            .collect(),
+            provisioned_at_ms: 0,
+        });
+        info.add_member(active.clone(), crate::groups::GroupRole::Admin, None, None);
+        // Removed agent is NOT an active member (state Removed).
+        {
+            let mut m = crate::groups::GroupMember::new_member(removed.clone(), None, None, 0);
+            m.state = crate::groups::GroupMemberState::Removed;
+            info.members_v2.insert(removed, m);
+        }
+        assert!(
+            home_roaming_warning_for(&info).is_some(),
+            "stale Roaming entry for a removed agent must NOT satisfy the guarantee"
+        );
+        // Mark the ACTIVE member Roaming — warning clears.
+        if let Some(home) = info.home.as_mut() {
+            home.placements
+                .insert(active, crate::groups::MemberPlacement::Roaming);
+        }
+        assert!(home_roaming_warning_for(&info).is_none());
+        Ok(())
+    }
+
+    /// WHY: an un-owned install provisions nothing.
     #[tokio::test]
     async fn unowned_install_provisions_nothing() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let state = unowned_state(dir.path()).await?;
         provision_home(&state).await;
-        assert!(find_home(state.as_ref()).await.is_none());
+        assert!(state
+            .named_groups
+            .read()
+            .await
+            .values()
+            .all(|i| i.home.is_none()));
         assert!(
             !tokio::fs::try_exists(dir.path().join(HOME_MARKER_FILE)).await?,
             "no marker written for an un-owned install"
@@ -450,56 +851,36 @@ mod tests {
         Ok(())
     }
 
-    /// WHY: GET /home resolves the (possibly renamed) Home, its primary
-    /// agent, members with placements, and the no-roaming warning until
-    /// ADR-0037 marks an agent Roaming.
+    /// WHY: GET /home resolves the Home and reports the no-roaming warning;
+    /// /health no longer leaks it (review fix 6).
     #[tokio::test]
-    async fn get_home_returns_metadata_and_warning() -> anyhow::Result<()> {
+    async fn get_home_reports_warning_health_does_not() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
-        let state = owned_state(dir.path(), [0x39; 32]).await?;
+        let state = owned_state(dir.path(), [0x41; 32]).await?;
         provision_home(&state).await;
-
         let response = get_home(State(Arc::clone(&state))).await.into_response();
         let (status, body) = response_json(response).await?;
         assert_eq!(status, StatusCode::OK, "{body}");
         assert_eq!(body["name"], "Home");
-        assert_eq!(body["ok"], true);
-        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
-        assert_eq!(body["primary_agent"]["agent_id"], local_hex);
-        assert!(
-            body["members"]
-                .as_array()
-                .is_some_and(|m| !m.is_empty() && m[0]["placement"] == "pinned"),
-            "members rendered with placement: {body}"
-        );
-        assert_eq!(
-            body["warnings"]["no_roaming_agent"], true,
-            "zero-Roaming Home must surface the warning: {body}"
-        );
-
-        // Health surfaces the same warning as a structured detail.
+        assert_eq!(body["warnings"]["no_roaming_agent"], true);
         let health_json = crate::server::routes::status::health(State(Arc::clone(&state))).await;
-        let body: serde_json::Value = serde_json::to_value(&health_json.0.data).unwrap_or_default();
-        let body = serde_json::json!({ "data": body });
-        assert_eq!(status, StatusCode::OK);
+        let health_body: serde_json::Value =
+            serde_json::to_value(&health_json.0).unwrap_or_default();
         assert!(
-            body["data"]["warnings"]
+            health_body["warnings"]
                 .as_array()
-                .is_some_and(|w| w.iter().any(|w| w["code"] == "home_no_roaming_agent")),
-            "health details carry the home warning: {body}"
+                .is_none_or(|w| w.is_empty()),
+            "auth-exempt /health must not leak Home existence: {health_body}"
         );
         Ok(())
     }
 
-    /// WHY: rename round-trips through the convenience endpoint (which
-    /// rides the sealed PATCH /groups/:id path).
+    /// WHY: rename round-trips through the convenience endpoint.
     #[tokio::test]
     async fn home_rename_round_trips() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
-        let state = owned_state(dir.path(), [0x3A; 32]).await?;
+        let state = owned_state(dir.path(), [0x42; 32]).await?;
         provision_home(&state).await;
-        let (group_id, _) = find_home(state.as_ref()).await.expect("home");
-
         let response = rename_home(
             State(Arc::clone(&state)),
             Json(RenameHomeRequest {
@@ -509,29 +890,9 @@ mod tests {
         .await;
         let (status, body) = response_json(response).await?;
         assert_eq!(status, StatusCode::OK, "{body}");
-
-        let response = get_home(State(Arc::clone(&state))).await.into_response();
-        let (status, body) = response_json(response).await?;
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(body["name"], "Irvine HQ", "renamed: {body}");
-        assert_eq!(body["group_id"], group_id);
-
-        // GET /groups/:id carries home details + warnings too.
-        let response = crate::server::routes::named_groups::get_named_group(
-            State(Arc::clone(&state)),
-            Path(group_id.clone()),
-        )
-        .await
-        .into_response();
-        let (status, body) = response_json(response).await?;
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(body["home"]["primary_agent"], body["creator"]);
-        assert!(
-            body["warnings"]
-                .as_array()
-                .is_some_and(|w| w.iter().any(|w| w["code"] == "home_no_roaming_agent")),
-            "group view carries the warning: {body}"
-        );
+        let owner = owner_of(&state);
+        let (_, info) = find_home(&state, &owner).await.expect("home");
+        assert_eq!(info.name, "Irvine HQ");
         Ok(())
     }
 
@@ -546,11 +907,11 @@ mod tests {
         Ok(())
     }
 
-    /// Router-level smoke: the routes are wired with the right methods.
+    /// Router-level smoke: routes wired with the right methods.
     #[tokio::test]
     async fn home_routes_wired() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
-        let state = owned_state(dir.path(), [0x3B; 32]).await?;
+        let state = owned_state(dir.path(), [0x43; 32]).await?;
         provision_home(&state).await;
         let app = axum::Router::new()
             .route("/home", axum::routing::get(get_home))

--- a/src/server/routes/home.rs
+++ b/src/server/routes/home.rs
@@ -1,0 +1,564 @@
+//! ADR-0038 Home — the owner's auto-provisioned personal space.
+//!
+//! An install with an owner (ADR-0036 `OwnerProfile` + user key) provisions
+//! exactly ONE Home at first daemon run: `Hidden + OwnerCertified(owner) +
+//! MlsEncrypted + MembersOnly/MembersOnly`, named "Home" (renamable). The
+//! daemon's own owner-certified agent is the founding member and the
+//! designated PRIMARY agent (`GroupInfo::home.primary_agent`); the
+//! provisioning commit is signed by that agent, so the Home metadata is
+//! owner-signed by construction.
+//!
+//! Genesis race scope (v1): dedup is PER-MACHINE — a marker file in the
+//! instance data dir plus a scan for an existing Home in the loaded roster.
+//! Two machines provisioning their own Homes for the same owner is expected
+//! until ADR-0041's tier-1 cross-machine sync decides adoption; this module
+//! deliberately does not invent that protocol (see the WP report).
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use super::named_groups::{
+    create_named_group, now_millis_u64, persist_named_groups_mutation, update_named_group,
+    AtomicWriteOutcome, CreateGroupRequest, UpdateGroupRequest,
+};
+use crate::server::AppState;
+
+/// Marker file in the instance data dir recording that this machine already
+/// provisioned its Home (per-machine dedup; cross-machine is ADR-0041).
+pub(in crate::server) const HOME_MARKER_FILE: &str = "home.json";
+
+/// On-disk marker: which group is this machine's Home, under which owner.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(in crate::server) struct HomeMarker {
+    pub group_id: String,
+    pub owner_user_id: String,
+    pub provisioned_at_ms: u64,
+}
+
+/// ADR-0038 Home policy: Hidden + OwnerCertified(owner) + MlsEncrypted +
+/// MembersOnly/MembersOnly.
+#[must_use]
+pub(in crate::server) fn home_policy(
+    owner: &crate::identity::UserId,
+) -> crate::groups::GroupPolicy {
+    crate::groups::GroupPolicy {
+        discoverability: crate::groups::GroupDiscoverability::Hidden,
+        admission: crate::groups::GroupAdmission::OwnerCertified(*owner),
+        confidentiality: crate::groups::GroupConfidentiality::MlsEncrypted,
+        read_access: crate::groups::GroupReadAccess::MembersOnly,
+        write_access: crate::groups::GroupWriteAccess::MembersOnly,
+    }
+}
+
+/// The loaded Home group, if this machine has one (roster scan —
+/// restart-safe even if the marker file was deleted).
+pub(in crate::server) async fn find_home(
+    state: &AppState,
+) -> Option<(String, crate::groups::GroupInfo)> {
+    let groups = state.named_groups.read().await;
+    groups
+        .iter()
+        .find(|(_, info)| info.home.is_some())
+        .map(|(id, info)| (id.clone(), info.clone()))
+}
+
+/// Auto-provision the Home space for an owned install. Idempotent and
+/// best-effort: never fails startup — a provisioning failure logs loudly
+/// and retries on the next daemon start (no marker is written on failure).
+pub(in crate::server) async fn provision_home(state: &Arc<AppState>) {
+    // Only an OWNED install provisions: user key + builder-issued
+    // certificate must both be live (OwnerCertified admission needs a
+    // certifiable founding member).
+    let Some(user_kp) = state.agent.identity().user_keypair() else {
+        tracing::debug!("no owner user key: Home not provisioned (anonymous install)");
+        return;
+    };
+    if state.agent.identity().agent_certificate().is_none() {
+        tracing::warn!("owner key present but no agent certificate: Home not provisioned");
+        return;
+    }
+    let marker_path = state.data_dir.join(HOME_MARKER_FILE);
+    if tokio::fs::try_exists(&marker_path).await.unwrap_or(false) {
+        return; // Already provisioned on this machine.
+    }
+    // Restart safety even without the marker: adopt any existing Home.
+    if let Some((id, info)) = find_home(state).await {
+        tracing::info!(
+            group_id = %id,
+            "Home already present; recording marker (no duplicate provisioned)"
+        );
+        write_marker(
+            &marker_path,
+            &HomeMarker {
+                group_id: id,
+                owner_user_id: hex::encode(user_kp.user_id().as_bytes()),
+                provisioned_at_ms: info
+                    .home
+                    .as_ref()
+                    .map_or_else(now_millis_u64, |h| h.provisioned_at_ms),
+            },
+        )
+        .await;
+        return;
+    }
+
+    let owner = user_kp.user_id();
+    let req = CreateGroupRequest {
+        name: "Home".to_string(),
+        description: "Owner's personal space (auto-provisioned)".to_string(),
+        display_name: None,
+        preset: None,
+        policy: Some(home_policy(&owner)),
+    };
+    let response = create_named_group(State(Arc::clone(state)), Json(req)).await;
+    let resp = response.into_response();
+    if !resp.status().is_success() {
+        tracing::error!(
+            status = %resp.status(),
+            "Home auto-provisioning failed (will retry on next start)"
+        );
+        return;
+    }
+    // Locate the freshly created Home and stamp its metadata + marker.
+    let Some((group_id, mut info)) = find_home_by_policy(state, &owner).await else {
+        tracing::error!("Home group created but not found afterwards; marker not written");
+        return;
+    };
+    let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+    let mut placements = std::collections::BTreeMap::new();
+    placements.insert(local_hex.clone(), crate::groups::MemberPlacement::Pinned);
+    info.home = Some(crate::groups::HomeMetadata {
+        primary_agent: local_hex,
+        placements,
+        provisioned_at_ms: now_millis_u64(),
+    });
+    let stamped = info;
+    if !matches!(
+        persist_named_groups_mutation(state, |groups| {
+            groups.insert(group_id.clone(), stamped.clone());
+            true
+        })
+        .await,
+        Ok(AtomicWriteOutcome::Durable)
+    ) {
+        tracing::error!(
+            "Home provisioning could not persist metadata (marker not written; will retry)"
+        );
+        return;
+    }
+    write_marker(
+        &marker_path,
+        &HomeMarker {
+            group_id: group_id.clone(),
+            owner_user_id: hex::encode(owner.as_bytes()),
+            provisioned_at_ms: stamped.home.as_ref().map_or(0, |h| h.provisioned_at_ms),
+        },
+    )
+    .await;
+    tracing::info!(group_id = %group_id, "provisioned Home (ADR-0038)");
+}
+
+/// Find the group just created with the Home policy for `owner` (used
+/// between creation and metadata stamping, when `home` is still None).
+async fn find_home_by_policy(
+    state: &AppState,
+    owner: &crate::identity::UserId,
+) -> Option<(String, crate::groups::GroupInfo)> {
+    let groups = state.named_groups.read().await;
+    groups
+        .iter()
+        .find(|(_, info)| {
+            info.policy.admission == crate::groups::GroupAdmission::OwnerCertified(*owner)
+                && info.home.is_none()
+                && info.name == "Home"
+        })
+        .map(|(id, info)| (id.clone(), info.clone()))
+}
+
+async fn write_marker(path: &std::path::Path, marker: &HomeMarker) {
+    match serde_json::to_vec_pretty(marker) {
+        Ok(bytes) => {
+            if let Err(e) = tokio::fs::write(path, bytes).await {
+                tracing::warn!(
+                    path = %path.display(),
+                    "failed to write Home marker (Home still provisioned; restart will adopt by scan): {e}"
+                );
+            }
+        }
+        Err(e) => tracing::warn!("failed to serialize Home marker: {e}"),
+    }
+}
+
+/// Structured roaming warning for an existing Home with zero Roaming
+/// agents (ADR-0038: Home always contains ≥1 roaming agent so it follows
+/// the user across machines — surface the violation until ADR-0037 lands).
+pub(in crate::server) async fn home_roaming_warning(state: &AppState) -> Option<serde_json::Value> {
+    let (_, info) = find_home(state).await?;
+    let has_roaming = info
+        .home
+        .as_ref()?
+        .placements
+        .values()
+        .any(|p| *p == crate::groups::MemberPlacement::Roaming);
+    if has_roaming {
+        return None;
+    }
+    Some(serde_json::json!({
+        "code": "home_no_roaming_agent",
+        "message": "Home has no Roaming agent — it will not follow the owner to a new \
+                    machine until one is marked Roaming (ADR-0037 placement wave)",
+    }))
+}
+
+/// Self-name for an agent, resolved from the identity-discovery cache
+/// (ADR-0036 self-names ride announces); `None` when unknown.
+async fn self_name_for(state: &AppState, agent_hex: &str) -> Option<String> {
+    let agent_id = crate::server::parse_agent_id_hex(agent_hex).ok()?;
+    let cache = state.agent.identity_discovery_cache();
+    let cache = cache.read().await;
+    cache
+        .get(&agent_id)
+        .and_then(|entry| entry.self_name.clone())
+}
+
+/// GET /home — resolve the Home group and its metadata.
+pub(in crate::server) async fn get_home(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let Some((group_id, info)) = find_home(state.as_ref()).await else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": "no Home provisioned (un-owned install or not yet created)"
+            })),
+        );
+    };
+    let home = info.home.clone().unwrap_or_else(|| {
+        // Adopted pre-metadata Home (should not happen; degrade honestly).
+        crate::groups::HomeMetadata {
+            primary_agent: hex::encode(state.agent.agent_id().as_bytes()),
+            placements: std::collections::BTreeMap::new(),
+            provisioned_at_ms: 0,
+        }
+    });
+    let mut members = Vec::new();
+    for member in info.active_members() {
+        members.push(serde_json::json!({
+            "agent_id": member.agent_id,
+            "role": format!("{:?}", member.role),
+            "placement": if home
+                .placements
+                .get(&member.agent_id)
+                .is_some_and(|p| *p == crate::groups::MemberPlacement::Roaming)
+            {
+                "roaming"
+            } else {
+                "pinned"
+            },
+            "self_name": self_name_for(state.as_ref(), &member.agent_id).await,
+        }));
+    }
+    let human_name = state.profile.read().await.human_name.clone();
+    let primary_self_name = self_name_for(state.as_ref(), &home.primary_agent).await;
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "ok": true,
+            "group_id": group_id,
+            "name": info.name,
+            "description": info.description,
+            "human_name": human_name,
+            "primary_agent": {
+                "agent_id": home.primary_agent,
+                "self_name": primary_self_name,
+            },
+            "members": members,
+            "warnings": {
+                "no_roaming_agent": home_roaming_warning(state.as_ref()).await.is_some(),
+            },
+        })),
+    )
+}
+
+#[derive(Debug, Deserialize)]
+pub(in crate::server) struct RenameHomeRequest {
+    name: String,
+}
+
+/// POST /home/rename — convenience wrapper over the existing
+/// PATCH /groups/:id (admin-gated, sealed, persisted).
+pub(in crate::server) async fn rename_home(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<RenameHomeRequest>,
+) -> Response {
+    let Some((group_id, _)) = find_home(state.as_ref()).await else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": "no Home provisioned"
+            })),
+        )
+            .into_response();
+    };
+    let update = UpdateGroupRequest {
+        name: Some(req.name),
+        description: None,
+    };
+    update_named_group(State(state), Path(group_id), Json(update))
+        .await
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::{to_bytes, Body};
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    /// Owned test state: user key (deterministic seed so the owner id is
+    /// stable across the "restart" arm) + builder-issued agent certificate —
+    /// the exact shape `serve` produces for an owned install.
+    async fn owned_state(
+        data_dir: &std::path::Path,
+        owner_seed: [u8; 32],
+    ) -> anyhow::Result<Arc<AppState>> {
+        let user = crate::identity::UserKeypair::from_seed(&owner_seed)?;
+        let agent = Arc::new(
+            crate::Agent::builder()
+                .with_machine_key(data_dir.join("machine.key"))
+                .with_agent_key(crate::identity::AgentKeypair::generate()?)
+                .with_agent_cert_path(data_dir.join("agent.cert"))
+                .with_user_key(user)
+                .with_contact_store_path(data_dir.join("contacts.json"))
+                .build()
+                .await?,
+        );
+        let state =
+            super::super::named_groups::tests::secure_endpoint_test_state_at(data_dir, agent)
+                .await?;
+        Ok(state)
+    }
+
+    /// Un-owned state: no user key (anonymous install).
+    async fn unowned_state(data_dir: &std::path::Path) -> anyhow::Result<Arc<AppState>> {
+        let agent = Arc::new(
+            crate::Agent::builder()
+                .with_machine_key(data_dir.join("machine.key"))
+                .with_agent_key(crate::identity::AgentKeypair::generate()?)
+                .with_agent_cert_path(data_dir.join("agent.cert"))
+                .with_contact_store_path(data_dir.join("contacts.json"))
+                .build()
+                .await?,
+        );
+        let state =
+            super::super::named_groups::tests::secure_endpoint_test_state_at(data_dir, agent)
+                .await?;
+        Ok(state)
+    }
+
+    async fn response_json(
+        response: axum::response::Response,
+    ) -> anyhow::Result<(StatusCode, serde_json::Value)> {
+        let status = response.status();
+        let body = to_bytes(response.into_body(), 1 << 20).await?;
+        Ok((status, serde_json::from_slice(&body)?))
+    }
+
+    /// WHY (ADR-0038 validation): a fresh owned install provisions exactly
+    /// one Home with the Home policy, the daemon's agent as founding member
+    /// and recorded primary agent — and a restart (fresh state over the
+    /// SAME data dir) does NOT provision a second one.
+    #[tokio::test]
+    async fn owned_install_provisions_home_once_across_restart() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x38; 32]).await?;
+        provision_home(&state).await;
+        let (group_id, info) = find_home(state.as_ref()).await.expect("Home provisioned");
+        assert_eq!(info.name, "Home");
+        assert_eq!(
+            info.policy.discoverability,
+            crate::groups::GroupDiscoverability::Hidden
+        );
+        assert!(matches!(
+            info.policy.admission,
+            crate::groups::GroupAdmission::OwnerCertified(_)
+        ));
+        assert_eq!(
+            info.policy.confidentiality,
+            crate::groups::GroupConfidentiality::MlsEncrypted
+        );
+        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+        assert!(
+            info.has_active_member(&local_hex),
+            "the daemon's own agent is the founding member"
+        );
+        let home = info.home.as_ref().expect("home metadata");
+        assert_eq!(home.primary_agent, local_hex, "primary agent persisted");
+        assert_eq!(
+            home.placements.get(&local_hex),
+            Some(&crate::groups::MemberPlacement::Pinned),
+            "placement placeholder defaults to Pinned"
+        );
+        // Owner-signed: the provisioning commit was authored by the
+        // owner-certified agent.
+        assert_eq!(
+            info.commit_log
+                .last()
+                .map(|c| c.commit.committed_by.as_str()),
+            Some(local_hex.as_str()),
+            "provisioning commit signed by the owner's agent"
+        );
+
+        // Restart: fresh state over the same data dir — no duplicate.
+        drop(state);
+        let state2 = owned_state(dir.path(), [0x38; 32]).await?;
+        provision_home(&state2).await;
+        provision_home(&state2).await; // and idempotent within one run
+        {
+            let groups = state2.named_groups.read().await;
+            let homes = groups.values().filter(|info| info.home.is_some()).count();
+            assert_eq!(homes, 1, "exactly one Home after restart + re-run");
+        }
+        let (group_id2, info2) = find_home(state2.as_ref()).await.expect("home found");
+        assert_eq!(group_id2, group_id, "same Home group id across restart");
+        assert_eq!(
+            info2.home.as_ref().expect("meta").primary_agent,
+            local_hex,
+            "primary agent persists"
+        );
+        Ok(())
+    }
+
+    /// WHY: an un-owned (anonymous) install provisions nothing — Home is
+    /// the OWNER's personal space.
+    #[tokio::test]
+    async fn unowned_install_provisions_nothing() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = unowned_state(dir.path()).await?;
+        provision_home(&state).await;
+        assert!(find_home(state.as_ref()).await.is_none());
+        assert!(
+            !tokio::fs::try_exists(dir.path().join(HOME_MARKER_FILE)).await?,
+            "no marker written for an un-owned install"
+        );
+        Ok(())
+    }
+
+    /// WHY: GET /home resolves the (possibly renamed) Home, its primary
+    /// agent, members with placements, and the no-roaming warning until
+    /// ADR-0037 marks an agent Roaming.
+    #[tokio::test]
+    async fn get_home_returns_metadata_and_warning() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x39; 32]).await?;
+        provision_home(&state).await;
+
+        let response = get_home(State(Arc::clone(&state))).await.into_response();
+        let (status, body) = response_json(response).await?;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["name"], "Home");
+        assert_eq!(body["ok"], true);
+        let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+        assert_eq!(body["primary_agent"]["agent_id"], local_hex);
+        assert!(
+            body["members"]
+                .as_array()
+                .is_some_and(|m| !m.is_empty() && m[0]["placement"] == "pinned"),
+            "members rendered with placement: {body}"
+        );
+        assert_eq!(
+            body["warnings"]["no_roaming_agent"], true,
+            "zero-Roaming Home must surface the warning: {body}"
+        );
+
+        // Health surfaces the same warning as a structured detail.
+        let health_json = crate::server::routes::status::health(State(Arc::clone(&state))).await;
+        let body: serde_json::Value = serde_json::to_value(&health_json.0.data).unwrap_or_default();
+        let body = serde_json::json!({ "data": body });
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body["data"]["warnings"]
+                .as_array()
+                .is_some_and(|w| w.iter().any(|w| w["code"] == "home_no_roaming_agent")),
+            "health details carry the home warning: {body}"
+        );
+        Ok(())
+    }
+
+    /// WHY: rename round-trips through the convenience endpoint (which
+    /// rides the sealed PATCH /groups/:id path).
+    #[tokio::test]
+    async fn home_rename_round_trips() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x3A; 32]).await?;
+        provision_home(&state).await;
+        let (group_id, _) = find_home(state.as_ref()).await.expect("home");
+
+        let response = rename_home(
+            State(Arc::clone(&state)),
+            Json(RenameHomeRequest {
+                name: "Irvine HQ".to_string(),
+            }),
+        )
+        .await;
+        let (status, body) = response_json(response).await?;
+        assert_eq!(status, StatusCode::OK, "{body}");
+
+        let response = get_home(State(Arc::clone(&state))).await.into_response();
+        let (status, body) = response_json(response).await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["name"], "Irvine HQ", "renamed: {body}");
+        assert_eq!(body["group_id"], group_id);
+
+        // GET /groups/:id carries home details + warnings too.
+        let response = crate::server::routes::named_groups::get_named_group(
+            State(Arc::clone(&state)),
+            Path(group_id.clone()),
+        )
+        .await
+        .into_response();
+        let (status, body) = response_json(response).await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["home"]["primary_agent"], body["creator"]);
+        assert!(
+            body["warnings"]
+                .as_array()
+                .is_some_and(|w| w.iter().any(|w| w["code"] == "home_no_roaming_agent")),
+            "group view carries the warning: {body}"
+        );
+        Ok(())
+    }
+
+    /// WHY: GET /home on an un-owned install is a clean 404.
+    #[tokio::test]
+    async fn get_home_without_home_is_404() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = unowned_state(dir.path()).await?;
+        let response = get_home(State(Arc::clone(&state))).await.into_response();
+        let (status, body) = response_json(response).await?;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+        Ok(())
+    }
+
+    /// Router-level smoke: the routes are wired with the right methods.
+    #[tokio::test]
+    async fn home_routes_wired() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let state = owned_state(dir.path(), [0x3B; 32]).await?;
+        provision_home(&state).await;
+        let app = axum::Router::new()
+            .route("/home", axum::routing::get(get_home))
+            .with_state(state);
+        let response = app
+            .oneshot(Request::get("/home").body(Body::empty())?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        Ok(())
+    }
+}

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -13,6 +13,7 @@ mod exec;
 mod files;
 mod groups;
 mod history;
+pub mod home;
 mod identity;
 mod machines;
 mod messaging;

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -19669,7 +19669,7 @@ pub(in crate::server) async fn load_predecessor_relay_outbox(
 
 #[must_use]
 #[cfg(test)]
-async fn save_named_groups(state: &AppState) -> bool {
+pub(in crate::server) async fn save_named_groups(state: &AppState) -> bool {
     match save_named_groups_checked(state).await {
         Ok(AtomicWriteOutcome::Durable) => true,
         Ok(AtomicWriteOutcome::ReplacedNotDurable) => {

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -8429,6 +8429,22 @@ pub(in crate::server) async fn create_named_group(
         if req.preset.is_some() {
             return bad_request("pass either `preset` or `policy`, not both");
         }
+        // ADR-0038 review fix 2: an explicit OwnerCertified(owner) claim is
+        // only honored when THIS daemon's agent certificate actually chains
+        // to that owner — otherwise any token holder could mint and
+        // advertise `OwnerCertified(victim)` groups and seat itself Admin.
+        if let Some(owner) = explicit.admission.owner_certified_user_id() {
+            let local_hex = hex::encode(state.agent.agent_id().as_bytes());
+            let evidence = super::home::owner_chain_evidence(state.as_ref(), &[&local_hex]).await;
+            if x0x::groups::owner_cert::verify_owner_certified_member(owner, &local_hex, &evidence)
+                .is_err()
+            {
+                return forbidden(
+                    "cannot create an OwnerCertified group: this agent's certificate does \
+                     not chain to the requested owner",
+                );
+            }
+        }
         explicit
     } else {
         match req.preset.as_deref() {
@@ -8729,6 +8745,14 @@ pub(in crate::server) async fn create_named_group(
                     "group_id": group_id_hex,
                     "name": info.name,
                     "chat_topic": chat_topic,
+                    // ADR-0038 review fix 2 (downgrade detection): echo
+                    // the EFFECTIVE policy. An older daemon that silently
+                    // ignored the unknown `policy` field returns no
+                    // `policy` echo — a caller that sent an explicit
+                    // policy treats the omission as a version downgrade
+                    // and can retry/fail loudly instead of trusting a
+                    // default-policy group it believes is OwnerCertified.
+                    "policy": info.policy,
                 })),
             )
         }
@@ -8799,14 +8823,9 @@ pub(in crate::server) async fn get_named_group(
                     (agent.clone(), serde_json::json!(if *placement == x0x::groups::MemberPlacement::Roaming { "roaming" } else { "pinned" }))
                 }).collect::<serde_json::Map<String, serde_json::Value>>(),
             })),
-            "warnings": if info.home.is_some() {
-                match super::home::home_roaming_warning(state.as_ref()).await {
-                    Some(warning) => vec![warning],
-                    None => Vec::new(),
-                }
-            } else {
-                Vec::new()
-            },
+            "warnings": super::home::home_roaming_warning_for(info)
+                .map(|warning| vec![warning])
+                .unwrap_or_default(),
         })),
     )
 }
@@ -13415,7 +13434,7 @@ pub(in crate::server) fn now_millis_u64() -> u64 {
 /// grow-only set. Agents whose hex does not parse produce no entry and so
 /// fail closed downstream (`NoCertificate`/not-revoked evidence still fails
 /// the chain check).
-async fn owner_cert_evidence_for(
+pub(in crate::server) async fn owner_cert_evidence_for(
     state: &AppState,
     agents: &[&str],
 ) -> x0x::groups::owner_cert::OwnerCertEvidence {
@@ -13516,7 +13535,7 @@ async fn owner_cert_seal_evidence(
 /// event, and would leave the GSS secret / TreeKEM leaves unrotated so the
 /// evicted member keeps decrypting). For every other admission axis — or a
 /// fully certified roster — this is exactly `seal_commit`.
-async fn seal_commit_owner_certified(
+pub(in crate::server) async fn seal_commit_owner_certified(
     state: &AppState,
     info: &mut x0x::groups::GroupInfo,
     signing_kp: &crate::identity::AgentKeypair,

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -357,16 +357,22 @@ pub(in crate::server) fn named_group_direct_delivery_config() -> x0x::dm::DmSend
 /// Request body for POST /groups.
 #[derive(Debug, Deserialize)]
 pub(in crate::server) struct CreateGroupRequest {
-    name: String,
+    pub(in crate::server) name: String,
     #[serde(default)]
-    description: String,
+    pub(in crate::server) description: String,
     /// Optional display name for the creator in this group.
     #[serde(default)]
-    display_name: Option<String>,
+    pub(in crate::server) display_name: Option<String>,
     /// Policy preset name (private_secure / public_request_secure / public_open /
     /// public_announce). Defaults to `private_secure`.
     #[serde(default)]
-    preset: Option<String>,
+    pub(in crate::server) preset: Option<String>,
+    /// ADR-0038: full explicit policy. When present it wins over `preset`
+    /// (passing both is a 400) — used by Home auto-provisioning to install
+    /// the OwnerCertified axis, whose owner id is install-specific and so
+    /// cannot be a named preset.
+    #[serde(default)]
+    pub(in crate::server) policy: Option<x0x::groups::GroupPolicy>,
 }
 
 /// Request body for POST /groups/join.
@@ -8419,14 +8425,21 @@ pub(in crate::server) async fn create_named_group(
     let agent_id = state.agent.agent_id();
 
     // Resolve policy preset (defaults to private_secure).
-    let policy = match req.preset.as_deref() {
-        Some(name) => match x0x::groups::GroupPolicyPreset::from_name(name) {
-            Some(preset) => preset.to_policy(),
-            None => {
-                return bad_request("unknown preset");
-            }
-        },
-        None => x0x::groups::GroupPolicy::default(),
+    let policy = if let Some(explicit) = req.policy {
+        if req.preset.is_some() {
+            return bad_request("pass either `preset` or `policy`, not both");
+        }
+        explicit
+    } else {
+        match req.preset.as_deref() {
+            Some(name) => match x0x::groups::GroupPolicyPreset::from_name(name) {
+                Some(preset) => preset.to_policy(),
+                None => {
+                    return bad_request("unknown preset");
+                }
+            },
+            None => x0x::groups::GroupPolicy::default(),
+        }
     };
 
     // Create the legacy demo MLS group object (kept for the `/mls/groups/:id`
@@ -8779,6 +8792,21 @@ pub(in crate::server) async fn get_named_group(
             "roster_revision": info.roster_revision,
             "member_count": members.len(),
             "members": members,
+            "home": info.home.as_ref().map(|home| serde_json::json!({
+                "primary_agent": home.primary_agent,
+                "provisioned_at_ms": home.provisioned_at_ms,
+                "placements": home.placements.iter().map(|(agent, placement)| {
+                    (agent.clone(), serde_json::json!(if *placement == x0x::groups::MemberPlacement::Roaming { "roaming" } else { "pinned" }))
+                }).collect::<serde_json::Map<String, serde_json::Value>>(),
+            })),
+            "warnings": if info.home.is_some() {
+                match super::home::home_roaming_warning(state.as_ref()).await {
+                    Some(warning) => vec![warning],
+                    None => Vec::new(),
+                }
+            } else {
+                Vec::new()
+            },
         })),
     )
 }
@@ -13344,8 +13372,8 @@ pub(in crate::server) async fn leave_group(
 
 #[derive(Debug, Deserialize)]
 pub(in crate::server) struct UpdateGroupRequest {
-    name: Option<String>,
-    description: Option<String>,
+    pub(in crate::server) name: Option<String>,
+    pub(in crate::server) description: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -30068,6 +30096,8 @@ pub(in crate::server) mod tests {
                 description: String::new(),
                 display_name: None,
                 preset: Some("private_secure".to_string()),
+
+                policy: None,
             }),
         )
         .await

--- a/src/server/routes/status.rs
+++ b/src/server/routes/status.rs
@@ -33,6 +33,10 @@ pub(in crate::server) struct HealthData {
     uptime_secs: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     degraded_reason: Option<String>,
+    /// Structured advisory warnings (never liveness-affecting). ADR-0038:
+    /// `home_no_roaming_agent` when the Home space has no Roaming agent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<serde_json::Value>,
 }
 
 /// Classify liveness for `GET /health` (issue #262).
@@ -119,6 +123,12 @@ pub(in crate::server) async fn health(
     let uptime_secs = state.start_time.elapsed().as_secs();
     let (status, degraded_reason) = classify_health(peers, send_ready_peers, uptime_secs);
 
+    // ADR-0038: surface the Home roaming-guarantee violation as a
+    // structured detail (advisory only — never flips `status`).
+    let mut warnings = Vec::new();
+    if let Some(warning) = super::home::home_roaming_warning(state.as_ref()).await {
+        warnings.push(warning);
+    }
     Json(ApiResponse {
         ok: true,
         data: HealthData {
@@ -128,6 +138,7 @@ pub(in crate::server) async fn health(
             send_ready_peers,
             uptime_secs,
             degraded_reason,
+            warnings,
         },
     })
 }

--- a/src/server/routes/status.rs
+++ b/src/server/routes/status.rs
@@ -33,8 +33,11 @@ pub(in crate::server) struct HealthData {
     uptime_secs: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     degraded_reason: Option<String>,
-    /// Structured advisory warnings (never liveness-affecting). ADR-0038:
-    /// `home_no_roaming_agent` when the Home space has no Roaming agent.
+    /// Structured advisory warnings (never liveness-affecting). ADR-0038
+    /// review fix: Home warnings live on AUTHED surfaces only (`GET /home`,
+    /// `GET /groups/:id`) — `/health` is auth-exempt and must not leak
+    /// Home/owner existence. Reserved (always empty) for future
+    /// non-sensitive advisories.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     warnings: Vec<serde_json::Value>,
 }
@@ -123,12 +126,6 @@ pub(in crate::server) async fn health(
     let uptime_secs = state.start_time.elapsed().as_secs();
     let (status, degraded_reason) = classify_health(peers, send_ready_peers, uptime_secs);
 
-    // ADR-0038: surface the Home roaming-guarantee violation as a
-    // structured detail (advisory only — never flips `status`).
-    let mut warnings = Vec::new();
-    if let Some(warning) = super::home::home_roaming_warning(state.as_ref()).await {
-        warnings.push(warning);
-    }
     Json(ApiResponse {
         ok: true,
         data: HealthData {
@@ -138,7 +135,7 @@ pub(in crate::server) async fn health(
             send_ready_peers,
             uptime_secs,
             degraded_reason,
-            warnings,
+            warnings: Vec::new(),
         },
     })
 }

--- a/tests/api_coverage.rs
+++ b/tests/api_coverage.rs
@@ -69,6 +69,8 @@ const COVERED: &[CoveredEndpoint] = &[
     ),
     covered!(Get, "/profile", daemon_api_profile_round_trip),
     covered!(Put, "/profile", daemon_api_profile_round_trip),
+    covered!(Get, "/home", home_routes_wired),
+    covered!(Post, "/home/rename", home_rename_round_trips),
     covered!(Get, "/owner/agents", daemon_api_profile_round_trip),
     // ── Network ─────────────────────────────────────────────────────────
     covered!(Get, "/peers", daemon_api_peers),
@@ -490,6 +492,10 @@ const COVERAGE_MARKER_SOURCES: &[(&str, &str)] = &[
         include_str!("history_point_lookup_wiring.rs"),
     ),
     ("tests/profile_api.rs", include_str!("profile_api.rs")),
+    (
+        "src/server/routes/home.rs",
+        include_str!("../src/server/routes/home.rs"),
+    ),
     (
         "tests/peer_lifecycle_integration.rs",
         include_str!("peer_lifecycle_integration.rs"),


### PR DESCRIPTION
Completes ADR-0038's product surface: one Home per owned install (auto-provisioned through the real group-creation path, per-machine dedup marker + full-policy crash recovery, cross-machine adoption deferred to ADR-0041), sealed Home metadata (`home_digest` in the signed state hash; restore re-verifies every record and reseals or strips), owner-chain gate on explicit-policy `POST /groups` with echo validation (CLI + GUI, full-tuple), primary-agent designation with truthful GUI owner chip (only when the sending agent IS the verified primary), Roaming founding agent (nominal until ADR-0043), `GET /home` + `x0x home`/`home rename` CLI, auth-safe warnings.

Review: 5-round loop — omp (GLM-5.3) implementation, Codex adversarial review + Claude verification each round; final round fixes applied directly by Claude after the omp session stalled; final verdict **APPROVE**.

Gates: fmt ✓ clippy -D warnings ✓ nextest 2941/2942 (sole failure = pre-existing env `addr_is_free` probe — fix pending in #433) ✓ manifest/CLI-parity/coverage registries green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR implements ADR-0038 Home auto-provisioning, signed Home metadata, owner-certified explicit group policies, Home API/CLI operations, and the corresponding GUI surface.

- Adds startup provisioning and recovery for one per-machine Home space.
- Commits Home metadata into the signed group-state hash.
- Adds explicit-policy creation with owner-chain and response-echo validation.
- Exposes Home inspection and rename operations through the API, CLI, and GUI.

<h3>Confidence Score: 4/5</h3>

The Home recovery selector should be fixed before merging because it can silently convert an unrelated owner-private group into the machine's Home.

Ordinary explicit-policy creation can produce a legitimate group matching the Home policy, while startup recovery uses only that policy and creation time to choose which unstamped group to mutate, seal, and record as Home.

**Files Needing Attention:** src/server/routes/home.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/routes/home.rs | Implements Home provisioning, recovery, verification, APIs, and tests; policy-only recovery can repurpose an unrelated explicit-policy group. |
| src/server/routes/named_groups.rs | Adds explicit-policy creation, owner-chain validation, policy echoing, and OwnerCertified sealing support. |
| src/groups/mod.rs | Adds Home metadata and incorporates its digest into group public metadata and state-hash calculations. |
| src/groups/state_commit.rs | Defines the canonical Home metadata digest while preserving the legacy hash encoding when Home metadata is absent. |
| src/server/mod.rs | Wires Home provisioning into startup and registers the Home HTTP routes. |
| src/gui/x0x-gui.html | Adds the Home space interface, primary-agent display, owner chip, rename control, and full policy-echo validation. |
| src/bin/x0x.rs | Adds Home commands and explicit JSON policy input to the CLI command tree. |
| src/cli/commands/group.rs | Sends explicit group policies and verifies the daemon's complete effective-policy echo. |
| src/cli/commands/identity.rs | Adds thin CLI clients for Home inspection and rename operations. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Daemon restores named groups] --> B{Trusted stamped Home exists?}
  B -->|Yes| C[Verify or reseal Home metadata]
  B -->|No| D[Scan unstamped groups]
  D --> E{Exact Home-policy match exists?}
  E -->|Yes| F[Select oldest match]
  F --> G[Stamp and seal as Home]
  E -->|No| H[Create Home through group API path]
  H --> G
  G --> I[Persist group state]
  I --> J[Write advisory Home marker]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/routes/home.rs:438-442
**Recovery adopts unrelated groups**

When an owner has created an ordinary group with the exact Home policy and startup finds no stamped Home, this scan selects that group solely by policy and age, then stamps, seals, and records it as Home, silently repurposing the existing group instead of provisioning the intended personal space.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(api): register /home endpoints in c..."](https://github.com/saorsa-labs/x0x/commit/d5de51d9066809dfe73f49a24eb018bf8f333244) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58180816)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Group lifecycle and membership](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/group-lifecycle.md)
- Knowledge Base — [Secure identity and trust](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/secure-identity-and-trust.md)
- Knowledge Base — [Client, daemon, and API platform](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/client-and-daemon-platform.md)
- Knowledge Base — [Server APIs and live streams](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api-and-live-streams.md)
- Knowledge Base — [Command-line and daemon entrypoints](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/command-line-and-daemon.md)
</details>


<!-- /greptile_comment -->