### PR TITLE
feat(sync): ADR-0041 Tier-1 — cross-machine owner-state sync

### DIFF
--- a/docs/design/api-manifest.json
+++ b/docs/design/api-manifest.json
@@ -170,6 +170,20 @@
       "path": "/owner/riders/:id"
     },
     {
+      "category": "identity",
+      "cli_name": "sync devices",
+      "description": "ADR-0041 Tier-1: enrolled owner devices + last-sync status",
+      "method": "GET",
+      "path": "/sync/devices"
+    },
+    {
+      "category": "identity",
+      "cli_name": "sync enroll",
+      "description": "Owner-key-sign a DeviceEnrollment for a machine (ADR-0041 Tier-1; owner-gated)",
+      "method": "POST",
+      "path": "/sync/devices/enroll"
+    },
+    {
       "category": "network",
       "cli_name": "peers",
       "description": "Connected gossip peers",

--- a/docs/design/api-manifest.json
+++ b/docs/design/api-manifest.json
@@ -1,5 +1,5 @@
 {
-  "endpoint_count": 160,
+  "endpoint_count": 163,
   "endpoints": [
     {
       "category": "status",

--- a/docs/design/api-manifest.json
+++ b/docs/design/api-manifest.json
@@ -184,6 +184,13 @@
       "path": "/sync/devices/enroll"
     },
     {
+      "category": "identity",
+      "cli_name": "sync revoke",
+      "description": "Remove a machine from the owner device set (ADR-0041 Tier-1; owner-gated)",
+      "method": "DELETE",
+      "path": "/sync/devices/:machine_id"
+    },
+    {
       "category": "network",
       "cli_name": "peers",
       "description": "Connected gossip peers",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -217,6 +217,17 @@ pub const ENDPOINTS: &[EndpointDef] = &[
         path: "/owner/riders/:id",
         cli_name: "owner riders revoke",
         description: "Revoke a rider token; it fails on the next request",
+        method: Method::Get,
+        path: "/sync/devices",
+        cli_name: "sync devices",
+        description: "ADR-0041 Tier-1: enrolled owner devices + last-sync status",
+        category: "identity",
+    },
+    EndpointDef {
+        method: Method::Post,
+        path: "/sync/devices/enroll",
+        cli_name: "sync enroll",
+        description: "Owner-key-sign a DeviceEnrollment for a machine (ADR-0041 Tier-1; owner-gated)",
         category: "identity",
     },
     // ── Network ─────────────────────────────────────────────────────────

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -217,6 +217,9 @@ pub const ENDPOINTS: &[EndpointDef] = &[
         path: "/owner/riders/:id",
         cli_name: "owner riders revoke",
         description: "Revoke a rider token; it fails on the next request",
+        category: "identity",
+    },
+    EndpointDef {
         method: Method::Get,
         path: "/sync/devices",
         cli_name: "sync devices",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -230,6 +230,13 @@ pub const ENDPOINTS: &[EndpointDef] = &[
         description: "Owner-key-sign a DeviceEnrollment for a machine (ADR-0041 Tier-1; owner-gated)",
         category: "identity",
     },
+    EndpointDef {
+        method: Method::Delete,
+        path: "/sync/devices/:machine_id",
+        cli_name: "sync revoke",
+        description: "Remove a machine from the owner device set (ADR-0041 Tier-1; owner-gated)",
+        category: "identity",
+    },
     // ── Network ─────────────────────────────────────────────────────────
     EndpointDef {
         method: Method::Get,

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -102,6 +102,11 @@ enum Commands {
         #[command(subcommand)]
         sub: Option<OwnerSub>,
     },
+    /// Cross-machine owner-state sync (ADR-0041 Tier-1).
+    Sync {
+        #[command(subcommand)]
+        sub: Option<SyncSub>,
+    },
     /// Manage user identity.
     UserId {
         #[command(subcommand)]
@@ -501,6 +506,20 @@ enum OwnerRidersSub {
         /// Numeric rider-token id from `x0x owner riders`.
         #[arg(value_name = "TOKEN_ID")]
         token_id: u64,
+    },
+}
+
+/// `x0x sync` subcommands (ADR-0041 Tier-1).
+#[derive(Subcommand)]
+enum SyncSub {
+    /// List the owner device set with last-sync status per device.
+    Devices,
+    /// Enroll a machine into the owner device set (owner-key-signed).
+    /// Omit the id to enroll this machine.
+    Enroll {
+        /// Machine id (64 hex chars). Defaults to THIS machine.
+        #[arg(value_name = "MACHINE_ID")]
+        machine_id: Option<String>,
     },
 }
 
@@ -1640,6 +1659,12 @@ async fn run(
                 sub: Some(OwnerRidersSub::Revoke { token_id }),
             }) => commands::identity::owner_riders_revoke(&client, token_id).await,
         },
+        Commands::Sync { sub } => match sub {
+            None | Some(SyncSub::Devices) => commands::identity::sync_devices(&client).await,
+            Some(SyncSub::Enroll { machine_id }) => {
+                commands::identity::sync_enroll(&client, machine_id.as_deref()).await
+            }
+        },
         Commands::Health => commands::network::health(&client).await,
         Commands::Status => commands::network::status(&client).await,
         Commands::Agent { sub } => match sub {
@@ -2274,7 +2299,8 @@ x0x (v{VERSION})
 |   +-- profile           Show stored self-profile names
 |   +-- profile set       Update self-profile names (partial update)
 |   +-- owner agents      List agents certified by this install's owner
-|   +-- announce           Announce identity to network
+|   +-- sync devices      List enrolled owner devices + last-sync status
+|   +-- sync enroll       Enroll a machine into the owner device set
 |
 +-- Network
 |   +-- health             Health check

--- a/src/bin/x0x.rs
+++ b/src/bin/x0x.rs
@@ -515,14 +515,22 @@ enum SyncSub {
     /// List the owner device set with last-sync status per device.
     Devices,
     /// Enroll a machine into the owner device set (owner-key-signed).
-    /// Omit the id to enroll this machine.
     Enroll {
         /// Machine id (64 hex chars). Defaults to THIS machine.
         #[arg(value_name = "MACHINE_ID")]
         machine_id: Option<String>,
+        /// Enrollment lifetime in seconds; omit for until-revoked.
+        #[arg(long, value_name = "SECS")]
+        ttl_secs: Option<u64>,
+    },
+    /// Remove a machine from the owner device set (refused at the next
+    /// stream accept).
+    Revoke {
+        /// Machine id (64 hex chars).
+        #[arg(value_name = "MACHINE_ID")]
+        machine_id: String,
     },
 }
-
 #[derive(Subcommand)]
 enum UserIdSub {
     /// Create a new user identity keypair (ML-DSA-65). Defaults to ~/.x0x/user.key.
@@ -1661,8 +1669,12 @@ async fn run(
         },
         Commands::Sync { sub } => match sub {
             None | Some(SyncSub::Devices) => commands::identity::sync_devices(&client).await,
-            Some(SyncSub::Enroll { machine_id }) => {
-                commands::identity::sync_enroll(&client, machine_id.as_deref()).await
+            Some(SyncSub::Enroll {
+                machine_id,
+                ttl_secs,
+            }) => commands::identity::sync_enroll(&client, machine_id.as_deref(), ttl_secs).await,
+            Some(SyncSub::Revoke { machine_id }) => {
+                commands::identity::sync_revoke(&client, &machine_id).await
             }
         },
         Commands::Health => commands::network::health(&client).await,
@@ -2301,6 +2313,7 @@ x0x (v{VERSION})
 |   +-- owner agents      List agents certified by this install's owner
 |   +-- sync devices      List enrolled owner devices + last-sync status
 |   +-- sync enroll       Enroll a machine into the owner device set
+|   +-- sync revoke       Remove a machine from the owner device set
 |
 +-- Network
 |   +-- health             Health check

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -293,6 +293,16 @@ pub async fn owner_agents_issue(
         body["label"] = serde_json::json!(label);
     }
     let resp = client.post("/owner/agents/issue", &body).await?;
+/// `x0x sync` / `x0x sync devices` — GET /sync/devices (ADR-0041 Tier-1).
+pub async fn sync_devices(client: &DaemonClient) -> Result<()> {
+    client.run_get("/sync/devices").await
+}
+
+/// `x0x sync enroll [MACHINE_ID]` — POST /sync/devices/enroll. Omitting
+/// the id enrolls THIS machine into the owner device set.
+pub async fn sync_enroll(client: &DaemonClient, machine_id: Option<&str>) -> Result<()> {
+    let body = serde_json::json!({ "machine_id": machine_id });
+    let resp = client.post("/sync/devices/enroll", &body).await?;
     print_value(client.format(), &resp);
     Ok(())
 }
@@ -335,7 +345,6 @@ pub async fn owner_riders_revoke(client: &DaemonClient, token_id: u64) -> Result
         .run_delete(&format!("/owner/riders/{token_id}"))
         .await
 }
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -299,9 +299,14 @@ pub async fn sync_devices(client: &DaemonClient) -> Result<()> {
 }
 
 /// `x0x sync enroll [MACHINE_ID]` — POST /sync/devices/enroll. Omitting
-/// the id enrolls THIS machine into the owner device set.
-pub async fn sync_enroll(client: &DaemonClient, machine_id: Option<&str>) -> Result<()> {
-    let body = serde_json::json!({ "machine_id": machine_id });
+/// the id enrolls THIS machine into the owner device set; `--ttl-secs`
+/// bounds the enrollment's lifetime.
+pub async fn sync_enroll(
+    client: &DaemonClient,
+    machine_id: Option<&str>,
+    ttl_secs: Option<u64>,
+) -> Result<()> {
+    let body = serde_json::json!({ "machine_id": machine_id, "ttl_secs": ttl_secs });
     let resp = client.post("/sync/devices/enroll", &body).await?;
     print_value(client.format(), &resp);
     Ok(())
@@ -335,6 +340,11 @@ pub async fn owner_riders_issue(
         body["ttl_secs"] = serde_json::json!(ttl);
     }
     let resp = client.post("/owner/riders", &body).await?;
+/// `x0x sync revoke MACHINE_ID` — DELETE /sync/devices/:machine_id.
+pub async fn sync_revoke(client: &DaemonClient, machine_id: &str) -> Result<()> {
+    let resp = client
+        .delete(&format!("/sync/devices/{machine_id}"))
+        .await?;
     print_value(client.format(), &resp);
     Ok(())
 }
@@ -347,7 +357,6 @@ pub async fn owner_riders_revoke(client: &DaemonClient, token_id: u64) -> Result
 }
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
     use super::*;
     use crate::cli::{DaemonClient, OutputFormat};
 

--- a/src/cli/commands/identity.rs
+++ b/src/cli/commands/identity.rs
@@ -293,6 +293,10 @@ pub async fn owner_agents_issue(
         body["label"] = serde_json::json!(label);
     }
     let resp = client.post("/owner/agents/issue", &body).await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}
+
 /// `x0x sync` / `x0x sync devices` — GET /sync/devices (ADR-0041 Tier-1).
 pub async fn sync_devices(client: &DaemonClient) -> Result<()> {
     client.run_get("/sync/devices").await
@@ -340,6 +344,10 @@ pub async fn owner_riders_issue(
         body["ttl_secs"] = serde_json::json!(ttl);
     }
     let resp = client.post("/owner/riders", &body).await?;
+    print_value(client.format(), &resp);
+    Ok(())
+}
+
 /// `x0x sync revoke MACHINE_ID` — DELETE /sync/devices/:machine_id.
 pub async fn sync_revoke(client: &DaemonClient, machine_id: &str) -> Result<()> {
     let resp = client

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -4162,6 +4162,15 @@ function renderSettings(){
     <div class="row"><input id="set-name" value="${esc(LS.get('display_name',''))}" placeholder="Your name"><button class="pri" onclick="saveName()">Save</button></div>
     <div style="font-size:11px;color:var(--tx3);margin-top:4px">Shown in chat messages and your identity card.</div>
   </div>
+  <div class="card mb2" id="sync-panel">
+    <h3 style="margin-top:0">Cross-Machine Sync (Tier 1)</h3>
+    <p style="font-size:11px;color:var(--tx3);margin:0 0 var(--sp2)">Owner-enrolled devices replicate names, the Home roster, and the agent issuance journal between your machines (ADR-0041).</p>
+    <div id="sync-devices" style="font-size:12px;color:var(--tx2)">Loading devices…</div>
+    <div class="row" style="gap:var(--sp2);margin-top:var(--sp2)">
+      <button class="pri" onclick="enrollThisMachine()">&#128279; Enroll This Machine</button>
+      <button onclick="loadSyncDevices()">Refresh</button>
+    </div>
+  </div>
   <div class="card mb2">
     <h3 style="margin-top:0">Symphony Daemon</h3>
     <div class="row" style="gap:var(--sp2);flex-wrap:wrap">
@@ -4191,7 +4200,33 @@ function renderSettings(){
   </div>`;
 }
 
-function mountSettings(){}
+function mountSettings(){loadSyncDevices();}
+
+async function loadSyncDevices(){
+  const el=document.getElementById('sync-devices');
+  if(!el)return;
+  const r=await api('/sync/devices');
+  if(!r||!r._http_ok){
+    el.innerHTML=r&&r.error?esc(r.error):'Sync unavailable (no owner identity configured).';
+    return;
+  }
+  const devices=r.devices||[];
+  if(!devices.length){el.innerHTML='No devices enrolled yet.';return;}
+  el.innerHTML='<table style="width:100%;border-collapse:collapse;font-size:12px">'+
+    '<tr style="color:var(--tx3);text-align:left"><th style="padding:2px 6px">Machine</th><th style="padding:2px 6px">Enrolled</th><th style="padding:2px 6px">Last sync</th></tr>'+
+    devices.map(d=>{
+      const mid=String(d.machine_id||'').slice(0,12)+'…';
+      const enrolled=d.enrolled_at_ms?new Date(d.enrolled_at_ms).toLocaleString():'—';
+      const last=d.last_session_ms?(new Date(d.last_session_ms).toLocaleString()+(d.last_session_ok?'':' (failed)')):'never';
+      return `<tr><td style="padding:2px 6px">${esc(mid)}${d.is_this_machine?' <span style="color:var(--lv)">(this machine)</span>':''}</td><td style="padding:2px 6px">${esc(enrolled)}</td><td style="padding:2px 6px">${esc(last)}</td></tr>`;
+    }).join('')+'</table>';
+}
+
+async function enrollThisMachine(){
+  const r=await api('/sync/devices/enroll',{method:'POST',body:JSON.stringify({})});
+  if(r&&r._http_ok){toast('Machine enrolled into the owner device set','success');loadSyncDevices();}
+  else{toast(r&&r.error?r.error:'Enroll failed','error');}
+}
 
 function setTheme(theme){
   LS.set('theme',theme);

--- a/src/gui/x0x-gui.html
+++ b/src/gui/x0x-gui.html
@@ -4213,12 +4213,13 @@ async function loadSyncDevices(){
   const devices=r.devices||[];
   if(!devices.length){el.innerHTML='No devices enrolled yet.';return;}
   el.innerHTML='<table style="width:100%;border-collapse:collapse;font-size:12px">'+
-    '<tr style="color:var(--tx3);text-align:left"><th style="padding:2px 6px">Machine</th><th style="padding:2px 6px">Enrolled</th><th style="padding:2px 6px">Last sync</th></tr>'+
+    '<tr style="color:var(--tx3);text-align:left"><th style="padding:2px 6px">Machine</th><th style="padding:2px 6px">Enrolled</th><th style="padding:2px 6px">Last sync</th><th style="padding:2px 6px"></th></tr>'+
     devices.map(d=>{
       const mid=String(d.machine_id||'').slice(0,12)+'…';
       const enrolled=d.enrolled_at_ms?new Date(d.enrolled_at_ms).toLocaleString():'—';
+      const exp=d.expires_at_ms?(' · expires '+new Date(d.expires_at_ms).toLocaleString()):'';
       const last=d.last_session_ms?(new Date(d.last_session_ms).toLocaleString()+(d.last_session_ok?'':' (failed)')):'never';
-      return `<tr><td style="padding:2px 6px">${esc(mid)}${d.is_this_machine?' <span style="color:var(--lv)">(this machine)</span>':''}</td><td style="padding:2px 6px">${esc(enrolled)}</td><td style="padding:2px 6px">${esc(last)}</td></tr>`;
+      return `<tr><td style="padding:2px 6px">${esc(mid)}${d.is_this_machine?' <span style="color:var(--lv)">(this machine)</span>':''}</td><td style="padding:2px 6px">${esc(enrolled+exp)}</td><td style="padding:2px 6px">${esc(last)}</td><td style="padding:2px 6px"><button style="padding:2px 8px;font-size:11px" onclick="revokeSyncDevice('${escJs(String(d.machine_id||''))}')">Revoke</button></td></tr>`;
     }).join('')+'</table>';
 }
 
@@ -4226,6 +4227,12 @@ async function enrollThisMachine(){
   const r=await api('/sync/devices/enroll',{method:'POST',body:JSON.stringify({})});
   if(r&&r._http_ok){toast('Machine enrolled into the owner device set','success');loadSyncDevices();}
   else{toast(r&&r.error?r.error:'Enroll failed','error');}
+}
+
+async function revokeSyncDevice(machineId){
+  const r=await api('/sync/devices/'+encodeURIComponent(machineId),{method:'DELETE'});
+  if(r&&r._http_ok){toast('Machine revoked from the owner device set','success');loadSyncDevices();}
+  else{toast(r&&r.error?r.error:'Revoke failed','error');}
 }
 
 function setTheme(theme){

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3359,18 +3359,6 @@ impl Agent {
         self.identity.user_id()
     }
 
-    /// Path of the owner certificate journal (`owner-cert-journal.jsonl`)
-    /// this agent appends to at certificate-issue time, if any.
-    ///
-    /// `None` when no user identity is configured. Exposed for ADR-0041
-    /// Tier-1 sync, which mirrors journal lines across the owner's
-    /// machines.
-    #[inline]
-    #[must_use]
-    pub fn cert_journal_path(&self) -> Option<&std::path::Path> {
-        self.cert_journal_path.as_deref()
-    }
-
     /// Get the agent certificate, if one exists.
     ///
     /// The certificate cryptographically binds this agent to a user identity.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,10 @@ pub mod storage;
 /// gossip-fed set consulted at every trust gate.
 pub mod revocation;
 
+/// ADR-0041 Tier-1 cross-machine owner-state sync (owner-signed versioned
+/// records over `SyncV1` streams between the owner's enrolled machines).
+pub mod owner_sync;
+
 pub mod announce_blob;
 /// V3 identity announcement (L3 slimming — merged + digest, self-verifying).
 pub mod announce_v3;
@@ -3353,6 +3357,18 @@ impl Agent {
     #[must_use]
     pub fn user_id(&self) -> Option<identity::UserId> {
         self.identity.user_id()
+    }
+
+    /// Path of the owner certificate journal (`owner-cert-journal.jsonl`)
+    /// this agent appends to at certificate-issue time, if any.
+    ///
+    /// `None` when no user identity is configured. Exposed for ADR-0041
+    /// Tier-1 sync, which mirrors journal lines across the owner's
+    /// machines.
+    #[inline]
+    #[must_use]
+    pub fn cert_journal_path(&self) -> Option<&std::path::Path> {
+        self.cert_journal_path.as_deref()
     }
 
     /// Get the agent certificate, if one exists.

--- a/src/owner_sync.rs
+++ b/src/owner_sync.rs
@@ -96,24 +96,42 @@ pub const SYNC_PROTOCOL_VERSION: u32 = 2;
 /// are tiny; anything larger is hostile or corrupt — fail closed.
 pub const MAX_FRAME_BYTES: u32 = 256 * 1024;
 
-/// Version-vector entries per `VersionVector` frame (paging keeps any one
-/// frame far below [`MAX_FRAME_BYTES`] and the writer inside the QUIC
-/// stream window even when the peer has not started reading).
+/// Version-vector entries per `VersionVector` frame (an upper bound; the
+/// byte budget below usually splits earlier). Paging keeps any one frame
+/// far below [`MAX_FRAME_BYTES`] and the writer inside the QUIC stream
+/// window even when the peer has not started reading.
 pub const VV_ENTRIES_PER_FRAME: usize = 256;
 
-/// Records per `Records` frame.
+/// Byte budget for one `VersionVector` frame.
+pub const VV_PAGE_BYTES: usize = 64 * 1024;
+
+/// Records per `Records` frame (an upper bound; the byte budget below
+/// splits earlier when values are large — review R3 finding 5).
 pub const RECORDS_PER_FRAME: usize = 16;
+
+/// Byte budget for one `Records` frame. A single record larger than the
+/// budget still ships alone: values are capped at [`MAX_VALUE_BYTES`], so
+/// any one frame stays far below [`MAX_FRAME_BYTES`].
+pub const RECORDS_PAGE_BYTES: usize = 64 * 1024;
 
 /// Total version-vector entries a session will accept (both directions of
 /// the state space are bounded; beyond this the peer is hostile).
 pub const MAX_VECTOR_ENTRIES: usize = 4096;
 
-/// Total records a session will accept in one batch.
-pub const MAX_RECORDS_PER_SESSION: usize = 1024;
+/// Total records a session will accept in one batch. Equal to the store
+/// capacity so a fresh peer can atomically synchronize a FULL valid store
+/// (review R3 finding 5).
+pub const MAX_RECORDS_PER_SESSION: usize = MAX_STORED_RECORDS;
 
 /// Hard cap on stored (winning) records. Tier-1 state is small by design;
 /// exceeding this is a StoreLimit failure, never silent truncation.
 pub const MAX_STORED_RECORDS: usize = 4096;
+
+/// Maximum serialized [`SyncValue`] size in bytes (review R3 finding 5:
+/// values are bounded so no legal record — and no 16-record page — can
+/// exceed the frame limit). Oversize values are rejected at verify and at
+/// mint.
+pub const MAX_VALUE_BYTES: usize = 64 * 1024;
 
 /// Maximum record key length in bytes.
 pub const MAX_KEY_BYTES: usize = 256;
@@ -377,12 +395,20 @@ impl VersionedRecord {
                 self.key.len()
             )));
         }
+        let value_bytes = bincode::serialize(&self.value)
+            .map_err(|e| SyncError::BadSignature(format!("value encode: {e}")))?;
+        if value_bytes.len() > MAX_VALUE_BYTES {
+            // Bounded values keep every legal page under the frame cap
+            // (review R3 finding 5).
+            return Err(SyncError::MalformedFrame(format!(
+                "record value of {} bytes exceeds limit {MAX_VALUE_BYTES}",
+                value_bytes.len()
+            )));
+        }
         let owner_pubkey = MlDsaPublicKey::from_bytes(&self.owner_public_key)
             .map_err(|_| SyncError::BadSignature("invalid owner public key".into()))?;
         let signature = MlDsaSignature::from_bytes(&self.signature)
             .map_err(|e| SyncError::BadSignature(format!("invalid signature format: {e:?}")))?;
-        let value_bytes = bincode::serialize(&self.value)
-            .map_err(|e| SyncError::BadSignature(format!("value encode: {e}")))?;
         let message = Self::canonical_message(&self.kind, &self.key, &self.clock, &value_bytes);
         verify_with_ml_dsa(&owner_pubkey, &message, &signature)
             .map_err(|e| SyncError::BadSignature(format!("bad signature: {e:?}")))?;
@@ -762,42 +788,33 @@ pub struct CommitOutcome {
 
 impl OwnerSyncStore {
     /// Load (or start empty under) `<data_dir>/sync`, creating the
-    /// directory. Corrupt or missing files start empty — the next session
-    /// re-derives Tier-1 state from a live peer, and records are
-    /// owner-signed so poison dies at verify.
+    /// directory. **Only genuine absence is empty** (fresh install): a
+    /// records/devices file that exists but is corrupt or unreadable is a
+    /// HARD error — silently starting with an empty anti-rollback store
+    /// would let an old owner-signed record win again (review R3
+    /// finding 2).
     ///
     /// # Errors
     ///
-    /// [`SyncError::Io`] when the directory cannot be created — persistence
-    /// would silently fail forever, so construction fails instead
-    /// (review R2 finding 2).
+    /// [`SyncError::Io`] when the directory cannot be created, or a state
+    /// file exists but cannot be read or parsed.
     pub async fn load(data_dir: &Path) -> Result<Self, SyncError> {
         let dir = data_dir.join(SYNC_DIR);
         tokio::fs::create_dir_all(&dir).await.map_err(|e| {
             SyncError::Io(format!("failed to create sync dir {}: {e}", dir.display()))
         })?;
-        let records = match tokio::fs::read(dir.join(RECORDS_FILE)).await {
-            Ok(bytes) => serde_json::from_slice::<PersistedRecords>(&bytes)
-                .map(|p| {
-                    p.records
-                        .into_iter()
-                        .map(|r| ((r.kind, r.key.clone()), r))
-                        .collect::<BTreeMap<_, _>>()
-                })
-                .unwrap_or_default(),
-            Err(_) => BTreeMap::new(),
-        };
-        let devices = match tokio::fs::read(dir.join(DEVICES_FILE)).await {
-            Ok(bytes) => serde_json::from_slice::<PersistedDevices>(&bytes)
-                .map(|p| {
-                    p.devices
-                        .into_iter()
-                        .map(|d| (d.machine_id, d))
-                        .collect::<BTreeMap<_, _>>()
-                })
-                .unwrap_or_default(),
-            Err(_) => BTreeMap::new(),
-        };
+        let persisted_records: PersistedRecords = Self::load_json(&dir.join(RECORDS_FILE)).await?;
+        let persisted_devices: PersistedDevices = Self::load_json(&dir.join(DEVICES_FILE)).await?;
+        let records = persisted_records
+            .records
+            .into_iter()
+            .map(|r| ((r.kind, r.key.clone()), r))
+            .collect::<BTreeMap<_, _>>();
+        let devices = persisted_devices
+            .devices
+            .into_iter()
+            .map(|d| (d.machine_id, d))
+            .collect::<BTreeMap<_, _>>();
         let (generation_tx, _) = tokio::sync::watch::channel(0);
         Ok(Self {
             dir,
@@ -808,14 +825,54 @@ impl OwnerSyncStore {
         })
     }
 
-    /// Write `bytes` to `path` via a unique temp file + rename (atomic for
-    /// same-directory renames; mirrors `src/profile.rs`).
+    /// Read a persisted state file: `NotFound` → default (fresh install);
+    /// any other read error, or a parse error, → hard error. Never a
+    /// silent fallback to empty (review R3 finding 2).
+    async fn load_json<T: serde::de::DeserializeOwned + Default>(
+        path: &Path,
+    ) -> Result<T, SyncError> {
+        match tokio::fs::read(path).await {
+            Ok(bytes) => serde_json::from_slice(&bytes).map_err(|e| {
+                SyncError::Io(format!(
+                    "corrupt sync state file {}: {e} — refusing to start with an empty store",
+                    path.display()
+                ))
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(T::default()),
+            Err(e) => Err(SyncError::Io(format!(
+                "unreadable sync state file {}: {e}",
+                path.display()
+            ))),
+        }
+    }
+
+    /// Write `bytes` to `path` durably and atomically: unique temp file →
+    /// fsync the temp file (data durable) → rename over the target →
+    /// fsync the target file and its parent directory (the rename entry
+    /// durable). A crash after a successful persist can no longer lose the
+    /// durable state the caller just verified (review R3 finding 2).
     async fn write_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+        use tokio::io::AsyncWriteExt as _;
         static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let unique = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let tmp = path.with_extension(format!("tmp-{}-{unique}", std::process::id()));
-        tokio::fs::write(&tmp, bytes).await?;
-        tokio::fs::rename(&tmp, path).await
+        let mut file = tokio::fs::File::create(&tmp).await?;
+        file.write_all(bytes).await?;
+        file.sync_all().await?;
+        drop(file);
+        tokio::fs::rename(&tmp, path).await?;
+        // fsync the renamed file and the parent directory so the new name
+        // survives a crash. (Directory fds support fsync on Unix.)
+        let target = tokio::fs::File::open(path).await?;
+        target.sync_all().await?;
+        #[cfg(unix)]
+        if let Some(parent) = path.parent() {
+            let dir = tokio::fs::File::open(parent).await?;
+            dir.sync_all().await?;
+        }
+        #[cfg(not(unix))]
+        let _ = path.parent();
+        Ok(())
     }
 
     /// Persist the winning records. Errors PROPAGATE — callers never report
@@ -962,10 +1019,17 @@ impl OwnerSyncStore {
     /// Commit a verified batch atomically (review R2 finding 4): all
     /// classification decisions are made against the live map, all accepted
     /// records inserted, and ONE file write persists the result. On any
-    /// failure the in-memory map is rolled back and the error propagates —
-    /// a partial batch is never committed or advertised.
+    /// failure the in-memory map is rolled back to its **pre-batch** state
+    /// — each key's pre-batch value is captured ONCE, on its first touch
+    /// in the batch, so a key replaced twice in a failing batch restores
+    /// the original, not an intermediate replacement (review R3 finding 4)
+    /// — and the error propagates. A partial batch is never committed or
+    /// advertised.
     ///
     /// Records must have been verified (`verify_owner`) by the caller.
+    /// Callers must NOT hold this future inside a cancellable timeout: the
+    /// rollback paths assume the await completes (the session wrapper
+    /// commits outside its time budget for exactly that reason).
     ///
     /// # Errors
     ///
@@ -977,7 +1041,8 @@ impl OwnerSyncStore {
         owner: &UserId,
     ) -> Result<CommitOutcome, SyncError> {
         let mut records = self.records.write().await;
-        let mut touched: Vec<((SyncKind, String), Option<VersionedRecord>)> = Vec::new();
+        // (kind, key) → the value held BEFORE this batch first touched it.
+        let mut touched: BTreeMap<(SyncKind, String), Option<VersionedRecord>> = BTreeMap::new();
         let mut outcome = CommitOutcome::default();
         let result = (|| -> Result<(), SyncError> {
             for record in batch {
@@ -991,7 +1056,8 @@ impl OwnerSyncStore {
                         "store at capacity ({MAX_STORED_RECORDS} records)"
                     )));
                 }
-                let stored = records.get(&(record.kind, record.key.clone()));
+                let key = (record.kind, record.key.clone());
+                let stored = records.get(&key);
                 // Equal clock with different signed content is an
                 // equivocation whichever side wins the hash tie-break —
                 // surfaced, never silently merged (review R2 finding 3).
@@ -1009,16 +1075,18 @@ impl OwnerSyncStore {
                 let decision = stored.map(|existing| Self::classify(&record, existing));
                 match decision {
                     None => {
-                        touched.push(((record.kind, record.key.clone()), None));
-                        records.insert((record.kind, record.key.clone()), record.clone());
+                        // First touch of a fresh key: pre-batch value None.
+                        touched.entry(key.clone()).or_insert(None);
+                        records.insert(key, record.clone());
                         outcome.accepted.push(record);
                     }
                     Some(MergeOutcome::Accepted) => {
-                        if let Some(prev) =
-                            records.insert((record.kind, record.key.clone()), record.clone())
-                        {
-                            touched.push(((record.kind, record.key.clone()), Some(prev)));
-                        }
+                        // Capture the pre-batch value ONCE (entry.or_insert
+                        // keeps the first capture even on repeat touches).
+                        touched
+                            .entry(key.clone())
+                            .or_insert_with(|| stored.cloned());
+                        records.insert(key, record.clone());
                         outcome.accepted.push(record);
                     }
                     Some(MergeOutcome::Superseded) => {
@@ -1052,10 +1120,11 @@ impl OwnerSyncStore {
         }
     }
 
-    /// Restore the in-memory map to its pre-batch state.
+    /// Restore the in-memory map to its pre-batch state: every touched key
+    /// returns to the value captured on its FIRST touch in the batch.
     fn rollback(
         records: &mut BTreeMap<(SyncKind, String), VersionedRecord>,
-        touched: &[((SyncKind, String), Option<VersionedRecord>)],
+        touched: &BTreeMap<(SyncKind, String), Option<VersionedRecord>>,
     ) {
         for ((kind, key), previous) in touched {
             match previous {
@@ -1103,6 +1172,14 @@ impl OwnerSyncStore {
         owner: &UserKeypair,
         writer_machine: MachineId,
     ) -> Result<(), SyncError> {
+        let value_bytes = bincode::serialize(desired)
+            .map_err(|e| SyncError::BadSignature(format!("value encode: {e}")))?;
+        if value_bytes.len() > MAX_VALUE_BYTES {
+            return Err(SyncError::MalformedFrame(format!(
+                "value of {} bytes exceeds limit {MAX_VALUE_BYTES}",
+                value_bytes.len()
+            )));
+        }
         let now_ms = now_unix_ms();
         let mut records = self.records.write().await;
         let stored = records.get(&(kind, key.to_string()));
@@ -1316,36 +1393,49 @@ where
     R: AsyncRead + Unpin,
     F: FnMut(&VersionedRecord),
 {
-    tokio::time::timeout(
+    // The NETWORK protocol runs under the budget; the durable commit runs
+    // OUTSIDE it, after the timeout future has completed. Cancelling at the
+    // budget can therefore never rip a persistence await out from under
+    // commit_batch's rollback paths (review R3 finding 4).
+    let pending = tokio::time::timeout(
         budget,
-        run_sync_session_inner(
-            send,
-            recv,
-            store,
-            owner,
-            local_machine,
-            peer_machine,
-            &mut on_accept,
-        ),
+        negotiate_sync_session(send, recv, store, owner, local_machine, peer_machine),
     )
     .await
-    .map_err(|_| SyncError::SessionTimeout)?
+    .map_err(|_| SyncError::SessionTimeout)??;
+    let owner_id = owner.user_id();
+    let outcome = store.commit_batch(pending.verified, &owner_id).await?;
+    let mut summary = pending.summary;
+    summary.accepted = outcome.accepted.len();
+    summary.superseded = outcome.superseded;
+    summary.equivocations = outcome.equivocations;
+    // Apply committed records only now, so partial sessions never mutate
+    // live daemon state.
+    for record in outcome.accepted {
+        on_accept(&record);
+    }
+    Ok(summary)
 }
 
-/// The session body (no timeout wrapper).
-async fn run_sync_session_inner<S, R, F>(
+/// A session that cleared every gate and exchange but has not yet committed.
+struct PendingCommit {
+    summary: SessionSummary,
+    verified: Vec<VersionedRecord>,
+}
+
+/// The network protocol body (no timeout wrapper, no commit — the caller
+/// commits the verified batch outside the time budget).
+async fn negotiate_sync_session<S, R>(
     send: &mut S,
     recv: &mut R,
     store: &OwnerSyncStore,
     owner: &UserKeypair,
     local_machine: &MachineId,
     peer_machine: &MachineId,
-    on_accept: &mut F,
-) -> Result<SessionSummary, SyncError>
+) -> Result<PendingCommit, SyncError>
 where
     S: AsyncWrite + Unpin,
     R: AsyncRead + Unpin,
-    F: FnMut(&VersionedRecord),
 {
     let owner_id = owner.user_id();
     let mut summary = SessionSummary::default();
@@ -1447,25 +1537,16 @@ where
     write_frame(send, &SyncFrame::Done).await?;
 
     // Receive the peer's paged records (terminated by their Done or an
-    // Abort); verify EVERY record before any commit — one forgery aborts
-    // with nothing stored (review R2 finding 4).
+    // Abort); verify EVERY record before returning — one forgery aborts
+    // with nothing stored (review R2 finding 4). The caller commits the
+    // verified batch atomically, outside the session's time budget.
     let inbound = read_paged_records(recv).await?;
     let mut verified = Vec::with_capacity(inbound.len());
     for record in inbound {
         record.verify_owner(&owner_id)?;
         verified.push(record);
     }
-    let outcome = store.commit_batch(verified, &owner_id).await?;
-    summary.accepted = outcome.accepted.len();
-    summary.superseded = outcome.superseded;
-    summary.equivocations = outcome.equivocations;
-
-    // Apply committed records after the clean Done so partial sessions never
-    // mutate live daemon state.
-    for record in outcome.accepted {
-        on_accept(&record);
-    }
-    Ok(summary)
+    Ok(PendingCommit { summary, verified })
 }
 
 /// Write the version table as bounded pages (always at least one page, so
@@ -1474,14 +1555,35 @@ async fn write_paged_vector<S: AsyncWrite + Unpin>(
     send: &mut S,
     vector: &[KindVersions],
 ) -> Result<(), SyncError> {
-    // Each frame carries one kind with at most VV_ENTRIES_PER_FRAME entries.
+    // Each frame carries one kind with at most VV_ENTRIES_PER_FRAME
+    // entries AND at most ~VV_PAGE_BYTES of serialized entries (byte
+    // budget; review R3 finding 5).
+    const ENTRY_OVERHEAD_BYTES: usize = 96; // clock (48) + hash (32) + framing
     let mut pages: Vec<KindVersions> = Vec::new();
     for kv in vector {
-        for chunk in kv.entries.chunks(VV_ENTRIES_PER_FRAME) {
-            pages.push(KindVersions {
-                kind: kv.kind,
-                entries: chunk.to_vec(),
-            });
+        let mut current = KindVersions {
+            kind: kv.kind,
+            entries: Vec::new(),
+        };
+        let mut current_bytes = 0usize;
+        for entry in &kv.entries {
+            let entry_bytes = entry.0.len() + ENTRY_OVERHEAD_BYTES;
+            if !current.entries.is_empty()
+                && (current.entries.len() >= VV_ENTRIES_PER_FRAME
+                    || current_bytes + entry_bytes > VV_PAGE_BYTES)
+            {
+                pages.push(current);
+                current = KindVersions {
+                    kind: kv.kind,
+                    entries: Vec::new(),
+                };
+                current_bytes = 0;
+            }
+            current_bytes += entry_bytes;
+            current.entries.push(entry.clone());
+        }
+        if !current.entries.is_empty() {
+            pages.push(current);
         }
     }
     for page in pages {
@@ -1507,6 +1609,16 @@ async fn read_paged_vector<R: AsyncRead + Unpin>(
                         return Err(SyncError::TooManyRecords(format!(
                             "version vector exceeds {MAX_VECTOR_ENTRIES} entries"
                         )));
+                    }
+                    for (key, ..) in &kv.entries {
+                        if key.len() > MAX_KEY_BYTES {
+                            // Structural bound, same as records (review R3
+                            // finding 5).
+                            return Err(SyncError::MalformedFrame(format!(
+                                "vector key of {} bytes exceeds limit {MAX_KEY_BYTES}",
+                                key.len()
+                            )));
+                        }
                     }
                     merged.entry(kv.kind).or_default().extend(kv.entries);
                 }
@@ -1703,35 +1815,45 @@ impl OwnerSyncService {
         Some((owner, self.agent.machine_id()))
     }
 
-    /// Spawn the inbound acceptor drain loop. Each accepted stream is
-    /// enrollment-gated, then runs one session under a concurrency permit.
+    /// Spawn the inbound acceptor drain loop. A session permit is acquired
+    /// IN THE LOOP, BEFORE the per-stream task is spawned (review R3
+    /// finding 5): the permit moves into the task, so the set of live
+    /// session tasks is bounded by the semaphore — a flood of inbound
+    /// streams cannot spawn unbounded tasks. Without a permit the stream
+    /// is dropped (reset) right there.
     async fn spawn_acceptor_loop(self: &Arc<Self>, mut acceptor: crate::streams::StreamAcceptor) {
         let service = Arc::clone(self);
         let task = tokio::spawn(async move {
             while let Some(stream) = acceptor.next().await {
+                let permit = match service.session_permits.clone().try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        tracing::warn!(
+                            target: "x0x::owner_sync",
+                            "SyncV1 stream dropped: session limit reached"
+                        );
+                        continue; // drop => reset, fail closed and bounded
+                    }
+                };
                 let service = Arc::clone(&service);
-                tokio::spawn(async move { service.handle_inbound(stream).await });
+                tokio::spawn(async move { service.handle_inbound(stream, permit).await });
             }
         });
         self.tasks.lock().await.push(task);
     }
 
     /// Inbound path: the ADR-0022 machine identity gates have already
-    /// cleared in the shared accept loop; enforce the owner device set
-    /// (blocker 30) — an unenrolled machine's stream is dropped (reset)
-    /// with zero application bytes read. A session permit is REQUIRED
-    /// before any protocol byte: without one the stream is dropped, so a
-    /// flood of streams cannot wedge an unbounded task set.
-    async fn handle_inbound(&self, stream: crate::streams::PeerStream) {
+    /// cleared in the shared accept loop; the caller holds the session
+    /// permit (acquired before this task was spawned). Enforce the owner
+    /// device set (blocker 30) — an unenrolled machine's stream is dropped
+    /// (reset) with zero application bytes read.
+    async fn handle_inbound(
+        &self,
+        stream: crate::streams::PeerStream,
+        _permit: tokio::sync::OwnedSemaphorePermit,
+    ) {
         let Some(owner_kp) = self.owner_kp() else {
             return;
-        };
-        let Ok(permit) = self.session_permits.clone().try_acquire_owned() else {
-            tracing::warn!(
-                target: "x0x::owner_sync",
-                "SyncV1 stream dropped: session limit reached"
-            );
-            return; // drop => reset, fail closed and bounded
         };
         let local_machine = self.agent.machine_id();
         let peer = stream.peer();
@@ -1754,7 +1876,6 @@ impl OwnerSyncService {
             |record| self.apply_record(record),
         )
         .await;
-        drop(permit);
         match result {
             Ok(summary) => {
                 tracing::debug!(
@@ -2064,22 +2185,22 @@ impl Drop for OwnerSyncService {
 mod tests {
     use super::*;
 
-    fn owner_kp(seed: u8) -> UserKeypair {
+    pub(in crate::owner_sync) fn owner_kp(seed: u8) -> UserKeypair {
         UserKeypair::from_seed(&[seed; 32]).expect("deterministic keypair")
     }
 
-    fn machine(id: u8) -> MachineId {
+    pub(in crate::owner_sync) fn machine(id: u8) -> MachineId {
         MachineId([id; 32])
     }
 
-    fn names_value(display: &str) -> SyncValue {
+    pub(in crate::owner_sync) fn names_value(display: &str) -> SyncValue {
         SyncValue::MachineNames {
             display_name: Some(display.to_string()),
             machine_name: None,
         }
     }
 
-    fn clock(version: u64, ts: u64, writer: u8) -> RecordClock {
+    pub(in crate::owner_sync) fn clock(version: u64, ts: u64, writer: u8) -> RecordClock {
         RecordClock {
             version,
             signed_at_ms: ts,
@@ -2087,7 +2208,21 @@ mod tests {
         }
     }
 
-    fn sign_names(
+    /// Cross-enroll two machines under `owner` for r3 session tests.
+    pub(in crate::owner_sync) async fn cross_enroll_for_tests(
+        a: &OwnerSyncStore,
+        b: &OwnerSyncStore,
+        owner: &UserKeypair,
+    ) {
+        a.enroll(OwnerEnrollment::sign(machine(2), owner, 1_000, None).unwrap())
+            .await
+            .unwrap();
+        b.enroll(OwnerEnrollment::sign(machine(1), owner, 1_000, None).unwrap())
+            .await
+            .unwrap();
+    }
+
+    pub(in crate::owner_sync) fn sign_names(
         key: &str,
         display: &str,
         clock: RecordClock,
@@ -2742,5 +2877,279 @@ mod tests {
         .expect_err("stalled peer must time out");
         assert_eq!(err, SyncError::SessionTimeout);
         peer_hello.abort();
+    }
+}
+
+#[cfg(test)]
+mod r3_tests {
+    use super::tests::{clock, machine, names_value, owner_kp, sign_names};
+    use super::*;
+
+    #[tokio::test]
+    async fn corrupt_or_unreadable_state_files_fail_loud() {
+        // WHY: review R3 finding 2 — a records/devices file that EXISTS
+        // but is corrupt or unreadable must be a hard error, never a
+        // silent fallback to an empty anti-rollback store. Only genuine
+        // absence (fresh install) is empty.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let sync_dir = dir.path().join(SYNC_DIR);
+        tokio::fs::create_dir_all(&sync_dir).await.unwrap();
+
+        // Fresh install (both files absent) → empty store, Ok.
+        let store = OwnerSyncStore::load(dir.path()).await.expect("fresh load");
+        assert!(store.records_snapshot().await.is_empty());
+        assert!(store.enrolled_devices().await.is_empty());
+
+        // Corrupt records.json → Err.
+        tokio::fs::write(sync_dir.join(RECORDS_FILE), b"{ not json")
+            .await
+            .unwrap();
+        let err = match OwnerSyncStore::load(dir.path()).await {
+            Err(e) => e,
+            Ok(_) => panic!("corrupt records must fail loud"),
+        };
+        assert!(err.to_string().contains("refusing to start"), "{err}");
+        tokio::fs::remove_file(sync_dir.join(RECORDS_FILE))
+            .await
+            .unwrap();
+
+        // Corrupt devices.json → Err.
+        tokio::fs::write(sync_dir.join(DEVICES_FILE), b"]]]")
+            .await
+            .unwrap();
+        assert!(OwnerSyncStore::load(dir.path()).await.is_err());
+
+        // Unreadable (permission-denied) records.json → Err (Unix only).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tokio::fs::remove_file(sync_dir.join(DEVICES_FILE))
+                .await
+                .unwrap();
+            tokio::fs::write(sync_dir.join(RECORDS_FILE), b"{}")
+                .await
+                .unwrap();
+            std::fs::set_permissions(
+                sync_dir.join(RECORDS_FILE),
+                std::fs::Permissions::from_mode(0o000),
+            )
+            .unwrap();
+            let result = OwnerSyncStore::load(dir.path()).await;
+            std::fs::set_permissions(
+                sync_dir.join(RECORDS_FILE),
+                std::fs::Permissions::from_mode(0o644),
+            )
+            .unwrap();
+            assert!(result.is_err(), "unreadable state file must fail loud");
+        }
+    }
+
+    #[tokio::test]
+    async fn rollback_restores_pre_batch_value_not_first_replacement() {
+        // WHY: review R3 finding 4 — a batch that replaces the SAME key
+        // twice and then fails (persistence error here) must restore the
+        // PRE-BATCH value, not the first replacement.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
+        let owner = owner_kp(1);
+        let owner_id = owner.user_id();
+        let key = "double";
+        let pre = sign_names(key, "pre", clock(1, 1, 1), &owner);
+        store
+            .commit_batch(vec![pre.clone()], &owner_id)
+            .await
+            .expect("seed");
+
+        // Break persistence, then commit a batch replacing the key twice.
+        let sync_dir = dir.path().join(SYNC_DIR);
+        std::fs::remove_dir_all(&sync_dir).unwrap();
+        std::fs::write(&sync_dir, b"not a directory").unwrap();
+        let batch = vec![
+            sign_names(key, "first-replacement", clock(2, 2, 1), &owner),
+            sign_names(key, "second-replacement", clock(3, 3, 1), &owner),
+        ];
+        assert!(store.commit_batch(batch, &owner_id).await.is_err());
+
+        // The store holds the PRE-batch value, not the first replacement.
+        let snapshot = store.records_snapshot().await;
+        assert_eq!(snapshot.len(), 1, "one record");
+        assert_eq!(snapshot[0].value, names_value("pre"));
+        assert_eq!(snapshot[0].clock.version, 1, "pre-batch clock restored");
+    }
+
+    #[tokio::test]
+    async fn oversize_values_rejected_at_verify_and_mint() {
+        // WHY: review R3 finding 5 — values are bounded so no legal record
+        // or page can exceed the frame limit.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
+        let owner = owner_kp(1);
+
+        let huge = SyncValue::IssuanceJournal {
+            agent_id: "a".into(),
+            cert_digest: "x".repeat(MAX_VALUE_BYTES + 1024),
+            issued_at: 1,
+            not_after: None,
+        };
+        // mint refuses before signing.
+        let err = store
+            .mint(SyncKind::IssuanceJournal, "a", &huge, &owner, machine(1))
+            .await
+            .expect_err("oversize value must not mint");
+        assert!(matches!(err, SyncError::MalformedFrame(_)), "{err:?}");
+
+        // A hand-signed record with an oversize value fails verify (and
+        // therefore every merge/session path).
+        let record = VersionedRecord::sign(
+            SyncKind::IssuanceJournal,
+            "a",
+            &huge,
+            clock(1, 1, 1),
+            &owner,
+        )
+        .expect("sign (sign itself does not check size)");
+        let err = record.verify().expect_err("oversize value must not verify");
+        assert!(err.to_string().contains("exceeds limit"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn store_larger_than_old_session_cap_syncs_to_fresh_peer() {
+        // WHY: review R3 finding 5 — the session record cap must cover a
+        // FULL valid store (previously 1024 < 4096, so a fresh peer could
+        // never atomically sync a full store).
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let owner = owner_kp(7);
+        let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await.unwrap());
+        let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await.unwrap());
+        super::tests::cross_enroll_for_tests(&store_a, &store_b, &owner).await;
+
+        // 1_100 records — above the old 1_024 cap, one atomic commit (fast;
+        // per-record minting would re-write the file per record).
+        const N: usize = 1_100;
+        let owner_id = owner.user_id();
+        let batch: Vec<VersionedRecord> = (0..N)
+            .map(|i| {
+                VersionedRecord::sign(
+                    SyncKind::IssuanceJournal,
+                    &format!("agent-{i:04}"),
+                    &SyncValue::IssuanceJournal {
+                        agent_id: format!("agent-{i:04}"),
+                        cert_digest: format!("digest-{i:04}"),
+                        issued_at: i as u64,
+                        not_after: None,
+                    },
+                    clock(1, 1, 1),
+                    &owner,
+                )
+                .unwrap()
+            })
+            .collect();
+        store_a.commit_batch(batch, &owner_id).await.unwrap();
+        assert_eq!(store_a.records_snapshot().await.len(), N);
+
+        let (client, server) = tokio::io::duplex(256 * 1024);
+        let (mut c_recv, mut c_send) = tokio::io::split(server);
+        let (mut r_recv, mut r_send) = tokio::io::split(client);
+        let responder_owner = UserKeypair::from_seed(&[7u8; 32]).expect("same owner keypair");
+        let b = Arc::clone(&store_b);
+        let responder = tokio::spawn(async move {
+            run_sync_session(
+                &mut r_send,
+                &mut r_recv,
+                &b,
+                &responder_owner,
+                &machine(2),
+                &machine(1),
+                |_| {},
+            )
+            .await
+            .expect("responder")
+        });
+        let summary = run_sync_session(
+            &mut c_send,
+            &mut c_recv,
+            &store_a,
+            &owner,
+            &machine(1),
+            &machine(2),
+            |_| {},
+        )
+        .await
+        .expect("initiator syncs a full store");
+        responder.await.unwrap();
+        assert_eq!(summary.shipped, N);
+        assert_eq!(
+            store_b.records_snapshot().await.len(),
+            N,
+            "fresh peer received the FULL store atomically"
+        );
+    }
+
+    #[tokio::test]
+    async fn large_values_page_by_bytes_and_converge() {
+        // WHY: review R3 finding 5 — pages split on a BYTE budget, not a
+        // fixed record count, so values near the (bounded) cap cannot push
+        // a 16-record page over the frame limit.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let owner = owner_kp(7);
+        let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await.unwrap());
+        let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await.unwrap());
+        super::tests::cross_enroll_for_tests(&store_a, &store_b, &owner).await;
+
+        // 10 records × ~8 KiB values: under the 16-record page count but
+        // ~80 KiB total — the byte budget MUST split the pages.
+        const N: usize = 10;
+        let owner_id = owner.user_id();
+        let batch: Vec<VersionedRecord> = (0..N)
+            .map(|i| {
+                VersionedRecord::sign(
+                    SyncKind::IssuanceJournal,
+                    &format!("big-{i}"),
+                    &SyncValue::IssuanceJournal {
+                        agent_id: format!("big-{i}"),
+                        cert_digest: "d".repeat(8 * 1024),
+                        issued_at: i as u64,
+                        not_after: None,
+                    },
+                    clock(1, 1, 1),
+                    &owner,
+                )
+                .unwrap()
+            })
+            .collect();
+        store_a.commit_batch(batch, &owner_id).await.unwrap();
+
+        let (client, server) = tokio::io::duplex(256 * 1024);
+        let (mut c_recv, mut c_send) = tokio::io::split(server);
+        let (mut r_recv, mut r_send) = tokio::io::split(client);
+        let responder_owner = UserKeypair::from_seed(&[7u8; 32]).expect("same owner keypair");
+        let b = Arc::clone(&store_b);
+        let responder = tokio::spawn(async move {
+            run_sync_session(
+                &mut r_send,
+                &mut r_recv,
+                &b,
+                &responder_owner,
+                &machine(2),
+                &machine(1),
+                |_| {},
+            )
+            .await
+            .expect("responder")
+        });
+        let summary = run_sync_session(
+            &mut c_send,
+            &mut c_recv,
+            &store_a,
+            &owner,
+            &machine(1),
+            &machine(2),
+            |_| {},
+        )
+        .await
+        .expect("byte-paged session");
+        responder.await.unwrap();
+        assert_eq!(summary.shipped, N);
+        assert_eq!(store_b.records_snapshot().await.len(), N);
     }
 }

--- a/src/owner_sync.rs
+++ b/src/owner_sync.rs
@@ -1009,6 +1009,15 @@ impl OwnerSyncStore {
             .clone()
     }
 
+    /// The typed refusal for a poisoned store, if it is poisoned. Every
+    /// state-mutating entry point checks this FIRST (review R6): after a
+    /// post-rename durability failure, no mutation may proceed against
+    /// state whose memory/disk agreement is unrecoverable — even after the
+    /// underlying fault clears — until an explicit reload.
+    fn poison_refusal(&self) -> Option<SyncError> {
+        self.poisoned_reason().map(SyncError::Poisoned)
+    }
+
     fn fail_after_rename_for_testing(&self) -> bool {
         self.fail_after_rename
             .load(std::sync::atomic::Ordering::Relaxed)
@@ -1046,6 +1055,9 @@ impl OwnerSyncStore {
     /// (disk already advanced) and the store refuses further sync until
     /// reload (review R5 finding 2).
     pub async fn enroll(&self, enrollment: OwnerEnrollment) -> Result<(), SyncError> {
+        if let Some(err) = self.poison_refusal() {
+            return Err(err);
+        }
         let mut devices = self.devices.write().await;
         let previous = devices.get(&enrollment.machine_id).cloned();
         let keep = previous
@@ -1083,6 +1095,9 @@ impl OwnerSyncStore {
     /// `/sync/devices/:id` path; review R2 finding 1). Poisoning semantics
     /// match [`Self::enroll`]. Returns `Ok(false)` when not enrolled.
     pub async fn unenroll(&self, machine: &MachineId) -> Result<bool, SyncError> {
+        if let Some(err) = self.poison_refusal() {
+            return Err(err);
+        }
         let mut devices = self.devices.write().await;
         if let Some(previous) = devices.remove(&machine.0) {
             if let Err(e) = self.persist_devices(&devices).await {
@@ -1165,6 +1180,9 @@ impl OwnerSyncStore {
         batch: Vec<VersionedRecord>,
         owner: &UserId,
     ) -> Result<CommitOutcome, SyncError> {
+        if let Some(err) = self.poison_refusal() {
+            return Err(err);
+        }
         let mut records = self.records.write().await;
         // (kind, key) → the value held BEFORE this batch first touched it.
         let mut touched: BTreeMap<(SyncKind, String), Option<VersionedRecord>> = BTreeMap::new();
@@ -1313,6 +1331,9 @@ impl OwnerSyncStore {
         owner: &UserKeypair,
         writer_machine: MachineId,
     ) -> Result<(), SyncError> {
+        if let Some(err) = self.poison_refusal() {
+            return Err(err);
+        }
         let value_bytes = bincode::serialize(desired)
             .map_err(|e| SyncError::BadSignature(format!("value encode: {e}")))?;
         if value_bytes.len() > MAX_VALUE_BYTES {
@@ -1450,6 +1471,9 @@ impl OwnerSyncStore {
     /// every real path (`mint`, `commit_batch`) verifies signatures.
     #[doc(hidden)]
     pub async fn records_insert_for_testing(&self, record: VersionedRecord) {
+        if self.poison_refusal().is_some() {
+            return; // test helper respects poison too
+        }
         let mut records = self.records.write().await;
         records.insert((record.kind, record.key.clone()), record);
         let _ = self.persist_records(&records).await;
@@ -3619,7 +3643,14 @@ mod r5_tests {
             "disk holds the new batch the callers saw fail"
         );
 
-        // Every further mutation refuses: poisoned.
+        // Disable the fault injector FIRST (review R6): with it left on,
+        // the refusals below could come from the injector firing again
+        // rather than the poison flag. With it off, a refusal can ONLY
+        // come from the poison check at the mutator entry points.
+        store.set_fail_after_rename_for_testing(false);
+
+        // Every further mutation refuses BECAUSE the store is poisoned —
+        // the transient fault has cleared, the flag has not.
         let err = store
             .mint(
                 SyncKind::OwnerProfile,
@@ -3637,6 +3668,19 @@ mod r5_tests {
             .enroll(OwnerEnrollment::sign(machine(9), &owner, 1, None).unwrap())
             .await
             .expect_err("poisoned store refuses enroll");
+        assert!(matches!(err, SyncError::Poisoned(_)));
+        let err = store
+            .commit_batch(
+                vec![sign_names("post", "v", clock(9, 9, 1), &owner)],
+                &owner_id,
+            )
+            .await
+            .expect_err("poisoned store refuses commit_batch");
+        assert!(matches!(err, SyncError::Poisoned(_)));
+        let err = store
+            .unenroll(&machine(9))
+            .await
+            .expect_err("poisoned store refuses unenroll");
         assert!(matches!(err, SyncError::Poisoned(_)));
 
         // Sessions refuse too — even with a fully enrolled peer.

--- a/src/owner_sync.rs
+++ b/src/owner_sync.rs
@@ -1,0 +1,1826 @@
+//! ADR-0041 Tier-1 cross-machine owner-state sync.
+//!
+//! Tier 1 replicates exactly four kinds of small owner-signed state between
+//! the owner's machines over ADR-0022 byte streams ([`crate::streams`]):
+//! the owner profile, per-machine agent/machine names, the Home roster +
+//! policy pointer, and the sub-agent issuance journal. Tier 2 (history
+//! backfill) and Tier 3 (never-replicates state) are out of scope here.
+//!
+//! # Trust model — same-owner, enrolled machines only (gapcheck blocker 30)
+//!
+//! A stream carrying [`crate::streams::StreamProtocol::SyncV1`] is accepted
+//! only when BOTH hold:
+//!
+//! 1. the ADR-0022 machine identity gates (transport-verified, trusted,
+//!    non-revoked) have already cleared — enforced by the shared accept loop
+//!    before this protocol's acceptor sees the stream;
+//! 2. the remote machine is in the local **owner device set**: an
+//!    [`OwnerEnrollment`] record signed by the owner key, whose public key
+//!    derives to this install's `UserId`. This is the enrollment direction
+//!    of ADR-0043 (owner-key-signed, machine-scoped), reused — not a rival
+//!    scheme.
+//!
+//! Fail closed: any signature or enrollment failure aborts the session and
+//! the peer learns nothing beyond the refusal.
+//!
+//! # Object model (gapcheck blocker 31)
+//!
+//! Each Tier-1 object is an owner-signed [`VersionedRecord`]. Conflict rule
+//! (deliberately decoupled from state-commit heights): highest `version`
+//! wins; tie → highest `signed_at_ms`; tie → lexicographically greatest
+//! `writer_machine`. Anti-rollback: a record is accepted only when it
+//! *strictly beats* the stored clock under that ordering, so a replayed or
+//! stale record can never overwrite a newer one.
+//!
+//! # Protocol
+//!
+//! On connect the two sides exchange a [`SyncFrame::Hello`] (same owner,
+//! same protocol version, non-self), then per-kind version vectors, then
+//! ship exactly the records the other side is missing or would accept.
+//! Sessions run periodically and are re-triggered on local change (the
+//! store's generation channel) — "periodic + on-change".
+//!
+//! # Tier-3 boundary (gapcheck blocker 32 scope note)
+//!
+//! The sync surface serializes ONLY the four Tier-1 kinds: [`SyncKind`] and
+//! [`SyncValue`] are closed enums with no catch-all. A record whose kind tag
+//! is not one of the four fails to decode, and a record whose kind does not
+//! match its value variant is rejected whole.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use ant_quic::crypto::raw_public_keys::pqc::{
+    sign_with_ml_dsa, verify_with_ml_dsa, MlDsaPublicKey, MlDsaSignature,
+};
+use ant_quic::derive_peer_id_from_public_key;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use crate::error::IdentityError;
+use crate::groups::{GroupMemberState, GroupPolicy, GroupRole};
+use crate::identity::{MachineId, UserId, UserKeypair};
+
+/// Domain-separation prefix for the bytes an owner enrollment signs.
+const ENROLL_MSG_PREFIX: &[u8] = b"x0x-adr0041-enroll-v1";
+/// Domain-separation prefix for the bytes a versioned record signs.
+const RECORD_MSG_PREFIX: &[u8] = b"x0x-adr0041-record-v1";
+
+/// Wire protocol version for the SyncV1 handshake.
+pub const SYNC_PROTOCOL_VERSION: u32 = 1;
+
+/// Maximum size of one sync frame (length-prefixed payload). Tier-1 records
+/// are tiny; anything larger is hostile or corrupt — fail closed.
+pub const MAX_FRAME_BYTES: u32 = 256 * 1024;
+
+/// File holding the owner device set, inside `<data_dir>/sync/`.
+const DEVICES_FILE: &str = "devices.json";
+/// File holding the winning versioned records, inside `<data_dir>/sync/`.
+const RECORDS_FILE: &str = "records.json";
+/// Directory under the instance data dir holding all sync state.
+const SYNC_DIR: &str = "sync";
+
+/// The Tier-1 kinds — exhaustive, no catch-all (ADR-0041; gapcheck 32).
+///
+/// `from_u8` returns `None` for every unassigned byte, so a record or frame
+/// carrying any other kind tag is undecodable and rejected whole.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum SyncKind {
+    /// Owner profile (`{ human_name }`) — one record, key `"owner"`.
+    OwnerProfile = 0x01,
+    /// Per-machine agent/machine names — key = machine id hex.
+    MachineNames = 0x02,
+    /// Home roster + policy pointer — one record, key `"home"`.
+    HomePointer = 0x03,
+    /// Sub-agent issuance journal — key = agent id hex.
+    IssuanceJournal = 0x04,
+}
+
+impl SyncKind {
+    /// All Tier-1 kinds. Length 4 is a load-bearing constant: Tier 3 states
+    /// that no other state can be emitted.
+    pub const ALL: [SyncKind; 4] = [
+        SyncKind::OwnerProfile,
+        SyncKind::MachineNames,
+        SyncKind::HomePointer,
+        SyncKind::IssuanceJournal,
+    ];
+
+    /// Parse a kind tag. `None` for every unassigned byte.
+    #[must_use]
+    pub fn from_u8(byte: u8) -> Option<Self> {
+        match byte {
+            0x01 => Some(Self::OwnerProfile),
+            0x02 => Some(Self::MachineNames),
+            0x03 => Some(Self::HomePointer),
+            0x04 => Some(Self::IssuanceJournal),
+            _ => None,
+        }
+    }
+
+    /// The on-wire kind tag.
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+/// One member line of the Home roster snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HomeRosterEntry {
+    /// Agent id, hex-encoded (matches `GroupMember` keys).
+    pub agent_id: String,
+    pub role: GroupRole,
+    pub state: GroupMemberState,
+}
+
+/// The value of a Tier-1 record — a closed four-variant enum mirroring
+/// [`SyncKind`] with NO catch-all. Compiling a new variant forces every
+/// exhaustive match (including [`SyncValue::kind`]) to handle it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SyncValue {
+    /// Owner profile: the owner's human-facing name.
+    OwnerProfile {
+        /// Owner's human name (ADR-0036 `human_name`).
+        human_name: Option<String>,
+    },
+    /// Agent and machine names for one machine (key = machine id hex).
+    MachineNames {
+        /// The daemon agent's display name (announce self-name).
+        display_name: Option<String>,
+        /// Label for the machine itself.
+        machine_name: Option<String>,
+    },
+    /// Home roster + policy pointer (ADR-0038): enough to identify and
+    /// re-adopt the Home space on another machine; NOT a full group state
+    /// transfer (TreeKEM material is deliberately out of Tier 1).
+    HomePointer {
+        group_id: String,
+        policy: GroupPolicy,
+        roster: Vec<HomeRosterEntry>,
+        primary_agent: String,
+        provisioned_at_ms: u64,
+    },
+    /// One line of the sub-agent issuance journal (ADR-0039).
+    IssuanceJournal {
+        agent_id: String,
+        cert_digest: String,
+        issued_at: u64,
+        not_after: Option<u64>,
+    },
+}
+
+impl SyncValue {
+    /// The kind of this value — exhaustive match, no wildcard, so adding a
+    /// variant without extending [`SyncKind`] is a compile error (the
+    /// Tier-3 deny-by-default allowlist is structural, not conventional).
+    #[must_use]
+    pub fn kind(&self) -> SyncKind {
+        match self {
+            SyncValue::OwnerProfile { .. } => SyncKind::OwnerProfile,
+            SyncValue::MachineNames { .. } => SyncKind::MachineNames,
+            SyncValue::HomePointer { .. } => SyncKind::HomePointer,
+            SyncValue::IssuanceJournal { .. } => SyncKind::IssuanceJournal,
+        }
+    }
+}
+
+/// The per-record clock the conflict rule orders on (gapcheck blocker 31).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RecordClock {
+    /// Writer-minted monotonic version for this `(kind, key)`.
+    pub version: u64,
+    /// Unix ms when the record was signed.
+    pub signed_at_ms: u64,
+    /// Machine id of the writer — final tie-break, lexicographic.
+    pub writer_machine: [u8; 32],
+}
+
+impl RecordClock {
+    /// Whether `self` strictly beats `other` under the ADR-0041 rule:
+    /// highest `version`, then highest `signed_at_ms`, then lexicographically
+    /// greatest `writer_machine`. Equal clocks beat nothing (idempotent
+    /// re-delivery), and a lower `version` never wins — rollback protection.
+    #[must_use]
+    pub fn beats(&self, other: &Self) -> bool {
+        match self.version.cmp(&other.version) {
+            std::cmp::Ordering::Greater => return true,
+            std::cmp::Ordering::Less => return false,
+            std::cmp::Ordering::Equal => {}
+        }
+        match self.signed_at_ms.cmp(&other.signed_at_ms) {
+            std::cmp::Ordering::Greater => return true,
+            std::cmp::Ordering::Less => return false,
+            std::cmp::Ordering::Equal => {}
+        }
+        self.writer_machine > other.writer_machine
+    }
+}
+
+/// An owner-signed Tier-1 object (gapcheck blocker 31).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionedRecord {
+    pub kind: SyncKind,
+    /// Record key within the kind (see [`SyncKind`] variant docs).
+    pub key: String,
+    pub value: SyncValue,
+    pub clock: RecordClock,
+    /// Owner ML-DSA-65 public key bytes (self-authenticating record).
+    pub owner_public_key: Vec<u8>,
+    /// ML-DSA-65 signature over [`VersionedRecord::canonical_message`].
+    pub signature: Vec<u8>,
+}
+
+impl VersionedRecord {
+    /// Canonical signed bytes: domain prefix, kind tag, length-prefixed key,
+    /// clock fields, and the bincode-canonical value.
+    fn canonical_message(
+        kind: &SyncKind,
+        key: &str,
+        clock: &RecordClock,
+        value_bytes: &[u8],
+    ) -> Vec<u8> {
+        let key_bytes = key.as_bytes();
+        let mut msg = Vec::with_capacity(
+            RECORD_MSG_PREFIX.len() + 1 + 8 + key_bytes.len() + 16 + 32 + value_bytes.len(),
+        );
+        msg.extend_from_slice(RECORD_MSG_PREFIX);
+        msg.push(kind.as_u8());
+        msg.extend_from_slice(&(key_bytes.len() as u64).to_le_bytes());
+        msg.extend_from_slice(key_bytes);
+        msg.extend_from_slice(&clock.version.to_le_bytes());
+        msg.extend_from_slice(&clock.signed_at_ms.to_le_bytes());
+        msg.extend_from_slice(&clock.writer_machine);
+        msg.extend_from_slice(value_bytes);
+        msg
+    }
+
+    /// Sign a fresh record with the owner key.
+    ///
+    /// # Errors
+    ///
+    /// [`IdentityError::CertificateVerification`] when signing fails or the
+    /// value fails canonical serialization.
+    pub fn sign(
+        kind: SyncKind,
+        key: &str,
+        value: &SyncValue,
+        clock: RecordClock,
+        owner: &UserKeypair,
+    ) -> Result<Self, IdentityError> {
+        let value_bytes = bincode::serialize(value)
+            .map_err(|e| IdentityError::CertificateVerification(format!("value encode: {e}")))?;
+        let owner_public_key = owner.public_key().as_bytes().to_vec();
+        let message = Self::canonical_message(&kind, key, &clock, &value_bytes);
+        let signature = sign_with_ml_dsa(owner.secret_key(), &message).map_err(|e| {
+            IdentityError::CertificateVerification(format!("record signing failed: {e:?}"))
+        })?;
+        Ok(Self {
+            kind,
+            key: key.to_string(),
+            value: value.clone(),
+            clock,
+            owner_public_key,
+            signature: signature.as_bytes().to_vec(),
+        })
+    }
+
+    /// Verify the signature and that the record's kind matches its value
+    /// variant. Fail closed on any mismatch.
+    ///
+    /// # Errors
+    ///
+    /// [`SyncError::BadSignature`] on an invalid signature or malformed key
+    /// material; [`SyncError::KindMismatch`] when the kind tag and value
+    /// variant disagree.
+    pub fn verify(&self) -> Result<(), SyncError> {
+        if self.value.kind() != self.kind {
+            return Err(SyncError::KindMismatch);
+        }
+        let owner_pubkey = MlDsaPublicKey::from_bytes(&self.owner_public_key)
+            .map_err(|_| SyncError::BadSignature("invalid owner public key".into()))?;
+        let signature = MlDsaSignature::from_bytes(&self.signature)
+            .map_err(|e| SyncError::BadSignature(format!("invalid signature format: {e:?}")))?;
+        let value_bytes = bincode::serialize(&self.value)
+            .map_err(|e| SyncError::BadSignature(format!("value encode: {e}")))?;
+        let message = Self::canonical_message(&self.kind, &self.key, &self.clock, &value_bytes);
+        verify_with_ml_dsa(&owner_pubkey, &message, &signature)
+            .map_err(|e| SyncError::BadSignature(format!("bad signature: {e:?}")))?;
+        Ok(())
+    }
+
+    /// Verify the signature AND that the signer is the given owner.
+    ///
+    /// # Errors
+    ///
+    /// [`SyncError::OwnerMismatch`] when the signing key does not derive to
+    /// `owner`; see [`VersionedRecord::verify`].
+    pub fn verify_owner(&self, owner: &UserId) -> Result<(), SyncError> {
+        self.verify()?;
+        let pubkey = MlDsaPublicKey::from_bytes(&self.owner_public_key)
+            .map_err(|_| SyncError::BadSignature("invalid owner public key".into()))?;
+        if derive_peer_id_from_public_key(&pubkey).0 != owner.0 {
+            return Err(SyncError::OwnerMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// Owner-key-signed enrollment of one machine into the owner device set
+/// (gapcheck blocker 30; enrollment direction per ADR-0043).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnerEnrollment {
+    pub machine_id: [u8; 32],
+    /// Unix ms when the owner enrolled this machine.
+    pub enrolled_at_ms: u64,
+    /// Owner ML-DSA-65 public key bytes.
+    pub owner_public_key: Vec<u8>,
+    /// Signature over the canonical enrollment message.
+    pub signature: Vec<u8>,
+}
+
+impl OwnerEnrollment {
+    fn canonical_message(machine_id: &[u8; 32], enrolled_at_ms: u64, owner_pub: &[u8]) -> Vec<u8> {
+        let mut msg = Vec::with_capacity(ENROLL_MSG_PREFIX.len() + 32 + 8 + owner_pub.len());
+        msg.extend_from_slice(ENROLL_MSG_PREFIX);
+        msg.extend_from_slice(machine_id);
+        msg.extend_from_slice(&enrolled_at_ms.to_le_bytes());
+        msg.extend_from_slice(owner_pub);
+        msg
+    }
+
+    /// Sign an enrollment for `machine_id` with the owner key.
+    ///
+    /// # Errors
+    ///
+    /// [`IdentityError::CertificateVerification`] when signing fails.
+    pub fn sign(
+        machine_id: MachineId,
+        owner: &UserKeypair,
+        enrolled_at_ms: u64,
+    ) -> Result<Self, IdentityError> {
+        let owner_public_key = owner.public_key().as_bytes().to_vec();
+        let message = Self::canonical_message(&machine_id.0, enrolled_at_ms, &owner_public_key);
+        let signature = sign_with_ml_dsa(owner.secret_key(), &message).map_err(|e| {
+            IdentityError::CertificateVerification(format!("enrollment signing failed: {e:?}"))
+        })?;
+        Ok(Self {
+            machine_id: machine_id.0,
+            enrolled_at_ms,
+            owner_public_key,
+            signature: signature.as_bytes().to_vec(),
+        })
+    }
+
+    /// Verify the signature and that the signer derives to `owner`.
+    ///
+    /// # Errors
+    ///
+    /// [`SyncError::BadSignature`] / [`SyncError::OwnerMismatch`] — fail
+    /// closed on any enrollment failure.
+    pub fn verify_owner(&self, owner: &UserId) -> Result<(), SyncError> {
+        let pubkey = MlDsaPublicKey::from_bytes(&self.owner_public_key)
+            .map_err(|_| SyncError::BadSignature("invalid owner public key".into()))?;
+        if derive_peer_id_from_public_key(&pubkey).0 != owner.0 {
+            return Err(SyncError::OwnerMismatch);
+        }
+        let signature = MlDsaSignature::from_bytes(&self.signature)
+            .map_err(|e| SyncError::BadSignature(format!("invalid signature format: {e:?}")))?;
+        let message = Self::canonical_message(
+            &self.machine_id,
+            self.enrolled_at_ms,
+            &self.owner_public_key,
+        );
+        verify_with_ml_dsa(&pubkey, &message, &signature)
+            .map_err(|e| SyncError::BadSignature(format!("bad signature: {e:?}")))?;
+        Ok(())
+    }
+}
+
+/// Typed sync failures — every one is fail-closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncError {
+    Io(String),
+    /// Frame body exceeded [`MAX_FRAME_BYTES`] or a decode failed.
+    MalformedFrame(String),
+    ProtocolVersion {
+        local: u32,
+        remote: u32,
+    },
+    OwnerMismatch,
+    /// The peer machine is not in the local owner device set.
+    NotEnrolled {
+        machine: [u8; 32],
+    },
+    /// A machine tried to sync with itself.
+    SelfSync,
+    BadSignature(String),
+    /// Record kind tag and value variant disagree.
+    KindMismatch,
+    /// Undecodable kind tag on the wire (Tier-3 allowlist).
+    UnknownKind {
+        tag: u8,
+    },
+}
+
+impl std::fmt::Display for SyncError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "sync io error: {e}"),
+            Self::MalformedFrame(e) => write!(f, "malformed sync frame: {e}"),
+            Self::ProtocolVersion { local, remote } => {
+                write!(
+                    f,
+                    "sync protocol version mismatch: local {local}, remote {remote}"
+                )
+            }
+            Self::OwnerMismatch => write!(f, "sync peer is not the same owner"),
+            Self::NotEnrolled { machine } => {
+                write!(
+                    f,
+                    "machine {} is not in the owner device set",
+                    hex::encode(machine)
+                )
+            }
+            Self::SelfSync => write!(f, "refusing to sync with this machine itself"),
+            Self::BadSignature(e) => write!(f, "sync signature failure: {e}"),
+            Self::KindMismatch => write!(f, "record kind does not match its value variant"),
+            Self::UnknownKind { tag } => {
+                write!(f, "unknown sync kind tag 0x{tag:02x} (Tier-3 allowlist)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SyncError {}
+
+impl From<std::io::Error> for SyncError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e.to_string())
+    }
+}
+
+/// Outcome of merging one inbound record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeOutcome {
+    /// Stored — the record beat what we had.
+    Accepted,
+    /// Not stored — did not beat the stored clock (stale, rollback, or
+    /// identical re-delivery). Never an error: partitions heal.
+    Superseded,
+}
+
+/// Per-kind version vector entry: the peer's clock for one key.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KindVersions {
+    pub kind: SyncKind,
+    /// `(key, clock)` for every record the peer holds under the kind.
+    pub entries: Vec<(String, RecordClock)>,
+}
+
+/// One frame of the SyncV1 wire protocol. Length-prefixed bincode on the
+/// stream following the `SyncV1` protocol byte.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum SyncFrame {
+    /// Handshake: protocol version, sender machine, sender owner.
+    Hello {
+        protocol_version: u32,
+        machine_id: [u8; 32],
+        owner_user_id: [u8; 32],
+    },
+    /// Per-kind version vectors (the sender's full Tier-1 clock table).
+    VersionVector { kinds: Vec<KindVersions> },
+    /// Records the peer is missing or would accept.
+    Records { records: Vec<VersionedRecord> },
+    /// Clean end of session.
+    Done,
+    /// Fail-closed abort with a reason (best-effort, one-way).
+    Abort { reason: String },
+}
+
+/// Write one frame: `u32` big-endian length + bincode body.
+///
+/// # Errors
+///
+/// [`SyncError::MalformedFrame`] when the body exceeds [`MAX_FRAME_BYTES`] or
+/// fails to encode; [`SyncError::Io`] on write failure.
+pub async fn write_frame<S: AsyncWrite + Unpin>(
+    send: &mut S,
+    frame: &SyncFrame,
+) -> Result<(), SyncError> {
+    let body =
+        bincode::serialize(frame).map_err(|e| SyncError::MalformedFrame(format!("encode: {e}")))?;
+    let len = u32::try_from(body.len())
+        .map_err(|_| SyncError::MalformedFrame("frame too large".into()))?;
+    if len > MAX_FRAME_BYTES {
+        return Err(SyncError::MalformedFrame(format!(
+            "frame of {len} bytes exceeds limit {MAX_FRAME_BYTES}"
+        )));
+    }
+    send.write_all(&len.to_be_bytes()).await?;
+    send.write_all(&body).await?;
+    send.flush().await?;
+    Ok(())
+}
+
+/// Read one frame written by [`write_frame`]. Fails closed on an oversized
+/// or undecodable body.
+///
+/// # Errors
+///
+/// [`SyncError::MalformedFrame`] on oversize/undecodable frames (which
+/// includes any record carrying an unknown [`SyncKind`] tag — the bincode
+/// `from_u8` path rejects unassigned bytes).
+pub async fn read_frame<R: AsyncRead + Unpin>(recv: &mut R) -> Result<SyncFrame, SyncError> {
+    let mut len_buf = [0u8; 4];
+    recv.read_exact(&mut len_buf).await?;
+    let len = u32::from_be_bytes(len_buf);
+    if len > MAX_FRAME_BYTES {
+        return Err(SyncError::MalformedFrame(format!(
+            "frame of {len} bytes exceeds limit {MAX_FRAME_BYTES}"
+        )));
+    }
+    let mut body = vec![0u8; len as usize];
+    recv.read_exact(&mut body).await?;
+    bincode::deserialize(&body).map_err(|e| SyncError::MalformedFrame(format!("decode: {e}")))
+}
+
+/// Outcome of one sync session, for surfaces and tests.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SessionSummary {
+    pub accepted: usize,
+    pub superseded: usize,
+    pub shipped: usize,
+}
+
+/// The local Tier-1 store: the owner device set plus the winning record for
+/// every `(kind, key)` this machine holds. Persisted as two small JSON files
+/// under `<data_dir>/sync/`, written atomically (temp file + rename).
+pub struct OwnerSyncStore {
+    dir: PathBuf,
+    records: tokio::sync::RwLock<BTreeMap<(SyncKind, String), VersionedRecord>>,
+    devices: tokio::sync::RwLock<BTreeMap<[u8; 32], OwnerEnrollment>>,
+    last_session: tokio::sync::RwLock<BTreeMap<[u8; 32], DeviceSyncStatus>>,
+    generation_tx: tokio::sync::watch::Sender<u64>,
+}
+
+/// Per-device sync status surfaced by `GET /sync/devices`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceSyncStatus {
+    /// Unix ms of the last completed session with this device.
+    pub last_session_ms: u64,
+    /// Whether that session completed cleanly (`true`) or failed.
+    pub last_session_ok: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct PersistedRecords {
+    records: Vec<VersionedRecord>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct PersistedDevices {
+    devices: Vec<OwnerEnrollment>,
+}
+
+impl OwnerSyncStore {
+    /// Load (or start empty under) `<data_dir>/sync`. Corrupt or missing
+    /// files start empty — the next session re-derives Tier-1 state from a
+    /// live peer, and records are owner-signed so poison dies at verify.
+    #[must_use]
+    pub async fn load(data_dir: &Path) -> Self {
+        let dir = data_dir.join(SYNC_DIR);
+        let records = match tokio::fs::read(dir.join(RECORDS_FILE)).await {
+            Ok(bytes) => serde_json::from_slice::<PersistedRecords>(&bytes)
+                .map(|p| {
+                    p.records
+                        .into_iter()
+                        .map(|r| ((r.kind, r.key.clone()), r))
+                        .collect::<BTreeMap<_, _>>()
+                })
+                .unwrap_or_default(),
+            Err(_) => BTreeMap::new(),
+        };
+        let devices = match tokio::fs::read(dir.join(DEVICES_FILE)).await {
+            Ok(bytes) => serde_json::from_slice::<PersistedDevices>(&bytes)
+                .map(|p| {
+                    p.devices
+                        .into_iter()
+                        .map(|d| (d.machine_id, d))
+                        .collect::<BTreeMap<_, _>>()
+                })
+                .unwrap_or_default(),
+            Err(_) => BTreeMap::new(),
+        };
+        let (generation_tx, _) = tokio::sync::watch::channel(0);
+        Self {
+            dir,
+            records: tokio::sync::RwLock::new(records),
+            devices: tokio::sync::RwLock::new(devices),
+            last_session: tokio::sync::RwLock::new(BTreeMap::new()),
+            generation_tx,
+        }
+    }
+
+    /// Write `bytes` to `path` via a unique temp file + rename (atomic for
+    /// same-directory renames; mirrors `src/profile.rs`).
+    async fn write_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = path.with_extension(format!("tmp-{}-{unique}", std::process::id()));
+        tokio::fs::write(&tmp, bytes).await?;
+        tokio::fs::rename(&tmp, path).await
+    }
+
+    async fn persist_records(records: &BTreeMap<(SyncKind, String), VersionedRecord>, dir: &Path) {
+        let persisted = PersistedRecords {
+            records: records.values().cloned().collect(),
+        };
+        if let Ok(bytes) = serde_json::to_vec(&persisted) {
+            if let Err(e) = Self::write_atomically(&dir.join(RECORDS_FILE), &bytes).await {
+                tracing::warn!("failed to persist sync records: {e}");
+            }
+        }
+    }
+
+    async fn persist_devices(devices: &BTreeMap<[u8; 32], OwnerEnrollment>, dir: &Path) {
+        let persisted = PersistedDevices {
+            devices: devices.values().cloned().collect(),
+        };
+        if let Ok(bytes) = serde_json::to_vec(&persisted) {
+            if let Err(e) = Self::write_atomically(&dir.join(DEVICES_FILE), &bytes).await {
+                tracing::warn!("failed to persist sync device set: {e}");
+            }
+        }
+    }
+
+    /// The enrollment gate (blocker 30): is `machine` enrolled for `owner`?
+    ///
+    /// Every stored enrollment is (re-)verified against `owner` here — a
+    /// corrupt or foreign-key record fails closed, so persistence poison
+    /// cannot wedge the gate open.
+    #[must_use]
+    pub async fn is_enrolled(&self, machine: &MachineId, owner: &UserId) -> bool {
+        let devices = self.devices.read().await;
+        devices
+            .get(&machine.0)
+            .is_some_and(|e| e.verify_owner(owner).is_ok())
+    }
+
+    /// Store a (verified-by-caller) enrollment, keeping the latest
+    /// `enrolled_at_ms` per machine so a replayed older enrollment cannot
+    /// rewind the clock.
+    pub async fn enroll(&self, enrollment: OwnerEnrollment) {
+        let mut devices = self.devices.write().await;
+        let keep = devices
+            .get(&enrollment.machine_id)
+            .is_none_or(|old| enrollment.enrolled_at_ms >= old.enrolled_at_ms);
+        if keep {
+            devices.insert(enrollment.machine_id, enrollment.clone());
+            Self::persist_devices(&devices, &self.dir).await;
+        }
+        self.kick();
+    }
+
+    /// Enrolled machines (raw records, for surfaces).
+    pub async fn enrolled_devices(&self) -> Vec<OwnerEnrollment> {
+        self.devices.read().await.values().cloned().collect()
+    }
+
+    /// On-change trigger: bump the generation the periodic task waits on.
+    pub fn kick(&self) {
+        self.generation_tx.send_modify(|g| *g = g.wrapping_add(1));
+    }
+
+    /// Subscribe to generation changes.
+    pub fn generation_rx(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.generation_tx.subscribe()
+    }
+
+    /// Merge one verified inbound record under the conflict rule.
+    ///
+    /// Verifies the owner signature first — fail closed (error, session
+    /// aborts) on any signature failure; a merely stale or replayed record is
+    /// [`MergeOutcome::Superseded`] (anti-rollback, not an error).
+    pub async fn merge_record(
+        &self,
+        record: VersionedRecord,
+        owner: &UserId,
+    ) -> Result<MergeOutcome, SyncError> {
+        record.verify_owner(owner)?;
+        let mut records = self.records.write().await;
+        let stored = records.get(&(record.kind, record.key.clone()));
+        match stored {
+            Some(existing) if !record.clock.beats(&existing.clock) => Ok(MergeOutcome::Superseded),
+            _ => {
+                records.insert((record.kind, record.key.clone()), record);
+                Self::persist_records(&records, &self.dir).await;
+                Ok(MergeOutcome::Accepted)
+            }
+        }
+    }
+
+    /// Mint a local record for `(kind, key)` from `desired`: no-op when the
+    /// stored winner already carries exactly this value; otherwise version =
+    /// stored version + 1, signed now by this machine.
+    ///
+    /// # Errors
+    ///
+    /// Propagates signing failures from [`VersionedRecord::sign`].
+    pub async fn mint(
+        &self,
+        kind: SyncKind,
+        key: &str,
+        desired: &SyncValue,
+        owner: &UserKeypair,
+        writer_machine: MachineId,
+    ) -> Result<(), IdentityError> {
+        let now_ms = now_unix_ms();
+        let mut records = self.records.write().await;
+        let stored = records.get(&(kind, key.to_string()));
+        if stored.is_some_and(|r| r.value == *desired) {
+            return Ok(());
+        }
+        let version = stored.map_or(1, |r| r.clock.version.saturating_add(1));
+        let clock = RecordClock {
+            version,
+            signed_at_ms: now_ms,
+            writer_machine: writer_machine.0,
+        };
+        let record = VersionedRecord::sign(kind, key, desired, clock, owner)?;
+        records.insert((kind, key.to_string()), record);
+        Self::persist_records(&records, &self.dir).await;
+        drop(records);
+        self.kick();
+        Ok(())
+    }
+
+    /// Test-only: insert a pre-built record WITHOUT verification, so
+    /// integration tests can simulate a compromised writer whose forgery
+    /// the receiving side must reject. Never call from production code —
+    /// every real path (`mint`, `merge_record`) verifies signatures.
+    #[doc(hidden)]
+    pub async fn records_insert_for_testing(&self, record: VersionedRecord) {
+        let mut records = self.records.write().await;
+        records.insert((record.kind, record.key.clone()), record);
+        Self::persist_records(&records, &self.dir).await;
+    }
+
+    /// Full record snapshot (winners only), for surfaces and sessions.
+    pub async fn records_snapshot(&self) -> Vec<VersionedRecord> {
+        self.records.read().await.values().cloned().collect()
+    }
+
+    /// The per-kind version vectors for the handshake.
+    pub async fn version_vector(&self) -> Vec<KindVersions> {
+        let records = self.records.read().await;
+        let mut by_kind: BTreeMap<SyncKind, Vec<(String, RecordClock)>> = BTreeMap::new();
+        for ((kind, key), record) in records.iter() {
+            by_kind
+                .entry(*kind)
+                .or_default()
+                .push((key.clone(), record.clock));
+        }
+        SyncKind::ALL
+            .into_iter()
+            .map(|kind| KindVersions {
+                kind,
+                entries: by_kind.remove(&kind).unwrap_or_default(),
+            })
+            .collect()
+    }
+
+    /// Records the peer is missing or would accept under [`RecordClock`].
+    pub async fn records_for_peer(&self, peer_vector: &[KindVersions]) -> Vec<VersionedRecord> {
+        let peer_clocks: BTreeMap<(SyncKind, String), RecordClock> = peer_vector
+            .iter()
+            .flat_map(|kv| {
+                kv.entries
+                    .iter()
+                    .map(move |(k, c)| ((kv.kind, k.clone()), *c))
+            })
+            .collect();
+        let records = self.records.read().await;
+        records
+            .iter()
+            .filter(
+                |((kind, key), record)| match peer_clocks.get(&(*kind, key.clone())) {
+                    None => true,
+                    Some(peer_clock) => record.clock.beats(peer_clock),
+                },
+            )
+            .map(|(_, record)| record.clone())
+            .collect()
+    }
+
+    /// Record the outcome of a session with `machine`.
+    pub async fn set_session_status(&self, machine: &MachineId, ok: bool) {
+        let mut last = self.last_session.write().await;
+        last.insert(
+            machine.0,
+            DeviceSyncStatus {
+                last_session_ms: now_unix_ms(),
+                last_session_ok: ok,
+            },
+        );
+    }
+
+    /// Last-session status per device (for `GET /sync/devices`).
+    pub async fn session_statuses(&self) -> BTreeMap<[u8; 32], DeviceSyncStatus> {
+        self.last_session.read().await.clone()
+    }
+}
+
+/// Unix epoch milliseconds.
+fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Run one fail-closed sync session over the two halves of a SyncV1 stream.
+///
+/// Both sides run this same symmetric protocol: Hello → version vectors →
+/// records both ways → Done. The caller has already cleared the ADR-0022
+/// machine identity gates; this function enforces the same-owner +
+/// enrollment gates (blocker 30) and verifies EVERY record's owner signature
+/// (fail closed on any failure).
+///
+/// `on_accept` fires for each record this side stored, so callers can apply
+/// Tier-1 state to live daemon surfaces.
+///
+/// # Errors
+///
+/// Any [`SyncError`] aborts the session; the store keeps whatever verified
+/// records preceded the failure.
+pub async fn run_sync_session<S, R, F>(
+    send: &mut S,
+    recv: &mut R,
+    store: &OwnerSyncStore,
+    owner: &UserId,
+    local_machine: &MachineId,
+    peer_machine: &MachineId,
+    mut on_accept: F,
+) -> Result<SessionSummary, SyncError>
+where
+    S: AsyncWrite + Unpin,
+    R: AsyncRead + Unpin,
+    F: FnMut(&VersionedRecord),
+{
+    let mut summary = SessionSummary::default();
+
+    // Same-owner gate: a peer machine that is not enrolled locally never
+    // gets past the first byte (blocker 30).
+    if peer_machine.0 == local_machine.0 {
+        return Err(SyncError::SelfSync);
+    }
+    if !store.is_enrolled(peer_machine, owner).await {
+        return Err(SyncError::NotEnrolled {
+            machine: peer_machine.0,
+        });
+    }
+
+    // Hello both ways.
+    let hello = SyncFrame::Hello {
+        protocol_version: SYNC_PROTOCOL_VERSION,
+        machine_id: local_machine.0,
+        owner_user_id: owner.0,
+    };
+    write_frame(send, &hello).await?;
+    match read_frame(recv).await? {
+        SyncFrame::Hello {
+            protocol_version,
+            machine_id,
+            owner_user_id,
+        } => {
+            if protocol_version != SYNC_PROTOCOL_VERSION {
+                return Err(SyncError::ProtocolVersion {
+                    local: SYNC_PROTOCOL_VERSION,
+                    remote: protocol_version,
+                });
+            }
+            if owner_user_id != owner.0 {
+                return Err(SyncError::OwnerMismatch);
+            }
+            if machine_id != peer_machine.0 {
+                // Hello machine must match the transport-authenticated peer.
+                return Err(SyncError::MalformedFrame(
+                    "hello machine differs from transport peer".into(),
+                ));
+            }
+        }
+        other => {
+            return Err(SyncError::MalformedFrame(format!(
+                "expected hello, got {other:?}"
+            )));
+        }
+    }
+
+    // Version vectors both ways.
+    let local_vector = store.version_vector().await;
+    write_frame(
+        send,
+        &SyncFrame::VersionVector {
+            kinds: local_vector,
+        },
+    )
+    .await?;
+    let peer_vector = match read_frame(recv).await? {
+        SyncFrame::VersionVector { kinds } => kinds,
+        other => {
+            return Err(SyncError::MalformedFrame(format!(
+                "expected version vector, got {other:?}"
+            )));
+        }
+    };
+
+    // Ship what the peer lacks; receive what we lack. Every inbound record
+    // is owner-verified — one forgery aborts the whole session.
+    let to_ship = store.records_for_peer(&peer_vector).await;
+    summary.shipped = to_ship.len();
+    write_frame(send, &SyncFrame::Records { records: to_ship }).await?;
+    let accepted: Vec<VersionedRecord> = match read_frame(recv).await? {
+        SyncFrame::Records { records } => {
+            let mut accepted = Vec::new();
+            for record in records {
+                match store.merge_record(record.clone(), owner).await {
+                    Ok(MergeOutcome::Accepted) => {
+                        summary.accepted += 1;
+                        accepted.push(store_last_winner(store, &record).await);
+                    }
+                    Ok(MergeOutcome::Superseded) => {
+                        summary.superseded += 1;
+                    }
+                    Err(e) => {
+                        let _ = write_frame(
+                            send,
+                            &SyncFrame::Abort {
+                                reason: e.to_string(),
+                            },
+                        )
+                        .await;
+                        return Err(e);
+                    }
+                }
+            }
+            accepted
+        }
+        other => {
+            return Err(SyncError::MalformedFrame(format!(
+                "expected records, got {other:?}"
+            )));
+        }
+    };
+
+    // Done both ways.
+    write_frame(send, &SyncFrame::Done).await?;
+    match read_frame(recv).await? {
+        SyncFrame::Done => {}
+        SyncFrame::Abort { reason } => {
+            return Err(SyncError::MalformedFrame(format!("peer aborted: {reason}")));
+        }
+        other => {
+            return Err(SyncError::MalformedFrame(format!(
+                "expected done, got {other:?}"
+            )));
+        }
+    }
+
+    // Apply accepted records only after the clean Done, so an aborted
+    // session never mutates live daemon state. (The stored winner is
+    // re-read: a later record in the same batch may have superseded it.)
+    for record in accepted {
+        on_accept(&record);
+    }
+    Ok(summary)
+}
+
+/// The stored winner for a freshly merged record's `(kind, key)`.
+async fn store_last_winner(store: &OwnerSyncStore, merged: &VersionedRecord) -> VersionedRecord {
+    store
+        .records_snapshot()
+        .await
+        .into_iter()
+        .find(|r| r.kind == merged.kind && r.key == merged.key)
+        .unwrap_or_else(|| merged.clone())
+}
+/// Default period between automatic sync passes (also wakes on any local
+/// Tier-1 change via the store's generation channel).
+pub const DEFAULT_SYNC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Current daemon self-profile names, best-effort snapshot.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SyncProfileNames {
+    pub human_name: Option<String>,
+    pub display_name: Option<String>,
+    pub machine_name: Option<String>,
+}
+
+/// Live daemon view the server installs into [`OwnerSyncService`] after
+/// `AppState` exists. Keeps this module decoupled from server internals:
+/// reads are best-effort (a contended lock reads as "unchanged" and the
+/// next pass retries), applies are fire-and-forget (the implementation
+/// owns locking and persistence).
+pub trait SyncDaemonView: Send + Sync + 'static {
+    /// Snapshot of the current self-profile names.
+    fn profile_names(&self) -> SyncProfileNames;
+    /// Home roster + policy pointer snapshot, `None` when no Home exists.
+    fn home_pointer(&self) -> Option<SyncValue>;
+    /// Apply winning Tier-1 names to live daemon state.
+    fn apply_names(
+        &self,
+        human_name: Option<String>,
+        display_name: Option<String>,
+        machine_name: Option<String>,
+    );
+}
+
+/// Daemon-resident Tier-1 sync service (the `ForwardService` pattern for
+/// `SyncV1`): owns the single registered acceptor for
+/// [`crate::streams::StreamProtocol::SyncV1`], gates each inbound stream on
+/// the owner device set, dials every enrolled machine it can resolve, and
+/// mints local Tier-1 records from live daemon state before each pass.
+///
+/// Constructed only when the install has an owner key (`user.key`); an
+/// ownerless install registers no acceptor and syncs nothing.
+pub struct OwnerSyncService {
+    agent: Arc<crate::Agent>,
+    store: Arc<OwnerSyncStore>,
+    journal_path: Option<PathBuf>,
+    view: std::sync::RwLock<Option<Arc<dyn SyncDaemonView>>>,
+    tasks: tokio::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
+}
+
+impl OwnerSyncService {
+    /// Build the service, load its store from `<data_dir>/sync`, and
+    /// register the `SyncV1` acceptor (single-acceptor rule — a conflict is
+    /// a hard startup error). The acceptor is moved into its drain task,
+    /// which deregisters it when the task ends.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::error::NetworkError::StreamAcceptorConflict`] when another
+    /// consumer already owns `SyncV1`.
+    pub async fn new(
+        agent: Arc<crate::Agent>,
+        data_dir: &Path,
+    ) -> crate::error::NetworkResult<Arc<Self>> {
+        let acceptor = agent.register_stream_acceptor(crate::streams::StreamProtocol::SyncV1)?;
+        let journal_path = agent.cert_journal_path().map(Path::to_path_buf);
+        let service = Arc::new(Self {
+            agent,
+            store: Arc::new(OwnerSyncStore::load(data_dir).await),
+            journal_path,
+            view: std::sync::RwLock::new(None),
+            tasks: tokio::sync::Mutex::new(Vec::new()),
+        });
+        service.spawn_acceptor_loop(acceptor).await;
+        Ok(service)
+    }
+
+    /// Install the live daemon view (idempotent; called by the daemon right
+    /// after `AppState` construction).
+    pub fn attach_view(&self, view: Arc<dyn SyncDaemonView>) {
+        *self
+            .view
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(view);
+    }
+
+    /// The shared store (routes read device/session status from it).
+    #[must_use]
+    pub fn store(&self) -> &Arc<OwnerSyncStore> {
+        &self.store
+    }
+
+    /// On-change trigger: wake the periodic pass early.
+    pub fn kick(&self) {
+        self.store.kick();
+    }
+
+    fn view(&self) -> Option<Arc<dyn SyncDaemonView>> {
+        self.view
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    fn owner_kp(&self) -> Option<&UserKeypair> {
+        self.agent.identity().user_keypair()
+    }
+
+    fn owner_and_machine(&self) -> Option<(UserId, MachineId)> {
+        let owner = self.owner_kp()?.user_id();
+        Some((owner, self.agent.machine_id()))
+    }
+
+    /// Spawn the inbound acceptor drain loop. Each accepted stream is
+    /// enrollment-gated, then runs one session.
+    async fn spawn_acceptor_loop(self: &Arc<Self>, mut acceptor: crate::streams::StreamAcceptor) {
+        let service = Arc::clone(self);
+        let task = tokio::spawn(async move {
+            while let Some(stream) = acceptor.next().await {
+                let service = Arc::clone(&service);
+                tokio::spawn(async move { service.handle_inbound(stream).await });
+            }
+        });
+        self.tasks.lock().await.push(task);
+    }
+
+    /// Inbound path: the ADR-0022 machine identity gates have already
+    /// cleared in the shared accept loop; enforce the owner device set
+    /// (blocker 30) — an unenrolled machine's stream is dropped (reset)
+    /// with zero application bytes read.
+    async fn handle_inbound(&self, stream: crate::streams::PeerStream) {
+        let Some((owner, local_machine)) = self.owner_and_machine() else {
+            return;
+        };
+        let peer = stream.peer();
+        if !self.store.is_enrolled(&peer, &owner).await {
+            tracing::warn!(
+                target: "x0x::owner_sync",
+                machine = %hex::encode(peer.0),
+                "refusing SyncV1 stream from non-enrolled machine"
+            );
+            return; // drop => stream reset, fail closed
+        }
+        let (mut send, mut recv) = stream.into_split();
+        let result = run_sync_session(
+            &mut send,
+            &mut recv,
+            &self.store,
+            &owner,
+            &local_machine,
+            &peer,
+            |record| self.apply_record(record),
+        )
+        .await;
+        match result {
+            Ok(summary) => {
+                tracing::debug!(
+                    target: "x0x::owner_sync",
+                    machine = %hex::encode(peer.0),
+                    accepted = summary.accepted,
+                    superseded = summary.superseded,
+                    shipped = summary.shipped,
+                    "Tier-1 sync session complete"
+                );
+                self.store.set_session_status(&peer, true).await;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "x0x::owner_sync",
+                    machine = %hex::encode(peer.0),
+                    error = %e,
+                    "Tier-1 sync session failed (fail closed)"
+                );
+                self.store.set_session_status(&peer, false).await;
+            }
+        }
+    }
+
+    /// Dial `machine` and run one session as the initiator. Errors are
+    /// strings by design: dial outcomes are logged, never fatal to the pass.
+    async fn dial_and_sync(&self, machine: &MachineId) -> Result<SessionSummary, String> {
+        let (owner, local_machine) = self
+            .owner_and_machine()
+            .ok_or_else(|| "no owner key".to_string())?;
+        if !self.store.is_enrolled(machine, &owner).await {
+            return Err(format!(
+                "machine {} is not enrolled",
+                hex::encode(machine.0)
+            ));
+        }
+        // Resolve the deterministic first agent on the target machine —
+        // open_peer_stream authorizes per agent, sessions are per machine.
+        let target_agent = self
+            .agent
+            .discovered_agents()
+            .await
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .filter(|d| d.machine_id == *machine)
+            .min_by_key(|d| d.agent_id.as_bytes().to_vec())
+            .ok_or_else(|| "machine not in discovery cache".to_string())?
+            .agent_id;
+        let stream = self
+            .agent
+            .open_peer_stream(&target_agent, crate::streams::StreamProtocol::SyncV1)
+            .await
+            .map_err(|e| e.to_string())?;
+        let peer = stream.peer();
+        let (mut send, mut recv) = stream.into_split();
+        let result = run_sync_session(
+            &mut send,
+            &mut recv,
+            &self.store,
+            &owner,
+            &local_machine,
+            &peer,
+            |record| self.apply_record(record),
+        )
+        .await;
+        self.store.set_session_status(&peer, result.is_ok()).await;
+        result.map_err(|e| e.to_string())
+    }
+
+    /// One full pass: mint local Tier-1 records from live daemon state,
+    /// then sync with every enrolled machine we can resolve.
+    pub async fn sync_all(&self) {
+        if let Err(e) = self.reconcile_local_state().await {
+            tracing::warn!(target: "x0x::owner_sync", error = %e, "local reconcile failed");
+        }
+        let Some((owner, local)) = self.owner_and_machine() else {
+            return;
+        };
+        for device in self.store.enrolled_devices().await {
+            let machine = MachineId(device.machine_id);
+            if machine == local {
+                continue;
+            }
+            if !self.store.is_enrolled(&machine, &owner).await {
+                continue;
+            }
+            if let Err(e) = self.dial_and_sync(&machine).await {
+                tracing::debug!(
+                    target: "x0x::owner_sync",
+                    machine = %hex::encode(machine.0),
+                    error = %e,
+                    "Tier-1 dial skipped/failed until next pass"
+                );
+            }
+        }
+    }
+
+    /// Mint local Tier-1 records from live daemon state (no-op when a kind
+    /// is unchanged since its stored winner).
+    async fn reconcile_local_state(&self) -> Result<(), SyncError> {
+        let Some(owner_kp) = self.owner_kp() else {
+            return Ok(()); // ownerless installs mint nothing
+        };
+        let local_machine = self.agent.machine_id();
+        let local_hex = hex::encode(local_machine.0);
+
+        // Kinds 1 + 2 + 3: profile names and the Home pointer, via the
+        // daemon view when attached.
+        if let Some(view) = self.view() {
+            let names = view.profile_names();
+            self.mint_or_log(
+                SyncKind::OwnerProfile,
+                "owner",
+                SyncValue::OwnerProfile {
+                    human_name: names.human_name,
+                },
+                owner_kp,
+                local_machine,
+            )
+            .await;
+            self.mint_or_log(
+                SyncKind::MachineNames,
+                &local_hex,
+                SyncValue::MachineNames {
+                    display_name: names.display_name,
+                    machine_name: names.machine_name,
+                },
+                owner_kp,
+                local_machine,
+            )
+            .await;
+            if let Some(home_value) = view.home_pointer() {
+                self.mint_or_log(
+                    SyncKind::HomePointer,
+                    "home",
+                    home_value,
+                    owner_kp,
+                    local_machine,
+                )
+                .await;
+            }
+        }
+
+        // Kind 4: issuance journal lines (latest per agent, owner-scoped).
+        if let Some(path) = self.journal_path.as_ref() {
+            let owner_hex = hex::encode(owner_kp.user_id().0);
+            let mut latest: BTreeMap<String, crate::profile::IssuedCertRecord> = BTreeMap::new();
+            for record in crate::profile::IssuedCertRecord::load(path).await {
+                if record.user_id != owner_hex {
+                    continue;
+                }
+                let keep = latest
+                    .get(&record.agent_id)
+                    .is_none_or(|old| record.issued_at >= old.issued_at);
+                if keep {
+                    latest.insert(record.agent_id.clone(), record);
+                }
+            }
+            for (agent_hex, record) in latest {
+                self.mint_or_log(
+                    SyncKind::IssuanceJournal,
+                    &agent_hex,
+                    SyncValue::IssuanceJournal {
+                        agent_id: record.agent_id,
+                        cert_digest: record.cert_digest,
+                        issued_at: record.issued_at,
+                        not_after: record.not_after,
+                    },
+                    owner_kp,
+                    local_machine,
+                )
+                .await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn mint_or_log(
+        &self,
+        kind: SyncKind,
+        key: &str,
+        value: SyncValue,
+        owner_kp: &UserKeypair,
+        machine: MachineId,
+    ) {
+        if let Err(e) = self.store.mint(kind, key, &value, owner_kp, machine).await {
+            tracing::warn!(target: "x0x::owner_sync", kind = ?kind, error = %e, "mint failed");
+        }
+    }
+
+    /// Apply an accepted record to live daemon state (post-Done only).
+    ///
+    /// Exhaustive over [`SyncValue`] — Tier-3 kinds cannot reach here.
+    fn apply_record(&self, record: &VersionedRecord) {
+        match &record.value {
+            SyncValue::OwnerProfile { human_name } => {
+                if let Some(view) = self.view() {
+                    view.apply_names(human_name.clone(), None, None);
+                }
+            }
+            SyncValue::MachineNames {
+                display_name,
+                machine_name,
+            } => {
+                let local_hex = hex::encode(self.agent.machine_id().0);
+                if record.key == local_hex {
+                    if let Some(view) = self.view() {
+                        view.apply_names(None, display_name.clone(), machine_name.clone());
+                    }
+                }
+                // Remote machines' names stay in the record store for
+                // future surfacing (ADR-0041 Tier-1 scope).
+            }
+            SyncValue::HomePointer { .. } => {
+                // Stored in the record map for adoption by future Home
+                // provisioning; cross-machine Home adoption (TreeKEM
+                // re-key, key packages) is deliberately out of Tier-1
+                // scope (gapcheck blocker 32).
+            }
+            SyncValue::IssuanceJournal {
+                agent_id,
+                cert_digest,
+                issued_at,
+                ..
+            } => {
+                self.apply_journal_line(agent_id, cert_digest, *issued_at);
+            }
+        }
+    }
+
+    /// Append a synced journal line to the local file when missing
+    /// (idempotent; fire-and-forget).
+    fn apply_journal_line(&self, agent_hex: &str, cert_digest: &str, issued_at: u64) {
+        let Some(path) = self.journal_path.clone() else {
+            return;
+        };
+        let Some(owner_hex) = self.owner_kp().map(|kp| hex::encode(kp.user_id().0)) else {
+            return;
+        };
+        let agent_hex = agent_hex.to_string();
+        let cert_digest = cert_digest.to_string();
+        tokio::spawn(async move {
+            let existing = crate::profile::IssuedCertRecord::load(&path).await;
+            if existing
+                .iter()
+                .any(|r| r.agent_id == agent_hex && r.cert_digest == cert_digest)
+            {
+                return; // already local
+            }
+            let record = crate::profile::IssuedCertRecord {
+                user_id: owner_hex,
+                agent_id: agent_hex,
+                cert_digest,
+                issued_at,
+                not_after: None,
+            };
+            if let Err(e) = crate::profile::IssuedCertRecord::append(&path, &record).await {
+                tracing::warn!(
+                    target: "x0x::owner_sync",
+                    "failed to append synced journal line: {e}"
+                );
+            }
+        });
+    }
+
+    /// Spawn the periodic + on-change pass loop (owned by the daemon's
+    /// bg-task list; ends when `shutdown_rx` fires or the service drops).
+    pub async fn spawn_periodic(
+        self: &Arc<Self>,
+        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    ) {
+        let mut generation = self.store.generation_rx();
+        let mut ticker = tokio::time::interval(DEFAULT_SYNC_INTERVAL);
+        ticker.tick().await; // consume the immediate first tick
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.changed() => break,
+                _ = generation.changed() => {}
+                _ = ticker.tick() => {}
+            }
+            self.sync_all().await;
+        }
+    }
+}
+
+impl Drop for OwnerSyncService {
+    fn drop(&mut self) {
+        // Best-effort leak protection (voice `X0xLinkTransport` pattern):
+        // abort owned tasks; the acceptor deregisters when its task drops.
+        if let Ok(mut tasks) = self.tasks.try_lock() {
+            for task in tasks.drain(..) {
+                task.abort();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn owner_kp(seed: u8) -> UserKeypair {
+        UserKeypair::from_seed(&[seed; 32]).expect("deterministic keypair")
+    }
+
+    fn machine(id: u8) -> MachineId {
+        MachineId([id; 32])
+    }
+
+    fn names_value(display: &str) -> SyncValue {
+        SyncValue::MachineNames {
+            display_name: Some(display.to_string()),
+            machine_name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn conflict_rule_orders_version_then_time_then_writer() {
+        // WHY: blocker 31 — the exact tie-break chain must hold.
+        let base = RecordClock {
+            version: 5,
+            signed_at_ms: 100,
+            writer_machine: [2; 32],
+        };
+        let higher_version = RecordClock {
+            version: 6,
+            signed_at_ms: 0, // older time must NOT matter
+            writer_machine: [0; 32],
+        };
+        assert!(higher_version.beats(&base));
+        let lower_version = RecordClock {
+            version: 4,
+            signed_at_ms: 1_000_000, // newer time must NOT rescue it
+            writer_machine: [9; 32],
+        };
+        assert!(!lower_version.beats(&base));
+        let tie_higher_time = RecordClock {
+            version: 5,
+            signed_at_ms: 101,
+            writer_machine: [0; 32],
+        };
+        assert!(tie_higher_time.beats(&base));
+        let tie_lexicographic = RecordClock {
+            version: 5,
+            signed_at_ms: 100,
+            writer_machine: [3; 32],
+        };
+        assert!(tie_lexicographic.beats(&base));
+        assert!(!base.beats(&tie_lexicographic));
+        assert!(!base.beats(&base), "identical clocks beat nothing");
+    }
+
+    #[tokio::test]
+    async fn rollback_and_stale_records_are_rejected() {
+        // WHY: rollback protection — version < stored is never accepted,
+        // and equal-version-but-older is superseded, not stored.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await;
+        let owner = owner_kp(1);
+        let owner_id = owner.user_id();
+        let key = hex::encode(machine(1).0);
+        store
+            .mint(
+                SyncKind::MachineNames,
+                &key,
+                &names_value("v1"),
+                &owner,
+                machine(1),
+            )
+            .await
+            .expect("mint v1");
+        // Bump to a high version by hand.
+        let high = VersionedRecord::sign(
+            SyncKind::MachineNames,
+            &key,
+            &names_value("v9"),
+            RecordClock {
+                version: 9,
+                signed_at_ms: 1,
+                writer_machine: machine(2).0,
+            },
+            &owner,
+        )
+        .expect("sign v9");
+        assert_eq!(
+            store.merge_record(high, &owner_id).await.expect("merge v9"),
+            MergeOutcome::Accepted
+        );
+
+        // Rollback: version 3 (and 9-with-older-clock) rejected.
+        let rollback = VersionedRecord::sign(
+            SyncKind::MachineNames,
+            &key,
+            &names_value("old"),
+            RecordClock {
+                version: 3,
+                signed_at_ms: 999,
+                writer_machine: machine(3).0,
+            },
+            &owner,
+        )
+        .expect("sign rollback");
+        assert_eq!(
+            store
+                .merge_record(rollback, &owner_id)
+                .await
+                .expect("merge rollback"),
+            MergeOutcome::Superseded
+        );
+        let stale_equal = VersionedRecord::sign(
+            SyncKind::MachineNames,
+            &key,
+            &names_value("stale"),
+            RecordClock {
+                version: 9,
+                signed_at_ms: 0,
+                writer_machine: machine(3).0,
+            },
+            &owner,
+        )
+        .expect("sign stale");
+        assert_eq!(
+            store
+                .merge_record(stale_equal, &owner_id)
+                .await
+                .expect("merge stale"),
+            MergeOutcome::Superseded
+        );
+
+        let snapshot = store.records_snapshot().await;
+        assert_eq!(snapshot.len(), 1, "one winner for the key");
+        assert_eq!(snapshot[0].clock.version, 9);
+        assert_eq!(
+            snapshot[0].value,
+            names_value("v9"),
+            "neither rollback nor stale overwrote the winner"
+        );
+    }
+
+    #[tokio::test]
+    async fn forged_non_owner_record_rejected_fail_closed() {
+        // WHY: ADR-0041 validation — a forged state-commit from a non-owner
+        // key is rejected, and the failure is typed so sessions abort.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await;
+        let owner = owner_kp(1);
+        let attacker = owner_kp(2);
+        let forged = VersionedRecord::sign(
+            SyncKind::OwnerProfile,
+            "owner",
+            &SyncValue::OwnerProfile {
+                human_name: Some("Mallory".into()),
+            },
+            RecordClock {
+                version: 100,
+                signed_at_ms: 200,
+                writer_machine: machine(9).0,
+            },
+            &attacker,
+        )
+        .expect("sign forged");
+        let err = store
+            .merge_record(forged, &owner.user_id())
+            .await
+            .expect_err("non-owner record must be rejected");
+        assert_eq!(err, SyncError::OwnerMismatch);
+        assert!(
+            store.records_snapshot().await.is_empty(),
+            "nothing was stored"
+        );
+    }
+
+    #[tokio::test]
+    async fn tampered_signature_rejected() {
+        let owner = owner_kp(1);
+        let mut record = VersionedRecord::sign(
+            SyncKind::OwnerProfile,
+            "owner",
+            &SyncValue::OwnerProfile {
+                human_name: Some("A".into()),
+            },
+            RecordClock {
+                version: 1,
+                signed_at_ms: 1,
+                writer_machine: machine(1).0,
+            },
+            &owner,
+        )
+        .expect("sign");
+        // Tamper with the payload after signing.
+        record.value = SyncValue::OwnerProfile {
+            human_name: Some("B".into()),
+        };
+        let result = record.verify_owner(&owner.user_id());
+        assert!(
+            matches!(result, Err(SyncError::BadSignature(_))),
+            "tampered payload must fail signature verification, got {result:?}"
+        );
+    }
+    #[tokio::test]
+    async fn enrollment_gate_rejects_unenrolled_and_forged_machines() {
+        // WHY: blocker 30 — only owner-enrolled machines pass the gate.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await;
+        let owner = owner_kp(1);
+        let owner_id = owner.user_id();
+        let enrolled_machine = machine(7);
+        let enrollment = OwnerEnrollment::sign(enrolled_machine, &owner, 1_000).expect("enroll");
+        store.enroll(enrollment).await;
+
+        assert!(store.is_enrolled(&enrolled_machine, &owner_id).await);
+        assert!(
+            !store.is_enrolled(&machine(8), &owner_id).await,
+            "unenrolled machine fails the gate"
+        );
+
+        // Forged enrollment signed by a different key fails closed.
+        let attacker = owner_kp(2);
+        let forged = OwnerEnrollment::sign(machine(9), &attacker, 2_000).expect("sign");
+        assert_eq!(
+            forged.verify_owner(&owner_id),
+            Err(SyncError::OwnerMismatch)
+        );
+        // Directly planted in the file, it still fails verification at the gate.
+        store.enroll(forged).await;
+        assert!(
+            !store.is_enrolled(&machine(9), &owner_id).await,
+            "foreign-key enrollment never passes the gate"
+        );
+    }
+
+    #[tokio::test]
+    async fn tier3_surface_is_exactly_the_four_kinds() {
+        // WHY: blocker 32 — the sync surface serializes ONLY Tier-1 kinds;
+        // every other kind tag is undecodable (deny-by-default allowlist).
+        assert_eq!(SyncKind::ALL.len(), 4);
+        for byte in 0u8..=255 {
+            let decoded = SyncKind::from_u8(byte);
+            let known = SyncKind::ALL.iter().any(|k| k.as_u8() == byte);
+            assert_eq!(
+                decoded.is_some(),
+                known,
+                "kind tag 0x{byte:02x} must decode iff it is one of the four kinds"
+            );
+        }
+        // Every one of the four kinds must round-trip through the wire
+        // value enum — these are the only shapes a record can carry.
+        let owner = owner_kp(1);
+        for kind in SyncKind::ALL {
+            let value = match kind {
+                SyncKind::OwnerProfile => SyncValue::OwnerProfile {
+                    human_name: Some("H".into()),
+                },
+                SyncKind::MachineNames => names_value("n"),
+                SyncKind::HomePointer => SyncValue::HomePointer {
+                    group_id: "g".into(),
+                    policy: GroupPolicy::default(),
+                    roster: vec![],
+                    primary_agent: "a".into(),
+                    provisioned_at_ms: 0,
+                },
+                SyncKind::IssuanceJournal => SyncValue::IssuanceJournal {
+                    agent_id: "a".into(),
+                    cert_digest: "d".into(),
+                    issued_at: 1,
+                    not_after: None,
+                },
+            };
+            assert_eq!(value.kind(), kind);
+            let record = VersionedRecord::sign(
+                kind,
+                "k",
+                &value,
+                RecordClock {
+                    version: 1,
+                    signed_at_ms: 1,
+                    writer_machine: machine(1).0,
+                },
+                &owner,
+            )
+            .expect("sign");
+            record.verify().expect("all four kinds verify");
+        }
+
+        // Behavioral Tier-3 check: kind/value coherence is enforced, so no
+        // foreign state can ride a record under a mismatched kind tag.
+        let mismatched = VersionedRecord {
+            kind: SyncKind::HomePointer,
+            key: "home".into(),
+            value: names_value("evil"),
+            clock: RecordClock {
+                version: 1,
+                signed_at_ms: 1,
+                writer_machine: machine(1).0,
+            },
+            owner_public_key: vec![],
+            signature: vec![],
+        };
+        assert_eq!(
+            mismatched.verify(),
+            Err(SyncError::KindMismatch),
+            "kind must match value variant — no other state can ride a record"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_kind_tag_fails_record_decode() {
+        // WHY: Tier-3 allowlist — bincode deserialization of SyncKind with
+        // an out-of-range discriminant fails, so no fifth kind can arrive.
+        let bad = bincode::serialize(&SyncKind::OwnerProfile).expect("encode");
+        // A u8-repr enum serializes as its tag; corrupt it to 0x2A.
+        let mut hostile = bad;
+        hostile[0] = 0x2A;
+        let decoded: Result<SyncKind, _> = bincode::deserialize(&hostile);
+        assert!(decoded.is_err(), "unknown kind tag must not decode");
+        assert_eq!(SyncKind::from_u8(0x2A), None);
+    }
+
+    #[tokio::test]
+    async fn frame_round_trip_and_oversize_rejected() {
+        // WHY: bounded framing — an oversized length prefix fails closed
+        // instead of allocating.
+        let frame = SyncFrame::Done;
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &frame).await.expect("write");
+        let mut cursor = std::io::Cursor::new(buf);
+        let back = read_frame(&mut cursor).await.expect("read");
+        assert_eq!(back, frame);
+
+        let mut evil = Vec::new();
+        evil.extend_from_slice(&(MAX_FRAME_BYTES + 1).to_be_bytes());
+        let mut cursor = std::io::Cursor::new(evil);
+        assert!(matches!(
+            read_frame(&mut cursor).await,
+            Err(SyncError::MalformedFrame(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn session_rejects_non_enrolled_peer_and_self() {
+        // WHY: blocker 30 — the stream accept path fails closed before any
+        // application byte for unenrolled (or self) peers.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await;
+        let owner = owner_kp(1);
+        let owner_id = owner.user_id();
+        let local = machine(1);
+        let (mut tx, mut rx) = tokio::io::duplex(64);
+        let err = run_sync_session(
+            &mut tx,
+            &mut rx,
+            &store,
+            &owner_id,
+            &local,
+            &machine(2),
+            |_| {},
+        )
+        .await
+        .expect_err("unenrolled peer refused");
+        assert!(matches!(err, SyncError::NotEnrolled { .. }));
+        let err = run_sync_session(&mut tx, &mut rx, &store, &owner_id, &local, &local, |_| {})
+            .await
+            .expect_err("self-sync refused");
+        assert_eq!(err, SyncError::SelfSync);
+    }
+}

--- a/src/owner_sync.rs
+++ b/src/owner_sync.rs
@@ -16,7 +16,7 @@
 //!    non-revoked) have already cleared — enforced by the shared accept loop
 //!    before this protocol's acceptor sees the stream;
 //! 2. the remote machine is in the local **owner device set**: an
-//!    [`OwnerEnrollment`] record signed by the owner key, whose public key
+//!    [`crate::owner_sync::OwnerEnrollment`] record signed by the owner key, whose public key
 //!    derives to this install's `UserId`, and whose optional expiry has not
 //!    elapsed (enrollment currency, not just signature validity). This is
 //!    the enrollment direction of ADR-0043, reused — not a rival scheme.
@@ -33,7 +33,7 @@
 //!
 //! # Object model (gapcheck blocker 31)
 //!
-//! Each Tier-1 object is an owner-signed [`VersionedRecord`]. Conflict rule
+//! Each Tier-1 object is an owner-signed [`crate::owner_sync::VersionedRecord`]. Conflict rule
 //! (deliberately decoupled from state-commit heights): highest `version`
 //! wins; tie → highest `signed_at_ms`; tie → lexicographically greatest
 //! `writer_machine`; **exact-clock tie with different signed content →
@@ -54,14 +54,14 @@
 //! side carrying a fresh nonce) → mutual `Proof` (owner-key possession) →
 //! per-kind **paged** version vectors → **paged** record batches both ways
 //! → `Done` → atomic local commit. The whole session runs under a total
-//! timeout ([`SESSION_TIMEOUT`]); a peer that stalls at any stage is
+//! timeout ([`crate::owner_sync::SESSION_TIMEOUT`]); a peer that stalls at any stage is
 //! dropped, never held. Sessions run periodically and are re-triggered on
 //! local change (the store's generation channel).
 //!
 //! # Tier-3 boundary (gapcheck blocker 32 scope note)
 //!
-//! The sync surface serializes ONLY the four Tier-1 kinds: [`SyncKind`] and
-//! [`SyncValue`] are closed enums with no catch-all. A record whose kind tag
+//! The sync surface serializes ONLY the four Tier-1 kinds: [`crate::owner_sync::SyncKind`] and
+//! [`crate::owner_sync::SyncValue`] are closed enums with no catch-all. A record whose kind tag
 //! is not one of the four fails to decode, and a record whose kind does not
 //! match its value variant is rejected whole.
 

--- a/src/owner_sync.rs
+++ b/src/owner_sync.rs
@@ -1671,35 +1671,6 @@ async fn read_paged_records<R: AsyncRead + Unpin>(
     Ok(records)
 }
 
-/// Write records as bounded pages (always at least one page).
-async fn write_paged_records<S: AsyncWrite + Unpin>(
-    send: &mut S,
-    records: &[VersionedRecord],
-) -> Result<(), SyncError> {
-    if records.is_empty() {
-        write_frame(
-            send,
-            &SyncFrame::Records {
-                records: Vec::new(),
-            },
-        )
-        .await?;
-        return Ok(());
-    }
-    for page in records.chunks(RECORDS_PER_FRAME) {
-        write_frame(
-            send,
-            &SyncFrame::Records {
-                records: page.to_vec(),
-            },
-        )
-        .await?;
-    }
-    Ok(())
-}
-
-/// Default period between automatic sync passes (also wakes on any local
-/// Tier-1 change via the store's generation channel).
 pub const DEFAULT_SYNC_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Concurrent sync sessions this daemon will run at once (inbound +
@@ -1730,12 +1701,58 @@ pub struct SyncProfileNames {
     pub display_name: Option<String>,
     pub machine_name: Option<String>,
 }
-
+/// Write records as bounded pages: each page fills up to BOTH
+/// [`RECORDS_PER_FRAME`] records and [`RECORDS_PAGE_BYTES`] cumulative
+/// serialized bytes before flushing, so a page of large (individually
+/// value-capped) records cannot approach the frame limit (review R4).
+/// Always at least one page; a single record always ships (its own size is
+/// value-capped well under [`MAX_FRAME_BYTES`]).
+async fn write_paged_records<S: AsyncWrite + Unpin>(
+    send: &mut S,
+    records: &[VersionedRecord],
+) -> Result<(), SyncError> {
+    if records.is_empty() {
+        write_frame(
+            send,
+            &SyncFrame::Records {
+                records: Vec::new(),
+            },
+        )
+        .await?;
+        return Ok(());
+    }
+    let mut page: Vec<VersionedRecord> = Vec::new();
+    let mut page_bytes = 0usize;
+    for record in records {
+        let record_bytes = bincode::serialize(record)
+            .map_err(|e| SyncError::MalformedFrame(format!("encode record: {e}")))?
+            .len();
+        if !page.is_empty()
+            && (page.len() >= RECORDS_PER_FRAME || page_bytes + record_bytes > RECORDS_PAGE_BYTES)
+        {
+            write_frame(
+                send,
+                &SyncFrame::Records {
+                    records: std::mem::take(&mut page),
+                },
+            )
+            .await?;
+            page_bytes = 0;
+        }
+        page_bytes += record_bytes;
+        page.push(record.clone());
+    }
+    if !page.is_empty() {
+        write_frame(send, &SyncFrame::Records { records: page }).await?;
+    }
+    Ok(())
+}
 /// Daemon-resident Tier-1 sync service (the `ForwardService` pattern for
 /// `SyncV1`): owns the single registered acceptor for
 /// [`crate::streams::StreamProtocol::SyncV1`], gates each inbound stream on
-/// the owner device set, dials every enrolled machine it can resolve, and
-/// mints local Tier-1 records from live daemon state before each pass.
+/// the owner device set (permit acquired before the per-stream task is
+/// spawned), dials every enrolled machine it can resolve, and mints local
+/// Tier-1 records from live daemon state before each pass.
 ///
 /// Constructed only when the install has an owner key (`user.key`); an
 /// ownerless install registers no acceptor and syncs nothing.
@@ -3151,5 +3168,185 @@ mod r3_tests {
         responder.await.unwrap();
         assert_eq!(summary.shipped, N);
         assert_eq!(store_b.records_snapshot().await.len(), N);
+    }
+}
+
+#[cfg(test)]
+mod r4_tests {
+    use super::tests::{clock, owner_kp};
+    use super::*;
+
+    /// A `Vec<u8>` sink for `write_frame`, decoded back frame-by-frame so
+    /// tests can assert the PAGE COUNT and each frame's encoded body size.
+    async fn count_record_frames(records: &[VersionedRecord]) -> Vec<usize> {
+        let mut sink = Vec::new();
+        write_paged_records(&mut sink, records)
+            .await
+            .expect("write pages");
+        let mut cursor = std::io::Cursor::new(sink);
+        let mut sizes = Vec::new();
+        loop {
+            let before = cursor.position();
+            match read_frame(&mut cursor).await {
+                Ok(_) => sizes.push((cursor.position() - before - 4) as usize),
+                Err(_) => break,
+            }
+        }
+        sizes
+    }
+
+    /// WHY (review R4): pages fill by CUMULATIVE BYTES, not a fixed count —
+    /// a set of large (individually capped) records splits into multiple
+    /// frames each well under the frame limit, and many small records still
+    /// respect the per-frame count cap.
+    #[tokio::test]
+    async fn record_pages_fill_by_cumulative_bytes() {
+        let owner = owner_kp(7);
+        // 10 records × 8 KiB values ≈ 83 KiB of records: the 64 KiB byte
+        // budget MUST split them even though 10 < the 16-record count cap.
+        let big: Vec<VersionedRecord> = (0..10)
+            .map(|i| {
+                VersionedRecord::sign(
+                    SyncKind::IssuanceJournal,
+                    &format!("big-{i}"),
+                    &SyncValue::IssuanceJournal {
+                        agent_id: format!("big-{i}"),
+                        cert_digest: "d".repeat(8 * 1024),
+                        issued_at: i as u64,
+                        not_after: None,
+                    },
+                    clock(1, 1, 1),
+                    &owner,
+                )
+                .unwrap()
+            })
+            .collect();
+        let sizes = count_record_frames(&big).await;
+        assert!(
+            sizes.len() > 1,
+            "byte budget must split the pages: {sizes:?}"
+        );
+        // Every frame stays far below the 256 KiB frame limit: the page
+        // budget plus at most one value-capped record.
+        let max_record_overhead = 12 * 1024; // pubkey + ML-DSA sig + framing
+        for size in &sizes {
+            assert!(
+                *size <= RECORDS_PAGE_BYTES + MAX_VALUE_BYTES + max_record_overhead,
+                "frame body of {size} bytes exceeds the page bound"
+            );
+            assert!(
+                (*size as u32) < MAX_FRAME_BYTES,
+                "frame body of {size} bytes must stay under the frame limit"
+            );
+        }
+        // All records fit in the emitted frames (decode side already proved
+        // frames are well-formed; count the payload).
+        let total_records: usize = sizes.len(); // ≥ 1 page per flush
+        assert!(total_records >= 1);
+
+        // Many small records: the 16-record count cap still binds.
+        let small: Vec<VersionedRecord> = (0..40)
+            .map(|i| {
+                VersionedRecord::sign(
+                    SyncKind::IssuanceJournal,
+                    &format!("s-{i}"),
+                    &SyncValue::IssuanceJournal {
+                        agent_id: format!("s-{i}"),
+                        cert_digest: format!("d{i}"),
+                        issued_at: i as u64,
+                        not_after: None,
+                    },
+                    clock(1, 1, 1),
+                    &owner,
+                )
+                .unwrap()
+            })
+            .collect();
+        let small_sizes = count_record_frames(&small).await;
+        // 40 tiny records ≈ 40 × ~3.5 KiB ≈ 140 KiB — split by EITHER the
+        // byte or the count cap; every frame remains bounded.
+        assert!(
+            small_sizes.len() >= 3,
+            "40 records cannot fit one page: {small_sizes:?}"
+        );
+        for size in &small_sizes {
+            assert!((*size as u32) < MAX_FRAME_BYTES);
+        }
+    }
+
+    /// WHY (review R4): an oversize single value is rejected AT THE
+    /// BOUNDARY — typed error at mint, at merge (pre-commit), and at the
+    /// frame decoder for anything that would exceed the frame limit — never
+    /// discovered mid-stream during commit or apply.
+    #[tokio::test]
+    async fn oversize_value_rejected_at_every_boundary() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
+        let owner = owner_kp(1);
+        let owner_id = owner.user_id();
+
+        // A decodable frame (≈ 68 KiB < 256 KiB) carrying ONE oversize
+        // value: rejected by MERGE with a typed error, before any commit.
+        let oversize = VersionedRecord::sign(
+            SyncKind::IssuanceJournal,
+            "big",
+            &SyncValue::IssuanceJournal {
+                agent_id: "big".into(),
+                cert_digest: "d".repeat(MAX_VALUE_BYTES + 2048),
+                issued_at: 1,
+                not_after: None,
+            },
+            clock(1, 1, 1),
+            &owner,
+        )
+        .expect("sign");
+        let err = store
+            .merge_record(oversize, &owner_id)
+            .await
+            .expect_err("merge must reject an oversize value");
+        assert!(
+            matches!(err, SyncError::MalformedFrame(ref m) if m.contains("exceeds limit")),
+            "typed boundary rejection, got: {err:?}"
+        );
+        assert!(
+            store.records_snapshot().await.is_empty(),
+            "nothing committed from the rejected record"
+        );
+
+        // A frame whose BODY itself would exceed MAX_FRAME_BYTES is
+        // rejected by the frame decoder — the outermost boundary, before
+        // any record is even deserialized.
+        let mut hostile = Vec::new();
+        hostile.extend_from_slice(&(MAX_FRAME_BYTES + 1).to_be_bytes());
+        let mut cursor = std::io::Cursor::new(hostile);
+        assert!(matches!(
+            read_frame(&mut cursor).await,
+            Err(SyncError::MalformedFrame(_))
+        ));
+
+        // A legitimately-framed batch that CONTAINS an oversize record is
+        // rejected during ingest verification (the session's verify stage),
+        // never reaching commit: simulate by verifying the batch records
+        // exactly as the session does.
+        let oversize_two = VersionedRecord::sign(
+            SyncKind::IssuanceJournal,
+            "huge",
+            &SyncValue::IssuanceJournal {
+                agent_id: "huge".into(),
+                cert_digest: "d".repeat(MAX_VALUE_BYTES * 2),
+                issued_at: 1,
+                not_after: None,
+            },
+            clock(1, 1, 1),
+            &owner,
+        )
+        .expect("sign");
+        let err = oversize_two
+            .verify_owner(&owner_id)
+            .expect_err("session verify stage rejects oversize values");
+        assert!(
+            matches!(err, SyncError::MalformedFrame(ref m) if m.contains("exceeds limit")),
+            "got: {err:?}"
+        );
     }
 }

--- a/src/owner_sync.rs
+++ b/src/owner_sync.rs
@@ -6,39 +6,57 @@
 //! policy pointer, and the sub-agent issuance journal. Tier 2 (history
 //! backfill) and Tier 3 (never-replicates state) are out of scope here.
 //!
-//! # Trust model — same-owner, enrolled machines only (gapcheck blocker 30)
+//! # Trust model — same-owner, enrolled machines, key possession
+//! (gapcheck blocker 30; review R2)
 //!
 //! A stream carrying [`crate::streams::StreamProtocol::SyncV1`] is accepted
-//! only when BOTH hold:
+//! only when ALL hold:
 //!
 //! 1. the ADR-0022 machine identity gates (transport-verified, trusted,
 //!    non-revoked) have already cleared — enforced by the shared accept loop
 //!    before this protocol's acceptor sees the stream;
 //! 2. the remote machine is in the local **owner device set**: an
 //!    [`OwnerEnrollment`] record signed by the owner key, whose public key
-//!    derives to this install's `UserId`. This is the enrollment direction
-//!    of ADR-0043 (owner-key-signed, machine-scoped), reused — not a rival
-//!    scheme.
+//!    derives to this install's `UserId`, and whose optional expiry has not
+//!    elapsed (enrollment currency, not just signature validity). This is
+//!    the enrollment direction of ADR-0043, reused — not a rival scheme.
+//!    Enrollments are removed with the DELETE `/sync/devices/:id` path.
+//! 3. the peer **proves possession of the owner key**: after the transport
+//!    handshake each side sends a random nonce and the peer must return an
+//!    ML-DSA signature over `nonce || both machine ids || owner_user_id`
+//!    under the owner key. Echoing the owner id (as the unsigned `Hello`
+//!    alone allowed) is worthless; a stale-but-enrolled machine that no
+//!    longer holds the owner key learns nothing.
 //!
-//! Fail closed: any signature or enrollment failure aborts the session and
-//! the peer learns nothing beyond the refusal.
+//! Fail closed: any signature, enrollment, or proof failure aborts the
+//! session, and the peer learns nothing beyond the refusal.
 //!
 //! # Object model (gapcheck blocker 31)
 //!
 //! Each Tier-1 object is an owner-signed [`VersionedRecord`]. Conflict rule
 //! (deliberately decoupled from state-commit heights): highest `version`
 //! wins; tie → highest `signed_at_ms`; tie → lexicographically greatest
-//! `writer_machine`. Anti-rollback: a record is accepted only when it
-//! *strictly beats* the stored clock under that ordering, so a replayed or
-//! stale record can never overwrite a newer one.
+//! `writer_machine`; **exact-clock tie with different signed content →
+//! greatest `record_hash`** (deterministic convergence under equal-clock
+//! equivocation; detected and surfaced). Anti-rollback: nothing ever
+//! replaces a stored record it does not strictly outrank.
+//!
+//! Durability (review R2): the store directory is created at load, and
+//! every mutating path propagates persistence errors — success is never
+//! reported on a swallowed write. Accepted batches are committed in ONE
+//! atomic file write only after the whole batch verified and the session
+//! reached a clean `Done`, so a forged tail cannot leave a partial batch
+//! committed and advertised.
 //!
 //! # Protocol
 //!
-//! On connect the two sides exchange a [`SyncFrame::Hello`] (same owner,
-//! same protocol version, non-self), then per-kind version vectors, then
-//! ship exactly the records the other side is missing or would accept.
-//! Sessions run periodically and are re-triggered on local change (the
-//! store's generation channel) — "periodic + on-change".
+//! On connect: `Hello` (same owner, same protocol version, non-self, each
+//! side carrying a fresh nonce) → mutual `Proof` (owner-key possession) →
+//! per-kind **paged** version vectors → **paged** record batches both ways
+//! → `Done` → atomic local commit. The whole session runs under a total
+//! timeout ([`SESSION_TIMEOUT`]); a peer that stalls at any stage is
+//! dropped, never held. Sessions run periodically and are re-triggered on
+//! local change (the store's generation channel).
 //!
 //! # Tier-3 boundary (gapcheck blocker 32 scope note)
 //!
@@ -50,6 +68,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use ant_quic::crypto::raw_public_keys::pqc::{
     sign_with_ml_dsa, verify_with_ml_dsa, MlDsaPublicKey, MlDsaSignature,
@@ -66,13 +85,46 @@ use crate::identity::{MachineId, UserId, UserKeypair};
 const ENROLL_MSG_PREFIX: &[u8] = b"x0x-adr0041-enroll-v1";
 /// Domain-separation prefix for the bytes a versioned record signs.
 const RECORD_MSG_PREFIX: &[u8] = b"x0x-adr0041-record-v1";
+/// Domain-separation prefix for the owner-key possession proof.
+const PROOF_MSG_PREFIX: &[u8] = b"x0x-adr0041-proof-v1";
 
-/// Wire protocol version for the SyncV1 handshake.
-pub const SYNC_PROTOCOL_VERSION: u32 = 1;
+/// Wire protocol version for the SyncV1 handshake. Bumped to 2 in review
+/// R2 (Hello carries a nonce; `Proof` frame added; vectors/records paged).
+pub const SYNC_PROTOCOL_VERSION: u32 = 2;
 
 /// Maximum size of one sync frame (length-prefixed payload). Tier-1 records
 /// are tiny; anything larger is hostile or corrupt — fail closed.
 pub const MAX_FRAME_BYTES: u32 = 256 * 1024;
+
+/// Version-vector entries per `VersionVector` frame (paging keeps any one
+/// frame far below [`MAX_FRAME_BYTES`] and the writer inside the QUIC
+/// stream window even when the peer has not started reading).
+pub const VV_ENTRIES_PER_FRAME: usize = 256;
+
+/// Records per `Records` frame.
+pub const RECORDS_PER_FRAME: usize = 16;
+
+/// Total version-vector entries a session will accept (both directions of
+/// the state space are bounded; beyond this the peer is hostile).
+pub const MAX_VECTOR_ENTRIES: usize = 4096;
+
+/// Total records a session will accept in one batch.
+pub const MAX_RECORDS_PER_SESSION: usize = 1024;
+
+/// Hard cap on stored (winning) records. Tier-1 state is small by design;
+/// exceeding this is a StoreLimit failure, never silent truncation.
+pub const MAX_STORED_RECORDS: usize = 4096;
+
+/// Maximum record key length in bytes.
+pub const MAX_KEY_BYTES: usize = 256;
+
+/// Enrollment expiry clock skew tolerance, in milliseconds (mirrors
+/// [`crate::identity::EXPIRY_CLOCK_SKEW_SECS`]).
+const ENROLL_EXPIRY_SKEW_MS: u64 = 300_000;
+
+/// Total session budget after the protocol prefix. A peer that stalls at
+/// any protocol stage holds no task beyond this.
+pub const SESSION_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// File holding the owner device set, inside `<data_dir>/sync/`.
 const DEVICES_FILE: &str = "devices.json";
@@ -201,8 +253,9 @@ pub struct RecordClock {
 impl RecordClock {
     /// Whether `self` strictly beats `other` under the ADR-0041 rule:
     /// highest `version`, then highest `signed_at_ms`, then lexicographically
-    /// greatest `writer_machine`. Equal clocks beat nothing (idempotent
-    /// re-delivery), and a lower `version` never wins — rollback protection.
+    /// greatest `writer_machine`. Equal clocks beat nothing — the
+    /// equal-clock case is resolved by signed-content hash in
+    /// [`OwnerSyncStore`] so peers converge deterministically.
     #[must_use]
     pub fn beats(&self, other: &Self) -> bool {
         match self.version.cmp(&other.version) {
@@ -229,7 +282,7 @@ pub struct VersionedRecord {
     pub clock: RecordClock,
     /// Owner ML-DSA-65 public key bytes (self-authenticating record).
     pub owner_public_key: Vec<u8>,
-    /// ML-DSA-65 signature over [`VersionedRecord::canonical_message`].
+    /// ML-DSA-65 signature over the canonical message.
     pub signature: Vec<u8>,
 }
 
@@ -255,6 +308,23 @@ impl VersionedRecord {
         msg.extend_from_slice(&clock.writer_machine);
         msg.extend_from_slice(value_bytes);
         msg
+    }
+
+    /// The canonical bytes of this record (self-shaped).
+    fn canonical_bytes(&self) -> Vec<u8> {
+        let value_bytes = bincode::serialize(&self.value).unwrap_or_default();
+        Self::canonical_message(&self.kind, &self.key, &self.clock, &value_bytes)
+    }
+
+    /// BLAKE3 over the canonical bytes plus the signature — the
+    /// deterministic equal-clock tie-break. Two peers holding different
+    /// records under the same clock agree on the greater hash.
+    #[must_use]
+    pub fn record_hash(&self) -> [u8; 32] {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&self.canonical_bytes());
+        hasher.update(&self.signature);
+        *hasher.finalize().as_bytes()
     }
 
     /// Sign a fresh record with the owner key.
@@ -288,16 +358,24 @@ impl VersionedRecord {
     }
 
     /// Verify the signature and that the record's kind matches its value
-    /// variant. Fail closed on any mismatch.
+    /// variant, plus structural bounds (key length). Fail closed on any
+    /// mismatch.
     ///
     /// # Errors
     ///
     /// [`SyncError::BadSignature`] on an invalid signature or malformed key
     /// material; [`SyncError::KindMismatch`] when the kind tag and value
-    /// variant disagree.
+    /// variant disagree; [`SyncError::MalformedFrame`] when the key exceeds
+    /// [`MAX_KEY_BYTES`].
     pub fn verify(&self) -> Result<(), SyncError> {
         if self.value.kind() != self.kind {
             return Err(SyncError::KindMismatch);
+        }
+        if self.key.len() > MAX_KEY_BYTES {
+            return Err(SyncError::MalformedFrame(format!(
+                "record key of {} bytes exceeds limit {MAX_KEY_BYTES}",
+                self.key.len()
+            )));
         }
         let owner_pubkey = MlDsaPublicKey::from_bytes(&self.owner_public_key)
             .map_err(|_| SyncError::BadSignature("invalid owner public key".into()))?;
@@ -335,6 +413,11 @@ pub struct OwnerEnrollment {
     pub machine_id: [u8; 32],
     /// Unix ms when the owner enrolled this machine.
     pub enrolled_at_ms: u64,
+    /// Optional expiry (Unix ms). `None` = until explicitly deleted.
+    /// [`OwnerSyncStore::is_enrolled`] checks currency, not just signature —
+    /// a stale enrollment must not keep the sync gate open (review R2).
+    #[serde(default)]
+    pub expires_at_ms: Option<u64>,
     /// Owner ML-DSA-65 public key bytes.
     pub owner_public_key: Vec<u8>,
     /// Signature over the canonical enrollment message.
@@ -342,16 +425,29 @@ pub struct OwnerEnrollment {
 }
 
 impl OwnerEnrollment {
-    fn canonical_message(machine_id: &[u8; 32], enrolled_at_ms: u64, owner_pub: &[u8]) -> Vec<u8> {
-        let mut msg = Vec::with_capacity(ENROLL_MSG_PREFIX.len() + 32 + 8 + owner_pub.len());
+    fn canonical_message(
+        machine_id: &[u8; 32],
+        enrolled_at_ms: u64,
+        expires_at_ms: Option<u64>,
+        owner_pub: &[u8],
+    ) -> Vec<u8> {
+        let mut msg = Vec::with_capacity(ENROLL_MSG_PREFIX.len() + 32 + 16 + owner_pub.len());
         msg.extend_from_slice(ENROLL_MSG_PREFIX);
         msg.extend_from_slice(machine_id);
         msg.extend_from_slice(&enrolled_at_ms.to_le_bytes());
+        match expires_at_ms {
+            Some(expiry) => {
+                msg.push(1);
+                msg.extend_from_slice(&expiry.to_le_bytes());
+            }
+            None => msg.push(0),
+        }
         msg.extend_from_slice(owner_pub);
         msg
     }
 
-    /// Sign an enrollment for `machine_id` with the owner key.
+    /// Sign an enrollment for `machine_id` with the owner key. `expires_at_ms`
+    /// bounds the enrollment's lifetime (`None` = until deleted).
     ///
     /// # Errors
     ///
@@ -360,15 +456,22 @@ impl OwnerEnrollment {
         machine_id: MachineId,
         owner: &UserKeypair,
         enrolled_at_ms: u64,
+        expires_at_ms: Option<u64>,
     ) -> Result<Self, IdentityError> {
         let owner_public_key = owner.public_key().as_bytes().to_vec();
-        let message = Self::canonical_message(&machine_id.0, enrolled_at_ms, &owner_public_key);
+        let message = Self::canonical_message(
+            &machine_id.0,
+            enrolled_at_ms,
+            expires_at_ms,
+            &owner_public_key,
+        );
         let signature = sign_with_ml_dsa(owner.secret_key(), &message).map_err(|e| {
             IdentityError::CertificateVerification(format!("enrollment signing failed: {e:?}"))
         })?;
         Ok(Self {
             machine_id: machine_id.0,
             enrolled_at_ms,
+            expires_at_ms,
             owner_public_key,
             signature: signature.as_bytes().to_vec(),
         })
@@ -391,11 +494,20 @@ impl OwnerEnrollment {
         let message = Self::canonical_message(
             &self.machine_id,
             self.enrolled_at_ms,
+            self.expires_at_ms,
             &self.owner_public_key,
         );
         verify_with_ml_dsa(&pubkey, &message, &signature)
             .map_err(|e| SyncError::BadSignature(format!("bad signature: {e:?}")))?;
         Ok(())
+    }
+
+    /// Whether the enrollment is still current at `now_ms` (expiry with
+    /// skew tolerance; `None` never expires).
+    #[must_use]
+    pub fn is_current_at(&self, now_ms: u64) -> bool {
+        self.expires_at_ms
+            .is_none_or(|expiry| now_ms <= expiry.saturating_add(ENROLL_EXPIRY_SKEW_MS))
     }
 }
 
@@ -403,7 +515,8 @@ impl OwnerEnrollment {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SyncError {
     Io(String),
-    /// Frame body exceeded [`MAX_FRAME_BYTES`] or a decode failed.
+    /// Frame body exceeded [`MAX_FRAME_BYTES`], a decode failed, or a
+    /// structural bound (key length) was violated.
     MalformedFrame(String),
     ProtocolVersion {
         local: u32,
@@ -414,6 +527,10 @@ pub enum SyncError {
     NotEnrolled {
         machine: [u8; 32],
     },
+    /// The peer's owner-key possession proof failed (challenge-response).
+    ChallengeFailed(String),
+    /// The session exceeded its total time budget.
+    SessionTimeout,
     /// A machine tried to sync with itself.
     SelfSync,
     BadSignature(String),
@@ -423,6 +540,10 @@ pub enum SyncError {
     UnknownKind {
         tag: u8,
     },
+    /// Store cardinality limit exceeded ([`MAX_STORED_RECORDS`]).
+    StoreLimit(String),
+    /// Inbound batch/vector exceeded its session cap.
+    TooManyRecords(String),
 }
 
 impl std::fmt::Display for SyncError {
@@ -437,19 +558,23 @@ impl std::fmt::Display for SyncError {
                 )
             }
             Self::OwnerMismatch => write!(f, "sync peer is not the same owner"),
-            Self::NotEnrolled { machine } => {
-                write!(
-                    f,
-                    "machine {} is not in the owner device set",
-                    hex::encode(machine)
-                )
+            Self::NotEnrolled { machine } => write!(
+                f,
+                "machine {} is not in the owner device set",
+                hex::encode(machine)
+            ),
+            Self::ChallengeFailed(e) => {
+                write!(f, "owner-key possession proof failed: {e}")
             }
+            Self::SessionTimeout => write!(f, "sync session timed out"),
             Self::SelfSync => write!(f, "refusing to sync with this machine itself"),
             Self::BadSignature(e) => write!(f, "sync signature failure: {e}"),
             Self::KindMismatch => write!(f, "record kind does not match its value variant"),
             Self::UnknownKind { tag } => {
                 write!(f, "unknown sync kind tag 0x{tag:02x} (Tier-3 allowlist)")
             }
+            Self::StoreLimit(e) => write!(f, "sync store limit: {e}"),
+            Self::TooManyRecords(e) => write!(f, "sync session record cap: {e}"),
         }
     }
 }
@@ -462,42 +587,78 @@ impl From<std::io::Error> for SyncError {
     }
 }
 
-/// Outcome of merging one inbound record.
+/// Outcome of classifying one inbound record against the stored winner.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MergeOutcome {
-    /// Stored — the record beat what we had.
+    /// Stored — the record outranks what we had.
     Accepted,
-    /// Not stored — did not beat the stored clock (stale, rollback, or
-    /// identical re-delivery). Never an error: partitions heal.
+    /// Not stored — the stored record outranks it (stale, rollback, exact
+    /// replay, or lost equal-clock hash tie-break). Never an error:
+    /// partitions heal.
     Superseded,
 }
 
-/// Per-kind version vector entry: the peer's clock for one key.
+/// Per-kind version vector entry: the peer's clock and record hash for one
+/// key. The hash makes equal-clock divergence visible so the tie-break can
+/// ship the deterministic winner (review R2 finding 3).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KindVersions {
     pub kind: SyncKind,
-    /// `(key, clock)` for every record the peer holds under the kind.
-    pub entries: Vec<(String, RecordClock)>,
+    /// `(key, clock, record_hash)` for every record the peer holds under
+    /// the kind.
+    pub entries: Vec<(String, RecordClock, [u8; 32])>,
 }
 
 /// One frame of the SyncV1 wire protocol. Length-prefixed bincode on the
 /// stream following the `SyncV1` protocol byte.
+///
+/// `VersionVector` and `Records` frames are **paged**: a session may carry
+/// several of each (bounded by [`MAX_VECTOR_ENTRIES`] /
+/// [`MAX_RECORDS_PER_SESSION`]) so a large state set never produces a frame
+/// over [`MAX_FRAME_BYTES`] (review R2 finding 5).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SyncFrame {
-    /// Handshake: protocol version, sender machine, sender owner.
+    /// Handshake: protocol version, sender machine, sender owner, and a
+    /// fresh random nonce for the possession proof.
     Hello {
         protocol_version: u32,
         machine_id: [u8; 32],
         owner_user_id: [u8; 32],
+        nonce: [u8; 32],
     },
-    /// Per-kind version vectors (the sender's full Tier-1 clock table).
+    /// Owner-key signature over
+    /// `proof_prefix || peer_nonce || sender_machine || peer_machine || owner_user_id`
+    /// — proves the sender holds the owner key (review R2 finding 1).
+    Proof { signature: Vec<u8> },
+    /// One page of the sender's per-kind version table.
     VersionVector { kinds: Vec<KindVersions> },
-    /// Records the peer is missing or would accept.
+    /// End of the version-vector stage. The records stage follows. An
+    /// explicit terminator (rather than peeking the first records frame)
+    /// keeps both sides' write-then-read stages from deadlocking.
+    VectorEnd,
+    /// One page of records the peer is missing or would accept.
     Records { records: Vec<VersionedRecord> },
     /// Clean end of session.
     Done,
     /// Fail-closed abort with a reason (best-effort, one-way).
     Abort { reason: String },
+}
+
+/// Canonical proof message: prefix || the verifier's nonce (the nonce the
+/// PROVER is answering) || prover machine || verifier machine || owner id.
+fn proof_message(
+    nonce: &[u8; 32],
+    prover: &[u8; 32],
+    verifier: &[u8; 32],
+    owner: &[u8; 32],
+) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(PROOF_MSG_PREFIX.len() + 32 * 3 + 32);
+    msg.extend_from_slice(PROOF_MSG_PREFIX);
+    msg.extend_from_slice(nonce);
+    msg.extend_from_slice(prover);
+    msg.extend_from_slice(verifier);
+    msg.extend_from_slice(owner);
+    msg
 }
 
 /// Write one frame: `u32` big-endian length + bincode body.
@@ -552,12 +713,18 @@ pub async fn read_frame<R: AsyncRead + Unpin>(recv: &mut R) -> Result<SyncFrame,
 pub struct SessionSummary {
     pub accepted: usize,
     pub superseded: usize,
+    /// Equal-clock records with DIFFERENT signed content seen this session:
+    /// a writer equivocated (or forked). Resolved deterministically by
+    /// record hash and surfaced, never silently merged.
+    pub equivocations: usize,
     pub shipped: usize,
 }
 
 /// The local Tier-1 store: the owner device set plus the winning record for
 /// every `(kind, key)` this machine holds. Persisted as two small JSON files
-/// under `<data_dir>/sync/`, written atomically (temp file + rename).
+/// under `<data_dir>/sync/` (created at load), written atomically (temp
+/// file + rename). Every mutation PROPAGATES persistence errors — success
+/// is never reported on a swallowed write (review R2 finding 2).
 pub struct OwnerSyncStore {
     dir: PathBuf,
     records: tokio::sync::RwLock<BTreeMap<(SyncKind, String), VersionedRecord>>,
@@ -585,13 +752,30 @@ struct PersistedDevices {
     devices: Vec<OwnerEnrollment>,
 }
 
+/// Result of a batch commit: what the caller should apply/count.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CommitOutcome {
+    pub accepted: Vec<VersionedRecord>,
+    pub superseded: usize,
+    pub equivocations: usize,
+}
+
 impl OwnerSyncStore {
-    /// Load (or start empty under) `<data_dir>/sync`. Corrupt or missing
-    /// files start empty — the next session re-derives Tier-1 state from a
-    /// live peer, and records are owner-signed so poison dies at verify.
-    #[must_use]
-    pub async fn load(data_dir: &Path) -> Self {
+    /// Load (or start empty under) `<data_dir>/sync`, creating the
+    /// directory. Corrupt or missing files start empty — the next session
+    /// re-derives Tier-1 state from a live peer, and records are
+    /// owner-signed so poison dies at verify.
+    ///
+    /// # Errors
+    ///
+    /// [`SyncError::Io`] when the directory cannot be created — persistence
+    /// would silently fail forever, so construction fails instead
+    /// (review R2 finding 2).
+    pub async fn load(data_dir: &Path) -> Result<Self, SyncError> {
         let dir = data_dir.join(SYNC_DIR);
+        tokio::fs::create_dir_all(&dir).await.map_err(|e| {
+            SyncError::Io(format!("failed to create sync dir {}: {e}", dir.display()))
+        })?;
         let records = match tokio::fs::read(dir.join(RECORDS_FILE)).await {
             Ok(bytes) => serde_json::from_slice::<PersistedRecords>(&bytes)
                 .map(|p| {
@@ -615,13 +799,13 @@ impl OwnerSyncStore {
             Err(_) => BTreeMap::new(),
         };
         let (generation_tx, _) = tokio::sync::watch::channel(0);
-        Self {
+        Ok(Self {
             dir,
             records: tokio::sync::RwLock::new(records),
             devices: tokio::sync::RwLock::new(devices),
             last_session: tokio::sync::RwLock::new(BTreeMap::new()),
             generation_tx,
-        }
+        })
     }
 
     /// Write `bytes` to `path` via a unique temp file + rename (atomic for
@@ -634,54 +818,108 @@ impl OwnerSyncStore {
         tokio::fs::rename(&tmp, path).await
     }
 
-    async fn persist_records(records: &BTreeMap<(SyncKind, String), VersionedRecord>, dir: &Path) {
+    /// Persist the winning records. Errors PROPAGATE — callers never report
+    /// success on a swallowed write (review R2 finding 2).
+    async fn persist_records(
+        records: &BTreeMap<(SyncKind, String), VersionedRecord>,
+        dir: &Path,
+    ) -> Result<(), SyncError> {
         let persisted = PersistedRecords {
             records: records.values().cloned().collect(),
         };
-        if let Ok(bytes) = serde_json::to_vec(&persisted) {
-            if let Err(e) = Self::write_atomically(&dir.join(RECORDS_FILE), &bytes).await {
-                tracing::warn!("failed to persist sync records: {e}");
-            }
-        }
+        let bytes = serde_json::to_vec(&persisted)
+            .map_err(|e| SyncError::Io(format!("encode records: {e}")))?;
+        Self::write_atomically(&dir.join(RECORDS_FILE), &bytes)
+            .await
+            .map_err(|e| SyncError::Io(format!("persist records: {e}")))
     }
 
-    async fn persist_devices(devices: &BTreeMap<[u8; 32], OwnerEnrollment>, dir: &Path) {
+    /// Persist the device set; errors propagate (see [`Self::persist_records`]).
+    async fn persist_devices(
+        devices: &BTreeMap<[u8; 32], OwnerEnrollment>,
+        dir: &Path,
+    ) -> Result<(), SyncError> {
         let persisted = PersistedDevices {
             devices: devices.values().cloned().collect(),
         };
-        if let Ok(bytes) = serde_json::to_vec(&persisted) {
-            if let Err(e) = Self::write_atomically(&dir.join(DEVICES_FILE), &bytes).await {
-                tracing::warn!("failed to persist sync device set: {e}");
-            }
-        }
+        let bytes = serde_json::to_vec(&persisted)
+            .map_err(|e| SyncError::Io(format!("encode devices: {e}")))?;
+        Self::write_atomically(&dir.join(DEVICES_FILE), &bytes)
+            .await
+            .map_err(|e| SyncError::Io(format!("persist devices: {e}")))
     }
 
-    /// The enrollment gate (blocker 30): is `machine` enrolled for `owner`?
+    /// The enrollment gate (blocker 30): is `machine` enrolled for `owner`
+    /// AND is that enrollment current?
     ///
-    /// Every stored enrollment is (re-)verified against `owner` here — a
-    /// corrupt or foreign-key record fails closed, so persistence poison
-    /// cannot wedge the gate open.
+    /// Every stored enrollment is (re-)verified against `owner` and its
+    /// expiry checked here — a corrupt, foreign-key, or stale record fails
+    /// closed, so persistence poison or an expired grant cannot wedge the
+    /// gate open (review R2 finding 1).
     #[must_use]
     pub async fn is_enrolled(&self, machine: &MachineId, owner: &UserId) -> bool {
         let devices = self.devices.read().await;
         devices
             .get(&machine.0)
-            .is_some_and(|e| e.verify_owner(owner).is_ok())
+            .is_some_and(|e| e.verify_owner(owner).is_ok() && e.is_current_at(now_unix_ms()))
     }
 
     /// Store a (verified-by-caller) enrollment, keeping the latest
     /// `enrolled_at_ms` per machine so a replayed older enrollment cannot
-    /// rewind the clock.
-    pub async fn enroll(&self, enrollment: OwnerEnrollment) {
+    /// rewind the clock. The new expiry replaces any previous one.
+    ///
+    /// # Errors
+    ///
+    /// [`SyncError::Io`] when the device set cannot be persisted — the
+    /// caller must fail, not report success (review R2 finding 2).
+    pub async fn enroll(&self, enrollment: OwnerEnrollment) -> Result<(), SyncError> {
         let mut devices = self.devices.write().await;
-        let keep = devices
-            .get(&enrollment.machine_id)
+        let previous = devices.get(&enrollment.machine_id).cloned();
+        let keep = previous
+            .as_ref()
             .is_none_or(|old| enrollment.enrolled_at_ms >= old.enrolled_at_ms);
         if keep {
             devices.insert(enrollment.machine_id, enrollment.clone());
-            Self::persist_devices(&devices, &self.dir).await;
+            if let Err(e) = Self::persist_devices(&devices, &self.dir).await {
+                // Roll back so memory matches the failed disk write
+                // (review R2 finding 2).
+                match previous {
+                    Some(old) => {
+                        devices.insert(old.machine_id, old);
+                    }
+                    None => {
+                        devices.remove(&enrollment.machine_id);
+                    }
+                }
+                return Err(e);
+            }
         }
+        drop(devices);
         self.kick();
+        Ok(())
+    }
+
+    /// Remove a machine from the owner device set (the DELETE
+    /// `/sync/devices/:id` path; review R2 finding 1).
+    ///
+    /// # Errors
+    ///
+    /// [`SyncError::Io`] when the device set cannot be persisted (the
+    /// in-memory set is restored — removal never half-applies).
+    /// Returns `Ok(false)` when the machine was not enrolled.
+    pub async fn unenroll(&self, machine: &MachineId) -> Result<bool, SyncError> {
+        let mut devices = self.devices.write().await;
+        if let Some(previous) = devices.remove(&machine.0) {
+            if let Err(e) = Self::persist_devices(&devices, &self.dir).await {
+                devices.insert(previous.machine_id, previous);
+                return Err(e);
+            }
+        } else {
+            return Ok(false);
+        }
+        drop(devices);
+        self.kick();
+        Ok(true)
     }
 
     /// Enrolled machines (raw records, for surfaces).
@@ -699,27 +937,154 @@ impl OwnerSyncStore {
         self.generation_tx.subscribe()
     }
 
-    /// Merge one verified inbound record under the conflict rule.
+    /// Pure classification of `record` against `stored` under the full
+    /// conflict rule: `beats`, else equal-clock with identical content
+    /// (idempotent supersede), else equal-clock with different content
+    /// (deterministic greater-hash winner — convergence under
+    /// equivocation).
+    fn classify(record: &VersionedRecord, stored: &VersionedRecord) -> MergeOutcome {
+        if record.clock.beats(&stored.clock) {
+            return MergeOutcome::Accepted;
+        }
+        if record.clock == stored.clock {
+            if record.value == stored.value {
+                return MergeOutcome::Superseded; // exact replay
+            }
+            // Equal clock, different signed content: the greater record
+            // hash wins on every peer.
+            if record.record_hash() > stored.record_hash() {
+                return MergeOutcome::Accepted;
+            }
+        }
+        MergeOutcome::Superseded
+    }
+
+    /// Commit a verified batch atomically (review R2 finding 4): all
+    /// classification decisions are made against the live map, all accepted
+    /// records inserted, and ONE file write persists the result. On any
+    /// failure the in-memory map is rolled back and the error propagates —
+    /// a partial batch is never committed or advertised.
     ///
-    /// Verifies the owner signature first — fail closed (error, session
-    /// aborts) on any signature failure; a merely stale or replayed record is
-    /// [`MergeOutcome::Superseded`] (anti-rollback, not an error).
+    /// Records must have been verified (`verify_owner`) by the caller.
+    ///
+    /// # Errors
+    ///
+    /// [`SyncError::StoreLimit`] when the batch would exceed
+    /// [`MAX_STORED_RECORDS`]; [`SyncError::Io`] when persistence fails.
+    pub async fn commit_batch(
+        &self,
+        batch: Vec<VersionedRecord>,
+        owner: &UserId,
+    ) -> Result<CommitOutcome, SyncError> {
+        let mut records = self.records.write().await;
+        let mut touched: Vec<((SyncKind, String), Option<VersionedRecord>)> = Vec::new();
+        let mut outcome = CommitOutcome::default();
+        let result = (|| -> Result<(), SyncError> {
+            for record in batch {
+                // Re-verify inside the lock: the caller's verification and
+                // the commit must not be separated by a store mutation.
+                record.verify_owner(owner)?;
+                if records.len() >= MAX_STORED_RECORDS
+                    && !records.contains_key(&(record.kind, record.key.clone()))
+                {
+                    return Err(SyncError::StoreLimit(format!(
+                        "store at capacity ({MAX_STORED_RECORDS} records)"
+                    )));
+                }
+                let stored = records.get(&(record.kind, record.key.clone()));
+                // Equal clock with different signed content is an
+                // equivocation whichever side wins the hash tie-break —
+                // surfaced, never silently merged (review R2 finding 3).
+                if let Some(existing) = stored {
+                    if existing.clock == record.clock && existing.value != record.value {
+                        outcome.equivocations += 1;
+                        tracing::warn!(
+                            target: "x0x::owner_sync",
+                            kind = ?existing.kind,
+                            key = %existing.key,
+                            "equal-clock equivocation resolved deterministically by record hash"
+                        );
+                    }
+                }
+                let decision = stored.map(|existing| Self::classify(&record, existing));
+                match decision {
+                    None => {
+                        touched.push(((record.kind, record.key.clone()), None));
+                        records.insert((record.kind, record.key.clone()), record.clone());
+                        outcome.accepted.push(record);
+                    }
+                    Some(MergeOutcome::Accepted) => {
+                        if let Some(prev) =
+                            records.insert((record.kind, record.key.clone()), record.clone())
+                        {
+                            touched.push(((record.kind, record.key.clone()), Some(prev)));
+                        }
+                        outcome.accepted.push(record);
+                    }
+                    Some(MergeOutcome::Superseded) => {
+                        outcome.superseded += 1;
+                    }
+                }
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                if outcome.accepted.is_empty() {
+                    return Ok(outcome); // nothing new — no write needed
+                }
+                match Self::persist_records(&records, &self.dir).await {
+                    Ok(()) => {
+                        drop(records);
+                        self.kick();
+                        Ok(outcome)
+                    }
+                    Err(e) => {
+                        Self::rollback(&mut records, &touched);
+                        Err(e)
+                    }
+                }
+            }
+            Err(e) => {
+                Self::rollback(&mut records, &touched);
+                Err(e)
+            }
+        }
+    }
+
+    /// Restore the in-memory map to its pre-batch state.
+    fn rollback(
+        records: &mut BTreeMap<(SyncKind, String), VersionedRecord>,
+        touched: &[((SyncKind, String), Option<VersionedRecord>)],
+    ) {
+        for ((kind, key), previous) in touched {
+            match previous {
+                Some(prev) => {
+                    records.insert((*kind, key.clone()), prev.clone());
+                }
+                None => {
+                    records.remove(&(*kind, key.clone()));
+                }
+            }
+        }
+    }
+
+    /// Merge one verified inbound record — a single-record batch commit.
+    ///
+    /// # Errors
+    ///
+    /// See [`VersionedRecord::verify_owner`] and [`Self::commit_batch`].
     pub async fn merge_record(
         &self,
         record: VersionedRecord,
         owner: &UserId,
     ) -> Result<MergeOutcome, SyncError> {
-        record.verify_owner(owner)?;
-        let mut records = self.records.write().await;
-        let stored = records.get(&(record.kind, record.key.clone()));
-        match stored {
-            Some(existing) if !record.clock.beats(&existing.clock) => Ok(MergeOutcome::Superseded),
-            _ => {
-                records.insert((record.kind, record.key.clone()), record);
-                Self::persist_records(&records, &self.dir).await;
-                Ok(MergeOutcome::Accepted)
-            }
-        }
+        let outcome = self.commit_batch(vec![record], owner).await?;
+        Ok(if outcome.accepted.is_empty() {
+            MergeOutcome::Superseded
+        } else {
+            MergeOutcome::Accepted
+        })
     }
 
     /// Mint a local record for `(kind, key)` from `desired`: no-op when the
@@ -728,7 +1093,8 @@ impl OwnerSyncStore {
     ///
     /// # Errors
     ///
-    /// Propagates signing failures from [`VersionedRecord::sign`].
+    /// [`SyncError::BadSignature`] when signing fails; [`SyncError::Io`]
+    /// when persistence fails (never swallowed — review R2 finding 2).
     pub async fn mint(
         &self,
         kind: SyncKind,
@@ -736,7 +1102,7 @@ impl OwnerSyncStore {
         desired: &SyncValue,
         owner: &UserKeypair,
         writer_machine: MachineId,
-    ) -> Result<(), IdentityError> {
+    ) -> Result<(), SyncError> {
         let now_ms = now_unix_ms();
         let mut records = self.records.write().await;
         let stored = records.get(&(kind, key.to_string()));
@@ -749,23 +1115,28 @@ impl OwnerSyncStore {
             signed_at_ms: now_ms,
             writer_machine: writer_machine.0,
         };
-        let record = VersionedRecord::sign(kind, key, desired, clock, owner)?;
-        records.insert((kind, key.to_string()), record);
-        Self::persist_records(&records, &self.dir).await;
-        drop(records);
-        self.kick();
-        Ok(())
-    }
-
-    /// Test-only: insert a pre-built record WITHOUT verification, so
-    /// integration tests can simulate a compromised writer whose forgery
-    /// the receiving side must reject. Never call from production code —
-    /// every real path (`mint`, `merge_record`) verifies signatures.
-    #[doc(hidden)]
-    pub async fn records_insert_for_testing(&self, record: VersionedRecord) {
-        let mut records = self.records.write().await;
-        records.insert((record.kind, record.key.clone()), record);
-        Self::persist_records(&records, &self.dir).await;
+        let record = VersionedRecord::sign(kind, key, desired, clock, owner)
+            .map_err(|e| SyncError::BadSignature(format!("mint: {e}")))?;
+        let previous = records.insert((kind, key.to_string()), record);
+        match Self::persist_records(&records, &self.dir).await {
+            Ok(()) => {
+                drop(records);
+                self.kick();
+                Ok(())
+            }
+            Err(e) => {
+                // Roll back so memory matches the failed disk write.
+                match previous {
+                    Some(prev) => {
+                        records.insert((kind, key.to_string()), prev);
+                    }
+                    None => {
+                        records.remove(&(kind, key.to_string()));
+                    }
+                }
+                Err(e)
+            }
+        }
     }
 
     /// Full record snapshot (winners only), for surfaces and sessions.
@@ -773,15 +1144,16 @@ impl OwnerSyncStore {
         self.records.read().await.values().cloned().collect()
     }
 
-    /// The per-kind version vectors for the handshake.
+    /// The per-kind version table (with record hashes) for the handshake.
     pub async fn version_vector(&self) -> Vec<KindVersions> {
         let records = self.records.read().await;
-        let mut by_kind: BTreeMap<SyncKind, Vec<(String, RecordClock)>> = BTreeMap::new();
+        let mut by_kind: BTreeMap<SyncKind, Vec<(String, RecordClock, [u8; 32])>> = BTreeMap::new();
         for ((kind, key), record) in records.iter() {
-            by_kind
-                .entry(*kind)
-                .or_default()
-                .push((key.clone(), record.clock));
+            by_kind.entry(*kind).or_default().push((
+                key.clone(),
+                record.clock,
+                record.record_hash(),
+            ));
         }
         SyncKind::ALL
             .into_iter()
@@ -792,23 +1164,38 @@ impl OwnerSyncStore {
             .collect()
     }
 
-    /// Records the peer is missing or would accept under [`RecordClock`].
+    /// Records the peer is missing or would accept under the full conflict
+    /// rule (`beats`, or equal clock with a greater record hash — so the
+    /// deterministic equal-clock winner always ships; review R2 finding 3).
     pub async fn records_for_peer(&self, peer_vector: &[KindVersions]) -> Vec<VersionedRecord> {
-        let peer_clocks: BTreeMap<(SyncKind, String), RecordClock> = peer_vector
+        struct PeerEntry {
+            clock: RecordClock,
+            hash: [u8; 32],
+        }
+        let peer_entries: BTreeMap<(SyncKind, String), PeerEntry> = peer_vector
             .iter()
             .flat_map(|kv| {
-                kv.entries
-                    .iter()
-                    .map(move |(k, c)| ((kv.kind, k.clone()), *c))
+                kv.entries.iter().map(move |(k, c, h)| {
+                    (
+                        (kv.kind, k.clone()),
+                        PeerEntry {
+                            clock: *c,
+                            hash: *h,
+                        },
+                    )
+                })
             })
             .collect();
         let records = self.records.read().await;
         records
             .iter()
             .filter(
-                |((kind, key), record)| match peer_clocks.get(&(*kind, key.clone())) {
+                |((kind, key), record)| match peer_entries.get(&(*kind, key.clone())) {
                     None => true,
-                    Some(peer_clock) => record.clock.beats(peer_clock),
+                    Some(peer) => {
+                        record.clock.beats(&peer.clock)
+                            || (record.clock == peer.clock && record.record_hash() > peer.hash)
+                    }
                 },
             )
             .map(|(_, record)| record.clone())
@@ -831,6 +1218,17 @@ impl OwnerSyncStore {
     pub async fn session_statuses(&self) -> BTreeMap<[u8; 32], DeviceSyncStatus> {
         self.last_session.read().await.clone()
     }
+
+    /// Test-only: insert a pre-built record WITHOUT verification, so
+    /// integration tests can simulate a compromised writer whose forgery
+    /// the receiving side must reject. Never call from production code —
+    /// every real path (`mint`, `commit_batch`) verifies signatures.
+    #[doc(hidden)]
+    pub async fn records_insert_for_testing(&self, record: VersionedRecord) {
+        let mut records = self.records.write().await;
+        records.insert((record.kind, record.key.clone()), record);
+        let _ = Self::persist_records(&records, &self.dir).await;
+    }
 }
 
 /// Unix epoch milliseconds.
@@ -841,26 +1239,74 @@ fn now_unix_ms() -> u64 {
         .unwrap_or(0)
 }
 
-/// Run one fail-closed sync session over the two halves of a SyncV1 stream.
-///
-/// Both sides run this same symmetric protocol: Hello → version vectors →
-/// records both ways → Done. The caller has already cleared the ADR-0022
-/// machine identity gates; this function enforces the same-owner +
-/// enrollment gates (blocker 30) and verifies EVERY record's owner signature
-/// (fail closed on any failure).
-///
-/// `on_accept` fires for each record this side stored, so callers can apply
-/// Tier-1 state to live daemon surfaces.
+/// A fresh random 32-byte nonce.
+fn fresh_nonce() -> [u8; 32] {
+    use rand::RngCore;
+    let mut nonce = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut nonce);
+    nonce
+}
+
+/// Run one fail-closed sync session over the two halves of a SyncV1 stream
+/// under the default [`SESSION_TIMEOUT`] budget.
 ///
 /// # Errors
 ///
-/// Any [`SyncError`] aborts the session; the store keeps whatever verified
-/// records preceded the failure.
+/// Any [`SyncError`] aborts the session; see
+/// [`run_sync_session_with_timeout`].
 pub async fn run_sync_session<S, R, F>(
     send: &mut S,
     recv: &mut R,
     store: &OwnerSyncStore,
-    owner: &UserId,
+    owner: &UserKeypair,
+    local_machine: &MachineId,
+    peer_machine: &MachineId,
+    on_accept: F,
+) -> Result<SessionSummary, SyncError>
+where
+    S: AsyncWrite + Unpin,
+    R: AsyncRead + Unpin,
+    F: FnMut(&VersionedRecord),
+{
+    run_sync_session_with_timeout(
+        SESSION_TIMEOUT,
+        send,
+        recv,
+        store,
+        owner,
+        local_machine,
+        peer_machine,
+        on_accept,
+    )
+    .await
+}
+
+/// [`run_sync_session`] with an explicit total budget (tests use short
+/// ones; production uses [`SESSION_TIMEOUT`]). A peer that stalls at any
+/// protocol stage — after the transport-level protocol prefix — is dropped
+/// when the budget elapses, never held indefinitely (review R2 finding 5).
+///
+/// Both sides run the same symmetric protocol: Hello (with nonce) → mutual
+/// owner-key possession Proof → paged version vectors → paged records both
+/// ways → Done → ONE atomic local commit of the verified batch. The caller
+/// has already cleared the ADR-0022 machine identity gates; this function
+/// enforces the same-owner + enrollment + possession gates (blocker 30) and
+/// verifies EVERY record before anything is committed (review R2 finding 4).
+///
+/// `on_accept` fires for each record committed by this session, after the
+/// clean `Done`, so callers can apply Tier-1 state to live daemon surfaces.
+///
+/// # Errors
+///
+/// Any [`SyncError`] aborts the session with NOTHING from the inbound batch
+/// committed.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_sync_session_with_timeout<S, R, F>(
+    budget: Duration,
+    send: &mut S,
+    recv: &mut R,
+    store: &OwnerSyncStore,
+    owner: &UserKeypair,
     local_machine: &MachineId,
     peer_machine: &MachineId,
     mut on_accept: F,
@@ -870,31 +1316,66 @@ where
     R: AsyncRead + Unpin,
     F: FnMut(&VersionedRecord),
 {
+    tokio::time::timeout(
+        budget,
+        run_sync_session_inner(
+            send,
+            recv,
+            store,
+            owner,
+            local_machine,
+            peer_machine,
+            &mut on_accept,
+        ),
+    )
+    .await
+    .map_err(|_| SyncError::SessionTimeout)?
+}
+
+/// The session body (no timeout wrapper).
+async fn run_sync_session_inner<S, R, F>(
+    send: &mut S,
+    recv: &mut R,
+    store: &OwnerSyncStore,
+    owner: &UserKeypair,
+    local_machine: &MachineId,
+    peer_machine: &MachineId,
+    on_accept: &mut F,
+) -> Result<SessionSummary, SyncError>
+where
+    S: AsyncWrite + Unpin,
+    R: AsyncRead + Unpin,
+    F: FnMut(&VersionedRecord),
+{
+    let owner_id = owner.user_id();
     let mut summary = SessionSummary::default();
 
-    // Same-owner gate: a peer machine that is not enrolled locally never
-    // gets past the first byte (blocker 30).
+    // Same-owner gate: a peer machine that is not enrolled locally (and
+    // current) never gets past the first byte (blocker 30).
     if peer_machine.0 == local_machine.0 {
         return Err(SyncError::SelfSync);
     }
-    if !store.is_enrolled(peer_machine, owner).await {
+    if !store.is_enrolled(peer_machine, &owner_id).await {
         return Err(SyncError::NotEnrolled {
             machine: peer_machine.0,
         });
     }
 
-    // Hello both ways.
+    // Hello both ways (each side contributes a fresh nonce).
+    let local_nonce = fresh_nonce();
     let hello = SyncFrame::Hello {
         protocol_version: SYNC_PROTOCOL_VERSION,
         machine_id: local_machine.0,
-        owner_user_id: owner.0,
+        owner_user_id: owner_id.0,
+        nonce: local_nonce,
     };
     write_frame(send, &hello).await?;
-    match read_frame(recv).await? {
+    let peer_nonce = match read_frame(recv).await? {
         SyncFrame::Hello {
             protocol_version,
             machine_id,
             owner_user_id,
+            nonce,
         } => {
             if protocol_version != SYNC_PROTOCOL_VERSION {
                 return Err(SyncError::ProtocolVersion {
@@ -902,7 +1383,7 @@ where
                     remote: protocol_version,
                 });
             }
-            if owner_user_id != owner.0 {
+            if owner_user_id != owner_id.0 {
                 return Err(SyncError::OwnerMismatch);
             }
             if machine_id != peer_machine.0 {
@@ -911,119 +1392,211 @@ where
                     "hello machine differs from transport peer".into(),
                 ));
             }
+            nonce
         }
         other => {
             return Err(SyncError::MalformedFrame(format!(
                 "expected hello, got {other:?}"
             )));
         }
-    }
+    };
 
-    // Version vectors both ways.
-    let local_vector = store.version_vector().await;
+    // Mutual owner-key possession proof (review R2 finding 1): each side
+    // signs the PEER's nonce bound to both machines and the owner id, and
+    // verifies the peer's proof against its OWN nonce. A machine that
+    // merely echoes the victim's owner id — without holding the owner key —
+    // cannot produce the proof and learns nothing.
+    let proof_msg = proof_message(&peer_nonce, &local_machine.0, &peer_machine.0, &owner_id.0);
+    let proof_sig = sign_with_ml_dsa(owner.secret_key(), &proof_msg)
+        .map_err(|e| SyncError::ChallengeFailed(format!("signing: {e:?}")))?;
     write_frame(
         send,
-        &SyncFrame::VersionVector {
-            kinds: local_vector,
+        &SyncFrame::Proof {
+            signature: proof_sig.as_bytes().to_vec(),
         },
     )
     .await?;
-    let peer_vector = match read_frame(recv).await? {
-        SyncFrame::VersionVector { kinds } => kinds,
-        other => {
-            return Err(SyncError::MalformedFrame(format!(
-                "expected version vector, got {other:?}"
-            )));
-        }
-    };
-
-    // Ship what the peer lacks; receive what we lack. Every inbound record
-    // is owner-verified — one forgery aborts the whole session.
-    let to_ship = store.records_for_peer(&peer_vector).await;
-    summary.shipped = to_ship.len();
-    write_frame(send, &SyncFrame::Records { records: to_ship }).await?;
-    let accepted: Vec<VersionedRecord> = match read_frame(recv).await? {
-        SyncFrame::Records { records } => {
-            let mut accepted = Vec::new();
-            for record in records {
-                match store.merge_record(record.clone(), owner).await {
-                    Ok(MergeOutcome::Accepted) => {
-                        summary.accepted += 1;
-                        accepted.push(store_last_winner(store, &record).await);
-                    }
-                    Ok(MergeOutcome::Superseded) => {
-                        summary.superseded += 1;
-                    }
-                    Err(e) => {
-                        let _ = write_frame(
-                            send,
-                            &SyncFrame::Abort {
-                                reason: e.to_string(),
-                            },
-                        )
-                        .await;
-                        return Err(e);
-                    }
-                }
-            }
-            accepted
-        }
-        other => {
-            return Err(SyncError::MalformedFrame(format!(
-                "expected records, got {other:?}"
-            )));
-        }
-    };
-
-    // Done both ways.
-    write_frame(send, &SyncFrame::Done).await?;
     match read_frame(recv).await? {
-        SyncFrame::Done => {}
-        SyncFrame::Abort { reason } => {
-            return Err(SyncError::MalformedFrame(format!("peer aborted: {reason}")));
+        SyncFrame::Proof { signature } => {
+            let expected_msg =
+                proof_message(&local_nonce, &peer_machine.0, &local_machine.0, &owner_id.0);
+            let sig = MlDsaSignature::from_bytes(&signature)
+                .map_err(|e| SyncError::ChallengeFailed(format!("invalid proof format: {e:?}")))?;
+            verify_with_ml_dsa(owner.public_key(), &expected_msg, &sig)
+                .map_err(|e| SyncError::ChallengeFailed(format!("bad proof: {e:?}")))?;
         }
         other => {
             return Err(SyncError::MalformedFrame(format!(
-                "expected done, got {other:?}"
+                "expected proof, got {other:?}"
             )));
         }
     }
 
-    // Apply accepted records only after the clean Done, so an aborted
-    // session never mutates live daemon state. (The stored winner is
-    // re-read: a later record in the same batch may have superseded it.)
-    for record in accepted {
+    // Paged version vectors both ways (bounded, explicitly terminated).
+    let local_vector = store.version_vector().await;
+    write_paged_vector(send, &local_vector).await?;
+    let peer_vector = read_paged_vector(recv).await?;
+
+    // Compute the outbound set from the FULL peer vector, then ship it in
+    // bounded pages, ending with Done ("finished shipping"). Done is sent
+    // BEFORE reading the peer's records — both sides' reads must be able
+    // to complete independently of their own send state.
+    let to_ship = store.records_for_peer(&peer_vector).await;
+    summary.shipped = to_ship.len();
+    write_paged_records(send, &to_ship).await?;
+    write_frame(send, &SyncFrame::Done).await?;
+
+    // Receive the peer's paged records (terminated by their Done or an
+    // Abort); verify EVERY record before any commit — one forgery aborts
+    // with nothing stored (review R2 finding 4).
+    let inbound = read_paged_records(recv).await?;
+    let mut verified = Vec::with_capacity(inbound.len());
+    for record in inbound {
+        record.verify_owner(&owner_id)?;
+        verified.push(record);
+    }
+    let outcome = store.commit_batch(verified, &owner_id).await?;
+    summary.accepted = outcome.accepted.len();
+    summary.superseded = outcome.superseded;
+    summary.equivocations = outcome.equivocations;
+
+    // Apply committed records after the clean Done so partial sessions never
+    // mutate live daemon state.
+    for record in outcome.accepted {
         on_accept(&record);
     }
     Ok(summary)
 }
 
-/// The stored winner for a freshly merged record's `(kind, key)`.
-async fn store_last_winner(store: &OwnerSyncStore, merged: &VersionedRecord) -> VersionedRecord {
-    store
-        .records_snapshot()
-        .await
-        .into_iter()
-        .find(|r| r.kind == merged.kind && r.key == merged.key)
-        .unwrap_or_else(|| merged.clone())
+/// Write the version table as bounded pages (always at least one page, so
+/// the reader's stage loop always advances).
+async fn write_paged_vector<S: AsyncWrite + Unpin>(
+    send: &mut S,
+    vector: &[KindVersions],
+) -> Result<(), SyncError> {
+    // Each frame carries one kind with at most VV_ENTRIES_PER_FRAME entries.
+    let mut pages: Vec<KindVersions> = Vec::new();
+    for kv in vector {
+        for chunk in kv.entries.chunks(VV_ENTRIES_PER_FRAME) {
+            pages.push(KindVersions {
+                kind: kv.kind,
+                entries: chunk.to_vec(),
+            });
+        }
+    }
+    for page in pages {
+        write_frame(send, &SyncFrame::VersionVector { kinds: vec![page] }).await?;
+    }
+    // Explicit stage terminator — see [`SyncFrame::VectorEnd`].
+    write_frame(send, &SyncFrame::VectorEnd).await?;
+    Ok(())
 }
+/// Read paged version frames until the explicit [`SyncFrame::VectorEnd`]
+/// terminator. Total entries are capped ([`MAX_VECTOR_ENTRIES`]).
+async fn read_paged_vector<R: AsyncRead + Unpin>(
+    recv: &mut R,
+) -> Result<Vec<KindVersions>, SyncError> {
+    let mut merged: BTreeMap<SyncKind, Vec<(String, RecordClock, [u8; 32])>> = BTreeMap::new();
+    let mut total = 0usize;
+    loop {
+        match read_frame(recv).await? {
+            SyncFrame::VersionVector { kinds } => {
+                for kv in kinds {
+                    total += kv.entries.len();
+                    if total > MAX_VECTOR_ENTRIES {
+                        return Err(SyncError::TooManyRecords(format!(
+                            "version vector exceeds {MAX_VECTOR_ENTRIES} entries"
+                        )));
+                    }
+                    merged.entry(kv.kind).or_default().extend(kv.entries);
+                }
+            }
+            SyncFrame::VectorEnd => {
+                return Ok(SyncKind::ALL
+                    .into_iter()
+                    .map(|kind| KindVersions {
+                        kind,
+                        entries: merged.remove(&kind).unwrap_or_default(),
+                    })
+                    .collect());
+            }
+            other => {
+                return Err(SyncError::MalformedFrame(format!(
+                    "expected version-vector page or end, got {other:?}"
+                )));
+            }
+        }
+    }
+}
+
+/// Read the peer's paged records until `Done`/`Abort`. Capped at
+/// [`MAX_RECORDS_PER_SESSION`].
+async fn read_paged_records<R: AsyncRead + Unpin>(
+    recv: &mut R,
+) -> Result<Vec<VersionedRecord>, SyncError> {
+    let mut records = Vec::new();
+    loop {
+        match read_frame(recv).await? {
+            SyncFrame::Records { records: page } => {
+                records.extend(page);
+                if records.len() > MAX_RECORDS_PER_SESSION {
+                    return Err(SyncError::TooManyRecords(format!(
+                        "inbound batch exceeds {MAX_RECORDS_PER_SESSION} records"
+                    )));
+                }
+            }
+            SyncFrame::Done => break,
+            SyncFrame::Abort { reason } => {
+                return Err(SyncError::Io(format!("peer aborted: {reason}")));
+            }
+            other => {
+                return Err(SyncError::MalformedFrame(format!(
+                    "expected records page or done, got {other:?}"
+                )));
+            }
+        }
+    }
+    Ok(records)
+}
+
+/// Write records as bounded pages (always at least one page).
+async fn write_paged_records<S: AsyncWrite + Unpin>(
+    send: &mut S,
+    records: &[VersionedRecord],
+) -> Result<(), SyncError> {
+    if records.is_empty() {
+        write_frame(
+            send,
+            &SyncFrame::Records {
+                records: Vec::new(),
+            },
+        )
+        .await?;
+        return Ok(());
+    }
+    for page in records.chunks(RECORDS_PER_FRAME) {
+        write_frame(
+            send,
+            &SyncFrame::Records {
+                records: page.to_vec(),
+            },
+        )
+        .await?;
+    }
+    Ok(())
+}
+
 /// Default period between automatic sync passes (also wakes on any local
 /// Tier-1 change via the store's generation channel).
-pub const DEFAULT_SYNC_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+pub const DEFAULT_SYNC_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Current daemon self-profile names, best-effort snapshot.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct SyncProfileNames {
-    pub human_name: Option<String>,
-    pub display_name: Option<String>,
-    pub machine_name: Option<String>,
-}
+/// Concurrent sync sessions this daemon will run at once (inbound +
+/// outbound combined). The acceptor's bounded queue drops (resets) streams
+/// beyond this — an enrolled peer cannot wedge an unbounded task set
+/// (review R2 finding 5).
+pub const MAX_CONCURRENT_SESSIONS: usize = 16;
 
-/// Live daemon view the server installs into [`OwnerSyncService`] after
-/// `AppState` exists. Keeps this module decoupled from server internals:
-/// reads are best-effort (a contended lock reads as "unchanged" and the
-/// next pass retries), applies are fire-and-forget (the implementation
-/// owns locking and persistence).
+/// Live daemon view contract; implemented by the server subtree.
 pub trait SyncDaemonView: Send + Sync + 'static {
     /// Snapshot of the current self-profile names.
     fn profile_names(&self) -> SyncProfileNames;
@@ -1036,6 +1609,14 @@ pub trait SyncDaemonView: Send + Sync + 'static {
         display_name: Option<String>,
         machine_name: Option<String>,
     );
+}
+
+/// Current daemon self-profile names, best-effort snapshot.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SyncProfileNames {
+    pub human_name: Option<String>,
+    pub display_name: Option<String>,
+    pub machine_name: Option<String>,
 }
 
 /// Daemon-resident Tier-1 sync service (the `ForwardService` pattern for
@@ -1052,30 +1633,35 @@ pub struct OwnerSyncService {
     journal_path: Option<PathBuf>,
     view: std::sync::RwLock<Option<Arc<dyn SyncDaemonView>>>,
     tasks: tokio::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
+    session_permits: Arc<tokio::sync::Semaphore>,
 }
 
 impl OwnerSyncService {
-    /// Build the service, load its store from `<data_dir>/sync`, and
-    /// register the `SyncV1` acceptor (single-acceptor rule — a conflict is
-    /// a hard startup error). The acceptor is moved into its drain task,
-    /// which deregisters it when the task ends.
+    /// Build the service, load its store from `<data_dir>/sync` (creating
+    /// the directory — failure is a hard startup error, review R2 finding
+    /// 2), and register the `SyncV1` acceptor (single-acceptor rule).
     ///
     /// # Errors
     ///
     /// [`crate::error::NetworkError::StreamAcceptorConflict`] when another
-    /// consumer already owns `SyncV1`.
+    /// consumer already owns `SyncV1`; storage errors when the sync
+    /// directory cannot be created.
     pub async fn new(
         agent: Arc<crate::Agent>,
         data_dir: &Path,
     ) -> crate::error::NetworkResult<Arc<Self>> {
         let acceptor = agent.register_stream_acceptor(crate::streams::StreamProtocol::SyncV1)?;
         let journal_path = agent.cert_journal_path().map(Path::to_path_buf);
+        let store = OwnerSyncStore::load(data_dir)
+            .await
+            .map_err(|e| crate::error::NetworkError::CacheError(format!("sync store: {e}")))?;
         let service = Arc::new(Self {
             agent,
-            store: Arc::new(OwnerSyncStore::load(data_dir).await),
+            store: Arc::new(store),
             journal_path,
             view: std::sync::RwLock::new(None),
             tasks: tokio::sync::Mutex::new(Vec::new()),
+            session_permits: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_SESSIONS)),
         });
         service.spawn_acceptor_loop(acceptor).await;
         Ok(service)
@@ -1118,7 +1704,7 @@ impl OwnerSyncService {
     }
 
     /// Spawn the inbound acceptor drain loop. Each accepted stream is
-    /// enrollment-gated, then runs one session.
+    /// enrollment-gated, then runs one session under a concurrency permit.
     async fn spawn_acceptor_loop(self: &Arc<Self>, mut acceptor: crate::streams::StreamAcceptor) {
         let service = Arc::clone(self);
         let task = tokio::spawn(async move {
@@ -1133,13 +1719,23 @@ impl OwnerSyncService {
     /// Inbound path: the ADR-0022 machine identity gates have already
     /// cleared in the shared accept loop; enforce the owner device set
     /// (blocker 30) — an unenrolled machine's stream is dropped (reset)
-    /// with zero application bytes read.
+    /// with zero application bytes read. A session permit is REQUIRED
+    /// before any protocol byte: without one the stream is dropped, so a
+    /// flood of streams cannot wedge an unbounded task set.
     async fn handle_inbound(&self, stream: crate::streams::PeerStream) {
-        let Some((owner, local_machine)) = self.owner_and_machine() else {
+        let Some(owner_kp) = self.owner_kp() else {
             return;
         };
+        let Ok(permit) = self.session_permits.clone().try_acquire_owned() else {
+            tracing::warn!(
+                target: "x0x::owner_sync",
+                "SyncV1 stream dropped: session limit reached"
+            );
+            return; // drop => reset, fail closed and bounded
+        };
+        let local_machine = self.agent.machine_id();
         let peer = stream.peer();
-        if !self.store.is_enrolled(&peer, &owner).await {
+        if !self.store.is_enrolled(&peer, &owner_kp.user_id()).await {
             tracing::warn!(
                 target: "x0x::owner_sync",
                 machine = %hex::encode(peer.0),
@@ -1152,12 +1748,13 @@ impl OwnerSyncService {
             &mut send,
             &mut recv,
             &self.store,
-            &owner,
+            owner_kp,
             &local_machine,
             &peer,
             |record| self.apply_record(record),
         )
         .await;
+        drop(permit);
         match result {
             Ok(summary) => {
                 tracing::debug!(
@@ -1165,6 +1762,7 @@ impl OwnerSyncService {
                     machine = %hex::encode(peer.0),
                     accepted = summary.accepted,
                     superseded = summary.superseded,
+                    equivocations = summary.equivocations,
                     shipped = summary.shipped,
                     "Tier-1 sync session complete"
                 );
@@ -1185,10 +1783,10 @@ impl OwnerSyncService {
     /// Dial `machine` and run one session as the initiator. Errors are
     /// strings by design: dial outcomes are logged, never fatal to the pass.
     async fn dial_and_sync(&self, machine: &MachineId) -> Result<SessionSummary, String> {
-        let (owner, local_machine) = self
-            .owner_and_machine()
-            .ok_or_else(|| "no owner key".to_string())?;
-        if !self.store.is_enrolled(machine, &owner).await {
+        let owner_kp = self.owner_kp().ok_or_else(|| "no owner key".to_string())?;
+        let owner_id = owner_kp.user_id();
+        let local_machine = self.agent.machine_id();
+        if !self.store.is_enrolled(machine, &owner_id).await {
             return Err(format!(
                 "machine {} is not enrolled",
                 hex::encode(machine.0)
@@ -1213,11 +1811,17 @@ impl OwnerSyncService {
             .map_err(|e| e.to_string())?;
         let peer = stream.peer();
         let (mut send, mut recv) = stream.into_split();
+        let _permit = self
+            .session_permits
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|e| e.to_string())?;
         let result = run_sync_session(
             &mut send,
             &mut recv,
             &self.store,
-            &owner,
+            owner_kp,
             &local_machine,
             &peer,
             |record| self.apply_record(record),
@@ -1256,7 +1860,8 @@ impl OwnerSyncService {
     }
 
     /// Mint local Tier-1 records from live daemon state (no-op when a kind
-    /// is unchanged since its stored winner).
+    /// is unchanged since its stored winner). Persistence failures are
+    /// surfaced per-kind; a failed mint is retried next pass.
     async fn reconcile_local_state(&self) -> Result<(), SyncError> {
         let Some(owner_kp) = self.owner_kp() else {
             return Ok(()); // ownerless installs mint nothing
@@ -1348,7 +1953,7 @@ impl OwnerSyncService {
         }
     }
 
-    /// Apply an accepted record to live daemon state (post-Done only).
+    /// Apply an accepted record to live daemon state (post-commit only).
     ///
     /// Exhaustive over [`SyncValue`] — Tier-3 kinds cannot reach here.
     fn apply_record(&self, record: &VersionedRecord) {
@@ -1474,6 +2079,30 @@ mod tests {
         }
     }
 
+    fn clock(version: u64, ts: u64, writer: u8) -> RecordClock {
+        RecordClock {
+            version,
+            signed_at_ms: ts,
+            writer_machine: machine(writer).0,
+        }
+    }
+
+    fn sign_names(
+        key: &str,
+        display: &str,
+        clock: RecordClock,
+        owner: &UserKeypair,
+    ) -> VersionedRecord {
+        VersionedRecord::sign(
+            SyncKind::MachineNames,
+            key,
+            &names_value(display),
+            clock,
+            owner,
+        )
+        .expect("sign")
+    }
+
     #[tokio::test]
     async fn conflict_rule_orders_version_then_time_then_writer() {
         // WHY: blocker 31 — the exact tie-break chain must hold.
@@ -1515,7 +2144,7 @@ mod tests {
         // WHY: rollback protection — version < stored is never accepted,
         // and equal-version-but-older is superseded, not stored.
         let dir = tempfile::tempdir().expect("tmpdir");
-        let store = OwnerSyncStore::load(dir.path()).await;
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
         let owner = owner_kp(1);
         let owner_id = owner.user_id();
         let key = hex::encode(machine(1).0);
@@ -1530,36 +2159,14 @@ mod tests {
             .await
             .expect("mint v1");
         // Bump to a high version by hand.
-        let high = VersionedRecord::sign(
-            SyncKind::MachineNames,
-            &key,
-            &names_value("v9"),
-            RecordClock {
-                version: 9,
-                signed_at_ms: 1,
-                writer_machine: machine(2).0,
-            },
-            &owner,
-        )
-        .expect("sign v9");
+        let high = sign_names(&key, "v9", clock(9, 1, 2), &owner);
         assert_eq!(
             store.merge_record(high, &owner_id).await.expect("merge v9"),
             MergeOutcome::Accepted
         );
 
         // Rollback: version 3 (and 9-with-older-clock) rejected.
-        let rollback = VersionedRecord::sign(
-            SyncKind::MachineNames,
-            &key,
-            &names_value("old"),
-            RecordClock {
-                version: 3,
-                signed_at_ms: 999,
-                writer_machine: machine(3).0,
-            },
-            &owner,
-        )
-        .expect("sign rollback");
+        let rollback = sign_names(&key, "old", clock(3, 999, 3), &owner);
         assert_eq!(
             store
                 .merge_record(rollback, &owner_id)
@@ -1567,18 +2174,7 @@ mod tests {
                 .expect("merge rollback"),
             MergeOutcome::Superseded
         );
-        let stale_equal = VersionedRecord::sign(
-            SyncKind::MachineNames,
-            &key,
-            &names_value("stale"),
-            RecordClock {
-                version: 9,
-                signed_at_ms: 0,
-                writer_machine: machine(3).0,
-            },
-            &owner,
-        )
-        .expect("sign stale");
+        let stale_equal = sign_names(&key, "stale", clock(9, 0, 3), &owner);
         assert_eq!(
             store
                 .merge_record(stale_equal, &owner_id)
@@ -1602,7 +2198,7 @@ mod tests {
         // WHY: ADR-0041 validation — a forged state-commit from a non-owner
         // key is rejected, and the failure is typed so sessions abort.
         let dir = tempfile::tempdir().expect("tmpdir");
-        let store = OwnerSyncStore::load(dir.path()).await;
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
         let owner = owner_kp(1);
         let attacker = owner_kp(2);
         let forged = VersionedRecord::sign(
@@ -1611,11 +2207,7 @@ mod tests {
             &SyncValue::OwnerProfile {
                 human_name: Some("Mallory".into()),
             },
-            RecordClock {
-                version: 100,
-                signed_at_ms: 200,
-                writer_machine: machine(9).0,
-            },
+            clock(100, 200, 9),
             &attacker,
         )
         .expect("sign forged");
@@ -1639,11 +2231,7 @@ mod tests {
             &SyncValue::OwnerProfile {
                 human_name: Some("A".into()),
             },
-            RecordClock {
-                version: 1,
-                signed_at_ms: 1,
-                writer_machine: machine(1).0,
-            },
+            clock(1, 1, 1),
             &owner,
         )
         .expect("sign");
@@ -1657,16 +2245,19 @@ mod tests {
             "tampered payload must fail signature verification, got {result:?}"
         );
     }
+
     #[tokio::test]
-    async fn enrollment_gate_rejects_unenrolled_and_forged_machines() {
-        // WHY: blocker 30 — only owner-enrolled machines pass the gate.
+    async fn enrollment_gate_rejects_unenrolled_forged_and_expired() {
+        // WHY: blocker 30 + review R2 finding 1 — only owner-enrolled AND
+        // CURRENT machines pass the gate.
         let dir = tempfile::tempdir().expect("tmpdir");
-        let store = OwnerSyncStore::load(dir.path()).await;
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
         let owner = owner_kp(1);
         let owner_id = owner.user_id();
         let enrolled_machine = machine(7);
-        let enrollment = OwnerEnrollment::sign(enrolled_machine, &owner, 1_000).expect("enroll");
-        store.enroll(enrollment).await;
+        let enrollment =
+            OwnerEnrollment::sign(enrolled_machine, &owner, 1_000, None).expect("enroll");
+        store.enroll(enrollment).await.expect("persist enroll");
 
         assert!(store.is_enrolled(&enrolled_machine, &owner_id).await);
         assert!(
@@ -1676,16 +2267,227 @@ mod tests {
 
         // Forged enrollment signed by a different key fails closed.
         let attacker = owner_kp(2);
-        let forged = OwnerEnrollment::sign(machine(9), &attacker, 2_000).expect("sign");
+        let forged = OwnerEnrollment::sign(machine(9), &attacker, 2_000, None).expect("sign");
         assert_eq!(
             forged.verify_owner(&owner_id),
             Err(SyncError::OwnerMismatch)
         );
-        // Directly planted in the file, it still fails verification at the gate.
-        store.enroll(forged).await;
+        store.enroll(forged).await.expect("persist forged");
         assert!(
             !store.is_enrolled(&machine(9), &owner_id).await,
             "foreign-key enrollment never passes the gate"
+        );
+
+        // Expired enrollment fails the currency check even though the
+        // signature is valid (review R2 finding 1).
+        let expired = OwnerEnrollment::sign(
+            machine(4),
+            &owner,
+            1_000,
+            Some(now_unix_ms().saturating_sub(10 * ENROLL_EXPIRY_SKEW_MS)),
+        )
+        .expect("sign");
+        assert!(expired.verify_owner(&owner_id).is_ok(), "signature valid");
+        store.enroll(expired).await.expect("persist");
+        assert!(
+            !store.is_enrolled(&machine(4), &owner_id).await,
+            "expired enrollment must not keep the gate open"
+        );
+    }
+
+    #[tokio::test]
+    async fn unenroll_removes_device_and_persists() {
+        // WHY: review R2 finding 1 — a DELETE path so stale enrollments
+        // don't linger.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
+        let owner = owner_kp(1);
+        let owner_id = owner.user_id();
+        let target = machine(6);
+        store
+            .enroll(OwnerEnrollment::sign(target, &owner, 1_000, None).expect("sign"))
+            .await
+            .expect("persist");
+        assert!(store.is_enrolled(&target, &owner_id).await);
+
+        assert!(
+            store.unenroll(&target).await.expect("persist unenroll"),
+            "removal reports true"
+        );
+        assert!(!store.is_enrolled(&target, &owner_id).await);
+        assert!(
+            !store.unenroll(&target).await.expect("idempotent"),
+            "second removal reports false"
+        );
+
+        // Persistence survived: a fresh load over the same dir has no
+        // devices (review R2 finding 2 — durable state must be real).
+        let reloaded = OwnerSyncStore::load(dir.path()).await.expect("reload");
+        assert!(reloaded.enrolled_devices().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn persistence_failures_propagate_never_swallowed() {
+        // WHY: review R2 finding 2 — enroll/mint/commit must FAIL (and roll
+        // back in-memory state) when the disk write fails; success is never
+        // reported on a swallowed error.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
+        let owner = owner_kp(1);
+        let owner_id = owner.user_id();
+
+        // Break the sync dir: remove it and place a FILE where it was, so
+        // every write under it fails.
+        let sync_dir = dir.path().join(SYNC_DIR);
+        std::fs::remove_dir_all(&sync_dir).expect("remove dir");
+        std::fs::write(&sync_dir, b"not a directory").expect("block path");
+
+        let enrollment = OwnerEnrollment::sign(machine(5), &owner, 1_000, None).expect("sign");
+        assert!(
+            store.enroll(enrollment).await.is_err(),
+            "enroll must fail on persistence failure"
+        );
+        assert!(
+            !store.is_enrolled(&machine(5), &owner_id).await,
+            "in-memory state rolled back / never admitted"
+        );
+
+        let record = sign_names("k", "v", clock(1, 1, 1), &owner);
+        assert!(
+            store.commit_batch(vec![record], &owner_id).await.is_err(),
+            "commit must fail on persistence failure"
+        );
+        assert!(
+            store.records_snapshot().await.is_empty(),
+            "commit rolled back — nothing advertised"
+        );
+
+        assert!(
+            store
+                .mint(
+                    SyncKind::OwnerProfile,
+                    "owner",
+                    &SyncValue::OwnerProfile {
+                        human_name: Some("X".into())
+                    },
+                    &owner,
+                    machine(1)
+                )
+                .await
+                .is_err(),
+            "mint must fail on persistence failure"
+        );
+        assert!(store.records_snapshot().await.is_empty());
+
+        // load over a blocked path fails outright (fresh installs must not
+        // silently run with unwritable storage).
+        assert!(OwnerSyncStore::load(dir.path()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn equal_clock_equivocation_converges_by_hash() {
+        // WHY: review R2 finding 3 — two different records with the SAME
+        // clock must converge deterministically on every peer (greater
+        // record hash), never stay split by arrival order.
+        let owner = owner_kp(1);
+        let key = "shared";
+        let a = sign_names(key, "content-a", clock(4, 500, 1), &owner);
+        let b = sign_names(key, "content-b", clock(4, 500, 1), &owner);
+        assert_ne!(a.record_hash(), b.record_hash());
+        let (winner, loser) = if a.record_hash() > b.record_hash() {
+            (&a, &b)
+        } else {
+            (&b, &a)
+        };
+
+        // Two stores, OPPOSITE arrival orders.
+        let dir1 = tempfile::tempdir().expect("tmpdir");
+        let dir2 = tempfile::tempdir().expect("tmpdir");
+        let s1 = OwnerSyncStore::load(dir1.path()).await.expect("store");
+        let s2 = OwnerSyncStore::load(dir2.path()).await.expect("store");
+        let owner_id = owner.user_id();
+        s1.commit_batch(vec![a.clone()], &owner_id)
+            .await
+            .expect("c");
+        s1.commit_batch(vec![b.clone()], &owner_id)
+            .await
+            .expect("c");
+        s2.commit_batch(vec![b.clone()], &owner_id)
+            .await
+            .expect("c");
+        s2.commit_batch(vec![a.clone()], &owner_id)
+            .await
+            .expect("c");
+
+        for store in [&s1, &s2] {
+            let snapshot = store.records_snapshot().await;
+            assert_eq!(snapshot.len(), 1);
+            assert_eq!(snapshot[0].value, winner.value, "hash winner everywhere");
+            assert_eq!(snapshot[0].record_hash(), winner.record_hash());
+        }
+        let _ = loser;
+    }
+
+    #[tokio::test]
+    async fn batch_with_forgery_commits_nothing() {
+        // WHY: review R2 finding 4 — a later forgery in a batch must leave
+        // NOTHING committed, not even the earlier valid records.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
+        let owner = owner_kp(1);
+        let owner_id = owner.user_id();
+        let attacker = owner_kp(2);
+        let valid = sign_names("k1", "good", clock(1, 1, 1), &owner);
+        let forged = VersionedRecord::sign(
+            SyncKind::OwnerProfile,
+            "owner",
+            &SyncValue::OwnerProfile {
+                human_name: Some("Evil".into()),
+            },
+            clock(99, 99, 9),
+            &attacker,
+        )
+        .expect("sign");
+        let err = store
+            .commit_batch(vec![valid, forged], &owner_id)
+            .await
+            .expect_err("batch containing a forgery must fail whole");
+        assert_eq!(err, SyncError::OwnerMismatch);
+        assert!(
+            store.records_snapshot().await.is_empty(),
+            "no partial commit: the earlier valid record is NOT stored"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_cardinality_and_key_caps_fail_closed() {
+        // WHY: review R2 finding 5 — record/key cardinality is bounded with
+        // typed failures, never silent truncation.
+        let owner = owner_kp(1);
+        let long_key = "k".repeat(MAX_KEY_BYTES + 1);
+        let record = VersionedRecord::sign(
+            SyncKind::MachineNames,
+            &long_key,
+            &names_value("x"),
+            clock(1, 1, 1),
+            &owner,
+        )
+        .expect("sign");
+        let err = record.verify().expect_err("over-length key rejected");
+        assert!(matches!(err, SyncError::MalformedFrame(_)));
+
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
+        let owner_id = owner.user_id();
+        let over: Vec<VersionedRecord> = (0..=MAX_STORED_RECORDS)
+            .map(|i| sign_names(&format!("k{i}"), "v", clock(1, 1, 1), &owner))
+            .collect();
+        assert!(
+            matches!(
+                store.commit_batch(over, &owner_id).await,
+                Err(SyncError::StoreLimit(_))
+            ),
+            "store capacity is enforced with a typed error"
         );
     }
 
@@ -1727,18 +2529,8 @@ mod tests {
                 },
             };
             assert_eq!(value.kind(), kind);
-            let record = VersionedRecord::sign(
-                kind,
-                "k",
-                &value,
-                RecordClock {
-                    version: 1,
-                    signed_at_ms: 1,
-                    writer_machine: machine(1).0,
-                },
-                &owner,
-            )
-            .expect("sign");
+            let record =
+                VersionedRecord::sign(kind, "k", &value, clock(1, 1, 1), &owner).expect("sign");
             record.verify().expect("all four kinds verify");
         }
 
@@ -1748,11 +2540,7 @@ mod tests {
             kind: SyncKind::HomePointer,
             key: "home".into(),
             value: names_value("evil"),
-            clock: RecordClock {
-                version: 1,
-                signed_at_ms: 1,
-                writer_machine: machine(1).0,
-            },
+            clock: clock(1, 1, 1),
             owner_public_key: vec![],
             signature: vec![],
         };
@@ -1801,16 +2589,17 @@ mod tests {
         // WHY: blocker 30 — the stream accept path fails closed before any
         // application byte for unenrolled (or self) peers.
         let dir = tempfile::tempdir().expect("tmpdir");
-        let store = OwnerSyncStore::load(dir.path()).await;
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
         let owner = owner_kp(1);
-        let owner_id = owner.user_id();
         let local = machine(1);
-        let (mut tx, mut rx) = tokio::io::duplex(64);
+        let (tx, mut rx) = tokio::io::duplex(64);
+        let mut tx = tx;
+        let _ = &mut rx;
         let err = run_sync_session(
             &mut tx,
             &mut rx,
             &store,
-            &owner_id,
+            &owner,
             &local,
             &machine(2),
             |_| {},
@@ -1818,9 +2607,140 @@ mod tests {
         .await
         .expect_err("unenrolled peer refused");
         assert!(matches!(err, SyncError::NotEnrolled { .. }));
-        let err = run_sync_session(&mut tx, &mut rx, &store, &owner_id, &local, &local, |_| {})
+        let err = run_sync_session(&mut tx, &mut rx, &store, &owner, &local, &local, |_| {})
             .await
             .expect_err("self-sync refused");
         assert_eq!(err, SyncError::SelfSync);
+    }
+
+    #[tokio::test]
+    async fn session_proof_rejects_peer_without_owner_key() {
+        // WHY: review R2 finding 1 — a stale-enrolled machine that ECHOES
+        // the victim's owner id but does not hold the owner key must fail
+        // the possession proof and receive nothing.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let victim_store = OwnerSyncStore::load(&dir.path().join("v"))
+            .await
+            .expect("store");
+        let owner = owner_kp(1);
+        let attacker_kp = owner_kp(2); // different owner key in hand
+        let attacker_id = attacker_kp.user_id();
+        let victim = machine(1);
+        let attacker = machine(2);
+
+        // The victim enrolled the attacker's machine long ago (stale but
+        // unexpired), so the enrollment gate passes...
+        victim_store
+            .enroll(OwnerEnrollment::sign(attacker, &owner, 1_000, None).expect("sign"))
+            .await
+            .expect("persist");
+
+        // ...and run both sides over a duplex pipe: the attacker side
+        // signs its proof with the WRONG key.
+        let (client, server) = tokio::io::duplex(64 * 1024);
+        let (mut v_recv, mut v_send) = tokio::io::split(server);
+        let (mut a_recv, mut a_send) = tokio::io::split(client);
+        let owner_id_bytes = owner.user_id().0;
+        let attacker_signer = Arc::new(attacker_kp);
+
+        // Attacker handshake: honest Hello claiming the victim's owner id,
+        // then a proof signed by the attacker's key.
+        let attacker_hello = tokio::spawn(async move {
+            let hello = SyncFrame::Hello {
+                protocol_version: SYNC_PROTOCOL_VERSION,
+                machine_id: attacker.0,
+                owner_user_id: owner_id_bytes, // echoed, not held
+                nonce: fresh_nonce(),
+            };
+            write_frame(&mut a_send, &hello).await?;
+            let v_hello = match read_frame(&mut a_recv).await? {
+                SyncFrame::Hello { nonce, .. } => nonce,
+                other => return Err(SyncError::MalformedFrame(format!("{other:?}"))),
+            };
+            // Proof over the victim's nonce — but with the ATTACKER key.
+            let msg = proof_message(&v_hello, &attacker.0, &victim.0, &owner_id_bytes);
+            let sig = sign_with_ml_dsa(attacker_signer.secret_key(), &msg)
+                .map_err(|e| SyncError::ChallengeFailed(format!("{e:?}")))?;
+            write_frame(
+                &mut a_send,
+                &SyncFrame::Proof {
+                    signature: sig.as_bytes().to_vec(),
+                },
+            )
+            .await?;
+            // Keep the pipe open briefly so the victim can send its error.
+            let _ = read_frame(&mut a_recv).await;
+            Ok::<(), SyncError>(())
+        });
+
+        let err = run_sync_session(
+            &mut v_send,
+            &mut v_recv,
+            &victim_store,
+            &owner,
+            &victim,
+            &attacker,
+            |_| {},
+        )
+        .await
+        .expect_err("peer without the owner key must fail the proof");
+        assert!(matches!(err, SyncError::ChallengeFailed(_)), "got: {err:?}");
+        let _ = attacker_hello.await;
+        let _ = attacker_id;
+        assert!(
+            victim_store.records_snapshot().await.is_empty(),
+            "victim shipped nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_times_out_when_peer_stalls() {
+        // WHY: review R2 finding 5 — an enrolled peer that stalls after the
+        // handshake holds the session only until the budget elapses.
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let store = OwnerSyncStore::load(dir.path()).await.expect("store");
+        let owner = owner_kp(1);
+        let local = machine(1);
+        let peer = machine(2);
+        store
+            .enroll(OwnerEnrollment::sign(peer, &owner, 1_000, None).expect("sign"))
+            .await
+            .expect("persist");
+
+        // A duplex peer that sends an honest Hello then goes silent.
+        let (client, server) = tokio::io::duplex(4096);
+        let (mut s_recv, mut s_send) = tokio::io::split(server);
+        let (mut c_recv, mut c_send) = tokio::io::split(client);
+        let owner_id_bytes = owner.user_id().0;
+        let peer_hello = tokio::spawn(async move {
+            let hello = SyncFrame::Hello {
+                protocol_version: SYNC_PROTOCOL_VERSION,
+                machine_id: peer.0,
+                owner_user_id: owner_id_bytes,
+                nonce: fresh_nonce(),
+            };
+            write_frame(&mut c_send, &hello).await?;
+            // Read the local Hello, then stall forever (never send Proof).
+            let _ = read_frame(&mut c_recv).await;
+            std::future::pending::<()>().await;
+            #[allow(unreachable_code)]
+            Ok::<(), SyncError>(())
+        });
+        let _ = &mut s_send;
+        let _ = &mut s_recv;
+        let err = run_sync_session_with_timeout(
+            Duration::from_millis(150),
+            &mut s_send,
+            &mut s_recv,
+            &store,
+            &owner,
+            &local,
+            &peer,
+            |_| {},
+        )
+        .await
+        .expect_err("stalled peer must time out");
+        assert_eq!(err, SyncError::SessionTimeout);
+        peer_hello.abort();
     }
 }

--- a/src/owner_sync.rs
+++ b/src/owner_sync.rs
@@ -570,6 +570,11 @@ pub enum SyncError {
     StoreLimit(String),
     /// Inbound batch/vector exceeded its session cap.
     TooManyRecords(String),
+    /// A durable write crossed the rename but could not be synced: disk
+    /// holds the NEW state while the caller saw an error. The store is
+    /// POISONED — every further mutation and session fails until the
+    /// process reloads state from disk (review R5 finding 2).
+    Poisoned(String),
 }
 
 impl std::fmt::Display for SyncError {
@@ -599,10 +604,27 @@ impl std::fmt::Display for SyncError {
             Self::UnknownKind { tag } => {
                 write!(f, "unknown sync kind tag 0x{tag:02x} (Tier-3 allowlist)")
             }
-            Self::StoreLimit(e) => write!(f, "sync store limit: {e}"),
+            Self::Poisoned(e) => write!(
+                f,
+                "sync store poisoned (state replaced but not durable): {e}"
+            ),
             Self::TooManyRecords(e) => write!(f, "sync session record cap: {e}"),
+            Self::StoreLimit(e) => write!(f, "sync store limit: {e}"),
         }
     }
+}
+
+/// Which half of a durable atomic write failed — the two halves have
+/// OPPOSITE rollback semantics (review R5 finding 2).
+#[derive(Debug)]
+enum DurableWriteError {
+    /// Failed before the rename: the OLD state is still on disk; callers
+    /// may safely roll in-memory state back.
+    BeforeRename(std::io::Error),
+    /// The rename happened but the post-rename sync failed: the NEW state
+    /// is already visible on disk; rolling memory back would leave memory
+    /// behind an advanced disk. The store must be poisoned instead.
+    AfterRename(std::io::Error),
 }
 
 impl std::error::Error for SyncError {}
@@ -746,17 +768,20 @@ pub struct SessionSummary {
     pub shipped: usize,
 }
 
-/// The local Tier-1 store: the owner device set plus the winning record for
-/// every `(kind, key)` this machine holds. Persisted as two small JSON files
-/// under `<data_dir>/sync/` (created at load), written atomically (temp
-/// file + rename). Every mutation PROPAGATES persistence errors — success
-/// is never reported on a swallowed write (review R2 finding 2).
 pub struct OwnerSyncStore {
     dir: PathBuf,
     records: tokio::sync::RwLock<BTreeMap<(SyncKind, String), VersionedRecord>>,
     devices: tokio::sync::RwLock<BTreeMap<[u8; 32], OwnerEnrollment>>,
     last_session: tokio::sync::RwLock<BTreeMap<[u8; 32], DeviceSyncStatus>>,
     generation_tx: tokio::sync::watch::Sender<u64>,
+    /// Set when a durable write crossed the rename but could not be
+    /// synced: memory/disk agreement is no longer reconstructable by
+    /// rollback, so every further mutation and session fails until the
+    /// process reloads from disk (review R5 finding 2).
+    poisoned: std::sync::Mutex<Option<String>>,
+    /// Test injection: make the next durable writes fail AFTER the rename
+    /// (simulates a post-rename fsync failure). Never set in production.
+    fail_after_rename: std::sync::atomic::AtomicBool,
 }
 
 /// Per-device sync status surfaced by `GET /sync/devices`.
@@ -822,6 +847,8 @@ impl OwnerSyncStore {
             devices: tokio::sync::RwLock::new(devices),
             last_session: tokio::sync::RwLock::new(BTreeMap::new()),
             generation_tx,
+            poisoned: std::sync::Mutex::new(None),
+            fail_after_rename: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -851,64 +878,150 @@ impl OwnerSyncStore {
     /// fsync the target file and its parent directory (the rename entry
     /// durable). A crash after a successful persist can no longer lose the
     /// durable state the caller just verified (review R3 finding 2).
-    async fn write_atomically(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    ///
+    /// The error distinguishes the two transaction halves (review R5
+    /// finding 2): [`DurableWriteError::BeforeRename`] leaves the OLD
+    /// state on disk (callers may roll memory back); [`DurableWriteError::AfterRename`]
+    /// means the NEW state is already in place and the process can no
+    /// longer reconstruct memory/disk agreement by rolling back — the
+    /// store must be poisoned instead.
+    async fn write_atomically(
+        path: &Path,
+        bytes: &[u8],
+        fail_after_rename: bool,
+    ) -> Result<(), DurableWriteError> {
         use tokio::io::AsyncWriteExt as _;
         static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let unique = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let tmp = path.with_extension(format!("tmp-{}-{unique}", std::process::id()));
-        let mut file = tokio::fs::File::create(&tmp).await?;
-        file.write_all(bytes).await?;
-        file.sync_all().await?;
+        let mut file = tokio::fs::File::create(&tmp)
+            .await
+            .map_err(DurableWriteError::BeforeRename)?;
+        file.write_all(bytes)
+            .await
+            .map_err(DurableWriteError::BeforeRename)?;
+        file.sync_all()
+            .await
+            .map_err(DurableWriteError::BeforeRename)?;
         drop(file);
-        tokio::fs::rename(&tmp, path).await?;
+        tokio::fs::rename(&tmp, path)
+            .await
+            .map_err(DurableWriteError::BeforeRename)?;
+        // Everything below runs with the NEW state already visible.
+        if fail_after_rename {
+            // Test injection: simulate a post-rename fsync failure.
+            return Err(DurableWriteError::AfterRename(std::io::Error::other(
+                "injected post-rename fsync failure",
+            )));
+        }
         // fsync the renamed file and the parent directory so the new name
         // survives a crash. (Directory fds support fsync on Unix.)
-        let target = tokio::fs::File::open(path).await?;
-        target.sync_all().await?;
+        let target = tokio::fs::File::open(path)
+            .await
+            .map_err(DurableWriteError::AfterRename)?;
+        target
+            .sync_all()
+            .await
+            .map_err(DurableWriteError::AfterRename)?;
         #[cfg(unix)]
         if let Some(parent) = path.parent() {
-            let dir = tokio::fs::File::open(parent).await?;
-            dir.sync_all().await?;
+            let dir = tokio::fs::File::open(parent)
+                .await
+                .map_err(DurableWriteError::AfterRename)?;
+            dir.sync_all()
+                .await
+                .map_err(DurableWriteError::AfterRename)?;
         }
         #[cfg(not(unix))]
         let _ = path.parent();
         Ok(())
     }
 
-    /// Persist the winning records. Errors PROPAGATE — callers never report
-    /// success on a swallowed write (review R2 finding 2).
+    /// Persist the winning records. `Poisoned` tells the caller the write
+    /// crossed the rename but could not be made durable — memory must NOT
+    /// be rolled back (disk already advanced); the store must be poisoned.
+    /// Errors PROPAGATE — callers never report success on a swallowed
+    /// write (review R2 finding 2).
     async fn persist_records(
+        &self,
         records: &BTreeMap<(SyncKind, String), VersionedRecord>,
-        dir: &Path,
     ) -> Result<(), SyncError> {
         let persisted = PersistedRecords {
             records: records.values().cloned().collect(),
         };
         let bytes = serde_json::to_vec(&persisted)
             .map_err(|e| SyncError::Io(format!("encode records: {e}")))?;
-        Self::write_atomically(&dir.join(RECORDS_FILE), &bytes)
-            .await
-            .map_err(|e| SyncError::Io(format!("persist records: {e}")))
+        Self::write_atomically(
+            &self.dir.join(RECORDS_FILE),
+            &bytes,
+            self.fail_after_rename_for_testing(),
+        )
+        .await
+        .map_err(|e| match e {
+            DurableWriteError::BeforeRename(io) => SyncError::Io(format!("persist records: {io}")),
+            DurableWriteError::AfterRename(io) => {
+                SyncError::Poisoned(format!("records replaced but not durable: {io}"))
+            }
+        })
     }
 
     /// Persist the device set; errors propagate (see [`Self::persist_records`]).
     async fn persist_devices(
+        &self,
         devices: &BTreeMap<[u8; 32], OwnerEnrollment>,
-        dir: &Path,
     ) -> Result<(), SyncError> {
         let persisted = PersistedDevices {
             devices: devices.values().cloned().collect(),
         };
         let bytes = serde_json::to_vec(&persisted)
             .map_err(|e| SyncError::Io(format!("encode devices: {e}")))?;
-        Self::write_atomically(&dir.join(DEVICES_FILE), &bytes)
-            .await
-            .map_err(|e| SyncError::Io(format!("persist devices: {e}")))
+        Self::write_atomically(
+            &self.dir.join(DEVICES_FILE),
+            &bytes,
+            self.fail_after_rename_for_testing(),
+        )
+        .await
+        .map_err(|e| match e {
+            DurableWriteError::BeforeRename(io) => SyncError::Io(format!("persist devices: {io}")),
+            DurableWriteError::AfterRename(io) => {
+                SyncError::Poisoned(format!("devices replaced but not durable: {io}"))
+            }
+        })
     }
 
-    /// The enrollment gate (blocker 30): is `machine` enrolled for `owner`
-    /// AND is that enrollment current?
-    ///
+    /// Poison the store: a durable write crossed the rename but could not
+    /// be synced, so memory/disk agreement is not reconstructable — all
+    /// further mutations and sessions fail until a fresh `load` (review R5
+    /// finding 2).
+    fn poison(&self, reason: String) {
+        *self
+            .poisoned
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(reason);
+    }
+
+    /// Why the store is poisoned, if it is.
+    #[must_use]
+    pub fn poisoned_reason(&self) -> Option<String> {
+        self.poisoned
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    fn fail_after_rename_for_testing(&self) -> bool {
+        self.fail_after_rename
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Test-only: make subsequent durable writes fail AFTER the rename,
+    /// simulating a post-rename fsync failure (review R5 finding 2).
+    #[doc(hidden)]
+    pub fn set_fail_after_rename_for_testing(&self, fail: bool) {
+        self.fail_after_rename
+            .store(fail, std::sync::atomic::Ordering::Relaxed);
+    }
+
     /// Every stored enrollment is (re-)verified against `owner` and its
     /// expiry checked here — a corrupt, foreign-key, or stale record fails
     /// closed, so persistence poison or an expired grant cannot wedge the
@@ -927,8 +1040,11 @@ impl OwnerSyncStore {
     ///
     /// # Errors
     ///
-    /// [`SyncError::Io`] when the device set cannot be persisted — the
-    /// caller must fail, not report success (review R2 finding 2).
+    /// [`SyncError::Io`] when persistence failed BEFORE the rename (the
+    /// in-memory set is rolled back); [`SyncError::Poisoned`] when the
+    /// write crossed the rename but was not durable — the mutation STAYS
+    /// (disk already advanced) and the store refuses further sync until
+    /// reload (review R5 finding 2).
     pub async fn enroll(&self, enrollment: OwnerEnrollment) -> Result<(), SyncError> {
         let mut devices = self.devices.write().await;
         let previous = devices.get(&enrollment.machine_id).cloned();
@@ -937,9 +1053,16 @@ impl OwnerSyncStore {
             .is_none_or(|old| enrollment.enrolled_at_ms >= old.enrolled_at_ms);
         if keep {
             devices.insert(enrollment.machine_id, enrollment.clone());
-            if let Err(e) = Self::persist_devices(&devices, &self.dir).await {
-                // Roll back so memory matches the failed disk write
-                // (review R2 finding 2).
+            if let Err(e) = self.persist_devices(&devices).await {
+                if matches!(e, SyncError::Poisoned(_)) {
+                    // Disk already holds the new device set: keep the
+                    // mutation (memory matches disk) and poison.
+                    drop(devices);
+                    self.poison(e.to_string());
+                    return Err(e);
+                }
+                // Pre-rename failure: roll back so memory matches the
+                // unchanged disk (review R2 finding 2).
                 match previous {
                     Some(old) => {
                         devices.insert(old.machine_id, old);
@@ -957,17 +1080,18 @@ impl OwnerSyncStore {
     }
 
     /// Remove a machine from the owner device set (the DELETE
-    /// `/sync/devices/:id` path; review R2 finding 1).
-    ///
-    /// # Errors
-    ///
-    /// [`SyncError::Io`] when the device set cannot be persisted (the
-    /// in-memory set is restored — removal never half-applies).
-    /// Returns `Ok(false)` when the machine was not enrolled.
+    /// `/sync/devices/:id` path; review R2 finding 1). Poisoning semantics
+    /// match [`Self::enroll`]. Returns `Ok(false)` when not enrolled.
     pub async fn unenroll(&self, machine: &MachineId) -> Result<bool, SyncError> {
         let mut devices = self.devices.write().await;
         if let Some(previous) = devices.remove(&machine.0) {
-            if let Err(e) = Self::persist_devices(&devices, &self.dir).await {
+            if let Err(e) = self.persist_devices(&devices).await {
+                if matches!(e, SyncError::Poisoned(_)) {
+                    // Disk already holds the removal: keep it and poison.
+                    drop(devices);
+                    self.poison(e.to_string());
+                    return Err(e);
+                }
                 devices.insert(previous.machine_id, previous);
                 return Err(e);
             }
@@ -995,20 +1119,21 @@ impl OwnerSyncStore {
     }
 
     /// Pure classification of `record` against `stored` under the full
-    /// conflict rule: `beats`, else equal-clock with identical content
-    /// (idempotent supersede), else equal-clock with different content
-    /// (deterministic greater-hash winner — convergence under
-    /// equivocation).
+    /// conflict rule: `beats`, else equal-clock resolved by the FULL
+    /// record hash (canonical signed bytes including the randomized
+    /// ML-DSA signature): an identical hash is an exact replay
+    /// (idempotent supersede); any difference under the same clock —
+    /// value OR signature-only — makes the greater hash the deterministic
+    /// winner on every peer (review R5 finding 1).
     fn classify(record: &VersionedRecord, stored: &VersionedRecord) -> MergeOutcome {
         if record.clock.beats(&stored.clock) {
             return MergeOutcome::Accepted;
         }
         if record.clock == stored.clock {
-            if record.value == stored.value {
-                return MergeOutcome::Superseded; // exact replay
-            }
-            // Equal clock, different signed content: the greater record
-            // hash wins on every peer.
+            // Signature-only differences (the same writer double-signing
+            // identical content) MUST also converge to one canonical
+            // record — deciding by value equality would leave replicas
+            // holding different records under the same clock forever.
             if record.record_hash() > stored.record_hash() {
                 return MergeOutcome::Accepted;
             }
@@ -1058,16 +1183,22 @@ impl OwnerSyncStore {
                 }
                 let key = (record.kind, record.key.clone());
                 let stored = records.get(&key);
-                // Equal clock with different signed content is an
+                // Equal clock with ANY differing signed bytes (different
+                // value, or the same value double-signed) is an
                 // equivocation whichever side wins the hash tie-break —
-                // surfaced, never silently merged (review R2 finding 3).
+                // surfaced, never silently merged (review R2 finding 3,
+                // extended in R5 to signature-only differences).
                 if let Some(existing) = stored {
-                    if existing.clock == record.clock && existing.value != record.value {
+                    if existing.clock == record.clock
+                        && existing.record_hash() != record.record_hash()
+                    {
                         outcome.equivocations += 1;
+                        let values_differ = existing.value != record.value;
                         tracing::warn!(
                             target: "x0x::owner_sync",
                             kind = ?existing.kind,
                             key = %existing.key,
+                            values_differ,
                             "equal-clock equivocation resolved deterministically by record hash"
                         );
                     }
@@ -1101,11 +1232,21 @@ impl OwnerSyncStore {
                 if outcome.accepted.is_empty() {
                     return Ok(outcome); // nothing new — no write needed
                 }
-                match Self::persist_records(&records, &self.dir).await {
+                match self.persist_records(&records).await {
                     Ok(()) => {
                         drop(records);
                         self.kick();
                         Ok(outcome)
+                    }
+                    Err(e) if matches!(e, SyncError::Poisoned(_)) => {
+                        // The batch crossed the rename but was not durable:
+                        // disk already holds it — KEEP the mutations (memory
+                        // matches the advanced disk) and poison the store;
+                        // never roll memory back below an advanced disk
+                        // (review R5 finding 2).
+                        drop(records);
+                        self.poison(e.to_string());
+                        Err(e)
                     }
                     Err(e) => {
                         Self::rollback(&mut records, &touched);
@@ -1195,14 +1336,21 @@ impl OwnerSyncStore {
         let record = VersionedRecord::sign(kind, key, desired, clock, owner)
             .map_err(|e| SyncError::BadSignature(format!("mint: {e}")))?;
         let previous = records.insert((kind, key.to_string()), record);
-        match Self::persist_records(&records, &self.dir).await {
+        match self.persist_records(&records).await {
             Ok(()) => {
                 drop(records);
                 self.kick();
                 Ok(())
             }
+            Err(e) if matches!(e, SyncError::Poisoned(_)) => {
+                // Disk already holds the minted record: keep it and poison.
+                drop(records);
+                self.poison(e.to_string());
+                Err(e)
+            }
             Err(e) => {
-                // Roll back so memory matches the failed disk write.
+                // Pre-rename failure: roll back so memory matches the
+                // unchanged disk.
                 match previous {
                     Some(prev) => {
                         records.insert((kind, key.to_string()), prev);
@@ -1304,7 +1452,7 @@ impl OwnerSyncStore {
     pub async fn records_insert_for_testing(&self, record: VersionedRecord) {
         let mut records = self.records.write().await;
         records.insert((record.kind, record.key.clone()), record);
-        let _ = Self::persist_records(&records, &self.dir).await;
+        let _ = self.persist_records(&records).await;
     }
 }
 
@@ -1440,6 +1588,11 @@ where
     let owner_id = owner.user_id();
     let mut summary = SessionSummary::default();
 
+    // A poisoned store never syncs: memory/disk agreement is unrecoverable
+    // until the process reloads state from disk (review R5 finding 2).
+    if let Some(reason) = store.poisoned_reason() {
+        return Err(SyncError::Poisoned(reason));
+    }
     // Same-owner gate: a peer machine that is not enrolled locally (and
     // current) never gets past the first byte (blocker 30).
     if peer_machine.0 == local_machine.0 {
@@ -3348,5 +3501,163 @@ mod r4_tests {
             matches!(err, SyncError::MalformedFrame(ref m) if m.contains("exceeds limit")),
             "got: {err:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod r5_tests {
+    use super::tests::{clock, cross_enroll_for_tests, machine, names_value, owner_kp, sign_names};
+    use super::*;
+
+    /// WHY (review R5 finding 1): ML-DSA signatures are randomized, so the
+    /// same writer can produce two records with identical kind/key/value/
+    /// clock but different signatures. Equal-clock classification must
+    /// compare the FULL record hash (signature included) so every replica
+    /// converges on one canonical record — deciding by value equality left
+    /// replicas permanently split.
+    #[tokio::test]
+    async fn equal_clock_signature_only_records_converge() {
+        let owner = owner_kp(1);
+        let owner_id = owner.user_id();
+        let key = "same-value";
+        let same_clock = clock(4, 500, 1);
+        // Sign the SAME value twice: different signature bytes, identical
+        // content otherwise.
+        let first = VersionedRecord::sign(
+            SyncKind::MachineNames,
+            key,
+            &names_value("identical"),
+            same_clock,
+            &owner,
+        )
+        .unwrap();
+        let second = VersionedRecord::sign(
+            SyncKind::MachineNames,
+            key,
+            &names_value("identical"),
+            same_clock,
+            &owner,
+        )
+        .unwrap();
+        assert_eq!(first.value, second.value);
+        assert_ne!(
+            first.record_hash(),
+            second.record_hash(),
+            "randomized ML-DSA signatures must produce different record hashes"
+        );
+        let canonical = if first.record_hash() > second.record_hash() {
+            &first
+        } else {
+            &second
+        };
+
+        // Two stores, OPPOSITE arrival orders — both must hold the
+        // canonical record afterwards.
+        let dir1 = tempfile::tempdir().unwrap();
+        let dir2 = tempfile::tempdir().unwrap();
+        let s1 = OwnerSyncStore::load(dir1.path()).await.unwrap();
+        let s2 = OwnerSyncStore::load(dir2.path()).await.unwrap();
+        s1.commit_batch(vec![first.clone()], &owner_id)
+            .await
+            .unwrap();
+        s1.commit_batch(vec![second.clone()], &owner_id)
+            .await
+            .unwrap();
+        s2.commit_batch(vec![second.clone()], &owner_id)
+            .await
+            .unwrap();
+        s2.commit_batch(vec![first.clone()], &owner_id)
+            .await
+            .unwrap();
+
+        for store in [&s1, &s2] {
+            let snapshot = store.records_snapshot().await;
+            assert_eq!(snapshot.len(), 1);
+            assert_eq!(
+                snapshot[0].record_hash(),
+                canonical.record_hash(),
+                "signature-only equal-clock divergence converges to the canonical record"
+            );
+        }
+    }
+
+    /// WHY (review R5 finding 2): when a durable write crosses the rename
+    /// but its post-rename sync fails, disk already holds the NEW state —
+    /// memory must NOT be rolled back (that would leave memory behind an
+    /// advanced disk); instead the store is poisoned and refuses every
+    /// further mutation and session until a reload.
+    #[tokio::test]
+    async fn post_rename_failure_keeps_memory_advanced_and_poisons() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = OwnerSyncStore::load(dir.path()).await.unwrap();
+        let owner = owner_kp(1);
+        let owner_id = owner.user_id();
+
+        // Inject a post-rename fsync failure for the next write.
+        store.set_fail_after_rename_for_testing(true);
+        let record = sign_names("k", "v", clock(1, 1, 1), &owner);
+        let err = store
+            .commit_batch(vec![record], &owner_id)
+            .await
+            .expect_err("post-rename failure must surface");
+        assert!(
+            matches!(err, SyncError::Poisoned(_)),
+            "typed poison error, got: {err:?}"
+        );
+        assert!(store.poisoned_reason().is_some(), "store is poisoned");
+
+        // Memory was NOT rolled back: it matches the advanced disk.
+        let snapshot = store.records_snapshot().await;
+        assert_eq!(snapshot.len(), 1, "memory keeps the crossed-rename batch");
+
+        // A fresh load over the same directory sees the same advanced state
+        // — memory and disk agree, just not durably.
+        let reloaded = OwnerSyncStore::load(dir.path()).await.unwrap();
+        assert_eq!(
+            reloaded.records_snapshot().await.len(),
+            1,
+            "disk holds the new batch the callers saw fail"
+        );
+
+        // Every further mutation refuses: poisoned.
+        let err = store
+            .mint(
+                SyncKind::OwnerProfile,
+                "owner",
+                &SyncValue::OwnerProfile {
+                    human_name: Some("X".into()),
+                },
+                &owner,
+                machine(1),
+            )
+            .await
+            .expect_err("poisoned store refuses mint");
+        assert!(matches!(err, SyncError::Poisoned(_)));
+        let err = store
+            .enroll(OwnerEnrollment::sign(machine(9), &owner, 1, None).unwrap())
+            .await
+            .expect_err("poisoned store refuses enroll");
+        assert!(matches!(err, SyncError::Poisoned(_)));
+
+        // Sessions refuse too — even with a fully enrolled peer.
+        cross_enroll_for_tests(
+            &Arc::new(OwnerSyncStore::load(dir.path()).await.unwrap()),
+            &Arc::new(OwnerSyncStore::load(dir.path()).await.unwrap()),
+            &owner,
+        )
+        .await;
+        let (mut tx, mut rx) = tokio::io::duplex(64);
+        let err = run_sync_session(
+            &mut tx,
+            &mut rx,
+            &store,
+            &owner,
+            &machine(1),
+            &machine(2),
+            |_| {},
+        )
+        .await
+        .expect_err("poisoned store refuses sessions");
+        assert!(matches!(err, SyncError::Poisoned(_)));
     }
 }

--- a/src/owner_sync.rs
+++ b/src/owner_sync.rs
@@ -2333,6 +2333,13 @@ impl OwnerSyncService {
                 cert_digest,
                 issued_at,
                 not_after: None,
+                // ADR-0039 fields are not part of the Tier-1 sync value:
+                // a synced line records the issuance fact (digest + time);
+                // mode defaults to Acp (the pre-ADR-0039 line shape) and
+                // no certificate bytes travel Tier 1 (Tier-3 boundary).
+                mode: crate::profile::CertMode::Acp,
+                label: None,
+                cert_b64: None,
             };
             if let Err(e) = crate::profile::IssuedCertRecord::append(&path, &record).await {
                 tracing::warn!(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -43,14 +43,14 @@ use routes::{
     daemon_shutdown_hook, delete_contact, delete_discovery_subscription, delete_kv_value,
     delete_machine, direct_connections, direct_message_send_config, direct_send, discover_groups,
     discover_groups_nearby, discovered_agent, discovered_agents, discovered_machine,
-    discovered_machines, dm_diagnostics, ensure_named_group_listeners, evaluate_trust, exec_cancel,
-    exec_diagnostics, exec_run, exec_sessions, file_accept_handler, file_reject_handler,
-    file_send_handler, file_transfer_status_handler, file_transfers_handler, find_agent,
-    forward_add, forward_list, forward_remove, get_a2a_agent_card, get_agent_card,
+    discovered_machines, dm_diagnostics, enroll_device, ensure_named_group_listeners,
+    evaluate_trust, exec_cancel, exec_diagnostics, exec_run, exec_sessions, file_accept_handler,
+    file_reject_handler, file_send_handler, file_transfer_status_handler, file_transfers_handler,
+    find_agent, forward_add, forward_list, forward_remove, get_a2a_agent_card, get_agent_card,
     get_constitution, get_constitution_json, get_group_card, get_group_public_messages,
     get_group_state, get_group_state_commits, get_kv_value, get_mls_group, get_named_group,
-    get_named_group_members, get_profile, gossip_diagnostics, group_membership_lock,
-    groups_diagnostics, handle_file_message, handle_join_result_message,
+    get_named_group_members, get_profile, get_sync_devices, gossip_diagnostics,
+    group_membership_lock, groups_diagnostics, handle_file_message, handle_join_result_message,
     handle_treekem_catchup_request, handle_treekem_catchup_response, handle_welcome_blob_message,
     health, history_diagnostics, history_list, history_message, history_purge, history_search,
     history_stats, identity_revocations, identity_revoke, import_agent_card, import_group_card,
@@ -796,6 +796,20 @@ pub async fn serve_with_options(
         .unwrap_or_default();
     agent.set_self_name(profile.display_name.clone());
 
+    // ADR-0041 Tier-1: cross-machine owner-state sync. Only an install
+    // with an owner key can own or receive Tier-1 state; ownerless
+    // installs register no SyncV1 acceptor and answer 409 on the sync
+    // routes. The acceptor registration follows the single-acceptor rule
+    // (a conflict aborts startup).
+    let owner_sync = if agent.identity().user_keypair().is_some() {
+        let service = x0x::owner_sync::OwnerSyncService::new(Arc::clone(&agent), &config.data_dir)
+            .await
+            .context("failed to register SyncV1 stream acceptor")?;
+        Some(service)
+    } else {
+        None
+    };
+
     let state = Arc::new(AppState {
         agent: Arc::clone(&agent),
         history_record_topics: config.history.record_topics.clone(),
@@ -887,6 +901,7 @@ pub async fn serve_with_options(
         groups_diagnostics: Arc::new(x0x::groups::GroupsDiagnostics::new()),
         connect_diagnostics,
         forward_service,
+        owner_sync,
     });
 
     let port_file = config.data_dir.join("api.port");
@@ -897,6 +912,17 @@ pub async fn serve_with_options(
     // are owned by the Agent/ExecService and stopped by their own `shutdown()`
     // calls in the shutdown tail — issue #116 — not collected here.)
     let mut bg_tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+
+    // ADR-0041 Tier-1: bridge the sync service to live daemon state and
+    // start the periodic + on-change pass loop (shuts down with the watch).
+    if let Some(sync) = state.owner_sync.as_ref() {
+        sync.attach_view(Arc::new(routes::DaemonView::new(Arc::clone(&state))));
+        let service = Arc::clone(sync);
+        let shutdown_rx = state.shutdown_notify.subscribe();
+        bg_tasks.push(tokio::spawn(async move {
+            service.spawn_periodic(shutdown_rx).await;
+        }));
+    }
 
     // A previous daemon instance may have left an API advertisement behind.
     // Remove it before any fallible causal-state loader runs so a rejected
@@ -1647,6 +1673,8 @@ pub async fn serve_with_options(
         .route("/agent", get(agent_info))
         .route("/introduction", get(introduction))
         .route("/agent/card", get(get_agent_card))
+        .route("/sync/devices", get(get_sync_devices))
+        .route("/sync/devices/enroll", post(enroll_device))
         .route("/profile", get(get_profile).put(update_profile))
         .route("/home", get(routes::home::get_home))
         .route("/home/rename", post(routes::home::rename_home))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -75,16 +75,17 @@ use routes::{
     spawn_directory_resubscribe, spawn_global_discovery_listener,
     spawn_global_public_message_listener, spawn_listed_to_contacts_listener, status,
     store_named_group_info, streams_diagnostics, subscribe, transport_diagnostics,
-    unban_group_member, unpin_machine, unsubscribe, update_contact, update_group_policy,
-    update_member_role, update_named_group, update_profile, update_task, withdraw_group_state,
-    AtomicWriteOutcome, JoinResultMessage, KvStoreDirectDelta, NamedGroupMetadataEvent,
-    PendingListenerAdmission, PredecessorRelayObligation, PublicGroupBootstrap,
-    SelfPublishedReleaseManifests, TreeKemCatchupRequest, TreeKemCatchupResponse,
-    WelcomeBlobMessage, CAUSAL_ENVELOPE_MAX_BYTES, CAUSAL_RELAY_OUTBOX_PER_DAEMON_BYTE_CAP,
-    CAUSAL_RELAY_OUTBOX_PER_DAEMON_CAP, CAUSAL_RELAY_OUTBOX_PER_GROUP_BYTE_CAP,
-    CAUSAL_RELAY_OUTBOX_PER_GROUP_CAP, CAUSAL_RELAY_TARGETS_PER_DAEMON_CAP,
-    DIRECTORY_DIGEST_INTERVAL_SECS, DIRECTORY_RESUBSCRIBE_JITTER_MS,
-    GROUP_PREDECESSOR_RELAY_DM_PREFIX, GROUP_PUBLIC_MESSAGE_DM_PREFIX, KV_STORE_DELTA_DM_PREFIX,
+    unban_group_member, unenroll_device, unpin_machine, unsubscribe, update_contact,
+    update_group_policy, update_member_role, update_named_group, update_profile, update_task,
+    withdraw_group_state, AtomicWriteOutcome, JoinResultMessage, KvStoreDirectDelta,
+    NamedGroupMetadataEvent, PendingListenerAdmission, PredecessorRelayObligation,
+    PublicGroupBootstrap, SelfPublishedReleaseManifests, TreeKemCatchupRequest,
+    TreeKemCatchupResponse, WelcomeBlobMessage, CAUSAL_ENVELOPE_MAX_BYTES,
+    CAUSAL_RELAY_OUTBOX_PER_DAEMON_BYTE_CAP, CAUSAL_RELAY_OUTBOX_PER_DAEMON_CAP,
+    CAUSAL_RELAY_OUTBOX_PER_GROUP_BYTE_CAP, CAUSAL_RELAY_OUTBOX_PER_GROUP_CAP,
+    CAUSAL_RELAY_TARGETS_PER_DAEMON_CAP, DIRECTORY_DIGEST_INTERVAL_SECS,
+    DIRECTORY_RESUBSCRIBE_JITTER_MS, GROUP_PREDECESSOR_RELAY_DM_PREFIX,
+    GROUP_PUBLIC_MESSAGE_DM_PREFIX, KV_STORE_DELTA_DM_PREFIX,
 };
 use sse::{direct_events_sse, events_sse, peer_events_handler, presence_events, SseEvent};
 pub use state::{
@@ -1675,6 +1676,10 @@ pub async fn serve_with_options(
         .route("/agent/card", get(get_agent_card))
         .route("/sync/devices", get(get_sync_devices))
         .route("/sync/devices/enroll", post(enroll_device))
+        .route(
+            "/sync/devices/:machine_id",
+            axum::routing::delete(unenroll_device),
+        )
         .route("/profile", get(get_profile).put(update_profile))
         .route("/home", get(routes::home::get_home))
         .route("/home/rename", post(routes::home::rename_home))

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -25,6 +25,7 @@ mod profile;
 pub(crate) mod public_group_bootstrap_outbox;
 mod status;
 mod stores;
+mod sync;
 mod tasks;
 mod trust;
 mod upgrade;
@@ -120,6 +121,7 @@ pub(super) use stores::{
     apply_direct_kv_store_delta, create_kv_store, delete_kv_value, get_kv_value, join_kv_store,
     list_kv_keys, list_kv_stores, put_kv_value, KvStoreDirectDelta, KV_STORE_DELTA_DM_PREFIX,
 };
+pub(super) use sync::{enroll_device, get_sync_devices, DaemonView};
 pub(super) use tasks::{
     add_task, apply_group_authorization, create_task_list, list_task_lists, list_tasks, update_task,
 };

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -121,7 +121,7 @@ pub(super) use stores::{
     apply_direct_kv_store_delta, create_kv_store, delete_kv_value, get_kv_value, join_kv_store,
     list_kv_keys, list_kv_stores, put_kv_value, KvStoreDirectDelta, KV_STORE_DELTA_DM_PREFIX,
 };
-pub(super) use sync::{enroll_device, get_sync_devices, DaemonView};
+pub(super) use sync::{enroll_device, get_sync_devices, unenroll_device, DaemonView};
 pub(super) use tasks::{
     add_task, apply_group_authorization, create_task_list, list_task_lists, list_tasks, update_task,
 };

--- a/src/server/routes/named_groups.rs
+++ b/src/server/routes/named_groups.rs
@@ -21818,6 +21818,15 @@ pub(in crate::server) mod tests {
             &named_groups,
         )
         .await?;
+        // ADR-0041 Tier-1: mirror daemon startup — owned agents get the
+        // SyncV1 acceptor + store under `<data_dir>/sync`.
+        let owner_sync = if agent.identity().user_keypair().is_some() {
+            x0x::owner_sync::OwnerSyncService::new(Arc::clone(&agent), data_dir)
+                .await
+                .ok()
+        } else {
+            None
+        };
         let contacts = Arc::clone(agent.contacts());
         agent.set_contacts(Arc::clone(&contacts));
 
@@ -21931,6 +21940,7 @@ pub(in crate::server) mod tests {
                 x0x::connect::ConnectPolicy::default().summary(),
             )),
             forward_service: None,
+            owner_sync,
         }))
     }
 

--- a/src/server/routes/profile.rs
+++ b/src/server/routes/profile.rs
@@ -114,6 +114,11 @@ pub(in crate::server) async fn update_profile(
             })),
         );
     }
+    // ADR-0041 Tier-1: names are synced state — kick an early sync pass so
+    // the owner's other machines learn the change before the next period.
+    if let Some(sync) = state.owner_sync.as_ref() {
+        sync.kick();
+    }
     (
         StatusCode::OK,
         Json(serde_json::json!({

--- a/src/server/routes/sync.rs
+++ b/src/server/routes/sync.rs
@@ -185,6 +185,7 @@ impl SyncDaemonView for DaemonView {
 pub(in crate::server) struct SyncDeviceEntry {
     machine_id: String,
     enrolled_at_ms: u64,
+    expires_at_ms: Option<u64>,
     last_session_ms: Option<u64>,
     last_session_ok: Option<bool>,
     #[serde(rename = "is_this_machine")]
@@ -224,6 +225,7 @@ pub(in crate::server) async fn get_sync_devices(
             SyncDeviceEntry {
                 machine_id: hex::encode(enrollment.machine_id),
                 enrolled_at_ms: enrollment.enrolled_at_ms,
+                expires_at_ms: enrollment.expires_at_ms,
                 last_session_ms: status.map(|s| s.last_session_ms),
                 last_session_ok: status.map(|s| s.last_session_ok),
                 is_this_machine: enrollment.machine_id == this_machine.0,
@@ -246,10 +248,12 @@ pub(in crate::server) async fn get_sync_devices(
 }
 
 /// POST /sync/devices/enroll request body — `machine_id` optional;
-/// omitted = enroll THIS machine.
+/// omitted = enroll THIS machine. `ttl_secs` optional bounds the
+/// enrollment's lifetime (review R2 finding 1); omitted = until deleted.
 #[derive(Debug, Default, Deserialize)]
 pub(in crate::server) struct EnrollRequest {
     machine_id: Option<String>,
+    ttl_secs: Option<u64>,
 }
 
 /// POST /sync/devices/enroll response body.
@@ -257,6 +261,7 @@ pub(in crate::server) struct EnrollRequest {
 pub(in crate::server) struct EnrollData {
     machine_id: String,
     enrolled_at_ms: u64,
+    expires_at_ms: Option<u64>,
     device_count: usize,
 }
 
@@ -264,8 +269,10 @@ pub(in crate::server) struct EnrollData {
 /// machine and add it to the local owner device set (owner-gated: the
 /// daemon must hold the owner key; ADR-0043 enrollment direction).
 ///
-/// The signature is verified again at every stream accept, so a corrupt or
-/// foreign-key enrollment can never open the sync gate.
+/// The signature and the enrollment's currency (expiry) are verified again
+/// at every stream accept, so a corrupt, foreign-key, or stale enrollment
+/// can never open the sync gate. A persistence failure is a 500 — success
+/// is never reported on a swallowed write (review R2 finding 2).
 pub(in crate::server) async fn enroll_device(
     State(state): State<Arc<AppState>>,
     Json(req): Json<EnrollRequest>,
@@ -292,12 +299,21 @@ pub(in crate::server) async fn enroll_device(
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0);
-    let enrollment = match OwnerEnrollment::sign(machine, owner_kp, enrolled_at_ms) {
+    let expires_at_ms = req
+        .ttl_secs
+        .map(|ttl| enrolled_at_ms.saturating_add(ttl.saturating_mul(1000)));
+    let enrollment = match OwnerEnrollment::sign(machine, owner_kp, enrolled_at_ms, expires_at_ms) {
         Ok(enrollment) => enrollment,
         Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
     };
     let machine_hex = hex::encode(enrollment.machine_id);
-    sync.store().enroll(enrollment).await;
+    if let Err(e) = sync.store().enroll(enrollment).await {
+        // Never report success on a swallowed write (review R2 finding 2).
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("failed to persist enrollment: {e}"),
+        );
+    }
     let device_count = sync.store().enrolled_devices().await.len();
     // Enrollment is Tier-1-relevant state: kick an early sync pass.
     sync.kick();
@@ -306,6 +322,7 @@ pub(in crate::server) async fn enroll_device(
         data: EnrollData {
             machine_id: machine_hex,
             enrolled_at_ms,
+            expires_at_ms,
             device_count,
         },
     };
@@ -313,6 +330,54 @@ pub(in crate::server) async fn enroll_device(
         StatusCode::OK,
         Json(serde_json::to_value(body).unwrap_or_default()),
     )
+}
+
+/// DELETE /sync/devices/:machine_id response body.
+#[derive(Debug, Serialize)]
+pub(in crate::server) struct UnenrollData {
+    machine_id: String,
+    device_count: usize,
+}
+
+/// DELETE /sync/devices/:machine_id — remove a machine from the owner
+/// device set (owner-gated). The very next inbound SyncV1 stream from that
+/// machine is refused at the enrollment gate; existing streams are not
+/// torn down mid-flight (per-accept gating, ADR-0022 posture).
+pub(in crate::server) async fn unenroll_device(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(machine_hex): axum::extract::Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(sync) = state.owner_sync.as_ref() else {
+        return error_response(StatusCode::CONFLICT, "no owner identity configured");
+    };
+    let Some(machine) = decode_machine_id(&machine_hex) else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "machine_id must be 64 hex characters",
+        );
+    };
+    match sync.store().unenroll(&machine).await {
+        Ok(true) => {
+            let device_count = sync.store().enrolled_devices().await.len();
+            sync.kick();
+            let body = ApiResponse {
+                ok: true,
+                data: UnenrollData {
+                    machine_id: machine_hex,
+                    device_count,
+                },
+            };
+            (
+                StatusCode::OK,
+                Json(serde_json::to_value(body).unwrap_or_default()),
+            )
+        }
+        Ok(false) => error_response(StatusCode::NOT_FOUND, "machine not enrolled"),
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("failed to persist device set: {e}"),
+        ),
+    }
 }
 
 fn decode_machine_id(hex_id: &str) -> Option<crate::identity::MachineId> {
@@ -423,6 +488,10 @@ mod tests {
         let app = axum::Router::new()
             .route("/sync/devices", axum::routing::get(get_sync_devices))
             .route("/sync/devices/enroll", axum::routing::post(enroll_device))
+            .route(
+                "/sync/devices/:machine_id",
+                axum::routing::delete(unenroll_device),
+            )
             .with_state(Arc::clone(&state));
         let (status, body) = response_json(
             app.clone()
@@ -440,7 +509,8 @@ mod tests {
         assert_eq!(body["machine_id"].as_str(), Some(this_machine.as_str()));
 
         let (status, body) = response_json(
-            app.oneshot(axum::http::Request::get("/sync/devices").body(axum::body::Body::empty())?)
+            app.clone()
+                .oneshot(axum::http::Request::get("/sync/devices").body(axum::body::Body::empty())?)
                 .await?,
         )
         .await?;
@@ -451,7 +521,58 @@ mod tests {
             devices[0]["machine_id"].as_str(),
             Some(this_machine.as_str())
         );
-        assert!(devices[0]["is_this_machine"].as_bool().unwrap_or(false));
+        // Enroll with a TTL, then revoke it via the DELETE path: the list
+        // empties and a second revoke 404s (review R2 finding 1).
+        let (status, body) = response_json(
+            app.clone()
+                .oneshot(
+                    axum::http::Request::post("/sync/devices/enroll")
+                        .header("content-type", "application/json")
+                        .body(axum::body::Body::from(r#"{"ttl_secs":3600}"#))?,
+                )
+                .await?,
+        )
+        .await?;
+        assert_eq!(status, StatusCode::OK, "enroll with ttl: {body:?}");
+        assert!(
+            body["expires_at_ms"].as_u64().is_some(),
+            "ttl produced an expiry"
+        );
+        let (status, body) = response_json(
+            app.clone()
+                .oneshot(
+                    axum::http::Request::delete(format!("/sync/devices/{this_machine}"))
+                        .body(axum::body::Body::empty())?,
+                )
+                .await?,
+        )
+        .await?;
+        assert_eq!(status, StatusCode::OK, "revoke: {body:?}");
+        let (status, body) = response_json(
+            app.clone()
+                .oneshot(axum::http::Request::get("/sync/devices").body(axum::body::Body::empty())?)
+                .await?,
+        )
+        .await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["devices"].as_array().map(Vec::len),
+            Some(0),
+            "revoked machine gone from the device set"
+        );
+        let (status, body) = response_json(
+            app.oneshot(
+                axum::http::Request::delete(format!("/sync/devices/{this_machine}"))
+                    .body(axum::body::Body::empty())?,
+            )
+            .await?,
+        )
+        .await?;
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "second revoke 404s: {body:?}"
+        );
 
         // Malformed machine id: 400, nothing enrolled.
         let dir3 = tempfile::tempdir()?;

--- a/src/server/routes/sync.rs
+++ b/src/server/routes/sync.rs
@@ -1,0 +1,474 @@
+//! ADR-0041 Tier-1 sync routes: `GET /sync/devices` and
+//! `POST /sync/devices/enroll`, plus the [`SyncDaemonView`] adapter that
+//! bridges the sync service to live `AppState` (this module is inside the
+//! `server` subtree, so it may read the daemon state fields the library
+//! module cannot).
+//!
+//! Both routes are owner-gated: the bearer-token middleware has already
+//! authenticated the caller; an install with no owner key (`user.key`) has
+//! no device set to serve or extend and answers `409`, mirroring
+//! `GET /owner/agents`.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::status::ApiResponse;
+use crate::owner_sync::{OwnerEnrollment, SyncDaemonView, SyncProfileNames, SyncValue};
+use crate::server::state::AppState;
+
+/// Adapter over live daemon state for the sync service.
+///
+/// `profile_names` keeps a last-seen mirror: `apply_names` writes it
+/// synchronously so the very next reconcile pass cannot re-mint a
+/// pre-merge value (LWW flip-back), while the live `AppState` profile and
+/// its persisted file catch up in a spawned task.
+pub(in crate::server) struct DaemonView {
+    state: Arc<AppState>,
+    names: std::sync::RwLock<SyncProfileNames>,
+}
+
+impl DaemonView {
+    pub(in crate::server) fn new(state: Arc<AppState>) -> Self {
+        let names = match state.profile.try_read() {
+            Ok(profile) => SyncProfileNames {
+                human_name: profile.human_name.clone(),
+                display_name: profile.display_name.clone(),
+                machine_name: profile.machine_name.clone(),
+            },
+            Err(_) => SyncProfileNames::default(),
+        };
+        Self {
+            state,
+            names: std::sync::RwLock::new(names),
+        }
+    }
+}
+
+impl SyncDaemonView for DaemonView {
+    fn profile_names(&self) -> SyncProfileNames {
+        if let Ok(profile) = self.state.profile.try_read() {
+            let fresh = SyncProfileNames {
+                human_name: profile.human_name.clone(),
+                display_name: profile.display_name.clone(),
+                machine_name: profile.machine_name.clone(),
+            };
+            *self
+                .names
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = fresh.clone();
+            return fresh;
+        }
+        // Lock contended: report the last-seen mirror (never a regression
+        // to empty — a mint from a wrong default would fight the winner).
+        self.names
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    fn home_pointer(&self) -> Option<SyncValue> {
+        let owner = self.state.agent.identity().user_keypair()?.user_id();
+        let groups = self.state.named_groups.try_read().ok()?;
+        // Mirror of `routes::home::find_home` (same module subtree): any
+        // group stamped as Home for this owner.
+        groups
+            .values()
+            .find(|info| {
+                info.home.is_some()
+                    && info
+                        .policy
+                        .admission
+                        .owner_certified_user_id()
+                        .is_some_and(|u| *u == owner)
+            })
+            .map(|info| SyncValue::HomePointer {
+                group_id: info.stable_group_id().to_string(),
+                policy: info.policy.clone(),
+                roster: info
+                    .members_v2
+                    .values()
+                    .map(|m| crate::owner_sync::HomeRosterEntry {
+                        agent_id: m.agent_id.clone(),
+                        role: m.role,
+                        state: m.state,
+                    })
+                    .collect(),
+                primary_agent: info
+                    .home
+                    .as_ref()
+                    .map(|h| h.primary_agent.clone())
+                    .unwrap_or_default(),
+                provisioned_at_ms: info
+                    .home
+                    .as_ref()
+                    .map(|h| h.provisioned_at_ms)
+                    .unwrap_or_default(),
+            })
+    }
+
+    fn apply_names(
+        &self,
+        human_name: Option<String>,
+        display_name: Option<String>,
+        machine_name: Option<String>,
+    ) {
+        // 1. Synchronous mirror merge — closes the LWW flip-back window.
+        {
+            let mut names = self
+                .names
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if human_name.is_some() {
+                names.human_name = human_name.clone();
+            }
+            if display_name.is_some() {
+                names.display_name = display_name.clone();
+            }
+            if machine_name.is_some() {
+                names.machine_name = machine_name.clone();
+            }
+        }
+        // 2. Async live-state + persistence catch-up. `None` args mean
+        // "leave unchanged" (PUT /profile semantics); nothing to do when
+        // all three are absent.
+        if human_name.is_none() && display_name.is_none() && machine_name.is_none() {
+            return;
+        }
+        let state = Arc::clone(&self.state);
+        tokio::spawn(async move {
+            let mut profile = state.profile.write().await;
+            let mut changed = false;
+            if let Some(human) = human_name {
+                if profile.human_name != Some(human.clone()) {
+                    profile.human_name = Some(human);
+                    changed = true;
+                }
+            }
+            if let Some(display) = display_name {
+                if profile.display_name != Some(display.clone()) {
+                    profile.display_name = Some(display.clone());
+                    changed = true;
+                }
+            }
+            if let Some(machine) = machine_name {
+                if profile.machine_name != Some(machine.clone()) {
+                    profile.machine_name = Some(machine);
+                    changed = true;
+                }
+            }
+            if !changed {
+                return;
+            }
+            let snapshot = profile.clone();
+            let path = state.profile_path.clone();
+            drop(profile);
+            // The announce self-name follows the merged display name
+            // (mirrors PUT /profile).
+            state.agent.set_self_name(snapshot.display_name.clone());
+            if let Err(e) = snapshot.save_to(&path).await {
+                tracing::warn!(
+                    target: "x0x::owner_sync",
+                    "failed to persist synced profile: {e}"
+                );
+            }
+        });
+    }
+}
+
+/// One enrolled device in the `GET /sync/devices` response.
+#[derive(Debug, Serialize)]
+pub(in crate::server) struct SyncDeviceEntry {
+    machine_id: String,
+    enrolled_at_ms: u64,
+    last_session_ms: Option<u64>,
+    last_session_ok: Option<bool>,
+    #[serde(rename = "is_this_machine")]
+    is_this_machine: bool,
+}
+
+/// GET /sync/devices response body.
+#[derive(Debug, Serialize)]
+pub(in crate::server) struct SyncDevicesData {
+    owner_user_id: String,
+    this_machine_id: String,
+    devices: Vec<SyncDeviceEntry>,
+}
+
+/// GET /sync/devices — the owner device set plus last-sync status per
+/// device (ADR-0041 Tier-1; GUI Settings › Sync panel).
+///
+/// `409` when no owner identity is configured (owner-gated).
+pub(in crate::server) async fn get_sync_devices(
+    State(state): State<Arc<AppState>>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(sync) = state.owner_sync.as_ref() else {
+        return error_response(StatusCode::CONFLICT, "no owner identity configured");
+    };
+    let Some(owner) = state.agent.identity().user_keypair() else {
+        return error_response(StatusCode::CONFLICT, "no owner identity configured");
+    };
+    let this_machine = state.agent.machine_id();
+    let statuses = sync.store().session_statuses().await;
+    let mut devices: Vec<SyncDeviceEntry> = sync
+        .store()
+        .enrolled_devices()
+        .await
+        .into_iter()
+        .map(|enrollment| {
+            let status = statuses.get(&enrollment.machine_id);
+            SyncDeviceEntry {
+                machine_id: hex::encode(enrollment.machine_id),
+                enrolled_at_ms: enrollment.enrolled_at_ms,
+                last_session_ms: status.map(|s| s.last_session_ms),
+                last_session_ok: status.map(|s| s.last_session_ok),
+                is_this_machine: enrollment.machine_id == this_machine.0,
+            }
+        })
+        .collect();
+    devices.sort_by(|a, b| a.machine_id.cmp(&b.machine_id));
+    let body = ApiResponse {
+        ok: true,
+        data: SyncDevicesData {
+            owner_user_id: hex::encode(owner.user_id().0),
+            this_machine_id: hex::encode(this_machine.0),
+            devices,
+        },
+    };
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(body).unwrap_or_default()),
+    )
+}
+
+/// POST /sync/devices/enroll request body — `machine_id` optional;
+/// omitted = enroll THIS machine.
+#[derive(Debug, Default, Deserialize)]
+pub(in crate::server) struct EnrollRequest {
+    machine_id: Option<String>,
+}
+
+/// POST /sync/devices/enroll response body.
+#[derive(Debug, Serialize)]
+pub(in crate::server) struct EnrollData {
+    machine_id: String,
+    enrolled_at_ms: u64,
+    device_count: usize,
+}
+
+/// POST /sync/devices/enroll — owner-key-sign a `DeviceEnrollment` for a
+/// machine and add it to the local owner device set (owner-gated: the
+/// daemon must hold the owner key; ADR-0043 enrollment direction).
+///
+/// The signature is verified again at every stream accept, so a corrupt or
+/// foreign-key enrollment can never open the sync gate.
+pub(in crate::server) async fn enroll_device(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<EnrollRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let Some(sync) = state.owner_sync.as_ref() else {
+        return error_response(StatusCode::CONFLICT, "no owner identity configured");
+    };
+    let Some(owner_kp) = state.agent.identity().user_keypair() else {
+        return error_response(StatusCode::CONFLICT, "no owner identity configured");
+    };
+    let machine = match req.machine_id.as_deref() {
+        None => state.agent.machine_id(),
+        Some(hex_id) => match decode_machine_id(hex_id) {
+            Some(machine) => machine,
+            None => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "machine_id must be 64 hex characters",
+                );
+            }
+        },
+    };
+    let enrolled_at_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let enrollment = match OwnerEnrollment::sign(machine, owner_kp, enrolled_at_ms) {
+        Ok(enrollment) => enrollment,
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+    let machine_hex = hex::encode(enrollment.machine_id);
+    sync.store().enroll(enrollment).await;
+    let device_count = sync.store().enrolled_devices().await.len();
+    // Enrollment is Tier-1-relevant state: kick an early sync pass.
+    sync.kick();
+    let body = ApiResponse {
+        ok: true,
+        data: EnrollData {
+            machine_id: machine_hex,
+            enrolled_at_ms,
+            device_count,
+        },
+    };
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(body).unwrap_or_default()),
+    )
+}
+
+fn decode_machine_id(hex_id: &str) -> Option<crate::identity::MachineId> {
+    let bytes = hex::decode(hex_id).ok()?;
+    let fixed: [u8; 32] = bytes.try_into().ok()?;
+    Some(crate::identity::MachineId(fixed))
+}
+
+fn error_response(status: StatusCode, message: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        status,
+        Json(serde_json::json!({ "ok": false, "error": message })),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::routes::sync::DaemonView;
+
+    /// WHY: the profile mirror must never regress to defaults while the
+    /// AppState lock is contended — a default read would mint a record
+    /// that fights the remote winner (LWW flip-back).
+    #[tokio::test]
+    async fn daemon_view_mirror_survives_lock_contention() {
+        let (state, _dir) =
+            crate::server::routes::named_groups::tests::secure_endpoint_test_state()
+                .await
+                .expect("test state");
+        let view = DaemonView::new(Arc::clone(&state));
+        view.apply_names(
+            Some("David".into()),
+            Some("primary-agent".into()),
+            Some("laptop".into()),
+        );
+        // Contend the profile lock so the refresh path fails and the
+        // last-seen mirror is served instead.
+        let guard = state.profile.write().await;
+        let names = view.profile_names();
+        drop(guard);
+        assert_eq!(names.human_name.as_deref(), Some("David"));
+        assert_eq!(names.display_name.as_deref(), Some("primary-agent"));
+        assert_eq!(names.machine_name.as_deref(), Some("laptop"));
+    }
+
+    /// Owned test state: user key (deterministic seed) + builder-issued
+    /// agent certificate, so `secure_endpoint_test_state_at` wires the
+    /// ADR-0041 sync service exactly like daemon startup.
+    async fn owned_state(
+        data_dir: &std::path::Path,
+        owner_seed: [u8; 32],
+    ) -> anyhow::Result<Arc<AppState>> {
+        let user = crate::identity::UserKeypair::from_seed(&owner_seed)?;
+        let agent = Arc::new(
+            crate::Agent::builder()
+                .with_machine_key(data_dir.join("machine.key"))
+                .with_agent_key_path(data_dir.join("agent.key"))
+                .with_agent_cert_path(data_dir.join("agent.cert"))
+                .with_user_key(user)
+                .with_contact_store_path(data_dir.join("contacts.json"))
+                .build()
+                .await?,
+        );
+        crate::server::routes::named_groups::tests::secure_endpoint_test_state_at(data_dir, agent)
+            .await
+    }
+
+    async fn response_json(
+        response: axum::response::Response,
+    ) -> anyhow::Result<(StatusCode, serde_json::Value)> {
+        use axum::body::to_bytes;
+        let status = response.status();
+        let body = to_bytes(response.into_body(), 1 << 20).await?;
+        Ok((status, serde_json::from_slice(&body)?))
+    }
+
+    /// WHY: `GET /sync/devices` / `POST /sync/devices/enroll` are wired and
+    /// owner-gated — an ownerless install answers 409, an owned one lists
+    /// and enrolls devices (the enrollment signature is re-verified at
+    /// every stream accept).
+    #[tokio::test]
+    async fn sync_routes_wired() -> anyhow::Result<()> {
+        use tower::ServiceExt;
+
+        // Ownerless: 409 on both routes.
+        let _dir = tempfile::tempdir()?;
+        let (unowned, _guard) =
+            crate::server::routes::named_groups::tests::secure_endpoint_test_state().await?;
+        let app = axum::Router::new()
+            .route("/sync/devices", axum::routing::get(get_sync_devices))
+            .route("/sync/devices/enroll", axum::routing::post(enroll_device))
+            .with_state(Arc::clone(&unowned));
+        let (status, body) = response_json(
+            app.clone()
+                .oneshot(
+                    axum::http::Request::post("/sync/devices/enroll")
+                        .header("content-type", "application/json")
+                        .body(axum::body::Body::from("{}"))?,
+                )
+                .await?,
+        )
+        .await?;
+        assert_eq!(status, StatusCode::CONFLICT, "ownerless enroll: {body:?}");
+
+        // Owned: enroll this machine, then list it.
+        let dir2 = tempfile::tempdir()?;
+        let state = owned_state(dir2.path(), [0x51; 32]).await?;
+        let app = axum::Router::new()
+            .route("/sync/devices", axum::routing::get(get_sync_devices))
+            .route("/sync/devices/enroll", axum::routing::post(enroll_device))
+            .with_state(Arc::clone(&state));
+        let (status, body) = response_json(
+            app.clone()
+                .oneshot(
+                    axum::http::Request::post("/sync/devices/enroll")
+                        .header("content-type", "application/json")
+                        .body(axum::body::Body::from("{}"))?,
+                )
+                .await?,
+        )
+        .await?;
+        assert_eq!(status, StatusCode::OK, "enroll this machine: {body:?}");
+        assert!(body["ok"].as_bool().unwrap_or(false));
+        let this_machine = hex::encode(state.agent.machine_id().0);
+        assert_eq!(body["machine_id"].as_str(), Some(this_machine.as_str()));
+
+        let (status, body) = response_json(
+            app.oneshot(axum::http::Request::get("/sync/devices").body(axum::body::Body::empty())?)
+                .await?,
+        )
+        .await?;
+        assert_eq!(status, StatusCode::OK);
+        let devices = body["devices"].as_array().expect("devices array");
+        assert_eq!(devices.len(), 1);
+        assert_eq!(
+            devices[0]["machine_id"].as_str(),
+            Some(this_machine.as_str())
+        );
+        assert!(devices[0]["is_this_machine"].as_bool().unwrap_or(false));
+
+        // Malformed machine id: 400, nothing enrolled.
+        let dir3 = tempfile::tempdir()?;
+        let state = owned_state(dir3.path(), [0x52; 32]).await?;
+        let app = axum::Router::new()
+            .route("/sync/devices/enroll", axum::routing::post(enroll_device))
+            .with_state(Arc::clone(&state));
+        let (status, body) = response_json(
+            app.oneshot(
+                axum::http::Request::post("/sync/devices/enroll")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(r#"{"machine_id":"zz"}"#))?,
+            )
+            .await?,
+        )
+        .await?;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "malformed id: {body:?}");
+        Ok(())
+    }
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -892,6 +892,11 @@ pub(super) struct AppState {
     /// consumer + outbound local-port listeners. `None` when connect is
     /// disabled (no policy) so the daemon runs zero forwarder tasks.
     pub(super) forward_service: Option<Arc<x0x::forward::ForwardService>>,
+    /// ADR-0041 Tier-1 owner-state sync service: owns the `SyncV1` stream
+    /// acceptor, the owner device set, and the winning versioned records.
+    /// `None` when the install has no owner key (ownerless installs sync
+    /// nothing and register no acceptor).
+    pub(super) owner_sync: Option<Arc<x0x::owner_sync::OwnerSyncService>>,
 }
 
 #[derive(Clone)]

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -379,6 +379,13 @@ pub enum StreamProtocol {
     /// gate apply exactly as for every other protocol; there is no
     /// voice-specific bypass.
     WebRtcV1 = 0x04,
+    /// ADR-0041 Tier-1 owner-state sync (`src/owner_sync.rs`). Carries
+    /// owner-signed versioned records between the owner's enrolled
+    /// machines. The ADR-0022 identity gates apply exactly as for every
+    /// other protocol; the sync acceptor additionally fails closed unless
+    /// the remote machine is in the local owner device set (owner-key
+    /// signed enrollment).
+    SyncV1 = 0x05,
 }
 
 impl StreamProtocol {
@@ -391,6 +398,7 @@ impl StreamProtocol {
             0x02 => Some(Self::SocksV1),
             0x03 => Some(Self::ForwardV2),
             0x04 => Some(Self::WebRtcV1),
+            0x05 => Some(Self::SyncV1),
             _ => None,
         }
     }
@@ -552,7 +560,7 @@ mod tests {
         for byte in 0x00u8..=0xFF {
             let parsed = StreamProtocol::from_u8(byte);
             match byte {
-                0x01..=0x04 => {
+                0x01..=0x05 => {
                     assert!(parsed.is_some(), "byte {byte:#x} should parse")
                 }
                 _ => assert_eq!(parsed, None, "byte {byte:#x} must be unknown"),

--- a/tests/adr0041_tier1_sync.rs
+++ b/tests/adr0041_tier1_sync.rs
@@ -41,10 +41,12 @@ fn names_value(display: &str, machine_name: &str) -> SyncValue {
 /// Cross-enroll two machines into each other's device sets under `owner`
 /// (the minimum for bidirectional sync — blocker 30).
 async fn cross_enroll(a: &OwnerSyncStore, b: &OwnerSyncStore, owner: &UserKeypair) {
-    a.enroll(OwnerEnrollment::sign(machine(2), owner, 1_000).unwrap())
-        .await;
-    b.enroll(OwnerEnrollment::sign(machine(1), owner, 1_000).unwrap())
-        .await;
+    a.enroll(OwnerEnrollment::sign(machine(2), owner, 1_000, None).unwrap())
+        .await
+        .unwrap();
+    b.enroll(OwnerEnrollment::sign(machine(1), owner, 1_000, None).unwrap())
+        .await
+        .unwrap();
 }
 
 /// Run one session between two stores over a duplex pipe. Returns both
@@ -57,7 +59,8 @@ async fn session_between(
     x0x::owner_sync::SessionSummary,
     x0x::owner_sync::SessionSummary,
 ) {
-    let owner_id = owner.user_id();
+    // Deterministic seeds: both sides hold the SAME owner key (same seed).
+    let responder_owner = UserKeypair::from_seed(&[7u8; 32]).expect("owner keypair");
     let (client, server) = tokio::io::duplex(64 * 1024);
     let b_clone = Arc::clone(b);
     let responder = tokio::spawn(async move {
@@ -66,7 +69,7 @@ async fn session_between(
             &mut r_send,
             &mut r_recv,
             &b_clone,
-            &owner_id,
+            &responder_owner,
             &machine(2),
             &machine(1),
             |_| {},
@@ -79,7 +82,7 @@ async fn session_between(
         &mut c_send,
         &mut c_recv,
         a,
-        &owner_id,
+        owner,
         &machine(1),
         &machine(2),
         |_| {},
@@ -96,8 +99,8 @@ async fn session_between(
 async fn two_machines_converge_names_and_journal_both_ways() {
     let dir = tempfile::tempdir().unwrap();
     let owner = owner_kp(7);
-    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await);
-    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await);
+    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await.unwrap());
+    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await.unwrap());
     cross_enroll(&store_a, &store_b, &owner).await;
 
     // Machine 1: names + a journal line for agent X.
@@ -219,8 +222,8 @@ async fn forged_non_owner_record_aborts_session_fail_closed() {
     let dir = tempfile::tempdir().unwrap();
     let owner = owner_kp(7);
     let attacker = owner_kp(9);
-    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await);
-    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await);
+    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await.unwrap());
+    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await.unwrap());
     cross_enroll(&store_a, &store_b, &owner).await;
 
     // Plant a forged record IN A's store (as if a compromised machine had
@@ -241,7 +244,7 @@ async fn forged_non_owner_record_aborts_session_fail_closed() {
     .unwrap();
     store_a.records_insert_for_testing(forged).await;
 
-    let owner_id = owner.user_id();
+    let responder_owner = UserKeypair::from_seed(&[7u8; 32]).expect("owner keypair");
     let (client, server) = tokio::io::duplex(64 * 1024);
     let b_clone = Arc::clone(&store_b);
     let responder = tokio::spawn(async move {
@@ -250,7 +253,7 @@ async fn forged_non_owner_record_aborts_session_fail_closed() {
             &mut r_send,
             &mut r_recv,
             &b_clone,
-            &owner_id,
+            &responder_owner,
             &machine(2),
             &machine(1),
             |_| {},
@@ -258,32 +261,42 @@ async fn forged_non_owner_record_aborts_session_fail_closed() {
         .await
     });
     let (mut c_recv, mut c_send) = tokio::io::split(server);
-    let initiator_err = run_sync_session(
+    let initiator = run_sync_session(
         &mut c_send,
         &mut c_recv,
         &store_a,
-        &owner_id,
+        &owner,
         &machine(1),
         &machine(2),
         |_| {},
     )
-    .await
-    .expect_err("session with a forged record must fail");
-    assert!(
-        initiator_err.to_string().contains("not the same owner"),
-        "initiator must see the peer's fail-closed abort, got: {initiator_err:?}"
-    );
-    let responder_err = responder.await.unwrap().expect_err("responder aborts too");
+    .await;
+    let responder_err = responder
+        .await
+        .unwrap()
+        .expect_err("receiving side must fail closed on the forgery");
     assert!(
         matches!(responder_err, x0x::owner_sync::SyncError::OwnerMismatch),
-        "responder saw the forgery: {responder_err:?}"
+        "verifier rejected the forged record: {responder_err:?}"
     );
-
-    // B stored nothing from the poisoned batch.
+    // The RECEIVING side is the security boundary: nothing from the forged
+    // batch is stored, ever. (The shipping side may complete its own send
+    // cleanly — it committed nothing inbound; the forged record stays in
+    // its own store where the test planted it.)
     assert!(
         store_b.records_snapshot().await.is_empty(),
         "fail-closed: no record from a forged batch is stored"
     );
+    match initiator {
+        Ok(summary) => assert_eq!(
+            summary.accepted, 0,
+            "shipper committed nothing inbound: {summary:?}"
+        ),
+        Err(e) => assert!(
+            e.to_string().contains("not the same owner"),
+            "unexpected initiator error: {e:?}"
+        ),
+    }
 }
 
 /// WHY: rollback protection survives the wire — after B already holds a
@@ -293,8 +306,8 @@ async fn forged_non_owner_record_aborts_session_fail_closed() {
 async fn replayed_older_record_never_overwrites_winner_over_the_wire() {
     let dir = tempfile::tempdir().unwrap();
     let owner = owner_kp(7);
-    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await);
-    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await);
+    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await.unwrap());
+    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await.unwrap());
     cross_enroll(&store_a, &store_b, &owner).await;
 
     // B already holds version 5 for its own names record...
@@ -384,6 +397,105 @@ async fn build_owned_agent(
         Err(e) => panic!("agent build failed: {e}"),
     }
 }
+/// WHY (review R2 finding 3): two machines holding DIFFERENT records under
+/// the SAME clock converge over the wire to the deterministic hash winner
+/// — arrival order cannot split them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn equal_clock_records_converge_over_the_wire() {
+    let dir = tempfile::tempdir().unwrap();
+    let owner = owner_kp(7);
+    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await.unwrap());
+    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await.unwrap());
+    cross_enroll(&store_a, &store_b, &owner).await;
+
+    let key = "shared";
+    let same_clock = x0x::owner_sync::RecordClock {
+        version: 4,
+        signed_at_ms: 500,
+        writer_machine: machine(1).0,
+    };
+    let record_a = VersionedRecord::sign(
+        SyncKind::MachineNames,
+        key,
+        &names_value("content-a", "m"),
+        same_clock,
+        &owner,
+    )
+    .unwrap();
+    let record_b = VersionedRecord::sign(
+        SyncKind::MachineNames,
+        key,
+        &names_value("content-b", "m"),
+        same_clock,
+        &owner,
+    )
+    .unwrap();
+    let winner_hash = if record_a.record_hash() > record_b.record_hash() {
+        record_a.record_hash()
+    } else {
+        record_b.record_hash()
+    };
+
+    store_a.records_insert_for_testing(record_a).await;
+    store_b.records_insert_for_testing(record_b).await;
+
+    let (summary_a, summary_b) = session_between(&store_a, &store_b, &owner).await;
+    assert!(
+        summary_a.equivocations >= 1 || summary_b.equivocations >= 1,
+        "equivocation surfaced: {summary_a:?} / {summary_b:?}"
+    );
+
+    let snap_a = store_a.records_snapshot().await;
+    let snap_b = store_b.records_snapshot().await;
+    assert_eq!(snap_a.len(), 1);
+    assert_eq!(snap_b.len(), 1);
+    assert_eq!(snap_a[0].record_hash(), winner_hash);
+    assert_eq!(snap_b[0].record_hash(), winner_hash);
+    assert_eq!(snap_a[0].value, snap_b[0].value, "converged values");
+}
+
+/// WHY (review R2 finding 5): a state set larger than one frame's entries
+/// syncs via PAGED version vectors and record batches — nothing wedges at
+/// the frame cap.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn large_state_syncs_via_paged_frames() {
+    let dir = tempfile::tempdir().unwrap();
+    let owner = owner_kp(7);
+    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await.unwrap());
+    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await.unwrap());
+    cross_enroll(&store_a, &store_b, &owner).await;
+
+    // 300 keys: the version vector exceeds VV_ENTRIES_PER_FRAME (256) and
+    // the record set exceeds RECORDS_PER_FRAME (16) — both must page.
+    const N: usize = 300;
+    for i in 0..N {
+        store_a
+            .mint(
+                SyncKind::IssuanceJournal,
+                &format!("agent-{i:03}"),
+                &SyncValue::IssuanceJournal {
+                    agent_id: format!("agent-{i:03}"),
+                    cert_digest: format!("digest-{i:03}"),
+                    issued_at: i as u64,
+                    not_after: None,
+                },
+                &owner,
+                machine(1),
+            )
+            .await
+            .unwrap();
+    }
+
+    let (summary_a, _) = session_between(&store_a, &store_b, &owner).await;
+    assert_eq!(summary_a.shipped, N, "all records paged out");
+
+    let snap_b = store_b.records_snapshot().await;
+    assert_eq!(snap_b.len(), N, "all records arrived through the pages");
+    // Convergence is exact: a second session ships nothing.
+    let (again_a, again_b) = session_between(&store_a, &store_b, &owner).await;
+    assert_eq!(again_a.accepted, 0);
+    assert_eq!(again_b.accepted, 0);
+}
 
 // ─────────────────────────────────────────────────────────────────────
 // Transport tier (#[ignore]): real sockets, real SyncV1 streams, the
@@ -436,12 +548,14 @@ async fn two_agents_converge_over_real_syncv1_stream() {
     let owner_id = owner.user_id();
     service_a
         .store()
-        .enroll(OwnerEnrollment::sign(bob.machine_id(), &owner, 1_000).unwrap())
-        .await;
+        .enroll(OwnerEnrollment::sign(bob.machine_id(), &owner, 1_000, None).unwrap())
+        .await
+        .unwrap();
     service_b
         .store()
-        .enroll(OwnerEnrollment::sign(alice.machine_id(), &owner, 1_000).unwrap())
-        .await;
+        .enroll(OwnerEnrollment::sign(alice.machine_id(), &owner, 1_000, None).unwrap())
+        .await
+        .unwrap();
 
     // Local Tier-1 state: distinct names per machine.
     service_a

--- a/tests/adr0041_tier1_sync.rs
+++ b/tests/adr0041_tier1_sync.rs
@@ -1,0 +1,592 @@
+//! ADR-0041 Tier-1 integration proofs.
+//!
+//! Two levels, matching the repo's tiering:
+//!
+//! - Always-on session tests over `tokio::io::duplex` — the full wire
+//!   protocol (Hello → per-kind version vectors → records → Done) between
+//!   two in-memory stores owned by the same owner key on two machines,
+//!   with NO network. These prove convergence both ways, the fail-closed
+//!   forgery path, and rollback rejection end-to-end through the codec.
+//! - `#[ignore]` transport tests that bind real UDP sockets (integration
+//!   tier, `--run-ignored ignored-only`): two full agents with the same
+//!   owner key, cross-enrolled, converging over a real `SyncV1` stream via
+//!   the daemon-side `OwnerSyncService` — the two-daemon convergence
+//!   proof the ADR's validation section names.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use x0x::identity::{MachineId, UserKeypair};
+use x0x::owner_sync::{
+    run_sync_session, OwnerEnrollment, OwnerSyncStore, SyncKind, SyncValue, VersionedRecord,
+};
+
+fn owner_kp(seed: u8) -> UserKeypair {
+    UserKeypair::from_seed(&[seed; 32]).expect("deterministic owner keypair")
+}
+
+fn machine(id: u8) -> MachineId {
+    MachineId([id; 32])
+}
+
+fn names_value(display: &str, machine_name: &str) -> SyncValue {
+    SyncValue::MachineNames {
+        display_name: Some(display.to_string()),
+        machine_name: Some(machine_name.to_string()),
+    }
+}
+
+/// Cross-enroll two machines into each other's device sets under `owner`
+/// (the minimum for bidirectional sync — blocker 30).
+async fn cross_enroll(a: &OwnerSyncStore, b: &OwnerSyncStore, owner: &UserKeypair) {
+    a.enroll(OwnerEnrollment::sign(machine(2), owner, 1_000).unwrap())
+        .await;
+    b.enroll(OwnerEnrollment::sign(machine(1), owner, 1_000).unwrap())
+        .await;
+}
+
+/// Run one session between two stores over a duplex pipe. Returns both
+/// summaries (initiator, responder).
+async fn session_between(
+    a: &Arc<OwnerSyncStore>,
+    b: &Arc<OwnerSyncStore>,
+    owner: &UserKeypair,
+) -> (
+    x0x::owner_sync::SessionSummary,
+    x0x::owner_sync::SessionSummary,
+) {
+    let owner_id = owner.user_id();
+    let (client, server) = tokio::io::duplex(64 * 1024);
+    let b_clone = Arc::clone(b);
+    let responder = tokio::spawn(async move {
+        let (mut r_recv, mut r_send) = tokio::io::split(client);
+        run_sync_session(
+            &mut r_send,
+            &mut r_recv,
+            &b_clone,
+            &owner_id,
+            &machine(2),
+            &machine(1),
+            |_| {},
+        )
+        .await
+        .expect("responder session")
+    });
+    let (mut c_recv, mut c_send) = tokio::io::split(server);
+    let initiator_summary = run_sync_session(
+        &mut c_send,
+        &mut c_recv,
+        a,
+        &owner_id,
+        &machine(1),
+        &machine(2),
+        |_| {},
+    )
+    .await
+    .expect("initiator session");
+    let responder_summary = responder.await.expect("responder task");
+    (initiator_summary, responder_summary)
+}
+
+/// WHY (ADR-0041 validation): two machines of one owner converge — names
+/// AND issuance-journal lines propagate BOTH ways in one session each.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn two_machines_converge_names_and_journal_both_ways() {
+    let dir = tempfile::tempdir().unwrap();
+    let owner = owner_kp(7);
+    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await);
+    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await);
+    cross_enroll(&store_a, &store_b, &owner).await;
+
+    // Machine 1: names + a journal line for agent X.
+    store_a
+        .mint(
+            SyncKind::MachineNames,
+            &hex::encode(machine(1).0),
+            &names_value("alpha", "laptop"),
+            &owner,
+            machine(1),
+        )
+        .await
+        .unwrap();
+    store_a
+        .mint(
+            SyncKind::IssuanceJournal,
+            "aa",
+            &SyncValue::IssuanceJournal {
+                agent_id: "aa".into(),
+                cert_digest: "digest-x".into(),
+                issued_at: 100,
+                not_after: None,
+            },
+            &owner,
+            machine(1),
+        )
+        .await
+        .unwrap();
+    // Machine 2: names + a DIFFERENT journal line for agent Y.
+    store_b
+        .mint(
+            SyncKind::MachineNames,
+            &hex::encode(machine(2).0),
+            &names_value("beta", "desktop"),
+            &owner,
+            machine(2),
+        )
+        .await
+        .unwrap();
+    store_b
+        .mint(
+            SyncKind::IssuanceJournal,
+            "bb",
+            &SyncValue::IssuanceJournal {
+                agent_id: "bb".into(),
+                cert_digest: "digest-y".into(),
+                issued_at: 200,
+                not_after: None,
+            },
+            &owner,
+            machine(2),
+        )
+        .await
+        .unwrap();
+
+    let (initiator, responder) = session_between(&store_a, &store_b, &owner).await;
+    assert!(initiator.accepted >= 2, "A accepted B's records");
+    assert!(responder.accepted >= 2, "B accepted A's records");
+
+    // Convergence: both sides hold all four records with equal clocks.
+    let snap_a = store_a.records_snapshot().await;
+    let snap_b = store_b.records_snapshot().await;
+    let mut clocks_a: Vec<_> = snap_a
+        .iter()
+        .map(|r| (r.kind, r.key.clone(), r.clock))
+        .collect();
+    let mut clocks_b: Vec<_> = snap_b
+        .iter()
+        .map(|r| (r.kind, r.key.clone(), r.clock))
+        .collect();
+    clocks_a.sort();
+    clocks_b.sort();
+    assert_eq!(clocks_a, clocks_b, "stores converge on identical clocks");
+    assert_eq!(snap_a.len(), 4, "names x2 + journal x2: {snap_a:#?}");
+
+    // The values agree too.
+    let find = |snap: &[VersionedRecord], kind: SyncKind, key: &str| {
+        snap.iter()
+            .find(|r| r.kind == kind && r.key == key)
+            .unwrap_or_else(|| panic!("missing {kind:?} {key}"))
+            .value
+            .clone()
+    };
+    assert_eq!(
+        find(&snap_a, SyncKind::MachineNames, &hex::encode(machine(2).0)),
+        names_value("beta", "desktop"),
+        "A learned B's names"
+    );
+    assert_eq!(
+        find(&snap_b, SyncKind::MachineNames, &hex::encode(machine(1).0)),
+        names_value("alpha", "laptop"),
+        "B learned A's names"
+    );
+    assert!(
+        matches!(
+            find(&snap_b, SyncKind::IssuanceJournal, "aa"),
+            SyncValue::IssuanceJournal { ref cert_digest, .. } if cert_digest == "digest-x"
+        ),
+        "B learned A's journal line"
+    );
+    assert!(
+        matches!(
+            find(&snap_a, SyncKind::IssuanceJournal, "bb"),
+            SyncValue::IssuanceJournal { ref cert_digest, .. } if cert_digest == "digest-y"
+        ),
+        "A learned B's journal line"
+    );
+
+    // A second session ships nothing new (fixed point).
+    let (again_a, again_b) = session_between(&store_a, &store_b, &owner).await;
+    assert_eq!(again_a.accepted, 0);
+    assert_eq!(again_b.accepted, 0);
+}
+
+/// WHY: a record signed by a NON-owner key aborts the session fail-closed
+/// and nothing from that batch is stored (ADR-0041 validation).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn forged_non_owner_record_aborts_session_fail_closed() {
+    let dir = tempfile::tempdir().unwrap();
+    let owner = owner_kp(7);
+    let attacker = owner_kp(9);
+    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await);
+    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await);
+    cross_enroll(&store_a, &store_b, &owner).await;
+
+    // Plant a forged record IN A's store (as if a compromised machine had
+    // written one) — the session must fail closed and B must learn nothing.
+    let forged = VersionedRecord::sign(
+        SyncKind::OwnerProfile,
+        "owner",
+        &SyncValue::OwnerProfile {
+            human_name: Some("Mallory".into()),
+        },
+        x0x::owner_sync::RecordClock {
+            version: 50,
+            signed_at_ms: 50,
+            writer_machine: machine(1).0,
+        },
+        &attacker,
+    )
+    .unwrap();
+    store_a.records_insert_for_testing(forged).await;
+
+    let owner_id = owner.user_id();
+    let (client, server) = tokio::io::duplex(64 * 1024);
+    let b_clone = Arc::clone(&store_b);
+    let responder = tokio::spawn(async move {
+        let (mut r_recv, mut r_send) = tokio::io::split(client);
+        run_sync_session(
+            &mut r_send,
+            &mut r_recv,
+            &b_clone,
+            &owner_id,
+            &machine(2),
+            &machine(1),
+            |_| {},
+        )
+        .await
+    });
+    let (mut c_recv, mut c_send) = tokio::io::split(server);
+    let initiator_err = run_sync_session(
+        &mut c_send,
+        &mut c_recv,
+        &store_a,
+        &owner_id,
+        &machine(1),
+        &machine(2),
+        |_| {},
+    )
+    .await
+    .expect_err("session with a forged record must fail");
+    assert!(
+        initiator_err.to_string().contains("not the same owner"),
+        "initiator must see the peer's fail-closed abort, got: {initiator_err:?}"
+    );
+    let responder_err = responder.await.unwrap().expect_err("responder aborts too");
+    assert!(
+        matches!(responder_err, x0x::owner_sync::SyncError::OwnerMismatch),
+        "responder saw the forgery: {responder_err:?}"
+    );
+
+    // B stored nothing from the poisoned batch.
+    assert!(
+        store_b.records_snapshot().await.is_empty(),
+        "fail-closed: no record from a forged batch is stored"
+    );
+}
+
+/// WHY: rollback protection survives the wire — after B already holds a
+/// higher-version record, a replayed older record is superseded and never
+/// overwrites the winner (gapcheck blocker 31).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replayed_older_record_never_overwrites_winner_over_the_wire() {
+    let dir = tempfile::tempdir().unwrap();
+    let owner = owner_kp(7);
+    let store_a = Arc::new(OwnerSyncStore::load(&dir.path().join("a")).await);
+    let store_b = Arc::new(OwnerSyncStore::load(&dir.path().join("b")).await);
+    cross_enroll(&store_a, &store_b, &owner).await;
+
+    // B already holds version 5 for its own names record...
+    store_b
+        .mint(
+            SyncKind::MachineNames,
+            &hex::encode(machine(2).0),
+            &names_value("beta-new", "desktop"),
+            &owner,
+            machine(2),
+        )
+        .await
+        .unwrap();
+    for extra in 0..4 {
+        // bump to version 5 with distinct values
+        store_b
+            .mint(
+                SyncKind::MachineNames,
+                &hex::encode(machine(2).0),
+                &names_value(&format!("beta-new-{extra}"), "desktop"),
+                &owner,
+                machine(2),
+            )
+            .await
+            .unwrap();
+    }
+    let b_winner = store_b
+        .records_snapshot()
+        .await
+        .into_iter()
+        .find(|r| r.kind == SyncKind::MachineNames)
+        .unwrap();
+    assert_eq!(b_winner.clock.version, 5);
+
+    // ...while A holds an older snapshot of B's record (version 2).
+    let older = VersionedRecord::sign(
+        SyncKind::MachineNames,
+        &hex::encode(machine(2).0),
+        &names_value("beta-old", "desktop"),
+        x0x::owner_sync::RecordClock {
+            version: 2,
+            signed_at_ms: 999_999,
+            writer_machine: machine(2).0,
+        },
+        &owner,
+    )
+    .unwrap();
+    store_a.records_insert_for_testing(older).await;
+
+    let (a_summary, b_summary) = session_between(&store_a, &store_b, &owner).await;
+    assert_eq!(
+        a_summary.accepted, 1,
+        "A converges UP to B's newer v5 record (not the rollback direction)"
+    );
+    assert_eq!(
+        b_summary.accepted, 0,
+        "B accepts nothing: A's v2 is a rollback"
+    );
+    let b_after = store_b
+        .records_snapshot()
+        .await
+        .into_iter()
+        .find(|r| r.kind == SyncKind::MachineNames)
+        .unwrap();
+    assert_eq!(b_after.clock.version, 5, "winner untouched");
+    assert_eq!(b_after.value, b_winner.value, "rollback did not apply");
+}
+
+async fn build_owned_agent(
+    dir: &std::path::Path,
+    name: &str,
+    owner_seed: [u8; 32],
+) -> Option<x0x::Agent> {
+    let owner = UserKeypair::from_seed(&owner_seed).expect("owner keypair");
+    match x0x::Agent::builder()
+        .with_machine_key(dir.join(format!("{name}-machine.key")))
+        .with_agent_key_path(dir.join(format!("{name}-agent.key")))
+        .with_agent_cert_path(dir.join(format!("{name}-agent.cert")))
+        .with_user_key(owner)
+        .with_contact_store_path(dir.join(format!("{name}-contacts.json")))
+        .with_network_config(loopback_network_config())
+        .build()
+        .await
+    {
+        Ok(agent) => Some(agent),
+        Err(e) if is_network_bind_permission_error(&e) => None,
+        Err(e) => panic!("agent build failed: {e}"),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Transport tier (#[ignore]): real sockets, real SyncV1 streams, the
+// daemon-side service wiring — the ADR's two-daemon convergence proof.
+// ─────────────────────────────────────────────────────────────────────
+
+fn loopback_network_config() -> x0x::network::NetworkConfig {
+    x0x::network::NetworkConfig {
+        bind_addr: Some("127.0.0.1:0".parse().expect("loopback addr literal")),
+        bootstrap_nodes: Vec::new(),
+        ..x0x::network::NetworkConfig::default()
+    }
+}
+
+fn is_network_bind_permission_error(error: &impl std::fmt::Display) -> bool {
+    let message = error.to_string();
+    message.contains("Operation not permitted")
+        && (message.contains("bind UDP socket")
+            || message.contains("network initialization failed"))
+}
+
+/// Two full agents, one owner key, cross-enrolled: the Tier-1 service
+/// converges names and journal lines over a REAL `SyncV1` stream
+/// (open_peer_stream → acceptor → session), both directions.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "two-agent loopback SyncV1 proof; binds UDP + waits on convergence. Integration tier."]
+async fn two_agents_converge_over_real_syncv1_stream() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let owner = owner_kp(7);
+    let Some(alice) = build_owned_agent(dir.path(), "alice", [7u8; 32]).await else {
+        return; // sandbox without UDP bind
+    };
+    let Some(bob) = build_owned_agent(dir.path(), "bob", [7u8; 32]).await else {
+        return;
+    };
+    let alice = Arc::new(alice);
+    let bob = Arc::new(bob);
+    assert_eq!(alice.user_id(), bob.user_id(), "same owner on both");
+
+    let service_a =
+        x0x::owner_sync::OwnerSyncService::new(Arc::clone(&alice), &dir.path().join("sync-a"))
+            .await
+            .expect("alice SyncV1 acceptor");
+    let service_b =
+        x0x::owner_sync::OwnerSyncService::new(Arc::clone(&bob), &dir.path().join("sync-b"))
+            .await
+            .expect("bob SyncV1 acceptor");
+
+    // Cross-enroll: each device set contains the OTHER machine.
+    let owner_id = owner.user_id();
+    service_a
+        .store()
+        .enroll(OwnerEnrollment::sign(bob.machine_id(), &owner, 1_000).unwrap())
+        .await;
+    service_b
+        .store()
+        .enroll(OwnerEnrollment::sign(alice.machine_id(), &owner, 1_000).unwrap())
+        .await;
+
+    // Local Tier-1 state: distinct names per machine.
+    service_a
+        .store()
+        .mint(
+            SyncKind::MachineNames,
+            &hex::encode(alice.machine_id().0),
+            &names_value("alice-agent", "alice-mac"),
+            &owner,
+            alice.machine_id(),
+        )
+        .await
+        .unwrap();
+    service_b
+        .store()
+        .mint(
+            SyncKind::MachineNames,
+            &hex::encode(bob.machine_id().0),
+            &names_value("bob-agent", "bob-mac"),
+            &owner,
+            bob.machine_id(),
+        )
+        .await
+        .unwrap();
+
+    // Transport bring-up (tailnet integration test pattern).
+    alice.join_network().await.expect("alice joins");
+    bob.join_network().await.expect("bob joins");
+    let alice_network = alice.network().expect("alice network").clone();
+    let bob_network = bob.network().expect("bob network").clone();
+    let bob_addr = {
+        let addr = bob_network.bound_addr().await.expect("bob bound");
+        if addr.ip().is_unspecified() {
+            std::net::SocketAddr::new(
+                std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                addr.port(),
+            )
+        } else {
+            addr
+        }
+    };
+    let connected = alice_network
+        .connect_addr(bob_addr)
+        .await
+        .expect("alice connects to bob");
+    assert_eq!(connected.0, bob.machine_id().0);
+
+    let bob_peer = ant_quic::PeerId(bob.machine_id().0);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if alice_network.is_connected(&bob_peer).await
+            && bob_network
+                .is_connected(&ant_quic::PeerId(alice.machine_id().0))
+                .await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        alice_network.is_connected(&bob_peer).await,
+        "alice→bob live"
+    );
+
+    // Identity gates: discovery-cache binding + Trusted contact, both ways.
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_secs();
+    let alice_addr = {
+        let addr = alice_network.bound_addr().await.expect("alice bound");
+        if addr.ip().is_unspecified() {
+            std::net::SocketAddr::new(
+                std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                addr.port(),
+            )
+        } else {
+            addr
+        }
+    };
+    let discovered = |agent: &x0x::Agent, addr, now| x0x::DiscoveredAgent {
+        self_name: None,
+        cert_digest: None,
+        agent_id: agent.agent_id(),
+        machine_id: agent.machine_id(),
+        user_id: None,
+        addresses: vec![addr],
+        announced_at: now,
+        last_seen: now,
+        machine_public_key: Vec::new(),
+        nat_type: None,
+        can_receive_direct: Some(true),
+        is_relay: None,
+        is_coordinator: None,
+        reachable_via: Vec::new(),
+        relay_candidates: Vec::new(),
+        cert_not_after: None,
+        agent_certificate: None,
+        agent_public_key: Vec::new(),
+    };
+    alice
+        .insert_discovered_agent_for_testing(discovered(&bob, bob_addr, now_secs))
+        .await;
+    alice.set_contact_trusted_for_testing(bob.agent_id()).await;
+    bob.insert_discovered_agent_for_testing(discovered(&alice, alice_addr, now_secs))
+        .await;
+    bob.set_contact_trusted_for_testing(alice.agent_id()).await;
+
+    // One pass from alice: dial bob, run the session. Bob's acceptor
+    // handles the inbound side. (The owner id check inside the session is
+    // the same-owner gate; the enrollment gates ran above.)
+    let _ = owner_id;
+    service_a.sync_all().await;
+
+    // Convergence: both stores hold both machines' names records.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let a = service_a.store().records_snapshot().await;
+        let b = service_b.store().records_snapshot().await;
+        let a_ok = a.iter().any(|r| {
+            r.kind == SyncKind::MachineNames && r.value == names_value("bob-agent", "bob-mac")
+        });
+        let b_ok = b.iter().any(|r| {
+            r.kind == SyncKind::MachineNames && r.value == names_value("alice-agent", "alice-mac")
+        });
+        if a_ok && b_ok {
+            break;
+        }
+        if Instant::now() > deadline {
+            panic!("no convergence: alice has {a:?}, bob has {b:?}");
+        }
+        // Retry the pass until the discovery caches settle.
+        service_a.sync_all().await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Non-enrolled machine rejected at accept: an unenrolled third agent's
+    // stream never reaches the session (gate refuses before any byte).
+    // Simulated at store level here (the transport path needs a third
+    // agent; the accept-gate unit tests cover the decision itself).
+    let outsider = machine(9);
+    assert!(
+        !service_a
+            .store()
+            .is_enrolled(&outsider, &owner.user_id())
+            .await
+    );
+}

--- a/tests/api_coverage.rs
+++ b/tests/api_coverage.rs
@@ -71,6 +71,8 @@ const COVERED: &[CoveredEndpoint] = &[
     covered!(Put, "/profile", daemon_api_profile_round_trip),
     covered!(Get, "/home", home_routes_wired),
     covered!(Post, "/home/rename", home_rename_round_trips),
+    covered!(Get, "/sync/devices", sync_routes_wired),
+    covered!(Post, "/sync/devices/enroll", sync_routes_wired),
     covered!(Get, "/owner/agents", daemon_api_profile_round_trip),
     covered!(
         Post,
@@ -520,6 +522,10 @@ const COVERAGE_MARKER_SOURCES: &[(&str, &str)] = &[
     (
         "src/server/routes/home.rs",
         include_str!("../src/server/routes/home.rs"),
+    ),
+    (
+        "src/server/routes/sync.rs",
+        include_str!("../src/server/routes/sync.rs"),
     ),
     (
         "tests/peer_lifecycle_integration.rs",

--- a/tests/api_coverage.rs
+++ b/tests/api_coverage.rs
@@ -73,6 +73,7 @@ const COVERED: &[CoveredEndpoint] = &[
     covered!(Post, "/home/rename", home_rename_round_trips),
     covered!(Get, "/sync/devices", sync_routes_wired),
     covered!(Post, "/sync/devices/enroll", sync_routes_wired),
+    covered!(Delete, "/sync/devices/:machine_id", sync_routes_wired),
     covered!(Get, "/owner/agents", daemon_api_profile_round_trip),
     covered!(
         Post,


### PR DESCRIPTION
Implements ADR-0041 Tier-1 (amends ADR-0023): owner-device enrollment with a nonce owner-key possession challenge, SyncV1 stream (single-acceptor, both machine gates + enrollment currency), versioned owner-signed records (version→timestamp→writer conflict rule, rollback-proof), fail-loud durable store with crash-consistent (poison-on-failure) atomic writes, byte-paged frames, exhaustive Tier-1-only kind enum (Tier-3 can't be emitted).

Review: 6-round codex adversarial + Claude loop; final APPROVE. Codex caught (and this fixes): unauthenticated Hello owner-id, swallowed-persist empty-store rollback hole, signature-only equal-clock divergence, poison-flag-not-checked. Owner-to-owner only — honors ADR-0023's no-network-archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements ADR-0041 Tier-1 owner-state synchronization across enrolled machines, including owner-key challenges, signed versioned records, durable storage, API/CLI/GUI controls, and SyncV1 stream integration.

- Adds the owner sync store, wire protocol, conflict resolution, paging, enrollment gates, and periodic service
- Adds device enrollment/list/revocation routes and corresponding CLI and GUI surfaces
- Integrates profile, Home pointer, and issuance-journal reconciliation with daemon state
- Adds unit and integration coverage for convergence, rollback resistance, persistence failures, and protocol limits

<h3>Confidence Score: 3/5</h3>

The PR should not merge until synchronized journal expiry metadata and cleared profile fields are preserved across receiving devices.

Accepted issuance records currently erase not_after during local journal application, while winning None-valued profile fields are treated as omitted updates, causing owner devices to retain or propagate incorrect Tier-1 state.

**Files Needing Attention:** src/owner_sync.rs, src/server/routes/sync.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/owner_sync.rs | Adds the complete Tier-1 store and SyncV1 protocol, but loses issuance certificate expiry while applying accepted journal records. |
| src/server/routes/sync.rs | Adds device-management routes and the daemon-state adapter, whose partial-update interpretation prevents synchronized name deletions from converging. |
| src/server/mod.rs | Registers the owner sync service, routes, shared state, and periodic lifecycle without an independently identified defect. |
| src/streams.rs | Adds the SyncV1 protocol discriminator to the existing authenticated peer-stream framework. |
| src/gui/x0x-gui.html | Adds an escaped device-management panel for enrollment status and revocation. |
| tests/adr0041_tier1_sync.rs | Adds extensive protocol and convergence coverage, but does not cover expiry preservation or clearing optional profile names. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as Owner device A
    participant AS as Sync store A
    participant B as Owner device B
    participant BS as Sync store B
    A->>B: Open authenticated SyncV1 stream
    A->>B: Hello(owner, machine, nonce)
    B->>A: Hello(owner, machine, nonce)
    A->>B: Owner-key proof over B nonce
    B->>A: Owner-key proof over A nonce
    A->>B: Paged version vector
    B->>A: Paged version vector
    A->>B: Missing signed records + Done
    B->>A: Missing signed records + Done
    A->>AS: Verify and atomically commit batch
    B->>BS: Verify and atomically commit batch
    AS-->>A: Apply accepted records to daemon state
    BS-->>B: Apply accepted records to daemon state
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/server/routes/sync.rs`, line 6958-6966 ([link](https://github.com/saorsa-labs/x0x/blob/103a0835a8346ad976d1d342c90041aa8679bb2e/src/server/routes/sync.rs#L6958-L6966)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cleared profile fields do not converge**

   When an owner clears a synchronized profile name, the winning `None` value is interpreted as “leave unchanged” in both the mirror and persisted profile, causing receiving machines to retain and re-mint the stale name instead of converging on the cleared state.

   **Knowledge Base Used:** [Replicated data and gossip](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/replicated-data-and-gossip.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/server/routes/sync.rs
   Line: 6958-6966
   
   Comment:
   **Cleared profile fields do not converge**
   
   When an owner clears a synchronized profile name, the winning `None` value is interpreted as “leave unchanged” in both the mirror and persisted profile, causing receiving machines to retain and re-mint the stale name instead of converging on the cleared state.
   
   **Knowledge Base Used:** [Replicated data and gossip](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/replicated-data-and-gossip.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/owner_sync.rs:2300-2307
**Journal expiry metadata is lost**

When a synchronized issuance record has `not_after` set, `apply_record` discards that field and `apply_journal_line` persists `None`, causing the receiving machine to report no certificate expiry and potentially re-mint the lossy value at a higher version for other devices.

### Issue 2
src/server/routes/sync.rs:6958-6966
**Cleared profile fields do not converge**

When an owner clears a synchronized profile name, the winning `None` value is interpreted as “leave unchanged” in both the mirror and persisted profile, causing receiving machines to retain and re-mint the stale name instead of converging on the cleared state.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sync): ADR-0041 R6 — poison flag che..."](https://github.com/saorsa-labs/x0x/commit/103a0835a8346ad976d1d342c90041aa8679bb2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58233147)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Secure identity and trust](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/secure-identity-and-trust.md)
- Knowledge Base — [Replicated data and gossip](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/replicated-data-and-gossip.md)
- Knowledge Base — [Client, daemon, and API platform](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/client-and-daemon-platform.md)
- Knowledge Base — [Server APIs and live streams](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/x0x/-/docs/server-api-and-live-streams.md)
</details>


<!-- /greptile_comment -->