### PR TITLE
feat(server): ADR-0039 — agent harness boundary (sub-agents, rider tokens, actor context)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -230,10 +230,16 @@ authority evidence), and the response returns the certificate
 (`certificate.storage_b64`) for ACP-attached harness instances.
 
 **Rider tokens** (`{ "sub_agent_id": <hex>, "groups": [gid…], "label"?:
-string, "ttl_secs"?: ≤ 90 days, default 7 }`) are stored hashed at rest
-(SHA-256), expire, and are revocable per-token or by revoking their
-sub-agent. A rider token authenticates as a distinct principal that may
-reach exactly:
+string, "ttl_secs"?: ≤ 90 days, default 7, "delegation": {
+"payload_b64", "signature" } }`) are stored hashed at rest (SHA-256),
+expire, and are revocable per-token or by revoking their sub-agent.
+The `delegation` capability is REQUIRED and is produced harness-side:
+the harness signs `rider_delegation_bytes(sub_agent_id,
+daemon_agent_id, groups, not_after)` with the sub-agent's OWN key
+(helper: `x0x::groups::sign_rider_delegation`); the daemon verifies it
+against the certified sub-agent key before minting, binds it into the
+token, and re-verifies it before every send. A rider token
+authenticates as a distinct principal that may reach exactly:
 
 - `POST /groups/:id/send` — `SignedPublic` groups in its grant list
 - `POST /groups/:id/secure/encrypt` — `MlsEncrypted` groups in its grant
@@ -242,11 +248,19 @@ reach exactly:
 
 Every other route — including `/agent/sign`, `/exec/*`, `/identity/*`,
 and `/shutdown` — answers `403`. Rider sends are signed by the daemon's
-own agent key carrying a provenance envelope
-(`rider_provenance.sub_agent_id`, `rider_token_id`, `rider_token_hash`,
-`scope`) **inside the signed bytes**: attribution without ever exposing a
-sub-agent signing key or a signing oracle. Rider Home encrypts record the
-sub-agent id as the history row's author.
+own agent key carrying a provenance envelope **inside the signed
+bytes** — `sub_agent_id`, `rider_token_id`, `rider_token_hash`,
+`scope`, and the sub-agent-signed delegation capability itself. The
+delegation makes the attribution cryptographic instead of asserted:
+receivers verify the embedded owner certificate, the capability
+signature under the certified sub-agent key, that the capability names
+the actual message-signing daemon, the group scope, and the expiry —
+then enforce ban/write policy against the sub-agent. A daemon can
+therefore only speak for sub-agents that explicitly authorized it. The
+per-message envelope carries the certificate (~10 KB overhead) so
+verification is self-contained. `/agent/sign` stays owner-only. Rider
+Home encrypts record the sub-agent id as the history row's author.
+
 
 
 ## Network

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -205,6 +205,50 @@ Notes:
   explicit rather than silent.
 - Response: `ok`, `valid` (boolean), `algorithm`.
 
+### Sub-agent harness boundary (ADR-0039)
+
+| Method | Endpoint | CLI | Purpose |
+|---|---|---|---|
+| GET | `/owner/agents` | `x0x owner agents` | Roster of owner-certified agents (journal-backed) |
+| POST | `/owner/agents/issue` | `x0x owner agents issue <PUB_HEX>` | Owner-sign an `AgentCertificate` over a harness-submitted agent **public** key |
+| DELETE | `/owner/agents/:id` | `x0x owner agents revoke <AGENT_ID>` | ADR-0018 owner issuer-revocation of a registered sub-agent |
+| POST | `/owner/riders` | `x0x owner riders issue <AGENT_ID>` | Mint a scoped rider token for a registered rider-mode sub-agent |
+| GET | `/owner/riders` | `x0x owner riders` | List rider-token records (no secrets) |
+| DELETE | `/owner/riders/:id` | `x0x owner riders revoke <TOKEN_ID>` | Revoke a rider token (fails on next request) |
+
+All six are owner-only: every `/owner/*` route rejects a rider token with
+`403` in the auth middleware before any handler runs. `409` when the
+daemon has no owner user key.
+
+**Issuance** takes `{ "agent_public_key": <hex ML-DSA-65 public key>,
+"mode": "acp"|"rider", "label"?: string, "not_after"?: unix-seconds }`.
+The harness generates and custodies the keypair; the daemon never sees
+the secret. The record lands in the owner-scoped ADR-0036 issuance
+journal (`owner-cert-journal.jsonl`) with the mode, label, and the full
+certificate bytes (retained so revocation can present the exact ADR-0018
+authority evidence), and the response returns the certificate
+(`certificate.storage_b64`) for ACP-attached harness instances.
+
+**Rider tokens** (`{ "sub_agent_id": <hex>, "groups": [gid…], "label"?:
+string, "ttl_secs"?: ≤ 90 days, default 7 }`) are stored hashed at rest
+(SHA-256), expire, and are revocable per-token or by revoking their
+sub-agent. A rider token authenticates as a distinct principal that may
+reach exactly:
+
+- `POST /groups/:id/send` — `SignedPublic` groups in its grant list
+- `POST /groups/:id/secure/encrypt` — `MlsEncrypted` groups in its grant
+  list plus Home (always granted)
+- `GET /history` — `group:` scopes it is granted, limit clamped to 100
+
+Every other route — including `/agent/sign`, `/exec/*`, `/identity/*`,
+and `/shutdown` — answers `403`. Rider sends are signed by the daemon's
+own agent key carrying a provenance envelope
+(`rider_provenance.sub_agent_id`, `rider_token_id`, `rider_token_hash`,
+`scope`) **inside the signed bytes**: attribution without ever exposing a
+sub-agent signing key or a signing oracle. Rider Home encrypts record the
+sub-agent id as the history row's author.
+
+
 ## Network
 
 | Method | Endpoint | CLI | Purpose |

--- a/docs/design/api-manifest.json
+++ b/docs/design/api-manifest.json
@@ -1,5 +1,5 @@
 {
-  "endpoint_count": 155,
+  "endpoint_count": 160,
   "endpoints": [
     {
       "category": "status",
@@ -133,6 +133,41 @@
       "description": "Roster of agents certified by this install's owner (journal-backed; survives restarts)",
       "method": "GET",
       "path": "/owner/agents"
+    },
+    {
+      "category": "identity",
+      "cli_name": "owner agents issue",
+      "description": "Owner-sign an AgentCertificate over a harness-submitted agent public key (ADR-0039)",
+      "method": "POST",
+      "path": "/owner/agents/issue"
+    },
+    {
+      "category": "identity",
+      "cli_name": "owner agents revoke",
+      "description": "ADR-0018 owner issuer-revocation of a registered sub-agent",
+      "method": "DELETE",
+      "path": "/owner/agents/:id"
+    },
+    {
+      "category": "identity",
+      "cli_name": "owner riders issue",
+      "description": "Mint a scoped rider token for a registered rider-mode sub-agent (ADR-0039)",
+      "method": "POST",
+      "path": "/owner/riders"
+    },
+    {
+      "category": "identity",
+      "cli_name": "owner riders",
+      "description": "List rider-token records (no secrets; hashed identifiers only)",
+      "method": "GET",
+      "path": "/owner/riders"
+    },
+    {
+      "category": "identity",
+      "cli_name": "owner riders revoke",
+      "description": "Revoke a rider token; it fails on the next request",
+      "method": "DELETE",
+      "path": "/owner/riders/:id"
     },
     {
       "category": "network",

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -207,10 +207,13 @@ one via the ADR-0018 owner revocation path.
 Harnesses that prefer to ride the **owner's** daemon instead of running
 their own instance use rider tokens (`POST /owner/riders`) — scoped,
 expiring bearer tokens confined to `POST /groups/:id/send`,
-`POST /groups/:id/secure/encrypt`, and a bounded `GET /history`. Rider
-sends are signed by the daemon with an attribution envelope binding the
-sub-agent inside the signed bytes; `/agent/sign` and every owner surface
-reject rider tokens outright.
+`POST /groups/:id/secure/encrypt`, and a bounded `GET /history`. At
+issuance the harness SIGNS a delegation capability with the sub-agent
+key (`x0x::groups::sign_rider_delegation`) naming the daemon and the
+granted groups; every rider message embeds that capability inside the
+signed bytes, and receivers verify the full owner-cert → sub-agent-key
+→ daemon chain before enforcing group policy against the sub-agent.
+`/agent/sign` and every owner surface reject rider tokens outright.
 
 
 ## Available Endpoints

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -164,13 +164,63 @@ async fn main() {
 }
 ```
 
+### ACP-attached harness agents (ADR-0039)
+
+An agent harness (pi, omp, or similar) that runs its **own** x0x instance
+gets a per-agent identity the owner has certified. The harness generates
+and custodies the agent keypair — the daemon never sees the secret — and
+submits only the public key:
+
+```bash
+# 1. The harness generates a fresh agent keypair (kept in the harness's
+#    own key file, e.g. ~/.saorsa-keys/<agent>.key) and exports the
+#    public half as hex.
+PUB=$(x0x-keygen --public-key-hex ~/.saorsa-keys/ci-agent.key)
+
+# 2. The OWNER's daemon certifies it (mode=acp — the harness runs its own
+#    instance with this key) and returns the signed certificate.
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"agent_public_key\":\"$PUB\",\"mode\":\"acp\",\"label\":\"ci-agent\"}" \
+  http://$API/owner/agents/issue
+# → {"ok":true,"agent_id":"…","certificate":{"storage_b64":"…", …}}
+
+# 3. Decode certificate.storage_b64 to agent.cert, place it beside the
+#    harness-owned agent.key, and start the harness's instance pointing
+#    at that identity directory:
+x0xd --config harness.toml
+# harness.toml:
+#   identity_dir = "~/.saorsa-keys/ci-agent"
+#   data_dir     = "~/.saorsa-local/ci-agent"
+
+# 4. The attached instance is Home-eligible: its owner-signed
+#    certificate passes the OwnerCertified admission rule (ADR-0038), so
+#    joining Home via an ordinary invite admits it like any owned agent.
+```
+
+No new transport code is involved — the harness instance is an ordinary
+x0x daemon whose identity was issued by the owner. `x0x owner agents`
+lists every certified agent (`mode: acp|rider`, label, revocation state);
+`DELETE /owner/agents/:id` (or `x0x owner agents revoke <id>`) revokes
+one via the ADR-0018 owner revocation path.
+
+Harnesses that prefer to ride the **owner's** daemon instead of running
+their own instance use rider tokens (`POST /owner/riders`) — scoped,
+expiring bearer tokens confined to `POST /groups/:id/send`,
+`POST /groups/:id/secure/encrypt`, and a bounded `GET /history`. Rider
+sends are signed by the daemon with an attribution envelope binding the
+sub-agent inside the signed bytes; `/agent/sign` and every owner surface
+reject rider tokens outright.
+
+
 ## Available Endpoints
 
-x0xd exposes 142 REST endpoints. Key categories:
+x0xd exposes 160 REST endpoints. Key categories:
 
 | Category | Endpoints | What you can do |
 |----------|-----------|-----------------|
 | Identity | `/agent`, `/agent/card` | Read agent/machine/user IDs, export identity card |
+| Owner | `/owner/agents`, `/owner/riders` | Certify harness sub-agents; rider-token lifecycle (ADR-0039) |
 | Messaging | `/publish`, `/subscribe`, `/events` | Gossip pub/sub, SSE event stream |
 | Direct | `/direct/send`, `/direct/events` | Point-to-point encrypted messages |
 | Groups | `/groups`, `/groups/:id/invite` | Named groups with invite links |

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -184,6 +184,41 @@ pub const ENDPOINTS: &[EndpointDef] = &[
         description: "Roster of agents certified by this install's owner (journal-backed; survives restarts)",
         category: "identity",
     },
+    EndpointDef {
+        method: Method::Post,
+        path: "/owner/agents/issue",
+        cli_name: "owner agents issue",
+        description: "Owner-sign an AgentCertificate over a harness-submitted agent public key (ADR-0039)",
+        category: "identity",
+    },
+    EndpointDef {
+        method: Method::Delete,
+        path: "/owner/agents/:id",
+        cli_name: "owner agents revoke",
+        description: "ADR-0018 owner issuer-revocation of a registered sub-agent",
+        category: "identity",
+    },
+    EndpointDef {
+        method: Method::Post,
+        path: "/owner/riders",
+        cli_name: "owner riders issue",
+        description: "Mint a scoped rider token for a registered rider-mode sub-agent (ADR-0039)",
+        category: "identity",
+    },
+    EndpointDef {
+        method: Method::Get,
+        path: "/owner/riders",
+        cli_name: "owner riders",
+        description: "List rider-token records (no secrets; hashed identifiers only)",
+        category: "identity",
+    },
+    EndpointDef {
+        method: Method::Delete,
+        path: "/owner/riders/:id",
+        cli_name: "owner riders revoke",
+        description: "Revoke a rider token; it fails on the next request",
+        category: "identity",
+    },
     // ── Network ─────────────────────────────────────────────────────────
     EndpointDef {
         method: Method::Get,

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -439,11 +439,69 @@ enum HomeSub {
     },
 }
 
-/// `x0x owner` subcommands (ADR-0036).
+/// `x0x owner` subcommands (ADR-0036 registry, ADR-0039 harness boundary).
 #[derive(Subcommand)]
 enum OwnerSub {
-    /// List agents certified by this install's owner (the "my agents" roster).
-    Agents,
+    /// Agents certified by this install's owner (the "my agents" roster).
+    Agents {
+        #[command(subcommand)]
+        sub: Option<OwnerAgentsSub>,
+    },
+    /// Rider-token lifecycle (ADR-0039 API-key riders).
+    Riders {
+        #[command(subcommand)]
+        sub: Option<OwnerRidersSub>,
+    },
+}
+
+/// `x0x owner agents` subcommands (ADR-0039).
+#[derive(Subcommand)]
+enum OwnerAgentsSub {
+    /// Certify a harness-submitted agent public key (the daemon never
+    /// sees the secret key).
+    Issue {
+        /// Hex ML-DSA-65 public key of the harness-generated keypair.
+        #[arg(value_name = "PUBLIC_KEY_HEX")]
+        public_key: String,
+        /// Hosting mode: `acp` (default) or `rider`.
+        #[arg(long, value_name = "MODE")]
+        mode: Option<String>,
+        /// Operator label for the roster.
+        #[arg(long, value_name = "LABEL")]
+        label: Option<String>,
+    },
+    /// Revoke a registered sub-agent (ADR-0018 owner issuer-revocation).
+    Revoke {
+        /// Hex agent id from the roster.
+        #[arg(value_name = "AGENT_ID")]
+        agent_id: String,
+    },
+}
+
+/// `x0x owner riders` subcommands (ADR-0039).
+#[derive(Subcommand)]
+enum OwnerRidersSub {
+    /// Mint a scoped rider token for a registered rider-mode sub-agent.
+    Issue {
+        /// Hex agent id of the registered sub-agent.
+        #[arg(value_name = "AGENT_ID")]
+        agent: String,
+        /// Granted named-group id (repeatable; Home is always granted).
+        #[arg(long = "group", value_name = "GROUP_ID")]
+        groups: Vec<String>,
+        /// Operator label.
+        #[arg(long, value_name = "LABEL")]
+        label: Option<String>,
+        /// Token lifetime seconds (default 7 days, max 90 days).
+        #[arg(long, value_name = "SECS")]
+        ttl_secs: Option<u64>,
+    },
+    /// Revoke a rider token by id; it fails on the next request.
+    Revoke {
+        /// Numeric rider-token id from `x0x owner riders`.
+        #[arg(value_name = "TOKEN_ID")]
+        token_id: u64,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1536,7 +1594,51 @@ async fn run(
             Some(HomeSub::Rename { name }) => commands::identity::home_rename(&client, &name).await,
         },
         Commands::Owner { sub } => match sub {
-            None | Some(OwnerSub::Agents) => commands::identity::owner_agents(&client).await,
+            None => commands::identity::owner_agents(&client).await,
+            Some(OwnerSub::Agents { sub: None }) => commands::identity::owner_agents(&client).await,
+            Some(OwnerSub::Agents {
+                sub:
+                    Some(OwnerAgentsSub::Issue {
+                        public_key,
+                        mode,
+                        label,
+                    }),
+            }) => {
+                commands::identity::owner_agents_issue(
+                    &client,
+                    &public_key,
+                    mode.as_deref().unwrap_or("acp"),
+                    label.as_deref(),
+                )
+                .await
+            }
+            Some(OwnerSub::Agents {
+                sub: Some(OwnerAgentsSub::Revoke { agent_id }),
+            }) => commands::identity::owner_agents_revoke(&client, &agent_id).await,
+            Some(OwnerSub::Riders { sub: None }) => {
+                commands::identity::owner_riders_list(&client).await
+            }
+            Some(OwnerSub::Riders {
+                sub:
+                    Some(OwnerRidersSub::Issue {
+                        agent,
+                        groups,
+                        label,
+                        ttl_secs,
+                    }),
+            }) => {
+                commands::identity::owner_riders_issue(
+                    &client,
+                    &agent,
+                    &groups,
+                    label.as_deref(),
+                    ttl_secs,
+                )
+                .await
+            }
+            Some(OwnerSub::Riders {
+                sub: Some(OwnerRidersSub::Revoke { token_id }),
+            }) => commands::identity::owner_riders_revoke(&client, token_id).await,
         },
         Commands::Health => commands::network::health(&client).await,
         Commands::Status => commands::network::status(&client).await,

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -281,6 +281,61 @@ pub async fn home_rename(client: &DaemonClient, name: &str) -> Result<()> {
     Ok(())
 }
 
+/// `x0x owner agents issue` — POST /owner/agents/issue (ADR-0039).
+pub async fn owner_agents_issue(
+    client: &DaemonClient,
+    public_key_hex: &str,
+    mode: &str,
+    label: Option<&str>,
+) -> Result<()> {
+    let mut body = serde_json::json!({ "agent_public_key": public_key_hex, "mode": mode });
+    if let Some(label) = label {
+        body["label"] = serde_json::json!(label);
+    }
+    let resp = client.post("/owner/agents/issue", &body).await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}
+
+/// `x0x owner agents revoke` — DELETE /owner/agents/:id (ADR-0039).
+pub async fn owner_agents_revoke(client: &DaemonClient, agent_id: &str) -> Result<()> {
+    client
+        .run_delete(&format!("/owner/agents/{agent_id}"))
+        .await
+}
+
+/// `x0x owner riders` — GET /owner/riders (ADR-0039).
+pub async fn owner_riders_list(client: &DaemonClient) -> Result<()> {
+    client.run_get("/owner/riders").await
+}
+
+/// `x0x owner riders issue` — POST /owner/riders (ADR-0039).
+pub async fn owner_riders_issue(
+    client: &DaemonClient,
+    sub_agent_id: &str,
+    groups: &[String],
+    label: Option<&str>,
+    ttl_secs: Option<u64>,
+) -> Result<()> {
+    let mut body = serde_json::json!({ "sub_agent_id": sub_agent_id, "groups": groups });
+    if let Some(label) = label {
+        body["label"] = serde_json::json!(label);
+    }
+    if let Some(ttl) = ttl_secs {
+        body["ttl_secs"] = serde_json::json!(ttl);
+    }
+    let resp = client.post("/owner/riders", &body).await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}
+
+/// `x0x owner riders revoke` — DELETE /owner/riders/:id (ADR-0039).
+pub async fn owner_riders_revoke(client: &DaemonClient, token_id: u64) -> Result<()> {
+    client
+        .run_delete(&format!("/owner/riders/{token_id}"))
+        .await
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -49,8 +49,8 @@ pub use self::policy::{
 };
 pub use self::public_message::{
     public_topic_for, validate_public_message, GroupPublicMessage, GroupPublicMessageKind,
-    IngestError as PublicMessageIngestError, PublicIngestContext, MAX_PUBLIC_MESSAGE_BYTES,
-    PUBLIC_GROUP_TOPIC_PREFIX, PUBLIC_MESSAGE_DOMAIN,
+    IngestError as PublicMessageIngestError, PublicIngestContext, RiderProvenance,
+    MAX_PUBLIC_MESSAGE_BYTES, PUBLIC_GROUP_TOPIC_PREFIX, PUBLIC_MESSAGE_DOMAIN,
 };
 pub use self::request::{JoinRequest, JoinRequestStatus};
 pub use self::state_commit::{

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -49,10 +49,11 @@ pub use self::policy::{
 };
 pub use self::public_message::{
     parse_rider_delegation, public_topic_for, rider_delegation_bytes, rider_mls_attribution_bytes,
-    sign_rider_delegation, validate_public_message, verify_rider_provenance, GroupPublicMessage,
-    GroupPublicMessageKind, IngestError as PublicMessageIngestError, PublicIngestContext,
-    RiderDelegation, RiderDelegationClaim, RiderProvenance, MAX_PUBLIC_MESSAGE_BYTES,
-    PUBLIC_GROUP_TOPIC_PREFIX, PUBLIC_MESSAGE_DOMAIN, RIDER_MLS_ATTRIBUTION_DOMAIN,
+    sign_rider_delegation, validate_public_message, validate_public_message_with_revocations,
+    verify_rider_provenance, GroupPublicMessage, GroupPublicMessageKind,
+    IngestError as PublicMessageIngestError, PublicIngestContext, RiderDelegation,
+    RiderDelegationClaim, RiderProvenance, MAX_PUBLIC_MESSAGE_BYTES, PUBLIC_GROUP_TOPIC_PREFIX,
+    PUBLIC_MESSAGE_DOMAIN, RIDER_MLS_ATTRIBUTION_DOMAIN,
 };
 pub use self::request::{JoinRequest, JoinRequestStatus};
 pub use self::state_commit::{

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -48,11 +48,11 @@ pub use self::policy::{
     GroupPolicySummary, GroupReadAccess, GroupWriteAccess,
 };
 pub use self::public_message::{
-    parse_rider_delegation, public_topic_for, rider_delegation_bytes, sign_rider_delegation,
-    validate_public_message, verify_rider_provenance, GroupPublicMessage, GroupPublicMessageKind,
-    IngestError as PublicMessageIngestError, PublicIngestContext, RiderDelegation,
-    RiderDelegationClaim, RiderProvenance, MAX_PUBLIC_MESSAGE_BYTES, PUBLIC_GROUP_TOPIC_PREFIX,
-    PUBLIC_MESSAGE_DOMAIN,
+    parse_rider_delegation, public_topic_for, rider_delegation_bytes, rider_mls_attribution_bytes,
+    sign_rider_delegation, validate_public_message, verify_rider_provenance, GroupPublicMessage,
+    GroupPublicMessageKind, IngestError as PublicMessageIngestError, PublicIngestContext,
+    RiderDelegation, RiderDelegationClaim, RiderProvenance, MAX_PUBLIC_MESSAGE_BYTES,
+    PUBLIC_GROUP_TOPIC_PREFIX, PUBLIC_MESSAGE_DOMAIN, RIDER_MLS_ATTRIBUTION_DOMAIN,
 };
 pub use self::request::{JoinRequest, JoinRequestStatus};
 pub use self::state_commit::{

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -48,9 +48,11 @@ pub use self::policy::{
     GroupPolicySummary, GroupReadAccess, GroupWriteAccess,
 };
 pub use self::public_message::{
-    public_topic_for, validate_public_message, GroupPublicMessage, GroupPublicMessageKind,
-    IngestError as PublicMessageIngestError, PublicIngestContext, RiderProvenance,
-    MAX_PUBLIC_MESSAGE_BYTES, PUBLIC_GROUP_TOPIC_PREFIX, PUBLIC_MESSAGE_DOMAIN,
+    parse_rider_delegation, public_topic_for, rider_delegation_bytes, sign_rider_delegation,
+    validate_public_message, verify_rider_provenance, GroupPublicMessage, GroupPublicMessageKind,
+    IngestError as PublicMessageIngestError, PublicIngestContext, RiderDelegation,
+    RiderDelegationClaim, RiderProvenance, MAX_PUBLIC_MESSAGE_BYTES, PUBLIC_GROUP_TOPIC_PREFIX,
+    PUBLIC_MESSAGE_DOMAIN,
 };
 pub use self::request::{JoinRequest, JoinRequestStatus};
 pub use self::state_commit::{

--- a/src/groups/public_message.rs
+++ b/src/groups/public_message.rs
@@ -117,19 +117,22 @@ pub struct GroupPublicMessage {
     pub signature: String,
 }
 
-/// Attribution envelope for a rider-sourced send (ADR-0039).
+/// Attribution envelope for a rider-sourced send (ADR-0039, review r3).
 ///
 /// The daemon never holds the sub-agent's secret key, so it cannot — and
-/// must not — sign *as* the sub-agent (that would make `/agent/sign`-style
-/// oracle abuse trivial). Instead the DAEMON's agent key signs the message
-/// and this envelope binds, inside those signed bytes, the identity of the
-/// registered sub-agent on whose behalf the send was made plus the rider
-/// token that authorized it (identified by opaque id and SHA-256 hash —
-/// never the token secret itself).
+/// must not — sign *as* the sub-agent. The daemon's agent key signs the
+/// message, and this envelope binds, inside those signed bytes, the
+/// registered sub-agent on whose behalf the send was made — **backed by
+/// a cryptographic delegation** ([`RiderDelegation`]) signed by the
+/// sub-agent's OWN key: the daemon may only speak for sub-agents that
+/// explicitly authorized THIS daemon, scoped to named groups and
+/// expiring. Receivers verify the whole chain; the asserted
+/// `sub_agent_id` string alone proves nothing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RiderProvenance {
     /// Hex `AgentId` of the registered sub-agent on whose behalf the
-    /// daemon sent (must match a `mode=rider` journal record).
+    /// daemon sent (must match a `mode=rider` journal record and the
+    /// delegation's certified subject).
     pub sub_agent_id: String,
     /// Opaque numeric id of the rider token that authorized the send.
     pub rider_token_id: u64,
@@ -138,6 +141,215 @@ pub struct RiderProvenance {
     pub rider_token_hash: String,
     /// The granted scope this send used: the target group id.
     pub scope: String,
+    /// The sub-agent-signed delegation authorizing THIS daemon. Required:
+    /// provenance without a verifiable delegation is exactly the forgery
+    /// vector and is rejected by receivers.
+    pub delegation: RiderDelegation,
+}
+
+/// A delegation-to-daemon capability signed by the SUB-AGENT's key
+/// (review r3, option B): `{sub_agent_id -> daemon_agent_id, scopes,
+/// not_after}`. The harness signs it once, locally, when the rider token
+/// is issued; the daemon stores it with the token and embeds it in every
+/// rider message. Receivers verify: (i) the embedded owner certificate
+/// is valid and binds the claimed `sub_agent_id`, (ii) the capability
+/// signature verifies under that certificate's agent key, (iii) the
+/// capability names the message's actual signer as the delegated
+/// daemon, (iv) the target group is in the capability scopes, and
+/// (v) the capability has not expired.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RiderDelegation {
+    /// Base64 `AgentCertificate` storage bytes for the sub-agent — the
+    /// self-contained trust anchor so receivers that have never seen the
+    /// sub-agent can verify the chain without a blob-cache fetch
+    /// (gapcheck 13: cache misses must not become fail-open pressure).
+    pub cert_b64: String,
+    /// Base64 canonical delegation bytes ([`rider_delegation_bytes`]).
+    pub payload_b64: String,
+    /// Hex ML-DSA-65 signature by the sub-agent key over the payload.
+    pub signature: String,
+}
+
+/// Domain-separation tag for delegation capabilities.
+pub const RIDER_DELEGATION_DOMAIN: &[u8] = b"x0x.rider-delegation.v1";
+
+/// Canonical delegation bytes:
+/// `domain || len(sub_agent_id) || sub_agent_id || len(daemon_agent_id)
+/// || daemon_agent_id || scope_count(LE u32) || (len+id)* ||
+/// not_after(LE u64)`.
+///
+/// Public so harnesses build the exact bytes they sign.
+#[must_use]
+pub fn rider_delegation_bytes(
+    sub_agent_id: &str,
+    daemon_agent_id: &str,
+    scopes: &[String],
+    not_after: u64,
+) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(64 + sub_agent_id.len() + daemon_agent_id.len());
+    buf.extend_from_slice(RIDER_DELEGATION_DOMAIN);
+    push_len_prefixed_str(&mut buf, sub_agent_id);
+    push_len_prefixed_str(&mut buf, daemon_agent_id);
+    buf.extend_from_slice(&(scopes.len() as u32).to_le_bytes());
+    for scope in scopes {
+        push_len_prefixed_str(&mut buf, scope);
+    }
+    buf.extend_from_slice(&not_after.to_le_bytes());
+    buf
+}
+
+fn push_len_prefixed_str(buf: &mut Vec<u8>, s: &str) {
+    buf.extend_from_slice(&(s.len() as u32).to_le_bytes());
+    buf.extend_from_slice(s.as_bytes());
+}
+
+/// The parsed delegation claim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RiderDelegationClaim {
+    pub sub_agent_id: String,
+    pub daemon_agent_id: String,
+    pub scopes: Vec<String>,
+    pub not_after: u64,
+}
+
+/// Parse canonical delegation bytes back into a claim (mirrors
+/// [`rider_delegation_bytes`]; rejects trailing garbage).
+#[must_use]
+pub fn parse_rider_delegation(payload: &[u8]) -> Option<RiderDelegationClaim> {
+    let mut rest = payload;
+    if rest.len() < RIDER_DELEGATION_DOMAIN.len()
+        || &rest[..RIDER_DELEGATION_DOMAIN.len()] != RIDER_DELEGATION_DOMAIN
+    {
+        return None;
+    }
+    rest = &rest[RIDER_DELEGATION_DOMAIN.len()..];
+    let sub_agent_id = take_len_prefixed_str(&mut rest)?;
+    let daemon_agent_id = take_len_prefixed_str(&mut rest)?;
+    let scope_count = u32::from_le_bytes(take_fixed(&mut rest, 4)?.try_into().ok()?) as usize;
+    if scope_count > 64 {
+        return None;
+    }
+    let mut scopes = Vec::with_capacity(scope_count);
+    for _ in 0..scope_count {
+        scopes.push(take_len_prefixed_str(&mut rest)?);
+    }
+    let not_after = u64::from_le_bytes(take_fixed(&mut rest, 8)?.try_into().ok()?);
+    if !rest.is_empty() {
+        return None;
+    }
+    Some(RiderDelegationClaim {
+        sub_agent_id,
+        daemon_agent_id,
+        scopes,
+        not_after,
+    })
+}
+
+fn take_fixed<'a>(rest: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+    if rest.len() < n {
+        return None;
+    }
+    let (head, tail) = rest.split_at(n);
+    *rest = tail;
+    Some(head)
+}
+
+fn take_len_prefixed_str(rest: &mut &[u8]) -> Option<String> {
+    let len = u32::from_le_bytes(take_fixed(rest, 4)?.try_into().ok()?) as usize;
+    if len > 512 {
+        return None;
+    }
+    let bytes = take_fixed(rest, len)?;
+    std::str::from_utf8(bytes).ok().map(str::to_string)
+}
+
+/// Verify a rider provenance chain against the message's actual signer.
+///
+/// Returns the certified `sub_agent_id` on success. Checks, in order:
+/// certificate decodes + verifies + binds the claimed sub-agent;
+/// delegation payload parses and re-states the same subject; the
+/// delegation signature verifies under the certificate's agent key; the
+/// delegation names `author_agent_id` (the daemon that actually signed
+/// the message) as the delegate; the capability is unexpired at
+/// `now_unix`; and `scope` (the target group) is inside the capability
+/// scopes. Every failure is a string reason for logs/403 bodies.
+pub fn verify_rider_provenance(
+    provenance: &RiderProvenance,
+    author_agent_id: &str,
+    scope: &str,
+
+    now_unix: u64,
+) -> Result<String, String> {
+    use base64::Engine as _;
+    let cert_bytes = base64::engine::general_purpose::STANDARD
+        .decode(&provenance.delegation.cert_b64)
+        .map_err(|_| "delegation certificate is not valid base64".to_string())?;
+    let cert = crate::identity::AgentCertificate::from_storage_bytes(&cert_bytes)
+        .map_err(|e| format!("delegation certificate does not decode: {e}"))?;
+    cert.verify()
+        .map_err(|_| "delegation certificate fails verification".to_string())?;
+    let certified_sub = cert
+        .agent_id()
+        .map(|id| hex::encode(id.as_bytes()))
+        .map_err(|_| "delegation certificate has no agent id".to_string())?;
+    if certified_sub != provenance.sub_agent_id {
+        return Err("provenance sub_agent_id does not match its certificate".to_string());
+    }
+    let payload = base64::engine::general_purpose::STANDARD
+        .decode(&provenance.delegation.payload_b64)
+        .map_err(|_| "delegation payload is not valid base64".to_string())?;
+    let claim = parse_rider_delegation(&payload)
+        .ok_or_else(|| "delegation payload does not parse".to_string())?;
+    if claim.sub_agent_id != provenance.sub_agent_id {
+        return Err("delegation subject differs from provenance".to_string());
+    }
+    if claim.daemon_agent_id != author_agent_id {
+        return Err(format!(
+            "delegation names daemon {daemon} but the message signer is {author_agent_id}",
+            daemon = claim.daemon_agent_id
+        ));
+    }
+    let sig_bytes = hex::decode(&provenance.delegation.signature)
+        .map_err(|_| "delegation signature is not valid hex".to_string())?;
+    let sig = MlDsaSignature::from_bytes(&sig_bytes)
+        .map_err(|e| format!("delegation signature does not decode: {e:?}"))?;
+    let agent_pub = MlDsaPublicKey::from_bytes(cert.agent_public_key())
+        .map_err(|_| "certificate agent key does not parse".to_string())?;
+    verify_with_ml_dsa(&agent_pub, &payload, &sig)
+        .map_err(|_| "delegation is not signed by the sub-agent's key".to_string())?;
+    if now_unix >= claim.not_after {
+        return Err("delegation has expired".to_string());
+    }
+    if !claim.scopes.iter().any(|s| s == scope) {
+        return Err("target group is not in the delegation scopes".to_string());
+    }
+    Ok(certified_sub)
+}
+
+/// Harness-side helper for the delegation flow (review r3): builds the
+/// canonical capability bytes binding this keypair's agent id to
+/// `daemon_agent_id` for `scopes` until `not_after`, and signs them
+/// with the sub-agent key. Returns `(payload_b64, signature_hex)` for
+/// the `delegation` field of `POST /owner/riders`.
+///
+/// # Errors
+///
+/// Returns [`ApplyError::InvalidSignature`] when ML-DSA signing fails.
+pub fn sign_rider_delegation(
+    sub_kp: &AgentKeypair,
+    daemon_agent_id: &str,
+    scopes: &[String],
+    not_after: u64,
+) -> Result<(String, String), ApplyError> {
+    use base64::Engine as _;
+    let sub_agent_id = hex::encode(sub_kp.agent_id().as_bytes());
+    let payload = rider_delegation_bytes(&sub_agent_id, daemon_agent_id, scopes, not_after);
+    let sig = sign_with_ml_dsa(sub_kp.secret_key(), &payload)
+        .map_err(|e| ApplyError::InvalidSignature(format!("delegation sign: {e:?}")))?;
+    Ok((
+        base64::engine::general_purpose::STANDARD.encode(&payload),
+        hex::encode(sig.as_bytes()),
+    ))
 }
 
 impl GroupPublicMessage {
@@ -186,13 +398,17 @@ impl GroupPublicMessage {
         }
         // ADR-0039: rider provenance rides INSIDE the signed bytes (absent
         // ⇒ byte-identical legacy encoding, preserving the ADR-0029 rule
-        // above; present ⇒ the attribution is authenticated by the
-        // author's signature and covered by `msg_id`).
+        // above). Review r3: the delegation capability (cert, payload,
+        // signature) is part of those signed bytes too — the daemon's
+        // signature authenticates the exact capability it acted on.
         if let Some(prov) = &self.rider_provenance {
             push_len_prefixed(&mut buf, prov.sub_agent_id.as_bytes());
             buf.extend_from_slice(&prov.rider_token_id.to_le_bytes());
             push_len_prefixed(&mut buf, prov.rider_token_hash.as_bytes());
             push_len_prefixed(&mut buf, prov.scope.as_bytes());
+            push_len_prefixed(&mut buf, prov.delegation.cert_b64.as_bytes());
+            push_len_prefixed(&mut buf, prov.delegation.payload_b64.as_bytes());
+            push_len_prefixed(&mut buf, prov.delegation.signature.as_bytes());
         }
         buf
     }
@@ -407,18 +623,33 @@ pub fn validate_public_message(
     msg.verify_signature()
         .map_err(|e| IngestError::InvalidSignature(format!("{e}")))?;
 
-    // Review fix #1 (receiver side): when a daemon-signed message
-    // carries rider provenance, the ACTING PRINCIPAL for ban and
-    // write-policy enforcement is the provenance sub-agent — NOT the
-    // daemon author. Without this, a rider message would inherit the
-    // daemon's admin role at every receiver and the provenance
-    // envelope would be cosmetic.
-    let acting_agent = msg
-        .rider_provenance
-        .as_ref()
-        .map_or(msg.author_agent_id.as_str(), |prov| {
+    // Review r3 (CRITICAL): rider provenance is only trustworthy behind
+    // a SUB-AGENT-SIGNED delegation. Before treating the asserted
+    // sub_agent_id as the acting principal, verify the full chain —
+    // owner cert → sub-agent key → delegation → THIS message's signer —
+    // or reject: any daemon can otherwise claim any member identity by
+    // fabricating a provenance string.
+    let acting_agent = match &msg.rider_provenance {
+        None => msg.author_agent_id.as_str(),
+        Some(prov) => {
+            if prov.scope != ctx.group_id {
+                return Err(IngestError::InvalidSignature(format!(
+                    "rider provenance scope {scope} does not match target group {group}",
+                    scope = prov.scope,
+                    group = ctx.group_id
+                )));
+            }
+            let now_unix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            verify_rider_provenance(prov, &msg.author_agent_id, &prov.scope, now_unix)
+                .map_err(IngestError::InvalidSignature)?;
+            // `verify_rider_provenance` proved the certified subject
+            // equals the asserted id, so the assertion is now trusted.
             prov.sub_agent_id.as_str()
-        });
+        }
+    };
 
     // 7. banned authors rejected
     if let Some(member) = ctx.members_v2.get(acting_agent) {
@@ -701,6 +932,39 @@ mod tests {
         assert!(matches!(err, IngestError::WritePolicyViolation { .. }));
     }
 
+    /// Build a REAL sub-agent-signed delegation (the harness's job in
+    /// production): owner cert over the sub key, capability signed by
+    /// the sub key.
+    fn make_delegation(
+        sub_kp: &AgentKeypair,
+        daemon_hex: &str,
+        scopes: &[&str],
+    ) -> RiderDelegation {
+        use base64::Engine as _;
+        let owner = crate::identity::UserKeypair::generate().unwrap();
+        let cert = crate::identity::AgentCertificate::issue_for_public_key(
+            &owner,
+            sub_kp.public_key().as_bytes(),
+            None,
+        )
+        .unwrap();
+        let sub_hex = hex::encode(sub_kp.agent_id().as_bytes());
+        let scopes: Vec<String> = scopes.iter().map(|s| (*s).to_string()).collect();
+        let not_after = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3_600;
+        let payload = rider_delegation_bytes(&sub_hex, daemon_hex, &scopes, not_after);
+        let sig = sign_with_ml_dsa(sub_kp.secret_key(), &payload).unwrap();
+        RiderDelegation {
+            cert_b64: base64::engine::general_purpose::STANDARD
+                .encode(cert.to_storage_bytes().unwrap()),
+            payload_b64: base64::engine::general_purpose::STANDARD.encode(&payload),
+            signature: hex::encode(sig.as_bytes()),
+        }
+    }
+
     #[test]
     fn ingest_enforces_policy_against_rider_provenance_sub_agent() {
         // WHY (review fix #1, receiver side): a daemon-signed rider
@@ -712,6 +976,7 @@ mod tests {
         let sub_kp = make_kp();
         let daemon_hex = hex::encode(daemon_kp.agent_id().as_bytes());
         let sub_hex = hex::encode(sub_kp.agent_id().as_bytes());
+        let delegation = make_delegation(&sub_kp, &daemon_hex, &["g1"]);
         let msg = GroupPublicMessage::sign(
             "g1".into(),
             "state-hash-1".into(),
@@ -728,6 +993,7 @@ mod tests {
                 rider_token_id: 1,
                 rider_token_hash: "ab".repeat(32),
                 scope: "g1".into(),
+                delegation,
             }),
         )
         .unwrap();
@@ -768,6 +1034,7 @@ mod tests {
         let sub_kp = make_kp();
         let daemon_hex = hex::encode(daemon_kp.agent_id().as_bytes());
         let sub_hex = hex::encode(sub_kp.agent_id().as_bytes());
+        let delegation = make_delegation(&sub_kp, &daemon_hex, &["g1"]);
         let msg = GroupPublicMessage::sign(
             "g1".into(),
             "state-hash-1".into(),
@@ -784,6 +1051,7 @@ mod tests {
                 rider_token_id: 1,
                 rider_token_hash: "ab".repeat(32),
                 scope: "g1".into(),
+                delegation,
             }),
         )
         .unwrap();
@@ -804,6 +1072,150 @@ mod tests {
             validate_public_message(&ctx, &msg),
             Err(IngestError::WritePolicyViolation { .. })
         ));
+    }
+
+    #[test]
+    fn ingest_rejects_unauthenticated_rider_provenance_forgery() {
+        // WHY (review r3, the CRITICAL): a validly daemon-signed message
+        // whose provenance CLAIMS a member sub-agent but is NOT backed
+        // by that sub-agent's cryptographic delegation must be rejected.
+        // Otherwise ANY daemon could impersonate any member/admin by
+        // fabricating the provenance string. Three forgery shapes:
+        // no delegation bytes at all, a delegation signed by a DIFFERENT
+        // sub-agent's key, and a delegation naming another daemon.
+        let daemon_kp = make_kp();
+        let victim_kp = make_kp(); // the member identity being impersonated
+        let attacker_kp = make_kp(); // signs the delegation
+        let daemon_hex = hex::encode(daemon_kp.agent_id().as_bytes());
+        let victim_hex = hex::encode(victim_kp.agent_id().as_bytes());
+        let mut members = BTreeMap::new();
+        members.insert(
+            daemon_hex.clone(),
+            active_member(&daemon_hex, GroupRole::Member),
+        );
+        members.insert(
+            victim_hex.clone(),
+            active_member(&victim_hex, GroupRole::Admin),
+        );
+        let policy = open_policy();
+
+        // Forge 1: provenance with a delegation signed by the ATTACKER's
+        // key while claiming the VICTIM sub-agent id.
+        let attacker_delegation = make_delegation(&attacker_kp, &daemon_hex, &["g1"]);
+        let forged = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &daemon_kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "forged".into(),
+            1_000,
+            None,
+            None,
+            Some(RiderProvenance {
+                sub_agent_id: victim_hex.clone(),
+                rider_token_id: 1,
+                rider_token_hash: "ab".repeat(32),
+                scope: "g1".into(),
+                delegation: attacker_delegation,
+            }),
+        )
+        .unwrap();
+        // The daemon signature is genuinely valid…
+        forged.verify_signature().unwrap();
+        let ctx = PublicIngestContext {
+            group_id: "g1",
+            policy: &policy,
+            members_v2: &members,
+        };
+        // …but ingest must reject the unauthenticated provenance.
+        assert!(matches!(
+            validate_public_message(&ctx, &forged),
+            Err(IngestError::InvalidSignature(_))
+        ));
+
+        // Forge 2: a legitimate victim-signed delegation that names a
+        // DIFFERENT daemon — this daemon is not the delegated signer.
+        let other_daemon = make_kp();
+        let other_daemon_hex = hex::encode(other_daemon.agent_id().as_bytes());
+        let cross_delegation = make_delegation(&victim_kp, &other_daemon_hex, &["g1"]);
+        let forged = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &daemon_kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "forged 2".into(),
+            1_000,
+            None,
+            None,
+            Some(RiderProvenance {
+                sub_agent_id: victim_hex.clone(),
+                rider_token_id: 1,
+                rider_token_hash: "ab".repeat(32),
+                scope: "g1".into(),
+                delegation: cross_delegation,
+            }),
+        )
+        .unwrap();
+        assert!(matches!(
+            validate_public_message(&ctx, &forged),
+            Err(IngestError::InvalidSignature(_))
+        ));
+
+        // Forge 3: victim-signed delegation scoped to a DIFFERENT group.
+        let other_scope_delegation = make_delegation(&victim_kp, &daemon_hex, &["g-other"]);
+        let forged = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &daemon_kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "forged 3".into(),
+            1_000,
+            None,
+            None,
+            Some(RiderProvenance {
+                sub_agent_id: victim_hex.clone(),
+                rider_token_id: 1,
+                rider_token_hash: "ab".repeat(32),
+                scope: "g1".into(),
+                delegation: other_scope_delegation,
+            }),
+        )
+        .unwrap();
+        assert!(matches!(
+            validate_public_message(&ctx, &forged),
+            Err(IngestError::InvalidSignature(_))
+        ));
+
+        // Control: a genuine victim-signed delegation to THIS daemon for
+        // THIS group passes ingest (victim is an admin member).
+        let genuine = make_delegation(&victim_kp, &daemon_hex, &["g1"]);
+        let legit = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &daemon_kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "legit".into(),
+            1_000,
+            None,
+            None,
+            Some(RiderProvenance {
+                sub_agent_id: victim_hex.clone(),
+                rider_token_id: 1,
+                rider_token_hash: "ab".repeat(32),
+                scope: "g1".into(),
+                delegation: genuine,
+            }),
+        )
+        .unwrap();
+        validate_public_message(&ctx, &legit).unwrap();
     }
 
     #[test]

--- a/src/groups/public_message.rs
+++ b/src/groups/public_message.rs
@@ -40,7 +40,7 @@ use ant_quic::crypto::raw_public_keys::pqc::{
 };
 use ant_quic::MlDsaPublicKey;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Domain-separation tag for public-message signatures (v1 — no thread fields).
 pub const PUBLIC_MESSAGE_DOMAIN: &[u8] = b"x0x.group.public-message.v1";
@@ -277,7 +277,7 @@ pub fn verify_rider_provenance(
     provenance: &RiderProvenance,
     author_agent_id: &str,
     scope: &str,
-
+    agent_revoked: bool,
     now_unix: u64,
 ) -> Result<String, String> {
     use base64::Engine as _;
@@ -319,6 +319,17 @@ pub fn verify_rider_provenance(
         .map_err(|_| "delegation is not signed by the sub-agent's key".to_string())?;
     if now_unix >= claim.not_after {
         return Err("delegation has expired".to_string());
+    }
+    // Review r5 item 2: authorization lifetime at the RECEIVER. The
+    // certificate's own expiry (a signature-only `verify` says nothing
+    // about `not_after`) and the caller's ADR-0018 revocation view of
+    // the sub-agent are both enforced here, mirroring the sending
+    // daemon's middleware fence.
+    if cert.is_expired(now_unix) {
+        return Err("delegation certificate has expired".to_string());
+    }
+    if agent_revoked {
+        return Err("sub-agent is revoked (ADR-0018)".to_string());
     }
     if !claim.scopes.iter().any(|s| s == scope) {
         return Err("target group is not in the delegation scopes".to_string());
@@ -362,12 +373,17 @@ pub const RIDER_MLS_ATTRIBUTION_DOMAIN: &[u8] = b"x0x.rider.mls-attribution.v1";
 
 /// Canonical MLS attribution bytes:
 /// `domain || (len-prefixed) sub_agent_id, scope, delegation
-/// cert_b64/payload_b64/signature || token_id(LE) || epoch(LE)`.
+/// cert_b64/payload_b64/signature || token_id(LE) || group || epoch(LE)
+/// || blake3(ciphertext)`. The ciphertext digest (review r5) binds the
+/// signature to the ACTUAL encrypted message — without it the artifact
+/// attested provenance for a (group, epoch) but not for any concrete
+/// ciphertext.
 #[must_use]
 pub fn rider_mls_attribution_bytes(
     provenance: &RiderProvenance,
     group_id: &str,
     epoch: u64,
+    ciphertext: &[u8],
 ) -> Vec<u8> {
     let mut buf = Vec::with_capacity(256 + provenance.delegation.cert_b64.len());
     buf.extend_from_slice(RIDER_MLS_ATTRIBUTION_DOMAIN);
@@ -379,6 +395,7 @@ pub fn rider_mls_attribution_bytes(
     buf.extend_from_slice(&provenance.rider_token_id.to_le_bytes());
     push_len_prefixed_str(&mut buf, group_id);
     buf.extend_from_slice(&epoch.to_le_bytes());
+    buf.extend_from_slice(blake3::hash(ciphertext).as_bytes());
     buf
 }
 
@@ -432,7 +449,7 @@ mod mls_attribution_tests {
             scope: "mls-group".to_string(),
             delegation: delegation_for(&sub_kp, &daemon_hex),
         };
-        let bytes = rider_mls_attribution_bytes(&prov, "mls-group", 42);
+        let bytes = rider_mls_attribution_bytes(&prov, "mls-group", 42, b"ciphertext");
         let sig = sign_with_ml_dsa(daemon_kp.secret_key(), &bytes).unwrap();
         // The daemon's signature verifies over the exact bytes…
         assert!(ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
@@ -443,7 +460,7 @@ mod mls_attribution_tests {
         .is_ok());
         // …and any (group, epoch) drift breaks verification — the
         // artifact is bound, not a free-floating string.
-        let tampered = rider_mls_attribution_bytes(&prov, "mls-group", 43);
+        let tampered = rider_mls_attribution_bytes(&prov, "mls-group", 43, b"ciphertext");
         assert!(
             ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
                 daemon_kp.public_key(),
@@ -453,7 +470,7 @@ mod mls_attribution_tests {
             .is_err(),
             "epoch drift must invalidate the attribution signature"
         );
-        let tampered = rider_mls_attribution_bytes(&prov, "other-group", 42);
+        let tampered = rider_mls_attribution_bytes(&prov, "other-group", 42, b"ciphertext");
         assert!(
             ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
                 daemon_kp.public_key(),
@@ -462,6 +479,101 @@ mod mls_attribution_tests {
             )
             .is_err(),
             "group drift must invalidate the attribution signature"
+        );
+        // Review r5: ciphertext drift must also break the signature —
+        // the artifact authenticates the CONCRETE encrypted message.
+        let tampered = rider_mls_attribution_bytes(&prov, "mls-group", 42, b"other-ciphertext");
+        assert!(
+            ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+                daemon_kp.public_key(),
+                &tampered,
+                &sig
+            )
+            .is_err(),
+            "ciphertext drift must invalidate the attribution signature"
+        );
+    }
+
+    #[test]
+    fn rider_provenance_dies_with_cert_expiry_and_revocation() {
+        // WHY (review r5): a signature-valid delegation inside a
+        // signature-valid message must STILL be refused at receive time
+        // when the underlying certificate has expired or the sub-agent
+        // is ADR-0018-revoked — receivers enforce the authorization
+        // lifetime, not just the cryptography.
+        let daemon_kp = AgentKeypair::generate().unwrap();
+        let sub_kp = AgentKeypair::generate().unwrap();
+        let daemon_hex = hex::encode(daemon_kp.agent_id().as_bytes());
+        let prov = RiderProvenance {
+            sub_agent_id: hex::encode(sub_kp.agent_id().as_bytes()),
+            rider_token_id: 7,
+            rider_token_hash: "ab".repeat(32),
+            scope: "mls-group".to_string(),
+            delegation: delegation_for(&sub_kp, &daemon_hex),
+        };
+        // Inside the delegation's validity window: the chain verifies;
+        // a revoked sub-agent is refused.
+        let in_window = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 60;
+        assert!(verify_rider_provenance(&prov, &daemon_hex, "mls-group", false, in_window).is_ok());
+        assert_eq!(
+            verify_rider_provenance(&prov, &daemon_hex, "mls-group", true, in_window).unwrap_err(),
+            "sub-agent is revoked (ADR-0018)"
+        );
+        // Delegation-expiry axis: a `now` past the capability's
+        // not_after must fail (the capability in `prov` expires at
+        // issuance + 3_600).
+        let after_expiry = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 4_000;
+        assert!(
+            verify_rider_provenance(&prov, &daemon_hex, "mls-group", false, after_expiry).is_err(),
+            "delegation expiry must be enforced"
+        );
+
+        // Expired CERTIFICATE with a still-valid delegation: refused —
+        // cert.verify() is signature-only; the not_after axis is
+        // enforced separately (review r5).
+        use base64::Engine as _;
+        let owner = crate::identity::UserKeypair::generate().unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let expired_cert = crate::identity::AgentCertificate::issue_for_public_key(
+            &owner,
+            sub_kp.public_key().as_bytes(),
+            Some(now - 3_600),
+        )
+        .unwrap();
+        let sub_hex = hex::encode(sub_kp.agent_id().as_bytes());
+        let payload = rider_delegation_bytes(
+            &sub_hex,
+            &daemon_hex,
+            &["mls-group".to_string()],
+            now + 3_600,
+        );
+        let sig = sign_with_ml_dsa(sub_kp.secret_key(), &payload).unwrap();
+        let prov = RiderProvenance {
+            sub_agent_id: sub_hex,
+            rider_token_id: 8,
+            rider_token_hash: "cd".repeat(32),
+            scope: "mls-group".to_string(),
+            delegation: RiderDelegation {
+                cert_b64: base64::engine::general_purpose::STANDARD
+                    .encode(expired_cert.to_storage_bytes().unwrap()),
+                payload_b64: base64::engine::general_purpose::STANDARD.encode(&payload),
+                signature: hex::encode(sig.as_bytes()),
+            },
+        };
+        assert_eq!(
+            verify_rider_provenance(&prov, &daemon_hex, "mls-group", false, now).unwrap_err(),
+            "delegation certificate has expired"
         );
     }
 }
@@ -679,9 +791,33 @@ pub struct PublicIngestContext<'a> {
 /// Returns `Ok(())` if the message should be accepted and cached;
 /// returns `Err` with a deterministic reason otherwise. The validator
 /// is pure and side-effect-free — it does not mutate any state.
+///
+/// This wrapper has no ADR-0018 revocation view (tests, offline
+/// replay); production ingest paths use
+/// [`validate_public_message_with_revocations`].
 pub fn validate_public_message(
     ctx: &PublicIngestContext<'_>,
     msg: &GroupPublicMessage,
+) -> Result<(), IngestError> {
+    validate_public_message_inner(ctx, msg, &BTreeSet::new())
+}
+
+/// [`validate_public_message`] with the receiver's ADR-0018 revocation
+/// view (review r5): hex agent ids the local revocation set covers.
+/// A rider message from a revoked sub-agent is rejected here, at
+/// receive time — mirroring the sending daemon's middleware fence.
+pub fn validate_public_message_with_revocations(
+    ctx: &PublicIngestContext<'_>,
+    msg: &GroupPublicMessage,
+    revoked_agents: &std::collections::BTreeSet<String>,
+) -> Result<(), IngestError> {
+    validate_public_message_inner(ctx, msg, revoked_agents)
+}
+
+fn validate_public_message_inner(
+    ctx: &PublicIngestContext<'_>,
+    msg: &GroupPublicMessage,
+    revoked_agents: &std::collections::BTreeSet<String>,
 ) -> Result<(), IngestError> {
     // 1. group_id match
     if msg.group_id != ctx.group_id {
@@ -757,8 +893,14 @@ pub fn validate_public_message(
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
-            verify_rider_provenance(prov, &msg.author_agent_id, &prov.scope, now_unix)
-                .map_err(IngestError::InvalidSignature)?;
+            verify_rider_provenance(
+                prov,
+                &msg.author_agent_id,
+                &prov.scope,
+                revoked_agents.contains(&prov.sub_agent_id),
+                now_unix,
+            )
+            .map_err(IngestError::InvalidSignature)?;
             // `verify_rider_provenance` proved the certified subject
             // equals the asserted id, so the assertion is now trusted.
             prov.sub_agent_id.as_str()

--- a/src/groups/public_message.rs
+++ b/src/groups/public_message.rs
@@ -352,6 +352,120 @@ pub fn sign_rider_delegation(
     ))
 }
 
+/// Domain-separation tag for MLS-plane rider attribution artifacts
+/// (review r4): the MLS ciphertext itself is opaque, so the daemon
+/// signs a small artifact binding the rider provenance — including the
+/// sub-agent-signed delegation — to the concrete (group, epoch) it was
+/// encrypted under. The artifact is recorded in durable history, making
+/// Home attribution cryptographic instead of a local string.
+pub const RIDER_MLS_ATTRIBUTION_DOMAIN: &[u8] = b"x0x.rider.mls-attribution.v1";
+
+/// Canonical MLS attribution bytes:
+/// `domain || (len-prefixed) sub_agent_id, scope, delegation
+/// cert_b64/payload_b64/signature || token_id(LE) || epoch(LE)`.
+#[must_use]
+pub fn rider_mls_attribution_bytes(
+    provenance: &RiderProvenance,
+    group_id: &str,
+    epoch: u64,
+) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(256 + provenance.delegation.cert_b64.len());
+    buf.extend_from_slice(RIDER_MLS_ATTRIBUTION_DOMAIN);
+    push_len_prefixed_str(&mut buf, &provenance.sub_agent_id);
+    push_len_prefixed_str(&mut buf, &provenance.scope);
+    push_len_prefixed_str(&mut buf, &provenance.delegation.cert_b64);
+    push_len_prefixed_str(&mut buf, &provenance.delegation.payload_b64);
+    push_len_prefixed_str(&mut buf, &provenance.delegation.signature);
+    buf.extend_from_slice(&provenance.rider_token_id.to_le_bytes());
+    push_len_prefixed_str(&mut buf, group_id);
+    buf.extend_from_slice(&epoch.to_le_bytes());
+    buf
+}
+
+#[cfg(test)]
+mod mls_attribution_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use crate::identity::AgentKeypair;
+
+    fn delegation_for(sub_kp: &AgentKeypair, daemon_hex: &str) -> RiderDelegation {
+        use base64::Engine as _;
+        let owner = crate::identity::UserKeypair::generate().unwrap();
+        let cert = crate::identity::AgentCertificate::issue_for_public_key(
+            &owner,
+            sub_kp.public_key().as_bytes(),
+            None,
+        )
+        .unwrap();
+        let sub_hex = hex::encode(sub_kp.agent_id().as_bytes());
+        let scopes = vec!["mls-group".to_string()];
+        let not_after = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3_600;
+        let payload = rider_delegation_bytes(&sub_hex, daemon_hex, &scopes, not_after);
+        let sig = sign_with_ml_dsa(sub_kp.secret_key(), &payload).unwrap();
+        RiderDelegation {
+            cert_b64: base64::engine::general_purpose::STANDARD
+                .encode(cert.to_storage_bytes().unwrap()),
+            payload_b64: base64::engine::general_purpose::STANDARD.encode(&payload),
+            signature: hex::encode(sig.as_bytes()),
+        }
+    }
+
+    #[test]
+    fn rider_mls_attribution_is_daemon_signed_and_binds_group_and_epoch() {
+        // WHY (review r4 item 2): Home/MLS attribution must be
+        // cryptographic — a daemon signature over bytes that bind the
+        // provenance (and its sub-agent-signed delegation), the group,
+        // AND the epoch, so the artifact cannot be replayed across
+        // groups or epochs unnoticed.
+        let daemon_kp = AgentKeypair::generate().unwrap();
+        let sub_kp = AgentKeypair::generate().unwrap();
+        let daemon_hex = hex::encode(daemon_kp.agent_id().as_bytes());
+        let prov = RiderProvenance {
+            sub_agent_id: hex::encode(sub_kp.agent_id().as_bytes()),
+            rider_token_id: 7,
+            rider_token_hash: "ab".repeat(32),
+            scope: "mls-group".to_string(),
+            delegation: delegation_for(&sub_kp, &daemon_hex),
+        };
+        let bytes = rider_mls_attribution_bytes(&prov, "mls-group", 42);
+        let sig = sign_with_ml_dsa(daemon_kp.secret_key(), &bytes).unwrap();
+        // The daemon's signature verifies over the exact bytes…
+        assert!(ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+            daemon_kp.public_key(),
+            &bytes,
+            &sig
+        )
+        .is_ok());
+        // …and any (group, epoch) drift breaks verification — the
+        // artifact is bound, not a free-floating string.
+        let tampered = rider_mls_attribution_bytes(&prov, "mls-group", 43);
+        assert!(
+            ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+                daemon_kp.public_key(),
+                &tampered,
+                &sig
+            )
+            .is_err(),
+            "epoch drift must invalidate the attribution signature"
+        );
+        let tampered = rider_mls_attribution_bytes(&prov, "other-group", 42);
+        assert!(
+            ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(
+                daemon_kp.public_key(),
+                &tampered,
+                &sig
+            )
+            .is_err(),
+            "group drift must invalidate the attribution signature"
+        );
+    }
+}
+
 impl GroupPublicMessage {
     /// Canonical bytes signed by the author to produce `signature`.
     ///

--- a/src/groups/public_message.rs
+++ b/src/groups/public_message.rs
@@ -104,8 +104,40 @@ pub struct GroupPublicMessage {
     /// When present, `thread_root` must also be present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thread_parent: Option<String>,
+    /// ADR-0039 rider provenance: present only when this message was sent
+    /// through the owner's daemon by an API-key rider. The envelope rides
+    /// INSIDE `signable_bytes()` — the daemon-agent signature over the
+    /// message authenticates the attribution (gapcheck blocker 24: the
+    /// provenance marker must be covered by the signed bytes). Additive and
+    /// serde-defaulted, so pre-ADR-0039 messages (and older verifiers that
+    /// drop the field) see the exact v1/v2 encoding when it is `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rider_provenance: Option<RiderProvenance>,
     /// Hex ML-DSA-65 signature over `signable_bytes()`.
     pub signature: String,
+}
+
+/// Attribution envelope for a rider-sourced send (ADR-0039).
+///
+/// The daemon never holds the sub-agent's secret key, so it cannot — and
+/// must not — sign *as* the sub-agent (that would make `/agent/sign`-style
+/// oracle abuse trivial). Instead the DAEMON's agent key signs the message
+/// and this envelope binds, inside those signed bytes, the identity of the
+/// registered sub-agent on whose behalf the send was made plus the rider
+/// token that authorized it (identified by opaque id and SHA-256 hash —
+/// never the token secret itself).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RiderProvenance {
+    /// Hex `AgentId` of the registered sub-agent on whose behalf the
+    /// daemon sent (must match a `mode=rider` journal record).
+    pub sub_agent_id: String,
+    /// Opaque numeric id of the rider token that authorized the send.
+    pub rider_token_id: u64,
+    /// SHA-256 hex of the rider token (the hashed-at-rest identifier;
+    /// the token secret is never placed on the wire).
+    pub rider_token_hash: String,
+    /// The granted scope this send used: the target group id.
+    pub scope: String,
 }
 
 impl GroupPublicMessage {
@@ -152,6 +184,16 @@ impl GroupPublicMessage {
                 self.thread_parent.as_deref().unwrap_or("").as_bytes(),
             );
         }
+        // ADR-0039: rider provenance rides INSIDE the signed bytes (absent
+        // ⇒ byte-identical legacy encoding, preserving the ADR-0029 rule
+        // above; present ⇒ the attribution is authenticated by the
+        // author's signature and covered by `msg_id`).
+        if let Some(prov) = &self.rider_provenance {
+            push_len_prefixed(&mut buf, prov.sub_agent_id.as_bytes());
+            buf.extend_from_slice(&prov.rider_token_id.to_le_bytes());
+            push_len_prefixed(&mut buf, prov.rider_token_hash.as_bytes());
+            push_len_prefixed(&mut buf, prov.scope.as_bytes());
+        }
         buf
     }
 
@@ -167,7 +209,10 @@ impl GroupPublicMessage {
     /// Build and sign a new public message.
     ///
     /// Pass `thread_root` / `thread_parent` to produce a v2-domain threaded
-    /// message (ADR-0029). Both `None` produces a v1-compatible message.
+    /// message (ADR-0029); both `None` produces a v1-compatible message.
+    /// Pass `rider_provenance` to stamp ADR-0039 attribution inside the
+    /// signed bytes (owner sends pass `None` and produce the exact legacy
+    /// encoding).
     #[allow(clippy::too_many_arguments)]
     pub fn sign(
         group_id: String,
@@ -180,6 +225,7 @@ impl GroupPublicMessage {
         timestamp: u64,
         thread_root: Option<String>,
         thread_parent: Option<String>,
+        rider_provenance: Option<RiderProvenance>,
     ) -> Result<Self, ApplyError> {
         let author_agent_id = hex::encode(keypair.agent_id().as_bytes());
         let author_public_key = hex::encode(keypair.public_key().as_bytes());
@@ -195,6 +241,7 @@ impl GroupPublicMessage {
             timestamp,
             thread_root,
             thread_parent,
+            rider_provenance,
             signature: String::new(),
         };
         let sig = sign_with_ml_dsa(keypair.secret_key(), &msg.signable_bytes())
@@ -463,6 +510,7 @@ mod tests {
             1_000,
             None,
             None,
+            None,
         )
         .unwrap()
     }
@@ -548,6 +596,7 @@ mod tests {
             GroupPublicMessageKind::Chat,
             "x".into(),
             1_000,
+            None,
             None,
             None,
         )
@@ -797,6 +846,7 @@ mod tests {
             2_000,
             Some(fake_root.clone()),
             Some(fake_root),
+            None,
         )
         .unwrap();
         let bytes = msg.signable_bytes();
@@ -824,6 +874,7 @@ mod tests {
             3_000,
             Some(fake_root.clone()),
             Some(fake_root),
+            None,
         )
         .unwrap();
         // Simulate an old node by stripping thread fields AFTER signing —
@@ -866,6 +917,7 @@ mod tests {
             4_000,
             Some(fake_root.clone()),
             Some(fake_root),
+            None,
         )
         .unwrap();
         msg.verify_signature().unwrap(); // baseline passes
@@ -948,6 +1000,7 @@ mod tests {
             5_000,
             Some(fake_root.clone()),
             Some(fake_root),
+            None,
         )
         .unwrap();
         // Strip root — now parent is present without root.
@@ -987,6 +1040,7 @@ mod tests {
             6_000,
             Some(fake_root),
             Some(fake_parent),
+            None,
         )
         .unwrap();
         let policy = open_policy();
@@ -1028,6 +1082,7 @@ mod tests {
             "self ref".into(),
             7_000,
             Some(base_id.clone()),
+            None,
             None,
         )
         .unwrap();

--- a/src/groups/public_message.rs
+++ b/src/groups/public_message.rs
@@ -403,13 +403,25 @@ pub fn validate_public_message(
             field: "thread_parent",
         });
     }
-
     // 5. signature + author binding
     msg.verify_signature()
         .map_err(|e| IngestError::InvalidSignature(format!("{e}")))?;
 
+    // Review fix #1 (receiver side): when a daemon-signed message
+    // carries rider provenance, the ACTING PRINCIPAL for ban and
+    // write-policy enforcement is the provenance sub-agent — NOT the
+    // daemon author. Without this, a rider message would inherit the
+    // daemon's admin role at every receiver and the provenance
+    // envelope would be cosmetic.
+    let acting_agent = msg
+        .rider_provenance
+        .as_ref()
+        .map_or(msg.author_agent_id.as_str(), |prov| {
+            prov.sub_agent_id.as_str()
+        });
+
     // 7. banned authors rejected
-    if let Some(member) = ctx.members_v2.get(&msg.author_agent_id) {
+    if let Some(member) = ctx.members_v2.get(acting_agent) {
         if member.state == GroupMemberState::Banned {
             return Err(IngestError::AuthorBanned);
         }
@@ -418,7 +430,7 @@ pub fn validate_public_message(
     // 8. write-access policy enforcement
     let author_role = ctx
         .members_v2
-        .get(&msg.author_agent_id)
+        .get(acting_agent)
         .filter(|m| m.state == GroupMemberState::Active)
         .map(|m| m.role);
 
@@ -687,6 +699,111 @@ mod tests {
         };
         let err = validate_public_message(&ctx, &msg).unwrap_err();
         assert!(matches!(err, IngestError::WritePolicyViolation { .. }));
+    }
+
+    #[test]
+    fn ingest_enforces_policy_against_rider_provenance_sub_agent() {
+        // WHY (review fix #1, receiver side): a daemon-signed rider
+        // message must be authorized by the SUB-AGENT named in the
+        // provenance envelope, never by the daemon author. The daemon
+        // here IS an active member; the provenance sub-agent is not —
+        // ingest must reject. With the sub-agent admitted, it passes.
+        let daemon_kp = make_kp();
+        let sub_kp = make_kp();
+        let daemon_hex = hex::encode(daemon_kp.agent_id().as_bytes());
+        let sub_hex = hex::encode(sub_kp.agent_id().as_bytes());
+        let msg = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &daemon_kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "x".into(),
+            1_000,
+            None,
+            None,
+            Some(RiderProvenance {
+                sub_agent_id: sub_hex.clone(),
+                rider_token_id: 1,
+                rider_token_hash: "ab".repeat(32),
+                scope: "g1".into(),
+            }),
+        )
+        .unwrap();
+        let policy = open_policy(); // MembersOnly write_access
+
+        // Daemon is a member, provenance sub-agent is NOT → reject.
+        let mut members = BTreeMap::new();
+        members.insert(
+            daemon_hex.clone(),
+            active_member(&daemon_hex, GroupRole::Admin),
+        );
+        let ctx = PublicIngestContext {
+            group_id: "g1",
+            policy: &policy,
+            members_v2: &members,
+        };
+        assert!(matches!(
+            validate_public_message(&ctx, &msg),
+            Err(IngestError::WritePolicyViolation { .. })
+        ));
+
+        // Admit the sub-agent as a plain member → accept.
+        members.insert(sub_hex.clone(), active_member(&sub_hex, GroupRole::Member));
+        let ctx = PublicIngestContext {
+            group_id: "g1",
+            policy: &policy,
+            members_v2: &members,
+        };
+        validate_public_message(&ctx, &msg).unwrap();
+    }
+
+    #[test]
+    fn ingest_admin_only_rider_provenance_needs_sub_agent_admin_role() {
+        // WHY: same principle under AdminOnly — the DAEMON author's
+        // admin role must not carry a rider whose sub-agent is a mere
+        // member.
+        let daemon_kp = make_kp();
+        let sub_kp = make_kp();
+        let daemon_hex = hex::encode(daemon_kp.agent_id().as_bytes());
+        let sub_hex = hex::encode(sub_kp.agent_id().as_bytes());
+        let msg = GroupPublicMessage::sign(
+            "g1".into(),
+            "state-hash-1".into(),
+            1,
+            &daemon_kp,
+            None,
+            GroupPublicMessageKind::Chat,
+            "x".into(),
+            1_000,
+            None,
+            None,
+            Some(RiderProvenance {
+                sub_agent_id: sub_hex.clone(),
+                rider_token_id: 1,
+                rider_token_hash: "ab".repeat(32),
+                scope: "g1".into(),
+            }),
+        )
+        .unwrap();
+        let mut policy = open_policy();
+        policy.write_access = GroupWriteAccess::AdminOnly;
+        let mut members = BTreeMap::new();
+        members.insert(
+            daemon_hex.clone(),
+            active_member(&daemon_hex, GroupRole::Owner),
+        );
+        members.insert(sub_hex.clone(), active_member(&sub_hex, GroupRole::Member));
+        let ctx = PublicIngestContext {
+            group_id: "g1",
+            policy: &policy,
+            members_v2: &members,
+        };
+        assert!(matches!(
+            validate_public_message(&ctx, &msg),
+            Err(IngestError::WritePolicyViolation { .. })
+        ));
     }
 
     #[test]

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -600,6 +600,66 @@ impl AgentCertificate {
         })
     }
 
+    /// Issue a certificate for an agent **public key** submitted by a
+    /// harness (ADR-0039 sub-agent issuance, `POST /owner/agents/issue`).
+    ///
+    /// The harness generates and custodies the fresh keypair; the daemon
+    /// only ever sees the public half — the secret never crosses the API
+    /// (gapcheck blocker 20). The returned certificate is signed by
+    /// `user_kp` with byte-identical message construction to
+    /// [`issue_with_expiry`](Self::issue_with_expiry), so it verifies
+    /// through the ordinary [`verify`](Self::verify) chain and satisfies
+    /// `GroupAdmission::OwnerCertified` (ADR-0038) like any other
+    /// owner-certified agent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::IdentityError::CertificateVerification`] if
+    /// the submitted key does not parse as an ML-DSA-65 public key, the
+    /// system clock is before the Unix epoch, or signing fails.
+    pub fn issue_for_public_key(
+        user_kp: &UserKeypair,
+        agent_public_key_bytes: &[u8],
+        not_after: Option<u64>,
+    ) -> Result<Self, crate::error::IdentityError> {
+        // Fail closed on a malformed key rather than certifying garbage.
+        if MlDsaPublicKey::from_bytes(agent_public_key_bytes).is_err() {
+            return Err(crate::error::IdentityError::CertificateVerification(
+                "submitted agent public key is not a valid ML-DSA-65 key".to_string(),
+            ));
+        }
+        let issued_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| {
+                crate::error::IdentityError::CertificateVerification(format!(
+                    "system time error: {}",
+                    e
+                ))
+            })?
+            .as_secs();
+
+        let user_pub_bytes = user_kp.public_key().as_bytes().to_vec();
+        let agent_pub_bytes = agent_public_key_bytes.to_vec();
+
+        let message = Self::build_message(&user_pub_bytes, &agent_pub_bytes, issued_at, not_after);
+
+        let signature = ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
+            user_kp.secret_key(),
+            &message,
+        )
+        .map_err(|e| {
+            crate::error::IdentityError::CertificateVerification(format!("signing failed: {:?}", e))
+        })?;
+
+        Ok(Self {
+            user_public_key: user_pub_bytes,
+            agent_public_key: agent_pub_bytes,
+            signature: signature.as_bytes().to_vec(),
+            issued_at,
+            not_after,
+        })
+    }
+
     /// Verify the certificate signature.
     ///
     /// Reconstructs the signed message and verifies the ML-DSA-65 signature
@@ -667,6 +727,19 @@ impl AgentCertificate {
     #[must_use]
     pub fn agent_public_key(&self) -> &[u8] {
         &self.agent_public_key
+    }
+
+    /// Raw ML-DSA-65 owner (user) public key bytes stored in this
+    /// certificate (ADR-0039 REST surface).
+    #[must_use]
+    pub fn user_public_key_bytes(&self) -> &[u8] {
+        &self.user_public_key
+    }
+
+    /// Raw ML-DSA-65 signature bytes (ADR-0039 REST surface).
+    #[must_use]
+    pub fn signature_bytes(&self) -> &[u8] {
+        &self.signature
     }
 
     /// Get the issuance timestamp.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1707,6 +1707,11 @@ pub struct OwnerIssuedCert {
     /// journal (survives restarts); `false` when it came from live
     /// discovery only.
     pub from_journal: bool,
+    /// ADR-0039 hosting mode of the latest journal issuance (`Acp` for
+    /// live-discovery-only entries and legacy lines).
+    pub mode: profile::CertMode,
+    /// ADR-0039 operator label of the latest journal issuance.
+    pub label: Option<String>,
 }
 
 /// ADR-0038 round-2: hard cap on live identity-discovery cache entries.
@@ -1717,9 +1722,7 @@ const DISCOVERY_CACHE_MAX_ENTRIES: usize = 1024;
 /// Cached machine endpoint data derived from signed machine announcements.
 #[derive(Debug, Clone)]
 pub struct DiscoveredMachine {
-    /// Machine identity, identical to the ant-quic `PeerId`.
     pub machine_id: identity::MachineId,
-    /// Reachability hints for this machine.
     pub addresses: Vec<std::net::SocketAddr>,
     /// Announcement timestamp from the sender.
     pub announced_at: u64,
@@ -9302,6 +9305,51 @@ impl Agent {
         Ok(record)
     }
 
+    /// Path of the ADR-0036 owner certificate journal for this install,
+    /// when one is configured (sibling of the agent certificate). The
+    /// ADR-0039 owner routes read and append it as the authoritative
+    /// sub-agent registry.
+    #[must_use]
+    pub fn cert_journal_path(&self) -> Option<&std::path::Path> {
+        self.cert_journal_path.as_deref()
+    }
+
+    /// Revoke a sub-agent as the OWNER (ADR-0018 issuer-revocation,
+    /// ADR-0039 `DELETE /owner/agents/:id`).
+    ///
+    /// Signs the revocation with the owner user key — not the daemon
+    /// agent key — and supplies `subject_cert` (the exact certificate
+    /// the owner issued for the subject) so
+    /// [`revocation::RevocationRecord::verify_authority`] accepts the
+    /// issuer path on receipt and on every reload of `revocations.bin`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when no owner key is loaded, signing fails, or
+    /// the authority check rejects the record.
+    pub async fn revoke_as_owner(
+        &self,
+        subject_cert: &identity::AgentCertificate,
+        reason: Option<String>,
+    ) -> error::Result<revocation::RevocationRecord> {
+        let Some(user_kp) = self.identity.user_keypair() else {
+            return Err(error::IdentityError::CertificateVerification(
+                "no owner user key loaded".to_string(),
+            ));
+        };
+        let subject = revocation::RevokedSubject::Agent(subject_cert.agent_id()?);
+        let record = revocation::RevocationRecord::sign(
+            subject,
+            user_kp.public_key(),
+            user_kp.secret_key(),
+            Self::unix_timestamp_secs(),
+            reason,
+        )?;
+        self.apply_and_publish_revocation(record.clone(), Some(subject_cert))
+            .await?;
+        Ok(record)
+    }
+
     /// Apply a revocation record to the local set, persist, publish, and evict.
     ///
     /// Used both by [`revoke`](Agent::revoke) (self-issued) and the gossip
@@ -9790,6 +9838,8 @@ impl Agent {
                     not_after: record.not_after,
                     digest: record.cert_digest,
                     from_journal: true,
+                    mode: record.mode,
+                    label: record.label,
                 };
                 best.insert(record.agent_id, entry);
             }
@@ -9837,6 +9887,8 @@ impl Agent {
                             not_after: record.not_after,
                             digest: record.cert_digest,
                             from_journal: false,
+                            mode: profile::CertMode::Acp,
+                            label: None,
                         },
                     );
                 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -198,7 +198,7 @@ impl SelfProfile {
 /// Write `bytes` to `path` via a unique temp file + rename (atomic on both
 /// unix and windows for same-directory renames). The temp name embeds the
 /// pid + a counter so concurrent writers never collide.
-async fn write_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+pub(crate) async fn write_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     use std::sync::atomic::{AtomicU64, Ordering};
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let dir = path
@@ -251,6 +251,38 @@ pub struct IssuedCertRecord {
     pub issued_at: u64,
     /// Certificate expiry (unix seconds); `None` = no expiry.
     pub not_after: Option<u64>,
+    /// Hosting mode of the certified agent (ADR-0039). Defaults to `Acp`
+    /// for pre-existing lines and the daemon's own self-issuance; rider
+    /// mode is written by `POST /owner/agents/issue` only.
+    #[serde(default)]
+    pub mode: CertMode,
+    /// Operator-assigned label for the certified agent (ADR-0039).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Base64 of the certificate's storage bytes. Retained ONLY for
+    /// sub-agents issued via `POST /owner/agents/issue`: ADR-0018
+    /// issuer-revocation (`DELETE /owner/agents/:id`) must re-present the
+    /// exact certificate binding that owner to the agent, and no other
+    /// durable copy of an offline sub-agent's certificate exists. The
+    /// daemon's own self-issuance keeps the journal lean (`agent.cert` is
+    /// the durable copy).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cert_b64: Option<String>,
+}
+
+/// Hosting mode of a certified sub-agent (ADR-0039): an ACP-attached
+/// harness instance running its own key file, or an API-key rider sending
+/// through the owner's daemon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CertMode {
+    /// Harness-attached instance owning its key (also the mode of the
+    /// daemon's own certificate and of pre-ADR-0039 journal lines).
+    #[default]
+    Acp,
+    /// API-key rider: scoped token authenticates to the owner's daemon,
+    /// which signs on the sub-agent's behalf with provenance marks.
+    Rider,
 }
 
 /// File name of the owner certificate journal, in the instance data dir
@@ -279,6 +311,38 @@ impl IssuedCertRecord {
             cert_digest: cert_storage_digest(cert),
             issued_at: cert.issued_at(),
             not_after: cert.not_after(),
+            mode: CertMode::Acp,
+            label: None,
+            cert_b64: None,
+        })
+    }
+
+    /// Build a sub-agent issuance record (ADR-0039) scoped to the issuing
+    /// owner, carrying the hosting `mode`, optional `label`, and the full
+    /// certificate bytes (base64) so a later
+    /// `DELETE /owner/agents/:id` can present the exact certificate the
+    /// ADR-0018 issuer-revocation authority check requires.
+    #[must_use]
+    pub fn from_cert_with_mode(
+        owner: &crate::identity::UserId,
+        cert: &crate::identity::AgentCertificate,
+        mode: CertMode,
+        label: Option<String>,
+    ) -> Option<Self> {
+        let agent_id = cert.agent_id().ok()?;
+        let cert_b64 = cert.to_storage_bytes().ok().map(|bytes| {
+            use base64::Engine as _;
+            base64::engine::general_purpose::STANDARD.encode(bytes)
+        });
+        Some(Self {
+            user_id: hex::encode(owner.as_bytes()),
+            agent_id: hex::encode(agent_id.as_bytes()),
+            cert_digest: cert_storage_digest(cert),
+            issued_at: cert.issued_at(),
+            not_after: cert.not_after(),
+            mode,
+            label,
+            cert_b64,
         })
     }
 
@@ -442,6 +506,9 @@ mod tests {
             cert_digest: "cd".repeat(32),
             issued_at: 100,
             not_after: None,
+            mode: CertMode::Acp,
+            label: None,
+            cert_b64: None,
         };
         let r2 = IssuedCertRecord {
             user_id: "07".repeat(32),
@@ -449,6 +516,9 @@ mod tests {
             cert_digest: "12".repeat(32),
             issued_at: 200,
             not_after: Some(300),
+            mode: CertMode::Rider,
+            label: Some("ci-agent".into()),
+            cert_b64: None,
         };
         IssuedCertRecord::append(&path, &r1).await.unwrap();
         IssuedCertRecord::append(&path, &r2).await.unwrap();
@@ -460,6 +530,23 @@ mod tests {
         tokio::fs::write(&path, text).await.unwrap();
         let loaded = IssuedCertRecord::load(&path).await;
         assert_eq!(loaded.len(), 2, "corrupt line skipped, records kept");
+        assert_eq!(
+            loaded[1].mode,
+            CertMode::Rider,
+            "ADR-0039 mode/label round-trip through the journal"
+        );
+        assert_eq!(loaded[1].label.as_deref(), Some("ci-agent"));
+        // Pre-ADR-0039 lines (no mode/label/cert_b64 keys) parse as ACP defaults.
+        let legacy_line = format!(
+            "{{\"user_id\":\"{}\",\"agent_id\":\"{}\",\"cert_digest\":\"{}\",\"issued_at\":300,\"not_after\":null}}",
+            "07".repeat(32),
+            "ab".repeat(32),
+            "cd".repeat(32)
+        );
+        let legacy: IssuedCertRecord = serde_json::from_str(&legacy_line).unwrap();
+        assert_eq!(legacy.mode, CertMode::Acp);
+        assert_eq!(legacy.label, None);
+        assert_eq!(legacy.cert_b64, None);
 
         // Missing file is an empty journal, not an error.
         assert!(IssuedCertRecord::load(&dir.path().join("nope.jsonl"))

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -104,6 +104,22 @@ fn extract_query_token(query: Option<&str>) -> Option<String> {
 /// owned strings (no request borrows survive across `next.run(req).await`),
 /// delegates the decision, and maps the result to either the next layer or a
 /// 401 JSON error.
+///
+/// # ADR-0039 actor resolution
+///
+/// After the owner-token checks fail, the presented **bearer** token is
+/// matched against the rider-token store (blocker 21/22). A live rider
+/// token becomes [`ActorContext::Rider`] — but only on the
+/// deny-by-default rider route set; every other route answers `403`
+/// before any handler runs. Riders are bearer-only: a rider token in a
+/// `?token=` query string is rejected exactly like any other non-session
+/// query token. Unknown/expired/revoked tokens stay `401`.
+///
+/// The resolved [`ActorContext`] is inserted into the request extensions
+/// so rider-aware handlers (`/groups/:id/send`,
+/// `/groups/:id/secure/encrypt`, `GET /history`) can consult it; every
+/// other handler ignores it and keeps deriving identity from
+/// `state.agent` as before.
 pub(super) async fn auth_middleware(
     State(state): State<Arc<AppState>>,
     req: axum::http::Request<axum::body::Body>,
@@ -115,7 +131,7 @@ pub(super) async fn auth_middleware(
     let query_token = extract_query_token(req.uri().query());
     let now = Instant::now();
 
-    match authorize(
+    let owner_ok = authorize(
         &path,
         &method,
         header_token.as_deref(),
@@ -123,16 +139,51 @@ pub(super) async fn auth_middleware(
         &state.api_token,
         &state.sessions,
         now,
-    ) {
-        Ok(()) => next.run(req).await,
-        Err(status) => (
-            status,
-            Json(serde_json::json!({
-                "error": "missing or invalid Authorization: Bearer token"
-            })),
-        )
-            .into_response(),
+    )
+    .is_ok();
+
+    if owner_ok {
+        let mut req = req;
+        req.extensions_mut()
+            .insert(super::rider_auth::ActorContext::Owner);
+        return next.run(req).await;
     }
+
+    // Rider fallback: bearer header only, never a query string.
+    if let Some(token) = header_token.as_deref() {
+        let rider = {
+            let store = state.rider_tokens.lock().await;
+            store.validate(token, super::rider_auth::unix_now_secs())
+        };
+        if let Some(rider) = rider {
+            if !super::rider_auth::rider_route_allowed(&method, &path) {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(serde_json::json!({
+                        "error": "rider tokens are denied on this route (ADR-0039 deny-by-default)"
+                    })),
+                )
+                    .into_response();
+            }
+            let actor = super::rider_auth::ActorContext::Rider {
+                sub_agent_id: rider.sub_agent_id,
+                token_id: rider.token_id,
+                token_hash: rider.token_hash,
+                groups: rider.groups,
+            };
+            let mut req = req;
+            req.extensions_mut().insert(actor);
+            return next.run(req).await;
+        }
+    }
+
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({
+            "error": "missing or invalid Authorization: Bearer token"
+        })),
+    )
+        .into_response()
 }
 
 /// `POST /auth/session` — exchange the durable API token for a short-lived

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -131,6 +131,14 @@ pub(super) async fn auth_middleware(
     let query_token = extract_query_token(req.uri().query());
     let now = Instant::now();
 
+    // Review fix #4: distinguish the DURABLE token (full authority,
+    // including owner-admin acts) from a short-lived browser session
+    // bearer (read-only principal). The durable check re-uses the same
+    // constant-time comparison as `authorize`.
+    let durable = header_token
+        .as_deref()
+        .is_some_and(|token| ct_eq(token, &state.api_token));
+
     let owner_ok = authorize(
         &path,
         &method,
@@ -145,17 +153,34 @@ pub(super) async fn auth_middleware(
     if owner_ok {
         let mut req = req;
         req.extensions_mut()
-            .insert(super::rider_auth::ActorContext::Owner);
+            .insert(super::rider_auth::ActorContext::Owner { durable });
         return next.run(req).await;
     }
 
     // Rider fallback: bearer header only, never a query string.
     if let Some(token) = header_token.as_deref() {
+        let now_unix = super::rider_auth::unix_now_secs();
         let rider = {
             let store = state.rider_tokens.lock().await;
-            store.validate(token, super::rider_auth::unix_now_secs())
+            store.validate(token, now_unix)
         };
         if let Some(rider) = rider {
+            // Review fix #2: the sub-agent's ADR-0018 revocation is
+            // checked on EVERY request, not only at token revocation
+            // time — a rider token cannot survive revocation of its
+            // agent even if the token-sweep write failed.
+            let agent_revoked = state.agent.revocation_records().await.iter().any(|record| {
+                record.subject_kind() == "agent" && record.subject_hex() == rider.sub_agent_id
+            });
+            if agent_revoked {
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({
+                        "error": "rider token rejected: sub-agent is revoked"
+                    })),
+                )
+                    .into_response();
+            }
             if !super::rider_auth::rider_route_allowed(&method, &path) {
                 return (
                     StatusCode::FORBIDDEN,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -882,6 +882,7 @@ pub async fn serve_with_options(
             rider_auth::RiderTokenStore::load(config.data_dir.join(rider_auth::RIDER_TOKENS_FILE))
                 .await,
         ),
+        cert_journal_lock: tokio::sync::Mutex::new(()),
         exec_service: Arc::clone(&exec_service),
         groups_diagnostics: Arc::new(x0x::groups::GroupsDiagnostics::new()),
         connect_diagnostics,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,6 +14,7 @@ pub(crate) use api_watchdog::ApiWatchdogConfig;
 mod auth;
 pub mod config;
 mod crdt_subscriptions;
+mod rider_auth;
 mod routes;
 mod sse;
 mod state;
@@ -59,9 +60,10 @@ use routes::{
     list_tasks, load_causal_approval_queue, load_named_groups, load_predecessor_relay_outbox,
     load_treekem_member_key_packages, machine_for_agent_handler, machines_by_user_handler,
     mls_decrypt, mls_encrypt, named_group_metadata_event_group_id, named_group_metadata_event_kind,
-    network_status, now_millis_u64, owner_agents, peer_health_handler, peers, pin_machine,
-    presence, presence_find, presence_foaf, presence_online, presence_status, probe_peer_handler,
-    publish, publish_group_card_to_discovery, put_kv_value, quick_trust,
+    network_status, now_millis_u64, owner_agents, owner_agents_issue, owner_agents_revoke,
+    owner_riders_issue, owner_riders_list, owner_riders_revoke, peer_health_handler, peers,
+    pin_machine, presence, presence_find, presence_foaf, presence_online, presence_status,
+    probe_peer_handler, publish, publish_group_card_to_discovery, put_kv_value, quick_trust,
     recover_treekem_named_journals, reject_join_request, reject_unverified_direct_public_message,
     relay_diagnostics, remove_mls_member, remove_named_group_member,
     replay_pending_causal_approvals, restore_treekem_groups, revoke_contact,
@@ -876,6 +878,10 @@ pub async fn serve_with_options(
         upgrade_apply_lock: Arc::new(Mutex::new(())),
         api_token,
         sessions: auth::SessionStore::new(auth::SESSION_TOKEN_TTL),
+        rider_tokens: tokio::sync::Mutex::new(
+            rider_auth::RiderTokenStore::load(config.data_dir.join(rider_auth::RIDER_TOKENS_FILE))
+                .await,
+        ),
         exec_service: Arc::clone(&exec_service),
         groups_diagnostics: Arc::new(x0x::groups::GroupsDiagnostics::new()),
         connect_diagnostics,
@@ -1644,6 +1650,13 @@ pub async fn serve_with_options(
         .route("/home", get(routes::home::get_home))
         .route("/home/rename", post(routes::home::rename_home))
         .route("/owner/agents", get(owner_agents))
+        .route("/owner/agents/issue", post(owner_agents_issue))
+        .route("/owner/agents/:id", delete(owner_agents_revoke))
+        .route(
+            "/owner/riders",
+            post(owner_riders_issue).get(owner_riders_list),
+        )
+        .route("/owner/riders/:id", delete(owner_riders_revoke))
         .route("/.well-known/agent-card.json", get(get_a2a_agent_card))
         .route("/agent/card/import", post(import_agent_card))
         .route("/agent/sign", post(agent_sign))

--- a/src/server/rider_auth.rs
+++ b/src/server/rider_auth.rs
@@ -181,6 +181,12 @@ pub(super) struct RiderTokenRecord {
     /// The bound certificate's expiry — the token can never outlive
     /// its certificate even if `expires_at` is later.
     pub cert_not_after: Option<u64>,
+    /// The sub-agent-signed delegation capability bound at issuance
+    /// (review r3, option B). `None` only for records predating the
+    /// capability requirement — such tokens cannot produce a
+    /// receiver-verifiable rider send and are refused at the send path.
+    #[serde(default)]
+    pub delegation: Option<crate::groups::RiderDelegation>,
     /// Unix seconds when the token was revoked, if it was.
     #[serde(default)]
     pub revoked_at: Option<u64>,
@@ -297,6 +303,7 @@ impl RiderTokenStore {
         ttl_secs: u64,
         cert_digest: String,
         cert_not_after: Option<u64>,
+        delegation: Option<crate::groups::RiderDelegation>,
         now_unix: u64,
     ) -> std::io::Result<(String, RiderTokenRecord)> {
         use rand::RngCore;
@@ -315,6 +322,7 @@ impl RiderTokenStore {
             expires_at: now_unix.saturating_add(ttl_secs.max(1)),
             cert_digest,
             cert_not_after,
+            delegation,
             revoked_at: None,
         };
         self.records.insert(token_id, record.clone());
@@ -325,6 +333,17 @@ impl RiderTokenStore {
             return Err(e);
         }
         Ok((token, record))
+    }
+
+    /// The delegation capability stored for a live token (send path,
+    /// review r3). `None` when the token is unknown or predates the
+    /// capability requirement — the send handler refuses those.
+    pub(super) fn delegation_of(&self, token_id: u64) -> Option<crate::groups::RiderDelegation> {
+        let record = self.records.get(&token_id)?;
+        if record.revoked_at.is_some() {
+            return None;
+        }
+        record.delegation.clone()
     }
 
     /// Validate a presented bearer token. `None` for unknown, expired,
@@ -553,6 +572,7 @@ mod tests {
                 60,
                 "d1".repeat(32),
                 None,
+                None,
                 1_000,
             )
             .await
@@ -584,6 +604,7 @@ mod tests {
                 10,
                 "d2".repeat(32),
                 None,
+                None,
                 1_000,
             )
             .await
@@ -611,6 +632,7 @@ mod tests {
                 10_000,
                 "d3".repeat(32),
                 Some(1_500),
+                None,
                 1_000,
             )
             .await
@@ -642,6 +664,7 @@ mod tests {
                 60,
                 "d4".repeat(32),
                 None,
+                None,
                 1_000,
             )
             .await
@@ -672,6 +695,7 @@ mod tests {
                     60,
                     "d5".repeat(32),
                     None,
+                    None,
                     1_000,
                 )
                 .await
@@ -683,6 +707,7 @@ mod tests {
                     None,
                     60,
                     "d5".repeat(32),
+                    None,
                     None,
                     1_000,
                 )

--- a/src/server/rider_auth.rs
+++ b/src/server/rider_auth.rs
@@ -53,10 +53,15 @@ pub(super) const RIDER_TOKENS_FILE: &str = "rider-tokens.json";
 /// rest of the control plane.
 #[derive(Debug, Clone)]
 pub(super) enum ActorContext {
-    /// The durable API token or a browser session token — the human
-    /// owner's full control plane. Also the context for exempt paths
-    /// (`/health`, CORS preflights) where no principal authenticated.
-    Owner,
+    /// The durable API token (`durable: true`) or a browser session
+    /// token (`durable: false`) — the human owner's control plane.
+    /// Also the context for exempt paths (`/health`, CORS preflights)
+    /// with `durable: false`. Owner-ADMIN acts — certifying sub-agents
+    /// and minting/revoking rider tokens — require `durable: true`
+    /// (review fix: a 10-minute session bearer must not mint 90-day
+    /// credentials or owner-signed certificates); read-only surfaces
+    /// accept either.
+    Owner { durable: bool },
     /// A scoped rider token: acts as the registered `sub_agent_id`
     /// through this daemon. `groups` is the explicit named-group grant
     /// list (Home is additionally always permitted).
@@ -75,11 +80,20 @@ pub(super) enum ActorContext {
 impl ActorContext {
     pub(super) fn rider_allows_group(&self, is_home: bool, group_id: &str) -> bool {
         match self {
-            ActorContext::Owner => true,
+            ActorContext::Owner { .. } => true,
             ActorContext::Rider { groups, .. } => {
                 is_home || groups.iter().any(|g| g.as_str() == group_id)
             }
         }
+    }
+
+    /// `true` only for the durable API token — the authority required
+    /// for owner-admin acts (`/owner/agents/issue`, the rider-token
+    /// lifecycle, agent revocation). Session bearers are read-only
+    /// principals (review fix: no privilege amplification from a
+    /// 10-minute browser token).
+    pub(super) fn is_durable_owner(&self) -> bool {
+        matches!(self, ActorContext::Owner { durable: true })
     }
 }
 
@@ -160,6 +174,13 @@ pub(super) struct RiderTokenRecord {
     pub issued_at: u64,
     /// Unix seconds after which the token is invalid.
     pub expires_at: u64,
+    /// BLAKE3 hex of the sub-agent certificate this token was issued
+    /// against (review fix #2: the token is bound to the exact
+    /// issuance).
+    pub cert_digest: String,
+    /// The bound certificate's expiry — the token can never outlive
+    /// its certificate even if `expires_at` is later.
+    pub cert_not_after: Option<u64>,
     /// Unix seconds when the token was revoked, if it was.
     #[serde(default)]
     pub revoked_at: Option<u64>,
@@ -180,6 +201,20 @@ fn token_hash_hex(token: &str) -> String {
     use sha2::Digest;
     let digest = sha2::Sha256::digest(token.as_bytes());
     hex::encode(digest)
+}
+
+/// Constant-time equality of two SHA-256 hex digests (review fix #6:
+/// token matching must not leak digest bytes through early-exit string
+/// comparison). Both sides decode to fixed 32-byte buffers first; a
+/// malformed hex digest simply never matches.
+fn constant_time_hex_eq(a: &str, b: &str) -> bool {
+    match (hex::decode(a), hex::decode(b)) {
+        (Ok(a), Ok(b)) if a.len() == 32 && b.len() == 32 => {
+            use subtle::ConstantTimeEq;
+            a.ct_eq(&b).into()
+        }
+        _ => false,
+    }
 }
 
 /// Persists as the plain JSON map `{"next_id": u64, "tokens": {id: rec}}`.
@@ -253,12 +288,15 @@ impl RiderTokenStore {
 
     /// Issue a new rider token. Returns the one-time secret (shown to
     /// the caller exactly once) alongside its record.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn issue(
         &mut self,
         sub_agent_id: String,
         groups: Vec<String>,
         label: Option<String>,
         ttl_secs: u64,
+        cert_digest: String,
+        cert_not_after: Option<u64>,
         now_unix: u64,
     ) -> std::io::Result<(String, RiderTokenRecord)> {
         use rand::RngCore;
@@ -275,6 +313,8 @@ impl RiderTokenStore {
             label,
             issued_at: now_unix,
             expires_at: now_unix.saturating_add(ttl_secs.max(1)),
+            cert_digest,
+            cert_not_after,
             revoked_at: None,
         };
         self.records.insert(token_id, record.clone());
@@ -288,11 +328,23 @@ impl RiderTokenStore {
     }
 
     /// Validate a presented bearer token. `None` for unknown, expired,
-    /// or revoked tokens — the middleware maps that to `401`.
+    /// or revoked tokens — and (review fix #2) for tokens whose bound
+    /// certificate has expired, so a token can never outlive its cert.
+    /// The middleware additionally checks ADR-0018 agent revocation on
+    /// every request.
     pub(super) fn validate(&self, token: &str, now_unix: u64) -> Option<ValidatedRider> {
         let hash = token_hash_hex(token);
-        let record = self.records.values().find(|r| r.token_hash == hash)?;
+        let record = self
+            .records
+            .values()
+            .find(|r| constant_time_hex_eq(&r.token_hash, &hash))?;
         if now_unix >= record.expires_at {
+            return None;
+        }
+        if record
+            .cert_not_after
+            .is_some_and(|not_after| now_unix >= not_after)
+        {
             return None;
         }
         if record.revoked_at.is_some() {
@@ -306,43 +358,66 @@ impl RiderTokenStore {
         })
     }
 
-    /// Revoke one token by id. Returns `false` when the id is unknown.
-    pub(super) async fn revoke(&mut self, token_id: u64, now_unix: u64) -> bool {
-        match self.records.get_mut(&token_id) {
-            Some(record) => {
-                if record.revoked_at.is_none() {
-                    record.revoked_at = Some(now_unix);
-                    if let Err(e) = self.persist().await {
-                        tracing::warn!(
-                            "failed to persist rider-token revocation: {e} — in-memory revocation stands"
-                        );
-                    }
-                }
-                true
-            }
-            None => false,
+    /// Revoke one token by id. `Ok(false)` when the id is unknown;
+    /// `Err` when the revocation could not be made DURABLE — the
+    /// in-memory mutation is rolled back so the token stays valid
+    /// everywhere and the caller reports failure (review fix #3:
+    /// revocation is persist-or-fail, never fail-open across a
+    /// restart).
+    pub(super) async fn revoke(
+        &mut self,
+        token_id: u64,
+        now_unix: u64,
+    ) -> Result<bool, std::io::Error> {
+        let Some(record) = self.records.get_mut(&token_id) else {
+            return Ok(false);
+        };
+        if record.revoked_at.is_some() {
+            return Ok(true);
         }
+        record.revoked_at = Some(now_unix);
+        if let Err(e) = self.persist().await {
+            // Roll back: on disk the token is still live, so it must
+            // remain live in memory too. The caller surfaces the error.
+            if let Some(record) = self.records.get_mut(&token_id) {
+                record.revoked_at = None;
+            }
+            return Err(e);
+        }
+        Ok(true)
     }
 
     /// Revoke every token bound to `sub_agent_id` (used when the
     /// sub-agent itself is revoked via `DELETE /owner/agents/:id`).
-    /// Returns the number of tokens revoked.
-    pub(super) async fn revoke_for_agent(&mut self, sub_agent_id: &str, now_unix: u64) -> usize {
-        let mut revoked = 0;
+    /// Same persist-or-fail contract as [`revoke`](Self::revoke): on a
+    /// persistence failure every in-memory mutation is rolled back and
+    /// the error is returned (the caller's cert-level revocation and
+    /// the middleware's per-request agent-revocation check still fence
+    /// the tokens).
+    pub(super) async fn revoke_for_agent(
+        &mut self,
+        sub_agent_id: &str,
+        now_unix: u64,
+    ) -> Result<usize, std::io::Error> {
+        let mut revoked_ids = Vec::new();
         for record in self.records.values_mut() {
             if record.sub_agent_id == sub_agent_id && record.revoked_at.is_none() {
                 record.revoked_at = Some(now_unix);
-                revoked += 1;
+                revoked_ids.push(record.token_id);
             }
         }
-        if revoked > 0 {
-            if let Err(e) = self.persist().await {
-                tracing::warn!(
-                    "failed to persist rider-token revocations: {e} — in-memory revocations stand"
-                );
-            }
+        if revoked_ids.is_empty() {
+            return Ok(0);
         }
-        revoked
+        if let Err(e) = self.persist().await {
+            for id in revoked_ids {
+                if let Some(record) = self.records.get_mut(&id) {
+                    record.revoked_at = None;
+                }
+            }
+            return Err(e);
+        }
+        Ok(revoked_ids.len())
     }
 
     /// All records, ordered by id (for `GET /owner/riders`). No secrets.
@@ -443,7 +518,7 @@ mod tests {
     fn rider_group_scope_home_or_granted_only() {
         // WHY: ADR-0039 — Home is the always-granted base scope; every
         // other group needs an explicit grant; owners are unrestricted.
-        let owner = ActorContext::Owner;
+        let owner = ActorContext::Owner { durable: true };
         let rider = ActorContext::Rider {
             sub_agent_id: "aa".repeat(32),
             token_id: 1,
@@ -476,16 +551,19 @@ mod tests {
                 vec!["g1".to_string()],
                 Some("ci-agent".into()),
                 60,
+                "d1".repeat(32),
+                None,
                 1_000,
             )
             .await
             .unwrap();
         assert_eq!(record.expires_at, 1_060);
+        assert_eq!(record.cert_digest, "d1".repeat(32));
         let ok = store.validate(&token, 1_050).unwrap();
         assert_eq!(ok.sub_agent_id, "ab".repeat(32));
         assert_eq!(ok.groups, vec!["g1".to_string()]);
 
-        assert!(store.revoke(record.token_id, 1_055).await);
+        assert!(store.revoke(record.token_id, 1_055).await.unwrap());
         assert!(
             store.validate(&token, 1_056).is_none(),
             "revoked token must fail closed"
@@ -499,7 +577,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut store = RiderTokenStore::load(dir.path().join(RIDER_TOKENS_FILE)).await;
         let (token, _) = store
-            .issue("cd".repeat(32), vec![], None, 10, 1_000)
+            .issue(
+                "cd".repeat(32),
+                vec![],
+                None,
+                10,
+                "d2".repeat(32),
+                None,
+                1_000,
+            )
             .await
             .unwrap();
         assert!(store.validate(&token, 1_009).is_some());
@@ -508,6 +594,64 @@ mod tests {
             "expired token must fail closed"
         );
         assert!(store.validate(&"0".repeat(64), 1_000).is_none());
+    }
+
+    #[tokio::test]
+    async fn rider_token_cannot_outlive_its_bound_certificate() {
+        // WHY (review fix #2): the token's TTL may outlast the
+        // sub-agent certificate; the store must refuse validation the
+        // moment the bound certificate expires.
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = RiderTokenStore::load(dir.path().join(RIDER_TOKENS_FILE)).await;
+        let (token, _) = store
+            .issue(
+                "ee".repeat(32),
+                vec![],
+                None,
+                10_000,
+                "d3".repeat(32),
+                Some(1_500),
+                1_000,
+            )
+            .await
+            .unwrap();
+        assert!(store.validate(&token, 1_499).is_some());
+        assert!(
+            store.validate(&token, 1_500).is_none(),
+            "token must die with its certificate, not at its own TTL"
+        );
+    }
+
+    #[tokio::test]
+    async fn revocation_is_persist_or_fail_never_fail_open() {
+        // WHY (review fix #3): if the revocation cannot be made durable,
+        // the caller must see the error and the token must stay live
+        // EVERYWHERE (in-memory rollback) — a silent success would
+        // resurrect the token after a restart.
+        let dir = tempfile::tempdir().unwrap();
+        // The store file is a DIRECTORY: every write fails.
+        let broken = dir.path().join(RIDER_TOKENS_FILE);
+        std::fs::create_dir(&broken).unwrap();
+        let mut store = RiderTokenStore::load(dir.path().join("alt.json")).await;
+        // Issue through a working path, then swap in the broken one.
+        let (token, record) = store
+            .issue(
+                "aa".repeat(32),
+                vec![],
+                None,
+                60,
+                "d4".repeat(32),
+                None,
+                1_000,
+            )
+            .await
+            .unwrap();
+        store.path = broken;
+        assert!(store.revoke(record.token_id, 1_010).await.is_err());
+        assert!(
+            store.validate(&token, 1_020).is_some(),
+            "in-memory rollback keeps the token live until revocation is durable"
+        );
     }
 
     #[tokio::test]
@@ -521,14 +665,30 @@ mod tests {
         let (token_a, rec_a) = {
             let mut store = RiderTokenStore::load(path.clone()).await;
             let (ta, ra) = store
-                .issue(agent.clone(), vec![], None, 60, 1_000)
+                .issue(
+                    agent.clone(),
+                    vec![],
+                    None,
+                    60,
+                    "d5".repeat(32),
+                    None,
+                    1_000,
+                )
                 .await
                 .unwrap();
             let (_tb, rb) = store
-                .issue(agent.clone(), vec![], None, 60, 1_000)
+                .issue(
+                    agent.clone(),
+                    vec![],
+                    None,
+                    60,
+                    "d5".repeat(32),
+                    None,
+                    1_000,
+                )
                 .await
                 .unwrap();
-            store.revoke(rb.token_id, 1_001).await;
+            store.revoke(rb.token_id, 1_001).await.unwrap();
             (ta, ra)
         };
         // Simulated restart: reload from disk.
@@ -537,7 +697,7 @@ mod tests {
             store.validate(&token_a, 1_020).is_some(),
             "survives restart"
         );
-        assert_eq!(store.revoke_for_agent(&agent, 1_030).await, 1);
+        assert_eq!(store.revoke_for_agent(&agent, 1_030).await.unwrap(), 1);
         assert!(store.validate(&token_a, 1_031).is_none());
         assert_eq!(rec_a.token_id, 1);
     }

--- a/src/server/rider_auth.rs
+++ b/src/server/rider_auth.rs
@@ -1,0 +1,544 @@
+//! ADR-0039 rider authentication: `ActorContext`, the persisted
+//! rider-token store, and the deny-by-default route predicate.
+//!
+//! A **rider** is a harness process that authenticates to the owner's
+//! daemon with a scoped bearer token instead of the durable API token
+//! (gapcheck blockers 21/22/24). Riders are a distinct principal class:
+//!
+//! - The durable API token and browser session tokens resolve to
+//!   [`ActorContext::Owner`] — full control plane, exactly as before.
+//! - A rider token resolves to [`ActorContext::Rider`] with the identity
+//!   of the registered sub-agent it belongs to and its granted scopes.
+//! - Every route NOT in [`rider_route_allowed`] rejects a rider token
+//!   with `403` **before any handler runs** — deny-by-default. In
+//!   particular `/agent/sign`, `/exec/*`, `/owner/*`, `/identity/*`,
+//!   `/shutdown` and every admin surface are permanently
+//!   rider-forbidden, so the daemon can never be turned into an
+//!   unscoped signing or exec oracle through a rider credential.
+//! - An unknown, expired, or revoked bearer is `401` —
+//!   indistinguishable from any other bad token.
+//!
+//! Rider tokens are 32 random bytes (64 hex chars), stored **hashed**
+//! (SHA-256) at rest in `<data_dir>/rider-tokens.json`, and carry an
+//! expiry and revocation time so lifecycle survives a daemon restart
+//! (blocker 24). Revocation takes effect on the next request — the
+//! middleware validates against the live store on every call, no
+//! restart, no cache.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Upper bound on granted named-group ids per rider token.
+pub(super) const RIDER_MAX_GROUPS: usize = 32;
+/// Default rider-token lifetime: 7 days.
+pub(super) const RIDER_DEFAULT_TTL_SECS: u64 = 7 * 24 * 60 * 60;
+/// Maximum rider-token lifetime: 90 days.
+pub(super) const RIDER_MAX_TTL_SECS: u64 = 90 * 24 * 60 * 60;
+/// Maximum rows a rider may pull from `GET /history` per request
+/// (owners keep the store-wide 500 cap).
+pub(super) const RIDER_HISTORY_MAX_LIMIT: usize = 100;
+
+/// File name of the persisted rider-token store, in the daemon data dir.
+pub(super) const RIDER_TOKENS_FILE: &str = "rider-tokens.json";
+
+/// The per-request acting principal, resolved by the auth middleware and
+/// inserted into the request extensions (ADR-0039, gapcheck blocker 22).
+///
+/// Handlers that care (the rider send/read surfaces) extract it with
+/// `Extension<ActorContext>`; every other handler keeps using
+/// `state.agent` unchanged — the deny-by-default predicate in the
+/// middleware, not a handler-side audit, is what keeps riders off the
+/// rest of the control plane.
+#[derive(Debug, Clone)]
+pub(super) enum ActorContext {
+    /// The durable API token or a browser session token — the human
+    /// owner's full control plane. Also the context for exempt paths
+    /// (`/health`, CORS preflights) where no principal authenticated.
+    Owner,
+    /// A scoped rider token: acts as the registered `sub_agent_id`
+    /// through this daemon. `groups` is the explicit named-group grant
+    /// list (Home is additionally always permitted).
+    Rider {
+        /// Hex `AgentId` of the registered sub-agent.
+        sub_agent_id: String,
+        /// Opaque numeric id of the rider token.
+        token_id: u64,
+        /// SHA-256 hex of the rider token (hashed-at-rest identifier).
+        token_hash: String,
+        /// Granted named-group ids (in addition to Home).
+        groups: Vec<String>,
+    },
+}
+
+impl ActorContext {
+    pub(super) fn rider_allows_group(&self, is_home: bool, group_id: &str) -> bool {
+        match self {
+            ActorContext::Owner => true,
+            ActorContext::Rider { groups, .. } => {
+                is_home || groups.iter().any(|g| g.as_str() == group_id)
+            }
+        }
+    }
+}
+
+/// Deny-by-default route predicate: the COMPLETE set of routes a rider
+/// token may reach (ADR-0039 "send to Home + explicitly named groups,
+/// bounded history read"). Everything else — including `/agent/sign`,
+/// `/exec/*`, `/owner/*`, `/identity/*`, `/shutdown`, every diagnostic
+/// and admin surface — returns `403` for riders in the middleware.
+///
+/// The concrete minimal set:
+///
+/// - `POST /groups/:id/send` — send to a `SignedPublic` named group
+///   (per-group scope still checked in the handler; Home is not
+///   `SignedPublic` and uses the secure plane below).
+/// - `POST /groups/:id/secure/encrypt` — the send surface for
+///   `MlsEncrypted` groups, which is what Home is (ADR-0038).
+/// - `GET /history` — bounded read (scope restricted to granted groups
+///   in the handler, limit clamped to [`RIDER_HISTORY_MAX_LIMIT`]).
+pub(super) fn rider_route_allowed(method: &axum::http::Method, path: &str) -> bool {
+    use axum::http::Method;
+    match *method {
+        Method::POST => is_group_send_path(path) || is_secure_encrypt_path(path),
+        Method::GET => path == "/history",
+        _ => false,
+    }
+}
+
+/// `true` for exactly `/groups/<id>/send` (two segments after the
+/// prefix). Static prefixes like `/groups/discover` cannot collide
+/// because the second segment must be the literal `send`.
+fn is_group_send_path(path: &str) -> bool {
+    is_two_segment_action(path, "send")
+}
+
+/// `true` for exactly `/groups/<id>/secure/encrypt`.
+fn is_secure_encrypt_path(path: &str) -> bool {
+    match path.strip_prefix("/groups/") {
+        Some(rest) => {
+            let mut segs = rest.split('/');
+            segs.next().is_some_and(|id| !id.is_empty())
+                && segs.next() == Some("secure")
+                && segs.next() == Some("encrypt")
+                && segs.next().is_none()
+        }
+        None => false,
+    }
+}
+
+/// `true` when `path` is `/groups/<nonempty-id>/<action>` for exactly
+/// the given single-segment action.
+fn is_two_segment_action(path: &str, action: &str) -> bool {
+    match path.strip_prefix("/groups/") {
+        Some(rest) => {
+            let mut segs = rest.split('/');
+            segs.next().is_some_and(|id| !id.is_empty())
+                && segs.next() == Some(action)
+                && segs.next().is_none()
+        }
+        None => false,
+    }
+}
+
+/// One persisted rider token. The token SECRET is never stored — only
+/// its SHA-256 hex digest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct RiderTokenRecord {
+    /// Opaque numeric id (monotonic per install).
+    pub token_id: u64,
+    /// SHA-256 hex of the 64-hex-char token secret.
+    pub token_hash: String,
+    /// Hex `AgentId` of the registered sub-agent this token acts as.
+    pub sub_agent_id: String,
+    /// Granted named-group ids (in addition to Home).
+    pub groups: Vec<String>,
+    /// Operator label.
+    pub label: Option<String>,
+    /// Unix seconds when the token was issued.
+    pub issued_at: u64,
+    /// Unix seconds after which the token is invalid.
+    pub expires_at: u64,
+    /// Unix seconds when the token was revoked, if it was.
+    #[serde(default)]
+    pub revoked_at: Option<u64>,
+}
+
+/// A validated rider credential — the data the middleware puts into
+/// [`ActorContext::Rider`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ValidatedRider {
+    pub token_id: u64,
+    pub sub_agent_id: String,
+    pub token_hash: String,
+    pub groups: Vec<String>,
+}
+
+/// SHA-256 hex of a token secret.
+fn token_hash_hex(token: &str) -> String {
+    use sha2::Digest;
+    let digest = sha2::Sha256::digest(token.as_bytes());
+    hex::encode(digest)
+}
+
+/// Persists as the plain JSON map `{"next_id": u64, "tokens": {id: rec}}`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct RiderTokenFile {
+    next_id: u64,
+    tokens: BTreeMap<String, RiderTokenRecord>,
+}
+
+/// The rider-token store: in-memory map guarded by a tokio mutex, with
+/// every mutation persisted atomically to `<data_dir>/rider-tokens.json`.
+pub(super) struct RiderTokenStore {
+    path: PathBuf,
+    next_id: u64,
+    records: BTreeMap<u64, RiderTokenRecord>,
+}
+
+impl RiderTokenStore {
+    /// Load the store from `path` (a missing file is an empty store; a
+    /// corrupt file is logged and treated as empty — rider tokens fail
+    /// closed, they can never grant more than was persisted).
+    pub(super) async fn load(path: PathBuf) -> Self {
+        let parsed = match tokio::fs::read(&path).await {
+            Ok(bytes) => serde_json::from_slice::<RiderTokenFile>(&bytes)
+                .map_err(|e| {
+                    tracing::warn!(
+                        "failed to parse {}: {e} — rider tokens start empty (fail closed)",
+                        path.display()
+                    );
+                    e
+                })
+                .ok(),
+            Err(_) => None,
+        };
+        match parsed {
+            Some(file) => {
+                let records = file
+                    .tokens
+                    .into_iter()
+                    .filter_map(|(k, v)| k.parse::<u64>().ok().map(|id| (id, v)))
+                    .collect();
+                Self {
+                    path,
+                    next_id: file.next_id.max(1),
+                    records,
+                }
+            }
+            None => Self {
+                path,
+                next_id: 1,
+                records: BTreeMap::new(),
+            },
+        }
+    }
+
+    /// Persist the current state atomically. Failures are returned to
+    /// the caller: an unpersisted token must not be reported as issued.
+    async fn persist(&self) -> std::io::Result<()> {
+        let file = RiderTokenFile {
+            next_id: self.next_id,
+            tokens: self
+                .records
+                .iter()
+                .map(|(id, rec)| (id.to_string(), rec.clone()))
+                .collect(),
+        };
+        let bytes = serde_json::to_vec_pretty(&file)
+            .map_err(|e| std::io::Error::other(format!("serialize rider tokens: {e}")))?;
+        crate::profile::write_atomically(&self.path, &bytes).await
+    }
+
+    /// Issue a new rider token. Returns the one-time secret (shown to
+    /// the caller exactly once) alongside its record.
+    pub(super) async fn issue(
+        &mut self,
+        sub_agent_id: String,
+        groups: Vec<String>,
+        label: Option<String>,
+        ttl_secs: u64,
+        now_unix: u64,
+    ) -> std::io::Result<(String, RiderTokenRecord)> {
+        use rand::RngCore;
+        let mut secret = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut secret);
+        let token = hex::encode(secret);
+        let token_id = self.next_id;
+        self.next_id = self.next_id.saturating_add(1);
+        let record = RiderTokenRecord {
+            token_id,
+            token_hash: token_hash_hex(&token),
+            sub_agent_id,
+            groups,
+            label,
+            issued_at: now_unix,
+            expires_at: now_unix.saturating_add(ttl_secs.max(1)),
+            revoked_at: None,
+        };
+        self.records.insert(token_id, record.clone());
+        if let Err(e) = self.persist().await {
+            // Roll back the in-memory insert: the token was never
+            // durably issued and must not validate.
+            self.records.remove(&token_id);
+            return Err(e);
+        }
+        Ok((token, record))
+    }
+
+    /// Validate a presented bearer token. `None` for unknown, expired,
+    /// or revoked tokens — the middleware maps that to `401`.
+    pub(super) fn validate(&self, token: &str, now_unix: u64) -> Option<ValidatedRider> {
+        let hash = token_hash_hex(token);
+        let record = self.records.values().find(|r| r.token_hash == hash)?;
+        if now_unix >= record.expires_at {
+            return None;
+        }
+        if record.revoked_at.is_some() {
+            return None;
+        }
+        Some(ValidatedRider {
+            token_id: record.token_id,
+            sub_agent_id: record.sub_agent_id.clone(),
+            token_hash: record.token_hash.clone(),
+            groups: record.groups.clone(),
+        })
+    }
+
+    /// Revoke one token by id. Returns `false` when the id is unknown.
+    pub(super) async fn revoke(&mut self, token_id: u64, now_unix: u64) -> bool {
+        match self.records.get_mut(&token_id) {
+            Some(record) => {
+                if record.revoked_at.is_none() {
+                    record.revoked_at = Some(now_unix);
+                    if let Err(e) = self.persist().await {
+                        tracing::warn!(
+                            "failed to persist rider-token revocation: {e} — in-memory revocation stands"
+                        );
+                    }
+                }
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Revoke every token bound to `sub_agent_id` (used when the
+    /// sub-agent itself is revoked via `DELETE /owner/agents/:id`).
+    /// Returns the number of tokens revoked.
+    pub(super) async fn revoke_for_agent(&mut self, sub_agent_id: &str, now_unix: u64) -> usize {
+        let mut revoked = 0;
+        for record in self.records.values_mut() {
+            if record.sub_agent_id == sub_agent_id && record.revoked_at.is_none() {
+                record.revoked_at = Some(now_unix);
+                revoked += 1;
+            }
+        }
+        if revoked > 0 {
+            if let Err(e) = self.persist().await {
+                tracing::warn!(
+                    "failed to persist rider-token revocations: {e} — in-memory revocations stand"
+                );
+            }
+        }
+        revoked
+    }
+
+    /// All records, ordered by id (for `GET /owner/riders`). No secrets.
+    pub(super) fn list(&self) -> Vec<RiderTokenRecord> {
+        self.records.values().cloned().collect()
+    }
+}
+
+/// Current wall-clock unix seconds (best effort; never panics).
+pub(super) fn unix_now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use axum::http::Method;
+
+    // ── Route predicate: the deny-by-default scope matrix ──────────────
+
+    #[test]
+    fn rider_routes_allow_exactly_send_secure_encrypt_and_history() {
+        // WHY: ADR-0039 validation — the allowlist must be minimal and
+        // exact; a fuzzy match here would silently widen rider reach.
+        assert!(rider_route_allowed(&Method::POST, "/groups/abc123/send"));
+        assert!(rider_route_allowed(
+            &Method::POST,
+            "/groups/abc123/secure/encrypt"
+        ));
+        assert!(rider_route_allowed(&Method::GET, "/history"));
+    }
+
+    #[test]
+    fn rider_routes_reject_signing_exec_owner_and_admin_surfaces() {
+        // WHY: gapcheck blocker 21 — a rider credential must never turn
+        // the daemon into a signing/exec oracle or reach owner/admin
+        // surfaces. These are the exact abuse paths named there.
+        let forbidden = [
+            ("/agent/sign", Method::POST),
+            ("/agent/verify", Method::POST),
+            ("/identity/revoke", Method::POST),
+            ("/exec/run", Method::POST),
+            ("/exec/cancel", Method::POST),
+            ("/owner/agents", Method::GET),
+            ("/owner/agents/issue", Method::POST),
+            ("/owner/agents/abc", Method::DELETE),
+            ("/owner/riders", Method::POST),
+            ("/shutdown", Method::POST),
+            ("/publish", Method::POST),
+            ("/direct/send", Method::POST),
+            ("/groups", Method::POST),
+            ("/groups/abc", Method::GET),
+            ("/groups/abc/members", Method::POST),
+            ("/groups/abc/secure/decrypt", Method::POST),
+            ("/history/search", Method::GET),
+            ("/history/stats", Method::GET),
+            ("/history", Method::DELETE),
+            ("/files/send", Method::POST),
+            ("/forwards", Method::POST),
+        ];
+        for (path, method) in forbidden {
+            assert!(
+                !rider_route_allowed(&method, path),
+                "{method} {path} must be rider-forbidden"
+            );
+        }
+    }
+
+    #[test]
+    fn rider_route_predicate_rejects_lookalike_paths() {
+        // WHY: path confusion (`/groups/discover/send`, empty ids,
+        // deeper nesting) must not slip through a prefix/ends-with match.
+        for path in [
+            "/groups//send",
+            "/groups/send",
+            "/groups/a/b/send",
+            "/groups/discover",
+            "/groups/abc/secure/encrypt/extra",
+            "/groups/abc/secure",
+            "/vgroups/abc/send",
+            "/history/",
+        ] {
+            assert!(
+                !rider_route_allowed(&Method::POST, path) || path == "/groups/a/b/send", // POST-only lookalike set
+                "lookalike {path} must not be allowed for POST"
+            );
+        }
+        assert!(!rider_route_allowed(&Method::GET, "/history/"));
+        assert!(!rider_route_allowed(&Method::PUT, "/history"));
+    }
+
+    #[test]
+    fn rider_group_scope_home_or_granted_only() {
+        // WHY: ADR-0039 — Home is the always-granted base scope; every
+        // other group needs an explicit grant; owners are unrestricted.
+        let owner = ActorContext::Owner;
+        let rider = ActorContext::Rider {
+            sub_agent_id: "aa".repeat(32),
+            token_id: 1,
+            token_hash: "deadbeef".to_string(),
+            groups: vec!["group-b".to_string()],
+        };
+        assert!(owner.rider_allows_group(false, "anything"));
+        assert!(
+            rider.rider_allows_group(true, "group-a"),
+            "Home always allowed"
+        );
+        assert!(rider.rider_allows_group(false, "group-b"), "granted group");
+        assert!(
+            !rider.rider_allows_group(false, "group-a"),
+            "ungranted group must be denied"
+        );
+    }
+
+    // ── Token store lifecycle ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn rider_token_issue_validate_revoke_round_trip() {
+        // WHY: blocker 24 lifecycle — a token validates until revoked,
+        // then the SAME secret stops validating immediately (no restart).
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = RiderTokenStore::load(dir.path().join(RIDER_TOKENS_FILE)).await;
+        let (token, record) = store
+            .issue(
+                "ab".repeat(32),
+                vec!["g1".to_string()],
+                Some("ci-agent".into()),
+                60,
+                1_000,
+            )
+            .await
+            .unwrap();
+        assert_eq!(record.expires_at, 1_060);
+        let ok = store.validate(&token, 1_050).unwrap();
+        assert_eq!(ok.sub_agent_id, "ab".repeat(32));
+        assert_eq!(ok.groups, vec!["g1".to_string()]);
+
+        assert!(store.revoke(record.token_id, 1_055).await);
+        assert!(
+            store.validate(&token, 1_056).is_none(),
+            "revoked token must fail closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn rider_token_expiry_and_bad_secret_fail_closed() {
+        // WHY: expiry must be enforced by the store (not just filtered
+        // elsewhere) and an unknown secret must never validate.
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = RiderTokenStore::load(dir.path().join(RIDER_TOKENS_FILE)).await;
+        let (token, _) = store
+            .issue("cd".repeat(32), vec![], None, 10, 1_000)
+            .await
+            .unwrap();
+        assert!(store.validate(&token, 1_009).is_some());
+        assert!(
+            store.validate(&token, 1_010).is_none(),
+            "expired token must fail closed"
+        );
+        assert!(store.validate(&"0".repeat(64), 1_000).is_none());
+    }
+
+    #[tokio::test]
+    async fn rider_tokens_survive_restart_and_agent_revocation_sweeps() {
+        // WHY: blocker 24 — lifecycle state (issued, revoked) must be
+        // durable across restarts, and revoking the SUB-AGENT must
+        // revoke all of its tokens in one sweep.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(RIDER_TOKENS_FILE);
+        let agent = "ef".repeat(32);
+        let (token_a, rec_a) = {
+            let mut store = RiderTokenStore::load(path.clone()).await;
+            let (ta, ra) = store
+                .issue(agent.clone(), vec![], None, 60, 1_000)
+                .await
+                .unwrap();
+            let (_tb, rb) = store
+                .issue(agent.clone(), vec![], None, 60, 1_000)
+                .await
+                .unwrap();
+            store.revoke(rb.token_id, 1_001).await;
+            (ta, ra)
+        };
+        // Simulated restart: reload from disk.
+        let mut store = RiderTokenStore::load(path).await;
+        assert!(
+            store.validate(&token_a, 1_020).is_some(),
+            "survives restart"
+        );
+        assert_eq!(store.revoke_for_agent(&agent, 1_030).await, 1);
+        assert!(store.validate(&token_a, 1_031).is_none());
+        assert_eq!(rec_a.token_id, 1);
+    }
+}

--- a/src/server/rider_auth.rs
+++ b/src/server/rider_auth.rs
@@ -78,12 +78,14 @@ pub(super) enum ActorContext {
 }
 
 impl ActorContext {
-    pub(super) fn rider_allows_group(&self, is_home: bool, group_id: &str) -> bool {
+    /// Whether this actor may operate on `group_id`. Owners are
+    /// unrestricted; a rider may only reach groups explicitly granted
+    /// to its token (review r4: the implicit Home grant is GONE — Home
+    /// is delegated like any other group, or not reachable at all).
+    pub(super) fn rider_allows_group(&self, group_id: &str) -> bool {
         match self {
             ActorContext::Owner { .. } => true,
-            ActorContext::Rider { groups, .. } => {
-                is_home || groups.iter().any(|g| g.as_str() == group_id)
-            }
+            ActorContext::Rider { groups, .. } => groups.iter().any(|g| g.as_str() == group_id),
         }
     }
 
@@ -534,9 +536,11 @@ mod tests {
     }
 
     #[test]
-    fn rider_group_scope_home_or_granted_only() {
-        // WHY: ADR-0039 — Home is the always-granted base scope; every
-        // other group needs an explicit grant; owners are unrestricted.
+    fn rider_group_scope_explicit_grants_only() {
+        // WHY (review r4): there is NO implicit Home grant — a rider
+        // reaches exactly the groups on its explicit grant list (which
+        // mirror the sub-agent-signed delegation scopes); owners are
+        // unrestricted.
         let owner = ActorContext::Owner { durable: true };
         let rider = ActorContext::Rider {
             sub_agent_id: "aa".repeat(32),
@@ -544,15 +548,11 @@ mod tests {
             token_hash: "deadbeef".to_string(),
             groups: vec!["group-b".to_string()],
         };
-        assert!(owner.rider_allows_group(false, "anything"));
+        assert!(owner.rider_allows_group("anything"));
+        assert!(rider.rider_allows_group("group-b"), "granted group");
         assert!(
-            rider.rider_allows_group(true, "group-a"),
-            "Home always allowed"
-        );
-        assert!(rider.rider_allows_group(false, "group-b"), "granted group");
-        assert!(
-            !rider.rider_allows_group(false, "group-a"),
-            "ungranted group must be denied"
+            !rider.rider_allows_group("group-a"),
+            "ungranted group must be denied — including Home unless delegated"
         );
     }
 

--- a/src/server/routes/history.rs
+++ b/src/server/routes/history.rs
@@ -109,6 +109,9 @@ fn group_history_message(
 /// paginated via `before_id`).
 pub(in crate::server) async fn history_list(
     State(state): State<Arc<AppState>>,
+    axum::extract::Extension(actor): axum::extract::Extension<
+        crate::server::rider_auth::ActorContext,
+    >,
     Query(params): Query<HistoryListParams>,
 ) -> impl IntoResponse {
     let Some(history) = state.agent.history() else {
@@ -118,6 +121,33 @@ pub(in crate::server) async fn history_list(
         Ok(s) => s,
         Err(e) => return api_error(StatusCode::BAD_REQUEST, e),
     };
+    // ADR-0039 bounded rider read: a rider may list only `group:` scopes
+    // it is granted (Home always), and never more than
+    // RIDER_HISTORY_MAX_LIMIT rows per request. The route itself is the
+    // only history surface the deny-by-default predicate lets riders
+    // reach — search/stats/message lookups stay owner-only.
+    let mut params = params;
+    if let crate::server::rider_auth::ActorContext::Rider { groups, .. } = &actor {
+        let allowed = match &scope {
+            x0x::history::Scope::Group(gid) => {
+                let home_id = home_stable_group_id(&state).await;
+                home_id.as_deref() == Some(gid.as_str()) || groups.contains(gid)
+            }
+            _ => false,
+        };
+        if !allowed {
+            return api_error(
+                StatusCode::FORBIDDEN,
+                "rider tokens may only read history scopes they are granted (ADR-0039)",
+            );
+        }
+        params.limit = Some(
+            params
+                .limit
+                .unwrap_or(crate::server::rider_auth::RIDER_HISTORY_MAX_LIMIT)
+                .min(crate::server::rider_auth::RIDER_HISTORY_MAX_LIMIT),
+        );
+    }
     let store = Arc::clone(history.store());
     let q = query_from(&params, scope);
     match tokio::task::spawn_blocking(move || store.query(&q)).await {
@@ -359,6 +389,16 @@ pub(in crate::server) async fn history_diagnostics(
     )
 }
 
+/// The stable group id of this install's Home group, when provisioned
+/// (ADR-0038). Home is the always-granted rider history scope.
+async fn home_stable_group_id(state: &Arc<AppState>) -> Option<String> {
+    let groups = state.named_groups.read().await;
+    groups
+        .values()
+        .find(|info| info.home.is_some())
+        .map(|info| info.stable_group_id().to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -380,6 +420,7 @@ mod tests {
             timestamp: 42,
             thread_root: Some(root.clone()),
             thread_parent: Some(root.clone()),
+            rider_provenance: None,
             signature: "signature-1".to_string(),
         };
         let artifact = serde_json::to_vec(&message).expect("serialize message");

--- a/src/server/routes/history.rs
+++ b/src/server/routes/history.rs
@@ -122,17 +122,15 @@ pub(in crate::server) async fn history_list(
         Err(e) => return api_error(StatusCode::BAD_REQUEST, e),
     };
     // ADR-0039 bounded rider read: a rider may list only `group:` scopes
-    // it is granted (Home always), and never more than
+    // EXPLICITLY granted to its token (review r4: no implicit Home —
+    // Home is delegated like any other group), and never more than
     // RIDER_HISTORY_MAX_LIMIT rows per request. The route itself is the
     // only history surface the deny-by-default predicate lets riders
     // reach — search/stats/message lookups stay owner-only.
     let mut params = params;
     if let crate::server::rider_auth::ActorContext::Rider { groups, .. } = &actor {
         let allowed = match &scope {
-            x0x::history::Scope::Group(gid) => {
-                let home_id = home_stable_group_id(&state).await;
-                home_id.as_deref() == Some(gid.as_str()) || groups.contains(gid)
-            }
+            x0x::history::Scope::Group(gid) => groups.contains(gid),
             _ => false,
         };
         if !allowed {
@@ -388,17 +386,6 @@ pub(in crate::server) async fn history_diagnostics(
         })),
     )
 }
-
-/// The stable group id of this install's Home group, when provisioned
-/// (ADR-0038). Home is the always-granted rider history scope.
-async fn home_stable_group_id(state: &Arc<AppState>) -> Option<String> {
-    let groups = state.named_groups.read().await;
-    groups
-        .values()
-        .find(|info| info.home.is_some())
-        .map(|info| info.stable_group_id().to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -19,6 +19,7 @@ mod machines;
 mod messaging;
 pub(crate) mod named_groups;
 mod network;
+mod owner;
 mod presence;
 mod profile;
 pub(crate) mod public_group_bootstrap_outbox;
@@ -103,6 +104,10 @@ pub(super) use network::{
     ack_diagnostics, bootstrap_cache_stats, connectivity_diagnostics, dm_diagnostics,
     gossip_diagnostics, groups_diagnostics, network_status, peer_health_handler, peers,
     probe_peer_handler, relay_diagnostics, transport_diagnostics,
+};
+pub(super) use owner::{
+    owner_agents_issue, owner_agents_revoke, owner_riders_issue, owner_riders_list,
+    owner_riders_revoke,
 };
 pub(super) use presence::{
     presence, presence_find, presence_foaf, presence_online, presence_status,

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -17,6 +17,7 @@ use super::files::{
 };
 use super::groups::save_mls_groups;
 use super::identity::populate_invite_base_state_from_group_info;
+use super::owner::verify_rider_admission_cert;
 use super::public_group_bootstrap_outbox::{
     cancel_public_group_bootstrap_obligations_for_removal,
     persist_named_group_info_with_bootstrap_obligation, public_group_bootstrap_obligation_for_add,
@@ -9335,12 +9336,25 @@ pub(in crate::server) async fn send_group_public_message(
         if info.policy.confidentiality != x0x::groups::GroupConfidentiality::SignedPublic {
             return bad_request("group is not SignedPublic — use /groups/:id/secure/encrypt");
         }
-        if info.is_banned(&local_hex) {
+        // Review fix #1 (CRITICAL): authorization uses the ACTING
+        // PRINCIPAL's identity. For the owner that is the daemon's own
+        // agent; for a rider it is the SUB-AGENT on whose behalf the
+        // daemon signs — ban state, membership, and role are checked
+        // against the sub-agent, so a rider can never inherit the
+        // daemon-admin's privileges and the provenance envelope is the
+        // authorization subject, not decoration.
+        let acting_hex = match &actor {
+            crate::server::rider_auth::ActorContext::Owner { .. } => local_hex.clone(),
+            crate::server::rider_auth::ActorContext::Rider { sub_agent_id, .. } => {
+                sub_agent_id.clone()
+            }
+        };
+        if info.is_banned(&acting_hex) {
             return forbidden("you are banned");
         }
         // Endpoint-side write-access enforcement. Mirror the ingest
         // validator so we reject locally rather than trust receivers.
-        let caller_role = info.caller_role(&local_hex);
+        let caller_role = info.caller_role(&acting_hex);
         match info.policy.write_access {
             x0x::groups::GroupWriteAccess::MembersOnly => {
                 if caller_role.is_none() {
@@ -9349,7 +9363,7 @@ pub(in crate::server) async fn send_group_public_message(
                         .record_sender_write_policy_rejection(info.stable_group_id());
                     tracing::warn!(
                         group_id = %info.stable_group_id(),
-                        author = %local_hex,
+                        author = %acting_hex,
                         "rejected public group send: members-only write policy"
                     );
                     return forbidden("members-only write policy");
@@ -9371,20 +9385,18 @@ pub(in crate::server) async fn send_group_public_message(
             .map(|member| member.agent_id.clone())
             .collect::<Vec<_>>();
 
-        // ADR-0039 rider scope check: the daemon's own membership carries
-        // the send; a rider may only reach Home (not applicable on this
-        // SignedPublic-only surface) or an explicitly granted group.
+        // ADR-0039 rider scope check: even with membership satisfied,
+        // the send must be inside the token's explicit grant (Home is
+        // not applicable on this SignedPublic-only surface).
         let rider_provenance = match &actor {
-            crate::server::rider_auth::ActorContext::Owner => None,
+            crate::server::rider_auth::ActorContext::Owner { .. } => None,
             crate::server::rider_auth::ActorContext::Rider {
                 sub_agent_id,
                 token_id,
                 token_hash,
                 groups,
             } => {
-                let is_home = info.home.is_some();
-                let granted =
-                    is_home || groups.iter().any(|g| g.as_str() == info.stable_group_id());
+                let granted = groups.iter().any(|g| g.as_str() == info.stable_group_id());
                 if !granted {
                     return forbidden(
                         "rider token is not granted this group (ADR-0039 deny-by-default)",
@@ -16594,26 +16606,56 @@ pub(in crate::server) async fn secure_group_encrypt(
     if !info.has_active_member(&caller_hex) {
         return forbidden("not a member");
     }
-    // ADR-0039: the DAEMON is the acting member; a rider reaches Home
-    // (and any granted MlsEncrypted group) through that membership, with
-    // the sub-agent attribution recorded in the local history row.
-    let rider_sub_agent_id = match &actor {
-        crate::server::rider_auth::ActorContext::Owner => None,
-        crate::server::rider_auth::ActorContext::Rider { .. } => {
-            let is_home = info.home.is_some();
-            if !actor.rider_allows_group(is_home, info.stable_group_id()) {
-                return forbidden(
-                    "rider token is not granted this group (ADR-0039 deny-by-default)",
-                );
-            }
-            match &actor {
-                crate::server::rider_auth::ActorContext::Rider { sub_agent_id, .. } => {
-                    Some(sub_agent_id.clone())
-                }
-                _ => None,
-            }
+    // ADR-0039 + review fix #1: the DAEMON carries the cryptography (it
+    // holds the group keys), but a rider's AUTHORIZATION is the
+    // SUB-AGENT's: ban, write policy, and — for OwnerCertified groups
+    // like Home, where admission is owner certification itself — the
+    // retained certificate must chain to the group's owner, be
+    // unexpired, and be unrevoked. Otherwise the rider send is 403.
+    let mut rider_sub_agent_id: Option<String> = None;
+    let mut cert_gate_owner: Option<crate::identity::UserId> = None;
+    if let crate::server::rider_auth::ActorContext::Rider { sub_agent_id, .. } = &actor {
+        let is_home = info.home.is_some();
+        if !actor.rider_allows_group(is_home, info.stable_group_id()) {
+            return forbidden("rider token is not granted this group (ADR-0039 deny-by-default)");
         }
-    };
+        if info.is_banned(sub_agent_id) {
+            return forbidden("sub-agent is banned from this group");
+        }
+        let sub_role = info.caller_role(sub_agent_id);
+        match info.policy.write_access {
+            x0x::groups::GroupWriteAccess::MembersOnly
+            | x0x::groups::GroupWriteAccess::AdminOnly => {
+                let ok = match info.policy.write_access {
+                    x0x::groups::GroupWriteAccess::AdminOnly => sub_role
+                        .map(|r| r.at_least(x0x::groups::GroupRole::Admin))
+                        .unwrap_or(false),
+                    _ => sub_role.is_some(),
+                };
+                if !ok {
+                    // MembersOnly/AdminOnly with no roster role: still
+                    // admissible when the group's admission rule is
+                    // OwnerCertified AND the sub-agent presents a live
+                    // owner-chained certificate (ADR-0038: admission IS
+                    // the owner's certificate).
+                    cert_gate_owner = info.policy.admission.owner_certified_user_id().cloned();
+                    if cert_gate_owner.is_none() {
+                        return forbidden("sub-agent is not a member of this group (ADR-0039)");
+                    }
+                }
+            }
+            x0x::groups::GroupWriteAccess::ModeratedPublic => { /* any non-banned */ }
+        }
+        rider_sub_agent_id = Some(sub_agent_id.clone());
+    }
+    if let (Some(owner), Some(sub_hex)) = (cert_gate_owner, rider_sub_agent_id.as_deref()) {
+        // The named-groups read guard is held across this await: the
+        // verification touches only the journal and revocation set, so
+        // there is no lock recursion — just bounded contention.
+        if let Err(reason) = verify_rider_admission_cert(&state, &owner, sub_hex).await {
+            return forbidden(reason);
+        }
+    }
     if info.policy.confidentiality != x0x::groups::GroupConfidentiality::MlsEncrypted {
         return bad_request("group is not MlsEncrypted — use public send instead");
     }
@@ -21676,6 +21718,7 @@ pub(in crate::server) mod tests {
                 )
                 .await,
             ),
+            cert_journal_lock: tokio::sync::Mutex::new(()),
             exec_service,
             groups_diagnostics: Arc::new(x0x::groups::GroupsDiagnostics::new()),
             connect_diagnostics: Arc::new(x0x::connect::ConnectDiagnostics::new(
@@ -22741,7 +22784,7 @@ pub(in crate::server) mod tests {
         let (status, body) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.to_string()),
-            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner { durable: true }),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(b"secret"),
             }),
@@ -22767,7 +22810,7 @@ pub(in crate::server) mod tests {
         let (encrypt_status, encrypted) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.to_string()),
-            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner { durable: true }),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(b"secret"),
             }),
@@ -24598,7 +24641,7 @@ pub(in crate::server) mod tests {
         let (enc_status, enc_body) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.clone()),
-            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner { durable: true }),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(plaintext),
             }),
@@ -25540,7 +25583,7 @@ pub(in crate::server) mod tests {
         let (status, body) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.to_string()),
-            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner { durable: true }),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(b"secret"),
             }),
@@ -25560,7 +25603,7 @@ pub(in crate::server) mod tests {
         let (encrypt_status, encrypted) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.to_string()),
-            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner { durable: true }),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(b"secret"),
             }),
@@ -25687,7 +25730,7 @@ pub(in crate::server) mod tests {
         let (status, body) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.to_string()),
-            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner { durable: true }),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(b"secret"),
             }),
@@ -27699,7 +27742,7 @@ pub(in crate::server) mod tests {
         let response = send_group_public_message(
             State(state),
             Path(group_id.to_string()),
-            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner { durable: true }),
             Json(req),
         )
         .await

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -17,7 +17,6 @@ use super::files::{
 };
 use super::groups::save_mls_groups;
 use super::identity::populate_invite_base_state_from_group_info;
-use super::owner::verify_rider_admission_cert;
 use super::public_group_bootstrap_outbox::{
     cancel_public_group_bootstrap_obligations_for_removal,
     persist_named_group_info_with_bootstrap_obligation, public_group_bootstrap_obligation_for_add,
@@ -9786,9 +9785,22 @@ fn record_group_public_history(state: &AppState, msg: &x0x::groups::GroupPublicM
     });
 }
 
+/// Signed rider attribution for an MLS-plane send (review r4): the
+/// daemon's signature over [`x0x::groups::rider_mls_attribution_bytes`]
+/// — binding the rider provenance, its sub-agent-signed delegation, and
+/// the concrete (group, epoch) — so durable Home attribution is
+/// cryptographic, not a local string.
+pub(in crate::server) struct MlsRiderAttribution {
+    pub(in crate::server) sub_agent_id: String,
+    pub(in crate::server) artifact: Vec<u8>,
+    pub(in crate::server) signature: Vec<u8>,
+}
+
 /// Record MLS-group plaintext obtained via a local secure-surface call
-/// (ADR-0023 §3/§4): unsigned, `provenance = LocalAppDecrypt`, author
-/// unattributed — no per-message author signature exists on this plane.
+/// (ADR-0023 §3/§4): `provenance = LocalAppDecrypt`, author
+/// unattributed for owner sends. Rider sends carry the signed
+/// [`MlsRiderAttribution`] (author = the certified sub-agent, signed
+/// artifact + signature + context stored for offline re-verification).
 /// `msg_id` is the v2 group+epoch helper so identical plaintext in two
 /// groups whose epochs coincide does not collide (#276).
 fn record_mls_history(
@@ -9797,7 +9809,7 @@ fn record_mls_history(
     plaintext: &[u8],
     direction: x0x::history::Direction,
     epoch: u64,
-    author_agent: Option<&str>,
+    attribution: Option<&MlsRiderAttribution>,
 ) {
     let Some(history) = state.agent.history() else {
         return;
@@ -9811,18 +9823,31 @@ fn record_mls_history(
         "application/octet-stream"
     };
     let now = i64::try_from(x0x::dm::now_unix_ms()).unwrap_or(i64::MAX);
-    // Group+epoch-salted id: ciphertext replays within one group+epoch
-    // dedupe; identical plaintext across groups or epochs survives.
-    // Identical plaintext *within* one group+epoch still collapses —
-    // per-message MLS identity is a future wire-format change (ADR-0023 §3).
+    // With a signed rider attribution the row is NON-opaque (see
+    // `HistoryRecord::validate`) and the msg_id is the canonical
+    // BLAKE3(artifact || payload); without one it stays the
+    // epoch-salted id (dedupes identical plaintext per group+epoch).
+    let (author_agent, signed_artifact, signature, sig_context, msg_id) = match attribution {
+        None => (None, None, None, None, None),
+        Some(att) => {
+            let msg_id =
+                x0x::history::HistoryRecord::compute_msg_id(Some(&att.artifact), plaintext);
+            (
+                Some(att.sub_agent_id.clone()),
+                Some(att.artifact.clone()),
+                Some(att.signature.clone()),
+                Some("x0x.rider.mls-attribution.v1".to_string()),
+                Some(msg_id),
+            )
+        }
+    };
+    let msg_id = msg_id.unwrap_or_else(|| {
+        x0x::history::HistoryRecord::compute_epoch_msg_id(stable_group_id, epoch, plaintext)
+    });
     history.record(x0x::history::HistoryRecord {
-        msg_id: x0x::history::HistoryRecord::compute_epoch_msg_id(
-            stable_group_id,
-            epoch,
-            plaintext,
-        ),
+        msg_id,
         scope: x0x::history::Scope::Group(stable_group_id.to_string()),
-        author_agent: author_agent.map(str::to_string),
+        author_agent,
         author_machine: None,
         author_pubkey: None,
         sent_at_ms: now,
@@ -9830,9 +9855,9 @@ fn record_mls_history(
         direction,
         content_type: content_type.to_string(),
         payload: plaintext.to_vec(),
-        signed_artifact: None,
-        signature: None,
-        sig_context: None,
+        signed_artifact,
+        signature,
+        sig_context,
         provenance: x0x::history::Provenance::LocalAppDecrypt,
         replace_key: None,
         thread_root: None,
@@ -9841,8 +9866,6 @@ fn record_mls_history(
         logical_request_id: None,
     });
 }
-
-/// Append a validated message to the per-group ring buffer (capped).
 async fn cache_public_message(state: &AppState, msg: x0x::groups::GroupPublicMessage) {
     record_group_public_history(state, &msg);
     let mut all = state.public_messages.write().await;
@@ -16449,7 +16472,7 @@ async fn treekem_group_encrypt(
     group_id_hex: &str,
     stable_group_id: Option<&str>,
     payload_b64: &str,
-    author_agent: Option<&str>,
+    attribution: Option<&MlsRiderAttribution>,
 ) -> (StatusCode, Json<serde_json::Value>) {
     use base64::Engine as _;
     let plaintext = match BASE64.decode(payload_b64) {
@@ -16512,7 +16535,7 @@ async fn treekem_group_encrypt(
         &plaintext,
         x0x::history::Direction::Outbound,
         epoch,
-        author_agent,
+        attribution,
     );
     secure_group_effect_response_after_terminality_recheck(
         state,
@@ -16633,54 +16656,94 @@ pub(in crate::server) async fn secure_group_encrypt(
     if !info.has_active_member(&caller_hex) {
         return forbidden("not a member");
     }
-    // ADR-0039 + review fix #1: the DAEMON carries the cryptography (it
-    // holds the group keys), but a rider's AUTHORIZATION is the
-    // SUB-AGENT's: ban, write policy, and — for OwnerCertified groups
-    // like Home, where admission is owner certification itself — the
-    // retained certificate must chain to the group's owner, be
-    // unexpired, and be unrevoked. Otherwise the rider send is 403.
-    let mut rider_sub_agent_id: Option<String> = None;
-    let mut cert_gate_owner: Option<crate::identity::UserId> = None;
-    if let crate::server::rider_auth::ActorContext::Rider { sub_agent_id, .. } = &actor {
-        let is_home = info.home.is_some();
-        if !actor.rider_allows_group(is_home, info.stable_group_id()) {
-            return forbidden("rider token is not granted this group (ADR-0039 deny-by-default)");
+    // ADR-0039 + reviews r2–r4: the DAEMON carries the cryptography (it
+    // holds the group keys), but a rider's AUTHORIZATION is exactly the
+    // SUB-AGENT's, mirroring the public-message path: explicit token
+    // grant (NO implicit Home), ban check, the group's write policy
+    // against the SUB-AGENT's roster role, and a valid sub-agent-signed
+    // delegation covering THIS group — verified against the same chain
+    // receivers verify. The provenance then produces the signed MLS
+    // attribution artifact below.
+    let mut rider_attribution: Option<MlsRiderAttribution> = None;
+    if let crate::server::rider_auth::ActorContext::Rider {
+        sub_agent_id,
+        token_id,
+        token_hash,
+        ..
+    } = &actor
+    {
+        if !actor.rider_allows_group(info.stable_group_id()) {
+            return forbidden(
+                "rider token is not granted this group (ADR-0039 deny-by-default; Home must be delegated explicitly)",
+            );
         }
         if info.is_banned(sub_agent_id) {
             return forbidden("sub-agent is banned from this group");
         }
         let sub_role = info.caller_role(sub_agent_id);
-        match info.policy.write_access {
-            x0x::groups::GroupWriteAccess::MembersOnly
-            | x0x::groups::GroupWriteAccess::AdminOnly => {
-                let ok = match info.policy.write_access {
-                    x0x::groups::GroupWriteAccess::AdminOnly => sub_role
-                        .map(|r| r.at_least(x0x::groups::GroupRole::Admin))
-                        .unwrap_or(false),
-                    _ => sub_role.is_some(),
-                };
-                if !ok {
-                    // MembersOnly/AdminOnly with no roster role: still
-                    // admissible when the group's admission rule is
-                    // OwnerCertified AND the sub-agent presents a live
-                    // owner-chained certificate (ADR-0038: admission IS
-                    // the owner's certificate).
-                    cert_gate_owner = info.policy.admission.owner_certified_user_id().cloned();
-                    if cert_gate_owner.is_none() {
-                        return forbidden("sub-agent is not a member of this group (ADR-0039)");
-                    }
-                }
-            }
-            x0x::groups::GroupWriteAccess::ModeratedPublic => { /* any non-banned */ }
+        let role_ok = match info.policy.write_access {
+            x0x::groups::GroupWriteAccess::MembersOnly => sub_role.is_some(),
+            x0x::groups::GroupWriteAccess::AdminOnly => sub_role
+                .map(|r| r.at_least(x0x::groups::GroupRole::Admin))
+                .unwrap_or(false),
+            x0x::groups::GroupWriteAccess::ModeratedPublic => true,
+        };
+        if !role_ok {
+            return forbidden("sub-agent lacks the required roster role in this group");
         }
-        rider_sub_agent_id = Some(sub_agent_id.clone());
-    }
-    if let (Some(owner), Some(sub_hex)) = (cert_gate_owner, rider_sub_agent_id.as_deref()) {
-        // The named-groups read guard is held across this await: the
-        // verification touches only the journal and revocation set, so
-        // there is no lock recursion — just bounded contention.
-        if let Err(reason) = verify_rider_admission_cert(&state, &owner, sub_hex).await {
-            return forbidden(reason);
+        // Same capability check as the public-message path (review r4):
+        // the stored delegation must verify for this group.
+        let delegation = state.rider_tokens.lock().await.delegation_of(*token_id);
+        let Some(delegation) = delegation else {
+            return forbidden("rider token has no sub-agent-signed delegation covering this group");
+        };
+        let provenance = x0x::groups::RiderProvenance {
+            sub_agent_id: sub_agent_id.clone(),
+            rider_token_id: *token_id,
+            rider_token_hash: token_hash.clone(),
+            scope: info.stable_group_id().to_string(),
+            delegation,
+        };
+        let now_unix = x0x::dm::now_unix_ms() / 1_000;
+        if let Err(reason) = x0x::groups::verify_rider_provenance(
+            &provenance,
+            &caller_hex,
+            info.stable_group_id(),
+            now_unix,
+        ) {
+            tracing::warn!(
+                group_id = %info.stable_group_id(),
+                sub_agent = %sub_agent_id,
+                "rejected rider MLS send: delegation verification failed: {reason}"
+            );
+            return forbidden("rider delegation does not verify for this group");
+        }
+        // Review r4 item 2: the attribution is CRYPTOGRAPHIC — the
+        // daemon signs an artifact binding the provenance (with its
+        // sub-agent-signed delegation) to this (group, epoch), recorded
+        // as the history row's signed artifact.
+        let epoch = info.secret_epoch;
+        let artifact =
+            x0x::groups::rider_mls_attribution_bytes(&provenance, info.stable_group_id(), epoch);
+        let signing_kp = state.agent.identity().agent_keypair();
+        match ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
+            signing_kp.secret_key(),
+            &artifact,
+        ) {
+            Ok(sig) => {
+                rider_attribution = Some(MlsRiderAttribution {
+                    sub_agent_id: sub_agent_id.clone(),
+                    artifact,
+                    signature: sig.as_bytes().to_vec(),
+                });
+            }
+            Err(e) => {
+                tracing::warn!("failed to sign rider MLS attribution: {e:?}");
+                return api_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "failed to sign rider attribution",
+                );
+            }
         }
     }
     if info.policy.confidentiality != x0x::groups::GroupConfidentiality::MlsEncrypted {
@@ -16696,7 +16759,7 @@ pub(in crate::server) async fn secure_group_encrypt(
             &id,
             Some(&stable_group_id),
             &req.payload_b64,
-            rider_sub_agent_id.as_deref(),
+            rider_attribution.as_ref(),
         )
         .await;
     }
@@ -16755,7 +16818,7 @@ pub(in crate::server) async fn secure_group_encrypt(
         &plaintext,
         x0x::history::Direction::Outbound,
         epoch,
-        rider_sub_agent_id.as_deref(),
+        rider_attribution.as_ref(),
     );
     secure_group_effect_response_after_terminality_recheck(
         state.as_ref(),
@@ -21619,6 +21682,11 @@ pub(in crate::server) mod tests {
                 .with_agent_cert_path(data_dir.join("agent.cert"))
                 .with_peer_cache_disabled()
                 .with_contact_store_path(data_dir.join("contacts.json"))
+                .with_history(x0x::history::HistoryConfig {
+                    enabled: true,
+                    db_path: Some(data_dir.join("history.db")),
+                    ..x0x::history::HistoryConfig::default()
+                })
                 .build()
                 .await?,
         );
@@ -25618,6 +25686,219 @@ pub(in crate::server) mod tests {
         .await;
 
         assert_lost_race_conflict_drops_fields(status, &body.0, &["ciphertext_b64"]);
+        Ok(())
+    }
+
+    /// Review r4: the MLS/Home rider path applies the SAME capability
+    /// check as public messages — explicit grant, sub-agent roster role,
+    /// and a sub-agent-SIGNED delegation covering the group — and the
+    /// durable attribution is a daemon-SIGNED artifact, not a string.
+    #[tokio::test]
+    async fn rider_mls_encrypt_requires_delegation_and_records_signed_attribution() -> Result<()> {
+        let (state, _dir) = secure_endpoint_test_state().await?;
+        let group_id = &"ab".repeat(16);
+        let stable_group_id = "rider-mls-stable";
+        install_secure_endpoint_group(
+            &state,
+            group_id,
+            stable_group_id,
+            x0x::mls::SecureGroupPlane::Gss,
+        )
+        .await;
+
+        // Harness side: sub-agent keypair, owner cert, delegation naming
+        // THIS daemon and covering the group.
+        let daemon_hex = hex::encode(state.agent.agent_id().as_bytes());
+        let sub_kp = x0x::identity::AgentKeypair::generate()?;
+        let sub_hex = hex::encode(sub_kp.agent_id().as_bytes());
+        let owner_kp = x0x::identity::UserKeypair::generate()?;
+        let cert = x0x::identity::AgentCertificate::issue_for_public_key(
+            &owner_kp,
+            sub_kp.public_key().as_bytes(),
+            None,
+        )?;
+        let not_after = x0x::dm::now_unix_ms() / 1_000 + 3_600;
+        let scopes = vec![stable_group_id.to_string()];
+        let (payload_b64, signature) =
+            x0x::groups::sign_rider_delegation(&sub_kp, &daemon_hex, &scopes, not_after)?;
+        let delegation = x0x::groups::RiderDelegation {
+            cert_b64: BASE64.encode(cert.to_storage_bytes()?),
+            payload_b64,
+            signature,
+        };
+
+        // Sub-agent must hold the MembersOnly roster role.
+        {
+            let mut groups = state.named_groups.write().await;
+            let Some(info) = groups.get_mut(group_id) else {
+                anyhow::bail!("group missing");
+            };
+            info.add_member(
+                sub_hex.clone(),
+                x0x::groups::GroupRole::Member,
+                Some(daemon_hex.clone()),
+                None,
+            );
+        }
+
+        // Token WITHOUT a delegation → 403 even with grant + role.
+        let now = x0x::dm::now_unix_ms() / 1_000;
+        let undel = state
+            .rider_tokens
+            .lock()
+            .await
+            .issue(
+                sub_hex.clone(),
+                vec![stable_group_id.to_string()],
+                None,
+                600,
+                "dd".repeat(32),
+                None,
+                None,
+                now,
+            )
+            .await?;
+        let (status, body) = secure_group_encrypt(
+            State(Arc::clone(&state)),
+            Path(group_id.to_string()),
+            axum::Extension(crate::server::rider_auth::ActorContext::Rider {
+                sub_agent_id: sub_hex.clone(),
+                token_id: undel.1.token_id,
+                token_hash: undel.1.token_hash.clone(),
+                groups: vec![stable_group_id.to_string()],
+            }),
+            Json(SecureEncryptRequest {
+                payload_b64: BASE64.encode(b"no delegation"),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "no delegation: {body:?}");
+
+        // Token WITH the verified delegation → 200, and the history row
+        // carries the daemon-signed attribution artifact.
+        let del = state
+            .rider_tokens
+            .lock()
+            .await
+            .issue(
+                sub_hex.clone(),
+                vec![stable_group_id.to_string()],
+                None,
+                600,
+                "dd".repeat(32),
+                None,
+                Some(delegation),
+                now,
+            )
+            .await?;
+        let (status, body) = secure_group_encrypt(
+            State(Arc::clone(&state)),
+            Path(group_id.to_string()),
+            axum::Extension(crate::server::rider_auth::ActorContext::Rider {
+                sub_agent_id: sub_hex.clone(),
+                token_id: del.1.token_id,
+                token_hash: del.1.token_hash.clone(),
+                groups: vec![stable_group_id.to_string()],
+            }),
+            Json(SecureEncryptRequest {
+                payload_b64: BASE64.encode(b"delegated rider plaintext"),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "delegated rider encrypt: {body:?}");
+
+        let Some(history) = state.agent.history() else {
+            anyhow::bail!("history store missing");
+        };
+        // The history writer is an async queue — poll briefly for the
+        // row to land.
+        let mut attributed = None;
+        for _ in 0..40 {
+            let rows = history
+                .store()
+                .query(&x0x::history::HistoryQuery {
+                    scope: Some(x0x::history::Scope::Group(stable_group_id.to_string())),
+                    ..Default::default()
+                })
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            if let Some(row) = rows
+                .iter()
+                .find(|r| r.record.author_agent.as_deref() == Some(sub_hex.as_str()))
+            {
+                attributed = Some((
+                    row.record.signature.is_some(),
+                    row.record.sig_context.clone(),
+                ));
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        let Some((has_signature, sig_context)) = attributed else {
+            let rows = history
+                .store()
+                .query(&x0x::history::HistoryQuery {
+                    ..Default::default()
+                })
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            anyhow::bail!(
+                "sub-agent-attributed history row never appeared; all rows: {:?}",
+                rows.iter()
+                    .map(|r| (r.record.scope.canonical(), r.record.author_agent.clone()))
+                    .collect::<Vec<_>>()
+            );
+        };
+        assert!(has_signature, "attribution is signed, not a bare string");
+        assert_eq!(sig_context.as_deref(), Some("x0x.rider.mls-attribution.v1"));
+
+        // Non-member sub-agent (role gate) → 403 even with delegation:
+        // remove the roster role and re-send with a fresh token.
+        {
+            let mut groups = state.named_groups.write().await;
+            if let Some(info) = groups.get_mut(group_id) {
+                info.remove_member(&sub_hex, None);
+            }
+        }
+        let del2 = state
+            .rider_tokens
+            .lock()
+            .await
+            .issue(
+                sub_hex.clone(),
+                vec![stable_group_id.to_string()],
+                None,
+                600,
+                "dd".repeat(32),
+                None,
+                Some(x0x::groups::RiderDelegation {
+                    cert_b64: BASE64.encode(
+                        x0x::identity::AgentCertificate::issue_for_public_key(
+                            &owner_kp,
+                            sub_kp.public_key().as_bytes(),
+                            None,
+                        )?
+                        .to_storage_bytes()?,
+                    ),
+                    payload_b64: del.1.delegation.clone().expect("delegation").payload_b64,
+                    signature: del.1.delegation.clone().expect("delegation").signature,
+                }),
+                now,
+            )
+            .await?;
+        let (status, body) = secure_group_encrypt(
+            State(Arc::clone(&state)),
+            Path(group_id.to_string()),
+            axum::Extension(crate::server::rider_auth::ActorContext::Rider {
+                sub_agent_id: sub_hex.clone(),
+                token_id: del2.1.token_id,
+                token_hash: del2.1.token_hash.clone(),
+                groups: vec![stable_group_id.to_string()],
+            }),
+            Json(SecureEncryptRequest {
+                payload_b64: BASE64.encode(b"not a member"),
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "non-member: {body:?}");
         Ok(())
     }
 

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -9270,6 +9270,9 @@ pub(in crate::server) struct SendGroupMessageRequest {
 pub(in crate::server) async fn send_group_public_message(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
+    axum::extract::Extension(actor): axum::extract::Extension<
+        crate::server::rider_auth::ActorContext,
+    >,
     Json(req): Json<SendGroupMessageRequest>,
 ) -> impl IntoResponse {
     let kind = match req.kind.as_deref().unwrap_or("chat") {
@@ -9368,6 +9371,34 @@ pub(in crate::server) async fn send_group_public_message(
             .map(|member| member.agent_id.clone())
             .collect::<Vec<_>>();
 
+        // ADR-0039 rider scope check: the daemon's own membership carries
+        // the send; a rider may only reach Home (not applicable on this
+        // SignedPublic-only surface) or an explicitly granted group.
+        let rider_provenance = match &actor {
+            crate::server::rider_auth::ActorContext::Owner => None,
+            crate::server::rider_auth::ActorContext::Rider {
+                sub_agent_id,
+                token_id,
+                token_hash,
+                groups,
+            } => {
+                let is_home = info.home.is_some();
+                let granted =
+                    is_home || groups.iter().any(|g| g.as_str() == info.stable_group_id());
+                if !granted {
+                    return forbidden(
+                        "rider token is not granted this group (ADR-0039 deny-by-default)",
+                    );
+                }
+                Some(x0x::groups::RiderProvenance {
+                    sub_agent_id: sub_agent_id.clone(),
+                    rider_token_id: *token_id,
+                    rider_token_hash: token_hash.clone(),
+                    scope: info.stable_group_id().to_string(),
+                })
+            }
+        };
+
         match x0x::groups::GroupPublicMessage::sign(
             info.stable_group_id().to_string(),
             info.state_hash.clone(),
@@ -9379,6 +9410,7 @@ pub(in crate::server) async fn send_group_public_message(
             now_ms,
             req.thread_root,
             req.thread_parent,
+            rider_provenance,
         ) {
             Ok(m) => (m, direct_recipients),
             Err(e) => {
@@ -9726,6 +9758,7 @@ fn record_mls_history(
     plaintext: &[u8],
     direction: x0x::history::Direction,
     epoch: u64,
+    author_agent: Option<&str>,
 ) {
     let Some(history) = state.agent.history() else {
         return;
@@ -9750,7 +9783,7 @@ fn record_mls_history(
             plaintext,
         ),
         scope: x0x::history::Scope::Group(stable_group_id.to_string()),
-        author_agent: None,
+        author_agent: author_agent.map(str::to_string),
         author_machine: None,
         author_pubkey: None,
         sent_at_ms: now,
@@ -16377,6 +16410,7 @@ async fn treekem_group_encrypt(
     group_id_hex: &str,
     stable_group_id: Option<&str>,
     payload_b64: &str,
+    author_agent: Option<&str>,
 ) -> (StatusCode, Json<serde_json::Value>) {
     use base64::Engine as _;
     let plaintext = match BASE64.decode(payload_b64) {
@@ -16439,6 +16473,7 @@ async fn treekem_group_encrypt(
         &plaintext,
         x0x::history::Direction::Outbound,
         epoch,
+        author_agent,
     );
     secure_group_effect_response_after_terminality_recheck(
         state,
@@ -16521,6 +16556,7 @@ async fn treekem_group_decrypt(
         &plaintext,
         x0x::history::Direction::Inbound,
         epoch,
+        None,
     );
     secure_group_effect_response_after_terminality_recheck(
         state,
@@ -16539,6 +16575,9 @@ async fn treekem_group_decrypt(
 pub(in crate::server) async fn secure_group_encrypt(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
+    axum::extract::Extension(actor): axum::extract::Extension<
+        crate::server::rider_auth::ActorContext,
+    >,
     Json(req): Json<SecureEncryptRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
     let caller_hex = hex::encode(state.agent.agent_id().as_bytes());
@@ -16555,6 +16594,26 @@ pub(in crate::server) async fn secure_group_encrypt(
     if !info.has_active_member(&caller_hex) {
         return forbidden("not a member");
     }
+    // ADR-0039: the DAEMON is the acting member; a rider reaches Home
+    // (and any granted MlsEncrypted group) through that membership, with
+    // the sub-agent attribution recorded in the local history row.
+    let rider_sub_agent_id = match &actor {
+        crate::server::rider_auth::ActorContext::Owner => None,
+        crate::server::rider_auth::ActorContext::Rider { .. } => {
+            let is_home = info.home.is_some();
+            if !actor.rider_allows_group(is_home, info.stable_group_id()) {
+                return forbidden(
+                    "rider token is not granted this group (ADR-0039 deny-by-default)",
+                );
+            }
+            match &actor {
+                crate::server::rider_auth::ActorContext::Rider { sub_agent_id, .. } => {
+                    Some(sub_agent_id.clone())
+                }
+                _ => None,
+            }
+        }
+    };
     if info.policy.confidentiality != x0x::groups::GroupConfidentiality::MlsEncrypted {
         return bad_request("group is not MlsEncrypted — use public send instead");
     }
@@ -16568,6 +16627,7 @@ pub(in crate::server) async fn secure_group_encrypt(
             &id,
             Some(&stable_group_id),
             &req.payload_b64,
+            rider_sub_agent_id.as_deref(),
         )
         .await;
     }
@@ -16626,6 +16686,7 @@ pub(in crate::server) async fn secure_group_encrypt(
         &plaintext,
         x0x::history::Direction::Outbound,
         epoch,
+        rider_sub_agent_id.as_deref(),
     );
     secure_group_effect_response_after_terminality_recheck(
         state.as_ref(),
@@ -16749,6 +16810,7 @@ pub(in crate::server) async fn secure_group_decrypt(
                 &plaintext,
                 x0x::history::Direction::Inbound,
                 req.secret_epoch,
+                None,
             );
             secure_group_effect_response_after_terminality_recheck(
                 state.as_ref(),
@@ -21608,6 +21670,12 @@ pub(in crate::server) mod tests {
             upgrade_apply_lock: Arc::new(Mutex::new(())),
             api_token: "test-token".to_string(),
             sessions: auth::SessionStore::new(auth::SESSION_TOKEN_TTL),
+            rider_tokens: tokio::sync::Mutex::new(
+                crate::server::rider_auth::RiderTokenStore::load(
+                    data_dir.join(crate::server::rider_auth::RIDER_TOKENS_FILE),
+                )
+                .await,
+            ),
             exec_service,
             groups_diagnostics: Arc::new(x0x::groups::GroupsDiagnostics::new()),
             connect_diagnostics: Arc::new(x0x::connect::ConnectDiagnostics::new(
@@ -22673,6 +22741,7 @@ pub(in crate::server) mod tests {
         let (status, body) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.to_string()),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(b"secret"),
             }),
@@ -22698,6 +22767,7 @@ pub(in crate::server) mod tests {
         let (encrypt_status, encrypted) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.to_string()),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(b"secret"),
             }),
@@ -24528,6 +24598,7 @@ pub(in crate::server) mod tests {
         let (enc_status, enc_body) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.clone()),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(plaintext),
             }),
@@ -25469,6 +25540,7 @@ pub(in crate::server) mod tests {
         let (status, body) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.to_string()),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(b"secret"),
             }),
@@ -25488,6 +25560,7 @@ pub(in crate::server) mod tests {
         let (encrypt_status, encrypted) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.to_string()),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(b"secret"),
             }),
@@ -25614,6 +25687,7 @@ pub(in crate::server) mod tests {
         let (status, body) = secure_group_encrypt(
             State(Arc::clone(&state)),
             Path(group_id.to_string()),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
             Json(SecureEncryptRequest {
                 payload_b64: BASE64.encode(b"secret"),
             }),
@@ -27486,6 +27560,7 @@ pub(in crate::server) mod tests {
             timestamp: 123,
             thread_root: None,
             thread_parent: None,
+            rider_provenance: None,
             signature: "cc".repeat(64),
         };
 
@@ -27522,6 +27597,7 @@ pub(in crate::server) mod tests {
             1_000,
             None,
             None,
+            None,
         )
         .expect("sign v1");
 
@@ -27538,6 +27614,7 @@ pub(in crate::server) mod tests {
             2_000,
             Some(fake_root.clone()),
             Some(fake_root),
+            None,
         )
         .expect("sign v2");
 
@@ -27619,10 +27696,14 @@ pub(in crate::server) mod tests {
     ) -> Result<(StatusCode, serde_json::Value)> {
         let req =
             serde_json::from_value(serde_json::json!({ "body": body })).context("send request")?;
-        let response =
-            send_group_public_message(State(state), Path(group_id.to_string()), Json(req))
-                .await
-                .into_response();
+        let response = send_group_public_message(
+            State(state),
+            Path(group_id.to_string()),
+            axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+            Json(req),
+        )
+        .await
+        .into_response();
         response_json(response).await
     }
 

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -9795,6 +9795,7 @@ fn record_group_public_history(state: &AppState, msg: &x0x::groups::GroupPublicM
 /// — binding the rider provenance, its sub-agent-signed delegation, and
 /// the concrete (group, epoch) — so durable Home attribution is
 /// cryptographic, not a local string.
+#[derive(Debug)]
 pub(in crate::server) struct MlsRiderAttribution {
     pub(in crate::server) sub_agent_id: String,
     pub(in crate::server) artifact: Vec<u8>,
@@ -9805,34 +9806,73 @@ pub(in crate::server) struct MlsRiderAttribution {
     pub(in crate::server) signing_pubkey: Vec<u8>,
 }
 
-/// Sign the MLS rider attribution for a completed encryption (review
-/// r5): canonical bytes over the provenance (incl. delegation), group,
-/// epoch, and the CIPHERTEXT DIGEST, signed with the daemon agent key.
-/// `None` when no rider provenance applies (owner sends).
+/// Sign the MLS rider attribution for a completed encryption (reviews
+/// r5/r6): canonical bytes over the provenance (incl. delegation),
+/// group, epoch, and the CIPHERTEXT DIGEST, signed with the daemon
+/// agent key.
+///
+/// FAIL-CLOSED (r6 regression fix): a rider send whose attribution
+/// cannot be signed returns `Err` (a 500 response) — the callers abort
+/// BEFORE recording any history, so no unattributed rider message ever
+/// persists. `Ok(None)` means no rider provenance applied (owner send).
 fn sign_mls_rider_attribution(
     state: &AppState,
     provenance: Option<&x0x::groups::RiderProvenance>,
     group_id: &str,
     epoch: u64,
     ciphertext: &[u8],
-) -> Option<MlsRiderAttribution> {
-    let provenance = provenance?;
+) -> Result<Option<MlsRiderAttribution>, (StatusCode, Json<serde_json::Value>)> {
+    let signing_kp = state.agent.identity().agent_keypair();
+    sign_mls_rider_attribution_with(
+        provenance,
+        group_id,
+        epoch,
+        ciphertext,
+        signing_kp,
+        ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa,
+    )
+}
+
+/// Injectable-signer core (review r6): the signer is a parameter so the
+/// FAIL-CLOSED contract is unit-testable — a rider send whose
+/// attribution cannot be signed yields `Err` (500), never
+/// `Ok(None)`-with-a-recorded-unattributed-row.
+#[allow(clippy::too_many_arguments)]
+fn sign_mls_rider_attribution_with<S>(
+    provenance: Option<&x0x::groups::RiderProvenance>,
+    group_id: &str,
+    epoch: u64,
+    ciphertext: &[u8],
+    signing_kp: &crate::identity::AgentKeypair,
+    signer: S,
+) -> Result<Option<MlsRiderAttribution>, (StatusCode, Json<serde_json::Value>)>
+where
+    S: FnOnce(
+        &ant_quic::MlDsaSecretKey,
+        &[u8],
+    ) -> Result<
+        ant_quic::crypto::pqc::types::MlDsaSignature,
+        ant_quic::crypto::pqc::types::PqcError,
+    >,
+{
+    let Some(provenance) = provenance else {
+        return Ok(None);
+    };
     let artifact =
         x0x::groups::rider_mls_attribution_bytes(provenance, group_id, epoch, ciphertext);
-    let signing_kp = state.agent.identity().agent_keypair();
-    match ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
-        signing_kp.secret_key(),
-        &artifact,
-    ) {
-        Ok(sig) => Some(MlsRiderAttribution {
+    match signer(signing_kp.secret_key(), &artifact) {
+        Ok(sig) => Ok(Some(MlsRiderAttribution {
             sub_agent_id: provenance.sub_agent_id.clone(),
             artifact,
             signature: sig.as_bytes().to_vec(),
             signing_pubkey: signing_kp.public_key().as_bytes().to_vec(),
-        }),
+        })),
         Err(e) => {
-            tracing::warn!("failed to sign rider MLS attribution: {e:?}");
-            None
+            tracing::error!("failed to sign rider MLS attribution: {e:?}");
+            Err(api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to sign rider attribution",
+            ))
         }
     }
 }
@@ -16587,14 +16627,20 @@ async fn treekem_group_encrypt(
     drop(guard);
     // Review r5: sign the attribution AFTER encryption over the
     // ciphertext digest (the self-describing ApplicationCiphertext
-    // bytes), then record.
-    let attribution = sign_mls_rider_attribution(
+    // bytes). Review r6: a signing failure FAILS CLOSED — return the
+    // 500 BEFORE recording, so no unattributed rider row persists (a
+    // burned ratchet generation without a persisted message is
+    // harmless; an unattributed rider message is not).
+    let attribution = match sign_mls_rider_attribution(
         state,
         rider_provenance,
         stable_group_id.unwrap_or(group_id_hex),
         epoch,
         &ciphertext,
-    );
+    ) {
+        Ok(attribution) => attribution,
+        Err(resp) => return resp,
+    };
     record_mls_history(
         state,
         stable_group_id.unwrap_or(group_id_hex),
@@ -16865,14 +16911,18 @@ pub(in crate::server) async fn secure_group_encrypt(
     };
 
     // Review r5: sign the attribution AFTER encryption over the
-    // ciphertext digest, then record.
-    let attribution = sign_mls_rider_attribution(
+    // ciphertext digest. Review r6: FAIL CLOSED — abort with the 500
+    // BEFORE recording, so no unattributed rider row ever persists.
+    let attribution = match sign_mls_rider_attribution(
         state.as_ref(),
         rider_provenance.as_ref(),
         &group_id_clone,
         epoch,
         &ciphertext,
-    );
+    ) {
+        Ok(attribution) => attribution,
+        Err(resp) => return resp,
+    };
     record_mls_history(
         state.as_ref(),
         &group_id_clone,
@@ -25701,6 +25751,39 @@ pub(in crate::server) mod tests {
             "withdrawn same-stable alias should remain terminal"
         );
         Ok(())
+    }
+
+    /// Review r6 regression: an attribution signing FAILURE must
+    /// produce Err (a 500 the callers return BEFORE recording) — the
+    /// r5 regression swallowed it to `None`, letting both encryption
+    /// paths persist an UNATTRIBUTED rider row and still answer 200.
+    #[test]
+    fn rider_attribution_signing_failure_fails_closed() {
+        // Minimal provenance: content is irrelevant to the sign path.
+        let prov = x0x::groups::RiderProvenance {
+            sub_agent_id: "ab".repeat(32),
+            rider_token_id: 1,
+            rider_token_hash: "cd".repeat(32),
+            scope: "g".to_string(),
+            delegation: x0x::groups::RiderDelegation {
+                cert_b64: String::new(),
+                payload_b64: String::new(),
+                signature: String::new(),
+            },
+        };
+        let kp = x0x::identity::AgentKeypair::generate().unwrap();
+        let failing = |_: &ant_quic::MlDsaSecretKey, _: &[u8]| {
+            Err(ant_quic::PqcError::SigningFailed("injected".to_string()))
+        };
+        let outcome = sign_mls_rider_attribution_with(Some(&prov), "g", 7, b"ct", &kp, failing);
+        let (status, body) = outcome.unwrap_err();
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "{body:?}");
+        assert!(
+            body.0.get("error").is_some(),
+            "error body carried to the caller: {body:?}"
+        );
+        // Owner sends (no provenance) are unaffected: Ok(None).
+        assert!(sign_mls_rider_attribution_with(None, "g", 7, b"ct", &kp, failing).is_ok());
     }
 
     async fn install_treekem_endpoint_group(

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -9420,10 +9420,15 @@ pub(in crate::server) async fn send_group_public_message(
                     delegation,
                 };
                 let now_unix = x0x::dm::now_unix_ms() / 1_000;
+                let sub_revoked =
+                    state.agent.revocation_records().await.iter().any(|rec| {
+                        rec.subject_kind() == "agent" && rec.subject_hex() == *sub_agent_id
+                    });
                 if let Err(reason) = x0x::groups::verify_rider_provenance(
                     &provenance,
                     &local_hex,
                     info.stable_group_id(),
+                    sub_revoked,
                     now_unix,
                 ) {
                     tracing::warn!(
@@ -9794,6 +9799,42 @@ pub(in crate::server) struct MlsRiderAttribution {
     pub(in crate::server) sub_agent_id: String,
     pub(in crate::server) artifact: Vec<u8>,
     pub(in crate::server) signature: Vec<u8>,
+    /// The daemon agent public key that produced `signature` —
+    /// persisted with the history row (review r5) so the attribution
+    /// is independently verifiable after the fact.
+    pub(in crate::server) signing_pubkey: Vec<u8>,
+}
+
+/// Sign the MLS rider attribution for a completed encryption (review
+/// r5): canonical bytes over the provenance (incl. delegation), group,
+/// epoch, and the CIPHERTEXT DIGEST, signed with the daemon agent key.
+/// `None` when no rider provenance applies (owner sends).
+fn sign_mls_rider_attribution(
+    state: &AppState,
+    provenance: Option<&x0x::groups::RiderProvenance>,
+    group_id: &str,
+    epoch: u64,
+    ciphertext: &[u8],
+) -> Option<MlsRiderAttribution> {
+    let provenance = provenance?;
+    let artifact =
+        x0x::groups::rider_mls_attribution_bytes(provenance, group_id, epoch, ciphertext);
+    let signing_kp = state.agent.identity().agent_keypair();
+    match ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
+        signing_kp.secret_key(),
+        &artifact,
+    ) {
+        Ok(sig) => Some(MlsRiderAttribution {
+            sub_agent_id: provenance.sub_agent_id.clone(),
+            artifact,
+            signature: sig.as_bytes().to_vec(),
+            signing_pubkey: signing_kp.public_key().as_bytes().to_vec(),
+        }),
+        Err(e) => {
+            tracing::warn!("failed to sign rider MLS attribution: {e:?}");
+            None
+        }
+    }
 }
 
 /// Record MLS-group plaintext obtained via a local secure-surface call
@@ -9823,24 +9864,28 @@ fn record_mls_history(
         "application/octet-stream"
     };
     let now = i64::try_from(x0x::dm::now_unix_ms()).unwrap_or(i64::MAX);
-    // With a signed rider attribution the row is NON-opaque (see
-    // `HistoryRecord::validate`) and the msg_id is the canonical
-    // BLAKE3(artifact || payload); without one it stays the
-    // epoch-salted id (dedupes identical plaintext per group+epoch).
-    let (author_agent, signed_artifact, signature, sig_context, msg_id) = match attribution {
-        None => (None, None, None, None, None),
-        Some(att) => {
-            let msg_id =
-                x0x::history::HistoryRecord::compute_msg_id(Some(&att.artifact), plaintext);
-            (
-                Some(att.sub_agent_id.clone()),
-                Some(att.artifact.clone()),
-                Some(att.signature.clone()),
-                Some("x0x.rider.mls-attribution.v1".to_string()),
-                Some(msg_id),
-            )
-        }
-    };
+    let (author_agent, signed_artifact, signature, sig_context, msg_id, author_pubkey) =
+        match attribution {
+            None => (None, None, None, None, None, None),
+            Some(att) => {
+                // With a signed rider attribution the row is NON-opaque (see
+                // `HistoryRecord::validate`) and the msg_id is the canonical
+                // BLAKE3(artifact || payload); without one it stays the
+                // epoch-salted id (dedupes identical plaintext per group+epoch).
+                let msg_id =
+                    x0x::history::HistoryRecord::compute_msg_id(Some(&att.artifact), plaintext);
+                (
+                    Some(att.sub_agent_id.clone()),
+                    Some(att.artifact.clone()),
+                    Some(att.signature.clone()),
+                    Some("x0x.rider.mls-attribution.v1".to_string()),
+                    Some(msg_id),
+                    // Review r5: persist the signing pubkey so the
+                    // attribution verifies after the fact.
+                    Some(att.signing_pubkey.clone()),
+                )
+            }
+        };
     let msg_id = msg_id.unwrap_or_else(|| {
         x0x::history::HistoryRecord::compute_epoch_msg_id(stable_group_id, epoch, plaintext)
     });
@@ -9849,7 +9894,7 @@ fn record_mls_history(
         scope: x0x::history::Scope::Group(stable_group_id.to_string()),
         author_agent,
         author_machine: None,
-        author_pubkey: None,
+        author_pubkey,
         sent_at_ms: now,
         seen_at_ms: now,
         direction,
@@ -10137,7 +10182,18 @@ pub(in crate::server) async fn ingest_public_message(
         policy: &policy,
         members_v2: &members,
     };
-    match x0x::groups::validate_public_message(&ctx, &msg) {
+    // Review r5: pass the receiver's ADR-0018 revocation view so a
+    // rider message from a revoked sub-agent is rejected at ingest —
+    // mirroring the sending daemon's middleware fence.
+    let revoked_agents: std::collections::BTreeSet<String> = state
+        .agent
+        .revocation_records()
+        .await
+        .iter()
+        .filter(|rec| rec.subject_kind() == "agent")
+        .map(|rec| rec.subject_hex())
+        .collect();
+    match x0x::groups::validate_public_message_with_revocations(&ctx, &msg, &revoked_agents) {
         Ok(()) => {
             state
                 .groups_diagnostics
@@ -16472,7 +16528,7 @@ async fn treekem_group_encrypt(
     group_id_hex: &str,
     stable_group_id: Option<&str>,
     payload_b64: &str,
-    attribution: Option<&MlsRiderAttribution>,
+    rider_provenance: Option<&x0x::groups::RiderProvenance>,
 ) -> (StatusCode, Json<serde_json::Value>) {
     use base64::Engine as _;
     let plaintext = match BASE64.decode(payload_b64) {
@@ -16529,13 +16585,23 @@ async fn treekem_group_encrypt(
     }
     let epoch = guard.epoch();
     drop(guard);
+    // Review r5: sign the attribution AFTER encryption over the
+    // ciphertext digest (the self-describing ApplicationCiphertext
+    // bytes), then record.
+    let attribution = sign_mls_rider_attribution(
+        state,
+        rider_provenance,
+        stable_group_id.unwrap_or(group_id_hex),
+        epoch,
+        &ciphertext,
+    );
     record_mls_history(
         state,
         stable_group_id.unwrap_or(group_id_hex),
         &plaintext,
         x0x::history::Direction::Outbound,
         epoch,
-        attribution,
+        attribution.as_ref(),
     );
     secure_group_effect_response_after_terminality_recheck(
         state,
@@ -16664,7 +16730,7 @@ pub(in crate::server) async fn secure_group_encrypt(
     // delegation covering THIS group — verified against the same chain
     // receivers verify. The provenance then produces the signed MLS
     // attribution artifact below.
-    let mut rider_attribution: Option<MlsRiderAttribution> = None;
+    let mut rider_provenance: Option<x0x::groups::RiderProvenance> = None;
     if let crate::server::rider_auth::ActorContext::Rider {
         sub_agent_id,
         token_id,
@@ -16705,10 +16771,17 @@ pub(in crate::server) async fn secure_group_encrypt(
             delegation,
         };
         let now_unix = x0x::dm::now_unix_ms() / 1_000;
+        let sub_revoked = state
+            .agent
+            .revocation_records()
+            .await
+            .iter()
+            .any(|rec| rec.subject_kind() == "agent" && rec.subject_hex() == *sub_agent_id);
         if let Err(reason) = x0x::groups::verify_rider_provenance(
             &provenance,
             &caller_hex,
             info.stable_group_id(),
+            sub_revoked,
             now_unix,
         ) {
             tracing::warn!(
@@ -16718,33 +16791,11 @@ pub(in crate::server) async fn secure_group_encrypt(
             );
             return forbidden("rider delegation does not verify for this group");
         }
-        // Review r4 item 2: the attribution is CRYPTOGRAPHIC — the
-        // daemon signs an artifact binding the provenance (with its
-        // sub-agent-signed delegation) to this (group, epoch), recorded
-        // as the history row's signed artifact.
-        let epoch = info.secret_epoch;
-        let artifact =
-            x0x::groups::rider_mls_attribution_bytes(&provenance, info.stable_group_id(), epoch);
-        let signing_kp = state.agent.identity().agent_keypair();
-        match ant_quic::crypto::raw_public_keys::pqc::sign_with_ml_dsa(
-            signing_kp.secret_key(),
-            &artifact,
-        ) {
-            Ok(sig) => {
-                rider_attribution = Some(MlsRiderAttribution {
-                    sub_agent_id: sub_agent_id.clone(),
-                    artifact,
-                    signature: sig.as_bytes().to_vec(),
-                });
-            }
-            Err(e) => {
-                tracing::warn!("failed to sign rider MLS attribution: {e:?}");
-                return api_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "failed to sign rider attribution",
-                );
-            }
-        }
+        // Review r5: the attribution is signed AFTER encryption, over
+        // bytes that include the CIPHERTEXT DIGEST, so it authenticates
+        // the concrete message — not just (group, epoch). The signing
+        // happens in both plane branches below.
+        rider_provenance = Some(provenance);
     }
     if info.policy.confidentiality != x0x::groups::GroupConfidentiality::MlsEncrypted {
         return bad_request("group is not MlsEncrypted — use public send instead");
@@ -16759,10 +16810,11 @@ pub(in crate::server) async fn secure_group_encrypt(
             &id,
             Some(&stable_group_id),
             &req.payload_b64,
-            rider_attribution.as_ref(),
+            rider_provenance.as_ref(),
         )
         .await;
     }
+
     let Some(key) = info.secure_message_key() else {
         return api_error(
             StatusCode::FAILED_DEPENDENCY,
@@ -16812,13 +16864,22 @@ pub(in crate::server) async fn secure_group_encrypt(
         }
     };
 
+    // Review r5: sign the attribution AFTER encryption over the
+    // ciphertext digest, then record.
+    let attribution = sign_mls_rider_attribution(
+        state.as_ref(),
+        rider_provenance.as_ref(),
+        &group_id_clone,
+        epoch,
+        &ciphertext,
+    );
     record_mls_history(
         state.as_ref(),
         &group_id_clone,
         &plaintext,
         x0x::history::Direction::Outbound,
         epoch,
-        rider_attribution.as_ref(),
+        attribution.as_ref(),
     );
     secure_group_effect_response_after_terminality_recheck(
         state.as_ref(),

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -9402,12 +9402,39 @@ pub(in crate::server) async fn send_group_public_message(
                         "rider token is not granted this group (ADR-0039 deny-by-default)",
                     );
                 }
-                Some(x0x::groups::RiderProvenance {
+                // Review r3: the sub-agent-SIGNED delegation must back
+                // the assertion — the daemon verifies the full chain
+                // (cert → sub-agent key → delegation → this daemon →
+                // scope → expiry) before it will sign, so it can never
+                // speak for a sub-agent that did not authorize it.
+                let delegation = state.rider_tokens.lock().await.delegation_of(*token_id);
+                let Some(delegation) = delegation else {
+                    return forbidden(
+                        "rider token has no sub-agent-signed delegation (re-issue it with a delegation capability)",
+                    );
+                };
+                let provenance = x0x::groups::RiderProvenance {
                     sub_agent_id: sub_agent_id.clone(),
                     rider_token_id: *token_id,
                     rider_token_hash: token_hash.clone(),
                     scope: info.stable_group_id().to_string(),
-                })
+                    delegation,
+                };
+                let now_unix = x0x::dm::now_unix_ms() / 1_000;
+                if let Err(reason) = x0x::groups::verify_rider_provenance(
+                    &provenance,
+                    &local_hex,
+                    info.stable_group_id(),
+                    now_unix,
+                ) {
+                    tracing::warn!(
+                        group_id = %info.stable_group_id(),
+                        sub_agent = %sub_agent_id,
+                        "rejected rider send: delegation verification failed: {reason}"
+                    );
+                    return forbidden("rider delegation does not verify");
+                }
+                Some(provenance)
             }
         };
 

--- a/src/server/routes/named_groups/tests/adr0038_owner_certified.rs
+++ b/src/server/routes/named_groups/tests/adr0038_owner_certified.rs
@@ -776,8 +776,13 @@ async fn restore_from_disk_quarantines_secure_ops_until_resealed() -> Result<()>
     // Secure encrypt refuses while quarantined.
     let req: SecureEncryptRequest =
         serde_json::from_value(serde_json::json!({ "payload_b64": "aGVsbG8=" }))?;
-    let (status, json) =
-        secure_group_encrypt(State(Arc::clone(&state)), Path(group_id.clone()), Json(req)).await;
+    let (status, json) = secure_group_encrypt(
+        State(Arc::clone(&state)),
+        Path(group_id.clone()),
+        axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+        Json(req),
+    )
+    .await;
     let body: serde_json::Value = json.0;
     assert_eq!(status, StatusCode::CONFLICT, "quarantined encrypt must 409");
     assert!(
@@ -1335,8 +1340,13 @@ async fn explicit_eviction_of_failed_member_clears_restore_quarantine() -> Resul
     // Secure ops work again (no 409 quarantine).
     let req: SecureEncryptRequest =
         serde_json::from_value(serde_json::json!({ "payload_b64": "aGVsbG8=" }))?;
-    let (status, json) =
-        secure_group_encrypt(State(Arc::clone(&state)), Path(group_id.clone()), Json(req)).await;
+    let (status, json) = secure_group_encrypt(
+        State(Arc::clone(&state)),
+        Path(group_id.clone()),
+        axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+        Json(req),
+    )
+    .await;
     assert_eq!(
         status,
         StatusCode::OK,

--- a/src/server/routes/named_groups/tests/adr0038_owner_certified.rs
+++ b/src/server/routes/named_groups/tests/adr0038_owner_certified.rs
@@ -779,7 +779,7 @@ async fn restore_from_disk_quarantines_secure_ops_until_resealed() -> Result<()>
     let (status, json) = secure_group_encrypt(
         State(Arc::clone(&state)),
         Path(group_id.clone()),
-        axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+        axum::Extension(crate::server::rider_auth::ActorContext::Owner { durable: true }),
         Json(req),
     )
     .await;
@@ -1343,7 +1343,7 @@ async fn explicit_eviction_of_failed_member_clears_restore_quarantine() -> Resul
     let (status, json) = secure_group_encrypt(
         State(Arc::clone(&state)),
         Path(group_id.clone()),
-        axum::Extension(crate::server::rider_auth::ActorContext::Owner),
+        axum::Extension(crate::server::rider_auth::ActorContext::Owner { durable: true }),
         Json(req),
     )
     .await;

--- a/src/server/routes/owner.rs
+++ b/src/server/routes/owner.rs
@@ -564,6 +564,23 @@ pub(in crate::server) async fn owner_riders_issue(
         .unwrap_or(crate::server::rider_auth::RIDER_DEFAULT_TTL_SECS)
         .clamp(1, crate::server::rider_auth::RIDER_MAX_TTL_SECS);
 
+    // Review r5: the delegation must not outlive its certificate or its
+    // token — cap not_after at min(cert.not_after, token expiry) and
+    // refuse longer capabilities.
+    let token_expires_at = now.saturating_add(ttl);
+    let cap = cert_not_after.unwrap_or(u64::MAX).min(token_expires_at);
+    if let Some(claim) = parse_delegation_claim(&delegation) {
+        if claim.not_after > cap {
+            return api_error(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "delegation not_after ({}) outlives min(cert expiry, token expiry) ({cap}) — sign a shorter capability",
+                    claim.not_after
+                ),
+            );
+        }
+    }
+
     let issued = state
         .rider_tokens
         .lock()
@@ -603,6 +620,17 @@ pub(in crate::server) async fn owner_riders_issue(
             "expires_at_unix": record.expires_at,
         })),
     )
+}
+
+/// Parse the claim back out of an assembled delegation (issuance-cap
+/// check, review r5). `None` if the stored payload does not parse —
+/// impossible for a just-verified delegation, but refuse silently-safe.
+fn parse_delegation_claim(
+    delegation: &crate::groups::RiderDelegation,
+) -> Option<crate::groups::RiderDelegationClaim> {
+    use base64::Engine as _;
+    let payload = BASE64.decode(&delegation.payload_b64).ok()?;
+    crate::groups::parse_rider_delegation(&payload)
 }
 
 /// GET /owner/riders — list rider-token records (no secrets). Durable

--- a/src/server/routes/owner.rs
+++ b/src/server/routes/owner.rs
@@ -1,0 +1,470 @@
+//! ADR-0039 owner routes: sub-agent registry issuance/revocation and the
+//! rider-token lifecycle.
+//!
+//! - `POST /owner/agents/issue` — the owner key signs an
+//!   [`AgentCertificate`] over a harness-submitted agent PUBLIC key. The
+//!   daemon never sees the secret (gapcheck blocker 20); the record
+//!   lands in the ADR-0036 issuance journal with `mode=acp|rider` and an
+//!   optional label, and the full certificate bytes are retained so a
+//!   later revocation can present the exact ADR-0018 authority evidence.
+//! - `DELETE /owner/agents/:id` — ADR-0018 issuer-revocation: the owner
+//!   key signs a `RevokedSubject::Agent` record carrying the retained
+//!   certificate, then every rider token bound to that agent is revoked.
+//! - `POST /owner/riders` / `GET /owner/riders` /
+//!   `DELETE /owner/riders/:id` — rider-token lifecycle (blocker 24):
+//!   hashed at rest, expiring, revocable, per registered sub-agent.
+//!
+//! All five are owner-only by construction: the deny-by-default rider
+//! predicate in the auth middleware returns `403` for riders on every
+//! `/owner/*` route before any handler runs.
+
+use super::super::state::AppState;
+use super::super::{api_error, parse_agent_id_hex};
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use serde::Deserialize;
+use std::sync::Arc;
+
+use crate::profile::{CertMode, IssuedCertRecord};
+
+/// Request body for `POST /owner/agents/issue`.
+#[derive(Debug, Deserialize)]
+pub(in crate::server) struct IssueAgentRequest {
+    /// Hex ML-DSA-65 PUBLIC key of the harness-generated agent keypair.
+    /// The secret never leaves the harness.
+    agent_public_key: String,
+    /// Hosting mode: `"acp"` (default) or `"rider"`.
+    #[serde(default)]
+    mode: Option<String>,
+    /// Optional operator label for the roster.
+    #[serde(default)]
+    label: Option<String>,
+    /// Optional certificate expiry (unix seconds).
+    #[serde(default)]
+    not_after: Option<u64>,
+}
+
+/// POST /owner/agents/issue — certify a harness-owned sub-agent key.
+///
+/// `409` without an owner key; `400` for a malformed key or mode. The
+/// journal append is part of the request contract (this endpoint IS the
+/// registry writer), so a failed append fails the request.
+pub(in crate::server) async fn owner_agents_issue(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<IssueAgentRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(user_kp) = state.agent.identity().user_keypair() else {
+        return owner_missing();
+    };
+    let mode = match req.mode.as_deref() {
+        None | Some("acp") => CertMode::Acp,
+        Some("rider") => CertMode::Rider,
+        Some(other) => {
+            return api_error(
+                StatusCode::BAD_REQUEST,
+                format!("unknown mode {other:?} (expected 'acp' or 'rider')"),
+            );
+        }
+    };
+    let key_bytes = match hex::decode(req.agent_public_key.trim()) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return api_error(
+                StatusCode::BAD_REQUEST,
+                "agent_public_key must be hex-encoded ML-DSA-65 public key bytes",
+            );
+        }
+    };
+    let cert = match crate::identity::AgentCertificate::issue_for_public_key(
+        user_kp,
+        &key_bytes,
+        req.not_after,
+    ) {
+        Ok(cert) => cert,
+        Err(e) => {
+            return api_error(StatusCode::BAD_REQUEST, format!("issuance rejected: {e}"));
+        }
+    };
+    let agent_hex = hex::encode(
+        cert.agent_id()
+            .map_or_else(|_| [0u8; 32], |id| *id.as_bytes()),
+    );
+    let owner = user_kp.user_id();
+
+    let record = IssuedCertRecord::from_cert_with_mode(&owner, &cert, mode, req.label.clone());
+    let Some(record) = record else {
+        return api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to build issuance journal record",
+        );
+    };
+    let Some(journal_path) = state
+        .agent
+        .cert_journal_path()
+        .map(std::path::Path::to_path_buf)
+    else {
+        return api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "no certificate journal configured for this install",
+        );
+    };
+    if let Err(e) = IssuedCertRecord::append(&journal_path, &record).await {
+        return api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to append issuance journal: {e}"),
+        );
+    }
+
+    let storage_b64 = cert
+        .to_storage_bytes()
+        .map(|bytes| BASE64.encode(bytes))
+        .unwrap_or_default();
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "ok": true,
+            "agent_id": agent_hex,
+            "mode": match mode { CertMode::Acp => "acp", CertMode::Rider => "rider" },
+            "label": req.label,
+            "certificate": {
+                "agent_public_key": hex::encode(&key_bytes),
+                "user_public_key": hex::encode(cert.user_public_key_bytes()),
+                "issued_at": cert.issued_at(),
+                "not_after": cert.not_after(),
+                "signature": hex::encode(cert.signature_bytes()),
+                "storage_b64": storage_b64,
+            },
+        })),
+    )
+}
+
+/// The shared `409` body for owner-less installs.
+fn owner_missing() -> (StatusCode, Json<serde_json::Value>) {
+    api_error(
+        StatusCode::CONFLICT,
+        "no owner: this daemon has no user identity (run `x0x user-id create`)",
+    )
+}
+
+/// Request body for `DELETE /owner/agents/:id`.
+#[derive(Debug, Default, Deserialize)]
+pub(in crate::server) struct RevokeAgentRequest {
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// DELETE /owner/agents/:id — revoke a registered sub-agent (ADR-0018
+/// issuer-revocation path).
+///
+/// The owner key signs a revocation for `RevokedSubject::Agent(target)`
+/// with the retained certificate as the authority evidence; the record
+/// persists to `revocations.bin` and gossips exactly like any other
+/// revocation. All rider tokens bound to the agent are revoked in the
+/// same stroke. `404` when the agent is not on this owner's journal;
+/// `409` when no retained certificate exists (e.g. the daemon's own
+/// agent — use `/identity/revoke` — or pre-ADR-0039 lines).
+pub(in crate::server) async fn owner_agents_revoke(
+    State(state): State<Arc<AppState>>,
+    Path(agent_id_hex): Path<String>,
+    body: Option<Json<RevokeAgentRequest>>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(user_kp) = state.agent.identity().user_keypair() else {
+        return owner_missing();
+    };
+    let Ok(agent_id) = parse_agent_id_hex(&agent_id_hex) else {
+        return api_error(StatusCode::BAD_REQUEST, "agent id must be 64 hex chars");
+    };
+    let owner_hex = hex::encode(user_kp.user_id().as_bytes());
+    let target_hex = hex::encode(agent_id.as_bytes());
+
+    // Locate the newest retained certificate for this agent on this
+    // owner's journal.
+    let Some(journal_path) = state
+        .agent
+        .cert_journal_path()
+        .map(std::path::Path::to_path_buf)
+    else {
+        return api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "no certificate journal configured for this install",
+        );
+    };
+    let records = IssuedCertRecord::load(&journal_path).await;
+    let mut on_roster = false;
+    let mut retained: Option<IssuedCertRecord> = None;
+    for record in records {
+        if record.user_id != owner_hex || record.agent_id != target_hex {
+            continue;
+        }
+        on_roster = true;
+        if record.cert_b64.is_some()
+            && retained
+                .as_ref()
+                .is_none_or(|best| record.issued_at >= best.issued_at)
+        {
+            retained = Some(record);
+        }
+    }
+    if !on_roster {
+        return api_error(
+            StatusCode::NOT_FOUND,
+            "agent is not on this owner's issuance journal",
+        );
+    }
+    let Some(record) = retained else {
+        return api_error(
+            StatusCode::CONFLICT,
+            "no retained certificate for this agent — issuer revocation requires the exact certificate (agent.cert holders: use /identity/revoke)",
+        );
+    };
+    let Some(cert_bytes) = record
+        .cert_b64
+        .as_deref()
+        .and_then(|b64| BASE64.decode(b64).ok())
+    else {
+        return api_error(
+            StatusCode::CONFLICT,
+            "retained certificate bytes are unreadable",
+        );
+    };
+    let cert = match crate::identity::AgentCertificate::from_storage_bytes(&cert_bytes) {
+        Ok(cert) => cert,
+        Err(e) => {
+            return api_error(
+                StatusCode::CONFLICT,
+                format!("retained certificate does not decode: {e}"),
+            );
+        }
+    };
+    let cert_valid = cert.verify().is_ok()
+        && cert.user_id().is_ok_and(|uid| uid == user_kp.user_id())
+        && cert.agent_id().is_ok_and(|aid| aid == agent_id);
+    if !cert_valid {
+        return api_error(
+            StatusCode::CONFLICT,
+            "retained certificate fails verification against the owner and target agent",
+        );
+    }
+
+    let reason = body.and_then(|Json(req)| req.reason);
+    if let Err(e) = state.agent.revoke_as_owner(&cert, reason).await {
+        return api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("owner revocation failed: {e}"),
+        );
+    }
+    let rider_tokens_revoked = state
+        .rider_tokens
+        .lock()
+        .await
+        .revoke_for_agent(&target_hex, crate::server::rider_auth::unix_now_secs())
+        .await;
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "ok": true,
+            "agent_id": target_hex,
+            "revoked": true,
+            "rider_tokens_revoked": rider_tokens_revoked,
+        })),
+    )
+}
+
+/// Request body for `POST /owner/riders`.
+#[derive(Debug, Default, Deserialize)]
+pub(in crate::server) struct IssueRiderRequest {
+    /// Hex AgentId of a registered `mode=rider` sub-agent.
+    sub_agent_id: String,
+    /// Explicitly granted named-group ids (Home is always granted).
+    #[serde(default)]
+    groups: Vec<String>,
+    #[serde(default)]
+    label: Option<String>,
+    /// Token lifetime in seconds (default 7 days, max 90 days).
+    #[serde(default)]
+    ttl_secs: Option<u64>,
+}
+
+/// POST /owner/riders — issue a scoped rider token for a registered
+/// rider-mode sub-agent (blocker 24 lifecycle).
+///
+/// The token secret is returned exactly once; only its SHA-256 hash is
+/// stored. `404` when the sub-agent is not registered in rider mode;
+/// `409` when it has been revoked.
+pub(in crate::server) async fn owner_riders_issue(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<IssueRiderRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(user_kp) = state.agent.identity().user_keypair() else {
+        return owner_missing();
+    };
+    let Ok(sub_agent) = parse_agent_id_hex(req.sub_agent_id.trim()) else {
+        return api_error(StatusCode::BAD_REQUEST, "sub_agent_id must be 64 hex chars");
+    };
+    let target_hex = hex::encode(sub_agent.as_bytes());
+    let owner_hex = hex::encode(user_kp.user_id().as_bytes());
+
+    let Some(journal_path) = state
+        .agent
+        .cert_journal_path()
+        .map(std::path::Path::to_path_buf)
+    else {
+        return api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "no certificate journal configured for this install",
+        );
+    };
+    let mut registered_rider = false;
+    for record in IssuedCertRecord::load(&journal_path).await {
+        if record.user_id == owner_hex
+            && record.agent_id == target_hex
+            && record.mode == CertMode::Rider
+        {
+            registered_rider = true;
+        }
+    }
+    if !registered_rider {
+        return api_error(
+            StatusCode::NOT_FOUND,
+            "sub_agent_id is not a registered rider-mode agent (POST /owner/agents/issue first)",
+        );
+    }
+    if state
+        .agent
+        .revocation_records()
+        .await
+        .iter()
+        .any(|record| record.subject_kind() == "agent" && record.subject_hex() == target_hex)
+    {
+        return api_error(StatusCode::CONFLICT, "sub-agent is revoked");
+    }
+
+    // Normalize the group grant list: dedupe in order, bounded.
+    let mut groups: Vec<String> = Vec::new();
+    for group in req.groups {
+        let group = group.trim().to_string();
+        if group.is_empty() || group.len() > 128 {
+            return api_error(
+                StatusCode::BAD_REQUEST,
+                "group ids must be 1-128 chars, non-empty after trimming",
+            );
+        }
+        if !groups.contains(&group) {
+            groups.push(group);
+        }
+        if groups.len() > crate::server::rider_auth::RIDER_MAX_GROUPS {
+            return api_error(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "at most {} groups may be granted per rider token",
+                    crate::server::rider_auth::RIDER_MAX_GROUPS
+                ),
+            );
+        }
+    }
+    let ttl = req
+        .ttl_secs
+        .unwrap_or(crate::server::rider_auth::RIDER_DEFAULT_TTL_SECS)
+        .clamp(1, crate::server::rider_auth::RIDER_MAX_TTL_SECS);
+
+    let now = crate::server::rider_auth::unix_now_secs();
+    let issued = state
+        .rider_tokens
+        .lock()
+        .await
+        .issue(
+            target_hex.clone(),
+            groups.clone(),
+            req.label.clone(),
+            ttl,
+            now,
+        )
+        .await;
+    let (token, record) = match issued {
+        Ok(issued) => issued,
+        Err(e) => {
+            return api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to persist rider token: {e}"),
+            );
+        }
+    };
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "ok": true,
+            // One-time secret: never retrievable again.
+            "token": token,
+            "token_id": record.token_id,
+            "sub_agent_id": target_hex,
+            "groups": groups,
+            "label": req.label,
+            "issued_at_unix": record.issued_at,
+            "expires_at_unix": record.expires_at,
+        })),
+    )
+}
+
+/// GET /owner/riders — list rider-token records (no secrets).
+pub(in crate::server) async fn owner_riders_list(
+    State(state): State<Arc<AppState>>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if state.agent.identity().user_keypair().is_none() {
+        return owner_missing();
+    }
+    let riders = state.rider_tokens.lock().await.list();
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "ok": true,
+            "riders": riders.iter().map(|record| serde_json::json!({
+                "token_id": record.token_id,
+                "sub_agent_id": record.sub_agent_id,
+                "groups": record.groups,
+                "label": record.label,
+                "issued_at_unix": record.issued_at,
+                "expires_at_unix": record.expires_at,
+                "revoked_at_unix": record.revoked_at,
+            })).collect::<Vec<_>>(),
+        })),
+    )
+}
+
+/// DELETE /owner/riders/:id — revoke one rider token. The token fails
+/// validation on the very next request (no restart, no cache).
+pub(in crate::server) async fn owner_riders_revoke(
+    State(state): State<Arc<AppState>>,
+    Path(token_id): Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if state.agent.identity().user_keypair().is_none() {
+        return owner_missing();
+    }
+    let Ok(token_id) = token_id.trim().parse::<u64>() else {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "token id must be a positive integer",
+        );
+    };
+    let revoked = state
+        .rider_tokens
+        .lock()
+        .await
+        .revoke(token_id, crate::server::rider_auth::unix_now_secs())
+        .await;
+    if !revoked {
+        return api_error(StatusCode::NOT_FOUND, "unknown rider token id");
+    }
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "ok": true,
+            "token_id": token_id,
+            "revoked": true,
+        })),
+    )
+}

--- a/src/server/routes/owner.rs
+++ b/src/server/routes/owner.rs
@@ -306,6 +306,7 @@ pub(in crate::server) async fn owner_agents_revoke(
             "agent is not on this owner's issuance journal",
         );
     }
+
     let Some(record) = retained else {
         return api_error(
             StatusCode::CONFLICT,
@@ -393,6 +394,81 @@ pub(in crate::server) struct IssueRiderRequest {
     /// Token lifetime in seconds (default 7 days, max 90 days).
     #[serde(default)]
     ttl_secs: Option<u64>,
+    /// The sub-agent-signed delegation capability (review r3, option B)
+    /// — REQUIRED: without it the daemon could assert any sub-agent and
+    /// receivers would have no proof.
+    delegation: Option<DelegationWire>,
+}
+
+/// The harness-supplied delegation capability: canonical payload bytes
+/// plus the sub-agent key's signature. The daemon contributes the
+/// certificate bytes from its journal when storing.
+#[derive(Debug, Deserialize)]
+pub(in crate::server) struct DelegationWire {
+    payload_b64: String,
+    signature: String,
+}
+
+/// Verify a harness-submitted delegation capability (review r3,
+/// option B) and assemble the storable [`RiderDelegation`] with the
+/// certificate bytes from the journal record.
+///
+/// Checks: payload parses; subject is the target sub-agent; delegate is
+/// THIS daemon; scopes are exactly the requested groups; the capability
+/// is unexpired; and the signature verifies under the sub-agent's
+/// certified agent key.
+#[allow(clippy::too_many_arguments)]
+fn verify_delegation_wire(
+    del: &DelegationWire,
+    cert: &crate::identity::AgentCertificate,
+    journal_record: &IssuedCertRecord,
+    target_hex: &str,
+    daemon_hex: &str,
+    groups: &[String],
+    now: u64,
+) -> Result<crate::groups::RiderDelegation, String> {
+    use base64::Engine as _;
+    let payload = BASE64
+        .decode(del.payload_b64.trim())
+        .map_err(|_| "delegation payload_b64 is invalid base64".to_string())?;
+    let claim = crate::groups::parse_rider_delegation(&payload)
+        .ok_or_else(|| "delegation payload does not parse".to_string())?;
+    if claim.sub_agent_id != target_hex {
+        return Err("delegation subject differs from sub_agent_id".to_string());
+    }
+    if claim.daemon_agent_id != daemon_hex {
+        return Err(format!(
+            "delegation names daemon {other} but this daemon is {daemon_hex}",
+            other = claim.daemon_agent_id
+        ));
+    }
+    let mut requested = groups.to_vec();
+    requested.sort();
+    let mut delegated = claim.scopes.clone();
+    delegated.sort();
+    if delegated != requested {
+        return Err("delegation scopes must equal the requested group grants".to_string());
+    }
+    if now >= claim.not_after {
+        return Err("delegation is already expired".to_string());
+    }
+    let sig_bytes = hex::decode(del.signature.trim())
+        .map_err(|_| "delegation signature is invalid hex".to_string())?;
+    let sig = ant_quic::crypto::raw_public_keys::pqc::MlDsaSignature::from_bytes(&sig_bytes)
+        .map_err(|e| format!("delegation signature does not decode: {e:?}"))?;
+    let agent_pub = ant_quic::MlDsaPublicKey::from_bytes(cert.agent_public_key())
+        .map_err(|_| "certificate agent key does not parse".to_string())?;
+    ant_quic::crypto::raw_public_keys::pqc::verify_with_ml_dsa(&agent_pub, &payload, &sig)
+        .map_err(|_| "delegation is not signed by the sub-agent's certified key".to_string())?;
+    let cert_b64 = journal_record
+        .cert_b64
+        .clone()
+        .ok_or_else(|| "journal record lacks retained certificate bytes".to_string())?;
+    Ok(crate::groups::RiderDelegation {
+        cert_b64,
+        payload_b64: del.payload_b64.trim().to_string(),
+        signature: del.signature.trim().to_string(),
+    })
 }
 
 /// POST /owner/riders — issue a scoped rider token for a registered
@@ -517,6 +593,29 @@ pub(in crate::server) async fn owner_riders_issue(
             );
         }
     }
+
+    // Review r3 (option B): verify the sub-agent-signed delegation and
+    // bind it into the token. The capability must name THIS daemon as
+    // the delegate, cover exactly the requested group scopes, be signed
+    // by the sub-agent's certified key, and expire in the future.
+    let Some(del) = req.delegation else {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "delegation is required: sign rider_delegation_bytes(sub, daemon, scopes, not_after) with the sub-agent key",
+        );
+    };
+    let delegation = match verify_delegation_wire(
+        &del,
+        &cert,
+        &record,
+        &target_hex,
+        &hex::encode(state.agent.agent_id().as_bytes()),
+        &groups,
+        now,
+    ) {
+        Ok(delegation) => delegation,
+        Err(reason) => return api_error(StatusCode::BAD_REQUEST, reason),
+    };
     let ttl = req
         .ttl_secs
         .unwrap_or(crate::server::rider_auth::RIDER_DEFAULT_TTL_SECS)
@@ -533,6 +632,7 @@ pub(in crate::server) async fn owner_riders_issue(
             ttl,
             cert_digest,
             cert_not_after,
+            Some(delegation),
             now,
         )
         .await;

--- a/src/server/routes/owner.rs
+++ b/src/server/routes/owner.rs
@@ -54,8 +54,20 @@ pub(in crate::server) struct IssueAgentRequest {
 /// registry writer), so a failed append fails the request.
 pub(in crate::server) async fn owner_agents_issue(
     State(state): State<Arc<AppState>>,
+    axum::extract::Extension(actor): axum::extract::Extension<
+        crate::server::rider_auth::ActorContext,
+    >,
     Json(req): Json<IssueAgentRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    // Review fix #4: certifying a sub-agent is an owner-ADMIN act —
+    // the durable API token is required; a browser session bearer
+    // cannot mint owner-signed certificates.
+    if !actor.is_durable_owner() {
+        return api_error(
+            StatusCode::FORBIDDEN,
+            "owner-admin endpoints require the durable API token (not a session token)",
+        );
+    }
     let Some(user_kp) = state.agent.identity().user_keypair() else {
         return owner_missing();
     };
@@ -111,12 +123,17 @@ pub(in crate::server) async fn owner_agents_issue(
             "no certificate journal configured for this install",
         );
     };
+    // Review fix #5: the journal append is a read-modify-write — hold
+    // the install-wide journal lock so concurrent issuances cannot
+    // interleave and lose lines.
+    let journal_guard = state.cert_journal_lock.lock().await;
     if let Err(e) = IssuedCertRecord::append(&journal_path, &record).await {
         return api_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("failed to append issuance journal: {e}"),
         );
     }
+    drop(journal_guard);
 
     let storage_b64 = cert
         .to_storage_bytes()
@@ -156,6 +173,72 @@ pub(in crate::server) struct RevokeAgentRequest {
     reason: Option<String>,
 }
 
+/// Decode a journal record's retained certificate bytes, if readable.
+fn decode_retained_cert(record: &IssuedCertRecord) -> Option<crate::identity::AgentCertificate> {
+    let bytes = record
+        .cert_b64
+        .as_deref()
+        .and_then(|b64| BASE64.decode(b64).ok())?;
+    crate::identity::AgentCertificate::from_storage_bytes(&bytes).ok()
+}
+
+/// Verify the sub-agent's admission evidence for an OwnerCertified
+/// group (review fix #1): the newest retained certificate must chain to
+/// the group's owner, verify, be unexpired, and the agent must not be
+/// ADR-0018-revoked. Returns `Err(reason)` for the 403 body.
+pub(in crate::server) async fn verify_rider_admission_cert(
+    state: &Arc<AppState>,
+    owner: &crate::identity::UserId,
+    sub_agent_hex: &str,
+) -> Result<(), String> {
+    let Some(journal_path) = state
+        .agent
+        .cert_journal_path()
+        .map(std::path::Path::to_path_buf)
+    else {
+        return Err("no certificate journal configured".to_string());
+    };
+    let owner_hex = hex::encode(owner.as_bytes());
+    let now = crate::server::rider_auth::unix_now_secs();
+    let records = IssuedCertRecord::load(&journal_path).await;
+    let best = records
+        .into_iter()
+        .filter(|record| {
+            record.user_id == owner_hex
+                && record.agent_id == sub_agent_hex
+                && record.cert_b64.is_some()
+        })
+        .max_by_key(|record| record.issued_at);
+    let Some(best) = best else {
+        return Err("sub-agent has no retained certificate for this owner".to_string());
+    };
+    let Some(cert) = decode_retained_cert(&best) else {
+        return Err("sub-agent certificate is unreadable".to_string());
+    };
+    let verdict = crate::groups::owner_cert::verify_cert_against_owner(
+        owner,
+        sub_agent_hex,
+        &cert,
+        false,
+        now,
+    );
+    if verdict.is_err() {
+        return Err(format!(
+            "sub-agent certificate fails OwnerCertified admission: {verdict:?}"
+        ));
+    }
+    if state
+        .agent
+        .revocation_records()
+        .await
+        .iter()
+        .any(|record| record.subject_kind() == "agent" && record.subject_hex() == sub_agent_hex)
+    {
+        return Err("sub-agent is revoked".to_string());
+    }
+    Ok(())
+}
+
 /// DELETE /owner/agents/:id — revoke a registered sub-agent (ADR-0018
 /// issuer-revocation path).
 ///
@@ -168,9 +251,18 @@ pub(in crate::server) struct RevokeAgentRequest {
 /// agent — use `/identity/revoke` — or pre-ADR-0039 lines).
 pub(in crate::server) async fn owner_agents_revoke(
     State(state): State<Arc<AppState>>,
+    axum::extract::Extension(actor): axum::extract::Extension<
+        crate::server::rider_auth::ActorContext,
+    >,
     Path(agent_id_hex): Path<String>,
     body: Option<Json<RevokeAgentRequest>>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if !actor.is_durable_owner() {
+        return api_error(
+            StatusCode::FORBIDDEN,
+            "owner-admin endpoints require the durable API token (not a session token)",
+        );
+    }
     let Some(user_kp) = state.agent.identity().user_keypair() else {
         return owner_missing();
     };
@@ -256,12 +348,26 @@ pub(in crate::server) async fn owner_agents_revoke(
             format!("owner revocation failed: {e}"),
         );
     }
-    let rider_tokens_revoked = state
+    // Review fix #3: the token sweep is persist-or-fail. The cert-level
+    // revocation above is already durable, and the middleware checks
+    // agent revocation on every rider request, so a failed sweep write
+    // is fenced twice over — surface it as 500 rather than reporting a
+    // success that did not happen.
+    let swept = state
         .rider_tokens
         .lock()
         .await
         .revoke_for_agent(&target_hex, crate::server::rider_auth::unix_now_secs())
         .await;
+    let rider_tokens_revoked = match swept {
+        Ok(n) => n,
+        Err(e) => {
+            return api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("agent revoked but rider-token sweep did not persist: {e}"),
+            );
+        }
+    };
 
     (
         StatusCode::OK,
@@ -294,11 +400,23 @@ pub(in crate::server) struct IssueRiderRequest {
 ///
 /// The token secret is returned exactly once; only its SHA-256 hash is
 /// stored. `404` when the sub-agent is not registered in rider mode;
-/// `409` when it has been revoked.
+/// `409` when it has been revoked. Review fix #2: the retained
+/// certificate is verified (signature, owner binding, expiry) at
+/// issuance and its digest + expiry are BOUND into the token, so a
+/// token can never precede or outlive its certificate.
 pub(in crate::server) async fn owner_riders_issue(
     State(state): State<Arc<AppState>>,
+    axum::extract::Extension(actor): axum::extract::Extension<
+        crate::server::rider_auth::ActorContext,
+    >,
     Json(req): Json<IssueRiderRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if !actor.is_durable_owner() {
+        return api_error(
+            StatusCode::FORBIDDEN,
+            "owner-admin endpoints require the durable API token (not a session token)",
+        );
+    }
     let Some(user_kp) = state.agent.identity().user_keypair() else {
         return owner_missing();
     };
@@ -318,27 +436,60 @@ pub(in crate::server) async fn owner_riders_issue(
             "no certificate journal configured for this install",
         );
     };
-    let mut registered_rider = false;
-    for record in IssuedCertRecord::load(&journal_path).await {
-        if record.user_id == owner_hex
-            && record.agent_id == target_hex
-            && record.mode == CertMode::Rider
-        {
-            registered_rider = true;
+    // Locate the newest rider-mode record WITH retained certificate
+    // bytes, then verify the certificate itself.
+    let mut retained: Option<IssuedCertRecord> = None;
+    {
+        let _journal_guard = state.cert_journal_lock.lock().await;
+        for record in IssuedCertRecord::load(&journal_path).await {
+            if record.user_id == owner_hex
+                && record.agent_id == target_hex
+                && record.mode == CertMode::Rider
+                && record.cert_b64.is_some()
+                && retained
+                    .as_ref()
+                    .is_none_or(|best| record.issued_at >= best.issued_at)
+            {
+                retained = Some(record);
+            }
         }
     }
-    if !registered_rider {
+    let Some(record) = retained else {
         return api_error(
             StatusCode::NOT_FOUND,
-            "sub_agent_id is not a registered rider-mode agent (POST /owner/agents/issue first)",
+            "sub_agent_id is not a registered rider-mode agent with a retained certificate (POST /owner/agents/issue first)",
+        );
+    };
+    // Review fix #2: verify the bound certificate before minting.
+    let now = crate::server::rider_auth::unix_now_secs();
+    let cert = decode_retained_cert(&record);
+    let cert_ok = cert.as_ref().is_some_and(|cert| {
+        cert.verify().is_ok()
+            && cert.user_id().is_ok_and(|uid| uid == user_kp.user_id())
+            && cert.agent_id().is_ok_and(|aid| aid == sub_agent)
+            && !cert.is_expired(now)
+    });
+    let Some(cert) = cert else {
+        return api_error(
+            StatusCode::CONFLICT,
+            "retained certificate bytes are unreadable",
+        );
+    };
+    if !cert_ok {
+        return api_error(
+            StatusCode::CONFLICT,
+            "retained certificate fails verification or has expired",
         );
     }
+    let cert_digest = record.cert_digest.clone();
+    let cert_not_after = cert.not_after();
+
     if state
         .agent
         .revocation_records()
         .await
         .iter()
-        .any(|record| record.subject_kind() == "agent" && record.subject_hex() == target_hex)
+        .any(|rec| rec.subject_kind() == "agent" && rec.subject_hex() == target_hex)
     {
         return api_error(StatusCode::CONFLICT, "sub-agent is revoked");
     }
@@ -371,7 +522,6 @@ pub(in crate::server) async fn owner_riders_issue(
         .unwrap_or(crate::server::rider_auth::RIDER_DEFAULT_TTL_SECS)
         .clamp(1, crate::server::rider_auth::RIDER_MAX_TTL_SECS);
 
-    let now = crate::server::rider_auth::unix_now_secs();
     let issued = state
         .rider_tokens
         .lock()
@@ -381,6 +531,8 @@ pub(in crate::server) async fn owner_riders_issue(
             groups.clone(),
             req.label.clone(),
             ttl,
+            cert_digest,
+            cert_not_after,
             now,
         )
         .await;
@@ -410,10 +562,21 @@ pub(in crate::server) async fn owner_riders_issue(
     )
 }
 
-/// GET /owner/riders — list rider-token records (no secrets).
+/// GET /owner/riders — list rider-token records (no secrets). Durable
+/// owner only (review fix #4): token ids and grant shapes are
+/// administrative metadata.
 pub(in crate::server) async fn owner_riders_list(
     State(state): State<Arc<AppState>>,
+    axum::extract::Extension(actor): axum::extract::Extension<
+        crate::server::rider_auth::ActorContext,
+    >,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if !actor.is_durable_owner() {
+        return api_error(
+            StatusCode::FORBIDDEN,
+            "owner-admin endpoints require the durable API token (not a session token)",
+        );
+    }
     if state.agent.identity().user_keypair().is_none() {
         return owner_missing();
     }
@@ -429,6 +592,7 @@ pub(in crate::server) async fn owner_riders_list(
                 "label": record.label,
                 "issued_at_unix": record.issued_at,
                 "expires_at_unix": record.expires_at,
+                "cert_digest": record.cert_digest,
                 "revoked_at_unix": record.revoked_at,
             })).collect::<Vec<_>>(),
         })),
@@ -437,10 +601,22 @@ pub(in crate::server) async fn owner_riders_list(
 
 /// DELETE /owner/riders/:id — revoke one rider token. The token fails
 /// validation on the very next request (no restart, no cache).
+/// Review fix #3: revocation is persist-or-fail — `revoked: true` is
+/// only ever reported for a DURABLE revocation; a failed disk write
+/// yields `500` and the token stays live everywhere.
 pub(in crate::server) async fn owner_riders_revoke(
     State(state): State<Arc<AppState>>,
+    axum::extract::Extension(actor): axum::extract::Extension<
+        crate::server::rider_auth::ActorContext,
+    >,
     Path(token_id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if !actor.is_durable_owner() {
+        return api_error(
+            StatusCode::FORBIDDEN,
+            "owner-admin endpoints require the durable API token (not a session token)",
+        );
+    }
     if state.agent.identity().user_keypair().is_none() {
         return owner_missing();
     }
@@ -456,15 +632,19 @@ pub(in crate::server) async fn owner_riders_revoke(
         .await
         .revoke(token_id, crate::server::rider_auth::unix_now_secs())
         .await;
-    if !revoked {
-        return api_error(StatusCode::NOT_FOUND, "unknown rider token id");
+    match revoked {
+        Ok(false) => api_error(StatusCode::NOT_FOUND, "unknown rider token id"),
+        Err(e) => api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("revocation did not persist: {e}"),
+        ),
+        Ok(true) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "ok": true,
+                "token_id": token_id,
+                "revoked": true,
+            })),
+        ),
     }
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({
-            "ok": true,
-            "token_id": token_id,
-            "revoked": true,
-        })),
-    )
 }

--- a/src/server/routes/owner.rs
+++ b/src/server/routes/owner.rs
@@ -182,63 +182,6 @@ fn decode_retained_cert(record: &IssuedCertRecord) -> Option<crate::identity::Ag
     crate::identity::AgentCertificate::from_storage_bytes(&bytes).ok()
 }
 
-/// Verify the sub-agent's admission evidence for an OwnerCertified
-/// group (review fix #1): the newest retained certificate must chain to
-/// the group's owner, verify, be unexpired, and the agent must not be
-/// ADR-0018-revoked. Returns `Err(reason)` for the 403 body.
-pub(in crate::server) async fn verify_rider_admission_cert(
-    state: &Arc<AppState>,
-    owner: &crate::identity::UserId,
-    sub_agent_hex: &str,
-) -> Result<(), String> {
-    let Some(journal_path) = state
-        .agent
-        .cert_journal_path()
-        .map(std::path::Path::to_path_buf)
-    else {
-        return Err("no certificate journal configured".to_string());
-    };
-    let owner_hex = hex::encode(owner.as_bytes());
-    let now = crate::server::rider_auth::unix_now_secs();
-    let records = IssuedCertRecord::load(&journal_path).await;
-    let best = records
-        .into_iter()
-        .filter(|record| {
-            record.user_id == owner_hex
-                && record.agent_id == sub_agent_hex
-                && record.cert_b64.is_some()
-        })
-        .max_by_key(|record| record.issued_at);
-    let Some(best) = best else {
-        return Err("sub-agent has no retained certificate for this owner".to_string());
-    };
-    let Some(cert) = decode_retained_cert(&best) else {
-        return Err("sub-agent certificate is unreadable".to_string());
-    };
-    let verdict = crate::groups::owner_cert::verify_cert_against_owner(
-        owner,
-        sub_agent_hex,
-        &cert,
-        false,
-        now,
-    );
-    if verdict.is_err() {
-        return Err(format!(
-            "sub-agent certificate fails OwnerCertified admission: {verdict:?}"
-        ));
-    }
-    if state
-        .agent
-        .revocation_records()
-        .await
-        .iter()
-        .any(|record| record.subject_kind() == "agent" && record.subject_hex() == sub_agent_hex)
-    {
-        return Err("sub-agent is revoked".to_string());
-    }
-    Ok(())
-}
-
 /// DELETE /owner/agents/:id — revoke a registered sub-agent (ADR-0018
 /// issuer-revocation path).
 ///

--- a/src/server/routes/profile.rs
+++ b/src/server/routes/profile.rs
@@ -145,6 +145,13 @@ pub(in crate::server) struct OwnerAgentEntry {
     /// True when the entry comes from the persisted issuance journal
     /// (survives restarts) rather than live discovery only.
     pub(in crate::server) from_journal: bool,
+    /// ADR-0039 hosting mode of the latest journal issuance
+    /// (`"acp"` or `"rider"`).
+    pub(in crate::server) mode: &'static str,
+    /// ADR-0039 operator label of the latest journal issuance.
+    pub(in crate::server) journal_label: Option<String>,
+    /// True when the agent has an ADR-0018 revocation on record.
+    pub(in crate::server) revoked: bool,
 }
 
 /// GET /owner/agents — the roster of agents certified by this install's
@@ -169,6 +176,14 @@ pub(in crate::server) async fn owner_agents(
     };
     let roster = state.agent.owner_issued_certificates().await;
     let contacts = state.contacts.read().await;
+    let revoked_ids: std::collections::HashSet<String> = state
+        .agent
+        .revocation_records()
+        .await
+        .iter()
+        .filter(|record| record.subject_kind() == "agent")
+        .map(|record| record.subject_hex())
+        .collect();
     let local_agent_id = state.agent.agent_id();
     let local_agent_hex = hex::encode(local_agent_id.as_bytes());
     let mut entries = Vec::with_capacity(roster.len());
@@ -197,6 +212,12 @@ pub(in crate::server) async fn owner_agents(
                 .map(|d| hex::encode(d.machine_id.as_bytes())),
             is_local: record.agent_id == local_agent_hex,
             from_journal: record.from_journal,
+            mode: match record.mode {
+                crate::profile::CertMode::Acp => "acp",
+                crate::profile::CertMode::Rider => "rider",
+            },
+            journal_label: record.label.clone(),
+            revoked: revoked_ids.contains(&record.agent_id),
         });
     }
     entries.sort_by(|a, b| a.agent_id.cmp(&b.agent_id));
@@ -516,6 +537,9 @@ mod tests {
             cert_digest: "77".repeat(32),
             issued_at: 9_999,
             not_after: None,
+            mode: crate::profile::CertMode::Acp,
+            label: None,
+            cert_b64: None,
         };
         // Higher issued_at than the real record: only the owner filter can
         // keep it out of the roster.

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -875,6 +875,10 @@ pub(super) struct AppState {
     /// the auth middleware on every request after the owner-token
     /// checks fail.
     pub(super) rider_tokens: tokio::sync::Mutex<super::rider_auth::RiderTokenStore>,
+    /// Serializes ADR-0036 journal read-modify-write cycles performed
+    /// by the ADR-0039 owner routes (review fix #5: issuance appends
+    /// must not interleave).
+    pub(super) cert_journal_lock: tokio::sync::Mutex<()>,
     /// Tier-1 remote exec service.
     pub(super) exec_service: Arc<x0x::exec::ExecService>,
     /// Per-group ingest diagnostics surfaced via `/diagnostics/groups`.

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -870,6 +870,11 @@ pub(super) struct AppState {
     /// Short-lived browser session tokens (#127 / WS1.6). The only tokens
     /// accepted via `?token=` query strings on WS/SSE endpoints.
     pub(super) sessions: SessionStore,
+    /// ADR-0039 rider-token store: scoped sub-agent bearer tokens
+    /// (hashed at rest, persisted in `rider-tokens.json`). Consulted by
+    /// the auth middleware on every request after the owner-token
+    /// checks fail.
+    pub(super) rider_tokens: tokio::sync::Mutex<super::rider_auth::RiderTokenStore>,
     /// Tier-1 remote exec service.
     pub(super) exec_service: Arc<x0x::exec::ExecService>,
     /// Per-group ingest diagnostics surfaced via `/diagnostics/groups`.

--- a/tests/api_coverage.rs
+++ b/tests/api_coverage.rs
@@ -72,7 +72,31 @@ const COVERED: &[CoveredEndpoint] = &[
     covered!(Get, "/home", home_routes_wired),
     covered!(Post, "/home/rename", home_rename_round_trips),
     covered!(Get, "/owner/agents", daemon_api_profile_round_trip),
-    // ── Network ─────────────────────────────────────────────────────────
+    covered!(
+        Post,
+        "/owner/agents/issue",
+        rider_issuance_journals_and_roster_lists
+    ),
+    covered!(
+        Delete,
+        "/owner/agents/:id",
+        rider_revoked_token_fails_on_next_request
+    ),
+    covered!(
+        Post,
+        "/owner/riders",
+        rider_scope_matrix_ungranted_verbs_forbidden
+    ),
+    covered!(
+        Get,
+        "/owner/riders",
+        rider_revoked_token_fails_on_next_request
+    ),
+    covered!(
+        Delete,
+        "/owner/riders/:id",
+        rider_revoked_token_fails_on_next_request
+    ),
     covered!(Get, "/peers", daemon_api_peers),
     // ── Presence ────────────────────────────────────────────────────────
     covered!(Get, "/presence", "GET /presence"),
@@ -487,6 +511,7 @@ const COVERAGE_MARKER_SOURCES: &[(&str, &str)] = &[
         include_str!("daemon_api_integration.rs"),
     ),
     ("tests/history_api.rs", include_str!("history_api.rs")),
+    ("tests/rider_harness.rs", include_str!("rider_harness.rs")),
     (
         "tests/history_point_lookup_wiring.rs",
         include_str!("history_point_lookup_wiring.rs"),

--- a/tests/group_bidirectional_delivery.rs
+++ b/tests/group_bidirectional_delivery.rs
@@ -240,6 +240,7 @@ async fn test_group_public_message_gossip_round_trip() -> Result<(), Box<dyn std
         1_000,
         None,
         None,
+        None,
     )
     .unwrap();
 
@@ -282,6 +283,7 @@ async fn test_group_public_message_gossip_round_trip() -> Result<(), Box<dyn std
         GroupPublicMessageKind::Chat,
         "reply from bob".into(),
         2_000,
+        None,
         None,
         None,
     )
@@ -358,6 +360,7 @@ async fn test_adr0029_threaded_message_delivery() -> Result<(), Box<dyn std::err
         1_000,
         None,
         None,
+        None,
     )
     .unwrap();
     let root_msg_id = root.msg_id();
@@ -374,6 +377,7 @@ async fn test_adr0029_threaded_message_delivery() -> Result<(), Box<dyn std::err
         2_000,
         Some(root_msg_id.clone()),
         Some(root_msg_id.clone()),
+        None,
     )
     .unwrap();
     let reply_msg_id = reply.msg_id();

--- a/tests/named_group_public_messages.rs
+++ b/tests/named_group_public_messages.rs
@@ -56,6 +56,7 @@ fn sign_msg(
         1_000,
         None,
         None,
+        None,
     )
     .unwrap()
 }

--- a/tests/rider_harness.rs
+++ b/tests/rider_harness.rs
@@ -359,6 +359,35 @@ async fn rider_send_carries_provenance_and_lands() {
 
     let (sub_agent, token) = issue_rider(&d, "provenance", vec![group_id.clone()]).await;
 
+    // Review fix #1 (CRITICAL regression): the sub-agent is NOT a
+    // member of this MembersOnly group — the rider send must be 403
+    // even though the DAEMON (the group creator/admin) is a member.
+    // Authorizing against the daemon's role would let a rider emit
+    // admin-authored messages; the grant alone must not suffice.
+    let (status, _) = rider_json(
+        &token,
+        reqwest::Method::POST,
+        d.url(&format!("/groups/{group_id}/send")),
+        Some(json!({ "body": "must be refused" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::FORBIDDEN,
+        "non-member sub-agent must not send via the daemon's membership"
+    );
+
+    // Admit the sub-agent to the roster (OpenJoin admission) — the
+    // send is now authorized as the SUB-AGENT and carries provenance.
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        &format!("/groups/{group_id}/members"),
+        Some(json!({ "agent_id": sub_agent })),
+    )
+    .await;
+    assert!(status.is_success(), "add sub-agent member: {body}");
+
     // Granted send → 200 with msg_id.
     let (status, body) = rider_json(
         &token,
@@ -590,6 +619,141 @@ async fn rider_revoked_token_fails_on_next_request() {
     )
     .await;
     assert_eq!(status, reqwest::StatusCode::NOT_FOUND);
+}
+
+/// Review fix #4: a 10-minute browser session token is a read-only
+/// principal. It must NOT mint owner-signed certificates, rider
+/// tokens, or revoke anything — those owner-admin acts require the
+/// durable API token.
+#[tokio::test]
+#[ignore]
+async fn session_token_cannot_mint_owner_credentials() {
+    let d = owned_daemon().await;
+    let (status, body) = owner_json(&d, reqwest::Method::POST, "/auth/session", None).await;
+    assert_eq!(status, reqwest::StatusCode::OK, "session mint: {body}");
+    let session = body["session_token"]
+        .as_str()
+        .expect("session token")
+        .to_string();
+
+    let kp = x0x::identity::AgentKeypair::generate().expect("keypair");
+    let admin_acts: &[(reqwest::Method, &str, Option<Value>)] = &[
+        (
+            reqwest::Method::POST,
+            "/owner/agents/issue",
+            Some(json!({
+                "agent_public_key": hex::encode(kp.public_key().as_bytes()),
+                "mode": "rider"
+            })),
+        ),
+        (
+            reqwest::Method::POST,
+            "/owner/riders",
+            Some(json!({ "sub_agent_id": "ab".repeat(32) })),
+        ),
+        (reqwest::Method::GET, "/owner/riders", None),
+        (reqwest::Method::DELETE, "/owner/riders/1", None),
+        (
+            reqwest::Method::DELETE,
+            &format!("/owner/agents/{}", "cd".repeat(32)),
+            None,
+        ),
+    ];
+    for (method, path, body) in admin_acts {
+        let (status, resp) = rider_json(&session, method.clone(), d.url(path), body.clone()).await;
+        assert_eq!(
+            status,
+            reqwest::StatusCode::FORBIDDEN,
+            "session bearer {method} {path} must be 403: {resp}"
+        );
+    }
+    // Read-only owner surfaces remain session-accessible (GUI parity).
+    let (status, _) =
+        rider_json(&session, reqwest::Method::GET, d.url("/owner/agents"), None).await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::OK,
+        "session may read the roster"
+    );
+}
+
+/// Review fix #1 (CRITICAL): a rider must not inherit the daemon's
+/// ADMIN role. In an AdminOnly-write group where the daemon is the
+/// creator-admin, a rider whose sub-agent is a plain member (or not a
+/// member at all) is 403 — the provenance envelope names the
+/// authorization subject and receivers enforce against it.
+#[tokio::test]
+#[ignore]
+async fn rider_cannot_escalate_to_daemon_admin_role() {
+    let d = owned_daemon().await;
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        "/groups",
+        Some(json!({
+            "name": "admin-only-target",
+            "policy": {
+                "discoverability": "public_directory",
+                "admission": "open_join",
+                "confidentiality": "signed_public",
+                "read_access": "public",
+                "write_access": "admin_only"
+            }
+        })),
+    )
+    .await;
+    assert!(status.is_success(), "create admin-only group: {body}");
+    let group_id = body["group_id"].as_str().expect("group id").to_string();
+
+    let (sub_agent, token) = issue_rider(&d, "escalator", vec![group_id.clone()]).await;
+
+    // Non-member sub-agent: 403 despite the token grant.
+    let (status, _) = rider_json(
+        &token,
+        reqwest::Method::POST,
+        d.url(&format!("/groups/{group_id}/send")),
+        Some(json!({ "body": "admin voice" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::FORBIDDEN,
+        "non-member in admin-only group"
+    );
+
+    // Plain-member sub-agent: still 403 — AdminOnly needs the
+    // sub-agent's OWN admin role, never the daemon's.
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        &format!("/groups/{group_id}/members"),
+        Some(json!({ "agent_id": sub_agent })),
+    )
+    .await;
+    assert!(status.is_success(), "add member: {body}");
+    let (status, resp) = rider_json(
+        &token,
+        reqwest::Method::POST,
+        d.url(&format!("/groups/{group_id}/send")),
+        Some(json!({ "body": "admin voice" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::FORBIDDEN,
+        "plain-member sub-agent must not write to an admin-only group: {resp}"
+    );
+
+    // The daemon itself (owner bearer) still can — the policy works;
+    // only the rider's privilege ceiling changed.
+    let (status, resp) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        &format!("/groups/{group_id}/send"),
+        Some(json!({ "body": "owner announcement" })),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "owner send: {resp}");
 }
 
 /// ACP-attached mode: a certificate issued over a submitted public key

--- a/tests/rider_harness.rs
+++ b/tests/rider_harness.rs
@@ -388,7 +388,39 @@ async fn rider_issuance_journals_and_roster_lists() {
         reqwest::StatusCode::BAD_REQUEST,
         "forged delegation refused: {body}"
     );
-    // Anonymous (no owner key) installs refuse issuance with 409 —
+
+    // Review r5: a delegation that outlives min(cert expiry, token
+    // expiry) is refused — here a 90-day capability against a 60-second
+    let long_b64 = {
+        // Same sub-agent key that owns `agent_id`: the delegation is
+        // fully valid EXCEPT for outliving the token TTL — so a 400
+        // here proves the CAP, not the subject/scope checks.
+        let not_after = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 90 * 24 * 60 * 60;
+        let (b64, sig) =
+            x0x::groups::sign_rider_delegation(&kp, &daemon_hex, &[], not_after).expect("sign");
+        json!({ "payload_b64": b64, "signature": sig })
+    };
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        "/owner/riders",
+        Some(json!({
+            "sub_agent_id": agent_id,
+            "groups": [],
+            "ttl_secs": 60,
+            "delegation": long_b64,
+        })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::BAD_REQUEST,
+        "delegation outliving the token must be refused: {body}"
+    );
     // covered by tests/profile_api.rs for GET; here the owned path is the
     // happy case and malformed keys are rejected:
     let (status, body) = owner_json(

--- a/tests/rider_harness.rs
+++ b/tests/rider_harness.rs
@@ -1,0 +1,655 @@
+//! ADR-0039 agent-harness boundary — integration suite.
+//!
+//! Runs a real in-process owned daemon (`x0x::server::serve` with a
+//! generated owner `user.key`), then exercises the full rider lifecycle:
+//!
+//! 1. **Scope matrix** — a rider token is `403` on every ungranted verb
+//!    (`/agent/sign`, `/exec/run`, `/owner/*`, `/shutdown`, …), `401` with
+//!    a bad token, and `200` only on the rider route set.
+//! 2. **Issuance → journal → roster** — `POST /owner/agents/issue` lands
+//!    a `mode`/`label`/`cert_b64` record in the ADR-0036 journal and
+//!    `GET /owner/agents` lists it.
+//! 3. **Provenance send** — a rider send to a granted `SignedPublic`
+//!    group carries the signed provenance envelope (it verifies and is
+//!    covered by `msg_id`), and a rider Home encrypt lands attributed
+//!    history in the Home scope.
+//! 4. **Revocation** — `DELETE /owner/riders/:id` makes the very next
+//!    request `401`; `DELETE /owner/agents/:id` sweeps the agent's
+//!    tokens and marks the roster entry revoked.
+//! 5. **ACP chain** — a certificate issued over a submitted public key
+//!    verifies against `GroupAdmission::OwnerCertified` evidence.
+//!
+//! Socket-binding tests are `#[ignore]` (repo convention): run with
+//! `cargo nextest run --all-features --test rider_harness --run-ignored all`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+/// An owned in-process daemon plus its bearer token and dirs.
+struct OwnedDaemon {
+    _handle: x0x::server::ServerHandle,
+    addr: SocketAddr,
+    api_token: String,
+    root: PathBuf,
+    _dir: tempfile::TempDir,
+}
+
+impl OwnedDaemon {
+    fn url(&self, path: &str) -> String {
+        format!("http://{}{path}", self.addr)
+    }
+}
+
+/// Start an owned daemon: fresh temp identity dir pre-seeded with a
+/// generated owner `user.key`, so startup auto-issues the agent
+/// certificate and provisions Home (ADR-0038).
+async fn owned_daemon() -> OwnedDaemon {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let identity_dir = dir.path().join("identity");
+    tokio::fs::create_dir_all(&identity_dir)
+        .await
+        .expect("mkdir identity");
+    let user_kp = x0x::identity::UserKeypair::generate().expect("owner keypair");
+    x0x::storage::save_user_keypair_to(&user_kp, identity_dir.join("user.key"))
+        .await
+        .expect("save owner key");
+
+    let mut config = x0x::server::DaemonConfig::default();
+    config.api_address = SocketAddr::from(([127, 0, 0, 1], 0));
+    config.bind_address = SocketAddr::from(([127, 0, 0, 1], 0));
+    config.bootstrap_peers = Some(Vec::new());
+    config.data_dir = dir.path().join("data");
+    config.identity_dir = Some(identity_dir.clone());
+
+    let handle = x0x::server::serve(config).await.expect("serve()");
+    let addr = handle.local_addr();
+
+    let token_path = dir.path().join("data").join("api-token");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let api_token = loop {
+        if let Ok(token) = tokio::fs::read_to_string(&token_path).await {
+            let token = token.trim().to_string();
+            if !token.is_empty() {
+                break token;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "api-token file never appeared"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    OwnedDaemon {
+        _handle: handle,
+        addr,
+        api_token,
+        root: dir.path().to_path_buf(),
+        _dir: dir,
+    }
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("client")
+}
+
+async fn owner_json(
+    d: &OwnedDaemon,
+    method: reqwest::Method,
+    path: &str,
+    body: Option<Value>,
+) -> (reqwest::StatusCode, Value) {
+    let mut req = client()
+        .request(method, d.url(path))
+        .bearer_auth(&d.api_token);
+    if let Some(body) = body {
+        req = req.json(&body);
+    }
+    let resp = req.send().await.expect("owner request");
+    let status = resp.status();
+    (status, resp.json().await.unwrap_or(Value::Null))
+}
+
+async fn rider_json(
+    token: &str,
+    method: reqwest::Method,
+    url: String,
+    body: Option<Value>,
+) -> (reqwest::StatusCode, Value) {
+    let mut req = client().request(method, url).bearer_auth(token);
+    if let Some(body) = body {
+        req = req.json(&body);
+    }
+    let resp = req.send().await.expect("rider request");
+    let status = resp.status();
+    (status, resp.json().await.unwrap_or(Value::Null))
+}
+
+/// Issue a rider-mode sub-agent + rider token bound to `groups`.
+/// Returns `(sub_agent_hex, rider_token)`.
+async fn issue_rider(d: &OwnedDaemon, label: &str, groups: Vec<String>) -> (String, String) {
+    let kp = x0x::identity::AgentKeypair::generate().expect("sub-agent keypair");
+    let public_hex = hex::encode(kp.public_key().as_bytes());
+    let (status, body) = owner_json(
+        d,
+        reqwest::Method::POST,
+        "/owner/agents/issue",
+        Some(json!({ "agent_public_key": public_hex, "mode": "rider", "label": label })),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "issue: {body}");
+    let sub_agent_id = body["agent_id"].as_str().expect("agent_id").to_string();
+
+    let (status, body) = owner_json(
+        d,
+        reqwest::Method::POST,
+        "/owner/riders",
+        Some(json!({ "sub_agent_id": sub_agent_id, "groups": groups, "label": label })),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "rider issue: {body}");
+    let token = body["token"].as_str().expect("one-time token").to_string();
+    (sub_agent_id, token)
+}
+
+/// The stable group id of this daemon's Home.
+async fn home_group_id(d: &OwnedDaemon) -> String {
+    let (status, body) = owner_json(d, reqwest::Method::GET, "/home", None).await;
+    assert_eq!(status, reqwest::StatusCode::OK, "home: {body}");
+    body["group_id"]
+        .as_str()
+        .expect("home group id")
+        .to_string()
+}
+
+/// 1. Scope matrix: riders are denied every ungranted verb (403) and
+/// unknown tokens are 401 — the deny-by-default gate is the middleware,
+/// before any handler.
+#[tokio::test]
+#[ignore]
+async fn rider_scope_matrix_ungranted_verbs_forbidden() {
+    let d = owned_daemon().await;
+    let home = home_group_id(&d).await;
+    let (_sub, token) = issue_rider(&d, "scope-matrix", vec![]).await;
+
+    let forbidden: &[(reqwest::Method, &str, Option<Value>)] = &[
+        // The signing oracle (gapcheck blocker 21).
+        (
+            reqwest::Method::POST,
+            "/agent/sign",
+            Some(json!({ "payload_b64": "aGk=", "context": "x0x-rider-abuse" })),
+        ),
+        // Remote exec.
+        (
+            reqwest::Method::POST,
+            "/exec/run",
+            Some(json!({ "target": "self", "command": "id" })),
+        ),
+        // Owner/admin surfaces — a rider must never mint riders or read the roster.
+        (reqwest::Method::GET, "/owner/agents", None),
+        (
+            reqwest::Method::POST,
+            "/owner/agents/issue",
+            Some(json!({ "agent_public_key": "00" })),
+        ),
+        (reqwest::Method::DELETE, "/owner/agents/abcd", None),
+        (reqwest::Method::GET, "/owner/riders", None),
+        (
+            reqwest::Method::POST,
+            "/owner/riders",
+            Some(json!({ "sub_agent_id": "00".repeat(32) })),
+        ),
+        // Control plane.
+        (reqwest::Method::POST, "/shutdown", None),
+        (
+            reqwest::Method::POST,
+            "/publish",
+            Some(json!({ "topic": "t", "payload_b64": "aGk=" })),
+        ),
+        (reqwest::Method::POST, "/announce", None),
+        (reqwest::Method::GET, "/groups", None),
+        (reqwest::Method::GET, "/history/stats", None),
+        (reqwest::Method::GET, "/history/search", None),
+        (reqwest::Method::GET, "/agent", None),
+    ];
+    for (method, path, body) in forbidden {
+        let (status, resp) = rider_json(&token, method.clone(), d.url(path), body.clone()).await;
+        assert_eq!(
+            status,
+            reqwest::StatusCode::FORBIDDEN,
+            "rider {method} {path} must be 403, got {status}: {resp}"
+        );
+    }
+
+    // Granted surfaces DO answer (possibly with domain errors, but 403 from
+    // the route gate is what must never happen).
+    let (status, _) = rider_json(
+        &token,
+        reqwest::Method::GET,
+        d.url(&format!("/history?scope=group:{home}&limit=5")),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "rider home history read");
+
+    // Unknown bearer stays a plain 401 — riders are not a side channel for
+    // token probing beyond what the owner token already allows.
+    let (status, _) = rider_json(
+        &"0".repeat(64),
+        reqwest::Method::GET,
+        d.url("/history?scope=group:x"),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED, "bad token 401");
+}
+
+/// 2. Issuance lands in the ADR-0036 journal (mode + label + retained
+/// cert) and the roster lists it; a rider cannot read the roster.
+#[tokio::test]
+#[ignore]
+async fn rider_issuance_journals_and_roster_lists() {
+    let d = owned_daemon().await;
+    let kp = x0x::identity::AgentKeypair::generate().expect("keypair");
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        "/owner/agents/issue",
+        Some(json!({
+            "agent_public_key": hex::encode(kp.public_key().as_bytes()),
+            "mode": "rider",
+            "label": "ci-agent",
+        })),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "issue: {body}");
+    let agent_id = body["agent_id"].as_str().expect("agent_id").to_string();
+    assert_eq!(
+        body["mode"].as_str(),
+        Some("rider"),
+        "response carries the hosting mode"
+    );
+    assert!(
+        !body["certificate"]["storage_b64"]
+            .as_str()
+            .unwrap_or("")
+            .is_empty(),
+        "certificate bytes are returned to the harness"
+    );
+
+    // Journal: owner-scoped record with mode/label and retained cert bytes.
+    let journal = tokio::fs::read_to_string(d.root.join("identity/owner-cert-journal.jsonl"))
+        .await
+        .expect("journal file");
+    let line = journal
+        .lines()
+        .rev()
+        .find(|line| line.contains(&agent_id))
+        .expect("journal line for the issued agent");
+    let record: Value = serde_json::from_str(line).expect("journal line is JSON");
+    assert_eq!(record["mode"], "rider");
+    assert_eq!(record["label"], "ci-agent");
+    assert!(!record["cert_b64"].as_str().unwrap_or("").is_empty());
+
+    // Roster lists it with mode/label, journal-backed.
+    let (status, body) = owner_json(&d, reqwest::Method::GET, "/owner/agents", None).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    let entry = body["agents"]
+        .as_array()
+        .expect("agents array")
+        .iter()
+        .find(|entry| entry["agent_id"].as_str() == Some(agent_id.as_str()))
+        .expect("roster entry");
+    assert_eq!(entry["mode"], "rider");
+    assert_eq!(entry["journal_label"], "ci-agent");
+    assert_eq!(entry["from_journal"], true, "journal is authoritative");
+    assert_eq!(entry["revoked"], false);
+
+    // Anonymous (no owner key) installs refuse issuance with 409 —
+    // covered by tests/profile_api.rs for GET; here the owned path is the
+    // happy case and malformed keys are rejected:
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        "/owner/agents/issue",
+        Some(json!({ "agent_public_key": "zz", "mode": "rider" })),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::BAD_REQUEST, "bad key: {body}");
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        "/owner/agents/issue",
+        Some(json!({ "agent_public_key": "ab", "mode": "wrong" })),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::BAD_REQUEST, "bad mode: {body}");
+}
+
+/// 3. A rider send to a granted SignedPublic group carries the signed
+/// provenance envelope (verifiable, covered by msg_id) and a rider Home
+/// encrypt lands attributed history in the Home scope.
+#[tokio::test]
+#[ignore]
+async fn rider_send_carries_provenance_and_lands() {
+    let d = owned_daemon().await;
+    let home = home_group_id(&d).await;
+
+    // A SignedPublic group (PublicOpen preset) the rider will be granted.
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        "/groups",
+        Some(json!({ "name": "rider-target", "preset": "public_open" })),
+    )
+    .await;
+    assert!(status.is_success(), "create group: {body}");
+    let group_id = body["group_id"]
+        .as_str()
+        .expect("stable group id")
+        .to_string();
+
+    let (sub_agent, token) = issue_rider(&d, "provenance", vec![group_id.clone()]).await;
+
+    // Granted send → 200 with msg_id.
+    let (status, body) = rider_json(
+        &token,
+        reqwest::Method::POST,
+        d.url(&format!("/groups/{group_id}/send")),
+        Some(json!({ "body": "hello from the rider" })),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "rider send: {body}");
+    let msg_id = body["msg_id"].as_str().expect("msg_id").to_string();
+
+    // The cached message carries provenance AND a verifiable signature —
+    // proving the envelope is inside the signed bytes (gapcheck 24).
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::GET,
+        &format!("/groups/{group_id}/messages"),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "messages: {body}");
+    let messages = body["messages"].as_array().cloned().unwrap_or_default();
+    let raw = messages
+        .iter()
+        .find(|m| m["msg_id"].as_str() == Some(msg_id.as_str()))
+        .or_else(|| messages.iter().find(|m| m["rider_provenance"].is_object()))
+        .cloned()
+        .unwrap_or_else(|| panic!("rider message not in group cache: {body}"));
+    assert_eq!(
+        raw["rider_provenance"]["sub_agent_id"].as_str(),
+        Some(sub_agent.as_str()),
+        "provenance names the sub-agent"
+    );
+    assert_eq!(
+        raw["rider_provenance"]["scope"].as_str(),
+        Some(group_id.as_str())
+    );
+    let parsed: x0x::groups::GroupPublicMessage =
+        serde_json::from_value(raw).expect("message parses as GroupPublicMessage");
+    parsed
+        .verify_signature()
+        .expect("daemon signature verifies over the provenance-bearing bytes");
+    assert_eq!(
+        parsed.msg_id(),
+        msg_id,
+        "msg_id covers the provenance envelope (BLAKE3 over signable bytes)"
+    );
+
+    // Ungranted group: a second group the rider has no grant for → 403.
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        "/groups",
+        Some(json!({ "name": "rider-forbidden", "preset": "public_open" })),
+    )
+    .await;
+    assert!(status.is_success(), "second group create: {body}");
+    let other_group = body["group_id"]
+        .as_str()
+        .expect("second group id")
+        .to_string();
+    let (status, _) = rider_json(
+        &token,
+        reqwest::Method::POST,
+        d.url(&format!("/groups/{other_group}/send")),
+        Some(json!({ "body": "nope" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::FORBIDDEN,
+        "ungranted group send"
+    );
+
+    // Home (MlsEncrypted): the rider encrypt surface lands attributed
+    // plaintext history in the Home scope.
+    use base64::Engine as _;
+    let payload = base64::engine::general_purpose::STANDARD.encode(b"rider to home");
+    let (status, body) = rider_json(
+        &token,
+        reqwest::Method::POST,
+        d.url(&format!("/groups/{home}/secure/encrypt")),
+        Some(json!({ "payload_b64": payload })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::OK,
+        "rider Home encrypt must succeed (Home is always granted): {body}"
+    );
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::GET,
+        &format!("/history?scope=group:{home}&limit=10"),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "home history: {body}");
+    let records = body["records"].as_array().cloned().unwrap_or_default();
+    assert!(
+        records
+            .iter()
+            .any(|r| r["author_agent"].as_str() == Some(sub_agent.as_str())),
+        "Home history row attributed to the sub-agent: {body}"
+    );
+
+    // Rider history is bounded to granted scopes: dm scope → 403.
+    let (status, _) = rider_json(
+        &token,
+        reqwest::Method::GET,
+        d.url(&format!("/history?scope=dm:{}", "ab".repeat(32))),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::FORBIDDEN, "dm scope denied");
+}
+
+/// 4. Revocation lifecycle: a revoked token fails on the NEXT request;
+/// revoking the sub-agent sweeps its tokens and marks the roster entry.
+#[tokio::test]
+#[ignore]
+async fn rider_revoked_token_fails_on_next_request() {
+    let d = owned_daemon().await;
+    let home = home_group_id(&d).await;
+    let (_sub_agent, token) = issue_rider(&d, "doomed", vec![]).await;
+
+    // Alive: the granted Home history read answers 200.
+    let (status, _) = rider_json(
+        &token,
+        reqwest::Method::GET,
+        d.url(&format!("/history?scope=group:{home}")),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "live token works");
+
+    // Revoke the token (owner), then the SAME bearer is 401 immediately.
+    let (status, _) = owner_json(&d, reqwest::Method::GET, "/owner/riders", None).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    let (status, _) = rider_json(
+        &token,
+        reqwest::Method::GET,
+        d.url(&format!("/history?scope=group:{home}")),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    // token_id 1 is the first issued rider token on this install.
+    let (status, body) = owner_json(&d, reqwest::Method::DELETE, "/owner/riders/1", None).await;
+    assert_eq!(status, reqwest::StatusCode::OK, "revoke: {body}");
+    let (status, _) = rider_json(
+        &token,
+        reqwest::Method::GET,
+        d.url(&format!("/history?scope=group:{home}")),
+        None,
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::UNAUTHORIZED,
+        "revoked token 401"
+    );
+    // Unknown id → 404.
+    let (status, _) = owner_json(&d, reqwest::Method::DELETE, "/owner/riders/99", None).await;
+    assert_eq!(status, reqwest::StatusCode::NOT_FOUND);
+
+    // Agent-level revocation (ADR-0018 issuer path) sweeps rider tokens
+    // and marks the roster entry revoked; new token issuance is refused.
+    let (sub2, token2) = issue_rider(&d, "sweep-me", vec![]).await;
+    let (status, _) = rider_json(
+        &token2,
+        reqwest::Method::GET,
+        d.url(&format!("/history?scope=group:{home}")),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::DELETE,
+        &format!("/owner/agents/{sub2}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "agent revoke: {body}");
+    assert_eq!(body["revoked"], true, "agent revoke response");
+    assert_eq!(
+        body["rider_tokens_revoked"], 1,
+        "agent revoke sweeps rider tokens"
+    );
+    let (status, _) = rider_json(
+        &token2,
+        reqwest::Method::GET,
+        d.url(&format!("/history?scope=group:{home}")),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED, "swept token 401");
+
+    let (status, body) = owner_json(&d, reqwest::Method::GET, "/owner/agents", None).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    let entry = body["agents"]
+        .as_array()
+        .expect("agents")
+        .iter()
+        .find(|e| e["agent_id"].as_str() == Some(sub2.as_str()))
+        .expect("revoked entry still listed (journal is append-only)");
+    assert_eq!(entry["revoked"], true, "roster shows revocation");
+
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        "/owner/riders",
+        Some(json!({ "sub_agent_id": sub2 })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::CONFLICT,
+        "no new rider tokens for a revoked agent: {body}"
+    );
+
+    // An unrelated agent id → 404.
+    let (status, _) = owner_json(
+        &d,
+        reqwest::Method::DELETE,
+        &format!("/owner/agents/{}", "07".repeat(32)),
+        None,
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::NOT_FOUND);
+}
+
+/// ACP-attached mode: a certificate issued over a submitted public key
+/// (the daemon never sees the secret) verifies against the
+/// OwnerCertified admission core — the exact chain a Home join presents.
+#[test]
+fn acp_cert_chain_verifies_against_owner_certified_admission() {
+    // WHY: ADR-0039 validation — the harness-key path must be
+    // indistinguishable to ADR-0038 admission from any owner-certified
+    // agent, while a foreign owner's certificate must NOT chain.
+    let owner = x0x::identity::UserKeypair::generate().expect("owner");
+    let harness = x0x::identity::AgentKeypair::generate().expect("harness keypair");
+    let cert = x0x::identity::AgentCertificate::issue_for_public_key(
+        &owner,
+        harness.public_key().as_bytes(),
+        None,
+    )
+    .expect("issue over public key only");
+    assert!(cert.verify().is_ok(), "cert verifies");
+    let agent_hex = hex::encode(harness.agent_id().as_bytes());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert_eq!(
+        x0x::groups::owner_cert::verify_cert_against_owner(
+            &owner.user_id(),
+            &agent_hex,
+            &cert,
+            false,
+            now
+        ),
+        Ok(()),
+        "issued cert chains for OwnerCertified admission"
+    );
+    // Revocation evidence fails the same check (fail-closed path).
+    assert_eq!(
+        x0x::groups::owner_cert::verify_cert_against_owner(
+            &owner.user_id(),
+            &agent_hex,
+            &cert,
+            true,
+            now
+        ),
+        Err(x0x::groups::owner_cert::OwnerCertFailure::Revoked)
+    );
+    // A different owner must not accept it.
+    let other = x0x::identity::UserKeypair::generate().expect("other owner");
+    assert_eq!(
+        x0x::groups::owner_cert::verify_cert_against_owner(
+            &other.user_id(),
+            &agent_hex,
+            &cert,
+            false,
+            now
+        ),
+        Err(x0x::groups::owner_cert::OwnerCertFailure::NotChainedToOwner)
+    );
+    // Garbage keys are rejected at issuance (fail closed, blocker 20).
+    assert!(
+        x0x::identity::AgentCertificate::issue_for_public_key(&owner, &[0u8; 7], None).is_err()
+    );
+}

--- a/tests/rider_harness.rs
+++ b/tests/rider_harness.rs
@@ -209,7 +209,7 @@ async fn home_group_id(d: &OwnedDaemon) -> String {
 async fn rider_scope_matrix_ungranted_verbs_forbidden() {
     let d = owned_daemon().await;
     let home = home_group_id(&d).await;
-    let (_sub, token) = issue_rider(&d, "scope-matrix", vec![]).await;
+    let (_sub, token) = issue_rider(&d, "scope-matrix", vec![home.clone()]).await;
 
     let forbidden: &[(reqwest::Method, &str, Option<Value>)] = &[
         // The signing oracle (gapcheck blocker 21).
@@ -537,11 +537,13 @@ async fn rider_send_carries_provenance_and_lands() {
         "ungranted group send"
     );
 
-    // Home (MlsEncrypted): the rider encrypt surface lands attributed
-    // plaintext history in the Home scope.
+    // Review r4 item 1: there is NO implicit Home grant. This rider's
+    // delegation covers only `group_id`, so the Home encrypt is 403 —
+    // the previous behavior (any rider could reach Home) encoded the
+    // bug this round removes.
     use base64::Engine as _;
     let payload = base64::engine::general_purpose::STANDARD.encode(b"rider to home");
-    let (status, body) = rider_json(
+    let (status, _) = rider_json(
         &token,
         reqwest::Method::POST,
         d.url(&format!("/groups/{home}/secure/encrypt")),
@@ -550,24 +552,17 @@ async fn rider_send_carries_provenance_and_lands() {
     .await;
     assert_eq!(
         status,
-        reqwest::StatusCode::OK,
-        "rider Home encrypt must succeed (Home is always granted): {body}"
+        reqwest::StatusCode::FORBIDDEN,
+        "Home must be delegated explicitly — no implicit grant"
     );
-    let (status, body) = owner_json(
-        &d,
-        reqwest::Method::GET,
-        &format!("/history?scope=group:{home}&limit=10"),
-        None,
-    )
-    .await;
-    assert_eq!(status, reqwest::StatusCode::OK, "home history: {body}");
-    let records = body["records"].as_array().cloned().unwrap_or_default();
-    assert!(
-        records
-            .iter()
-            .any(|r| r["author_agent"].as_str() == Some(sub_agent.as_str())),
-        "Home history row attributed to the sub-agent: {body}"
-    );
+
+    // The MLS happy path (delegated member rider encrypts, signed
+    // attribution recorded in durable history) is proven in the
+    // unit suite — `rider_mls_encrypt_requires_delegation_and_records_
+    // signed_attribution` in src/server/routes/named_groups.rs — because
+    // REST-created MlsEncrypted groups are TreeKem-plane and a direct
+    // member add there requires a TreeKEM key package, which a
+    // harness-held sub-agent key cannot produce.
 
     // Rider history is bounded to granted scopes: dm scope → 403.
     let (status, _) = rider_json(
@@ -587,7 +582,7 @@ async fn rider_send_carries_provenance_and_lands() {
 async fn rider_revoked_token_fails_on_next_request() {
     let d = owned_daemon().await;
     let home = home_group_id(&d).await;
-    let (_sub_agent, token) = issue_rider(&d, "doomed", vec![]).await;
+    let (_sub_agent, token) = issue_rider(&d, "doomed", vec![home.clone()]).await;
 
     // Alive: the granted Home history read answers 200.
     let (status, _) = rider_json(
@@ -631,7 +626,7 @@ async fn rider_revoked_token_fails_on_next_request() {
 
     // Agent-level revocation (ADR-0018 issuer path) sweeps rider tokens
     // and marks the roster entry revoked; new token issuance is refused.
-    let (sub2, token2) = issue_rider(&d, "sweep-me", vec![]).await;
+    let (sub2, token2) = issue_rider(&d, "sweep-me", vec![home.clone()]).await;
     let (status, _) = rider_json(
         &token2,
         reqwest::Method::GET,

--- a/tests/rider_harness.rs
+++ b/tests/rider_harness.rs
@@ -134,6 +134,11 @@ async fn rider_json(
 }
 
 /// Issue a rider-mode sub-agent + rider token bound to `groups`.
+///
+/// Simulates the full harness side of the delegation flow (review r3):
+/// the harness generates + custodies the sub-agent key, and SIGNS a
+/// delegation capability naming this daemon and the granted groups —
+/// the daemon then verifies that capability before minting the token.
 /// Returns `(sub_agent_hex, rider_token)`.
 async fn issue_rider(d: &OwnedDaemon, label: &str, groups: Vec<String>) -> (String, String) {
     let kp = x0x::identity::AgentKeypair::generate().expect("sub-agent keypair");
@@ -148,11 +153,37 @@ async fn issue_rider(d: &OwnedDaemon, label: &str, groups: Vec<String>) -> (Stri
     assert_eq!(status, reqwest::StatusCode::OK, "issue: {body}");
     let sub_agent_id = body["agent_id"].as_str().expect("agent_id").to_string();
 
+    // Harness learns the daemon's agent id (public) and signs the
+    // delegation capability with ITS OWN key.
+    let (status, body) = owner_json(d, reqwest::Method::GET, "/agent", None).await;
+    assert_eq!(status, reqwest::StatusCode::OK, "agent info: {body}");
+    let daemon_hex = body["agent_id"]
+        .as_str()
+        .expect("daemon agent id")
+        .to_string();
+    let not_after = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 3_600;
+    let (payload_b64, signature) =
+        x0x::groups::sign_rider_delegation(&kp, &daemon_hex, &groups, not_after)
+            .expect("harness signs delegation");
+    let delegation = json!({
+        "payload_b64": payload_b64,
+        "signature": signature,
+    });
+
     let (status, body) = owner_json(
         d,
         reqwest::Method::POST,
         "/owner/riders",
-        Some(json!({ "sub_agent_id": sub_agent_id, "groups": groups, "label": label })),
+        Some(json!({
+            "sub_agent_id": sub_agent_id,
+            "groups": groups,
+            "label": label,
+            "delegation": delegation,
+        })),
     )
     .await;
     assert_eq!(status, reqwest::StatusCode::OK, "rider issue: {body}");
@@ -313,6 +344,50 @@ async fn rider_issuance_journals_and_roster_lists() {
     assert_eq!(entry["from_journal"], true, "journal is authoritative");
     assert_eq!(entry["revoked"], false);
 
+    // Review r3: rider tokens require a sub-agent-SIGNED delegation.
+    // Without one → 400; with one signed by a DIFFERENT key → 400 (the
+    // daemon verifies the capability against the certified sub-agent
+    // key before minting).
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        "/owner/riders",
+        Some(json!({ "sub_agent_id": agent_id.clone(), "groups": [] })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::BAD_REQUEST,
+        "no delegation refused: {body}"
+    );
+    let (status, body) = owner_json(&d, reqwest::Method::GET, "/agent", None).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    let daemon_hex = body["agent_id"].as_str().expect("daemon id").to_string();
+    let impostor = x0x::identity::AgentKeypair::generate().expect("impostor key");
+    let not_after = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 3_600;
+    let (forged_b64, forged_sig) =
+        x0x::groups::sign_rider_delegation(&impostor, &daemon_hex, &[], not_after)
+            .expect("impostor signs");
+    let (status, body) = owner_json(
+        &d,
+        reqwest::Method::POST,
+        "/owner/riders",
+        Some(json!({
+            "sub_agent_id": agent_id,
+            "groups": [],
+            "delegation": { "payload_b64": forged_b64, "signature": forged_sig },
+        })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::BAD_REQUEST,
+        "forged delegation refused: {body}"
+    );
     // Anonymous (no owner key) installs refuse issuance with 409 —
     // covered by tests/profile_api.rs for GET; here the owned path is the
     // happy case and malformed keys are rejected:


### PR DESCRIPTION
Implements ADR-0039: owner-issued sub-agent identities (harness custodies the key; daemon never sees the secret), per-request ActorContext (Owner vs deny-by-default Rider), scoped rider tokens (hashed at rest, constant-time compare, persist-or-fail revocation, cert-expiry-bound), and a sub-agent-signed capability chain so rider messages are authorized as the SUB-AGENT (not the daemon) with cryptographic provenance. /agent/sign, /exec, /owner/* remain owner-durable-only.

Review: 6-round codex adversarial + Claude loop; final APPROVE. Codex caught (and this fixes): rider posting as daemon-admin, fail-open revocation, session-token→owner escalation, unauthenticated provenance. Gates green (2959 tests; sole failure = pre-existing env addr_is_free probe, #433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements ADR-0039’s owner-certified sub-agent and scoped rider boundary, including persisted token lifecycle, per-request actor resolution, delegation-backed message provenance, and owner management APIs.
- Adds owner routes and CLI commands for sub-agent certificate and rider-token lifecycle.
- Restricts rider credentials to scoped group sends and bounded history access.
- Adds receiver-verifiable public-message provenance and signed MLS history attribution.
- Extends journal, profile, API manifest, documentation, and integration coverage.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the unusable rider-issuance CLI is fixed; the clock fail-open and contradictory Home-grant documentation should also be corrected.

The server requires a delegation capability that the advertised CLI has no way to submit, while clock conversion errors can make expired rider credentials appear valid and the API documentation conflicts with explicit Home scoping.

**Files Needing Attention:** src/cli/commands/identity.rs, src/bin/x0x.rs, src/server/rider_auth.rs, src/groups/public_message.rs, docs/api-reference.md

<details open><summary><h3>Security Review</h3></summary>

Rider expiry checks fail open if the system clock is before the Unix epoch because clock conversion errors become timestamp zero. **How this was verified:** The zero fallback is passed directly to token, delegation, and certificate checks that reject only when the supplied timestamp reaches the stored expiry.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/rider_auth.rs | Adds the scoped token store and deny-by-default actor boundary, but its clock-error fallback can accept expired credentials. |
| src/server/routes/owner.rs | Adds durable certificate and rider-token lifecycle routes with owner-only checks and delegation verification. |
| src/server/routes/named_groups.rs | Applies rider identity, scope, policy, revocation, and provenance checks to public and MLS sends. |
| src/groups/public_message.rs | Adds signed rider provenance and delegation verification to the public-message contract. |
| src/cli/commands/identity.rs | Adds owner management commands, but rider issuance omits the server-required delegation field and therefore cannot succeed. |
| docs/api-reference.md | Documents the new API but incorrectly claims Home is implicitly granted to riders. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant H as Harness
  participant O as Owner API
  participant D as Owner daemon
  participant G as Group receiver
  H->>H: Generate and retain sub-agent keypair
  H->>O: Submit public key for certification
  O-->>H: Owner-signed AgentCertificate
  H->>H: Sign delegation to daemon and group scopes
  H->>O: Request scoped rider token
  O->>O: Verify delegation and persist token hash
  O-->>H: Return one-time rider token
  H->>D: Send using rider bearer token
  D->>D: Resolve Rider ActorContext and enforce scope
  D->>G: Daemon-signed message with rider provenance
  G->>G: Verify certificate, delegation, expiry, roster policy
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/cli/commands/identity.rs:320
**Rider CLI omits delegation**

When an operator runs `x0x owner riders issue`, this request body omits the server-required `delegation` field, so `/owner/riders` always returns 400 and the advertised CLI command cannot mint a rider token.

### Issue 2
src/server/rider_auth.rs:451-456
**Clock errors bypass expiry**

If the host clock is before the Unix epoch, `unix_now_secs` returns zero and the token, certificate, and delegation expiry comparisons treat expired rider credentials as valid, allowing public or MLS group sends until the clock is corrected.

**How this was verified:** The zero fallback is passed directly to expiry checks that reject only when the supplied timestamp reaches the stored expiry.

### Issue 3
docs/api-reference.md:237-238
**Home grant documentation conflicts**

The API reference says Home is always granted, but `rider_allows_group` checks only the explicit group list. A harness following this documentation can mint a token without the Home scope and then receive 403 on Home encryption.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(groups): ADR-0039 r6 — restore fail-..."](https://github.com/saorsa-labs/x0x/commit/836224a6c803e3e618838a967ede61cee9a57b78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58233138)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Secure identity and trust](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/secure-identity-and-trust.md)
- Knowledge Base — [Trust evaluation and revocation](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/trust-and-revocation.md)
- Knowledge Base — [Group lifecycle and membership](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/group-lifecycle.md)
- Knowledge Base — [Server APIs and live streams](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api-and-live-streams.md)
</details>


<!-- /greptile_comment -->